### PR TITLE
test: Add resilience tests for MCP connection collapse and tool watcher fan-out

### DIFF
--- a/src/strands/types/_events.py
+++ b/src/strands/types/_events.py
@@ -286,7 +286,8 @@ class ToolResultEvent(TypedEvent):
     @property
     def tool_use_id(self) -> str:
         """The toolUseId associated with this result."""
-        return cast(str, cast(ToolResult, self.get("tool_result")).get("toolUseId"))
+        tool_result = cast(ToolResult, self.get("tool_result"))
+        return tool_result.get("toolUseId")
 
     @property
     def tool_result(self) -> ToolResult:
@@ -314,7 +315,8 @@ class ToolStreamEvent(TypedEvent):
     @property
     def tool_use_id(self) -> str:
         """The toolUseId associated with this stream."""
-        return cast(str, cast(ToolUse, cast(dict, self.get("tool_stream_event")).get("tool_use")).get("toolUseId"))
+        tool_use = cast(dict, self.get("tool_stream_event")).get("tool_use")
+        return cast(ToolUse, tool_use).get("toolUseId")
 
 
 class ToolCancelEvent(TypedEvent):
@@ -332,7 +334,8 @@ class ToolCancelEvent(TypedEvent):
     @property
     def tool_use_id(self) -> str:
         """The id of the tool cancelled."""
-        return cast(str, cast(ToolUse, cast(dict, self.get("tool_cancel_event")).get("tool_use")).get("toolUseId"))
+        tool_use = cast(dict, self.get("tool_cancel_event")).get("tool_use")
+        return cast(ToolUse, tool_use).get("toolUseId")
 
     @property
     def message(self) -> str:
@@ -350,7 +353,8 @@ class ToolInterruptEvent(TypedEvent):
     @property
     def tool_use_id(self) -> str:
         """The id of the tool interrupted."""
-        return cast(str, cast(ToolUse, cast(dict, self.get("tool_interrupt_event")).get("tool_use")).get("toolUseId"))
+        tool_use = cast(dict, self.get("tool_interrupt_event")).get("tool_use")
+        return cast(ToolUse, tool_use).get("toolUseId")
 
     @property
     def interrupts(self) -> list[Interrupt]:


### PR DESCRIPTION
## Description
- Add resilience-focused unit tests: simulate MCP connection collapse to ensure `_invoke_on_background_thread` raises instead of hanging, and verify the tool watcher fans out file changes to all registries with a single observer.
- Reset shared ToolWatcher state between tests to avoid cross-test leakage.
- Clean up minor mypy complaints in `_events.py` tool/use accessors to keep lint passing.

## Related Issues
- #1269

## Documentation PR
- Not needed (test-only change).

## Type of Change
- [x] Test
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing
- [x] `pre-commit run --all-files` (includes lint/unit tests)
- [ ] `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
