### PR TITLE
fix(ts): respect store maxSearchResults during memory injection

### DIFF
--- a/site/src/content/docs/user-guide/concepts/memory/overview.mdx
+++ b/site/src/content/docs/user-guide/concepts/memory/overview.mdx
@@ -117,7 +117,7 @@ Each store carries its own identity and behavior:
 |-------|---------|
 | `name` | Unique identifier, used to target the store from tools and the programmatic API. |
 | `description` | Human-readable summary, surfaced in the memory tool descriptions so the model knows what each store holds. |
-| <Syntax py="max_search_results" ts="maxSearchResults" /> | Default result cap per search when a caller does not pass one. The manager falls back to `3` if neither is set. |
+| <Syntax py="max_search_results" ts="maxSearchResults" /> | Default result cap per store search when a caller does not pass one. The manager falls back to `3` if neither is set. During injection, a store-level cap remains the authoritative per-store retrieval limit before injected entries are sliced. |
 | `writable` | Whether the store accepts writes. |
 
 The manager attaches each store's `name` to its results, so the model and your code can tell which store produced each entry and target follow-up queries.
@@ -200,7 +200,7 @@ agent = Agent(
 </Tabs>
 
 - `trigger` accepts `'userTurn'` (the default, inject only on a fresh user ask), `'everyTurn'` (inject before every model call, for autonomous agents), or a predicate: a function that receives the injection context and returns whether to inject this call.
-- <Syntax py="max_entries" ts="maxEntries" /> caps how many entries are retrieved and injected.
+- <Syntax py="max_entries" ts="maxEntries" /> caps how many retrieved entries are injected. During injection it is also the fallback fetch size for stores that do not define <Syntax py="max_search_results" ts="maxSearchResults" />; a store-level search cap takes precedence for that store's retrieval.
 - `query` overrides the adaptive default with your own query logic. Return an empty value to skip injection for this call.
 - `format` renders the retrieved entries. The default emits an escaped `<memory>` block; a custom formatter that emits markup owns its own escaping.
 

--- a/strands-ts/src/memory/__tests__/memory-manager.test.ts
+++ b/strands-ts/src/memory/__tests__/memory-manager.test.ts
@@ -795,10 +795,7 @@ describe('MemoryManager', () => {
       })
 
       it('uses store maxSearchResults before injection maxEntries when fetching injected memory', async () => {
-        const store = createMockStore('s', {
-          maxSearchResults: 1,
-          entries: [{ content: 'A' }, { content: 'B' }, { content: 'C' }],
-        })
+        const store = createMockStore('s', { maxSearchResults: 1 })
         vi.mocked(store.search).mockImplementation(async (_query, options) =>
           [{ content: 'A' }, { content: 'B' }, { content: 'C' }].slice(0, options?.maxSearchResults)
         )

--- a/strands-ts/src/memory/__tests__/memory-manager.test.ts
+++ b/strands-ts/src/memory/__tests__/memory-manager.test.ts
@@ -793,6 +793,25 @@ describe('MemoryManager', () => {
         expect(store.search).toHaveBeenCalledWith('ask', { maxSearchResults: 2 })
         expect(text).toBe('A,B')
       })
+
+      it('uses store maxSearchResults before injection maxEntries when fetching injected memory', async () => {
+        const store = createMockStore('s', {
+          maxSearchResults: 1,
+          entries: [{ content: 'A' }, { content: 'B' }, { content: 'C' }],
+        })
+        vi.mocked(store.search).mockImplementation(async (_query, options) =>
+          [{ content: 'A' }, { content: 'B' }, { content: 'C' }].slice(0, options?.maxSearchResults)
+        )
+        const mm = new MemoryManager({
+          stores: [store],
+          injection: { maxEntries: 10, format: ({ entries }) => entries.map((e) => e.content).join(',') },
+        })
+
+        const text = await provide(mm, [assistant('prior'), user('ask')])
+
+        expect(store.search).toHaveBeenCalledWith('ask', { maxSearchResults: 1 })
+        expect(text).toBe('A')
+      })
     })
 
     describe('format', () => {

--- a/strands-ts/src/memory/memory-manager.ts
+++ b/strands-ts/src/memory/memory-manager.ts
@@ -305,7 +305,7 @@ export class MemoryManager implements Plugin {
         return undefined
       }
 
-      const entries = (await this.search(query, { maxSearchResults: maxResults })).slice(0, maxResults)
+      const entries = (await this._search(query, { maxSearchResults: maxResults }, true)).slice(0, maxResults)
       if (entries.length === 0) {
         end(false)
         return undefined
@@ -449,6 +449,21 @@ export class MemoryManager implements Plugin {
    * @returns Array of memory entries from matching stores
    */
   async search(query: string, options?: MemorySearchOptions): Promise<MemoryEntry[]> {
+    return this._search(query, options)
+  }
+
+  /**
+   * Internal search implementation.
+   *
+   * Public/tool searches treat `options.maxSearchResults` as an explicit caller override. Injection uses
+   * `maxEntries` as a fallback fetch size only: a store-level `maxSearchResults` remains the tighter
+   * per-store retrieval policy, then injection slices the combined results to `maxEntries` before rendering.
+   */
+  private async _search(
+    query: string,
+    options?: MemorySearchOptions,
+    preferStoreMaxSearchResults = false
+  ): Promise<MemoryEntry[]> {
     logger.debug(
       `query=<${query}>, max_search_results=<${options?.maxSearchResults}>, stores=<${options?.stores}> | searching stores`
     )
@@ -477,7 +492,9 @@ export class MemoryManager implements Plugin {
       settled = await Promise.allSettled(
         targetStores.map((store) =>
           store.search(query, {
-            maxSearchResults: options?.maxSearchResults ?? store.maxSearchResults ?? DEFAULT_MAX_SEARCH_RESULTS,
+            maxSearchResults: preferStoreMaxSearchResults
+              ? (store.maxSearchResults ?? options?.maxSearchResults ?? DEFAULT_MAX_SEARCH_RESULTS)
+              : (options?.maxSearchResults ?? store.maxSearchResults ?? DEFAULT_MAX_SEARCH_RESULTS),
           })
         )
       )

--- a/strands-ts/src/memory/memory-manager.ts
+++ b/strands-ts/src/memory/memory-manager.ts
@@ -48,6 +48,11 @@ export const DEFAULT_MAX_SEARCH_RESULTS = 3
  */
 const DEFAULT_MAX_ENTRIES = 5
 
+type InternalMemorySearchOptions = MemorySearchOptions & {
+  /** Internal-only: injection treats store-level maxSearchResults as the per-store retrieval cap. */
+  maxSearchResultsPrecedence?: 'caller' | 'store'
+}
+
 /** Flattens nested AggregateErrors so the leaves are concrete reasons, not errors-of-errors. */
 function _flattenReasons(reasons: unknown[]): unknown[] {
   return reasons.flatMap((reason) => (reason instanceof AggregateError ? _flattenReasons(reason.errors) : [reason]))
@@ -305,7 +310,12 @@ export class MemoryManager implements Plugin {
         return undefined
       }
 
-      const entries = (await this._search(query, { maxSearchResults: maxResults }, true)).slice(0, maxResults)
+      const entries = (
+        await this.search(query, {
+          maxSearchResults: maxResults,
+          maxSearchResultsPrecedence: 'store',
+        } as InternalMemorySearchOptions)
+      ).slice(0, maxResults)
       if (entries.length === 0) {
         end(false)
         return undefined
@@ -449,21 +459,8 @@ export class MemoryManager implements Plugin {
    * @returns Array of memory entries from matching stores
    */
   async search(query: string, options?: MemorySearchOptions): Promise<MemoryEntry[]> {
-    return this._search(query, options)
-  }
-
-  /**
-   * Internal search implementation.
-   *
-   * Public/tool searches treat `options.maxSearchResults` as an explicit caller override. Injection uses
-   * `maxEntries` as a fallback fetch size only: a store-level `maxSearchResults` remains the tighter
-   * per-store retrieval policy, then injection slices the combined results to `maxEntries` before rendering.
-   */
-  private async _search(
-    query: string,
-    options?: MemorySearchOptions,
-    preferStoreMaxSearchResults = false
-  ): Promise<MemoryEntry[]> {
+    const internalOptions = options as InternalMemorySearchOptions | undefined
+    const storeMaxSearchResultsPrecedence = internalOptions?.maxSearchResultsPrecedence === 'store'
     logger.debug(
       `query=<${query}>, max_search_results=<${options?.maxSearchResults}>, stores=<${options?.stores}> | searching stores`
     )
@@ -472,7 +469,8 @@ export class MemoryManager implements Plugin {
     const span = this._tracer.startMemorySearchSpan({
       query,
       storeNames: spanStoreNames,
-      ...(options?.maxSearchResults !== undefined && { maxSearchResults: options.maxSearchResults }),
+      ...(options?.maxSearchResults !== undefined &&
+        !storeMaxSearchResultsPrecedence && { maxSearchResults: options.maxSearchResults }),
     })
 
     let targetStores: MemoryStore[]
@@ -492,7 +490,7 @@ export class MemoryManager implements Plugin {
       settled = await Promise.allSettled(
         targetStores.map((store) =>
           store.search(query, {
-            maxSearchResults: preferStoreMaxSearchResults
+            maxSearchResults: storeMaxSearchResultsPrecedence
               ? (store.maxSearchResults ?? options?.maxSearchResults ?? DEFAULT_MAX_SEARCH_RESULTS)
               : (options?.maxSearchResults ?? store.maxSearchResults ?? DEFAULT_MAX_SEARCH_RESULTS),
           })


### PR DESCRIPTION
## Summary
- keep public/tool `MemoryManager.search()` behavior unchanged: explicit `maxSearchResults` still overrides store defaults
- make the injection path treat `maxEntries` as a fallback fetch size, while preserving a store-level `maxSearchResults` cap
- add a regression test for #2996 where injection `maxEntries: 10` must not override a store configured with `maxSearchResults: 1`

Fixes #2996.

## Validation
- `npx prettier --config /Users/chenchiyu/Desktop/open-source/harness-sdk/.prettierrc --check /Users/chenchiyu/Desktop/open-source/harness-sdk/strands-ts/src/memory/memory-manager.ts /Users/chenchiyu/Desktop/open-source/harness-sdk/strands-ts/src/memory/__tests__/memory-manager.test.ts`

Note: I used the GitHub API for the patch because full repository clone via codeload intermittently failed in this environment; the changed files are limited to the TypeScript memory manager and its focused unit test.