### PR TITLE
feat(hooks): add BeforeStreamChunkEvent for stream chunk interception

### DIFF
--- a/examples/test_stream_chunk_hook.py
+++ b/examples/test_stream_chunk_hook.py
@@ -1,0 +1,141 @@
+"""Test BeforeStreamChunkEvent with a real OpenAI model.
+
+Tests three scenarios:
+1. Chunk capture - intercept and log all stream chunks
+2. Chunk modification - redact text in-flight
+3. Chunk skipping - suppress content deltas entirely
+"""
+
+import asyncio
+import os
+
+from strands import Agent
+from strands.hooks import BeforeStreamChunkEvent
+from strands.models.openai import OpenAIModel
+
+
+def make_model():
+    return OpenAIModel(
+        model_id="gpt-4o-mini",
+        client_args={"api_key": os.environ["OPENAI_API_KEY"]},
+    )
+
+
+# ---------- Test 1: capture chunks ----------
+def test_capture():
+    print("=" * 60)
+    print("TEST 1: Capture every stream chunk")
+    print("=" * 60)
+
+    chunks = []
+
+    async def on_chunk(event: BeforeStreamChunkEvent):
+        chunks.append(event.chunk.copy())
+
+    agent = Agent(
+        model=make_model(),
+        system_prompt="Reply in exactly 5 words.",
+    )
+    agent.hooks.add_callback(BeforeStreamChunkEvent, on_chunk)
+
+    result = agent("Say hello")
+
+    print(f"\nFinal text : {result.message['content'][0].get('text', '')}")
+    print(f"Chunks seen: {len(chunks)}")
+
+    chunk_types = set()
+    for c in chunks:
+        chunk_types.update(c.keys())
+    print(f"Chunk types: {sorted(chunk_types)}")
+
+    assert len(chunks) > 0, "Expected at least one chunk"
+    assert "messageStart" in chunk_types, "Missing messageStart"
+    assert "contentBlockDelta" in chunk_types, "Missing contentBlockDelta"
+    print("PASSED\n")
+
+
+# ---------- Test 2: modify (redact) chunks ----------
+def test_modify():
+    print("=" * 60)
+    print("TEST 2: Redact text in-flight")
+    print("=" * 60)
+
+    async def redact(event: BeforeStreamChunkEvent):
+        if "contentBlockDelta" in event.chunk:
+            delta = event.chunk.get("contentBlockDelta", {}).get("delta", {})
+            if "text" in delta:
+                event.chunk = {"contentBlockDelta": {"delta": {"text": "[REDACTED]"}}}
+
+    agent = Agent(
+        model=make_model(),
+        system_prompt="Say exactly: the secret code is 12345",
+    )
+    agent.hooks.add_callback(BeforeStreamChunkEvent, redact)
+
+    text_events = []
+    result = None
+
+    async def run():
+        nonlocal result
+        async for event in agent.stream_async("go"):
+            if "data" in event:
+                text_events.append(event["data"])
+            if "result" in event:
+                result = event["result"]
+
+    asyncio.run(run())
+
+    final_text = result.message["content"][0].get("text", "")
+    print(f"\nStreamed text events: {text_events}")
+    print(f"Final message text : {final_text}")
+
+    assert all(t == "[REDACTED]" for t in text_events), "Some text events were not redacted"
+    assert "secret" not in final_text.lower(), "Final message still contains secret"
+    assert "[REDACTED]" in final_text, "Final message missing redaction marker"
+    print("PASSED\n")
+
+
+# ---------- Test 3: skip content deltas ----------
+def test_skip():
+    print("=" * 60)
+    print("TEST 3: Skip content deltas entirely")
+    print("=" * 60)
+
+    async def skip_deltas(event: BeforeStreamChunkEvent):
+        if "contentBlockDelta" in event.chunk:
+            event.skip = True
+
+    agent = Agent(
+        model=make_model(),
+        system_prompt="Reply with a greeting",
+    )
+    agent.hooks.add_callback(BeforeStreamChunkEvent, skip_deltas)
+
+    text_events = []
+    result = None
+
+    async def run():
+        nonlocal result
+        async for event in agent.stream_async("hi"):
+            if "data" in event:
+                text_events.append(event["data"])
+            if "result" in event:
+                result = event["result"]
+
+    asyncio.run(run())
+
+    print(f"\nText events received: {len(text_events)}")
+    print(f"Final content       : {result.message['content']}")
+
+    assert len(text_events) == 0, f"Expected 0 text events, got {len(text_events)}"
+    assert result.message["content"] == [], "Expected empty content"
+    print("PASSED\n")
+
+
+if __name__ == "__main__":
+    test_capture()
+    test_modify()
+    test_skip()
+    print("=" * 60)
+    print("ALL TESTS PASSED")
+    print("=" * 60)

--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -19,7 +19,7 @@ from opentelemetry import trace as trace_api
 from .._middleware.stages import InvokeModelContext, InvokeModelResult, InvokeModelStage
 from .._middleware.types import MiddlewareResult
 from ..experimental.checkpoint import Checkpoint, CheckpointPosition
-from ..hooks import AfterModelCallEvent, BeforeModelCallEvent, MessageAddedEvent
+from ..hooks import AfterModelCallEvent, BeforeModelCallEvent, BeforeStreamChunkEvent, MessageAddedEvent
 from ..telemetry.metrics import Trace
 from ..telemetry.tracer import Tracer, get_tracer
 from ..tools._validator import validate_and_prepare_tools
@@ -45,7 +45,7 @@ from ..types.exceptions import (
     MaxTokensReachedException,
     StructuredOutputException,
 )
-from ..types.streaming import StopReason
+from ..types.streaming import StopReason, StreamEvent
 from ..types.tools import ToolResult, ToolUse
 from ._recover_message_on_max_tokens_reached import recover_message_on_max_tokens_reached
 from ._retry import ModelRetryStrategy
@@ -664,6 +664,17 @@ def _make_invoke_model_terminal(
         )
         with trace_api.use_span(model_invoke_span, end_on_exit=False):
             try:
+                # Create chunk interceptor that invokes BeforeStreamChunkEvent hook
+                async def chunk_interceptor(chunk: StreamEvent) -> tuple[StreamEvent, bool]:
+                    """Intercept chunks and invoke BeforeStreamChunkEvent hook."""
+                    stream_chunk_event = BeforeStreamChunkEvent(
+                        agent=agent,
+                        chunk=chunk,
+                        invocation_state=ctx.invocation_state,
+                    )
+                    await agent.hooks.invoke_callbacks_async(stream_chunk_event)
+                    return stream_chunk_event.chunk, stream_chunk_event.skip
+
                 async for event in stream_messages(
                     agent.model,
                     system_prompt_str,
@@ -674,6 +685,7 @@ def _make_invoke_model_terminal(
                     invocation_state=ctx.invocation_state,
                     model_state=agent._model_state,
                     cancel_signal=agent._cancel_signal,
+                    chunk_interceptor=chunk_interceptor,
                 ):
                     yield event
 

--- a/strands-py/src/strands/event_loop/streaming.py
+++ b/strands-py/src/strands/event_loop/streaming.py
@@ -5,7 +5,7 @@ import logging
 import threading
 import time
 import warnings
-from collections.abc import AsyncGenerator, AsyncIterable
+from collections.abc import AsyncGenerator, AsyncIterable, Awaitable, Callable
 from typing import Any
 
 from ..models.model import Model
@@ -41,6 +41,10 @@ from ..types.streaming import (
 from ..types.tools import ToolSpec, ToolUse
 
 logger = logging.getLogger(__name__)
+
+# Type for chunk interceptor callback
+# Takes a chunk and returns (modified_chunk, skip) where skip=True means don't process this chunk
+ChunkInterceptor = Callable[[StreamEvent], Awaitable[tuple[StreamEvent, bool]]]
 
 
 def _normalize_messages(messages: Messages) -> Messages:
@@ -395,6 +399,7 @@ async def process_stream(
     chunks: AsyncIterable[StreamEvent],
     start_time: float | None = None,
     cancel_signal: threading.Event | None = None,
+    chunk_interceptor: ChunkInterceptor | None = None,
 ) -> AsyncGenerator[TypedEvent, None]:
     """Processes the response stream from the API, constructing the final message and extracting usage metrics.
 
@@ -402,6 +407,9 @@ async def process_stream(
         chunks: The chunks of the response stream from the model.
         start_time: Time when the model request is initiated
         cancel_signal: Optional threading.Event to check for cancellation during streaming.
+        chunk_interceptor: Optional callback to intercept and modify chunks before processing.
+            The callback receives a chunk and returns (modified_chunk, skip). If skip is True,
+            the chunk is not processed or yielded.
 
     Yields:
         The reason for stopping, the constructed message, and the usage metrics.
@@ -434,6 +442,12 @@ async def process_stream(
                 metrics=metrics,
             )
             return
+
+        # Invoke chunk interceptor BEFORE processing if provided
+        if chunk_interceptor is not None:
+            chunk, skip = await chunk_interceptor(chunk)
+            if skip:
+                continue
 
         # Track first byte time when we get first content
         if first_byte_time is None and ("contentBlockDelta" in chunk or "contentBlockStart" in chunk):
@@ -473,6 +487,7 @@ async def stream_messages(
     invocation_state: dict[str, Any] | None = None,
     model_state: dict[str, Any] | None = None,
     cancel_signal: threading.Event | None = None,
+    chunk_interceptor: ChunkInterceptor | None = None,
     **kwargs: Any,
 ) -> AsyncGenerator[TypedEvent, None]:
     """Streams messages to the model and processes the response.
@@ -488,6 +503,9 @@ async def stream_messages(
         invocation_state: Caller-provided state/context that was passed to the agent when it was invoked.
         model_state: Runtime state for model providers (e.g., server-side response ids).
         cancel_signal: Optional threading.Event to check for cancellation during streaming.
+        chunk_interceptor: Optional callback to intercept and modify chunks before processing.
+            The callback receives a chunk and returns (modified_chunk, skip). If skip is True,
+            the chunk is not processed or yielded.
         **kwargs: Additional keyword arguments for future extensibility.
 
     Yields:
@@ -511,5 +529,5 @@ async def stream_messages(
         model_state=model_state,
     )
 
-    async for event in process_stream(chunks, start_time, cancel_signal):
+    async for event in process_stream(chunks, start_time, cancel_signal, chunk_interceptor):
         yield event

--- a/strands-py/src/strands/hooks/__init__.py
+++ b/strands-py/src/strands/hooks/__init__.py
@@ -41,6 +41,7 @@ from .events import (
     BeforeModelCallEvent,
     BeforeMultiAgentInvocationEvent,
     BeforeNodeCallEvent,
+    BeforeStreamChunkEvent,
     BeforeToolCallEvent,
     MessageAddedEvent,
     MultiAgentInitializedEvent,
@@ -50,6 +51,7 @@ from .registry import BaseHookEvent, HookCallback, HookEvent, HookOrder, HookPro
 __all__ = [
     "AgentInitializedEvent",
     "BeforeInvocationEvent",
+    "BeforeStreamChunkEvent",
     "BeforeToolCallEvent",
     "AfterToolCallEvent",
     "BeforeModelCallEvent",

--- a/strands-py/src/strands/hooks/events.py
+++ b/strands-py/src/strands/hooks/events.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 from ..types.agent import AgentInput
 from ..types.content import Message, Messages
 from ..types.interrupt import _Interruptible
-from ..types.streaming import StopReason
+from ..types.streaming import StopReason, StreamEvent
 from ..types.tools import AgentTool, ToolResult, ToolUse
 from .registry import BaseHookEvent, HookEvent
 
@@ -315,6 +315,48 @@ class AfterModelCallEvent(HookEvent):
     def should_reverse_callbacks(self) -> bool:
         """True to invoke callbacks in reverse order."""
         return True
+
+
+@dataclass
+class BeforeStreamChunkEvent(HookEvent):
+    """Event triggered before each stream chunk is processed.
+
+    This event is fired for each chunk received from the model BEFORE the chunk
+    is processed for message building or yielded as stream events. Hook providers
+    can use this event to:
+
+    - Monitor streaming progress in real-time
+    - Modify chunk content before processing (affects final message and all events)
+    - Filter/skip chunks entirely by setting skip=True
+    - Implement content transformation (e.g., redaction, translation)
+
+    When skip=True:
+        - The chunk is not processed at all
+        - No events (ModelStreamChunkEvent, TextStreamEvent, etc.) are yielded
+        - The chunk does not contribute to the final message
+
+    When chunk is modified:
+        - The modified chunk is used for all downstream processing
+        - TextStreamEvent will contain the modified text
+        - The final message will contain the modified content
+
+    Performance Note:
+        This event fires for every stream chunk, so callbacks should execute
+        quickly to avoid impacting streaming latency.
+
+    Attributes:
+        chunk: The raw stream event from the model. Can be modified by hooks
+            to transform content before processing.
+        skip: When True, the chunk is skipped entirely (not processed or yielded).
+        invocation_state: State passed through agent invocation.
+    """
+
+    chunk: StreamEvent
+    invocation_state: dict[str, Any] = field(default_factory=dict)
+    skip: bool = False
+
+    def _can_write(self, name: str) -> bool:
+        return name in ["chunk", "skip"]
 
 
 # Multiagent hook events start here

--- a/strands-py/tests/strands/agent/hooks/test_events.py
+++ b/strands-py/tests/strands/agent/hooks/test_events.py
@@ -10,6 +10,7 @@ from strands.hooks import (
     AgentInitializedEvent,
     BeforeInvocationEvent,
     BeforeModelCallEvent,
+    BeforeStreamChunkEvent,
     BeforeToolCallEvent,
     MessageAddedEvent,
 )
@@ -279,3 +280,58 @@ def test_before_model_call_event_projected_input_tokens_not_writable(agent):
     event = BeforeModelCallEvent(agent=agent, projected_input_tokens=500)
     with pytest.raises(AttributeError, match="Property projected_input_tokens is not writable"):
         event.projected_input_tokens = 1000
+
+
+@pytest.fixture
+def before_stream_chunk_event(agent):
+    chunk = {"contentBlockDelta": {"delta": {"text": "Hello"}}}
+    return BeforeStreamChunkEvent(
+        agent=agent,
+        chunk=chunk,
+        invocation_state={"test": "state"},
+    )
+
+
+def test_before_stream_chunk_event_should_not_reverse_callbacks(before_stream_chunk_event):
+    """Test that BeforeStreamChunkEvent does not reverse callbacks."""
+    assert before_stream_chunk_event.should_reverse_callbacks is False
+
+
+def test_before_stream_chunk_event_can_write_chunk(before_stream_chunk_event):
+    """Test that BeforeStreamChunkEvent.chunk is writable."""
+    new_chunk = {"contentBlockDelta": {"delta": {"text": "Modified"}}}
+    before_stream_chunk_event.chunk = new_chunk
+    assert before_stream_chunk_event.chunk == new_chunk
+
+
+def test_before_stream_chunk_event_can_write_skip(before_stream_chunk_event):
+    """Test that BeforeStreamChunkEvent.skip is writable."""
+    assert before_stream_chunk_event.skip is False
+    before_stream_chunk_event.skip = True
+    assert before_stream_chunk_event.skip is True
+
+
+def test_before_stream_chunk_event_cannot_write_agent(before_stream_chunk_event):
+    """Test that BeforeStreamChunkEvent.agent is not writable."""
+    with pytest.raises(AttributeError, match="Property agent is not writable"):
+        before_stream_chunk_event.agent = Mock()
+
+
+def test_before_stream_chunk_event_cannot_write_invocation_state(before_stream_chunk_event):
+    """Test that BeforeStreamChunkEvent.invocation_state is not writable."""
+    with pytest.raises(AttributeError, match="Property invocation_state is not writable"):
+        before_stream_chunk_event.invocation_state = {}
+
+
+def test_before_stream_chunk_event_skip_defaults_to_false(agent):
+    """Test that BeforeStreamChunkEvent.skip defaults to False."""
+    chunk = {"contentBlockDelta": {"delta": {"text": "Hello"}}}
+    event = BeforeStreamChunkEvent(agent=agent, chunk=chunk)
+    assert event.skip is False
+
+
+def test_before_stream_chunk_event_invocation_state_defaults_to_empty(agent):
+    """Test that BeforeStreamChunkEvent.invocation_state defaults to empty dict."""
+    chunk = {"contentBlockDelta": {"delta": {"text": "Hello"}}}
+    event = BeforeStreamChunkEvent(agent=agent, chunk=chunk)
+    assert event.invocation_state == {}

--- a/strands-py/tests/strands/agent/test_agent_hooks.py
+++ b/strands-py/tests/strands/agent/test_agent_hooks.py
@@ -12,6 +12,7 @@ from strands.hooks import (
     AgentInitializedEvent,
     BeforeInvocationEvent,
     BeforeModelCallEvent,
+    BeforeStreamChunkEvent,
     BeforeToolCallEvent,
     MessageAddedEvent,
 )
@@ -1075,3 +1076,177 @@ def test_hooks_param_callable_invoked_during_lifecycle():
 
     assert len(before_events) == 1
     assert isinstance(before_events[0], BeforeInvocationEvent)
+
+
+def test_before_stream_chunk_event_fires_for_each_chunk():
+    """Test that BeforeStreamChunkEvent fires for each stream chunk."""
+    mock_provider = MockedModelProvider(
+        [
+            {
+                "role": "assistant",
+                "content": [{"text": "Hello world"}],
+            },
+        ]
+    )
+
+    chunk_events = []
+
+    async def capture_stream_chunks(event: BeforeStreamChunkEvent):
+        chunk_events.append(event.chunk)
+
+    agent = Agent(model=mock_provider)
+    agent.hooks.add_callback(BeforeStreamChunkEvent, capture_stream_chunks)
+
+    agent("Test message")
+
+    # Should have received multiple chunk events (messageStart, contentBlockStart, delta, stop, etc.)
+    assert len(chunk_events) > 0
+    # Should include content block delta with text
+    text_deltas = [c for c in chunk_events if "contentBlockDelta" in c]
+    assert len(text_deltas) == 1
+    assert text_deltas[0]["contentBlockDelta"]["delta"]["text"] == "Hello world"
+
+
+@pytest.mark.asyncio
+async def test_before_stream_chunk_event_can_skip_chunks():
+    """Test that setting skip=True prevents chunks from being processed entirely.
+
+    When skip=True, the chunk is not processed at all:
+    - No ModelStreamChunkEvent is yielded
+    - No TextStreamEvent is yielded
+    - The chunk does not contribute to the final message
+    """
+    mock_provider = MockedModelProvider(
+        [
+            {
+                "role": "assistant",
+                "content": [{"text": "Hello world"}],
+            },
+        ]
+    )
+
+    async def skip_text_chunks(event: BeforeStreamChunkEvent):
+        # Skip only contentBlockDelta chunks (text content)
+        if "contentBlockDelta" in event.chunk:
+            event.skip = True
+
+    agent = Agent(model=mock_provider)
+    agent.hooks.add_callback(BeforeStreamChunkEvent, skip_text_chunks)
+
+    # Collect all yielded events
+    text_events = []
+    result = None
+    async for event in agent.stream_async("Test message"):
+        if "data" in event:  # TextStreamEvent
+            text_events.append(event["data"])
+        if "result" in event:
+            result = event["result"]
+
+    # Verify no text events were yielded (because we skipped content deltas)
+    assert len(text_events) == 0
+
+    # Verify final message has no text content (skipped chunks don't contribute)
+    # The message will have empty content since we skipped the text blocks
+    assert result.message["content"] == []
+
+
+@pytest.mark.asyncio
+async def test_before_stream_chunk_event_can_modify_chunks():
+    """Test that chunk modifications affect both stream events and final message.
+
+    The BeforeStreamChunkEvent hook intercepts chunks BEFORE processing, so
+    modifications affect:
+    - The yielded ModelStreamChunkEvent (raw chunk)
+    - The yielded TextStreamEvent (processed text)
+    - The final message content
+    """
+    mock_provider = MockedModelProvider(
+        [
+            {
+                "role": "assistant",
+                "content": [{"text": "secret"}],
+            },
+        ]
+    )
+
+    async def redact_text_chunks(event: BeforeStreamChunkEvent):
+        # Modify text delta chunks
+        if "contentBlockDelta" in event.chunk:
+            delta = event.chunk["contentBlockDelta"]["delta"]
+            if "text" in delta:
+                # Create modified chunk with redacted text
+                event.chunk = {"contentBlockDelta": {"delta": {"text": "[REDACTED]"}}}
+
+    agent = Agent(model=mock_provider)
+    agent.hooks.add_callback(BeforeStreamChunkEvent, redact_text_chunks)
+
+    # Collect yielded events
+    text_events = []
+    result = None
+    async for event in agent.stream_async("Test message"):
+        if "data" in event:  # TextStreamEvent
+            text_events.append(event["data"])
+        if "result" in event:
+            result = event["result"]
+
+    # Verify TextStreamEvent contains modified text
+    assert len(text_events) == 1
+    assert text_events[0] == "[REDACTED]"
+
+    # Verify final message contains modified text
+    assert result.message["content"][0]["text"] == "[REDACTED]"
+
+
+@pytest.mark.asyncio
+async def test_before_stream_chunk_event_with_stream_async():
+    """Test that BeforeStreamChunkEvent works with stream_async."""
+    mock_provider = MockedModelProvider(
+        [
+            {
+                "role": "assistant",
+                "content": [{"text": "Hello"}],
+            },
+        ]
+    )
+
+    chunk_events = []
+
+    async def capture_stream_chunks(event: BeforeStreamChunkEvent):
+        chunk_events.append(event.chunk)
+
+    agent = Agent(model=mock_provider)
+    agent.hooks.add_callback(BeforeStreamChunkEvent, capture_stream_chunks)
+
+    async for _ in agent.stream_async("Test message"):
+        pass
+
+    # Should have received chunk events
+    assert len(chunk_events) > 0
+
+
+def test_before_stream_chunk_event_has_invocation_state():
+    """Test that BeforeStreamChunkEvent includes invocation_state."""
+    mock_provider = MockedModelProvider(
+        [
+            {
+                "role": "assistant",
+                "content": [{"text": "Hello"}],
+            },
+        ]
+    )
+
+    received_states = []
+
+    async def capture_invocation_state(event: BeforeStreamChunkEvent):
+        received_states.append(event.invocation_state.copy())
+
+    agent = Agent(model=mock_provider)
+    agent.hooks.add_callback(BeforeStreamChunkEvent, capture_invocation_state)
+
+    agent("Test message", invocation_state={"custom_key": "custom_value"})
+
+    # All captured states should have the custom key
+    assert len(received_states) > 0
+    for state in received_states:
+        assert "custom_key" in state
+        assert state["custom_key"] == "custom_value"

--- a/strands-py/tests_integ/hooks/test_stream_chunk_event.py
+++ b/strands-py/tests_integ/hooks/test_stream_chunk_event.py
@@ -1,0 +1,122 @@
+"""Integration tests for BeforeStreamChunkEvent hook."""
+
+import pytest
+
+from strands import Agent
+from strands.hooks import BeforeStreamChunkEvent
+
+
+@pytest.fixture
+def chunks_intercepted():
+    return []
+
+
+@pytest.fixture
+def agent_with_stream_hook(chunks_intercepted):
+    """Create an agent with BeforeStreamChunkEvent hook registered."""
+
+    async def intercept_chunks(event: BeforeStreamChunkEvent):
+        chunks_intercepted.append(event.chunk.copy())
+
+    agent = Agent(system_prompt="Be very brief. Reply with one word only.")
+    agent.hooks.add_callback(BeforeStreamChunkEvent, intercept_chunks)
+    return agent
+
+
+def test_before_stream_chunk_event_fires(agent_with_stream_hook, chunks_intercepted):
+    """Test that BeforeStreamChunkEvent fires for each stream chunk."""
+    agent_with_stream_hook("Say hello")
+
+    # Should have intercepted multiple chunks
+    assert len(chunks_intercepted) > 0
+
+    # Should have message start, content blocks, and message stop
+    chunk_types = set()
+    for chunk in chunks_intercepted:
+        chunk_types.update(chunk.keys())
+
+    assert "messageStart" in chunk_types
+    assert "messageStop" in chunk_types
+
+
+@pytest.mark.asyncio
+async def test_before_stream_chunk_event_modification():
+    """Test that chunk modifications affect both stream events and final message."""
+    modified_text = "[REDACTED]"
+
+    async def redact_chunks(event: BeforeStreamChunkEvent):
+        if "contentBlockDelta" in event.chunk:
+            delta = event.chunk.get("contentBlockDelta", {}).get("delta", {})
+            if "text" in delta:
+                event.chunk = {"contentBlockDelta": {"delta": {"text": modified_text}}}
+
+    agent = Agent(system_prompt="Say exactly: secret123")
+    agent.hooks.add_callback(BeforeStreamChunkEvent, redact_chunks)
+
+    text_events = []
+    result = None
+
+    async for event in agent.stream_async("go"):
+        if "data" in event:
+            text_events.append(event["data"])
+        if "result" in event:
+            result = event["result"]
+
+    # All text events should be the modified text
+    assert all(text == modified_text for text in text_events)
+
+    # Final message should only contain modified text
+    final_text = result.message["content"][0].get("text", "")
+    assert modified_text in final_text
+    assert "secret" not in final_text.lower()
+
+
+@pytest.mark.asyncio
+async def test_before_stream_chunk_event_skip():
+    """Test that skip=True excludes chunks from processing and final message."""
+
+    async def skip_content_deltas(event: BeforeStreamChunkEvent):
+        # Skip all content block deltas (text content)
+        if "contentBlockDelta" in event.chunk:
+            event.skip = True
+
+    agent = Agent(system_prompt="Say hello")
+    agent.hooks.add_callback(BeforeStreamChunkEvent, skip_content_deltas)
+
+    text_events = []
+    result = None
+
+    async for event in agent.stream_async("go"):
+        if "data" in event:
+            text_events.append(event["data"])
+        if "result" in event:
+            result = event["result"]
+
+    # No text events should be yielded
+    assert len(text_events) == 0
+
+    # Final message should have no content (all text was skipped)
+    assert result.message["content"] == []
+
+
+@pytest.mark.asyncio
+async def test_before_stream_chunk_event_has_invocation_state():
+    """Test that invocation_state is accessible in BeforeStreamChunkEvent."""
+    received_states = []
+
+    async def capture_state(event: BeforeStreamChunkEvent):
+        received_states.append(event.invocation_state.copy())
+
+    agent = Agent(system_prompt="Be brief")
+    agent.hooks.add_callback(BeforeStreamChunkEvent, capture_state)
+
+    custom_state = {"session_id": "test-123", "user_id": "user-456"}
+
+    async for _ in agent.stream_async("hi", invocation_state=custom_state):
+        pass
+
+    # All captured states should have our custom keys
+    assert len(received_states) > 0
+    for state in received_states:
+        assert state.get("session_id") == "test-123"
+        assert state.get("user_id") == "user-456"


### PR DESCRIPTION
## Motivation

There's currently no way to intercept stream chunks before they're processed. Hooks fire after processing, so modifications don't affect the TextStreamEvent or final message content.

The current hook lifecycle has a gap during streaming:

```
BeforeModelCallEvent
    ↓
[MODEL STREAMS CHUNKS]  ← no hook here currently
    ↓
AfterModelCallEvent
```

`BeforeModelCallEvent` fires before chunks exist. `AfterModelCallEvent` fires after chunks have already been streamed to the user. Neither allows chunk interception.

This adds `BeforeStreamChunkEvent` that fires before each chunk is processed, allowing:
- Chunk modification (affects downstream processing and final message)
- Chunk filtering via `skip=True` (excludes from all events and final message)
- Access to `invocation_state` for context

Resolves #1760

## Use Cases

- **Content redaction**: Modify sensitive data before it reaches the user
- **Filtering**: Skip certain chunks entirely (`skip=True`)
- **Real-time monitoring**: Observe streaming without modifying
- **Content transformation**: Translation, formatting, etc.

## Public API Changes

New event: `BeforeStreamChunkEvent`

```python
from strands.hooks import BeforeStreamChunkEvent

async def redact_chunks(event: BeforeStreamChunkEvent):
    if "contentBlockDelta" in event.chunk:
        delta = event.chunk["contentBlockDelta"]["delta"]
        if "text" in delta:
            # modify the chunk - affects TextStreamEvent and final message
            event.chunk = {"contentBlockDelta": {"delta": {"text": "[REDACTED]"}}}
            # or skip entirely
            # event.skip = True

agent.hooks.add_callback(BeforeStreamChunkEvent, redact_chunks)
```

Properties:
- `chunk` (writable) - the raw stream chunk
- `skip` (writable) - set True to exclude chunk from processing
- `invocation_state` (read-only) - context dict from invocation

## Reproduction and Demonstration

Issue reproduction (main branch): https://gist.github.com/fede-kamel/9d93429a3d6d7676906e41eb60890d46

Working demonstration (feature branch): https://gist.github.com/fede-kamel/a6a78d8d35eb9707d80c2327cd17b462

## Type of Change

New feature

## Testing

- [x] I ran `hatch run prepare` (lint, format, tests all pass)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.