### PR TITLE
fix: skip reasoningContent blocks in LlamaAPI, llama.cpp, and Writer models

### DIFF
--- a/strands-py/src/strands/models/llamaapi.py
+++ b/strands-py/src/strands/models/llamaapi.py
@@ -179,7 +179,7 @@ class LlamaAPIModel(Model):
             # Filter out location sources and unsupported block types
             filtered_contents = []
             for content in contents:
-                if any(block_type in content for block_type in ["toolResult", "toolUse"]):
+                if any(block_type in content for block_type in ["toolResult", "toolUse", "reasoningContent"]):
                     continue
                 if _has_location_source(content):
                     logger.warning("Location sources are not supported by LlamaAPI | skipping content block")

--- a/strands-py/src/strands/models/llamacpp.py
+++ b/strands-py/src/strands/models/llamacpp.py
@@ -305,7 +305,7 @@ class LlamaCppModel(Model):
             # Filter out location sources and unsupported block types
             filtered_contents = []
             for content in contents:
-                if any(block_type in content for block_type in ["toolResult", "toolUse"]):
+                if any(block_type in content for block_type in ["toolResult", "toolUse", "reasoningContent"]):
                     continue
                 if _has_location_source(content):
                     logger.warning("Location sources are not supported by llama.cpp | skipping content block")

--- a/strands-py/src/strands/models/writer.py
+++ b/strands-py/src/strands/models/writer.py
@@ -116,7 +116,7 @@ class WriterModel(Model):
         return [
             _format_content_vision(content)
             for content in contents
-            if not any(block_type in content for block_type in ["toolResult", "toolUse"])
+            if not any(block_type in content for block_type in ["toolResult", "toolUse", "reasoningContent"])
         ]
 
     def _format_request_message_contents(self, contents: list[ContentBlock]) -> str:
@@ -142,7 +142,7 @@ class WriterModel(Model):
         content_blocks = list(
             filter(
                 lambda content: content.get("text")
-                and not any(block_type in content for block_type in ["toolResult", "toolUse"]),
+                and not any(block_type in content for block_type in ["toolResult", "toolUse", "reasoningContent"]),
                 contents,
             )
         )

--- a/strands-py/tests/strands/models/test_llamaapi.py
+++ b/strands-py/tests/strands/models/test_llamaapi.py
@@ -241,6 +241,26 @@ def test_format_request_with_unsupported_type(model):
         model.format_request(messages)
 
 
+def test_format_request_skips_reasoning_content(model):
+    """Test that reasoningContent blocks from other providers are silently skipped."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"text": "Hello"},
+                {"reasoningContent": {"reasoningText": {"text": "Let me think...", "signature": "sig"}}},
+            ],
+        },
+    ]
+
+    # Should not raise — reasoningContent is silently dropped
+    request = model.format_request(messages)
+    # Only the text block should appear in the formatted request
+    user_messages = [m for m in request["messages"] if m["role"] == "user"]
+    assert len(user_messages) == 1
+    assert user_messages[0]["content"] == [{"type": "text", "text": "Hello"}]
+
+
 def test_format_chunk_message_start(model):
     event = {"chunk_type": "message_start"}
 

--- a/strands-py/tests/strands/models/test_llamacpp.py
+++ b/strands-py/tests/strands/models/test_llamacpp.py
@@ -825,3 +825,25 @@ class TestCountTokens:
         model.client.post.assert_not_called()
         assert isinstance(result, int)
         assert result >= 0
+
+
+def test_format_request_skips_reasoning_content() -> None:
+    """Test that reasoningContent blocks from other providers are silently skipped."""
+    model = LlamaCppModel()
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"text": "Hello"},
+                {"reasoningContent": {"reasoningText": {"text": "Let me think...", "signature": "sig"}}},
+            ],
+        },
+    ]
+
+    # Should not raise — reasoningContent is silently dropped
+    request = model._format_request(messages)
+    # Only the text block should appear in the formatted request
+    user_messages = [m for m in request["messages"] if m["role"] == "user"]
+    assert len(user_messages) == 1
+    assert user_messages[0]["content"] == [{"type": "text", "text": "Hello"}]

--- a/strands-py/tests/strands/models/test_writer.py
+++ b/strands-py/tests/strands/models/test_writer.py
@@ -250,7 +250,6 @@ def test_format_request_with_empty_content(model, model_id, stream_options):
     [
         ({"video": {}}, "video"),
         ({"document": {}}, "document"),
-        ({"reasoningContent": {}}, "reasoningContent"),
         ({"other": {}}, "other"),
     ],
 )
@@ -264,6 +263,22 @@ def test_format_request_with_unsupported_type(model, content, content_type):
 
     with pytest.raises(TypeError, match=f"content_type=<{content_type}> | unsupported type"):
         model.format_request(messages)
+
+
+def test_format_request_skips_reasoning_content(model):
+    """Test that reasoningContent blocks from other providers are silently skipped."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"text": "Hello"},
+                {"reasoningContent": {"reasoningText": {"text": "Let me think...", "signature": "sig"}}},
+            ],
+        },
+    ]
+
+    # Should not raise — reasoningContent is silently dropped
+    model.format_request(messages)
 
 
 class AsyncStreamWrapper:


### PR DESCRIPTION
## Description

In multi-provider Swarms, reasoning-capable models (e.g. Gemini, Claude) store
`reasoningContent` blocks in shared conversation history. When that history is
passed to `LlamaAPIModel`, `LlamaCppModel`, or `WriterModel` on a subsequent turn,
the content-type filter only skipped `toolResult` and `toolUse` blocks — not
`reasoningContent` — causing `TypeError: content_type=<reasoningContent> | unsupported type`.

PR #2013 fixed this for `openai.py` and `openai_responses.py`. This extends the
same fix to the three remaining affected providers by adding `"reasoningContent"`
to the skip list in each model's `_format_request_messages` (and the vision
formatter in `writer.py`).

## Related Issues

Resolves #1993

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

- Added `test_format_request_skips_reasoning_content` to each affected model's test file
- Removed `reasoningContent` from `test_writer.py`'s `test_format_request_with_unsupported_type` parametrize (it is no longer unsupported — it is silently skipped)
- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.