### PR TITLE
feat(session): add put_object_kwargs support to S3SessionManager

### DIFF
--- a/src/strands/session/s3_session_manager.py
+++ b/src/strands/session/s3_session_manager.py
@@ -64,9 +64,15 @@ class S3SessionManager(RepositorySessionManager, SessionRepository):
             boto_client_config: Optional boto3 client configuration
             region_name: AWS region for S3 storage
             **kwargs: Additional keyword arguments for future extensibility.
+                put_object_kwargs: Optional dictionary of additional keyword arguments
+                    to pass to all S3 put_object calls. Useful for configuring server-side
+                    encryption (SSE-KMS), storage class, tagging, or other S3 PutObject
+                    parameters. Example: {"ServerSideEncryption": "aws:kms",
+                    "SSEKMSKeyId": "arn:aws:kms:..."}
         """
         self.bucket = bucket
         self.prefix = prefix
+        self.put_object_kwargs: dict[str, Any] = kwargs.get("put_object_kwargs") or {}
 
         session = boto_session or boto3.Session(region_name=region_name)
 
@@ -152,9 +158,14 @@ class S3SessionManager(RepositorySessionManager, SessionRepository):
         """Write JSON object to S3."""
         try:
             content = json.dumps(data, indent=2, ensure_ascii=False)
-            self.client.put_object(
-                Bucket=self.bucket, Key=key, Body=content.encode("utf-8"), ContentType="application/json"
-            )
+            put_params: dict[str, Any] = {
+                "Bucket": self.bucket,
+                "Key": key,
+                "Body": content.encode("utf-8"),
+                "ContentType": "application/json",
+                **self.put_object_kwargs,
+            }
+            self.client.put_object(**put_params)
         except ClientError as e:
             raise SessionException(f"Failed to write S3 object {key}: {e}") from e
 

--- a/tests/strands/session/test_s3_session_manager.py
+++ b/tests/strands/session/test_s3_session_manager.py
@@ -510,3 +510,53 @@ def test_update_nonexistent_multi_agent(s3_manager, sample_session):
     nonexistent_mock.id = "nonexistent"
     with pytest.raises(SessionException):
         s3_manager.update_multi_agent(sample_session.session_id, nonexistent_mock)
+
+
+def test_init_with_put_object_kwargs(mocked_aws, s3_bucket):
+    """Test that put_object_kwargs is stored as an instance variable."""
+    kwargs = {"ServerSideEncryption": "aws:kms", "SSEKMSKeyId": "arn:aws:kms:us-east-1:123456789012:key/test-key"}
+    manager = S3SessionManager(session_id="test", bucket=s3_bucket, region_name="us-west-2", put_object_kwargs=kwargs)
+    assert manager.put_object_kwargs == kwargs
+
+
+def test_init_without_put_object_kwargs(mocked_aws, s3_bucket):
+    """Test that put_object_kwargs defaults to empty dict when not provided."""
+    manager = S3SessionManager(session_id="test", bucket=s3_bucket, region_name="us-west-2")
+    assert manager.put_object_kwargs == {}
+
+
+def test_put_object_kwargs_passed_to_s3(mocked_aws, s3_bucket, sample_session):
+    """Test that put_object_kwargs are forwarded to S3 put_object calls."""
+    manager = S3SessionManager(
+        session_id="test",
+        bucket=s3_bucket,
+        prefix="sessions/",
+        region_name="us-west-2",
+        put_object_kwargs={"ServerSideEncryption": "AES256"},
+    )
+
+    # Create a session — this calls _write_s3_object internally
+    manager.create_session(sample_session)
+
+    # Verify the session was written successfully (proves put_object didn't fail)
+    result = manager.read_session(sample_session.session_id)
+    assert result is not None
+    assert result.session_id == sample_session.session_id
+
+
+def test_put_object_kwargs_with_storage_class(mocked_aws, s3_bucket, sample_session):
+    """Test put_object_kwargs with StorageClass parameter."""
+    manager = S3SessionManager(
+        session_id="test",
+        bucket=s3_bucket,
+        prefix="sessions/",
+        region_name="us-west-2",
+        put_object_kwargs={"StorageClass": "STANDARD_IA"},
+    )
+
+    manager.create_session(sample_session)
+
+    # Verify session was created successfully
+    result = manager.read_session(sample_session.session_id)
+    assert result is not None
+    assert result.session_id == sample_session.session_id


### PR DESCRIPTION
## Description

Adds support for passing custom parameters to S3 `put_object` calls in `S3SessionManager`. This enables configuring server-side encryption (SSE-KMS), storage class, tagging, and other S3 PutObject parameters when storing session data.

## Changes

- Added `put_object_kwargs` extraction from `**kwargs` in `S3SessionManager.__init__()`
- Updated `_write_s3_object()` to spread `put_object_kwargs` into all `put_object` calls
- Added 4 unit tests covering initialization and S3 write behavior

## Usage

```python
from strands.session import S3SessionManager

session_manager = S3SessionManager(
    session_id="my-session",
    bucket="my-bucket",
    put_object_kwargs={
        "ServerSideEncryption": "aws:kms",
        "SSEKMSKeyId": "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
    }
)
```

## Design Decision

Following the maintainer's guidance in #1247, `put_object_kwargs` is passed via `**kwargs` and stored as an instance variable. This approach:
- Is backwards-compatible (no signature change)
- Follows the existing extensibility pattern (`**kwargs` already accepted)
- Scales with the S3 PutObject API without needing individual parameters

## Testing

- All 50 existing S3SessionManager tests pass
- 4 new tests added covering:
  - Initialization with `put_object_kwargs`
  - Default empty dict when not provided
  - Successful S3 writes with encryption params
  - Successful S3 writes with StorageClass param

Closes #1247