### PR TITLE
fix: normalize media format mappings

### DIFF
--- a/strands-py/src/strands/models/anthropic.py
+++ b/strands-py/src/strands/models/anthropic.py
@@ -28,6 +28,14 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=BaseModel)
 
+_IMAGE_MEDIA_TYPES = {
+    "gif": "image/gif",
+    "jpeg": "image/jpeg",
+    "jpg": "image/jpeg",
+    "png": "image/png",
+    "webp": "image/webp",
+}
+
 
 class AnthropicModel(Model):
     """Anthropic model provider implementation."""
@@ -131,10 +139,13 @@ class AnthropicModel(Model):
             }
 
         if "image" in content:
+            image_format = content["image"]["format"]
             return {
                 "source": {
                     "data": base64.b64encode(content["image"]["source"]["bytes"]).decode("utf-8"),
-                    "media_type": mimetypes.types_map.get(f".{content['image']['format']}", "application/octet-stream"),
+                    "media_type": _IMAGE_MEDIA_TYPES.get(
+                        image_format.lower(), mimetypes.types_map.get(f".{image_format}", "application/octet-stream")
+                    ),
                     "type": "base64",
                 },
                 "type": "image",

--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -29,6 +29,7 @@ from ..types.exceptions import (
     ModelThrottledException,
     ProviderTokenCountError,
 )
+from ..types.media import VIDEO_FORMAT_ALIASES
 from ..types.streaming import CitationsDelta, StreamEvent
 from ..types.tools import ToolChoice, ToolSpec
 from ._defaults import resolve_config_metadata
@@ -37,7 +38,6 @@ from ._validation import validate_config_keys
 from .model import BaseModelConfig, CacheConfig, CacheToolsConfig, Model
 
 logger = logging.getLogger(__name__)
-_VIDEO_FORMAT_ALIASES = {"3gp": "three_gp"}
 
 # See: `BedrockModel._get_default_model_with_warning` for why we need both
 DEFAULT_BEDROCK_MODEL_ID = "global.anthropic.claude-sonnet-4-6"
@@ -704,7 +704,7 @@ class BedrockModel(Model):
             elif "bytes" in source:
                 formatted_video_source = {"bytes": source["bytes"]}
             result = {
-                "format": _VIDEO_FORMAT_ALIASES.get(video["format"], video["format"]),
+                "format": VIDEO_FORMAT_ALIASES.get(video["format"], video["format"]),
                 "source": formatted_video_source,
             }
             return {"video": result}

--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -37,6 +37,7 @@ from ._validation import validate_config_keys
 from .model import BaseModelConfig, CacheConfig, CacheToolsConfig, Model
 
 logger = logging.getLogger(__name__)
+_VIDEO_FORMAT_ALIASES = {"3gp": "three_gp"}
 
 # See: `BedrockModel._get_default_model_with_warning` for why we need both
 DEFAULT_BEDROCK_MODEL_ID = "global.anthropic.claude-sonnet-4-6"
@@ -702,7 +703,10 @@ class BedrockModel(Model):
                     return None
             elif "bytes" in source:
                 formatted_video_source = {"bytes": source["bytes"]}
-            result = {"format": video["format"], "source": formatted_video_source}
+            result = {
+                "format": _VIDEO_FORMAT_ALIASES.get(video["format"], video["format"]),
+                "source": formatted_video_source,
+            }
             return {"video": result}
 
         # https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_CitationsContentBlock.html

--- a/strands-py/src/strands/multiagent/a2a/executor.py
+++ b/strands-py/src/strands/multiagent/a2a/executor.py
@@ -28,6 +28,7 @@ from ...agent.agent import Agent as SAAgent
 from ...agent.agent import AgentResult as SAAgentResult
 from ...types.content import ContentBlock
 from ...types.media import (
+    VIDEO_FORMAT_ALIASES,
     DocumentContent,
     DocumentSource,
     ImageContent,
@@ -51,8 +52,9 @@ class StrandsA2AExecutor(AgentExecutor):
     # Default formats for each file type when MIME type is unavailable or unrecognized
     DEFAULT_FORMATS = {"document": "txt", "image": "png", "video": "mp4", "unknown": "txt"}
 
-    # Handle special cases where format differs from extension
-    FORMAT_MAPPINGS = {"jpg": "jpeg", "htm": "html", "3gp": "three_gp", "3gpp": "three_gp", "3g2": "three_gp"}
+    # Handle special cases where format differs from extension.
+    # Video aliases are sourced from `types.media.VIDEO_FORMAT_ALIASES` so Bedrock and A2A stay in sync.
+    FORMAT_MAPPINGS = {"jpg": "jpeg", "htm": "html", **VIDEO_FORMAT_ALIASES}
 
     # A2A-compliant streaming mode
     _current_artifact_id: str | None

--- a/strands-py/src/strands/types/media.py
+++ b/strands-py/src/strands/types/media.py
@@ -107,7 +107,7 @@ class ImageContent(TypedDict):
     source: ImageSource
 
 
-VideoFormat = Literal["flv", "mkv", "mov", "mpeg", "mpg", "mp4", "three_gp", "webm", "wmv"]
+VideoFormat = Literal["flv", "mkv", "mov", "mpeg", "mpg", "mp4", "3gp", "three_gp", "webm", "wmv"]
 """Supported video formats."""
 
 

--- a/strands-py/src/strands/types/media.py
+++ b/strands-py/src/strands/types/media.py
@@ -77,8 +77,11 @@ class DocumentContent(TypedDict, total=False):
     context: str | None
 
 
-ImageFormat = Literal["png", "jpeg", "gif", "webp"]
-"""Supported image formats."""
+ImageFormat = Literal["png", "jpeg", "jpg", "gif", "webp"]
+"""Supported image formats.
+
+`jpg` is accepted as an alias for `jpeg`; providers normalize it to the canonical media type internally.
+"""
 
 
 class ImageSource(TypedDict, total=False):
@@ -107,8 +110,16 @@ class ImageContent(TypedDict):
     source: ImageSource
 
 
-VideoFormat = Literal["flv", "mkv", "mov", "mpeg", "mpg", "mp4", "3gp", "three_gp", "webm", "wmv"]
-"""Supported video formats."""
+VideoFormat = Literal["flv", "mkv", "mov", "mpeg", "mpg", "mp4", "3gp", "3gpp", "3g2", "three_gp", "webm", "wmv"]
+"""Supported video formats.
+
+Callers should pass the canonical extension (e.g. `3gp`, `3gpp`, `3g2`); providers translate to the
+Bedrock wire value `three_gp` via `VIDEO_FORMAT_ALIASES` when formatting requests. `three_gp` is
+retained for backward compatibility with callers that already pass the wire value directly.
+"""
+
+VIDEO_FORMAT_ALIASES: dict[str, str] = {"3gp": "three_gp", "3gpp": "three_gp", "3g2": "three_gp"}
+"""Canonical-extension -> provider-wire-value aliases for video formats."""
 
 
 class VideoSource(TypedDict, total=False):

--- a/strands-py/tests/strands/models/test_anthropic.py
+++ b/strands-py/tests/strands/models/test_anthropic.py
@@ -254,7 +254,7 @@ def test_format_request_with_image(model, model_id, max_tokens):
     assert tru_request == exp_request
 
 
-def test_format_request_with_webp_image_uses_explicit_media_type(model, monkeypatch):
+def test_format_request_with_webp_image_uses_explicit_media_type(model, model_id, max_tokens, monkeypatch):
     monkeypatch.delitem(strands.models.anthropic.mimetypes.types_map, ".webp", raising=False)
 
     messages = [
@@ -272,8 +272,28 @@ def test_format_request_with_webp_image_uses_explicit_media_type(model, monkeypa
     ]
 
     tru_request = model.format_request(messages)
+    exp_request = {
+        "max_tokens": max_tokens,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "source": {
+                            "data": "d2VicGltYWdl",
+                            "media_type": "image/webp",
+                            "type": "base64",
+                        },
+                        "type": "image",
+                    },
+                ],
+            },
+        ],
+        "model": model_id,
+        "tools": [],
+    }
 
-    assert tru_request["messages"][0]["content"][0]["source"]["media_type"] == "image/webp"
+    assert tru_request == exp_request
 
 
 def test_format_request_with_reasoning(model, model_id, max_tokens):

--- a/strands-py/tests/strands/models/test_anthropic.py
+++ b/strands-py/tests/strands/models/test_anthropic.py
@@ -254,6 +254,28 @@ def test_format_request_with_image(model, model_id, max_tokens):
     assert tru_request == exp_request
 
 
+def test_format_request_with_webp_image_uses_explicit_media_type(model, monkeypatch):
+    monkeypatch.delitem(strands.models.anthropic.mimetypes.types_map, ".webp", raising=False)
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "image": {
+                        "format": "webp",
+                        "source": {"bytes": b"webpimage"},
+                    },
+                },
+            ],
+        },
+    ]
+
+    tru_request = model.format_request(messages)
+
+    assert tru_request["messages"][0]["content"][0]["source"]["media_type"] == "image/webp"
+
+
 def test_format_request_with_reasoning(model, model_id, max_tokens):
     messages = [
         {

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -2254,6 +2254,27 @@ def test_format_request_video_s3_location(model, model_id):
     assert video_source == {"s3Location": {"uri": "s3://my-bucket/video.mp4"}}
 
 
+def test_format_request_video_3gp_maps_bedrock_enum(model, model_id):
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "video": {
+                        "format": "3gp",
+                        "source": {"bytes": b"video_data"},
+                    }
+                },
+            ],
+        }
+    ]
+
+    formatted_request = model._format_request(messages)
+    video_block = formatted_request["messages"][0]["content"][0]["video"]
+
+    assert video_block == {"format": "three_gp", "source": {"bytes": b"video_data"}}
+
+
 def test_format_request_filters_document_content_blocks(model, model_id):
     """Test that format_request filters extra fields from document content blocks."""
     messages = [

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -2254,14 +2254,15 @@ def test_format_request_video_s3_location(model, model_id):
     assert video_source == {"s3Location": {"uri": "s3://my-bucket/video.mp4"}}
 
 
-def test_format_request_video_3gp_maps_bedrock_enum(model, model_id):
+@pytest.mark.parametrize("input_format", ["3gp", "3gpp", "3g2"])
+def test_format_request_video_3gp_maps_bedrock_enum(model, model_id, input_format):
     messages = [
         {
             "role": "user",
             "content": [
                 {
                     "video": {
-                        "format": "3gp",
+                        "format": input_format,
                         "source": {"bytes": b"video_data"},
                     }
                 },


### PR DESCRIPTION
﻿Fixes part of #2204.

## Summary
- use explicit Anthropic image media-type mapping for common formats, including `webp`, instead of relying only on platform `mimetypes`
- accept `3gp` as a video input format alias and map it to Bedrock's `three_gp` enum value when formatting requests
- add focused regressions for WebP image MIME type and Bedrock 3GP video formatting

I kept this PR scoped to the two deterministic provider-format bugs. The broader type/guardContent expansion mentioned in the issue should be handled separately.

## To verify
- `python -m pytest tests/strands/models/test_anthropic.py::test_format_request_with_image tests/strands/models/test_anthropic.py::test_format_request_with_webp_image_uses_explicit_media_type tests/strands/models/test_bedrock.py::test_format_request_video_s3_location tests/strands/models/test_bedrock.py::test_format_request_video_3gp_maps_bedrock_enum -q`
- `python -m ruff check src/strands/models/anthropic.py src/strands/models/bedrock.py src/strands/types/media.py tests/strands/models/test_anthropic.py tests/strands/models/test_bedrock.py`
- `python -m ruff format --check src/strands/models/anthropic.py src/strands/models/bedrock.py src/strands/types/media.py tests/strands/models/test_anthropic.py tests/strands/models/test_bedrock.py`
