### PR TITLE
fix: Handle consecutive user messages in BedrockModel

### DIFF
--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -353,7 +353,25 @@ class BedrockModel(Model):
                 "Filtered DeepSeek reasoningContent content blocks from messages - https://api-docs.deepseek.com/guides/reasoning_model#multi-round-conversation"
             )
 
-        return cleaned_messages
+        # Bedrock requires alternating user/assistant roles.
+        # If we have consecutive user messages (e.g. tool result due to structured output followed by new prompt),
+        # we must insert a dummy assistant message.
+        # Refer: https://github.com/strands-agents/sdk-python/issues/1223
+        final_messages: list[dict[str, Any]] = []
+        for cleaned_message in cleaned_messages:
+            if final_messages and final_messages[-1]["role"] == cleaned_message["role"]:
+                # The structured output tool result is a user message and is the last message in the conversation
+                if cleaned_message["role"] == "user":
+                    # Only insert acknowledgement if the previous message was a tool result
+                    last_message_content = final_messages[-1].get("content", [])
+                    is_tool_result = any("toolResult" in block for block in last_message_content)
+
+                    if is_tool_result:
+                        final_messages.append({"role": "assistant", "content": [{"text": "acknowledged"}]})
+
+            final_messages.append(cleaned_message)
+
+        return final_messages
 
     def _should_include_tool_result_status(self) -> bool:
         """Determine whether to include tool result status based on current config."""

--- a/tests_integ/test_structured_output_bedrock_llama_models.py
+++ b/tests_integ/test_structured_output_bedrock_llama_models.py
@@ -1,0 +1,64 @@
+"""
+Comprehensive integration tests for structured output passed into the agent functionality.
+"""
+
+from pydantic import BaseModel, Field
+
+from strands import Agent
+from strands.models.bedrock import BedrockModel
+from strands.tools import tool
+
+
+class MathResult(BaseModel):
+    """Math operation result."""
+
+    operation: str = Field(description="the performed operation")
+    result: int = Field(description="the result of the operation")
+
+
+# ========== Tool Definitions ==========
+
+
+@tool
+def calculator(operation: str, a: float, b: float) -> float:
+    """Simple calculator tool for testing."""
+    if operation == "add":
+        return a + b
+    elif operation == "subtract":
+        return a - b
+    elif operation == "multiply":
+        return a * b
+    elif operation == "divide":
+        return b / a if a != 0 else 0
+    elif operation == "power":
+        return a**b
+    else:
+        return 0
+
+
+# ========== Test Classes ==========
+
+
+class TestBedrockLlamaModelsToolUsageWithStructuredOutput:
+    """Test structured output with tool usage."""
+
+    def test_multi_turn_calculator_tool_use_with_structured_output(self):
+        """Test tool usage with structured output."""
+        model = BedrockModel(
+            model_id="us.meta.llama4-maverick-17b-instruct-v1:0",
+            region_name="us-east-1",
+            max_tokens=2048,
+            streaming=False,
+        )
+        agent = Agent(model=model, tools=[calculator])
+
+        result = agent("Calculate 2 + 2 using the calculator tool", structured_output_model=MathResult)
+
+        assert result.structured_output is not None
+        assert isinstance(result.structured_output, MathResult)
+        assert result.structured_output.result == 4
+        # Check that tool was called
+        assert result.metrics.tool_metrics is not None
+        assert len(result.metrics.tool_metrics) > 0
+        result = agent("What is 5 multiplied by 3? Use the calculator tool.", structured_output_model=MathResult)
+        assert result.structured_output is not None


### PR DESCRIPTION
## Description
Updated BedrockModel to insert a dummy assistant message when consecutive user messages are detected, ensuring proper user/assistant role alternation required by Bedrock. Added integration tests for structured output with tool usage in Bedrock Llama models.

## Related Issues
https://github.com/strands-agents/sdk-python/issues/1223

## Type of Change
Bug fix

## Testing
I have ran all the unit tests but I have not ran all the integration tests.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
