### PR TITLE
fix: emit complete signal to callback handler when text block stops

### DIFF
--- a/strands-py/src/strands/event_loop/streaming.py
+++ b/strands-py/src/strands/event_loop/streaming.py
@@ -448,7 +448,10 @@ async def process_stream(
             state, typed_event = handle_content_block_delta(chunk["contentBlockDelta"], state)
             yield typed_event
         elif "contentBlockStop" in chunk:
+            had_text = bool(state.get("text"))
             state = handle_content_block_stop(state)
+            if had_text:
+                yield ModelStreamEvent({"complete": True})
         elif "messageStop" in chunk:
             stop_reason = handle_message_stop(chunk["messageStop"], state["message"].get("content", []))
         elif "metadata" in chunk:

--- a/strands-py/tests/strands/agent/hooks/test_agent_events.py
+++ b/strands-py/tests/strands/agent/hooks/test_agent_events.py
@@ -129,6 +129,7 @@ async def test_stream_e2e_success(alist):
             "delta": {"text": "Okay invoking normal tool"},
         },
         {"event": {"contentBlockStop": {}}},
+        {"complete": True},
         {"event": {"contentBlockStart": {"start": {"toolUse": {"name": "normal_tool", "toolUseId": "123"}}}}},
         {"event": {"contentBlockDelta": {"delta": {"toolUse": {"input": "{}"}}}}},
         {
@@ -183,6 +184,7 @@ async def test_stream_e2e_success(alist):
             "tool_config": tool_config,
         },
         {"event": {"contentBlockStop": {}}},
+        {"complete": True},
         {"event": {"contentBlockStart": {"start": {"toolUse": {"name": "async_tool", "toolUseId": "1234"}}}}},
         {"event": {"contentBlockDelta": {"delta": {"toolUse": {"input": "{}"}}}}},
         {
@@ -242,6 +244,7 @@ async def test_stream_e2e_success(alist):
             "tool_config": tool_config,
         },
         {"event": {"contentBlockStop": {}}},
+        {"complete": True},
         {"event": {"contentBlockStart": {"start": {"toolUse": {"name": "streaming_tool", "toolUseId": "12345"}}}}},
         {"event": {"contentBlockDelta": {"delta": {"toolUse": {"input": "{}"}}}}},
         {
@@ -309,6 +312,7 @@ async def test_stream_e2e_success(alist):
             "tool_config": tool_config,
         },
         {"event": {"contentBlockStop": {}}},
+        {"complete": True},
         {"event": {"messageStop": {"stopReason": "end_turn"}}},
         {"message": {"content": [{"text": "I invoked the tools!"}], "role": "assistant", "metadata": ANY}},
         {
@@ -373,6 +377,7 @@ async def test_stream_e2e_throttle_and_redact(alist, mock_sleep):
             "delta": {"text": "INPUT BLOCKED!"},
         },
         {"event": {"contentBlockStop": {}}},
+        {"complete": True},
         {"event": {"messageStop": {"stopReason": "guardrail_intervened"}}},
         {"message": {"content": [{"text": "INPUT BLOCKED!"}], "role": "assistant", "metadata": ANY}},
         {
@@ -437,6 +442,7 @@ async def test_stream_e2e_reasoning_redacted_content(alist):
             "delta": {"text": "Response with redacted reasoning"},
         },
         {"event": {"contentBlockStop": {}}},
+        {"complete": True},
         {"event": {"messageStop": {"stopReason": "end_turn"}}},
         {
             "message": {

--- a/strands-py/tests/strands/agent/test_agent.py
+++ b/strands-py/tests/strands/agent/test_agent.py
@@ -824,6 +824,7 @@ def test_agent__call__callback(mock_model, agent, callback_handler, agenerator):
             request_state={},
         ),
         unittest.mock.call(event={"contentBlockStop": {}}),
+        unittest.mock.call(complete=True),
         unittest.mock.call(
             message={
                 "role": "assistant",

--- a/strands-py/tests/strands/event_loop/test_streaming.py
+++ b/strands-py/tests/strands/event_loop/test_streaming.py
@@ -1469,64 +1469,6 @@ async def test_process_stream_keeps_tool_use_stop_reason_unchanged(agenerator, a
 
 
 @pytest.mark.asyncio
-async def test_complete_event_emitted_for_text_block(agenerator, alist):
-    """Test that a complete=True event is emitted when a text content block finishes.
-
-    This ensures callback handlers like PrintingCallbackHandler can detect the end
-    of text streaming and format output accordingly (e.g., printing a trailing newline).
-    See: https://github.com/strands-agents/sdk-python/issues/826
-    """
-    response = [
-        {"messageStart": {"role": "assistant"}},
-        {"contentBlockStart": {"start": {}}},
-        {"contentBlockDelta": {"delta": {"text": "Hello"}}},
-        {"contentBlockDelta": {"delta": {"text": " world"}}},
-        {"contentBlockStop": {}},
-        {"messageStop": {"stopReason": "end_turn"}},
-        {
-            "metadata": {
-                "usage": {"inputTokens": 1, "outputTokens": 1, "totalTokens": 1},
-                "metrics": {"latencyMs": 1},
-            }
-        },
-    ]
-
-    stream = strands.event_loop.streaming.process_stream(agenerator(response))
-    events = await alist(stream)
-
-    complete_events = [e for e in events if e.get("complete") is True]
-    assert len(complete_events) == 1, f"Expected exactly 1 complete event, got {len(complete_events)}"
-
-    complete_idx = next(i for i, e in enumerate(events) if e.get("complete") is True)
-    stop_idx = next(i for i, e in enumerate(events) if e.get("event", {}).get("contentBlockStop") is not None)
-    assert complete_idx == stop_idx + 1, "complete event must immediately follow contentBlockStop"
-
-
-@pytest.mark.asyncio
-async def test_no_complete_event_for_tool_use_block(agenerator, alist):
-    """Test that no complete event is emitted for toolUse content blocks."""
-    response = [
-        {"messageStart": {"role": "assistant"}},
-        {"contentBlockStart": {"start": {"toolUse": {"toolUseId": "t1", "name": "my_tool"}}}},
-        {"contentBlockDelta": {"delta": {"toolUse": {"input": "{}"}}}},
-        {"contentBlockStop": {}},
-        {"messageStop": {"stopReason": "tool_use"}},
-        {
-            "metadata": {
-                "usage": {"inputTokens": 1, "outputTokens": 1, "totalTokens": 1},
-                "metrics": {"latencyMs": 1},
-            }
-        },
-    ]
-
-    stream = strands.event_loop.streaming.process_stream(agenerator(response))
-    events = await alist(stream)
-
-    complete_events = [e for e in events if e.get("complete") is True]
-    assert len(complete_events) == 0, "No complete event should be emitted for tool_use blocks"
-
-
-@pytest.mark.asyncio
 async def test_no_complete_event_for_reasoning_block(agenerator, alist):
     """Test that no complete event is emitted for reasoning content blocks."""
     response = [

--- a/strands-py/tests/strands/event_loop/test_streaming.py
+++ b/strands-py/tests/strands/event_loop/test_streaming.py
@@ -852,6 +852,7 @@ def test_extract_usage_metrics_empty_metadata():
                     },
                 },
                 {"event": {"contentBlockStop": {}}},
+                {"complete": True},
                 {"event": {"messageStop": {"stopReason": "end_turn"}}},
                 {
                     "event": {
@@ -968,6 +969,7 @@ async def test_process_stream(response, exp_events, agenerator, alist):
                 {"event": {"contentBlockDelta": {"delta": {"text": "Hello!"}}}},
                 {"data": "Hello!", "delta": {"text": "Hello!"}},
                 {"event": {"contentBlockStop": {}}},
+                {"complete": True},
                 {"event": {"messageStop": {"stopReason": "guardrail_intervened"}}},
                 {
                     "event": {
@@ -1194,6 +1196,9 @@ async def test_stream_messages(agenerator, alist):
             "event": {
                 "contentBlockStop": {},
             },
+        },
+        {
+            "complete": True,
         },
         {
             "stop": (
@@ -1461,3 +1466,119 @@ async def test_process_stream_keeps_tool_use_stop_reason_unchanged(agenerator, a
     last_event = cast(ModelStopReason, (await alist(stream))[-1])
 
     assert last_event["stop"][0] == "tool_use"
+
+
+@pytest.mark.asyncio
+async def test_complete_event_emitted_for_text_block(agenerator, alist):
+    """Test that a complete=True event is emitted when a text content block finishes.
+
+    This ensures callback handlers like PrintingCallbackHandler can detect the end
+    of text streaming and format output accordingly (e.g., printing a trailing newline).
+    See: https://github.com/strands-agents/sdk-python/issues/826
+    """
+    response = [
+        {"messageStart": {"role": "assistant"}},
+        {"contentBlockStart": {"start": {}}},
+        {"contentBlockDelta": {"delta": {"text": "Hello"}}},
+        {"contentBlockDelta": {"delta": {"text": " world"}}},
+        {"contentBlockStop": {}},
+        {"messageStop": {"stopReason": "end_turn"}},
+        {
+            "metadata": {
+                "usage": {"inputTokens": 1, "outputTokens": 1, "totalTokens": 1},
+                "metrics": {"latencyMs": 1},
+            }
+        },
+    ]
+
+    stream = strands.event_loop.streaming.process_stream(agenerator(response))
+    events = await alist(stream)
+
+    complete_events = [e for e in events if e.get("complete") is True]
+    assert len(complete_events) == 1, f"Expected exactly 1 complete event, got {len(complete_events)}"
+
+    complete_idx = next(i for i, e in enumerate(events) if e.get("complete") is True)
+    stop_idx = next(i for i, e in enumerate(events) if e.get("event", {}).get("contentBlockStop") is not None)
+    assert complete_idx == stop_idx + 1, "complete event must immediately follow contentBlockStop"
+
+
+@pytest.mark.asyncio
+async def test_no_complete_event_for_tool_use_block(agenerator, alist):
+    """Test that no complete event is emitted for toolUse content blocks."""
+    response = [
+        {"messageStart": {"role": "assistant"}},
+        {"contentBlockStart": {"start": {"toolUse": {"toolUseId": "t1", "name": "my_tool"}}}},
+        {"contentBlockDelta": {"delta": {"toolUse": {"input": "{}"}}}},
+        {"contentBlockStop": {}},
+        {"messageStop": {"stopReason": "tool_use"}},
+        {
+            "metadata": {
+                "usage": {"inputTokens": 1, "outputTokens": 1, "totalTokens": 1},
+                "metrics": {"latencyMs": 1},
+            }
+        },
+    ]
+
+    stream = strands.event_loop.streaming.process_stream(agenerator(response))
+    events = await alist(stream)
+
+    complete_events = [e for e in events if e.get("complete") is True]
+    assert len(complete_events) == 0, "No complete event should be emitted for tool_use blocks"
+
+
+@pytest.mark.asyncio
+async def test_no_complete_event_for_reasoning_block(agenerator, alist):
+    """Test that no complete event is emitted for reasoning content blocks."""
+    response = [
+        {"messageStart": {"role": "assistant"}},
+        {"contentBlockStart": {"start": {}}},
+        {"contentBlockDelta": {"delta": {"reasoningContent": {"text": "thinking..."}}}},
+        {"contentBlockDelta": {"delta": {"reasoningContent": {"signature": "sig123"}}}},
+        {"contentBlockStop": {}},
+        {"contentBlockStart": {"start": {}}},
+        {"contentBlockDelta": {"delta": {"text": "answer"}}},
+        {"contentBlockStop": {}},
+        {"messageStop": {"stopReason": "end_turn"}},
+        {
+            "metadata": {
+                "usage": {"inputTokens": 1, "outputTokens": 1, "totalTokens": 1},
+                "metrics": {"latencyMs": 1},
+            }
+        },
+    ]
+
+    stream = strands.event_loop.streaming.process_stream(agenerator(response))
+    events = await alist(stream)
+
+    complete_events = [e for e in events if e.get("complete") is True]
+    assert len(complete_events) == 1, f"Expected 1 complete event (text only), got {len(complete_events)}"
+
+
+@pytest.mark.asyncio
+async def test_complete_event_with_multiple_text_blocks(agenerator, alist):
+    """Test that complete events are emitted for each text content block."""
+    response = [
+        {"messageStart": {"role": "assistant"}},
+        {"contentBlockStart": {"start": {}}},
+        {"contentBlockDelta": {"delta": {"text": "first"}}},
+        {"contentBlockStop": {}},
+        {"contentBlockStart": {"start": {"toolUse": {"toolUseId": "t1", "name": "tool"}}}},
+        {"contentBlockDelta": {"delta": {"toolUse": {"input": "{}"}}}},
+        {"contentBlockStop": {}},
+        {"contentBlockStart": {"start": {}}},
+        {"contentBlockDelta": {"delta": {"text": "second"}}},
+        {"contentBlockStop": {}},
+        {"messageStop": {"stopReason": "end_turn"}},
+        {
+            "metadata": {
+                "usage": {"inputTokens": 1, "outputTokens": 1, "totalTokens": 1},
+                "metrics": {"latencyMs": 1},
+            }
+        },
+    ]
+
+    stream = strands.event_loop.streaming.process_stream(agenerator(response))
+    events = await alist(stream)
+
+    complete_events = [e for e in events if e.get("complete") is True]
+    assert len(complete_events) == 2, f"Expected 2 complete events (one per text block), got {len(complete_events)}"


### PR DESCRIPTION
## Issue

Closes #826

## Problem

`PrintingCallbackHandler` checks `kwargs.get('complete', False)` to determine whether to print a trailing newline after text output, but **no event in the streaming pipeline ever sets `complete=True`**. This causes text output to never have proper line termination.

### Root Cause

The streaming pipeline emits `TextStreamEvent({'data': text, 'delta': delta})` for each text chunk but never signals completion. When `contentBlockStop` arrives, `handle_content_block_stop()` clears the accumulated text state—but yields no event to notify the callback handler that text streaming is done.

Meanwhile, `EventLoopStopEvent` and `ModelStopReason` both have `is_callback_event = False`, so they never reach the callback handler either.

## Solution

Before calling `handle_content_block_stop()`, check if text was being accumulated (`state['text']` is truthy). If so, yield a `ModelStreamEvent({'complete': True})` after the stop handler runs.

This event:
- Has `is_callback_event = True` (non-empty dict → `len(self.keys()) > 0`)
- Does NOT trigger `prepare()` invocation_state merge (no `'delta'` key in the dict)
- Is only emitted for **text** content blocks—not for `toolUse` or `reasoningContent` blocks

The fix is minimal (3 lines) and does not alter any existing event payloads or control flow.

## Testing

- **4 new tests** covering the complete signal behavior:
  - `test_complete_event_emitted_for_text_block` — verifies exactly 1 complete event after text stop
  - `test_no_complete_event_for_tool_use_block` — verifies no complete event for tool_use
  - `test_no_complete_event_for_reasoning_block` — verifies no complete event for reasoning
  - `test_complete_event_with_multiple_text_blocks` — verifies 1 complete event per text block
- **All 1870 existing tests pass** with updated expected event lists
- Updated tests: `test_process_stream`, `test_stream_messages`, `test_agent__call__callback`, `test_stream_e2e_*`

## Changes

| File | Change |
|------|--------|
| `src/strands/event_loop/streaming.py` | +3 lines: check `had_text`, yield `ModelStreamEvent({'complete': True})` |
| `tests/strands/event_loop/test_streaming.py` | +124 lines: 4 new tests + updated expected events |
| `tests/strands/agent/test_agent.py` | +1 line: updated callback expectations |
| `tests/strands/agent/hooks/test_agent_events.py` | +6 lines: updated E2E expected events |

By issuing a ticket, you agree to abide by the [Contributing Guidelines](https://github.com/strands-agents/sdk-python/blob/main/CONTRIBUTING.md).

> ⚠️ This reopens #1890 which was accidentally closed due to fork deletion.