### PR TITLE
feat(bedrock): allow text and content in Bedrock document sources

### DIFF
--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -398,7 +398,7 @@ class BedrockModel(Model):
 
             # Handle source
             if "source" in document:
-                result["source"] = {"bytes": document["source"]["bytes"]}
+                result["source"] = document["source"]
 
             # Handle optional fields
             if "citations" in document and document["citations"] is not None:

--- a/src/strands/types/media.py
+++ b/src/strands/types/media.py
@@ -5,7 +5,7 @@ These types are modeled after the Bedrock API.
 - Bedrock docs: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_Types_Amazon_Bedrock_Runtime.html
 """
 
-from typing import Literal, Optional
+from typing import Any, List, Literal, Optional
 
 from typing_extensions import TypedDict
 
@@ -15,14 +15,18 @@ DocumentFormat = Literal["pdf", "csv", "doc", "docx", "xls", "xlsx", "html", "tx
 """Supported document formats."""
 
 
-class DocumentSource(TypedDict):
+class DocumentSource(TypedDict, total=False):
     """Contains the content of a document.
 
     Attributes:
         bytes: The binary content of the document.
+        text: The text content of the document source.
+        content: The structured content of the document source.
     """
 
     bytes: bytes
+    text: str
+    content: List[Any]
 
 
 class DocumentContent(TypedDict, total=False):

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -2086,8 +2086,36 @@ def test_format_request_document_with_text_source(model):
 
     formatted_content = model._format_request_message_content(content_block)
 
-    expected_source = {"text": document_text}
-    assert "document" in formatted_content
-    assert "source" in formatted_content["document"]
+    assert formatted_content["document"]["source"] == {"text": document_text}
 
-    assert formatted_content["document"]["source"] == expected_source
+
+def test_format_request_document_with_bytes_source(model):
+    """Test that _format_request_message_content correctly handles a 'bytes' source."""
+
+    content_block: ContentBlock = {
+        "document": {
+            "name": "test_doc",
+            "source": {"bytes": b"some byte data"},
+            "format": "txt",
+        }
+    }
+
+    formatted_content = model._format_request_message_content(content_block)
+
+    assert formatted_content["document"]["source"] == {"bytes": b"some byte data"}
+
+
+def test_format_request_document_with_content_source(model):
+    """Test that _format_request_message_content correctly handles a 'content' source."""
+    doc_content = [{"text": "structured content"}]
+    content_block: ContentBlock = {
+        "document": {
+            "name": "test_doc",
+            "source": {"content": doc_content},
+            "format": "txt",
+        }
+    }
+
+    formatted_content = model._format_request_message_content(content_block)
+
+    assert formatted_content["document"]["source"] == {"content": doc_content}

--- a/tests/strands/models/test_bedrock.py
+++ b/tests/strands/models/test_bedrock.py
@@ -19,6 +19,7 @@ from strands.models.bedrock import (
     DEFAULT_BEDROCK_REGION,
     DEFAULT_READ_TIMEOUT,
 )
+from strands.types.content import ContentBlock
 from strands.types.exceptions import ModelThrottledException
 from strands.types.tools import ToolSpec
 
@@ -2070,3 +2071,23 @@ async def test_stream_backward_compatibility_system_prompt(bedrock_client, model
         "system": [{"text": system_prompt}],
     }
     bedrock_client.converse_stream.assert_called_once_with(**expected_request)
+
+
+def test_format_request_document_with_text_source(model):
+    """Test that _format_request_message_content correctly handles a document with a 'text' source."""
+    document_text = "This is the document content."
+    content_block: ContentBlock = {
+        "document": {
+            "name": "test_doc",
+            "source": {"text": document_text},
+            "format": "txt",
+        }
+    }
+
+    formatted_content = model._format_request_message_content(content_block)
+
+    expected_source = {"text": document_text}
+    assert "document" in formatted_content
+    assert "source" in formatted_content["document"]
+
+    assert formatted_content["document"]["source"] == expected_source


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR --> 
This PR resolves an issue where providing a document source as `text` to the `BedrockModel` would cause an error because bedrock updated their `DocumentSource` definition https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_DocumentSource.html .This PR updates the `DocumentSource` type and modifies the request formatting to correctly pass through any valid source type (`bytes`, `text`, `content`). Unit tests were added to verify the format request with bytes, text  and content,
## Related Issues

<!-- Link to related issues using #issue-number format -->
Closes #1066 

## Documentation PR 

<!-- Link to related associated PR in the agent-docs repo --> N/A

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->
New feature


## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`
- [x] I ran formatters, linters and unit tests 

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
