### PR TITLE
feat: add audio input support for Bedrock Converse API

### DIFF
--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -628,6 +628,20 @@ class BedrockModel(Model):
             result = {"format": image["format"], "source": formatted_image_source}
             return {"image": result}
 
+        # https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_AudioBlock.html
+        if "audio" in content:
+            audio = content["audio"]
+            source = audio["source"]
+            formatted_audio_source: dict[str, Any] | None
+            if "location" in source:
+                formatted_audio_source = self._handle_location(source["location"])
+                if formatted_audio_source is None:
+                    return None
+            elif "bytes" in source:
+                formatted_audio_source = {"bytes": source["bytes"]}
+            result = {"format": audio["format"], "source": formatted_audio_source}
+            return {"audio": result}
+
         # https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ReasoningContentBlock.html
         if "reasoningContent" in content:
             reasoning = content["reasoningContent"]

--- a/strands-py/src/strands/types/content.py
+++ b/strands-py/src/strands/types/content.py
@@ -12,7 +12,7 @@ from typing_extensions import NotRequired, TypedDict
 
 from .citations import CitationsContentBlock
 from .event_loop import Metrics, Usage
-from .media import DocumentContent, ImageContent, VideoContent
+from .media import AudioContent, DocumentContent, ImageContent, VideoContent
 from .tools import ToolResult, ToolUse
 
 
@@ -79,6 +79,7 @@ class ContentBlock(TypedDict, total=False):
     """A block of content for a message that you pass to, or receive from, a model.
 
     Attributes:
+        audio: Audio to include in the message.
         cachePoint: A cache point configuration to optimize conversation history.
         document: A document to include in the message.
         guardContent: Contains the content to assess with the guardrail.
@@ -91,6 +92,7 @@ class ContentBlock(TypedDict, total=False):
         citationsContent: Contains the citations for a document.
     """
 
+    audio: AudioContent
     cachePoint: CachePoint
     document: DocumentContent
     guardContent: GuardContent

--- a/strands-py/src/strands/types/media.py
+++ b/strands-py/src/strands/types/media.py
@@ -135,3 +135,35 @@ class VideoContent(TypedDict):
 
     format: VideoFormat
     source: VideoSource
+
+
+AudioFormat = Literal["mp3", "wav", "flac", "ogg", "webm"]
+"""Supported audio formats."""
+
+
+class AudioSource(TypedDict, total=False):
+    """Contains the content of an audio file.
+
+    Only one of `bytes` or `s3Location` should be specified.
+
+    Attributes:
+        bytes: The binary content of the audio.
+        location: Location of the audio.
+    """
+
+    bytes: bytes
+    location: SourceLocation
+
+
+class AudioContent(TypedDict):
+    """An audio file to include in a message.
+
+    - Docs: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_AudioBlock.html
+
+    Attributes:
+        format: The format of the audio (e.g., "mp3", "wav").
+        source: The source containing the audio's binary content.
+    """
+
+    format: AudioFormat
+    source: AudioSource

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -2337,6 +2337,104 @@ def test_format_request_filters_video_content_blocks(model, model_id):
     assert "resolution" not in video_block
 
 
+def test_format_request_audio_bytes_only(model, model_id):
+    """Test that audio with only bytes source is properly formatted."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "audio": {
+                        "format": "mp3",
+                        "source": {"bytes": b"audio_data"},
+                    }
+                }
+            ],
+        }
+    ]
+
+    formatted_request = model.format_request(messages)
+    audio_source = formatted_request["messages"][0]["content"][0]["audio"]["source"]
+
+    assert audio_source == {"bytes": b"audio_data"}
+
+
+def test_format_request_audio_s3_location(model, model_id):
+    """Test that audio with s3Location is properly formatted."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "audio": {
+                        "format": "wav",
+                        "source": {
+                            "location": {"type": "s3", "uri": "s3://my-bucket/audio.wav"},
+                        },
+                    }
+                },
+            ],
+        }
+    ]
+
+    formatted_request = model.format_request(messages)
+    audio_source = formatted_request["messages"][0]["content"][0]["audio"]["source"]
+
+    assert audio_source == {"s3Location": {"uri": "s3://my-bucket/audio.wav"}}
+
+
+def test_format_request_filters_audio_content_blocks(model, model_id):
+    """Test that format_request filters extra fields from audio content blocks."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "audio": {
+                        "format": "flac",
+                        "source": {"bytes": b"audio_data"},
+                        "duration": 30,  # Extra field that should be filtered
+                        "sampleRate": 44100,  # Extra field that should be filtered
+                    }
+                },
+            ],
+        }
+    ]
+
+    formatted_request = model.format_request(messages)
+
+    audio_block = formatted_request["messages"][0]["content"][0]["audio"]
+    expected = {"format": "flac", "source": {"bytes": b"audio_data"}}
+    assert audio_block == expected
+    assert "duration" not in audio_block
+    assert "sampleRate" not in audio_block
+
+
+def test_format_request_mixed_text_and_audio(model, model_id):
+    """Test that messages with both text and audio content are properly formatted."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"text": "Please transcribe this audio:"},
+                {
+                    "audio": {
+                        "format": "mp3",
+                        "source": {"bytes": b"audio_data"},
+                    }
+                },
+            ],
+        }
+    ]
+
+    formatted_request = model.format_request(messages)
+    content = formatted_request["messages"][0]["content"]
+
+    assert len(content) == 2
+    assert content[0] == {"text": "Please transcribe this audio:"}
+    assert content[1] == {"audio": {"format": "mp3", "source": {"bytes": b"audio_data"}}}
+
+
 def test_format_request_filters_cache_point_content_blocks(model, model_id):
     """Test that format_request filters extra fields from cachePoint content blocks."""
     messages = [


### PR DESCRIPTION
## Description
Related to #2629 (audio input support)

Add AudioBlock support to the Strands SDK, enabling agents to process audio input through the Bedrock Converse API. This is foundational infrastructure for voice agent use cases with AgentCore Runtime bidirectional streaming.

## Changes

### Types Layer
- **types/media.py**: Added AudioFormat, AudioSource, and AudioContent types following the established pattern of ImageContent/VideoContent`n- **types/content.py**: Added udio: AudioContent field to the ContentBlock TypedDict

### Model Layer
- **models/bedrock.py**: Added audio content block handling in _format_request_message_content(), supporting both bytes and S3 location sources (matching the image/video pattern)

### Tests
- 	est_format_request_audio_bytes_only — Audio with bytes source
- 	est_format_request_audio_s3_location — Audio with S3 location source
- 	est_format_request_filters_audio_content_blocks — Extra fields properly filtered
- 	est_format_request_mixed_text_and_audio — Multi-modal text+audio messages

## References
- [Bedrock AudioBlock API](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_AudioBlock.html)
- [AgentCore bidirectional streaming announcement](https://aws.amazon.com/blogs/aws/amazon-bedrock-agentcore/)

## Testing
All 4 new tests follow the existing patterns for image and video content blocks. The implementation mirrors the exact structure used for ImageContent and VideoContent to ensure consistency.