### PR TITLE
feat(models): add support for image content blocks in responses

### DIFF
--- a/src/strands/event_loop/streaming.py
+++ b/src/strands/event_loop/streaming.py
@@ -248,6 +248,13 @@ def handle_content_block_delta(
             state["redactedContent"] = state.get("redactedContent", b"") + redacted_content
             typed_event = ReasoningRedactedContentStreamEvent(redacted_content=redacted_content, delta=delta_content)
 
+    elif "image" in delta_content:
+        if "image" not in state:
+            state["image"] = []
+
+        state["image"].append(delta_content["image"])
+        typed_event = ModelStreamEvent(delta_content)
+
     return state, typed_event
 
 
@@ -313,6 +320,11 @@ def handle_content_block_stop(state: dict[str, Any]) -> dict[str, Any]:
     elif redacted_content:
         content.append({"reasoningContent": {"redactedContent": redacted_content}})
         state["redactedContent"] = b""
+    elif state.get("image"):
+        # Add all accumulated image blocks to content
+        for image_data in state["image"]:
+            content.append({"image": image_data})
+        state["image"] = []
 
     return state
 
@@ -382,6 +394,7 @@ async def process_stream(
         "current_tool_use": {},
         "reasoningText": "",
         "citationsContent": [],
+        "image": [],
     }
     state["content"] = state["message"]["content"]
 

--- a/src/strands/models/bedrock.py
+++ b/src/strands/models/bedrock.py
@@ -845,6 +845,13 @@ class BedrockModel(Model):
                         "sourceContent": citation["sourceContent"],
                     }
                     yield {"contentBlockDelta": {"delta": {"citation": citation_metadata}}}
+            elif "image" in content:
+                # Yield image content as a delta
+                yield {
+                    "contentBlockDelta": {
+                        "delta": {"image": content["image"]},
+                    }
+                }
 
             # Yield contentBlockStop event
             yield {"contentBlockStop": {}}


### PR DESCRIPTION
  ## Summary

  - Add image content block handling in bedrock non-streaming responses
  - Add image delta processing in streaming event loop
  - Initialize image state in process_stream
  - Add test case for image content block processing

  This enables multimodal models that accept various input types and generate images as output (e.g., Amazon Nova 2 Omni) to return generated images that 
  are properly parsed and included in agent responses.

  ## Description

  This PR adds support for image content blocks in model responses. Currently, the SDK handles text, toolUse, reasoningContent, and citationsContent 
  blocks, but image blocks returned by multimodal models are not processed.

  **Changes:**
  - `bedrock.py`: Added image handling in `_convert_non_streaming_to_streaming` method to yield image deltas
  - `streaming.py`: Added image processing in `handle_content_block_delta` and `handle_content_block_stop` functions, and initialized image state in
  `process_stream`
  - `test_streaming.py`: Added `test_process_stream_with_image_content` to verify image block processing

  The implementation follows the same pattern as other content block types, ensuring consistency and maintainability.

  ## Related Issues

  None

  ## Documentation PR

  None

  ## Type of Change

  New feature

  ## Testing

  How have you tested the change?

  - [x] I ran `hatch run prepare`
  - [x] All unit tests pass (1,609 tests)
  - [x] All integration tests pass (17 bedrock-specific tests)
  - [x] Verified with actual image generation using Amazon Nova 2 Omni (4.9MB PNG image successfully processed)
  - [x] Formatter and linter checks pass

  ## Checklist
  - [x] I have read the CONTRIBUTING document
  - [x] I have added any necessary tests that prove my fix is effective or my feature works
  - [x] I have updated the documentation accordingly
  - [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
  - [x] My changes generate no new warnings
  - [x] Any dependent changes have been merged and published