### PR TITLE
fix: Don't hang when MCP server returns 5xx

### DIFF
--- a/src/strands/tools/mcp/mcp_client.py
+++ b/src/strands/tools/mcp/mcp_client.py
@@ -119,10 +119,12 @@ class MCPClient(ToolProvider):
         mcp_instrumentation()
         self._session_id = uuid.uuid4()
         self._log_debug_with_thread("initializing MCPClient connection")
-        # Main thread blocks until future completesock
+        # Main thread blocks until future completes
         self._init_future: futures.Future[None] = futures.Future()
+        # Set within the inner loop as it needs the asyncio loop
+        self._close_future: asyncio.futures.Future[None] | None = None
+        self._close_exception: None | Exception = None
         # Do not want to block other threads while close event is false
-        self._close_event = asyncio.Event()
         self._transport_callable = transport_callable
 
         self._background_thread: threading.Thread | None = None
@@ -288,11 +290,12 @@ class MCPClient(ToolProvider):
         - _background_thread: Thread running the async event loop
         - _background_thread_session: MCP ClientSession (auto-closed by context manager)
         - _background_thread_event_loop: AsyncIO event loop in background thread
-        - _close_event: AsyncIO event to signal thread shutdown
+        - _close_future: AsyncIO future to signal thread shutdown
+        - _close_exception: Exception that caused the background thread shutdown; None if a normal shutdown occurred.
         - _init_future: Future for initialization synchronization
 
         Cleanup order:
-        1. Signal close event to background thread (if session initialized)
+        1. Signal close future to background thread (if session initialized)
         2. Wait for background thread to complete
         3. Reset all state for reuse
 
@@ -303,13 +306,14 @@ class MCPClient(ToolProvider):
         """
         self._log_debug_with_thread("exiting MCPClient context")
 
-        # Only try to signal close event if we have a background thread
+        # Only try to signal close future if we have a background thread
         if self._background_thread is not None:
-            # Signal close event if event loop exists
+            # Signal close future if event loop exists
             if self._background_thread_event_loop is not None:
 
                 async def _set_close_event() -> None:
-                    self._close_event.set()
+                    if self._close_future and not self._close_future.done():
+                        self._close_future.set_result(None)
 
                 # Not calling _invoke_on_background_thread since the session does not need to exist
                 # we only need the thread and event loop to exist.
@@ -317,11 +321,11 @@ class MCPClient(ToolProvider):
 
             self._log_debug_with_thread("waiting for background thread to join")
             self._background_thread.join()
+
         self._log_debug_with_thread("background thread is closed, MCPClient context exited")
 
         # Reset fields to allow instance reuse
         self._init_future = futures.Future()
-        self._close_event = asyncio.Event()
         self._background_thread = None
         self._background_thread_session = None
         self._background_thread_event_loop = None
@@ -329,6 +333,11 @@ class MCPClient(ToolProvider):
         self._loaded_tools = None
         self._tool_provider_started = False
         self._consumers = set()
+
+        if self._close_exception:
+            exception = self._close_exception
+            self._close_exception = None
+            raise RuntimeError("Connection to the MCP server was closed") from exception
 
     def list_tools_sync(
         self,
@@ -563,6 +572,10 @@ class MCPClient(ToolProvider):
         signals readiness to the main thread, and waits for a close signal.
         """
         self._log_debug_with_thread("starting async background thread for MCP connection")
+
+        # Initialized here so that it has the asyncio loop
+        self._close_future = asyncio.Future()
+
         try:
             async with self._transport_callable() as (read_stream, write_stream, *_):
                 self._log_debug_with_thread("transport connection established")
@@ -583,8 +596,9 @@ class MCPClient(ToolProvider):
 
                     self._log_debug_with_thread("waiting for close signal")
                     # Keep background thread running until signaled to close.
-                    # Thread is not blocked as this is an asyncio.Event not a threading.Event
-                    await self._close_event.wait()
+                    # Thread is not blocked as this a future
+                    await self._close_future
+
                     self._log_debug_with_thread("close signal received")
         except Exception as e:
             # If we encounter an exception and the future is still running,
@@ -592,6 +606,12 @@ class MCPClient(ToolProvider):
             if not self._init_future.done():
                 self._init_future.set_exception(e)
             else:
+                # _close_future is automatically cancelled by the framework which doesn't provide us with the useful
+                # exception, so instead we store the exception in a different field where stop() can read it
+                self._close_exception = e
+                if self._close_future and not self._close_future.done():
+                    self._close_future.set_result(None)
+
                 self._log_debug_with_thread(
                     "encountered exception on background thread after initialization %s", str(e)
                 )
@@ -601,7 +621,7 @@ class MCPClient(ToolProvider):
 
         This method creates a new event loop for the background thread,
         sets it as the current event loop, and runs the async_background_thread
-        coroutine until completion. In this case "until completion" means until the _close_event is set.
+        coroutine until completion. In this case "until completion" means until the _close_future is resolved.
         This allows for a long-running event loop.
         """
         self._log_debug_with_thread("setting up background task event loop")
@@ -699,9 +719,30 @@ class MCPClient(ToolProvider):
         )
 
     def _invoke_on_background_thread(self, coro: Coroutine[Any, Any, T]) -> futures.Future[T]:
-        if self._background_thread_session is None or self._background_thread_event_loop is None:
+        # save a reference to this so that even if it's reset we have the original
+        close_future = self._close_future
+
+        if self._background_thread_session is None or self._background_thread_event_loop is None or not close_future:
             raise MCPClientInitializationError("the client session was not initialized")
-        return asyncio.run_coroutine_threadsafe(coro=coro, loop=self._background_thread_event_loop)
+
+        async def run_async() -> T:
+            # Fix for strands-agents/sdk-python/issues/995 - cancel all pending invocations if/when the session closes
+            invoke_event = asyncio.create_task(coro)
+            tasks: list[asyncio.Task | asyncio.Future] = [
+                invoke_event,
+                close_future,
+            ]
+
+            done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+
+            if done.pop() == close_future:
+                self._log_debug_with_thread("event loop for the server closed before the invoke completed")
+                raise RuntimeError("Connection to the MCP server was closed")
+            else:
+                return await invoke_event
+
+        invoke_future = asyncio.run_coroutine_threadsafe(coro=run_async(), loop=self._background_thread_event_loop)
+        return invoke_future
 
     def _should_include_tool(self, tool: MCPAgentTool) -> bool:
         """Check if a tool should be included based on constructor filters."""

--- a/src/strands/tools/mcp/mcp_client.py
+++ b/src/strands/tools/mcp/mcp_client.py
@@ -722,7 +722,11 @@ class MCPClient(ToolProvider):
         # save a reference to this so that even if it's reset we have the original
         close_future = self._close_future
 
-        if self._background_thread_session is None or self._background_thread_event_loop is None or close_future is None:
+        if (
+            self._background_thread_session is None
+            or self._background_thread_event_loop is None
+            or close_future is None
+        ):
             raise MCPClientInitializationError("the client session was not initialized")
 
         async def run_async() -> T:

--- a/src/strands/tools/mcp/mcp_client.py
+++ b/src/strands/tools/mcp/mcp_client.py
@@ -722,7 +722,7 @@ class MCPClient(ToolProvider):
         # save a reference to this so that even if it's reset we have the original
         close_future = self._close_future
 
-        if self._background_thread_session is None or self._background_thread_event_loop is None or not close_future:
+        if self._background_thread_session is None or self._background_thread_event_loop is None or close_future is None:
             raise MCPClientInitializationError("the client session was not initialized")
 
         async def run_async() -> T:


### PR DESCRIPTION
## Description

### Problem

Per #995, if a MCP tool_call receives a 5XX error from the server, the call hangs and never ends.  

### Root Cause

The root cause is that Anthropic's MCP client - on receiving a 5XX - bubbles up an exception that ends up cancelling all TaskGroup tasks which results in the session/client/asyncio loop being torn down and the tool_call never resolves, thus the hang.

<details>
  <summary>Error flow</summary>
  The flow is that a tool_call makes a new request:


  1. [A new request is started to the server](https://github.com/modelcontextprotocol/python-sdk/blob/da4fce21956cd2ce9e1e94e0bbb4eb2eca888c79/src/mcp/client/streamable_http.py#L413)
  2. The server returns a 500
  3. [Our underlying MCP Client raises on 5XX exception errors](https://github.com/modelcontextprotocol/python-sdk/blob/da4fce21956cd2ce9e1e94e0bbb4eb2eca888c79/src/mcp/client/streamable_http.py#L278)
  4. As a result, the entire thread-group is taken down, [resulting in the entire async-io background thread being torn down](https://github.com/strands-agents/sdk-python/blob/2b0c6e662fff059ecbe65f927530c7e7bb9a0d05/src/strands/tools/mcp/mcp_client.py#L596)
  
  The bug is that our implementation of MCP Tool isn't paying attention to (4) and thus the hang occurs. There's a longer-term follow-up question of whether or not a 5XX should take down the entire connection, but going to scope the fix to the hanging issue.

</details>

### Fix

The fix is two fold:

- Detect that the situation occurs and trigger a close `close_future` future 
- Update all background_invokes to eagerly bail on `close_future` being triggered

### Notes

- As far as I can tell, a MCP returning a 5XX [[is out of spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#streamable-http)](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#streamable-http).
  - Bringing down the MCP connection at that point is not ideal, but it's better than hanging as it allows clients to recover however they'd like
- We can iterate on automatically recovering in the future if we so wish

### Testing

Added an integ test to verify that:

 - the tool_call resolves with an error
 - the MCP session bails out with an error

This test failed before the changes, but succeeds now

## Related Issues

#995,

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
