### PR TITLE
feat(bedrock): add requestId logging to BedrockModel

### DIFF
--- a/tests/strands/tools/test_decorator_pep563.py
+++ b/tests/strands/tools/test_decorator_pep563.py
@@ -10,10 +10,10 @@ https://github.com/strands-agents/sdk-python/issues/1208
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 import pytest
-from typing_extensions import Literal, TypedDict
+from typing_extensions import TypedDict
 
 from strands import tool
 


### PR DESCRIPTION
Implements bedrock-request-id-logging spec requirements

Adds request ID logging for Bedrock API calls using a dedicated child logger (strands.models.bedrock.requestId). This implements the approach suggested by @zastrowm - using Python's standard logging hierarchy instead of a custom configuration parameter.

Key changes:

Log request ID at DEBUG level for successful streaming/non-streaming requests
Log request ID at INFO level for failed requests (when users most need it for troubleshooting)
Child logger inherits from parent logger, respecting existing log configuration
Usage

Users can enable request ID logging via Python's standard logging configuration:
```
  import logging

 # Option 1: Enable via the child logger directly
  logging.getLogger('strands.models.bedrock.requestId').setLevel(logging.DEBUG)

 # Option 2: Enable via parent logger (will also show other debug logs)
  logging.getLogger('strands.models.bedrock').setLevel(logging.DEBUG)
```

