### PR TITLE
Ignore malformed message filenames when listing sessions

### DIFF
--- a/strands-py/src/strands/session/file_session_manager.py
+++ b/strands-py/src/strands/session/file_session_manager.py
@@ -232,7 +232,11 @@ class FileSessionManager(RepositorySessionManager, SessionRepository):
         for filename in os.listdir(messages_dir):
             if filename.startswith(MESSAGE_PREFIX) and filename.endswith(".json"):
                 # Extract index from message_<index>.json format
-                index = int(filename[len(MESSAGE_PREFIX) : -5])  # Remove prefix and .json suffix
+                try:
+                    index = int(filename[len(MESSAGE_PREFIX) : -5])  # Remove prefix and .json suffix
+                except ValueError:
+                    logger.warning("Skipping malformed message file: %s", filename)
+                    continue
                 message_index_files.append((index, filename))
 
         # Sort by index and extract just the filenames

--- a/strands-py/tests/strands/session/test_file_session_manager.py
+++ b/strands-py/tests/strands/session/test_file_session_manager.py
@@ -276,6 +276,25 @@ def test_list_messages_all(file_manager, sample_session, sample_agent):
     assert len(result) == 5
 
 
+def test_list_messages_ignores_malformed_message_filename(file_manager, sample_session, sample_agent, sample_message):
+    """Test listing messages skips files without a numeric message id."""
+    file_manager.create_session(sample_session)
+    file_manager.create_agent(sample_session.session_id, sample_agent)
+    file_manager.create_message(sample_session.session_id, sample_agent.agent_id, sample_message)
+
+    messages_dir = os.path.join(
+        file_manager._get_agent_path(sample_session.session_id, sample_agent.agent_id),
+        "messages",
+    )
+    with open(os.path.join(messages_dir, "message_backup.json"), "w", encoding="utf-8") as f:
+        json.dump({"message_id": "backup"}, f)
+
+    result = file_manager.list_messages(sample_session.session_id, sample_agent.agent_id)
+
+    assert len(result) == 1
+    assert result[0].message_id == sample_message.message_id
+
+
 def test_list_messages_with_limit(file_manager, sample_session, sample_agent):
     """Test listing messages with limit."""
     # Create session and agent


### PR DESCRIPTION
## What changed

`FileSessionManager.list_messages()` now skips files whose names match `message_*.json` but do not contain a numeric message id, instead of raising `ValueError` for the whole listing.

## Why

The message directory can contain backup or manually-created files such as `message_backup.json`. Before this change, one malformed filename prevented all valid session messages from being listed, even though valid `message_<id>.json` files were present.

## Validation

- `.\.venv\Scripts\python -m pytest strands-py/tests/strands/session/test_file_session_manager.py::test_list_messages_ignores_malformed_message_filename strands-py/tests/strands/session/test_file_session_manager.py::test_list_messages_all -q`
- `python -m ruff check strands-py/src/strands/session/file_session_manager.py strands-py/tests/strands/session/test_file_session_manager.py`
- `git diff --check`