### PR TITLE
feat(bedrock): add request_metadata for per-request cost attribution

### DIFF
--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -119,7 +119,8 @@ class BedrockModel(Model):
             temperature: Controls randomness in generation (higher = more random)
             top_p: Controls diversity via nucleus sampling (alternative to temperature)
             request_metadata: Key-value metadata to attach to the request for cost tracking and attribution.
-                Appears in model invocation logs for per-request finops. Max 16 entries, keys/values max 256 chars.
+                Appears in model invocation logs for per-request finops. Max 16 entries; keys/values max 256 chars
+                and limited to letters, digits, spaces, and ":_@$#=/+,-." (e.g. "team (eng)" or "cost%" are rejected by Bedrock).
                 See https://docs.aws.amazon.com/bedrock/latest/userguide/cost-mgmt-request-metadata.html
             use_native_token_count: Whether to use the native Bedrock CountTokens API.
                 When True, count_tokens() calls the Bedrock API for accurate counts.

--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -118,6 +118,9 @@ class BedrockModel(Model):
                 See https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html
             temperature: Controls randomness in generation (higher = more random)
             top_p: Controls diversity via nucleus sampling (alternative to temperature)
+            request_metadata: Key-value metadata to attach to the request for cost tracking and attribution.
+                Appears in model invocation logs for per-request finops. Max 16 entries, keys/values max 256 chars.
+                See https://docs.aws.amazon.com/bedrock/latest/userguide/cost-mgmt-request-metadata.html
             use_native_token_count: Whether to use the native Bedrock CountTokens API.
                 When True, count_tokens() calls the Bedrock API for accurate counts.
                 When False (default), skips the API call and uses the local estimator.
@@ -141,6 +144,7 @@ class BedrockModel(Model):
         max_tokens: int | None
         model_id: str
         include_tool_result_status: Literal["auto"] | bool | None
+        request_metadata: dict[str, str] | None
         service_tier: str | None
         stop_sequences: list[str] | None
         streaming: bool | None
@@ -333,6 +337,11 @@ class BedrockModel(Model):
                 ]
                 if value is not None
             },
+            **(
+                {"requestMetadata": self.config["request_metadata"]}
+                if self.config.get("request_metadata")
+                else {}
+            ),
             **(
                 self.config["additional_args"]
                 if "additional_args" in self.config and self.config["additional_args"] is not None

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -442,6 +442,25 @@ def test_format_request_with_service_tier(model, messages, model_id):
     assert tru_request == exp_request
 
 
+def test_format_request_with_request_metadata(model, messages, model_id):
+    model.update_config(request_metadata={"team": "orchestrator", "environment": "prod"})
+    tru_request = model._format_request(messages)
+    exp_request = {
+        "inferenceConfig": {},
+        "modelId": model_id,
+        "messages": messages,
+        "requestMetadata": {"team": "orchestrator", "environment": "prod"},
+        "system": [],
+    }
+
+    assert tru_request == exp_request
+
+
+def test_format_request_without_request_metadata(model, messages, model_id):
+    tru_request = model._format_request(messages)
+    assert "requestMetadata" not in tru_request
+
+
 def test_format_request_inference_config(model, messages, model_id, inference_config):
     model.update_config(**inference_config)
     tru_request = model._format_request(messages)


### PR DESCRIPTION
## Description

Add `request_metadata` config option to `BedrockModel` that maps to the `requestMetadata` field in Converse/ConverseStream API requests.

This enables per-request finops by attaching key-value tags (e.g. team, environment, feature) that appear in model invocation logs.

Default behavior is unchanged — no metadata is sent unless explicitly configured.

## Usage

```python
model = BedrockModel(
    model_id="anthropic.claude-sonnet-4-20250514",
    request_metadata={"team": "orchestrator", "environment": "prod"}
)

# Or update per-conversation:
model.update_config(request_metadata={"team": "billing", "session_id": "abc123"})
```

## Reference

https://docs.aws.amazon.com/bedrock/latest/userguide/cost-mgmt-request-metadata.html

## What was tested

- `test_format_request_with_request_metadata` — metadata included when configured
- `test_format_request_without_request_metadata` — backward compat (no key when unset)
- Full bedrock test suite (168 tests) passes with no regressions