### PR TITLE
docs: add CloudWatch trace export examples (ADOT collector + direct OTLP)

### DIFF
--- a/site/src/config/navigation.yml
+++ b/site/src/config/navigation.yml
@@ -283,6 +283,7 @@ sidebar:
       - docs/examples/python/meta_tooling
       - docs/examples/python/mcp_calculator
       - docs/examples/python/multimodal
+      - docs/examples/cloudwatch_traces
 
   - label: Community
     items:

--- a/site/src/content/docs/examples/README.mdx
+++ b/site/src/content/docs/examples/README.mdx
@@ -35,6 +35,12 @@ A collection of sample implementations to help you get started with Strands Agen
 | [Multimodal](python/multimodal.md) | Multimodal capabilities | ✅ | |
 | [Weather Forecaster](python/weather_forecaster.md) | Weather forecasting agent | ✅ | |
 
+## Observability Examples
+
+| Example | Description | Python | TypeScript |
+|---------|-------------|:------:|:----------:|
+| [CloudWatch Traces](cloudwatch_traces.md) | Export traces to CloudWatch via ADOT Collector or direct OTLP | ✅ | |
+
 ## Deployment Examples
 
 Also see [Operating Agents in Production](../user-guide/deploy/operating-agents-in-production.md) for best practices on security, monitoring, and scaling.

--- a/site/src/content/docs/examples/cloudwatch_traces.mdx
+++ b/site/src/content/docs/examples/cloudwatch_traces.mdx
@@ -1,0 +1,95 @@
+---
+title: CloudWatch Trace Export Example
+sidebar:
+  label: "CloudWatch Traces"
+---
+
+Strands emits OpenTelemetry traces, and CloudWatch can receive them. This example walks through both ways to connect the two: through an OpenTelemetry Collector, or by exporting straight from your agent to CloudWatch Transaction Search.
+
+For general tracing concepts and configuration options, see [Traces](../user-guide/observability-evaluation/traces.md).
+
+## Choosing a route
+
+| Route | When to use |
+|-------|-------------|
+| [ADOT Collector](#route-1-through-the-adot-collector) | You run on EC2, ECS, EKS, or Lambda and want one agent to batch traces — and CloudWatch metrics — from several services. |
+| [Direct OTLP](#route-2-direct-otlp-to-cloudwatch-transaction-search) | You want to skip the collector and have Strands export traces straight to CloudWatch. |
+
+## Route 1: Through the ADOT Collector
+
+Run the [AWS Distro for OpenTelemetry (ADOT) Collector](https://aws-otel.github.io/docs/getting-started/x-ray#configuring-the-aws-x-ray-exporter) next to your agent and have Strands export OTLP to it. The collector forwards spans to X-Ray, so your agent process never handles AWS credentials directly.
+
+### Configure the collector
+
+A minimal collector config that sends traces to X-Ray and metrics to CloudWatch (EMF):
+
+```yaml
+# otel-collector-config.yaml
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  batch:
+
+exporters:
+  awsxray:
+    region: us-east-1
+  awsemf:
+    region: us-east-1
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [awsxray]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [awsemf]
+```
+
+The collector uses the standard AWS credential chain (instance role, task role, or environment variables), so grant it an IAM policy allowing `xray:PutTraceSegments` and `xray:PutTelemetryRecords`. See the [ADOT X-Ray exporter docs](https://aws-otel.github.io/docs/getting-started/x-ray#configuring-the-aws-x-ray-exporter) for the full permission set and deployment options.
+
+### Point Strands at the collector
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318"
+```
+
+Then enable the OTLP exporter in your agent:
+
+```python
+from strands import Agent
+from strands.telemetry import StrandsTelemetry
+
+strands_telemetry = StrandsTelemetry()
+strands_telemetry.setup_otlp_exporter()
+
+agent = Agent(
+    model="us.anthropic.claude-sonnet-4-20250514-v1:0",
+    system_prompt="You are a helpful AI assistant",
+)
+
+agent("What is the capital of France?")
+```
+
+Spans reach the collector on `localhost:4318`, are batched, and land in X-Ray.
+
+## Route 2: Direct OTLP to CloudWatch (Transaction Search)
+
+CloudWatch can receive OTLP spans directly, so you can export from Strands without running a collector. This route requires [CloudWatch Transaction Search](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-OpenTelemetry-Sections.html) to be enabled, and requests to be signed with SigV4.
+
+1. Enable Transaction Search in the CloudWatch console (or through the API).
+2. Configure the OTLP endpoint and SigV4 authentication following the [AWS CloudWatch OpenTelemetry User Guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-OpenTelemetry-Sections.html). The endpoint and signing headers are AWS-managed, so refer to that guide rather than hardcoding them.
+
+Strands exports through the same `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS` variables documented under [Environment Variables](../user-guide/observability-evaluation/traces.md#environment-variables), so the agent code is identical to Route 1.
+
+## Viewing traces
+
+Once spans are flowing, open the CloudWatch console and find them under **X-Ray traces**. Each agent invocation appears as one trace, with child spans for model calls and tool executions — the same span structure described in [Traces](../user-guide/observability-evaluation/traces.md).

--- a/site/src/content/docs/examples/cloudwatch_traces.mdx
+++ b/site/src/content/docs/examples/cloudwatch_traces.mdx
@@ -12,7 +12,7 @@ For general tracing concepts and configuration options, see [Traces](../user-gui
 
 | Route | When to use |
 |-------|-------------|
-| [ADOT Collector](#route-1-through-the-adot-collector) | You run on EC2, ECS, EKS, or Lambda and want one agent to batch traces — and CloudWatch metrics — from several services. |
+| [ADOT Collector](#route-1-through-the-adot-collector) | You run on EC2, ECS, EKS, or Lambda and want one collector to batch traces from several services. |
 | [Direct OTLP](#route-2-direct-otlp-to-cloudwatch-transaction-search) | You want to skip the collector and have Strands export traces straight to CloudWatch. |
 
 ## Route 1: Through the ADOT Collector
@@ -21,7 +21,7 @@ Run the [AWS Distro for OpenTelemetry (ADOT) Collector](https://aws-otel.github.
 
 ### Configure the collector
 
-A minimal collector config that sends traces to X-Ray and metrics to CloudWatch (EMF):
+A minimal collector config that sends traces to X-Ray:
 
 ```yaml
 # otel-collector-config.yaml
@@ -39,8 +39,6 @@ processors:
 exporters:
   awsxray:
     region: us-east-1
-  awsemf:
-    region: us-east-1
 
 service:
   pipelines:
@@ -48,10 +46,6 @@ service:
       receivers: [otlp]
       processors: [batch]
       exporters: [awsxray]
-    metrics:
-      receivers: [otlp]
-      processors: [batch]
-      exporters: [awsemf]
 ```
 
 The collector uses the standard AWS credential chain (instance role, task role, or environment variables), so grant it an IAM policy allowing `xray:PutTraceSegments` and `xray:PutTelemetryRecords`. See the [ADOT X-Ray exporter docs](https://aws-otel.github.io/docs/getting-started/x-ray#configuring-the-aws-x-ray-exporter) for the full permission set and deployment options.
@@ -86,9 +80,22 @@ Spans reach the collector on `localhost:4318`, are batched, and land in X-Ray.
 CloudWatch can receive OTLP spans directly, so you can export from Strands without running a collector. This route requires [CloudWatch Transaction Search](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-OpenTelemetry-Sections.html) to be enabled, and requests to be signed with SigV4.
 
 1. Enable Transaction Search in the CloudWatch console (or through the API).
-2. Configure the OTLP endpoint and SigV4 authentication following the [AWS CloudWatch OpenTelemetry User Guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-OpenTelemetry-Sections.html). The endpoint and signing headers are AWS-managed, so refer to that guide rather than hardcoding them.
+2. Look up the OTLP endpoint for your region in the [AWS CloudWatch OpenTelemetry User Guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-OpenTelemetry-Sections.html). The endpoint is AWS-managed, so refer to that guide rather than hardcoding it.
 
-Strands exports through the same `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS` variables documented under [Environment Variables](../user-guide/observability-evaluation/traces.md#environment-variables), so the agent code is identical to Route 1.
+Unlike Route 1, environment variables alone are not enough here. `OTEL_EXPORTER_OTLP_HEADERS` carries only *static* headers, but SigV4 must be computed per request over the payload and timestamp — so setting the endpoint and headers will fail to authenticate against Transaction Search. You need an actual signing mechanism. Two options:
+
+- **Sign in-process.** `setup_otlp_exporter()` forwards its keyword arguments to OpenTelemetry's `OTLPSpanExporter`, which accepts a `session`. Pass a `requests.Session` that SigV4-signs outgoing requests (for example one wired up with `botocore`'s `SigV4Auth`):
+
+  ```python
+  strands_telemetry.setup_otlp_exporter(
+      endpoint="https://<transaction-search-otlp-endpoint>/v1/traces",
+      session=sigv4_signing_session,  # your SigV4-signing requests.Session
+  )
+  ```
+
+- **Sign out-of-process.** Point `OTEL_EXPORTER_OTLP_ENDPOINT` at a local signing proxy or sidecar that adds SigV4 and forwards to CloudWatch. The agent code is then identical to Route 1.
+
+If neither fits, Route 1 avoids the problem entirely — the collector handles AWS authentication for you.
 
 ## Viewing traces
 

--- a/site/src/content/docs/user-guide/observability-evaluation/traces.mdx
+++ b/site/src/content/docs/user-guide/observability-evaluation/traces.mdx
@@ -525,8 +525,65 @@ print(response)
 </Tab>
 </Tabs>
 
-## Sending traces to CloudWatch X-ray
-There are several ways to send traces, metrics, and logs to CloudWatch. Please visit the following pages for more details and configurations:
-1. [AWS Distro for OpenTelemetry Collector](https://aws-otel.github.io/docs/getting-started/x-ray#configuring-the-aws-x-ray-exporter)
-2. [AWS CloudWatch OpenTelemetry User Guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-OpenTelemetry-Sections.html)
-  - Please ensure Transaction Search is enabled in CloudWatch.
+## Sending traces to CloudWatch
+
+To get Strands traces into CloudWatch, point the OTLP exporter at an endpoint that forwards to CloudWatch. There are two routes; choose based on whether you want an OpenTelemetry Collector in the path.
+
+| Route | When to use |
+|-------|-------------|
+| [ADOT Collector](#route-1-through-the-adot-collector) | You run on EC2, ECS, EKS, or Lambda and want one agent to batch traces — and CloudWatch metrics — from several services. |
+| [Direct OTLP](#route-2-direct-otlp-to-cloudwatch-transaction-search) | You want to skip the collector and have Strands export traces straight to CloudWatch. |
+
+### Route 1: Through the ADOT Collector
+
+Run the [AWS Distro for OpenTelemetry (ADOT) Collector](https://aws-otel.github.io/docs/getting-started/x-ray#configuring-the-aws-x-ray-exporter) next to your agent and have Strands export OTLP to it. The collector forwards spans to X-Ray, so your agent process never handles AWS credentials directly.
+
+Point Strands at the local collector, then enable the OTLP exporter as shown in [Code Configuration](#code-configuration):
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318"
+```
+
+A minimal collector config that sends traces to X-Ray and metrics to CloudWatch (EMF):
+
+```yaml
+# otel-collector-config.yaml
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  batch:
+
+exporters:
+  awsxray:
+    region: us-east-1
+  awsemf:
+    region: us-east-1
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [awsxray]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [awsemf]
+```
+
+The collector uses the standard AWS credential chain (instance role, task role, or environment variables), so grant it an IAM policy allowing `xray:PutTraceSegments` and `xray:PutTelemetryRecords`. See the [ADOT X-Ray exporter docs](https://aws-otel.github.io/docs/getting-started/x-ray#configuring-the-aws-x-ray-exporter) for the full permission set and deployment options.
+
+### Route 2: Direct OTLP to CloudWatch (Transaction Search)
+
+CloudWatch can receive OTLP spans directly, so you can export from Strands without running a collector. This route requires [CloudWatch Transaction Search](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-OpenTelemetry-Sections.html) to be enabled, and requests to be signed with SigV4.
+
+1. Enable Transaction Search in the CloudWatch console (or through the API).
+2. Configure the OTLP endpoint and SigV4 authentication following the [AWS CloudWatch OpenTelemetry User Guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-OpenTelemetry-Sections.html). The endpoint and signing headers are AWS-managed, so refer to that guide rather than hardcoding them.
+
+Strands exports through the same `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS` variables documented under [Environment Variables](#environment-variables).

--- a/site/src/content/docs/user-guide/observability-evaluation/traces.mdx
+++ b/site/src/content/docs/user-guide/observability-evaluation/traces.mdx
@@ -527,63 +527,10 @@ print(response)
 
 ## Sending traces to CloudWatch
 
-To get Strands traces into CloudWatch, point the OTLP exporter at an endpoint that forwards to CloudWatch. There are two routes; choose based on whether you want an OpenTelemetry Collector in the path.
+Strands exports to CloudWatch through the OTLP exporter, either via an OpenTelemetry Collector or directly to CloudWatch Transaction Search. See the [CloudWatch trace export example](../../examples/cloudwatch_traces.md) for a walkthrough of both routes.
 
-| Route | When to use |
-|-------|-------------|
-| [ADOT Collector](#route-1-through-the-adot-collector) | You run on EC2, ECS, EKS, or Lambda and want one agent to batch traces — and CloudWatch metrics — from several services. |
-| [Direct OTLP](#route-2-direct-otlp-to-cloudwatch-transaction-search) | You want to skip the collector and have Strands export traces straight to CloudWatch. |
+Reference documentation:
 
-### Route 1: Through the ADOT Collector
-
-Run the [AWS Distro for OpenTelemetry (ADOT) Collector](https://aws-otel.github.io/docs/getting-started/x-ray#configuring-the-aws-x-ray-exporter) next to your agent and have Strands export OTLP to it. The collector forwards spans to X-Ray, so your agent process never handles AWS credentials directly.
-
-Point Strands at the local collector, then enable the OTLP exporter as shown in [Code Configuration](#code-configuration):
-
-```bash
-export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318"
-```
-
-A minimal collector config that sends traces to X-Ray and metrics to CloudWatch (EMF):
-
-```yaml
-# otel-collector-config.yaml
-receivers:
-  otlp:
-    protocols:
-      http:
-        endpoint: 0.0.0.0:4318
-      grpc:
-        endpoint: 0.0.0.0:4317
-
-processors:
-  batch:
-
-exporters:
-  awsxray:
-    region: us-east-1
-  awsemf:
-    region: us-east-1
-
-service:
-  pipelines:
-    traces:
-      receivers: [otlp]
-      processors: [batch]
-      exporters: [awsxray]
-    metrics:
-      receivers: [otlp]
-      processors: [batch]
-      exporters: [awsemf]
-```
-
-The collector uses the standard AWS credential chain (instance role, task role, or environment variables), so grant it an IAM policy allowing `xray:PutTraceSegments` and `xray:PutTelemetryRecords`. See the [ADOT X-Ray exporter docs](https://aws-otel.github.io/docs/getting-started/x-ray#configuring-the-aws-x-ray-exporter) for the full permission set and deployment options.
-
-### Route 2: Direct OTLP to CloudWatch (Transaction Search)
-
-CloudWatch can receive OTLP spans directly, so you can export from Strands without running a collector. This route requires [CloudWatch Transaction Search](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-OpenTelemetry-Sections.html) to be enabled, and requests to be signed with SigV4.
-
-1. Enable Transaction Search in the CloudWatch console (or through the API).
-2. Configure the OTLP endpoint and SigV4 authentication following the [AWS CloudWatch OpenTelemetry User Guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-OpenTelemetry-Sections.html). The endpoint and signing headers are AWS-managed, so refer to that guide rather than hardcoding them.
-
-Strands exports through the same `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS` variables documented under [Environment Variables](#environment-variables).
+1. [AWS Distro for OpenTelemetry Collector](https://aws-otel.github.io/docs/getting-started/x-ray#configuring-the-aws-x-ray-exporter)
+2. [AWS CloudWatch OpenTelemetry User Guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-OpenTelemetry-Sections.html)
+  - Please ensure Transaction Search is enabled in CloudWatch.


### PR DESCRIPTION
## Description

The "Sending traces to CloudWatch" section on the Traces page was two bare links with no Strands-side worked example, which is the exact gap reported in #2567. This expands it into two concrete routes a developer can follow:

- **Route 1 — ADOT Collector**: point Strands' OTLP exporter at a local collector, plus a minimal `otel-collector-config.yaml` (otlp receiver → `awsxray` for traces, `awsemf` for metrics) and the IAM permissions the collector needs.
- **Route 2 — Direct OTLP (Transaction Search)**: export straight from Strands when you don't want a collector, gated on enabling CloudWatch Transaction Search and SigV4 signing.

Both routes reuse the page's existing `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_HEADERS` configuration and cross-link to the existing **Environment Variables** and **Code Configuration** sections. The two canonical AWS docs links are kept, and SigV4 specifics are deferred to the AWS guide rather than re-documented here to avoid drift.

## Related Issues

Closes #2567

## Type of Change

Documentation update

## Testing

Docs-only change (no SDK code touched), so `hatch run prepare` doesn't apply. Validated with the site build instead:

- `npm run build` (from `site/`) — the Traces page renders and all four internal anchor links (`#route-1-...`, `#route-2-...`, `#code-configuration`, `#environment-variables`) resolve with no PageLink warnings. The build's only failure is the pre-existing local `MissingSharp` image-optimization step (unrelated assets), not page compilation.
- `npm run format:check` — no new issues from this file (it checks `*.ts`; the 9 pre-existing warnings are unrelated `.ts` snippet files).

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works (N/A — prose-only docs change)
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.