### PR TITLE
feat: adding terminate attribute for after-model-call-event hooks

### DIFF
--- a/src/strands/event_loop/event_loop.py
+++ b/src/strands/event_loop/event_loop.py
@@ -153,6 +153,11 @@ async def event_loop_cycle(
                 agent, cycle_span, cycle_trace, invocation_state, tracer, structured_output_context
             )
             async for model_event in model_events:
+                if isinstance(model_event, EventLoopStopEvent):
+                    agent.event_loop_metrics.end_cycle(cycle_start_time, cycle_trace)
+                    yield model_event
+                    await model_events.aclose()  # clean-up async for-loop to avoid CancelledError
+                    return
                 if not isinstance(model_event, ModelStopReason):
                     yield model_event
 
@@ -360,6 +365,18 @@ async def _handle_model_execution(
                         stop_reason,
                     )
                     continue  # Retry the model call
+                elif after_model_call_event.terminate:
+                    logger.debug(
+                        "stop_reason=<%s>, termination_requested=<True> | hook requested agent termination",
+                        stop_reason,
+                    )
+                    invocation_state["request_state"]["stop_event_loop"] = True
+                    yield EventLoopStopEvent(
+                        stop_reason,
+                        message,
+                        agent.event_loop_metrics,
+                        invocation_state["request_state"],
+                    )
 
                 if stop_reason == "max_tokens":
                     message = recover_message_on_max_tokens_reached(message)

--- a/src/strands/event_loop/event_loop.py
+++ b/src/strands/event_loop/event_loop.py
@@ -365,9 +365,9 @@ async def _handle_model_execution(
                         stop_reason,
                     )
                     continue  # Retry the model call
-                elif after_model_call_event.terminate:
+                elif after_model_call_event.stop_loop:
                     logger.debug(
-                        "stop_reason=<%s>, termination_requested=<True> | hook requested agent termination",
+                        "stop_reason=<%s>, stop_loop_requested=<True> | hook requested agent stop-loop",
                         stop_reason,
                     )
                     invocation_state["request_state"]["stop_event_loop"] = True

--- a/src/strands/hooks/events.py
+++ b/src/strands/hooks/events.py
@@ -188,6 +188,9 @@ class AfterToolCallEvent(HookEvent):
         retry: Whether to retry the tool invocation. Can be set by hook callbacks
             to trigger a retry. When True, the current result is discarded and the
             tool is called again. Defaults to False.
+        stop_loop: Whether to end the event-loop. Hooks can use this flag to terminate
+            the event-loop immediately. Setting to True would close the event loop and
+            perform proper closure of async loop. Defaults to False
     """
 
     selected_tool: AgentTool | None
@@ -278,12 +281,12 @@ class AfterModelCallEvent(HookEvent):
     stop_response: ModelStopResponse | None = None
     exception: Exception | None = None
     retry: bool = False
-    terminate: bool = False
+    stop_loop: bool = False
 
     def _can_write(self, name: str) -> bool:
         return name in (
             "retry",
-            "terminate",
+            "stop_loop",
         )
 
     @property

--- a/src/strands/hooks/events.py
+++ b/src/strands/hooks/events.py
@@ -278,9 +278,13 @@ class AfterModelCallEvent(HookEvent):
     stop_response: ModelStopResponse | None = None
     exception: Exception | None = None
     retry: bool = False
+    terminate: bool = False
 
     def _can_write(self, name: str) -> bool:
-        return name == "retry"
+        return name in (
+            "retry",
+            "terminate",
+        )
 
     @property
     def should_reverse_callbacks(self) -> bool:

--- a/tests/strands/agent/test_agent_hooks.py
+++ b/tests/strands/agent/test_agent_hooks.py
@@ -697,8 +697,8 @@ async def test_before_invocation_event_messages_none_in_structured_output(agener
 
 
 @pytest.mark.asyncio
-async def test_hook_terminate_on_successful_call():
-    """Test that hooks can terminate even on successful model calls based on response content."""
+async def test_hook_stop_loop_on_successful_call():
+    """Test that hooks can stop event loop even on successful model calls based on response content."""
 
     mock_provider = MockedModelProvider(
         [
@@ -713,8 +713,8 @@ async def test_hook_terminate_on_successful_call():
         ]
     )
 
-    # Hook that terminate if response is favorable
-    class SuccessfulTerminateHook:
+    # Hook that stop event loop if response is favorable
+    class SuccessfulStopLoopHook:
         def __init__(self, end_marker="success"):
             self.end_marker = end_marker
             self.call_count = 0
@@ -731,9 +731,9 @@ async def test_hook_terminate_on_successful_call():
                 text_content = "".join(block.get("text", "") for block in message.get("content", []))
 
                 if self.end_marker in text_content:
-                    event.terminate = True
+                    event.stop_loop = True
 
-    terminate_hook = SuccessfulTerminateHook(end_marker="success")
+    terminate_hook = SuccessfulStopLoopHook(end_marker="success")
     agent = Agent(model=mock_provider, hooks=[terminate_hook])
 
     result = agent("Generate a response")
@@ -746,8 +746,8 @@ async def test_hook_terminate_on_successful_call():
 
 
 @pytest.mark.asyncio
-async def test_hook_terminate_gracefully_on_limits(agent_tool, tool_use):
-    """Test that hooks can terminate agent gracefully after maximum counts reached."""
+async def test_hook_stop_loop_gracefully_on_limits(agent_tool, tool_use):
+    """Test that hooks can stop event-loop of agent gracefully after maximum counts reached."""
 
     mock_provider = MockedModelProvider(
         [
@@ -767,7 +767,7 @@ async def test_hook_terminate_gracefully_on_limits(agent_tool, tool_use):
     )
 
     # Hook that counts number of calls
-    class GracefulTerminateHook:
+    class GracefulStopLoopHook:
         def __init__(self, max_counts):
             self.max_counts = max_counts
             self.call_count = 0
@@ -779,9 +779,9 @@ async def test_hook_terminate_gracefully_on_limits(agent_tool, tool_use):
             self.call_count += 1
 
             if self.call_count > self.max_counts - 1:
-                event.terminate = True
+                event.stop_loop = True
 
-    terminate_hook = GracefulTerminateHook(max_counts=2)
+    terminate_hook = GracefulStopLoopHook(max_counts=2)
     agent = Agent(
         model=mock_provider,
         tools=[agent_tool],


### PR DESCRIPTION
## Description
Supporting agent event loop termination via after-model-call-event hooks


## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
[x] New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
