### PR TITLE
feat(mcp): add strands.mcp as canonical MCP import path (1/3)

### DIFF
--- a/src/strands/mcp/__init__.py
+++ b/src/strands/mcp/__init__.py
@@ -1,0 +1,17 @@
+"""Canonical import path for the Model Context Protocol (MCP) integration.
+
+Model Context Protocol functionality is being promoted from
+``strands.tools.mcp`` to this top-level ``strands.mcp`` package because MCP
+now spans tools, prompts, resources, tasks, and elicitation -- concepts
+that extend beyond ``tools``.
+
+For now this package is a thin re-export of ``strands.tools.mcp``. A
+follow-up change will invert the relationship: the implementation will
+live here and ``strands.tools.mcp`` will become a deprecated alias.
+Users can safely migrate imports to ``strands.mcp`` today; the public
+API is identical and object identity is preserved.
+"""
+
+from ..tools.mcp import MCPAgentTool, MCPClient, MCPTransport, TasksConfig, ToolFilters
+
+__all__ = ["MCPAgentTool", "MCPClient", "MCPTransport", "TasksConfig", "ToolFilters"]

--- a/strands-py/src/strands/mcp/__init__.py
+++ b/strands-py/src/strands/mcp/__init__.py
@@ -1,0 +1,17 @@
+"""Canonical import path for the Model Context Protocol (MCP) integration.
+
+Model Context Protocol functionality is being promoted from
+``strands.tools.mcp`` to this top-level ``strands.mcp`` package because MCP
+now spans tools, prompts, resources, tasks, and elicitation -- concepts
+that extend beyond ``tools``.
+
+For now this package is a thin re-export of ``strands.tools.mcp``. A
+follow-up change will invert the relationship: the implementation will
+live here and ``strands.tools.mcp`` will become a deprecated alias.
+Users can safely migrate imports to ``strands.mcp`` today; the public
+API is identical and object identity is preserved.
+"""
+
+from ..tools.mcp import MCPAgentTool, MCPClient, MCPTransport, TasksConfig, ToolFilters
+
+__all__ = ["MCPAgentTool", "MCPClient", "MCPTransport", "TasksConfig", "ToolFilters"]

--- a/strands-py/tests/strands/mcp/test_canonical_import_path.py
+++ b/strands-py/tests/strands/mcp/test_canonical_import_path.py
@@ -1,0 +1,25 @@
+"""Tests for the canonical ``strands.mcp`` import path.
+
+The implementation currently lives in ``strands.tools.mcp``. This test
+locks in the contract that ``strands.mcp`` re-exports the same objects so
+that users can migrate imports ahead of the follow-up refactor that
+moves the implementation.
+"""
+
+
+def test_strands_mcp_reexports_public_api() -> None:
+    import strands.mcp as new
+    import strands.tools.mcp as old
+
+    assert new.MCPClient is old.MCPClient
+    assert new.MCPAgentTool is old.MCPAgentTool
+    assert new.MCPTransport is old.MCPTransport
+    assert new.TasksConfig is old.TasksConfig
+    assert new.ToolFilters is old.ToolFilters
+
+
+def test_strands_mcp_all_matches_tools_mcp_all() -> None:
+    import strands.mcp as new
+    import strands.tools.mcp as old
+
+    assert sorted(new.__all__) == sorted(old.__all__)

--- a/tests/strands/mcp/test_canonical_import_path.py
+++ b/tests/strands/mcp/test_canonical_import_path.py
@@ -1,0 +1,25 @@
+"""Tests for the canonical ``strands.mcp`` import path.
+
+The implementation currently lives in ``strands.tools.mcp``. This test
+locks in the contract that ``strands.mcp`` re-exports the same objects so
+that users can migrate imports ahead of the follow-up refactor that
+moves the implementation.
+"""
+
+
+def test_strands_mcp_reexports_public_api() -> None:
+    import strands.mcp as new
+    import strands.tools.mcp as old
+
+    assert new.MCPClient is old.MCPClient
+    assert new.MCPAgentTool is old.MCPAgentTool
+    assert new.MCPTransport is old.MCPTransport
+    assert new.TasksConfig is old.TasksConfig
+    assert new.ToolFilters is old.ToolFilters
+
+
+def test_strands_mcp_all_matches_tools_mcp_all() -> None:
+    import strands.mcp as new
+    import strands.tools.mcp as old
+
+    assert sorted(new.__all__) == sorted(old.__all__)


### PR DESCRIPTION
## Strategy: 3-PR stack for a large refactor

Issue #1431 asks for two things at once: relocating the MCP package AND preserving backwards compatibility. An atomic implementation of both is ~2000 lines of changes (mostly because git can't detect a rename when both paths must keep working). Instead, the work is split into **three stacked PRs**:

| Step | PR | What it does | Size |
|---|---|---|---|
| **1 / 3** | **#2148 (this PR)** | Introduce `strands.mcp` as a pure re-export of `strands.tools.mcp`. Additive only. | +42 / -0 |
| 2 / 3 | #2152 | Move implementation to `strands.mcp` via `git mv`; `strands.tools.mcp` becomes a `sys.modules`-based deprecation shim. | +38 / -28 (git `-M`) |
| 3 / 3 | #2158 | Move tests, add backcompat-aliases suite, update `tests_integ/mcp`, README, and AGENTS.md. | +149 / -63 |

Each step leaves `main` in a valid state, is independently revertable, and is independently reviewable. The order matters:
- Step 1 must precede step 2 so that `strands.mcp` is part of the public API before the implementation moves.
- Step 3 must follow step 2 because the integration tests and docs can't reference the new canonical path until the code actually lives there.

---

## Summary

First of the three stacked PRs above. Adds a top-level `strands.mcp` package that re-exports the public API from `strands.tools.mcp`. Object identity is preserved so users can migrate `from strands.tools.mcp import X` → `from strands.mcp import X` today with zero behavior change.

## What this PR does

- Adds `src/strands/mcp/__init__.py` re-exporting `MCPAgentTool`, `MCPClient`, `MCPTransport`, `TasksConfig`, `ToolFilters` from `strands.tools.mcp`.
- Adds `tests/strands/mcp/test_canonical_import_path.py` covering identity (`strands.mcp.MCPClient is strands.tools.mcp.MCPClient`) and `__all__` parity.

## What this PR does NOT do

- Does not modify `strands.tools.mcp`.
- Does not add deprecation warnings anywhere.
- Does not move any implementation files.

All of the above happen in the follow-up #2152.

## Tests run locally (Python 3.13)

| Check | Command | Result |
|---|---|---|
| Full unit suite | `hatch test --python 3.13 tests/` | **2614 passed** |
| Lint | `hatch fmt --linter --check` | ruff clean |
| Type check | `mypy ./src` via hatch-static-analysis | Success, 143 source files |
| New identity tests | `hatch test tests/strands/mcp/test_canonical_import_path.py` | 2 passed |
| Manual smoke | `from strands.mcp import MCPClient; from strands.tools.mcp import MCPClient as Old; assert Old is MCPClient` | identity holds |

## Backwards compatibility

Strictly additive — nothing to break.

Refs #1431