### PR TITLE
fix(graph)!: keep running downstream nodes when a hook skips one

### DIFF
--- a/site/src/content/docs/user-guide/concepts/interrupts.mdx
+++ b/site/src/content/docs/user-guide/concepts/interrupts.mdx
@@ -532,7 +532,10 @@ while result.status == Status.INTERRUPTED:
 
     result = swarm(responses)
 
-print(f"MESSAGE: {json.dumps(result.results['cleanup'].result.message, indent=2)}")
+if "cleanup" not in result.results:
+    print("MESSAGE: cleanup was skipped, so the swarm stopped before it ran")
+else:
+    print(f"MESSAGE: {json.dumps(result.results['cleanup'].result.message, indent=2)}")
 ```
 </Tab>
 <Tab label="TypeScript">

--- a/site/src/content/docs/user-guide/concepts/interrupts.mdx
+++ b/site/src/content/docs/user-guide/concepts/interrupts.mdx
@@ -507,7 +507,7 @@ class ApprovalHook(HookProvider):
 
         approval = event.interrupt(f"{self.app_name}-approval", reason={"resources": "example"})
         if approval.lower() != "y":
-            event.cancel_node = "User denied permission to cleanup resources"
+            event.skip_node = "User denied permission to cleanup resources"
 
 
 swarm = Swarm(
@@ -560,8 +560,10 @@ Swarms also support interrupts raised from within the nodes themselves following
     - Each `interrupt` contains the user provided name and reason, along with an instance id.
 - `interruptResponse` - Content block type for configuring the interrupt responses.
     - Each `response` is uniquely identified by their interrupt's id and will be returned from the associated interrupt call when invoked the second time around. Note, the `response` must be JSON-serializable.
-- `event.cancel_node` - Cancel node execution based on interrupt response
-    - You can either set `cancel_node` to `True` or provide a custom cancellation message.
+- `event.skip_node` - Skip node execution based on interrupt response
+    - You can either set `skip_node` to `True` or provide a custom skip message.
+    - In a swarm, skipping a node ends the sequence and the result carries `Status.FAILED`, because each node builds on the previous node's output.
+    - `event.cancel_node` is a backward-compatible alias with the same behavior.
 </Tab>
 <Tab label="TypeScript">
 
@@ -615,7 +617,7 @@ class ApprovalHook(HookProvider):
 
         approval = event.interrupt(f"{self.app_name}-approval", reason={"resources": "example"})
         if approval.lower() != "y":
-            event.cancel_node = "User denied permission to cleanup resources"
+            event.skip_node = "User denied permission to cleanup resources"
 
 
 inspector_agent = Agent(name="inspector", system_prompt="You inspect resources.", callback_handler=None)
@@ -644,7 +646,11 @@ while result.status == Status.INTERRUPTED:
 
     result = graph(responses)
 
-print(f"MESSAGE: {json.dumps(result.results['cleanup'].result.message, indent=2)}")
+cleanup_result = result.results["cleanup"]
+if cleanup_result.status == Status.SKIPPED:
+    print("MESSAGE: cleanup was skipped, the rest of the graph still ran")
+else:
+    print(f"MESSAGE: {json.dumps(cleanup_result.result.message, indent=2)}")
 ```
 </Tab>
 <Tab label="TypeScript">
@@ -672,8 +678,10 @@ Graphs also support interrupts raised from within the nodes themselves following
     - Each `interrupt` contains the user provided name and reason, along with an instance id.
 - `interruptResponse` - Content block type for configuring the interrupt responses
     - Each `response` is uniquely identified by their interrupt's id and will be returned from the associated interrupt call when invoked the second time around. Note, the `response` must be JSON-serializable.
-- `event.cancel_node` - Cancel node execution based on interrupt response
-    - You can either set `cancel_node` to `True` or provide a custom cancellation message.
+- `event.skip_node` - Skip node execution based on interrupt response
+    - You can either set `skip_node` to `True` or provide a custom skip message.
+    - In a graph, the skipped node records a `NodeResult` with `Status.SKIPPED` and `result=None`, and downstream nodes still run. They receive no input from the skipped node, and an edge condition reading its output has to handle `None`.
+    - `event.cancel_node` is a backward-compatible alias with the same behavior.
 </Tab>
 <Tab label="TypeScript">
 

--- a/site/src/content/docs/user-guide/concepts/interrupts.mdx
+++ b/site/src/content/docs/user-guide/concepts/interrupts.mdx
@@ -533,7 +533,7 @@ while result.status == Status.INTERRUPTED:
     result = swarm(responses)
 
 if "cleanup" not in result.results:
-    print("MESSAGE: cleanup was skipped, so the swarm stopped before it ran")
+    print("MESSAGE: cleanup produced no result, which is how a skipped node looks in a swarm")
 else:
     print(f"MESSAGE: {json.dumps(result.results['cleanup'].result.message, indent=2)}")
 ```

--- a/site/src/content/docs/user-guide/concepts/multi-agent/graph.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/graph.mdx
@@ -839,4 +839,4 @@ The Graph pattern is available in multiple SDKs. While the core concept is the s
 
 **Error handling**: Python node failures throw exceptions (fail-fast), while orchestrator-level limit violations return a FAILED result. TypeScript does the inverse: node failures produce a FAILED result, allowing parallel paths to continue, while orchestrator-level limits (`maxSteps`) throw exceptions to promote fail-fast behavior for global failures.
 
-**Node cancellation**: Both SDKs support bypassing a node before execution via hook callbacks. In TypeScript, a cancelled node produces a CANCELLED result status, allowing the orchestrator to distinguish cancellation from failure. In Python, `skip_node` records a SKIPPED status with `result=None`, and downstream nodes still run.
+**Skipping a node**: Both SDKs support bypassing a node before execution via hook callbacks. In TypeScript, a cancelled node produces a CANCELLED result status, allowing the orchestrator to distinguish cancellation from failure. In Python, `skip_node` records a SKIPPED status with `result=None`, and downstream nodes still run.

--- a/site/src/content/docs/user-guide/concepts/multi-agent/graph.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/graph.mdx
@@ -54,7 +54,7 @@ A [`GraphNode`](@api/python/strands.multiagent.graph#GraphNode) represents a nod
 - **node_id**: Unique identifier for the node
 - **executor**: The Agent, A2AAgent, or MultiAgentBase instance to execute
 - **dependencies**: Set of nodes this node depends on
-- **execution_status**: Current status (PENDING, EXECUTING, COMPLETED, FAILED)
+- **execution_status**: Current status (PENDING, EXECUTING, COMPLETED, SKIPPED, FAILED, INTERRUPTED)
 - **result**: The NodeResult after execution
 - **execution_time**: Time taken to execute the node in milliseconds
 

--- a/site/src/content/docs/user-guide/concepts/multi-agent/graph.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/graph.mdx
@@ -600,6 +600,7 @@ print(f"Analysis: {analysis_result}")
 # Get performance metrics
 print(f"Total nodes: {result.total_nodes}")
 print(f"Completed nodes: {result.completed_nodes}")
+print(f"Skipped nodes: {result.skipped_nodes}")
 print(f"Failed nodes: {result.failed_nodes}")
 print(f"Execution time: {result.execution_time}ms")
 print(f"Token usage: {result.accumulated_usage}")
@@ -838,4 +839,4 @@ The Graph pattern is available in multiple SDKs. While the core concept is the s
 
 **Error handling**: Python node failures throw exceptions (fail-fast), while orchestrator-level limit violations return a FAILED result. TypeScript does the inverse: node failures produce a FAILED result, allowing parallel paths to continue, while orchestrator-level limits (`maxSteps`) throw exceptions to promote fail-fast behavior for global failures.
 
-**Node cancellation**: Both SDKs support cancelling a node before execution via hook callbacks. In TypeScript, a cancelled node produces a CANCELLED result status, allowing the orchestrator to distinguish cancellation from failure. In Python, a cancelled node results in a FAILED status.
+**Node cancellation**: Both SDKs support bypassing a node before execution via hook callbacks. In TypeScript, a cancelled node produces a CANCELLED result status, allowing the orchestrator to distinguish cancellation from failure. In Python, `skip_node` records a SKIPPED status with `result=None`, and downstream nodes still run.

--- a/strands-py/src/strands/hooks/events.py
+++ b/strands-py/src/strands/hooks/events.py
@@ -414,6 +414,7 @@ class BeforeNodeCallEvent(BaseHookEvent, _Interruptible):
         skip_node: A user defined message that when set, will skip the node execution and emit a
             :class:`~strands.types._events.MultiAgentNodeSkipEvent`. If set to ``True``, a default
             skip message is used. Any falsy value (``False``, ``""`` etc.) means "do not skip".
+            Takes precedence over ``cancel_node`` when both are truthy.
         cancel_node: Deprecated. Use ``skip_node`` instead. When set to a truthy value, behaves
             identically to ``skip_node`` but also emits a ``DeprecationWarning`` at the assignment
             site.

--- a/strands-py/src/strands/hooks/events.py
+++ b/strands-py/src/strands/hooks/events.py
@@ -4,7 +4,6 @@ This module defines the events that are emitted as Agents run through the lifecy
 """
 
 import uuid
-import warnings
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -415,9 +414,9 @@ class BeforeNodeCallEvent(BaseHookEvent, _Interruptible):
             :class:`~strands.types._events.MultiAgentNodeSkipEvent`. If set to ``True``, a default
             skip message is used. Any falsy value (``False``, ``""`` etc.) means "do not skip".
             Takes precedence over ``cancel_node`` when both are truthy.
-        cancel_node: Deprecated. Use ``skip_node`` instead. When set to a truthy value, behaves
-            identically to ``skip_node`` but also emits a ``DeprecationWarning`` at the assignment
-            site.
+        cancel_node: Alias for ``skip_node``, kept for backward compatibility. Reserved for the
+            abort-branch semantics tracked in #2401; until that lands it behaves identically to
+            ``skip_node``.
     """
 
     source: "MultiAgentBase"
@@ -428,16 +427,6 @@ class BeforeNodeCallEvent(BaseHookEvent, _Interruptible):
 
     def _can_write(self, name: str) -> bool:
         return name in ["skip_node", "cancel_node"]
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        """Set attribute, emitting a DeprecationWarning when cancel_node is assigned a truthy value."""
-        if name == "cancel_node" and value:
-            warnings.warn(
-                "BeforeNodeCallEvent.cancel_node is deprecated; use skip_node instead",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        super().__setattr__(name, value)
 
     @override
     def _interrupt_id(self, name: str) -> str:

--- a/strands-py/src/strands/hooks/events.py
+++ b/strands-py/src/strands/hooks/events.py
@@ -411,14 +411,13 @@ class BeforeNodeCallEvent(BaseHookEvent, _Interruptible):
         node_id: ID of the node about to execute
         invocation_state: Configuration that user passes in
         skip_node: A user defined message that when set, will skip the node execution and emit a
-            :class:`~strands.types._events.MultiAgentNodeSkipEvent`. If set to ``True``, a default
-            skip message is used. Any falsy value (``False``, ``""`` etc.) means "do not skip".
-            Takes precedence over ``cancel_node`` when both are truthy. In a graph the skipped node
-            records a ``NodeResult`` with ``result=None``, so an edge condition reading that node's
-            output has to handle ``None``.
-        cancel_node: Alias for ``skip_node``, kept for backward compatibility. Reserved for a
-            future abort-branch semantic, where downstream nodes do not run; until that exists it
-            behaves identically to ``skip_node``.
+            ``MultiAgentNodeSkipEvent``. If set to ``True``, a default skip message is used. Any
+            falsy value (``False``, ``""`` etc.) means "do not skip". Takes precedence over
+            ``cancel_node`` when both are truthy. In a graph the skipped node records a
+            ``NodeResult`` with ``result=None``, so an edge condition reading that node's output
+            has to handle ``None``.
+        cancel_node: Alias for ``skip_node``, kept so existing code keeps working. It behaves
+            identically today; the separate name leaves room for a distinct cancel semantic later.
     """
 
     source: "MultiAgentBase"

--- a/strands-py/src/strands/hooks/events.py
+++ b/strands-py/src/strands/hooks/events.py
@@ -4,6 +4,7 @@ This module defines the events that are emitted as Agents run through the lifecy
 """
 
 import uuid
+import warnings
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -410,18 +411,32 @@ class BeforeNodeCallEvent(BaseHookEvent, _Interruptible):
         source: The multi-agent orchestrator instance
         node_id: ID of the node about to execute
         invocation_state: Configuration that user passes in
-        cancel_node: A user defined message that when set, will skip the node execution and mark it as skipped,
-            allowing downstream nodes to continue executing. The message will be emitted under a MultiAgentNodeCancel
-            event. If set to `True`, Strands will skip the node using a default cancel message.
+        skip_node: A user defined message that when set, will skip the node execution and emit a
+            :class:`~strands.types._events.MultiAgentNodeSkipEvent`. If set to ``True``, a default
+            skip message is used. Any falsy value (``False``, ``""`` etc.) means "do not skip".
+        cancel_node: Deprecated. Use ``skip_node`` instead. When set to a truthy value, behaves
+            identically to ``skip_node`` but also emits a ``DeprecationWarning`` at the assignment
+            site.
     """
 
     source: "MultiAgentBase"
     node_id: str
     invocation_state: dict[str, Any] | None = None
+    skip_node: bool | str = False
     cancel_node: bool | str = False
 
     def _can_write(self, name: str) -> bool:
-        return name in ["cancel_node"]
+        return name in ["skip_node", "cancel_node"]
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Set attribute, emitting a DeprecationWarning when cancel_node is assigned a truthy value."""
+        if name == "cancel_node" and value:
+            warnings.warn(
+                "BeforeNodeCallEvent.cancel_node is deprecated; use skip_node instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        super().__setattr__(name, value)
 
     @override
     def _interrupt_id(self, name: str) -> str:

--- a/strands-py/src/strands/hooks/events.py
+++ b/strands-py/src/strands/hooks/events.py
@@ -413,7 +413,9 @@ class BeforeNodeCallEvent(BaseHookEvent, _Interruptible):
         skip_node: A user defined message that when set, will skip the node execution and emit a
             :class:`~strands.types._events.MultiAgentNodeSkipEvent`. If set to ``True``, a default
             skip message is used. Any falsy value (``False``, ``""`` etc.) means "do not skip".
-            Takes precedence over ``cancel_node`` when both are truthy.
+            Takes precedence over ``cancel_node`` when both are truthy. In a graph the skipped node
+            records a ``NodeResult`` with ``result=None``, so an edge condition reading that node's
+            output has to handle ``None``.
         cancel_node: Alias for ``skip_node``, kept for backward compatibility. Reserved for a
             future abort-branch semantic, where downstream nodes do not run; until that exists it
             behaves identically to ``skip_node``.

--- a/strands-py/src/strands/hooks/events.py
+++ b/strands-py/src/strands/hooks/events.py
@@ -423,8 +423,9 @@ class BeforeNodeCallEvent(BaseHookEvent, _Interruptible):
     source: "MultiAgentBase"
     node_id: str
     invocation_state: dict[str, Any] | None = None
-    skip_node: bool | str = False
     cancel_node: bool | str = False
+    # Appended rather than placed next to its alias so that cancel_node keeps its positional slot.
+    skip_node: bool | str = False
 
     def _can_write(self, name: str) -> bool:
         return name in ["skip_node", "cancel_node"]

--- a/strands-py/src/strands/hooks/events.py
+++ b/strands-py/src/strands/hooks/events.py
@@ -414,9 +414,9 @@ class BeforeNodeCallEvent(BaseHookEvent, _Interruptible):
             :class:`~strands.types._events.MultiAgentNodeSkipEvent`. If set to ``True``, a default
             skip message is used. Any falsy value (``False``, ``""`` etc.) means "do not skip".
             Takes precedence over ``cancel_node`` when both are truthy.
-        cancel_node: Alias for ``skip_node``, kept for backward compatibility. Reserved for the
-            abort-branch semantics tracked in #2401; until that lands it behaves identically to
-            ``skip_node``.
+        cancel_node: Alias for ``skip_node``, kept for backward compatibility. Reserved for a
+            future abort-branch semantic, where downstream nodes do not run; until that exists it
+            behaves identically to ``skip_node``.
     """
 
     source: "MultiAgentBase"

--- a/strands-py/src/strands/hooks/events.py
+++ b/strands-py/src/strands/hooks/events.py
@@ -410,9 +410,9 @@ class BeforeNodeCallEvent(BaseHookEvent, _Interruptible):
         source: The multi-agent orchestrator instance
         node_id: ID of the node about to execute
         invocation_state: Configuration that user passes in
-        cancel_node: A user defined message that when set, will cancel the node execution with status FAILED.
-            The message will be emitted under a MultiAgentNodeCancel event. If set to `True`, Strands will cancel the
-            node using a default cancel message.
+        cancel_node: A user defined message that when set, will skip the node and mark it as completed, allowing
+            downstream nodes to continue executing. The message will be emitted under a MultiAgentNodeCancel event.
+            If set to `True`, Strands will skip the node using a default cancel message.
     """
 
     source: "MultiAgentBase"

--- a/strands-py/src/strands/hooks/events.py
+++ b/strands-py/src/strands/hooks/events.py
@@ -410,9 +410,9 @@ class BeforeNodeCallEvent(BaseHookEvent, _Interruptible):
         source: The multi-agent orchestrator instance
         node_id: ID of the node about to execute
         invocation_state: Configuration that user passes in
-        cancel_node: A user defined message that when set, will skip the node and mark it as completed, allowing
-            downstream nodes to continue executing. The message will be emitted under a MultiAgentNodeCancel event.
-            If set to `True`, Strands will skip the node using a default cancel message.
+        cancel_node: A user defined message that when set, will skip the node execution and mark it as skipped,
+            allowing downstream nodes to continue executing. The message will be emitted under a MultiAgentNodeCancel
+            event. If set to `True`, Strands will skip the node using a default cancel message.
     """
 
     source: "MultiAgentBase"

--- a/strands-py/src/strands/multiagent/base.py
+++ b/strands-py/src/strands/multiagent/base.py
@@ -67,10 +67,13 @@ class NodeResult:
         - AgentResult: Uses AgentResult.__str__ (extracts text content)
         - MultiAgentResult: Uses MultiAgentResult.__str__ (recursive)
         - Exception: Uses the exception's string representation
+        - None (skipped node): Empty string, so callers that join node output omit it
 
         Returns:
             String representation of the node's result.
         """
+        if self.result is None:
+            return ""
         return str(self.result)
 
     def get_agent_results(self) -> list[AgentResult]:

--- a/strands-py/src/strands/multiagent/base.py
+++ b/strands-py/src/strands/multiagent/base.py
@@ -30,7 +30,7 @@ class Status(Enum):
         PENDING: Task has not started execution yet.
         EXECUTING: Task is currently running.
         COMPLETED: Task finished successfully.
-        SKIPPED: Task was intentionally bypassed via cancel_node; downstream nodes still execute.
+        SKIPPED: Task was intentionally bypassed via ``skip_node`` rather than executed.
         FAILED: Task encountered an error and could not complete.
         INTERRUPTED: Task was interrupted by user.
     """

--- a/strands-py/src/strands/multiagent/base.py
+++ b/strands-py/src/strands/multiagent/base.py
@@ -30,6 +30,7 @@ class Status(Enum):
         PENDING: Task has not started execution yet.
         EXECUTING: Task is currently running.
         COMPLETED: Task finished successfully.
+        SKIPPED: Task was intentionally bypassed via cancel_node; downstream nodes still execute.
         FAILED: Task encountered an error and could not complete.
         INTERRUPTED: Task was interrupted by user.
     """
@@ -37,6 +38,7 @@ class Status(Enum):
     PENDING = "pending"
     EXECUTING = "executing"
     COMPLETED = "completed"
+    SKIPPED = "skipped"
     FAILED = "failed"
     INTERRUPTED = "interrupted"
 
@@ -45,8 +47,8 @@ class Status(Enum):
 class NodeResult:
     """Unified result from node execution - handles both Agent and nested MultiAgentBase results."""
 
-    # Core result data - single AgentResult, nested MultiAgentResult, or Exception
-    result: Union[AgentResult, "MultiAgentResult", Exception]
+    # Core result data - single AgentResult, nested MultiAgentResult, Exception, or None (skipped)
+    result: Union[AgentResult, "MultiAgentResult", Exception, None]
 
     # Execution metadata
     execution_time: int = 0
@@ -73,8 +75,8 @@ class NodeResult:
 
     def get_agent_results(self) -> list[AgentResult]:
         """Get all AgentResult objects from this node, flattened if nested."""
-        if isinstance(self.result, Exception):
-            return []  # No agent results for exceptions
+        if self.result is None or isinstance(self.result, Exception):
+            return []
         elif isinstance(self.result, AgentResult):
             return [self.result]
         else:
@@ -86,8 +88,10 @@ class NodeResult:
 
     def to_dict(self) -> dict[str, Any]:
         """Convert NodeResult to JSON-serializable dict, ignoring state field."""
-        if isinstance(self.result, Exception):
-            result_data: dict[str, Any] = {"type": "exception", "message": str(self.result)}
+        if self.result is None:
+            result_data: dict[str, Any] = {"type": "skipped"}
+        elif isinstance(self.result, Exception):
+            result_data = {"type": "exception", "message": str(self.result)}
         elif isinstance(self.result, AgentResult):
             result_data = self.result.to_dict()
         else:
@@ -111,8 +115,10 @@ class NodeResult:
             raise TypeError("NodeResult.from_dict: missing 'result'")
         raw = data["result"]
 
-        result: AgentResult | MultiAgentResult | Exception
-        if isinstance(raw, dict) and raw.get("type") == "agent_result":
+        result: AgentResult | MultiAgentResult | Exception | None
+        if isinstance(raw, dict) and raw.get("type") == "skipped":
+            result = None
+        elif isinstance(raw, dict) and raw.get("type") == "agent_result":
             result = AgentResult.from_dict(raw)
         elif isinstance(raw, dict) and raw.get("type") == "exception":
             result = Exception(str(raw.get("message", "node failed")))

--- a/strands-py/src/strands/multiagent/graph.py
+++ b/strands-py/src/strands/multiagent/graph.py
@@ -110,7 +110,7 @@ class GraphState:
 
     Attributes:
         status: Current execution status of the graph.
-        completed_nodes: Set of nodes whose execution is settled — either completed normally or skipped via cancel_node.
+        completed_nodes: Set of nodes whose execution is settled — either completed normally or skipped via skip_node.
             Both statuses satisfy downstream readiness checks; inspect node.execution_status to distinguish them.
         failed_nodes: Set of nodes that failed during execution.
         interrupted_nodes: Set of nodes that user interrupted during execution.

--- a/strands-py/src/strands/multiagent/graph.py
+++ b/strands-py/src/strands/multiagent/graph.py
@@ -347,6 +347,9 @@ class GraphBuilder:
         The condition can be either:
         - A legacy callable: Callable[[GraphState], bool] - receives only graph state
         - A new-style callable: EdgeConditionWithContext - receives graph state and invocation_state
+
+        A condition that reads an upstream node's output must handle a ``NodeResult.result`` of ``None``:
+        a node bypassed via ``skip_node`` produced no output and records ``None`` there.
         """
 
         def resolve_node(node: str | GraphNode, node_type: str) -> GraphNode:

--- a/strands-py/src/strands/multiagent/graph.py
+++ b/strands-py/src/strands/multiagent/graph.py
@@ -177,7 +177,9 @@ class GraphResult(MultiAgentResult):
 
     total_nodes: int = 0
     completed_nodes: int = 0
+    """Number of nodes that successfully ran to completion (excludes skipped nodes)."""
     skipped_nodes: int = 0
+    """Number of nodes bypassed via skip_node or cancel_node; downstream nodes continued executing."""
     failed_nodes: int = 0
     interrupted_nodes: int = 0
     execution_order: list["GraphNode"] = field(default_factory=list)
@@ -1004,9 +1006,9 @@ class Graph(MultiAgentBase):
             skip_value = before_event.skip_node or before_event.cancel_node
 
             if skip_value:
-                cancel_message = skip_value if isinstance(skip_value, str) else "node skipped by user"
-                logger.debug("reason=<%s> | node skipped, graph continues", cancel_message)
-                yield MultiAgentNodeSkipEvent(node.node_id, cancel_message)
+                skip_message = skip_value if isinstance(skip_value, str) else "node skipped by user"
+                logger.debug("reason=<%s> | node skipped, graph continues", skip_message)
+                yield MultiAgentNodeSkipEvent(node.node_id, skip_message)
                 node_result = NodeResult(
                     result=None,
                     execution_time=0,

--- a/strands-py/src/strands/multiagent/graph.py
+++ b/strands-py/src/strands/multiagent/graph.py
@@ -182,12 +182,13 @@ class GraphResult(MultiAgentResult):
 
     total_nodes: int = 0
     completed_nodes: int = 0
-    skipped_nodes: int = 0
     failed_nodes: int = 0
     interrupted_nodes: int = 0
     execution_order: list["GraphNode"] = field(default_factory=list)
     edges: list[tuple["GraphNode", "GraphNode"]] = field(default_factory=list)
     entry_points: list["GraphNode"] = field(default_factory=list)
+    # Appended rather than grouped with the other counters so that no existing positional argument shifts.
+    skipped_nodes: int = 0
 
 
 @dataclass

--- a/strands-py/src/strands/multiagent/graph.py
+++ b/strands-py/src/strands/multiagent/graph.py
@@ -44,8 +44,8 @@ from ..session import SessionManager
 from ..telemetry import get_tracer
 from ..types._events import (
     MultiAgentHandoffEvent,
-    MultiAgentNodeCancelEvent,
     MultiAgentNodeInterruptEvent,
+    MultiAgentNodeSkipEvent,
     MultiAgentNodeStartEvent,
     MultiAgentNodeStopEvent,
     MultiAgentNodeStreamEvent,
@@ -1001,12 +1001,12 @@ class Graph(MultiAgentBase):
                 yield self._activate_interrupt(node, interrupts, from_hook=True)
                 return
 
-            if before_event.cancel_node:
-                cancel_message = (
-                    before_event.cancel_node if isinstance(before_event.cancel_node, str) else "node cancelled by user"
-                )
+            skip_value = before_event.skip_node or before_event.cancel_node
+
+            if skip_value:
+                cancel_message = skip_value if isinstance(skip_value, str) else "node skipped by user"
                 logger.debug("reason=<%s> | node skipped, graph continues", cancel_message)
-                yield MultiAgentNodeCancelEvent(node.node_id, cancel_message)
+                yield MultiAgentNodeSkipEvent(node.node_id, cancel_message)
                 node_result = NodeResult(
                     result=None,
                     execution_time=0,
@@ -1273,12 +1273,8 @@ class Graph(MultiAgentBase):
             execution_count=self.state.execution_count,
             execution_time=self._execution_time_with_active_interval(self.state.execution_time),
             total_nodes=self.state.total_nodes,
-            completed_nodes=sum(
-                1 for n in self.state.completed_nodes if n.execution_status == Status.COMPLETED
-            ),
-            skipped_nodes=sum(
-                1 for n in self.state.completed_nodes if n.execution_status == Status.SKIPPED
-            ),
+            completed_nodes=sum(1 for n in self.state.completed_nodes if n.execution_status == Status.COMPLETED),
+            skipped_nodes=sum(1 for n in self.state.completed_nodes if n.execution_status == Status.SKIPPED),
             failed_nodes=len(self.state.failed_nodes),
             interrupted_nodes=len(self.state.interrupted_nodes),
             execution_order=self.state.execution_order,

--- a/strands-py/src/strands/multiagent/graph.py
+++ b/strands-py/src/strands/multiagent/graph.py
@@ -1246,7 +1246,9 @@ class Graph(MultiAgentBase):
                 dependency_blocks.append(ContentBlock(text=f"  - {agent_name}: {str(agent_result)}"))
 
         if not dependency_blocks:
-            # No usable dependency output - return task as ContentBlocks
+            # Nothing upstream contributed content, so treat this like an entry node and hand it the bare task.
+            # The "Original Task:" prefix is dropped with it, since it only reads correctly against the
+            # "Inputs from previous nodes:" section that is no longer there.
             if isinstance(self.state.task, str):
                 return [ContentBlock(text=self.state.task)]
             else:

--- a/strands-py/src/strands/multiagent/graph.py
+++ b/strands-py/src/strands/multiagent/graph.py
@@ -1221,7 +1221,7 @@ class Graph(MultiAgentBase):
 
                     return node_responses
 
-        # Get satisfied dependencies, excluding skipped nodes (they produced no output)
+        # Get satisfied dependencies
         dependency_results = {}
         for edge in self.edges:
             if (
@@ -1230,13 +1230,11 @@ class Graph(MultiAgentBase):
                 and edge.from_node.node_id in self.state.results
             ):
                 if edge.should_traverse(self.state, invocation_state=self._current_invocation_state):
-                    node_result = self.state.results[edge.from_node.node_id]
-                    if node_result.status != Status.SKIPPED:
-                        dependency_results[edge.from_node.node_id] = node_result
+                    dependency_results[edge.from_node.node_id] = self.state.results[edge.from_node.node_id]
 
         # Render each dependency's output. A dependency that flattens to no agent results contributes nothing,
-        # so it must not leave an empty "From <node>:" header behind. A nested graph whose nodes were all
-        # skipped is the case that reaches here with a non-skipped status but no output.
+        # so it must not leave an empty "From <node>:" header behind. That covers both a skipped node, whose
+        # result is None, and a nested graph whose own nodes were all skipped.
         dependency_blocks: list[ContentBlock] = []
         for dep_id, node_result in dependency_results.items():
             agent_results = node_result.get_agent_results()

--- a/strands-py/src/strands/multiagent/graph.py
+++ b/strands-py/src/strands/multiagent/graph.py
@@ -158,7 +158,8 @@ class GraphState:
 
         Returns: (should_continue, reason)
         """
-        # Check node execution limit (only if set)
+        # Check node execution limit (only if set). A skipped node counts: the limit bounds graph traversal, and
+        # excluding skips lets a cycle whose nodes are all skipped loop forever.
         if max_node_executions is not None and len(self.execution_order) >= max_node_executions:
             return False, f"Max node executions reached: {max_node_executions}"
 
@@ -1231,8 +1232,21 @@ class Graph(MultiAgentBase):
                     if node_result.status != Status.SKIPPED:
                         dependency_results[edge.from_node.node_id] = node_result
 
-        if not dependency_results:
-            # No dependencies - return task as ContentBlocks
+        # Render each dependency's output. A dependency that flattens to no agent results contributes nothing,
+        # so it must not leave an empty "From <node>:" header behind. A nested graph whose nodes were all
+        # skipped is the case that reaches here with a non-skipped status but no output.
+        dependency_blocks: list[ContentBlock] = []
+        for dep_id, node_result in dependency_results.items():
+            agent_results = node_result.get_agent_results()
+            if not agent_results:
+                continue
+            dependency_blocks.append(ContentBlock(text=f"\nFrom {dep_id}:"))
+            for agent_result in agent_results:
+                agent_name = getattr(agent_result, "agent_name", "Agent")
+                dependency_blocks.append(ContentBlock(text=f"  - {agent_name}: {str(agent_result)}"))
+
+        if not dependency_blocks:
+            # No usable dependency output - return task as ContentBlocks
             if isinstance(self.state.task, str):
                 return [ContentBlock(text=self.state.task)]
             else:
@@ -1251,15 +1265,7 @@ class Graph(MultiAgentBase):
 
         # Add dependency outputs
         node_input.append(ContentBlock(text="\nInputs from previous nodes:"))
-
-        for dep_id, node_result in dependency_results.items():
-            node_input.append(ContentBlock(text=f"\nFrom {dep_id}:"))
-            # Get all agent results from this node (flattened if nested)
-            agent_results = node_result.get_agent_results()
-            for result in agent_results:
-                agent_name = getattr(result, "agent_name", "Agent")
-                result_text = str(result)
-                node_input.append(ContentBlock(text=f"  - {agent_name}: {result_text}"))
+        node_input.extend(dependency_blocks)
 
         return node_input
 

--- a/strands-py/src/strands/multiagent/graph.py
+++ b/strands-py/src/strands/multiagent/graph.py
@@ -1275,8 +1275,8 @@ class Graph(MultiAgentBase):
             execution_count=self.state.execution_count,
             execution_time=self._execution_time_with_active_interval(self.state.execution_time),
             total_nodes=self.state.total_nodes,
-            completed_nodes=sum(1 for n in self.state.completed_nodes if n.execution_status == Status.COMPLETED),
-            skipped_nodes=sum(1 for n in self.state.completed_nodes if n.execution_status == Status.SKIPPED),
+            completed_nodes=sum(1 for node in self.state.completed_nodes if node.execution_status == Status.COMPLETED),
+            skipped_nodes=sum(1 for node in self.state.completed_nodes if node.execution_status == Status.SKIPPED),
             failed_nodes=len(self.state.failed_nodes),
             interrupted_nodes=len(self.state.interrupted_nodes),
             execution_order=self.state.execution_order,
@@ -1503,8 +1503,10 @@ class Graph(MultiAgentBase):
             self.nodes[node_id] for node_id in (payload.get("completed_nodes") or []) if node_id in self.nodes
         )
         for node in self.state.completed_nodes:
-            nr = results.get(node.node_id)
-            node.execution_status = Status.SKIPPED if (nr and nr.status == Status.SKIPPED) else Status.COMPLETED
+            node_result = results.get(node.node_id)
+            node.execution_status = (
+                Status.SKIPPED if (node_result and node_result.status == Status.SKIPPED) else Status.COMPLETED
+            )
 
         # Execution order (only nodes that still exist)
         order_node_ids = payload.get("execution_order") or []

--- a/strands-py/src/strands/multiagent/graph.py
+++ b/strands-py/src/strands/multiagent/graph.py
@@ -110,7 +110,7 @@ class GraphState:
 
     Attributes:
         status: Current execution status of the graph.
-        completed_nodes: Set of nodes whose execution is settled — either completed normally or skipped via skip_node.
+        completed_nodes: Set of nodes whose execution is settled, either completed normally or skipped via skip_node.
             Both statuses satisfy downstream readiness checks; inspect node.execution_status to distinguish them.
         failed_nodes: Set of nodes that failed during execution.
         interrupted_nodes: Set of nodes that user interrupted during execution.
@@ -174,13 +174,15 @@ class GraphState:
 
 @dataclass
 class GraphResult(MultiAgentResult):
-    """Result from graph execution - extends MultiAgentResult with graph-specific details."""
+    """Result from graph execution - extends MultiAgentResult with graph-specific details.
+
+    ``completed_nodes`` counts only nodes that ran to completion. Nodes bypassed via ``skip_node``
+    are counted by ``skipped_nodes`` instead, and their downstream nodes still executed.
+    """
 
     total_nodes: int = 0
     completed_nodes: int = 0
-    """Number of nodes that successfully ran to completion (excludes skipped nodes)."""
     skipped_nodes: int = 0
-    """Number of nodes bypassed via skip_node or cancel_node; downstream nodes continued executing."""
     failed_nodes: int = 0
     interrupted_nodes: int = 0
     execution_order: list["GraphNode"] = field(default_factory=list)

--- a/strands-py/src/strands/multiagent/graph.py
+++ b/strands-py/src/strands/multiagent/graph.py
@@ -794,7 +794,9 @@ class Graph(MultiAgentBase):
 
             if self.state.status == Status.INTERRUPTED:
                 self._interrupt_state.context["completed_nodes"] = [
-                    node.node_id for node in current_batch if node.execution_status == Status.COMPLETED
+                    node.node_id
+                    for node in current_batch
+                    if node.execution_status in (Status.COMPLETED, Status.SKIPPED)
                 ]
                 return
 

--- a/strands-py/src/strands/multiagent/graph.py
+++ b/strands-py/src/strands/multiagent/graph.py
@@ -1003,9 +1003,25 @@ class Graph(MultiAgentBase):
                 cancel_message = (
                     before_event.cancel_node if isinstance(before_event.cancel_node, str) else "node cancelled by user"
                 )
-                logger.debug("reason=<%s> | cancelling execution", cancel_message)
+                logger.debug("reason=<%s> | node skipped, graph continues", cancel_message)
                 yield MultiAgentNodeCancelEvent(node.node_id, cancel_message)
-                raise RuntimeError(cancel_message)
+                node_result = NodeResult(
+                    result=RuntimeError(cancel_message),
+                    execution_time=0,
+                    status=Status.COMPLETED,
+                    accumulated_usage=Usage(inputTokens=0, outputTokens=0, totalTokens=0),
+                    accumulated_metrics=Metrics(latencyMs=0),
+                    execution_count=0,
+                )
+                node.result = node_result
+                node.execution_time = 0
+                node.execution_status = Status.COMPLETED
+                self.state.completed_nodes.add(node)
+                self.state.results[node.node_id] = node_result
+                self.state.execution_order.append(node)
+                self._accumulate_metrics(node_result)
+                yield MultiAgentNodeStopEvent(node_id=node.node_id, node_result=node_result)
+                return
 
             # Build node input from satisfied dependencies
             node_input = self._build_node_input(node)

--- a/strands-py/src/strands/multiagent/graph.py
+++ b/strands-py/src/strands/multiagent/graph.py
@@ -110,7 +110,8 @@ class GraphState:
 
     Attributes:
         status: Current execution status of the graph.
-        completed_nodes: Set of nodes that have completed execution.
+        completed_nodes: Set of nodes whose execution is settled — either completed normally or skipped via cancel_node.
+            Both statuses satisfy downstream readiness checks; inspect node.execution_status to distinguish them.
         failed_nodes: Set of nodes that failed during execution.
         interrupted_nodes: Set of nodes that user interrupted during execution.
         execution_order: List of nodes in the order they were executed.
@@ -176,6 +177,7 @@ class GraphResult(MultiAgentResult):
 
     total_nodes: int = 0
     completed_nodes: int = 0
+    skipped_nodes: int = 0
     failed_nodes: int = 0
     interrupted_nodes: int = 0
     execution_order: list["GraphNode"] = field(default_factory=list)
@@ -1006,16 +1008,16 @@ class Graph(MultiAgentBase):
                 logger.debug("reason=<%s> | node skipped, graph continues", cancel_message)
                 yield MultiAgentNodeCancelEvent(node.node_id, cancel_message)
                 node_result = NodeResult(
-                    result=RuntimeError(cancel_message),
+                    result=None,
                     execution_time=0,
-                    status=Status.COMPLETED,
+                    status=Status.SKIPPED,
                     accumulated_usage=Usage(inputTokens=0, outputTokens=0, totalTokens=0),
                     accumulated_metrics=Metrics(latencyMs=0),
                     execution_count=0,
                 )
                 node.result = node_result
                 node.execution_time = 0
-                node.execution_status = Status.COMPLETED
+                node.execution_status = Status.SKIPPED
                 self.state.completed_nodes.add(node)
                 self.state.results[node.node_id] = node_result
                 self.state.execution_order.append(node)
@@ -1209,7 +1211,7 @@ class Graph(MultiAgentBase):
 
                     return node_responses
 
-        # Get satisfied dependencies
+        # Get satisfied dependencies, excluding skipped nodes (they produced no output)
         dependency_results = {}
         for edge in self.edges:
             if (
@@ -1218,7 +1220,9 @@ class Graph(MultiAgentBase):
                 and edge.from_node.node_id in self.state.results
             ):
                 if edge.should_traverse(self.state, invocation_state=self._current_invocation_state):
-                    dependency_results[edge.from_node.node_id] = self.state.results[edge.from_node.node_id]
+                    node_result = self.state.results[edge.from_node.node_id]
+                    if node_result.status != Status.SKIPPED:
+                        dependency_results[edge.from_node.node_id] = node_result
 
         if not dependency_results:
             # No dependencies - return task as ContentBlocks
@@ -1269,7 +1273,12 @@ class Graph(MultiAgentBase):
             execution_count=self.state.execution_count,
             execution_time=self._execution_time_with_active_interval(self.state.execution_time),
             total_nodes=self.state.total_nodes,
-            completed_nodes=len(self.state.completed_nodes),
+            completed_nodes=sum(
+                1 for n in self.state.completed_nodes if n.execution_status == Status.COMPLETED
+            ),
+            skipped_nodes=sum(
+                1 for n in self.state.completed_nodes if n.execution_status == Status.SKIPPED
+            ),
             failed_nodes=len(self.state.failed_nodes),
             interrupted_nodes=len(self.state.interrupted_nodes),
             execution_order=self.state.execution_order,
@@ -1496,7 +1505,8 @@ class Graph(MultiAgentBase):
             self.nodes[node_id] for node_id in (payload.get("completed_nodes") or []) if node_id in self.nodes
         )
         for node in self.state.completed_nodes:
-            node.execution_status = Status.COMPLETED
+            nr = results.get(node.node_id)
+            node.execution_status = Status.SKIPPED if (nr and nr.status == Status.SKIPPED) else Status.COMPLETED
 
         # Execution order (only nodes that still exist)
         order_node_ids = payload.get("execution_order") or []

--- a/strands-py/src/strands/multiagent/swarm.py
+++ b/strands-py/src/strands/multiagent/swarm.py
@@ -44,8 +44,8 @@ from ..telemetry import get_tracer
 from ..tools.decorator import tool
 from ..types._events import (
     MultiAgentHandoffEvent,
-    MultiAgentNodeCancelEvent,
     MultiAgentNodeInterruptEvent,
+    MultiAgentNodeSkipEvent,
     MultiAgentNodeStartEvent,
     MultiAgentNodeStopEvent,
     MultiAgentNodeStreamEvent,
@@ -776,14 +776,12 @@ class Swarm(MultiAgentBase):
                         yield self._activate_interrupt(current_node, interrupts)
                         break
 
-                    if before_event.cancel_node:
-                        cancel_message = (
-                            before_event.cancel_node
-                            if isinstance(before_event.cancel_node, str)
-                            else "node cancelled by user"
-                        )
+                    skip_value = before_event.skip_node or before_event.cancel_node
+
+                    if skip_value:
+                        cancel_message = skip_value if isinstance(skip_value, str) else "node skipped by user"
                         logger.debug("reason=<%s> | cancelling execution", cancel_message)
-                        yield MultiAgentNodeCancelEvent(current_node.node_id, cancel_message)
+                        yield MultiAgentNodeSkipEvent(current_node.node_id, cancel_message)
                         self.state.completion_status = Status.FAILED
                         break
 

--- a/strands-py/src/strands/multiagent/swarm.py
+++ b/strands-py/src/strands/multiagent/swarm.py
@@ -782,10 +782,7 @@ class Swarm(MultiAgentBase):
                         skip_message = skip_value if isinstance(skip_value, str) else "node skipped by user"
                         logger.debug("reason=<%s> | node skipped, stopping swarm sequence", skip_message)
                         yield MultiAgentNodeSkipEvent(current_node.node_id, skip_message)
-                        # In a linear swarm each node depends on the previous one's output, so
-                        # skipping a node means the remaining nodes cannot execute; FAILED signals
-                        # the swarm did not run to completion (unlike a graph where downstream
-                        # nodes can continue independently).
+                        # Linear swarm: nodes depend on prior output; skip sets FAILED (unlike graph, which continues).
                         self.state.completion_status = Status.FAILED
                         break
 

--- a/strands-py/src/strands/multiagent/swarm.py
+++ b/strands-py/src/strands/multiagent/swarm.py
@@ -779,9 +779,13 @@ class Swarm(MultiAgentBase):
                     skip_value = before_event.skip_node or before_event.cancel_node
 
                     if skip_value:
-                        cancel_message = skip_value if isinstance(skip_value, str) else "node skipped by user"
-                        logger.debug("reason=<%s> | cancelling execution", cancel_message)
-                        yield MultiAgentNodeSkipEvent(current_node.node_id, cancel_message)
+                        skip_message = skip_value if isinstance(skip_value, str) else "node skipped by user"
+                        logger.debug("reason=<%s> | node skipped, stopping swarm sequence", skip_message)
+                        yield MultiAgentNodeSkipEvent(current_node.node_id, skip_message)
+                        # In a linear swarm each node depends on the previous one's output, so
+                        # skipping a node means the remaining nodes cannot execute; FAILED signals
+                        # the swarm did not run to completion (unlike a graph where downstream
+                        # nodes can continue independently).
                         self.state.completion_status = Status.FAILED
                         break
 

--- a/strands-py/src/strands/types/_events.py
+++ b/strands-py/src/strands/types/_events.py
@@ -574,7 +574,12 @@ class MultiAgentNodeStreamEvent(TypedEvent):
 
 
 class MultiAgentNodeCancelEvent(TypedEvent):
-    """Event emitted when a user cancels node execution from their BeforeNodeCallEvent hook."""
+    """Reserved for the future abort-branch CANCELLED semantic (see issue #2401).
+
+    .. deprecated::
+        Do not use this event to detect skipped nodes. Use :class:`MultiAgentNodeSkipEvent`
+        (type ``multiagent_node_skip``) instead.
+    """
 
     def __init__(self, node_id: str, message: str) -> None:
         """Initialize with cancel message.
@@ -586,6 +591,30 @@ class MultiAgentNodeCancelEvent(TypedEvent):
         super().__init__(
             {
                 "type": "multiagent_node_cancel",
+                "node_id": node_id,
+                "message": message,
+            }
+        )
+
+
+class MultiAgentNodeSkipEvent(TypedEvent):
+    """Event emitted when a node is skipped via :attr:`BeforeNodeCallEvent.skip_node`.
+
+    Emitted by all orchestrators when a node is bypassed. The orchestrator's behavior
+    after skip depends on its type: a graph continues executing downstream nodes,
+    while a swarm stops the current run.
+    """
+
+    def __init__(self, node_id: str, message: str) -> None:
+        """Initialize with skip message.
+
+        Args:
+            node_id: Unique identifier for the node.
+            message: The node skip message.
+        """
+        super().__init__(
+            {
+                "type": "multiagent_node_skip",
                 "node_id": node_id,
                 "message": message,
             }

--- a/strands-py/src/strands/types/_events.py
+++ b/strands-py/src/strands/types/_events.py
@@ -599,9 +599,9 @@ class MultiAgentNodeCancelEvent(TypedEvent):
 class MultiAgentNodeSkipEvent(TypedEvent):
     """Event emitted when a node is bypassed via :attr:`BeforeNodeCallEvent.skip_node`.
 
-    Also triggered by the deprecated :attr:`BeforeNodeCallEvent.cancel_node` alias. The
-    orchestrator's behavior after skip depends on its type: a graph continues executing
-    downstream nodes, while a swarm stops the current run.
+    Also triggered by the :attr:`BeforeNodeCallEvent.cancel_node` alias. The orchestrator's
+    behavior after skip depends on its type: a graph continues executing downstream nodes,
+    while a swarm stops the current run.
     """
 
     def __init__(self, node_id: str, message: str) -> None:

--- a/strands-py/src/strands/types/_events.py
+++ b/strands-py/src/strands/types/_events.py
@@ -574,11 +574,10 @@ class MultiAgentNodeStreamEvent(TypedEvent):
 
 
 class MultiAgentNodeCancelEvent(TypedEvent):
-    """Reserved for the future abort-branch CANCELLED semantic (see issue #2401).
+    """Planned event for when a node stops graph execution entirely (see issue #2401).
 
-    .. deprecated::
-        Do not use this event to detect skipped nodes. Use :class:`MultiAgentNodeSkipEvent`
-        (type ``multiagent_node_skip``) instead.
+    Not currently emitted by the library. To handle bypassed nodes, subscribe to
+    :class:`MultiAgentNodeSkipEvent` (type ``multiagent_node_skip``) instead.
     """
 
     def __init__(self, node_id: str, message: str) -> None:
@@ -598,11 +597,11 @@ class MultiAgentNodeCancelEvent(TypedEvent):
 
 
 class MultiAgentNodeSkipEvent(TypedEvent):
-    """Event emitted when a node is skipped via :attr:`BeforeNodeCallEvent.skip_node`.
+    """Event emitted when a node is bypassed via :attr:`BeforeNodeCallEvent.skip_node`.
 
-    Emitted by all orchestrators when a node is bypassed. The orchestrator's behavior
-    after skip depends on its type: a graph continues executing downstream nodes,
-    while a swarm stops the current run.
+    Also triggered by the deprecated :attr:`BeforeNodeCallEvent.cancel_node` alias. The
+    orchestrator's behavior after skip depends on its type: a graph continues executing
+    downstream nodes, while a swarm stops the current run.
     """
 
     def __init__(self, node_id: str, message: str) -> None:

--- a/strands-py/src/strands/types/_events.py
+++ b/strands-py/src/strands/types/_events.py
@@ -574,7 +574,7 @@ class MultiAgentNodeStreamEvent(TypedEvent):
 
 
 class MultiAgentNodeCancelEvent(TypedEvent):
-    """Planned event for when a node stops graph execution entirely (see issue #2401).
+    """Planned event for when a node stops graph execution entirely.
 
     Not currently emitted by the library. To handle bypassed nodes, subscribe to
     :class:`MultiAgentNodeSkipEvent` (type ``multiagent_node_skip``) instead.

--- a/strands-py/src/strands/types/_events.py
+++ b/strands-py/src/strands/types/_events.py
@@ -574,10 +574,10 @@ class MultiAgentNodeStreamEvent(TypedEvent):
 
 
 class MultiAgentNodeCancelEvent(TypedEvent):
-    """Planned event for when a node stops graph execution entirely.
+    """Superseded by :class:`MultiAgentNodeSkipEvent`. Nothing in the library emits this.
 
-    Not currently emitted by the library. To handle bypassed nodes, subscribe to
-    :class:`MultiAgentNodeSkipEvent` (type ``multiagent_node_skip``) instead.
+    Kept so that code importing it keeps working. Bypassed nodes now emit
+    ``multiagent_node_skip`` instead of ``multiagent_node_cancel``.
     """
 
     def __init__(self, node_id: str, message: str) -> None:

--- a/strands-py/tests/strands/multiagent/test_base.py
+++ b/strands-py/tests/strands/multiagent/test_base.py
@@ -261,6 +261,27 @@ def test_node_result_str_with_exception():
     assert str(node_result) == "something broke"
 
 
+def test_node_result_str_with_skipped_result():
+    """Test NodeResult.__str__ renders a skipped node as an empty string rather than "None"."""
+    node_result = NodeResult(result=None, status=Status.SKIPPED)
+    assert str(node_result) == ""
+
+
+def test_multi_agent_result_str_omits_skipped_node(agent_result):
+    """Test MultiAgentResult.__str__ omits skipped nodes instead of printing a literal "None"."""
+    result = MultiAgentResult(
+        status=Status.COMPLETED,
+        results={
+            "skipped": NodeResult(result=None, status=Status.SKIPPED),
+            "ran": NodeResult(result=agent_result),
+        },
+    )
+    output = str(result)
+    assert "None" not in output
+    assert "skipped" not in output
+    assert "ran: Test response" in output
+
+
 def test_multi_agent_result_str_single_node(agent_result):
     """Test MultiAgentResult.__str__ with a single node."""
     result = MultiAgentResult(

--- a/strands-py/tests/strands/multiagent/test_graph.py
+++ b/strands-py/tests/strands/multiagent/test_graph.py
@@ -2223,10 +2223,10 @@ async def test_graph_skip_node(skip_node, skip_message):
     assert tru_skip_event == exp_skip_event
 
     assert graph.state.status == Status.COMPLETED
-    assert any(n.node_id == "test_agent" for n in graph.state.completed_nodes)
+    assert any(node.node_id == "test_agent" for node in graph.state.completed_nodes)
     assert "test_agent" in graph.state.results
     assert graph.state.results["test_agent"].status == Status.SKIPPED
-    skipped_node = next(n for n in graph.state.completed_nodes if n.node_id == "test_agent")
+    skipped_node = next(node for node in graph.state.completed_nodes if node.node_id == "test_agent")
     assert skipped_node.execution_status == Status.SKIPPED
     agent.__call__.assert_not_called()
 
@@ -2259,10 +2259,10 @@ async def test_graph_cancel_node_backward_compat(cancel_node, cancel_message):
     assert tru_skip_event == exp_skip_event
 
     assert graph.state.status == Status.COMPLETED
-    assert any(n.node_id == "test_agent" for n in graph.state.completed_nodes)
+    assert any(node.node_id == "test_agent" for node in graph.state.completed_nodes)
     assert "test_agent" in graph.state.results
     assert graph.state.results["test_agent"].status == Status.SKIPPED
-    skipped_node = next(n for n in graph.state.completed_nodes if n.node_id == "test_agent")
+    skipped_node = next(node for node in graph.state.completed_nodes if node.node_id == "test_agent")
     assert skipped_node.execution_status == Status.SKIPPED
     agent.__call__.assert_not_called()
 
@@ -2297,15 +2297,15 @@ async def test_graph_skip_node_downstream_executes():
     step_a.__call__.assert_not_called()
     step_b.stream_async.assert_called_once()
 
-    assert any(n.node_id == "step_a" for n in graph.state.completed_nodes)
-    assert any(n.node_id == "step_b" for n in graph.state.completed_nodes)
+    assert any(node.node_id == "step_a" for node in graph.state.completed_nodes)
+    assert any(node.node_id == "step_b" for node in graph.state.completed_nodes)
     assert "step_a" in graph.state.results
     assert "step_b" in graph.state.results
 
     # step_a was skipped — its NodeResult must carry Status.SKIPPED, not COMPLETED
     assert graph.state.results["step_a"].status == Status.SKIPPED
     assert graph.state.results["step_b"].status == Status.COMPLETED
-    skipped_node = next(n for n in graph.state.completed_nodes if n.node_id == "step_a")
+    skipped_node = next(node for node in graph.state.completed_nodes if node.node_id == "step_a")
     assert skipped_node.execution_status == Status.SKIPPED
 
     # step_b must receive only the original task — no orphaned "From step_a:" header

--- a/strands-py/tests/strands/multiagent/test_graph.py
+++ b/strands-py/tests/strands/multiagent/test_graph.py
@@ -3582,3 +3582,111 @@ class TestResumeInFlightSibling:
         join_input_text = " ".join(str(block) for block in join_input)
         assert "From left:" in join_input_text
         assert "From right:" in join_input_text
+
+
+@pytest.mark.asyncio
+async def test_graph_skipped_node_survives_interrupted_sibling_resume():
+    """A node skipped in the same batch as an interrupted sibling still releases its downstream node on resume."""
+
+    def skip_a_interrupt_b(event):
+        if event.node_id == "step_a":
+            event.skip_node = "step_a skipped"
+        elif event.node_id == "step_b":
+            return event.interrupt("test_name", reason="test_reason")
+        return event
+
+    step_a = create_mock_agent("step_a", "Should not run")
+    step_b = create_mock_agent("step_b", "Step B completed")
+    step_c = create_mock_agent("step_c", "Step C completed")
+
+    builder = GraphBuilder()
+    builder.add_node(step_a, "step_a")
+    builder.add_node(step_b, "step_b")
+    builder.add_node(step_c, "step_c")
+    builder.add_edge("step_a", "step_c")
+    builder.set_entry_point("step_a")
+    builder.set_entry_point("step_b")
+    graph = builder.build()
+    graph.hooks.add_callback(BeforeNodeCallEvent, skip_a_interrupt_b)
+
+    result = await graph.invoke_async("test task")
+    assert result.status == Status.INTERRUPTED
+    assert graph.state.results["step_a"].status == Status.SKIPPED
+
+    interrupt = result.interrupts[0]
+    result = await graph.invoke_async(
+        [{"interruptResponse": {"interruptId": interrupt.id, "response": "test_response"}}]
+    )
+
+    assert result.status == Status.COMPLETED
+    assert "step_c" in graph.state.results, "downstream of the skipped node never ran after resume"
+    assert graph.state.results["step_c"].status == Status.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_graph_deserialize_state_restores_skipped_status():
+    """A skipped node round-trips through session serialization as SKIPPED rather than COMPLETED."""
+
+    def skip_a_interrupt_b(event):
+        if event.node_id == "step_a":
+            event.skip_node = "step_a skipped"
+        elif event.node_id == "step_b":
+            return event.interrupt("test_name", reason="test_reason")
+        return event
+
+    def build_graph():
+        builder = GraphBuilder()
+        builder.add_node(create_mock_agent("step_a", "Should not run"), "step_a")
+        builder.add_node(create_mock_agent("step_b", "Step B completed"), "step_b")
+        builder.add_node(create_mock_agent("step_c", "Step C completed"), "step_c")
+        builder.add_edge("step_a", "step_c")
+        builder.set_entry_point("step_a")
+        builder.set_entry_point("step_b")
+        return builder.build()
+
+    graph = build_graph()
+    graph.hooks.add_callback(BeforeNodeCallEvent, skip_a_interrupt_b)
+    await graph.invoke_async("test task")
+
+    payload = graph.serialize_state()
+    assert payload["next_nodes_to_execute"]
+
+    restored = build_graph()
+    restored.deserialize_state(payload)
+
+    assert restored.nodes["step_a"].execution_status == Status.SKIPPED
+    assert restored.nodes["step_b"].execution_status == Status.INTERRUPTED
+
+
+@pytest.mark.asyncio
+async def test_graph_fan_in_with_one_skipped_dependency():
+    """A fan-in node sees only its non-skipped dependency's output, with no header for the skipped one."""
+
+    def skip_step_a(event):
+        if event.node_id == "step_a":
+            event.skip_node = "step_a skipped"
+        return event
+
+    step_a = create_mock_agent("step_a", "Should not run")
+    step_b = create_mock_agent("step_b", "Step B completed")
+    step_c = create_mock_agent("step_c", "Step C completed")
+
+    builder = GraphBuilder()
+    builder.add_node(step_a, "step_a")
+    builder.add_node(step_b, "step_b")
+    builder.add_node(step_c, "step_c")
+    builder.add_edge("step_a", "step_c")
+    builder.add_edge("step_b", "step_c")
+    builder.set_entry_point("step_a")
+    builder.set_entry_point("step_b")
+    graph = builder.build()
+    graph.hooks.add_callback(BeforeNodeCallEvent, skip_step_a)
+
+    result = await graph.invoke_async("test task")
+
+    assert result.status == Status.COMPLETED
+    assert graph.state.results["step_c"].status == Status.COMPLETED
+
+    step_c_input = "".join(block.get("text", "") for block in step_c.stream_async.call_args.args[0])
+    assert "From step_b:" in step_c_input
+    assert "From step_a:" not in step_c_input

--- a/strands-py/tests/strands/multiagent/test_graph.py
+++ b/strands-py/tests/strands/multiagent/test_graph.py
@@ -2267,12 +2267,16 @@ async def test_graph_cancel_node_backward_compat(cancel_node, cancel_message):
     agent.__call__.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    ("skip_node", "expected_message"),
+    [(True, "node skipped by user"), ("skip_node message", "skip_node message")],
+)
 @pytest.mark.asyncio
-async def test_graph_skip_node_takes_precedence_over_cancel_node():
-    """When both fields are set, skip_node wins, so the generic message is used rather than the cancel_node string."""
+async def test_graph_skip_node_takes_precedence_over_cancel_node(skip_node, expected_message):
+    """When both fields are set, skip_node supplies the message and cancel_node is ignored."""
 
     def skip_callback(event):
-        event.skip_node = True
+        event.skip_node = skip_node
         event.cancel_node = "cancel_node message that must not win"
         return event
 
@@ -2288,7 +2292,7 @@ async def test_graph_skip_node_takes_precedence_over_cancel_node():
         if event.get("type") == "multiagent_node_skip":
             tru_skip_event = event
 
-    exp_skip_event = MultiAgentNodeSkipEvent(node_id="test_agent", message="node skipped by user")
+    exp_skip_event = MultiAgentNodeSkipEvent(node_id="test_agent", message=expected_message)
     assert tru_skip_event == exp_skip_event
 
     assert graph.state.results["test_agent"].status == Status.SKIPPED
@@ -2298,7 +2302,7 @@ async def test_graph_skip_node_takes_precedence_over_cancel_node():
 @pytest.mark.asyncio
 async def test_graph_skip_node_downstream_executes():
     """Downstream nodes must run after an upstream node is skipped via skip_node."""
-    skipped_nodes: list[str] = []
+    skip_event_ids: list[str] = []
 
     def skip_step_a(event):
         if event.node_id == "step_a":
@@ -2316,12 +2320,22 @@ async def test_graph_skip_node_downstream_executes():
     graph = builder.build()
     graph.hooks.add_callback(BeforeNodeCallEvent, skip_step_a)
 
+    result = None
     async for event in graph.stream_async("test task"):
         if event.get("type") == "multiagent_node_skip":
-            skipped_nodes.append(event["node_id"])
+            skip_event_ids.append(event["node_id"])
+        if "result" in event:
+            result = event["result"]
 
-    assert skipped_nodes == ["step_a"]
+    assert skip_event_ids == ["step_a"]
     assert graph.state.status == Status.COMPLETED
+
+    # GraphResult counts the skip separately: completed_nodes stays "ran to success"
+    assert result is not None
+    assert result.total_nodes == 2
+    assert result.completed_nodes == 1
+    assert result.skipped_nodes == 1
+    assert result.failed_nodes == 0
     step_a.__call__.assert_not_called()
     step_b.stream_async.assert_called_once()
 

--- a/strands-py/tests/strands/multiagent/test_graph.py
+++ b/strands-py/tests/strands/multiagent/test_graph.py
@@ -2236,8 +2236,8 @@ async def test_graph_skip_node(skip_node, skip_message):
     [(True, "node skipped by user"), ("custom cancel message", "custom cancel message")],
 )
 @pytest.mark.asyncio
-async def test_graph_cancel_node_deprecated(cancel_node, cancel_message):
-    """cancel_node still works but emits a DeprecationWarning and produces a multiagent_node_skip event."""
+async def test_graph_cancel_node_backward_compat(cancel_node, cancel_message):
+    """cancel_node works as a backward-compatible alias for skip_node and produces a multiagent_node_skip event."""
 
     def cancel_callback(event):
         event.cancel_node = cancel_node
@@ -2251,10 +2251,9 @@ async def test_graph_cancel_node_deprecated(cancel_node, cancel_message):
     graph.hooks.add_callback(BeforeNodeCallEvent, cancel_callback)
 
     tru_skip_event = None
-    with pytest.warns(DeprecationWarning, match="cancel_node is deprecated"):
-        async for event in graph.stream_async("test task"):
-            if event.get("type") == "multiagent_node_skip":
-                tru_skip_event = event
+    async for event in graph.stream_async("test task"):
+        if event.get("type") == "multiagent_node_skip":
+            tru_skip_event = event
 
     exp_skip_event = MultiAgentNodeSkipEvent(node_id="test_agent", message=cancel_message)
     assert tru_skip_event == exp_skip_event
@@ -2316,8 +2315,8 @@ async def test_graph_skip_node_downstream_executes():
 
 
 @pytest.mark.asyncio
-async def test_graph_cancel_node_deprecated_downstream_executes():
-    """Deprecated cancel_node still allows downstream nodes to run; emits DeprecationWarning."""
+async def test_graph_cancel_node_backward_compat_downstream_executes():
+    """cancel_node, the backward-compatible alias for skip_node, still allows downstream nodes to run."""
     skipped_nodes: list[str] = []
 
     def cancel_step_a(event):
@@ -2336,10 +2335,9 @@ async def test_graph_cancel_node_deprecated_downstream_executes():
     graph = builder.build()
     graph.hooks.add_callback(BeforeNodeCallEvent, cancel_step_a)
 
-    with pytest.warns(DeprecationWarning, match="cancel_node is deprecated"):
-        async for event in graph.stream_async("test task"):
-            if event.get("type") == "multiagent_node_skip":
-                skipped_nodes.append(event["node_id"])
+    async for event in graph.stream_async("test task"):
+        if event.get("type") == "multiagent_node_skip":
+            skipped_nodes.append(event["node_id"])
 
     assert skipped_nodes == ["step_a"]
     assert graph.state.results["step_a"].status == Status.SKIPPED

--- a/strands-py/tests/strands/multiagent/test_graph.py
+++ b/strands-py/tests/strands/multiagent/test_graph.py
@@ -2214,20 +2214,53 @@ async def test_graph_cancel_node(cancel_node, cancel_message):
     graph = builder.build()
     graph.hooks.add_callback(BeforeNodeCallEvent, cancel_callback)
 
-    stream = graph.stream_async("test task")
-
     tru_cancel_event = None
-    with pytest.raises(RuntimeError, match=cancel_message):
-        async for event in stream:
-            if event.get("type") == "multiagent_node_cancel":
-                tru_cancel_event = event
+    async for event in graph.stream_async("test task"):
+        if event.get("type") == "multiagent_node_cancel":
+            tru_cancel_event = event
 
     exp_cancel_event = MultiAgentNodeCancelEvent(node_id="test_agent", message=cancel_message)
     assert tru_cancel_event == exp_cancel_event
 
-    tru_status = graph.state.status
-    exp_status = Status.FAILED
-    assert tru_status == exp_status
+    assert graph.state.status == Status.COMPLETED
+    assert any(n.node_id == "test_agent" for n in graph.state.completed_nodes)
+    assert "test_agent" in graph.state.results
+    agent.__call__.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_graph_cancel_node_downstream_executes():
+    """Downstream nodes must run after an upstream node is skipped via cancel_node."""
+    cancelled_nodes: list[str] = []
+
+    def cancel_step_a(event):
+        if event.node_id == "step_a":
+            event.cancel_node = "step_a skipped"
+        return event
+
+    step_a = create_mock_agent("step_a", "Should not run")
+    step_b = create_mock_agent("step_b", "Step B completed")
+
+    builder = GraphBuilder()
+    builder.add_node(step_a, "step_a")
+    builder.add_node(step_b, "step_b")
+    builder.add_edge("step_a", "step_b")
+    builder.set_entry_point("step_a")
+    graph = builder.build()
+    graph.hooks.add_callback(BeforeNodeCallEvent, cancel_step_a)
+
+    async for event in graph.stream_async("test task"):
+        if event.get("type") == "multiagent_node_cancel":
+            cancelled_nodes.append(event["node_id"])
+
+    assert cancelled_nodes == ["step_a"]
+    assert graph.state.status == Status.COMPLETED
+    step_a.__call__.assert_not_called()
+    step_b.__call__.assert_not_called()  # stream_async uses stream_async on agent, not __call__
+    assert any(n.node_id == "step_a" for n in graph.state.completed_nodes)
+    assert any(n.node_id == "step_b" for n in graph.state.completed_nodes)
+    assert "step_a" in graph.state.results
+    assert "step_b" in graph.state.results
 
 
 def test_graph_interrupt_on_before_node_call_event(interrupt_hook):

--- a/strands-py/tests/strands/multiagent/test_graph.py
+++ b/strands-py/tests/strands/multiagent/test_graph.py
@@ -2228,7 +2228,7 @@ async def test_graph_skip_node(skip_node, skip_message):
     assert graph.state.results["test_agent"].status == Status.SKIPPED
     skipped_node = next(node for node in graph.state.completed_nodes if node.node_id == "test_agent")
     assert skipped_node.execution_status == Status.SKIPPED
-    agent.__call__.assert_not_called()
+    agent.stream_async.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -2264,7 +2264,7 @@ async def test_graph_cancel_node_backward_compat(cancel_node, cancel_message):
     assert graph.state.results["test_agent"].status == Status.SKIPPED
     skipped_node = next(node for node in graph.state.completed_nodes if node.node_id == "test_agent")
     assert skipped_node.execution_status == Status.SKIPPED
-    agent.__call__.assert_not_called()
+    agent.stream_async.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -2300,7 +2300,7 @@ async def test_graph_skip_node_precedence_over_cancel_node(skip_node, cancel_nod
     assert tru_skip_event == exp_skip_event
 
     assert graph.state.results["test_agent"].status == Status.SKIPPED
-    agent.__call__.assert_not_called()
+    agent.stream_async.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -2340,7 +2340,7 @@ async def test_graph_skip_node_downstream_executes():
     assert result.completed_nodes == 1
     assert result.skipped_nodes == 1
     assert result.failed_nodes == 0
-    step_a.__call__.assert_not_called()
+    step_a.stream_async.assert_not_called()
     step_b.stream_async.assert_called_once()
 
     assert any(node.node_id == "step_a" for node in graph.state.completed_nodes)

--- a/strands-py/tests/strands/multiagent/test_graph.py
+++ b/strands-py/tests/strands/multiagent/test_graph.py
@@ -3727,3 +3727,60 @@ async def test_graph_conditional_edge_from_skipped_node():
     assert result.status == Status.COMPLETED
     assert "step_b" not in graph.state.results
     assert graph.state.results["step_c"].status == Status.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_graph_skipped_node_counts_toward_max_node_executions():
+    """A skipped node still counts toward max_node_executions, which bounds traversal rather than work done."""
+
+    def skip_step_a(event):
+        if event.node_id == "step_a":
+            event.skip_node = "step_a skipped"
+        return event
+
+    builder = GraphBuilder()
+    builder.add_node(create_mock_agent("step_a", "Should not run"), "step_a")
+    builder.add_node(create_mock_agent("step_b", "Step B completed"), "step_b")
+    builder.add_edge("step_a", "step_b")
+    builder.set_entry_point("step_a")
+    builder.set_max_node_executions(1)
+    graph = builder.build()
+    graph.hooks.add_callback(BeforeNodeCallEvent, skip_step_a)
+
+    result = await graph.invoke_async("test task")
+
+    assert result.status == Status.FAILED
+    assert "step_b" not in graph.state.results
+    assert [node.node_id for node in graph.state.execution_order] == ["step_a"]
+
+
+@pytest.mark.asyncio
+async def test_graph_nested_graph_with_only_skipped_nodes_leaves_no_header():
+    """A nested graph whose nodes were all skipped contributes no orphaned "From <node>:" header downstream."""
+
+    def skip_inner(event):
+        if event.node_id == "inner_step":
+            event.skip_node = "inner_step skipped"
+        return event
+
+    inner_builder = GraphBuilder()
+    inner_builder.add_node(create_mock_agent("inner_step", "Should not run"), "inner_step")
+    inner_builder.set_entry_point("inner_step")
+    inner_graph = inner_builder.build()
+    inner_graph.hooks.add_callback(BeforeNodeCallEvent, skip_inner)
+
+    downstream = create_mock_agent("downstream", "Downstream completed")
+
+    builder = GraphBuilder()
+    builder.add_node(inner_graph, "inner")
+    builder.add_node(downstream, "downstream")
+    builder.add_edge("inner", "downstream")
+    builder.set_entry_point("inner")
+    graph = builder.build()
+
+    result = await graph.invoke_async("test task")
+
+    assert result.status == Status.COMPLETED
+    downstream_input = downstream.stream_async.call_args.args[0]
+    assert len(downstream_input) == 1
+    assert downstream_input[0]["text"] == "test task"

--- a/strands-py/tests/strands/multiagent/test_graph.py
+++ b/strands-py/tests/strands/multiagent/test_graph.py
@@ -2302,13 +2302,13 @@ async def test_graph_skip_node_downstream_executes():
     assert "step_a" in graph.state.results
     assert "step_b" in graph.state.results
 
-    # step_a was skipped — its NodeResult must carry Status.SKIPPED, not COMPLETED
+    # step_a was skipped, so its NodeResult must carry Status.SKIPPED, not COMPLETED
     assert graph.state.results["step_a"].status == Status.SKIPPED
     assert graph.state.results["step_b"].status == Status.COMPLETED
     skipped_node = next(node for node in graph.state.completed_nodes if node.node_id == "step_a")
     assert skipped_node.execution_status == Status.SKIPPED
 
-    # step_b must receive only the original task — no orphaned "From step_a:" header
+    # step_b must receive only the original task, with no orphaned "From step_a:" header
     step_b_input = step_b.stream_async.call_args.args[0]
     assert len(step_b_input) == 1
     assert step_b_input[0]["text"] == "test task"

--- a/strands-py/tests/strands/multiagent/test_graph.py
+++ b/strands-py/tests/strands/multiagent/test_graph.py
@@ -2268,16 +2268,20 @@ async def test_graph_cancel_node_backward_compat(cancel_node, cancel_message):
 
 
 @pytest.mark.parametrize(
-    ("skip_node", "expected_message"),
-    [(True, "node skipped by user"), ("skip_node message", "skip_node message")],
+    ("skip_node", "cancel_node", "expected_message"),
+    [
+        (True, "cancel_node message", "node skipped by user"),
+        ("skip_node message", "cancel_node message", "skip_node message"),
+        (False, "cancel_node message", "cancel_node message"),
+    ],
 )
 @pytest.mark.asyncio
-async def test_graph_skip_node_takes_precedence_over_cancel_node(skip_node, expected_message):
-    """When both fields are set, skip_node supplies the message and cancel_node is ignored."""
+async def test_graph_skip_node_precedence_over_cancel_node(skip_node, cancel_node, expected_message):
+    """A truthy skip_node supplies the message; cancel_node is only consulted when skip_node is falsy."""
 
     def skip_callback(event):
         event.skip_node = skip_node
-        event.cancel_node = "cancel_node message that must not win"
+        event.cancel_node = cancel_node
         return event
 
     agent = create_mock_agent("test_agent", "Should not execute")

--- a/strands-py/tests/strands/multiagent/test_graph.py
+++ b/strands-py/tests/strands/multiagent/test_graph.py
@@ -2225,6 +2225,9 @@ async def test_graph_cancel_node(cancel_node, cancel_message):
     assert graph.state.status == Status.COMPLETED
     assert any(n.node_id == "test_agent" for n in graph.state.completed_nodes)
     assert "test_agent" in graph.state.results
+    assert graph.state.results["test_agent"].status == Status.SKIPPED
+    skipped_node = next(n for n in graph.state.completed_nodes if n.node_id == "test_agent")
+    assert skipped_node.execution_status == Status.SKIPPED
     agent.__call__.assert_not_called()
 
 
@@ -2249,18 +2252,38 @@ async def test_graph_cancel_node_downstream_executes():
     graph = builder.build()
     graph.hooks.add_callback(BeforeNodeCallEvent, cancel_step_a)
 
+    graph_result = None
     async for event in graph.stream_async("test task"):
         if event.get("type") == "multiagent_node_cancel":
             cancelled_nodes.append(event["node_id"])
+        elif event.get("type") == "multiagent_result":
+            graph_result = event["result"]
 
     assert cancelled_nodes == ["step_a"]
     assert graph.state.status == Status.COMPLETED
     step_a.__call__.assert_not_called()
-    step_b.__call__.assert_not_called()  # stream_async uses stream_async on agent, not __call__
+    step_b.stream_async.assert_called_once()
+
     assert any(n.node_id == "step_a" for n in graph.state.completed_nodes)
     assert any(n.node_id == "step_b" for n in graph.state.completed_nodes)
     assert "step_a" in graph.state.results
     assert "step_b" in graph.state.results
+
+    # step_a was skipped — its NodeResult must carry Status.SKIPPED, not COMPLETED
+    assert graph.state.results["step_a"].status == Status.SKIPPED
+    assert graph.state.results["step_b"].status == Status.COMPLETED
+    skipped_node = next(n for n in graph.state.completed_nodes if n.node_id == "step_a")
+    assert skipped_node.execution_status == Status.SKIPPED
+
+    # step_b must receive only the original task — no orphaned "From step_a:" header
+    step_b_input = step_b.stream_async.call_args.args[0]
+    assert len(step_b_input) == 1
+    assert step_b_input[0]["text"] == "test task"
+
+    # GraphResult counters must separate skipped from completed
+    assert graph_result is not None
+    assert graph_result.completed_nodes == 1  # only step_b ran
+    assert graph_result.skipped_nodes == 1  # only step_a was skipped
 
 
 def test_graph_interrupt_on_before_node_call_event(interrupt_hook):

--- a/strands-py/tests/strands/multiagent/test_graph.py
+++ b/strands-py/tests/strands/multiagent/test_graph.py
@@ -3690,3 +3690,40 @@ async def test_graph_fan_in_with_one_skipped_dependency():
     step_c_input = "".join(block.get("text", "") for block in step_c.stream_async.call_args.args[0])
     assert "From step_b:" in step_c_input
     assert "From step_a:" not in step_c_input
+
+
+@pytest.mark.asyncio
+async def test_graph_conditional_edge_from_skipped_node():
+    """An edge condition that accounts for a skipped node's None result routes on it normally."""
+
+    def upstream_produced_output(state):
+        node_result = state.results.get("step_a")
+        return node_result is not None and node_result.result is not None
+
+    def upstream_was_skipped(state):
+        node_result = state.results.get("step_a")
+        return node_result is not None and node_result.result is None
+
+    def skip_step_a(event):
+        if event.node_id == "step_a":
+            event.skip_node = "step_a skipped"
+        return event
+
+    step_b = create_mock_agent("step_b", "Step B completed")
+    step_c = create_mock_agent("step_c", "Step C completed")
+
+    builder = GraphBuilder()
+    builder.add_node(create_mock_agent("step_a", "Should not run"), "step_a")
+    builder.add_node(step_b, "step_b")
+    builder.add_node(step_c, "step_c")
+    builder.add_edge("step_a", "step_b", condition=upstream_produced_output)
+    builder.add_edge("step_a", "step_c", condition=upstream_was_skipped)
+    builder.set_entry_point("step_a")
+    graph = builder.build()
+    graph.hooks.add_callback(BeforeNodeCallEvent, skip_step_a)
+
+    result = await graph.invoke_async("test task")
+
+    assert result.status == Status.COMPLETED
+    assert "step_b" not in graph.state.results
+    assert graph.state.results["step_c"].status == Status.COMPLETED

--- a/strands-py/tests/strands/multiagent/test_graph.py
+++ b/strands-py/tests/strands/multiagent/test_graph.py
@@ -2268,6 +2268,34 @@ async def test_graph_cancel_node_backward_compat(cancel_node, cancel_message):
 
 
 @pytest.mark.asyncio
+async def test_graph_skip_node_takes_precedence_over_cancel_node():
+    """When both fields are set, skip_node wins, so the generic message is used rather than the cancel_node string."""
+
+    def skip_callback(event):
+        event.skip_node = True
+        event.cancel_node = "cancel_node message that must not win"
+        return event
+
+    agent = create_mock_agent("test_agent", "Should not execute")
+    builder = GraphBuilder()
+    builder.add_node(agent, "test_agent")
+    builder.set_entry_point("test_agent")
+    graph = builder.build()
+    graph.hooks.add_callback(BeforeNodeCallEvent, skip_callback)
+
+    tru_skip_event = None
+    async for event in graph.stream_async("test task"):
+        if event.get("type") == "multiagent_node_skip":
+            tru_skip_event = event
+
+    exp_skip_event = MultiAgentNodeSkipEvent(node_id="test_agent", message="node skipped by user")
+    assert tru_skip_event == exp_skip_event
+
+    assert graph.state.results["test_agent"].status == Status.SKIPPED
+    agent.__call__.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_graph_skip_node_downstream_executes():
     """Downstream nodes must run after an upstream node is skipped via skip_node."""
     skipped_nodes: list[str] = []

--- a/strands-py/tests/strands/multiagent/test_graph.py
+++ b/strands-py/tests/strands/multiagent/test_graph.py
@@ -13,7 +13,7 @@ from strands.multiagent.base import MultiAgentBase, MultiAgentResult, NodeResult
 from strands.multiagent.graph import Graph, GraphBuilder, GraphEdge, GraphNode, GraphResult, GraphState, Status
 from strands.session.file_session_manager import FileSessionManager
 from strands.session.session_manager import SessionManager
-from strands.types._events import MultiAgentNodeCancelEvent
+from strands.types._events import MultiAgentNodeSkipEvent
 
 
 def _make_graph(
@@ -2198,11 +2198,47 @@ async def test_graph_tracing_setup_failure_does_not_leak_timer(mock_strands_trac
 
 
 @pytest.mark.parametrize(
-    ("cancel_node", "cancel_message"),
-    [(True, "node cancelled by user"), ("custom cancel message", "custom cancel message")],
+    ("skip_node", "skip_message"),
+    [(True, "node skipped by user"), ("custom skip message", "custom skip message")],
 )
 @pytest.mark.asyncio
-async def test_graph_cancel_node(cancel_node, cancel_message):
+async def test_graph_skip_node(skip_node, skip_message):
+    def skip_callback(event):
+        event.skip_node = skip_node
+        return event
+
+    agent = create_mock_agent("test_agent", "Should not execute")
+    builder = GraphBuilder()
+    builder.add_node(agent, "test_agent")
+    builder.set_entry_point("test_agent")
+    graph = builder.build()
+    graph.hooks.add_callback(BeforeNodeCallEvent, skip_callback)
+
+    tru_skip_event = None
+    async for event in graph.stream_async("test task"):
+        if event.get("type") == "multiagent_node_skip":
+            tru_skip_event = event
+
+    exp_skip_event = MultiAgentNodeSkipEvent(node_id="test_agent", message=skip_message)
+    assert tru_skip_event == exp_skip_event
+
+    assert graph.state.status == Status.COMPLETED
+    assert any(n.node_id == "test_agent" for n in graph.state.completed_nodes)
+    assert "test_agent" in graph.state.results
+    assert graph.state.results["test_agent"].status == Status.SKIPPED
+    skipped_node = next(n for n in graph.state.completed_nodes if n.node_id == "test_agent")
+    assert skipped_node.execution_status == Status.SKIPPED
+    agent.__call__.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("cancel_node", "cancel_message"),
+    [(True, "node skipped by user"), ("custom cancel message", "custom cancel message")],
+)
+@pytest.mark.asyncio
+async def test_graph_cancel_node_deprecated(cancel_node, cancel_message):
+    """cancel_node still works but emits a DeprecationWarning and produces a multiagent_node_skip event."""
+
     def cancel_callback(event):
         event.cancel_node = cancel_node
         return event
@@ -2214,13 +2250,14 @@ async def test_graph_cancel_node(cancel_node, cancel_message):
     graph = builder.build()
     graph.hooks.add_callback(BeforeNodeCallEvent, cancel_callback)
 
-    tru_cancel_event = None
-    async for event in graph.stream_async("test task"):
-        if event.get("type") == "multiagent_node_cancel":
-            tru_cancel_event = event
+    tru_skip_event = None
+    with pytest.warns(DeprecationWarning, match="cancel_node is deprecated"):
+        async for event in graph.stream_async("test task"):
+            if event.get("type") == "multiagent_node_skip":
+                tru_skip_event = event
 
-    exp_cancel_event = MultiAgentNodeCancelEvent(node_id="test_agent", message=cancel_message)
-    assert tru_cancel_event == exp_cancel_event
+    exp_skip_event = MultiAgentNodeSkipEvent(node_id="test_agent", message=cancel_message)
+    assert tru_skip_event == exp_skip_event
 
     assert graph.state.status == Status.COMPLETED
     assert any(n.node_id == "test_agent" for n in graph.state.completed_nodes)
@@ -2232,13 +2269,13 @@ async def test_graph_cancel_node(cancel_node, cancel_message):
 
 
 @pytest.mark.asyncio
-async def test_graph_cancel_node_downstream_executes():
-    """Downstream nodes must run after an upstream node is skipped via cancel_node."""
-    cancelled_nodes: list[str] = []
+async def test_graph_skip_node_downstream_executes():
+    """Downstream nodes must run after an upstream node is skipped via skip_node."""
+    skipped_nodes: list[str] = []
 
-    def cancel_step_a(event):
+    def skip_step_a(event):
         if event.node_id == "step_a":
-            event.cancel_node = "step_a skipped"
+            event.skip_node = "step_a skipped"
         return event
 
     step_a = create_mock_agent("step_a", "Should not run")
@@ -2250,16 +2287,13 @@ async def test_graph_cancel_node_downstream_executes():
     builder.add_edge("step_a", "step_b")
     builder.set_entry_point("step_a")
     graph = builder.build()
-    graph.hooks.add_callback(BeforeNodeCallEvent, cancel_step_a)
+    graph.hooks.add_callback(BeforeNodeCallEvent, skip_step_a)
 
-    graph_result = None
     async for event in graph.stream_async("test task"):
-        if event.get("type") == "multiagent_node_cancel":
-            cancelled_nodes.append(event["node_id"])
-        elif event.get("type") == "multiagent_result":
-            graph_result = event["result"]
+        if event.get("type") == "multiagent_node_skip":
+            skipped_nodes.append(event["node_id"])
 
-    assert cancelled_nodes == ["step_a"]
+    assert skipped_nodes == ["step_a"]
     assert graph.state.status == Status.COMPLETED
     step_a.__call__.assert_not_called()
     step_b.stream_async.assert_called_once()
@@ -2280,10 +2314,36 @@ async def test_graph_cancel_node_downstream_executes():
     assert len(step_b_input) == 1
     assert step_b_input[0]["text"] == "test task"
 
-    # GraphResult counters must separate skipped from completed
-    assert graph_result is not None
-    assert graph_result.completed_nodes == 1  # only step_b ran
-    assert graph_result.skipped_nodes == 1  # only step_a was skipped
+
+@pytest.mark.asyncio
+async def test_graph_cancel_node_deprecated_downstream_executes():
+    """Deprecated cancel_node still allows downstream nodes to run; emits DeprecationWarning."""
+    skipped_nodes: list[str] = []
+
+    def cancel_step_a(event):
+        if event.node_id == "step_a":
+            event.cancel_node = "step_a skipped"
+        return event
+
+    step_a = create_mock_agent("step_a", "Should not run")
+    step_b = create_mock_agent("step_b", "Step B completed")
+
+    builder = GraphBuilder()
+    builder.add_node(step_a, "step_a")
+    builder.add_node(step_b, "step_b")
+    builder.add_edge("step_a", "step_b")
+    builder.set_entry_point("step_a")
+    graph = builder.build()
+    graph.hooks.add_callback(BeforeNodeCallEvent, cancel_step_a)
+
+    with pytest.warns(DeprecationWarning, match="cancel_node is deprecated"):
+        async for event in graph.stream_async("test task"):
+            if event.get("type") == "multiagent_node_skip":
+                skipped_nodes.append(event["node_id"])
+
+    assert skipped_nodes == ["step_a"]
+    assert graph.state.results["step_a"].status == Status.SKIPPED
+    assert graph.state.results["step_b"].status == Status.COMPLETED
 
 
 def test_graph_interrupt_on_before_node_call_event(interrupt_hook):

--- a/strands-py/tests/strands/multiagent/test_swarm.py
+++ b/strands-py/tests/strands/multiagent/test_swarm.py
@@ -1336,11 +1336,48 @@ async def test_swarm_handle_handoff():
 
 
 @pytest.mark.parametrize(
-    ("cancel_node", "cancel_message"),
-    [(True, "node cancelled by user"), ("custom cancel message", "custom cancel message")],
+    ("skip_node", "skip_message"),
+    [(True, "node skipped by user"), ("custom skip message", "custom skip message")],
 )
 @pytest.mark.asyncio
-async def test_swarm_cancel_node(cancel_node, cancel_message, alist):
+async def test_swarm_skip_node(skip_node, skip_message, alist):
+    def skip_callback(event):
+        event.skip_node = skip_node
+        return event
+
+    agent = create_mock_agent("test_agent", "Should not execute")
+    swarm = Swarm([agent])
+    swarm.hooks.add_callback(BeforeNodeCallEvent, skip_callback)
+
+    stream = swarm.stream_async("test task")
+
+    tru_events = await alist(stream)
+    exp_events = [
+        {
+            "message": skip_message,
+            "node_id": "test_agent",
+            "type": "multiagent_node_skip",
+        },
+        {
+            "result": ANY,
+            "type": "multiagent_result",
+        },
+    ]
+    assert tru_events == exp_events
+
+    tru_status = swarm.state.completion_status
+    exp_status = Status.FAILED
+    assert tru_status == exp_status
+
+
+@pytest.mark.parametrize(
+    ("cancel_node", "cancel_message"),
+    [(True, "node skipped by user"), ("custom cancel message", "custom cancel message")],
+)
+@pytest.mark.asyncio
+async def test_swarm_cancel_node_deprecated(cancel_node, cancel_message, alist):
+    """Deprecated cancel_node still works but emits DeprecationWarning and produces multiagent_node_skip."""
+
     def cancel_callback(event):
         event.cancel_node = cancel_node
         return event
@@ -1349,14 +1386,14 @@ async def test_swarm_cancel_node(cancel_node, cancel_message, alist):
     swarm = Swarm([agent])
     swarm.hooks.add_callback(BeforeNodeCallEvent, cancel_callback)
 
-    stream = swarm.stream_async("test task")
+    with pytest.warns(DeprecationWarning, match="cancel_node is deprecated"):
+        tru_events = await alist(swarm.stream_async("test task"))
 
-    tru_events = await alist(stream)
     exp_events = [
         {
             "message": cancel_message,
             "node_id": "test_agent",
-            "type": "multiagent_node_cancel",
+            "type": "multiagent_node_skip",
         },
         {
             "result": ANY,

--- a/strands-py/tests/strands/multiagent/test_swarm.py
+++ b/strands-py/tests/strands/multiagent/test_swarm.py
@@ -1375,8 +1375,8 @@ async def test_swarm_skip_node(skip_node, skip_message, alist):
     [(True, "node skipped by user"), ("custom cancel message", "custom cancel message")],
 )
 @pytest.mark.asyncio
-async def test_swarm_cancel_node_deprecated(cancel_node, cancel_message, alist):
-    """Deprecated cancel_node still works but emits DeprecationWarning and produces multiagent_node_skip."""
+async def test_swarm_cancel_node_backward_compat(cancel_node, cancel_message, alist):
+    """cancel_node works as a backward-compatible alias for skip_node and produces multiagent_node_skip."""
 
     def cancel_callback(event):
         event.cancel_node = cancel_node
@@ -1386,8 +1386,7 @@ async def test_swarm_cancel_node_deprecated(cancel_node, cancel_message, alist):
     swarm = Swarm([agent])
     swarm.hooks.add_callback(BeforeNodeCallEvent, cancel_callback)
 
-    with pytest.warns(DeprecationWarning, match="cancel_node is deprecated"):
-        tru_events = await alist(swarm.stream_async("test task"))
+    tru_events = await alist(swarm.stream_async("test task"))
 
     exp_events = [
         {

--- a/strands-py/tests_integ/hooks/multiagent/test_cancel.py
+++ b/strands-py/tests_integ/hooks/multiagent/test_cancel.py
@@ -4,7 +4,7 @@ from strands import Agent
 from strands.hooks import BeforeNodeCallEvent, HookProvider
 from strands.multiagent import GraphBuilder, Swarm
 from strands.multiagent.base import Status
-from strands.types._events import MultiAgentNodeCancelEvent
+from strands.types._events import MultiAgentNodeSkipEvent
 
 
 @pytest.fixture
@@ -49,15 +49,15 @@ def graph(cancel_hook, info_agent, weather_agent):
 
 @pytest.mark.asyncio
 async def test_swarm_cancel_node(swarm):
-    tru_cancel_event = None
+    tru_skip_event = None
     async for event in swarm.stream_async("What is the weather"):
-        if event.get("type") == "multiagent_node_cancel":
-            tru_cancel_event = event
+        if event.get("type") == "multiagent_node_skip":
+            tru_skip_event = event
 
     multiagent_result = event["result"]
 
-    exp_cancel_event = MultiAgentNodeCancelEvent(node_id="weather", message="test cancel")
-    assert tru_cancel_event == exp_cancel_event
+    exp_skip_event = MultiAgentNodeSkipEvent(node_id="weather", message="test cancel")
+    assert tru_skip_event == exp_skip_event
 
     tru_status = multiagent_result.status
     exp_status = Status.FAILED
@@ -71,17 +71,16 @@ async def test_swarm_cancel_node(swarm):
 
 @pytest.mark.asyncio
 async def test_graph_cancel_node(graph):
-    tru_cancel_event = None
-    with pytest.raises(RuntimeError, match="test cancel"):
-        async for event in graph.stream_async("What is the weather"):
-            if event.get("type") == "multiagent_node_cancel":
-                tru_cancel_event = event
+    tru_skip_event = None
+    async for event in graph.stream_async("What is the weather"):
+        if event.get("type") == "multiagent_node_skip":
+            tru_skip_event = event
 
-    exp_cancel_event = MultiAgentNodeCancelEvent(node_id="weather", message="test cancel")
-    assert tru_cancel_event == exp_cancel_event
+    exp_skip_event = MultiAgentNodeSkipEvent(node_id="weather", message="test cancel")
+    assert tru_skip_event == exp_skip_event
 
     state = graph.state
 
     tru_status = state.status
-    exp_status = Status.FAILED
+    exp_status = Status.COMPLETED
     assert tru_status == exp_status

--- a/strands-py/tests_integ/interrupts/multiagent/test_hook.py
+++ b/strands-py/tests_integ/interrupts/multiagent/test_hook.py
@@ -166,15 +166,15 @@ async def test_swarm_interrupt_reject(swarm):
             },
         },
     ]
-    tru_cancel_id = None
+    tru_skip_id = None
     async for event in swarm.stream_async(responses):
-        if event.get("type") == "multiagent_node_cancel":
-            tru_cancel_id = event["node_id"]
+        if event.get("type") == "multiagent_node_skip":
+            tru_skip_id = event["node_id"]
 
     multiagent_result = event["result"]
 
-    exp_cancel_id = "weather"
-    assert tru_cancel_id == exp_cancel_id
+    exp_skip_id = "weather"
+    assert tru_skip_id == exp_skip_id
 
     tru_status = multiagent_result.status
     exp_status = Status.FAILED
@@ -287,17 +287,14 @@ async def test_graph_interrupt_reject(graph):
         },
     ]
 
-    try:
-        async for event in graph.stream_async(responses):
-            if event.get("type") == "multiagent_node_cancel":
-                tru_cancel_id = event["node_id"]
+    tru_skip_id = None
+    async for event in graph.stream_async(responses):
+        if event.get("type") == "multiagent_node_skip":
+            tru_skip_id = event["node_id"]
 
-    except RuntimeError as e:
-        assert "node rejected" in str(e)
-
-    exp_cancel_id = "weather"
-    assert tru_cancel_id == exp_cancel_id
+    exp_skip_id = "weather"
+    assert tru_skip_id == exp_skip_id
 
     tru_state_status = graph.state.status
-    exp_state_status = Status.FAILED
+    exp_state_status = Status.COMPLETED
     assert tru_state_status == exp_state_status


### PR DESCRIPTION
## Description

A `BeforeNodeCallEvent` hook that set `cancel_node` did not skip the node, it killed the graph. The graph raised `RuntimeError`, every downstream node was abandoned, and the state persisted as `FAILED`. Resuming that session raised again, so the run could not be recovered. Users reaching for `cancel_node` want the opposite: drop one node and carry on with the rest of the graph.

This adds `Status.SKIPPED`. A skipped node records `SKIPPED` with `result=None`, joins `completed_nodes` so its dependents become ready, and the graph keeps running. Nothing raises. The hook field is renamed `skip_node` to say what it actually does, and `cancel_node` keeps working as an alias.

`yananym` proposed the split this PR implements, that a skip and an abort are different operations deserving different statuses, and argued for keeping `cancel_node` undeprecated. `JackYPCOnline` caught the leftover `cancel_message` naming and the swarm/graph asymmetry.

### Public API Changes

```python
# Before: the hook killed the graph
class ApprovalHook(HookProvider):
    def on_before_node_call(self, event: BeforeNodeCallEvent) -> None:
        if not approved(event):
            event.cancel_node = "not approved"   # RuntimeError, whole graph FAILED

# After: the node is skipped, downstream still runs
class ApprovalHook(HookProvider):
    def on_before_node_call(self, event: BeforeNodeCallEvent) -> None:
        if not approved(event):
            event.skip_node = "not approved"

result = graph("...")
result.results["cleanup"].status        # Status.SKIPPED
result.results["cleanup"].result        # None
result.skipped_nodes                    # 1
```

`Status.SKIPPED` is new. `GraphResult.skipped_nodes` is new. `NodeResult.result` now permits `None`. Both new fields are appended last in their dataclasses so no positional argument shifts.

In a swarm, a skip still ends the sequence and the result carries `Status.FAILED`, because each swarm node builds on the previous node's output. Only the graph continues.

### Breaking Changes

The Python API is additive: `skip_node` is new, `cancel_node` still works, and `MultiAgentNodeCancelEvent` is still exported. What changes is observable behavior.

`"multiagent_node_cancel"` is no longer emitted. `"multiagent_node_skip"` takes its place, so a stream filter on the old string silently stops matching.

```python
# Before
if event.get("type") == "multiagent_node_cancel": ...

# After
if event.get("type") == "multiagent_node_skip": ...
```

`GraphResult.completed_nodes` no longer counts a skipped node. A two-node graph with one skip now reports `completed_nodes=1, skipped_nodes=1` where it previously reported `2`.

Code that caught `RuntimeError` around a skipped node no longer sees it, because nothing raises.

Sessions are forward-only. A session written here with a skipped node cannot be read by a pre-PR deployment: `NodeResult.from_dict` rejects the payload at its unknown-type branch. It fails loudly rather than corrupting state, but an in-flight graph resumed on an older worker mid-rollout will crash rather than degrade.

## Related Issues

Resolves #2240
Resolves #1500

#1524 took the other available reading of #1500, aligning graph with swarm by setting the whole graph to `FAILED` and stopping. It was closed unmerged. That reading answers "do not raise" but not #2240's "downstream should still run", which is why this goes the skip-and-continue route instead. Happy to be redirected if the maintainers prefer the #1524 semantics.

## Documentation PR

Included here, since the docs live in this repo. `interrupts.mdx` and `multi-agent/graph.mdx` both used `event.cancel_node` and both ended their examples on an expression that breaks once a skipped node stores `result=None`. Updated to `skip_node`, with the examples branching on the new status.

## Type of Change

Breaking change

## Testing

Unit tests cover the skip path, downstream execution, `skip_node`/`cancel_node` precedence, fan-in with a skipped dependency, conditional edges out of a skipped node, resume alongside an interrupted sibling, and session round-trip.

Two tests in `tests_integ` filtered the stream for the removed event string and are fixed here. `pyproject.toml` sets `testpaths = ["tests"]`, so `hatch test` never reaches `tests_integ` and the integration workflow is maintainer-gated. Those two need real model credentials, so I have confirmed they collect and lint but have not executed them.

- [ ] I ran `hatch run prepare`

`hatch run prepare` shells out to a POSIX script and does not run on Windows. The individual steps it wraps were run directly instead.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
