### PR TITLE
feat(swarm): add AgentBase protocol support

### DIFF
--- a/strands-py/src/strands/multiagent/swarm.py
+++ b/strands-py/src/strands/multiagent/swarm.py
@@ -27,6 +27,7 @@ from opentelemetry import trace as trace_api
 
 from .._async import run_async
 from ..agent import Agent
+from ..agent.base import AgentBase
 from ..agent.state import AgentState
 from ..hooks.events import (
     AfterMultiAgentInvocationEvent,
@@ -68,7 +69,7 @@ class SwarmNode:
     """Represents a node (e.g. Agent) in the swarm."""
 
     node_id: str
-    executor: Agent
+    executor: AgentBase
     swarm: Optional["Swarm"] = None
     _initial_messages: Messages = field(default_factory=list, init=False)
     _initial_state: AgentState = field(default_factory=AgentState, init=False)
@@ -77,9 +78,14 @@ class SwarmNode:
     def __post_init__(self) -> None:
         """Capture initial executor state after initialization."""
         # Deep copy the initial messages and state to preserve them
-        self._initial_messages = copy.deepcopy(self.executor.messages)
-        self._initial_state = AgentState(self.executor.state.get())
-        self._initial_model_state = copy.deepcopy(self.executor._model_state)
+        if hasattr(self.executor, "messages"):
+            self._initial_messages = copy.deepcopy(self.executor.messages)
+
+        if hasattr(self.executor, "state") and hasattr(self.executor.state, "get"):
+            self._initial_state = AgentState(self.executor.state.get())
+
+        if hasattr(self.executor, "_model_state"):
+            self._initial_model_state = copy.deepcopy(self.executor._model_state)
 
     def __hash__(self) -> int:
         """Return hash for SwarmNode based on node_id."""
@@ -104,7 +110,10 @@ class SwarmNode:
 
         If Swarm is resuming from an interrupt, we reset the executor state from the interrupt context.
         """
-        if self.swarm and self.swarm._interrupt_state.activated:
+        # Handle interrupt state restoration (Agent-specific)
+        if self.swarm and self.swarm._interrupt_state.activated and isinstance(self.executor, Agent):
+            if self.node_id not in self.swarm._interrupt_state.context:
+                return
             context = self.swarm._interrupt_state.context[self.node_id]
             self.executor.messages = context["messages"]
             self.executor.state = AgentState(context["state"])
@@ -112,9 +121,15 @@ class SwarmNode:
             self.executor._model_state = context.get("model_state", {})
             return
 
-        self.executor.messages = copy.deepcopy(self._initial_messages)
-        self.executor.state = AgentState(self._initial_state.get())
-        self.executor._model_state = copy.deepcopy(self._initial_model_state)
+        # Reset to initial state (works with any AgentBase that has these attributes)
+        if hasattr(self.executor, "messages"):
+            self.executor.messages = copy.deepcopy(self._initial_messages)
+
+        if hasattr(self.executor, "state"):
+            self.executor.state = AgentState(self._initial_state.get())
+
+        if hasattr(self.executor, "_model_state"):
+            self.executor._model_state = copy.deepcopy(self._initial_model_state)
 
 
 @dataclass
@@ -239,9 +254,9 @@ class Swarm(MultiAgentBase):
 
     def __init__(
         self,
-        nodes: list[Agent],
+        nodes: list[AgentBase],
         *,
-        entry_point: Agent | None = None,
+        entry_point: AgentBase | None = None,
         max_handoffs: int = 20,
         max_iterations: int = 20,
         execution_timeout: float = 900.0,
@@ -311,6 +326,7 @@ class Swarm(MultiAgentBase):
 
         self._resume_from_session = False
 
+        self._handoff_capable_nodes: set[str] = set()
         self._setup_swarm(nodes)
         self._inject_swarm_tools()
         run_async(lambda: self.hooks.invoke_callbacks_async(MultiAgentInitializedEvent(self)))
@@ -483,19 +499,20 @@ class Swarm(MultiAgentBase):
                     raise Exception(timeout_message)
                 yield event
 
-    def _setup_swarm(self, nodes: list[Agent]) -> None:
+    def _setup_swarm(self, nodes: list[AgentBase]) -> None:
         """Initialize swarm configuration."""
         # Validate nodes before setup
         self._validate_swarm(nodes)
 
         # Validate agents have names and create SwarmNode objects
         for i, node in enumerate(nodes):
-            if not node.name:
+            # Only access name if it exists (AgentBase protocol doesn't guarantee it)
+            node_name = getattr(node, "name", None)
+            if not node_name:
                 node_id = f"node_{i}"
-                node.name = node_id
-                logger.debug("node_id=<%s> | agent has no name, dynamically generating one", node_id)
-
-            node_id = str(node.name)
+                logger.debug("node_id=<%s> | agent has no name, using generated id", node_id)
+            else:
+                node_id = str(node_name)
 
             # Ensure node IDs are unique
             if node_id in self.nodes:
@@ -503,13 +520,14 @@ class Swarm(MultiAgentBase):
 
             self.nodes[node_id] = SwarmNode(node_id, node, swarm=self)
 
-        # Validate entry point if specified
+        # Validate entry point if specified (use identity-based lookup to handle nameless AgentBase)
         if self.entry_point is not None:
-            entry_point_node_id = str(self.entry_point.name)
-            if (
-                entry_point_node_id not in self.nodes
-                or self.nodes[entry_point_node_id].executor is not self.entry_point
-            ):
+            entry_node = None
+            for swarm_node in self.nodes.values():
+                if swarm_node.executor is self.entry_point:
+                    entry_node = swarm_node
+                    break
+            if entry_node is None:
                 available_agents = [
                     f"{node_id} ({type(node.executor).__name__})" for node_id, node in self.nodes.items()
                 ]
@@ -525,7 +543,7 @@ class Swarm(MultiAgentBase):
             first_node = next(iter(self.nodes.keys()))
             logger.debug("entry_point=<%s> | using first node as entry point", first_node)
 
-    def _validate_swarm(self, nodes: list[Agent]) -> None:
+    def _validate_swarm(self, nodes: list[AgentBase]) -> None:
         """Validate swarm structure and nodes."""
         # Check for duplicate object instances
         seen_instances = set()
@@ -534,18 +552,31 @@ class Swarm(MultiAgentBase):
                 raise ValueError("Duplicate node instance detected. Each node must have a unique object instance.")
             seen_instances.add(id(node))
 
-            # Check for session persistence
-            if node._session_manager is not None:
+            # Check for session persistence (only Agent has _session_manager attribute)
+            if isinstance(node, Agent) and node._session_manager is not None:
                 raise ValueError("Session persistence is not supported for Swarm agents yet.")
 
     def _inject_swarm_tools(self) -> None:
-        """Add swarm coordination tools to each agent."""
+        """Add swarm coordination tools to each agent.
+
+        Note: Only Agent instances can receive swarm tools. AgentBase implementations
+        without tool_registry will not have handoff capabilities.
+        """
         # Create tool functions with proper closures
         swarm_tools = [
             self._create_handoff_tool(),
         ]
 
+        injected_count = 0
         for node in self.nodes.values():
+            # Only Agent (not generic AgentBase) has tool_registry attribute
+            if not isinstance(node.executor, Agent):
+                logger.debug(
+                    "node_id=<%s> | skipping tool injection for non-Agent node",
+                    node.node_id,
+                )
+                continue
+
             # Check for existing tools with conflicting names
             existing_tools = node.executor.tool_registry.registry
             conflicting_tools = []
@@ -561,11 +592,14 @@ class Swarm(MultiAgentBase):
 
             # Use the agent's tool registry to process and register the tools
             node.executor.tool_registry.process_tools(swarm_tools)
+            self._handoff_capable_nodes.add(node.node_id)
+            injected_count += 1
 
         logger.debug(
-            "tool_count=<%d>, node_count=<%d> | injected coordination tools into agents",
+            "tool_count=<%d>, node_count=<%d>, injected_count=<%d> | injected coordination tools",
             len(swarm_tools),
             len(self.nodes),
+            injected_count,
         )
 
     def _create_handoff_tool(self) -> Callable[..., Any]:
@@ -694,10 +728,13 @@ class Swarm(MultiAgentBase):
                 context_text += "\n"
             context_text += "\n"
 
-        context_text += (
-            "You have access to swarm coordination tools if you need help from other agents. "
-            "If you don't hand off to another agent, the swarm will consider the task complete."
-        )
+        if target_node.node_id in self._handoff_capable_nodes:
+            context_text += (
+                "You have access to swarm coordination tools if you need help from other agents. "
+                "If you don't hand off to another agent, the swarm will consider the task complete."
+            )
+        else:
+            context_text += "If you complete your task, the swarm will consider the task complete."
 
         return context_text
 
@@ -717,13 +754,19 @@ class Swarm(MultiAgentBase):
         logger.debug("node=<%s> | node interrupted", node.node_id)
         self.state.completion_status = Status.INTERRUPTED
 
+        # Only Agent (not generic AgentBase) has _interrupt_state, state, and messages attributes
         self._interrupt_state.context[node.node_id] = {
-            "activated": node.executor._interrupt_state.activated,
-            "interrupt_state": node.executor._interrupt_state.to_dict(),
-            "state": node.executor.state.get(),
-            "messages": node.executor.messages,
-            "model_state": node.executor._model_state,
+            "activated": isinstance(node.executor, Agent) and node.executor._interrupt_state.activated,
         }
+        if isinstance(node.executor, Agent):
+            self._interrupt_state.context[node.node_id].update(
+                {
+                    "interrupt_state": node.executor._interrupt_state.to_dict(),
+                    "state": node.executor.state.get(),
+                    "messages": node.executor.messages,
+                    "model_state": node.executor._model_state,
+                }
+            )
 
         self._interrupt_state.interrupts.update({interrupt.id: interrupt for interrupt in interrupts})
         self._interrupt_state.activate()
@@ -1063,5 +1106,7 @@ class Swarm(MultiAgentBase):
 
     def _initial_node(self) -> SwarmNode:
         if self.entry_point:
-            return self.nodes[str(self.entry_point.name)]
+            for node in self.nodes.values():
+                if node.executor is self.entry_point:
+                    return node
         return next(iter(self.nodes.values()))  # First SwarmNode

--- a/strands-py/tests/strands/multiagent/test_swarm_agentbase.py
+++ b/strands-py/tests/strands/multiagent/test_swarm_agentbase.py
@@ -1,0 +1,308 @@
+"""Unit tests for Swarm AgentBase protocol support.
+
+Tests that Swarm correctly handles AgentBase implementations that are not
+concrete Agent instances, following the same patterns as Graph.
+"""
+
+import asyncio
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from strands.agent import Agent, AgentResult
+from strands.agent.state import AgentState
+from strands.hooks.registry import HookRegistry
+from strands.interrupt import Interrupt, _InterruptState
+from strands.multiagent.base import Status
+from strands.multiagent.swarm import Swarm, SwarmNode
+
+
+class MockAgentBase:
+    """Mock implementation of AgentBase protocol for testing.
+
+    Provides the minimal AgentBase interface without Agent-specific attributes
+    like messages, state, tool_registry, etc.
+    """
+
+    def __init__(self, name: str, response_text: str = "AgentBase response"):
+        """Initialize mock AgentBase.
+
+        Args:
+            name: Name of the agent.
+            response_text: Text to return in responses.
+        """
+        self.name = name
+        self._response_text = response_text
+        self._call_count = 0
+
+    def __call__(self, prompt: Any = None, **kwargs: Any) -> AgentResult:
+        """Synchronous invocation."""
+        return asyncio.run(self.invoke_async(prompt, **kwargs))
+
+    async def invoke_async(self, prompt: Any = None, **kwargs: Any) -> AgentResult:
+        """Asynchronous invocation."""
+        self._call_count += 1
+        return AgentResult(
+            message={"role": "assistant", "content": [{"text": self._response_text}]},
+            stop_reason="end_turn",
+            state={},
+            metrics=Mock(
+                accumulated_usage={"inputTokens": 5, "outputTokens": 10, "totalTokens": 15},
+                accumulated_metrics={"latencyMs": 50.0},
+            ),
+        )
+
+    async def stream_async(self, prompt: Any = None, **kwargs: Any):
+        """Stream agent execution asynchronously."""
+        yield {"agent_start": True, "node": self.name}
+        result = await self.invoke_async(prompt, **kwargs)
+        yield {"result": result}
+
+
+class NamelessAgentBase:
+    """AgentBase without a name attribute."""
+
+    async def invoke_async(self, prompt: Any = None, **kwargs: Any) -> AgentResult:
+        """Asynchronous invocation."""
+        return AgentResult(
+            message={"role": "assistant", "content": [{"text": "response"}]},
+            stop_reason="end_turn",
+            state={},
+            metrics=None,
+        )
+
+    def __call__(self, prompt: Any = None, **kwargs: Any) -> AgentResult:
+        """Synchronous invocation."""
+        return asyncio.run(self.invoke_async(prompt, **kwargs))
+
+    async def stream_async(self, prompt: Any = None, **kwargs: Any):
+        """Stream agent execution asynchronously."""
+        result = await self.invoke_async(prompt, **kwargs)
+        yield {"result": result}
+
+
+def create_mock_agent(name: str, response_text: str = "Agent response") -> Agent:
+    """Create a mock Agent for comparison tests.
+
+    Mirrors the pattern in test_swarm.py but with minimal attributes needed for AgentBase tests.
+    """
+    agent = Mock(spec=Agent)
+    agent.name = name
+    agent.id = f"{name}_id"
+    agent.messages = []
+    agent.state = AgentState()
+    agent._interrupt_state = _InterruptState()
+    agent._model_state = {}
+    agent.tool_registry = Mock()
+    agent.tool_registry.registry = {}
+    agent.tool_registry.process_tools = Mock()
+    agent._session_manager = None
+    agent.hooks = HookRegistry()
+
+    async def mock_stream_async(*args: Any, **kwargs: Any) -> Any:
+        yield {"agent_start": True, "node": name}
+        result = AgentResult(
+            message={"role": "assistant", "content": [{"text": response_text}]},
+            stop_reason="end_turn",
+            state={},
+            metrics=Mock(
+                accumulated_usage={"inputTokens": 10, "outputTokens": 20, "totalTokens": 30},
+                accumulated_metrics={"latencyMs": 100.0},
+            ),
+        )
+        yield {"result": result}
+
+    agent.stream_async = Mock(side_effect=mock_stream_async)
+    return agent
+
+
+# --- Node creation and setup ---
+
+
+def test_swarm_accepts_agentbase_implementations():
+    """Test that Swarm accepts AgentBase implementations (not just Agent)."""
+    agentbase1 = MockAgentBase("agentbase1")
+    agentbase2 = MockAgentBase("agentbase2")
+
+    swarm = Swarm(nodes=[agentbase1, agentbase2])
+
+    assert len(swarm.nodes) == 2
+    assert swarm.nodes["agentbase1"].executor is agentbase1
+    assert swarm.nodes["agentbase2"].executor is agentbase2
+
+
+def test_swarm_mixed_agent_and_agentbase():
+    """Test Swarm with both Agent and AgentBase implementations."""
+    agent = create_mock_agent("regular_agent")
+    agentbase = MockAgentBase("agentbase_node")
+
+    swarm = Swarm(nodes=[agent, agentbase])
+
+    assert len(swarm.nodes) == 2
+    assert "regular_agent" in swarm.nodes
+    assert "agentbase_node" in swarm.nodes
+
+
+def test_swarm_agentbase_without_name_attribute():
+    """Test Swarm handles AgentBase without name attribute."""
+    agentbase = NamelessAgentBase()
+
+    swarm = Swarm(nodes=[agentbase])
+
+    assert "node_0" in swarm.nodes
+
+
+# --- Entry point resolution ---
+
+
+def test_swarm_entry_point_named_agentbase():
+    """Test that entry_point resolves correctly for a named AgentBase."""
+    agentbase = MockAgentBase("my_entry")
+    other = MockAgentBase("other")
+
+    swarm = Swarm(nodes=[other, agentbase], entry_point=agentbase)
+
+    initial = swarm._initial_node()
+    assert initial.executor is agentbase
+    assert initial.node_id == "my_entry"
+
+
+def test_swarm_entry_point_nameless_agentbase():
+    """Test that entry_point resolves correctly for a nameless AgentBase via identity lookup."""
+    agentbase = NamelessAgentBase()
+    named = MockAgentBase("other_agent")
+
+    swarm = Swarm(nodes=[agentbase, named], entry_point=agentbase)
+
+    initial = swarm._initial_node()
+    assert initial.executor is agentbase
+
+
+def test_swarm_entry_point_not_in_nodes_raises():
+    """Test that entry_point not in nodes raises ValueError."""
+    agentbase = MockAgentBase("in_swarm")
+    outsider = MockAgentBase("not_in_swarm")
+
+    with pytest.raises(ValueError, match="Entry point agent not found"):
+        Swarm(nodes=[agentbase], entry_point=outsider)
+
+
+# --- Tool injection ---
+
+
+def test_swarm_tool_injection_skips_agentbase():
+    """Test that tool injection skips non-Agent nodes."""
+    agentbase = MockAgentBase("agentbase_node")
+    agent = create_mock_agent("agent_with_tools")
+
+    Swarm(nodes=[agentbase, agent])
+
+    agent.tool_registry.process_tools.assert_called_once()
+    assert not hasattr(agentbase, "tool_registry")
+
+
+def test_swarm_prompt_text_conditional_on_handoff_capability():
+    """Test that node input prompt reflects actual handoff capability."""
+    agent = create_mock_agent("agent_node")
+    agentbase = MockAgentBase("agentbase_node")
+
+    swarm = Swarm(nodes=[agent, agentbase])
+
+    agent_prompt = swarm._build_node_input(swarm.nodes["agent_node"])
+    assert "swarm coordination tools" in agent_prompt
+
+    agentbase_prompt = swarm._build_node_input(swarm.nodes["agentbase_node"])
+    assert "swarm coordination tools" not in agentbase_prompt
+
+
+def test_swarm_prompt_includes_agent_description():
+    """Test that node input prompt includes description when available."""
+    agent = create_mock_agent("agent_node")
+    agentbase = MockAgentBase("agentbase_node")
+    agentbase.description = "A helpful assistant"
+
+    swarm = Swarm(nodes=[agent, agentbase])
+
+    prompt = swarm._build_node_input(swarm.nodes["agent_node"])
+    assert "A helpful assistant" in prompt
+
+
+# --- State management ---
+
+
+def test_swarm_node_state_management_with_agentbase():
+    """Test SwarmNode handles missing Agent-specific attributes gracefully."""
+    agentbase = MockAgentBase("agentbase_node")
+
+    node = SwarmNode(node_id="test_node", executor=agentbase)
+
+    assert node._initial_messages == []
+    assert node._initial_state.get() == {}
+
+    node.reset_executor_state()
+
+
+# --- Interrupt handling ---
+
+
+def test_swarm_interrupt_saves_context_for_agent_only():
+    """Test that interrupt handling saves Agent-specific context but records all nodes."""
+    agent = create_mock_agent("agent_node")
+    agentbase = MockAgentBase("agentbase_node")
+    swarm = Swarm(nodes=[agent, agentbase])
+    interrupts = [Interrupt(id="test_id", name="test_interrupt", reason="test")]
+
+    # Interrupt on Agent node saves full context
+    swarm._activate_interrupt(swarm.nodes["agent_node"], interrupts)
+    assert "agent_node" in swarm._interrupt_state.context
+    assert "interrupt_state" in swarm._interrupt_state.context["agent_node"]
+    assert "messages" in swarm._interrupt_state.context["agent_node"]
+
+    # Interrupt on AgentBase node records the node but without Agent-specific fields
+    swarm._activate_interrupt(swarm.nodes["agentbase_node"], interrupts)
+    assert "agentbase_node" in swarm._interrupt_state.context
+    assert "interrupt_state" not in swarm._interrupt_state.context["agentbase_node"]
+    assert swarm._interrupt_state.activated
+
+
+def test_swarm_interrupt_resume_no_keyerror_for_agentbase():
+    """Test that interrupt resume handles non-Agent nodes without KeyError."""
+    agent = create_mock_agent("agent_node")
+    agentbase = MockAgentBase("agentbase_node")
+    swarm = Swarm(nodes=[agent, agentbase])
+    interrupts = [Interrupt(id="test_id", name="test_interrupt", reason="test")]
+
+    swarm._activate_interrupt(swarm.nodes["agentbase_node"], interrupts)
+
+    # Should not raise KeyError
+    swarm.nodes["agentbase_node"].reset_executor_state()
+
+
+def test_swarm_interrupt_resume_agent_without_context_returns_early():
+    """Test that reset_executor_state returns early when Agent node has no saved context."""
+    agent = create_mock_agent("agent_node")
+    other = create_mock_agent("other_node")
+    swarm = Swarm(nodes=[agent, other])
+
+    # Manually activate interrupt state without saving context for agent_node
+    swarm._interrupt_state.activate()
+
+    # Should return early without KeyError (defensive guard)
+    swarm.nodes["agent_node"].reset_executor_state()
+
+
+# --- Execution ---
+
+
+@pytest.mark.asyncio
+async def test_swarm_execution_with_agentbase():
+    """Test end-to-end Swarm execution with an AgentBase node."""
+    agentbase = MockAgentBase("agentbase_node", "AgentBase completed task")
+
+    swarm = Swarm(nodes=[agentbase])
+    result = await swarm.invoke_async("Test task for AgentBase")
+
+    assert result.status == Status.COMPLETED
+    assert "agentbase_node" in result.results
+    assert agentbase._call_count >= 1

--- a/strands-py/tests_integ/test_multiagent_swarm_agentbase.py
+++ b/strands-py/tests_integ/test_multiagent_swarm_agentbase.py
@@ -1,0 +1,243 @@
+"""Integration tests for Swarm AgentBase protocol support.
+
+Tests that Swarm correctly handles real AgentBase implementations in production scenarios.
+"""
+
+from typing import Any
+
+import pytest
+
+from strands import Agent, AgentResult
+from strands.agent.base import AgentBase
+from strands.multiagent.swarm import Swarm
+
+
+class SimpleCustomAgent(AgentBase):
+    """A simple custom AgentBase implementation for testing.
+
+    This demonstrates a minimal AgentBase that doesn't use LLMs,
+    simulating a deterministic agent or rule-based system.
+    """
+
+    def __init__(self, name: str, response: str):
+        """Initialize the custom agent.
+
+        Args:
+            name: Agent name
+            response: Fixed response to return
+        """
+        self.name = name
+        self.id = f"{name}_custom_id"
+        self._response = response
+        self._call_count = 0
+
+    def __call__(self, prompt: Any = None, **kwargs: Any) -> AgentResult:
+        """Synchronous invocation."""
+        import asyncio
+
+        return asyncio.run(self.invoke_async(prompt, **kwargs))
+
+    async def invoke_async(self, prompt: Any = None, **kwargs: Any) -> AgentResult:
+        """Asynchronous invocation.
+
+        Returns a deterministic response without calling an LLM.
+        """
+        self._call_count += 1
+
+        # Simulate processing time
+        import asyncio
+
+        await asyncio.sleep(0.01)
+
+        return AgentResult(
+            message={"role": "assistant", "content": [{"text": self._response}]},
+            stop_reason="end_turn",
+            state={},
+            metrics={
+                "accumulated_usage": {"inputTokens": 0, "outputTokens": 0, "totalTokens": 0},
+                "accumulated_metrics": {"latencyMs": 10.0},
+            },
+        )
+
+    async def stream_async(self, prompt: Any = None, **kwargs: Any):
+        """Stream agent execution asynchronously."""
+        # Yield some events to simulate streaming
+        yield {"agent_start": True, "node": self.name}
+        yield {"agent_thinking": True, "thought": f"Processing with {self.name}"}
+
+        # Get the result
+        result = await self.invoke_async(prompt, **kwargs)
+
+        # Yield the final result
+        yield {"result": result}
+
+
+@pytest.mark.timeout(120)
+@pytest.mark.asyncio
+async def test_swarm_with_custom_agentbase_only():
+    """Test Swarm execution with only custom AgentBase implementations (no LLM agents)."""
+    # Create custom AgentBase implementations
+    agent1 = SimpleCustomAgent("custom_agent_1", "Response from custom agent 1")
+    agent2 = SimpleCustomAgent("custom_agent_2", "Response from custom agent 2")
+
+    # Create swarm with only custom agents
+    swarm = Swarm(nodes=[agent1, agent2])
+
+    # Execute the swarm
+    result = await swarm.invoke_async("Test task")
+
+    # Verify execution completed successfully
+    assert result.status.value == "completed"
+    assert len(result.results) == 1  # Only entry point should execute without handoff
+    assert "custom_agent_1" in result.results
+
+    # Verify the custom agent was called
+    assert agent1._call_count >= 1
+
+    # Verify response content
+    agent_results = result.results["custom_agent_1"].get_agent_results()
+    assert len(agent_results) == 1
+    assert "Response from custom agent 1" in agent_results[0].message["content"][0]["text"]
+
+
+@pytest.mark.timeout(120)
+@pytest.mark.asyncio
+async def test_swarm_mixed_llm_and_custom_agents():
+    """Test Swarm with both real LLM Agent and custom AgentBase implementations."""
+    # Create a real LLM agent
+    llm_agent = Agent(
+        name="llm_agent",
+        model="us.amazon.nova-lite-v1:0",
+        system_prompt="You are a helpful assistant. Answer questions concisely without handing off.",
+    )
+
+    # Create a custom AgentBase implementation
+    custom_agent = SimpleCustomAgent("custom_agent", "Deterministic response from custom agent")
+
+    # Create swarm with mixed agent types
+    swarm = Swarm(nodes=[llm_agent, custom_agent])
+
+    # Execute with LLM agent as entry point
+    result = await swarm.invoke_async("What is 2 + 2?")
+
+    # Verify execution completed
+    assert result.status.value in ["completed", "failed"]  # May fail due to credentials
+
+    # If execution succeeded, verify the structure
+    if result.status.value == "completed":
+        assert len(result.results) >= 1
+        assert "llm_agent" in result.results
+
+        # Verify LLM agent result structure
+        llm_result = result.results["llm_agent"]
+        assert llm_result.result.message is not None
+        assert llm_result.accumulated_usage["totalTokens"] >= 0
+
+
+@pytest.mark.timeout(120)
+@pytest.mark.asyncio
+async def test_swarm_custom_agent_streaming():
+    """Test that custom AgentBase implementations stream events correctly."""
+    # Create custom agents
+    agent1 = SimpleCustomAgent("streamer_1", "Streaming response 1")
+    agent2 = SimpleCustomAgent("streamer_2", "Streaming response 2")
+
+    # Create swarm
+    swarm = Swarm(nodes=[agent1, agent2])
+
+    # Collect streaming events
+    events = []
+    async for event in swarm.stream_async("Test streaming"):
+        events.append(event)
+
+    # Verify we received events
+    assert len(events) > 0
+
+    # Verify event types
+    node_start_events = [e for e in events if e.get("type") == "multiagent_node_start"]
+    node_stream_events = [e for e in events if e.get("type") == "multiagent_node_stream"]
+    node_stop_events = [e for e in events if e.get("type") == "multiagent_node_stop"]
+    result_events = [e for e in events if "result" in e and e.get("type") != "multiagent_node_stream"]
+
+    # Should have proper event structure
+    assert len(node_start_events) >= 1
+    assert len(node_stream_events) >= 1  # Custom agents yield streaming events
+    assert len(node_stop_events) >= 1
+    assert len(result_events) == 1
+
+    # Verify node start event structure
+    start_event = node_start_events[0]
+    assert start_event["node_id"] == "streamer_1"
+    assert start_event["node_type"] == "agent"
+
+    # Verify custom agent events were forwarded
+    custom_events = [e for e in node_stream_events if e.get("node_id") == "streamer_1"]
+    assert len(custom_events) >= 1
+
+
+@pytest.mark.timeout(120)
+@pytest.mark.asyncio
+async def test_swarm_custom_agent_no_state_attributes():
+    """Test that custom AgentBase without state/messages attributes works correctly."""
+
+    class MinimalAgent:
+        """Minimal AgentBase implementation without messages or state."""
+
+        def __init__(self, name: str):
+            self.name = name
+            self.id = f"{name}_minimal_id"
+
+        async def invoke_async(self, prompt: Any = None, **kwargs: Any) -> AgentResult:
+            return AgentResult(
+                message={"role": "assistant", "content": [{"text": f"Response from {self.name}"}]},
+                stop_reason="end_turn",
+                state={},
+                metrics=None,
+            )
+
+        def __call__(self, prompt: Any = None, **kwargs: Any) -> AgentResult:
+            import asyncio
+
+            return asyncio.run(self.invoke_async(prompt, **kwargs))
+
+        async def stream_async(self, prompt: Any = None, **kwargs: Any):
+            yield {"agent_start": True}
+            result = await self.invoke_async(prompt, **kwargs)
+            yield {"result": result}
+
+    # Verify it satisfies AgentBase protocol
+    minimal = MinimalAgent("minimal")
+    assert isinstance(minimal, AgentBase)
+
+    # Create swarm with minimal agent
+    swarm = Swarm(nodes=[minimal])
+
+    # Execute should work without state/messages attributes
+    result = await swarm.invoke_async("Test minimal agent")
+
+    # Verify execution completed
+    assert result.status.value == "completed"
+    assert len(result.results) == 1
+    assert "minimal" in result.results
+
+
+@pytest.mark.timeout(120)
+def test_swarm_custom_agent_synchronous_execution():
+    """Test synchronous execution of Swarm with custom AgentBase implementations."""
+    # Create custom agents
+    agent1 = SimpleCustomAgent("sync_agent_1", "Sync response 1")
+    agent2 = SimpleCustomAgent("sync_agent_2", "Sync response 2")
+
+    # Create swarm
+    swarm = Swarm(nodes=[agent1, agent2])
+
+    # Execute synchronously
+    result = swarm("Test synchronous execution")
+
+    # Verify execution completed
+    assert result.status.value == "completed"
+    assert len(result.results) == 1
+    assert "sync_agent_1" in result.results
+
+    # Verify custom agent was called
+    assert agent1._call_count >= 1


### PR DESCRIPTION
## Description

Enable Swarm to accept any `AgentBase` implementation, not just concrete `Agent` instances. This allows developers to integrate agents from LangGraph, Quick Suite, or custom frameworks into Swarm orchestration alongside native Strands agents, reducing development overhead when extending multi-agent systems with existing agent implementations.

## Motivation

Customers have existing agent investments in other frameworks. Currently, using these agents in Strands Swarm requires rebuilding them as native Strands agents, creating significant duplication of effort. This change enables customers to leverage Strands' swarm orchestration while reusing existing agent implementations, providing a migration path and reducing maintenance burden.

Resolves: #1720

## Public API Changes

Swarm now accepts `AgentBase` implementations:

```python
# Before: Only Agent instances
from strands import Agent
swarm = Swarm([agent1, agent2])  # All must be Agent

# After: Mix Agent and AgentBase
from strands.agent.base import AgentBase

class CustomAgent(AgentBase):
    # Implement AgentBase protocol
    ...

swarm = Swarm([strands_agent, custom_agent])  # Mix both types
```

External agents participate in execution and return results. Full Swarm features (handoffs, state management) require native `Agent` instances; external agents degrade gracefully. No breaking changes.

## Use Cases

Integrate existing agents from other frameworks without rebuilding, enabling quick prototyping and incremental migration from other frameworks to Strands.

## Related Issues

Resolves: #1720

## Documentation PR

strands-agents/docs#755

## Type of Change

New feature

## Testing

How have you tested the change?

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.