### PR TITLE
feat(anthropic): add User-Agent header for API calls

### DIFF
--- a/src/strands/models/anthropic.py
+++ b/src/strands/models/anthropic.py
@@ -8,6 +8,7 @@ import json
 import logging
 import mimetypes
 from collections.abc import AsyncGenerator
+from importlib.metadata import PackageNotFoundError, version
 from typing import Any, TypedDict, TypeVar, cast
 
 import anthropic
@@ -76,6 +77,19 @@ class AnthropicModel(Model):
         logger.debug("config=<%s> | initializing", self.config)
 
         client_args = client_args or {}
+
+        # Add User-Agent header if not already set
+        if "default_headers" not in client_args:
+            client_args["default_headers"] = {}
+        else:
+            client_args["default_headers"] = {**client_args["default_headers"]}
+        if "User-Agent" not in client_args["default_headers"]:
+            try:
+                strands_version = version("strands-agents")
+            except PackageNotFoundError:
+                strands_version = "unknown"
+            client_args["default_headers"]["User-Agent"] = f"strands-agents/{strands_version}"
+
         self.client = anthropic.AsyncAnthropic(**client_args)
 
     @override


### PR DESCRIPTION
## Description

Adds user-agent headers for backend calls to anthropic, so that distinct open-source libraries can be differentiated and supported properly

## Type of Change

New feature

## Testing

- [ ] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
