### PR TITLE
docs(conversation-manager): cache-aligned summarization example + docs page

### DIFF
--- a/site/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
@@ -181,6 +181,7 @@ Configuration parameters:
 - **`preserveRecentMessages`** (number, default: 10): Minimum number of recent messages to always keep
 - **`summarizationSystemPrompt`** (string, optional): Custom system prompt for summarization. If not provided, uses a default prompt that creates structured bullet-point summaries focusing on key topics, tools used, and technical information in third-person format.
 - **`proactiveCompression`** (`boolean | { compressionThreshold: number }`, optional): Enable proactive context compression before the model call. Pass `true` for the default 0.7 threshold, or an object with a custom threshold. See [Proactive Context Compression](#proactive-context-compression).
+- **`cacheAligned`** (boolean, default: false): Reuse the provider prompt cache for proactive summarization requests by aligning them with the live conversation's request. Only takes effect when `proactiveCompression` is enabled. See [Cache-Aligned Summarization](#cache-aligned-summarization).
 
 </Tab>
 </Tabs>
@@ -324,6 +325,51 @@ Pass a custom `model` to `SummarizingConversationManager` to override the model 
 
 --8<-- "user-guide/concepts/agents/conversation-management.ts:summarizing_conversation_manager_advanced"
 ```
+
+</Tab>
+</Tabs>
+
+#### Cache-Aligned Summarization
+
+When your model serves the conversation from a prompt cache, you can have summarization read from that same cache instead of paying full input-token price to re-read the history. By default it cannot: the summarization request (a slice of history under a dedicated summarization system prompt) looks nothing like the live conversation's requests, so the provider re-reads every token.
+
+<Tabs>
+<Tab label="Python">
+
+```python
+# Not supported in Python
+```
+
+</Tab>
+<Tab label="TypeScript">
+
+Enable cache alignment alongside proactive compression:
+
+```typescript
+--8<-- "user-guide/concepts/agents/conversation-management_imports.ts:cache_aligned_imports"
+
+--8<-- "user-guide/concepts/agents/conversation-management.ts:cache_aligned"
+```
+
+When proactive compression triggers, the summarization request reuses the agent's live system prompt, tool specs, and full message history, delivering the summarization instruction at the tail of the conversation. The request prefix is byte-identical to the live conversation's request, so the provider serves the history from its prompt cache at the cached-read price instead of re-reading it. The outcome is unchanged: the oldest messages are still replaced by the summary according to `summaryRatio` and `preserveRecentMessages`. One semantic difference: the summarizing model sees the entire history, including the recent messages kept verbatim, and the default instruction directs it to leave those out of the summary.
+
+Cache alignment pays off when the cache is warm and the history is large:
+
+- Prompt caching must be enabled on the model (see [Caching](../model-providers/amazon-bedrock/#caching) for Amazon Bedrock), and a live turn must have run recently. Anthropic's prompt cache expires after roughly five minutes of inactivity.
+- The larger the history, the bigger the saving: cache reads are billed at a fraction of the regular input-token price.
+
+With a cold cache or a small history it does not pay off. The aligned request is a superset of the live request (the full history plus the instruction), so an uncached read costs more than the slice a standard summarization request would send, and histories below the provider's minimum cacheable prompt size are never cached at all.
+
+Two cases always use slice-based summarization even when `cacheAligned` is enabled:
+
+- **Reactive overflow recovery.** The aligned request only fits under the proactive threshold; after a context window overflow it would overflow again.
+- **An unresolved tool-use tail.** When the last message is an assistant tool use still awaiting its result, the summarization instruction cannot be delivered without breaking the tool-use/result pair, so that pass falls back to slice-based summarization.
+
+:::caution[Model override disables cache alignment]
+Do not combine `cacheAligned` with the `model` override. A different model cannot reuse the live model's prompt cache, so when both are configured the manager ignores `cacheAligned` and uses slice-based summarization. The constructor logs a warning.
+:::
+
+**Summarizing on idle.** The short cache TTL makes idle time the cheapest moment to summarize: a few minutes after a turn completes, the cache entry written by that turn is still warm, but once the user walks away for longer it expires and the next read costs full price. The [cache-aligned-summarization example](https://github.com/strands-agents/harness-sdk/tree/main/strands-ts/examples/cache-aligned-summarization) wires this up: a 3-minute idle timer armed when a turn completes, cancelled if the user replies first, skipping unresolved tool-use tails, and calling the conversation manager's `reduce()` directly when it fires.
 
 </Tab>
 </Tabs>

--- a/site/src/content/docs/user-guide/concepts/agents/conversation-management.ts
+++ b/site/src/content/docs/user-guide/concepts/agents/conversation-management.ts
@@ -175,3 +175,20 @@ async function pinFirstExample() {
   })
   // --8<-- [end:pin_first]
 }
+
+async function cacheAlignedSummarization() {
+  // --8<-- [start:cache_aligned]
+  // Prompt caching must be enabled on the model for alignment to pay off
+  const model = new BedrockModel({
+    cacheConfig: { strategy: 'auto' },
+  })
+
+  const agent = new Agent({
+    model,
+    conversationManager: new SummarizingConversationManager({
+      cacheAligned: true,
+      proactiveCompression: true,
+    }),
+  })
+  // --8<-- [end:cache_aligned]
+}

--- a/site/src/content/docs/user-guide/concepts/agents/conversation-management_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/agents/conversation-management_imports.ts
@@ -55,4 +55,6 @@ import { Agent, SummarizingConversationManager } from '@strands-agents/sdk'
 import { Agent, SlidingWindowConversationManager } from '@strands-agents/sdk'
 // --8<-- [end:pin_first_imports]
 
-
+// --8<-- [start:cache_aligned_imports]
+import { Agent, SummarizingConversationManager, BedrockModel } from '@strands-agents/sdk'
+// --8<-- [end:cache_aligned_imports]

--- a/strands-ts/examples/README.md
+++ b/strands-ts/examples/README.md
@@ -27,3 +27,4 @@ npm start
 | [agents-as-tools](./agents-as-tools/) | Agents as tools pattern (orchestrator delegates to specialized tool agents) |
 | [browser-agent](./browser-agent/) | Browser-based agent with DOM manipulation canvas (OpenAI, Anthropic, Bedrock) |
 | [telemetry](./telemetry/) | OpenTelemetry tracing with Jaeger (requires Docker, see its [README](./telemetry/README.md)) |
+| [cache-aligned-summarization](./cache-aligned-summarization/) | Idle-triggered conversation summarization that reuses the provider prompt cache (see its [README](./cache-aligned-summarization/README.md)) |

--- a/strands-ts/examples/cache-aligned-summarization/.gitignore
+++ b/strands-ts/examples/cache-aligned-summarization/.gitignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+package-lock.json

--- a/strands-ts/examples/cache-aligned-summarization/README.md
+++ b/strands-ts/examples/cache-aligned-summarization/README.md
@@ -1,0 +1,104 @@
+# Strands Agents — Cache-Aligned Idle Summarization Example
+
+Proactively summarize a conversation while the agent sits idle — using the
+`cacheAligned` option of `SummarizingConversationManager` so the summarization
+request reads the history from the provider prompt cache instead of paying
+full input price for it.
+
+## The idea
+
+Provider prompt caches are short-lived: Anthropic's prompt cache TTL is about
+5 minutes, and the same applies to Anthropic models on Amazon Bedrock, where
+cached content expires after 5 minutes of inactivity.
+
+`cacheAligned: true` makes proactive summarization reuse the agent's live
+system prompt, tool specs, and message history so the request prefix is
+byte-identical to the live conversation's request — the provider serves the
+whole history read from its prompt cache. But that only works while the cache
+entry written by the last live turn is still warm.
+
+That makes idle time the perfect moment to summarize:
+
+- **Summarize at minute 3 of idleness** → the cache is still warm, the history
+  is read at the cached-token price (roughly a 10x discount on those tokens).
+- **Wait until the user comes back an hour later** → the cache has expired, and
+  summarization (or the next live turn against the full history) pays full
+  input cost for every token.
+
+This example wires a 3-minute idle timer around a small interactive chat
+agent. After each completed turn, the timer is armed; if the user replies
+first, it is cancelled. When it fires, it runs the conversation manager's
+proactive reduction directly — compressing the oldest messages into a summary
+while the read is still cheap, so the *next* turn starts from a smaller
+history.
+
+The trigger is careful about two things:
+
+- **It never fires mid-turn.** The timer is only armed while the agent is
+  waiting for human input, and is cancelled as soon as the user submits the
+  next message. If the user replies while a summarization is already in
+  flight, the new turn waits for it to finish before running.
+- **It skips an unresolved tool-use tail.** If the last message is an
+  assistant tool use still awaiting its result, the summarization instruction
+  can't be delivered without breaking the tool-use/result pair — the manager's
+  documented fallback to slice-based (cache-missing) summarization — so the
+  idle pass skips instead of paying for an unaligned summary.
+
+## Prerequisites
+
+- Node.js 20+
+- AWS credentials configured (for the default Bedrock model provider), or an
+  Anthropic API key (see below)
+
+## Quick Start
+
+```bash
+npm install
+npm start
+```
+
+Chat with the agent for a few turns, then leave it idle. By default the timer
+is 3 minutes; to see the pattern without waiting, shorten it:
+
+```bash
+IDLE_SUMMARIZE_MS=15000 npm start
+```
+
+Watch the `[usage]` line after each turn — `cacheWrite` shows the provider
+storing the prefix, `cacheRead` shows it being reused — and the `[idle]` lines
+when the timer fires.
+
+## Model providers
+
+- **Amazon Bedrock (default)**: uses `cacheConfig: { strategy: 'auto' }`, so
+  the SDK places prompt-cache points automatically and every live turn leaves
+  a warm cache entry.
+- **Anthropic**: run with `MODEL_PROVIDER=anthropic` and `ANTHROPIC_API_KEY`
+  set. The direct Anthropic provider has no automatic cache strategy — you
+  place explicit `CachePointBlock` markers yourself. The idle-summarize wiring
+  is identical; without cache points the summary still works but reads at the
+  uncached price.
+
+## Configuration shown
+
+```typescript
+const conversationManager = new SummarizingConversationManager({
+  cacheAligned: true,
+  proactiveCompression: { compressionThreshold: 0.7 },
+  summaryRatio: 0.5,
+  preserveRecentMessages: 4,
+})
+```
+
+Two things to keep in mind when enabling `cacheAligned`:
+
+- Don't pass a `model` override — a different model cannot reuse the live
+  model's prompt cache, so the manager skips the aligned path entirely (and
+  logs a warning) when the two are combined.
+- `cacheAligned` only takes effect on proactive compression. Reactive overflow
+  recovery always uses slice-based summarization, because the cache-aligned
+  request is a superset of the live request — on overflow it would overflow
+  again.
+
+See the [Conversation Management documentation](https://strandsagents.com/latest/documentation/docs/user-guide/concepts/agents/conversation-management/)
+for the full feature reference.

--- a/strands-ts/examples/cache-aligned-summarization/package.json
+++ b/strands-ts/examples/cache-aligned-summarization/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "cache-aligned-summarization",
+  "private": true,
+  "main": "dist/index.js",
+  "type": "module",
+  "scripts": {
+    "prepare": "npm ci --prefix ../../..",
+    "clean": "rm -rf dist node_modules package-lock.json",
+    "build": "tsc",
+    "start": "tsc && node dist/index.js"
+  },
+  "workspaces": [
+    "../../"
+  ],
+  "dependencies": {
+    "@strands-agents/sdk": "*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/strands-ts/examples/cache-aligned-summarization/src/index.ts
+++ b/strands-ts/examples/cache-aligned-summarization/src/index.ts
@@ -1,0 +1,223 @@
+/**
+ * Cache-aligned summarization with an idle-summarize trigger.
+ *
+ * This example demonstrates the `cacheAligned` option of
+ * `SummarizingConversationManager`, plus a pattern it enables: proactively
+ * summarizing the conversation while the agent is idle and the provider
+ * prompt cache is still warm.
+ *
+ * Why idle time matters: provider prompt caches are short-lived — Anthropic's
+ * cache TTL is ~5 minutes (the same applies to Anthropic models on Amazon
+ * Bedrock, where cached content expires after 5 minutes of inactivity). A
+ * cache-aligned summarization request reuses the agent's live system prompt,
+ * tool specs, and message history byte-for-byte, so it reads the whole
+ * conversation at the cached-token price — but only while the cache entry from
+ * the last live turn is still alive. Summarizing at minute 3 of idleness pays
+ * cached price for the history read; waiting until the user comes back an hour
+ * later pays full input cost for every token.
+ *
+ * The idle trigger below:
+ * - arms a timer when a turn completes and the agent is waiting for input
+ * - cancels the timer as soon as the user starts a new turn
+ * - never fires mid-turn (it is only armed between turns)
+ * - skips summarization when the message tail is an assistant tool use still
+ *   awaiting its result — the feature's documented fallback case, where the
+ *   summarization instruction cannot be delivered without breaking the
+ *   tool-use/result pair, so the manager falls back to a slice-based
+ *   (cache-missing) summary anyway
+ */
+import * as readline from 'node:readline/promises'
+import { env, stdin, stdout } from 'node:process'
+import { Agent, BedrockModel, SummarizingConversationManager, tool, type Model } from '@strands-agents/sdk'
+import { AnthropicModel } from '@strands-agents/sdk/models/anthropic'
+import { z } from 'zod'
+
+/**
+ * How long the agent must sit idle before we summarize. Three minutes leaves a
+ * comfortable margin inside the ~5 minute prompt-cache TTL: late enough that a
+ * quick follow-up question usually cancels it, early enough that the cache
+ * entry written by the last live turn is still warm when the summary request
+ * reads the history. Override with IDLE_SUMMARIZE_MS (e.g. 15000) to try the
+ * pattern without waiting three minutes.
+ */
+const IDLE_SUMMARIZE_MS = Number(env.IDLE_SUMMARIZE_MS ?? 3 * 60 * 1000)
+
+/**
+ * Pick a model provider. Both work with cache alignment:
+ *
+ * - Bedrock (default): `cacheConfig: { strategy: 'auto' }` makes the SDK place
+ *   cache points automatically on the tool specs and the latest user message,
+ *   so each live turn leaves a warm cache entry covering the whole prefix.
+ * - Anthropic (MODEL_PROVIDER=anthropic, needs ANTHROPIC_API_KEY): the direct
+ *   Anthropic provider has no automatic cache strategy — you place explicit
+ *   `CachePointBlock` markers yourself. The idle-summarize wiring is identical;
+ *   without cache points the summary still works but reads at uncached price.
+ */
+function createModel(): Model {
+  if (env.MODEL_PROVIDER === 'anthropic') {
+    return new AnthropicModel()
+  }
+  return new BedrockModel({
+    cacheConfig: { strategy: 'auto' },
+  })
+}
+
+const weatherTool = tool({
+  name: 'get_weather',
+  description: 'Get the current weather for a specific location.',
+  inputSchema: z.object({
+    location: z.string().describe('The city and state, e.g., San Francisco, CA'),
+  }),
+  callback: (input) => {
+    return `The weather in ${input.location} is 72°F and sunny.`
+  },
+})
+
+// Keep a reference to the conversation manager: the idle trigger calls its
+// public reduce() directly, outside the agent loop.
+//
+// Do NOT pass a `model` override here — a different model cannot reuse the
+// live model's prompt cache, so the manager skips the aligned path entirely
+// and logs a warning if you combine the two.
+const conversationManager = new SummarizingConversationManager({
+  cacheAligned: true,
+  // cacheAligned only takes effect on proactive compression. Reactive overflow
+  // recovery always uses slice-based summarization: the cache-aligned request
+  // is a superset of the live request, so on overflow it would overflow again.
+  proactiveCompression: { compressionThreshold: 0.7 },
+  // Small values so the demo summarizes after a handful of turns. Production
+  // agents usually keep the defaults (summaryRatio 0.3, preserveRecentMessages 10).
+  summaryRatio: 0.5,
+  preserveRecentMessages: 4,
+})
+
+const agent = new Agent({
+  model: createModel(),
+  systemPrompt: 'You are a helpful, concise assistant. Use the get_weather tool when the user asks about the weather.',
+  tools: [weatherTool],
+  conversationManager,
+})
+
+/**
+ * Returns true when the last message is an assistant tool use still awaiting
+ * its tool result. The summarization instruction cannot be delivered at such
+ * a tail, so the manager would fall back to slice-based summarization — no
+ * cache reuse — and the idle pass skips instead, waiting for the next
+ * completed turn.
+ *
+ * (Between completed turns this is normally false; it protects against idle
+ * timers armed around interrupted or resumed sessions.)
+ */
+function tailAwaitsToolResult(): boolean {
+  const last = agent.messages[agent.messages.length - 1]
+  if (!last) {
+    return false
+  }
+  const hasToolUse = last.content.some((block) => block.type === 'toolUseBlock')
+  const hasToolResult = last.content.some((block) => block.type === 'toolResultBlock')
+  return hasToolUse && !hasToolResult
+}
+
+/** Aborting this controller cancels the pending idle timer. */
+let idleController: AbortController | undefined
+/** Set while an idle summarization is in flight, so a new turn can await it. */
+let idleTask: Promise<void> | undefined
+
+/**
+ * Arm the idle timer. Called only when a turn has completed and the agent is
+ * waiting for human input — so the timer can never fire mid-turn.
+ */
+function armIdleSummarize(): void {
+  idleController?.abort()
+  const controller = new AbortController()
+  idleController = controller
+
+  const timer = setTimeout(() => {
+    idleTask = summarizeWhileCacheIsWarm().finally(() => {
+      idleTask = undefined
+    })
+  }, IDLE_SUMMARIZE_MS)
+
+  controller.signal.addEventListener('abort', () => clearTimeout(timer), { once: true })
+}
+
+/** Cancel a pending (not yet fired) idle summarization. */
+function cancelIdleSummarize(): void {
+  idleController?.abort()
+  idleController = undefined
+}
+
+/**
+ * The idle pass: run the manager's proactive reduction directly while the
+ * prompt cache written by the last live turn is still warm. Because `error`
+ * is not set, this takes the proactive path — which is where cacheAligned
+ * applies — and it is best-effort: reduce() returns false when there is not
+ * enough history to summarize yet.
+ */
+async function summarizeWhileCacheIsWarm(): Promise<void> {
+  if (tailAwaitsToolResult()) {
+    console.log('\n[idle] tail is an unresolved tool use — skipping (cache alignment would fall back to slice-based)')
+    return
+  }
+
+  const before = agent.messages.length
+  console.log(`\n[idle] ${IDLE_SUMMARIZE_MS / 1000}s idle — summarizing while the prompt cache is warm...`)
+  try {
+    const reduced = await conversationManager.reduce({ agent, model: agent.model })
+    if (reduced) {
+      console.log(`[idle] summarized: ${before} -> ${agent.messages.length} messages`)
+    } else {
+      console.log('[idle] nothing to summarize yet')
+    }
+  } catch (error) {
+    console.log(`[idle] summarization failed: ${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+
+async function main(): Promise<void> {
+  console.log('Cache-aligned idle summarization demo')
+  console.log(`Idle timer: ${IDLE_SUMMARIZE_MS / 1000}s (override with IDLE_SUMMARIZE_MS)`)
+  console.log('Chat with the agent; leave it idle to see the summarization fire. Type "exit" to quit.\n')
+
+  const rl = readline.createInterface({ input: stdin, output: stdout })
+
+  for (;;) {
+    const line = (await rl.question('you> ')).trim()
+
+    // The human is back: cancel the pending idle summarization...
+    cancelIdleSummarize()
+    // ...and if one already fired and is mid-flight, let it finish before the
+    // new turn mutates the message history.
+    if (idleTask) {
+      await idleTask
+    }
+
+    if (line === 'exit' || line === 'quit') {
+      break
+    }
+    if (line.length === 0) {
+      continue
+    }
+
+    const result = await agent.invoke(line)
+
+    // cacheWrite on a turn means the provider stored the prefix; cacheRead on
+    // the next request (including an idle summarization) means it was reused.
+    const usage = result.metrics?.accumulatedUsage
+    if (usage) {
+      console.log(
+        `\n[usage] input=${usage.inputTokens} output=${usage.outputTokens} ` +
+          `cacheRead=${usage.cacheReadInputTokens ?? 0} cacheWrite=${usage.cacheWriteInputTokens ?? 0} ` +
+          `| ${agent.messages.length} messages in history\n`
+      )
+    }
+
+    // Turn complete, waiting for the human again — start the idle clock.
+    armIdleSummarize()
+  }
+
+  cancelIdleSummarize()
+  rl.close()
+}
+
+await main().catch(console.error)

--- a/strands-ts/examples/cache-aligned-summarization/tsconfig.json
+++ b/strands-ts/examples/cache-aligned-summarization/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests*"]
+}

--- a/strands-ts/src/conversation-manager/__tests__/context-compression.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/context-compression.test.ts
@@ -259,20 +259,43 @@ describe('generateSummaryCacheAligned', () => {
     })
   })
 
-  it('sends the full history plus a trailing instruction user turn', async () => {
+  it('appends the instruction as a new user turn when the history ends with an assistant message', async () => {
+    const model = mockModel('Summary')
+    const history = [textMsg('user', 'hello'), textMsg('assistant', 'hi')]
+    await generateSummaryCacheAligned(history, model as any, { systemPrompt: 'Live', toolSpecs })
+
+    const passedMessages = (model.streamAggregated.mock.calls[0] as unknown as [Message[]])[0]
+    expect(passedMessages).toHaveLength(3)
+    expect(passedMessages.slice(0, 2)).toEqual(history)
+    const trailing = passedMessages[2]!
+    expect(trailing.role).toBe('user')
+    expect(trailing.content).toHaveLength(1)
+    expect((trailing.content[0] as TextBlock).text).toBe(DEFAULT_SUMMARIZATION_INSTRUCTION)
+  })
+
+  it('merges the instruction into a clone of the final user message when the history ends with a user message', async () => {
     const model = mockModel('Summary')
     const history = [textMsg('user', 'hello'), textMsg('assistant', 'hi'), textMsg('user', 'more')]
     await generateSummaryCacheAligned(history, model as any, { systemPrompt: 'Live', toolSpecs })
 
     const passedMessages = (model.streamAggregated.mock.calls[0] as unknown as [Message[]])[0]
-    expect(passedMessages).toHaveLength(4)
-    expect(passedMessages.slice(0, 3)).toEqual(history)
-    const trailing = passedMessages[3]!
-    expect(trailing.role).toBe('user')
-    expect((trailing.content[0] as TextBlock).text).toBe(DEFAULT_SUMMARIZATION_INSTRUCTION)
+    // No extra turn: consecutive user roles would be rejected by providers like Bedrock
+    expect(passedMessages).toHaveLength(3)
+    // The prefix is the exact same message instances as the live history
+    expect(passedMessages[0]).toBe(history[0])
+    expect(passedMessages[1]).toBe(history[1])
+    const merged = passedMessages[2]!
+    expect(merged.role).toBe('user')
+    expect(merged).not.toBe(history[2])
+    expect(merged.content).toHaveLength(2)
+    expect((merged.content[0] as TextBlock).text).toBe('more')
+    expect((merged.content[1] as TextBlock).text).toBe(DEFAULT_SUMMARIZATION_INSTRUCTION)
+    // The live history's final message is not mutated
+    expect(history[2]!.content).toHaveLength(1)
+    expect((history[2]!.content[0] as TextBlock).text).toBe('more')
   })
 
-  it('delivers the instruction as a user turn, not the system prompt', async () => {
+  it('delivers the instruction as a user-turn text block, not the system prompt', async () => {
     const model = mockModel('Summary')
     await generateSummaryCacheAligned([textMsg('user', 'hello')], model as any, { systemPrompt: 'Live' })
 
@@ -282,7 +305,9 @@ describe('generateSummaryCacheAligned', () => {
     ]
     expect(options.systemPrompt).toBe('Live')
     const trailing = passedMessages[passedMessages.length - 1]!
-    expect((trailing.content[0] as TextBlock).text).toBe(DEFAULT_SUMMARIZATION_INSTRUCTION)
+    expect(trailing.role).toBe('user')
+    const lastBlock = trailing.content[trailing.content.length - 1]!
+    expect((lastBlock as TextBlock).text).toBe(DEFAULT_SUMMARIZATION_INSTRUCTION)
   })
 
   it('uses a custom instruction when provided', async () => {
@@ -291,14 +316,16 @@ describe('generateSummaryCacheAligned', () => {
 
     const passedMessages = (model.streamAggregated.mock.calls[0] as unknown as [Message[]])[0]
     const trailing = passedMessages[passedMessages.length - 1]!
-    expect((trailing.content[0] as TextBlock).text).toBe('Custom instruction')
+    const lastBlock = trailing.content[trailing.content.length - 1]!
+    expect((lastBlock as TextBlock).text).toBe('Custom instruction')
   })
 
-  it('does not mutate the original messages', async () => {
+  it('does not mutate the original messages array on the assistant-tail path', async () => {
     const model = mockModel('Summary')
     const original = [textMsg('user', 'hello'), textMsg('assistant', 'hi')]
     await generateSummaryCacheAligned(original, model as any, {})
     expect(original).toHaveLength(2)
+    expect(original[1]!.content).toHaveLength(1)
   })
 
   it('throws if the model returns no response', async () => {

--- a/strands-ts/src/conversation-manager/__tests__/context-compression.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/context-compression.test.ts
@@ -3,9 +3,12 @@ import {
   adjustSplitPointForToolPairs,
   findValidTrimPoint,
   generateSummary,
+  generateSummaryCacheAligned,
   matchesMessageType,
   DEFAULT_SUMMARIZATION_PROMPT,
+  DEFAULT_SUMMARIZATION_INSTRUCTION,
 } from '../compression/context-compression.js'
+import type { ToolSpec } from '../../tools/types.js'
 import { pinMessage, partitionPinned } from '../compression/pin-message.js'
 import { Message, TextBlock, ToolUseBlock, ToolResultBlock } from '../../types/messages.js'
 
@@ -216,6 +219,97 @@ describe('generateSummary', () => {
     }
 
     await expect(generateSummary([textMsg('user', 'hello')], model as any)).rejects.toThrow(
+      'Failed to generate summary'
+    )
+  })
+})
+
+describe('generateSummaryCacheAligned', () => {
+  function mockModel(summaryText: string) {
+    const message = new Message({ role: 'assistant', content: [new TextBlock(summaryText)] })
+    return {
+      streamAggregated: vi.fn(() => ({
+        next: vi
+          .fn()
+          .mockResolvedValueOnce({ done: false, value: undefined })
+          .mockResolvedValueOnce({ done: true, value: { message } }),
+        [Symbol.asyncIterator]: vi.fn(),
+      })),
+    }
+  }
+
+  const toolSpecs: ToolSpec[] = [{ name: 'search', description: 'search tool', inputSchema: { type: 'object' } }]
+
+  it('returns a user-role message', async () => {
+    const model = mockModel('Summary')
+    const result = await generateSummaryCacheAligned([textMsg('user', 'hello')], model as any, {})
+    expect(result.role).toBe('user')
+  })
+
+  it('passes the system prompt and tool specs through', async () => {
+    const model = mockModel('Summary')
+    await generateSummaryCacheAligned([textMsg('user', 'hello')], model as any, {
+      systemPrompt: 'Live system prompt',
+      toolSpecs,
+    })
+
+    expect(model.streamAggregated).toHaveBeenCalledWith(expect.any(Array), {
+      systemPrompt: 'Live system prompt',
+      toolSpecs,
+    })
+  })
+
+  it('sends the full history plus a trailing instruction user turn', async () => {
+    const model = mockModel('Summary')
+    const history = [textMsg('user', 'hello'), textMsg('assistant', 'hi'), textMsg('user', 'more')]
+    await generateSummaryCacheAligned(history, model as any, { systemPrompt: 'Live', toolSpecs })
+
+    const passedMessages = (model.streamAggregated.mock.calls[0] as unknown as [Message[]])[0]
+    expect(passedMessages).toHaveLength(4)
+    expect(passedMessages.slice(0, 3)).toEqual(history)
+    const trailing = passedMessages[3]!
+    expect(trailing.role).toBe('user')
+    expect((trailing.content[0] as TextBlock).text).toBe(DEFAULT_SUMMARIZATION_INSTRUCTION)
+  })
+
+  it('delivers the instruction as a user turn, not the system prompt', async () => {
+    const model = mockModel('Summary')
+    await generateSummaryCacheAligned([textMsg('user', 'hello')], model as any, { systemPrompt: 'Live' })
+
+    const [passedMessages, options] = model.streamAggregated.mock.calls[0] as unknown as [
+      Message[],
+      { systemPrompt?: string },
+    ]
+    expect(options.systemPrompt).toBe('Live')
+    const trailing = passedMessages[passedMessages.length - 1]!
+    expect((trailing.content[0] as TextBlock).text).toBe(DEFAULT_SUMMARIZATION_INSTRUCTION)
+  })
+
+  it('uses a custom instruction when provided', async () => {
+    const model = mockModel('Summary')
+    await generateSummaryCacheAligned([textMsg('user', 'hello')], model as any, { instruction: 'Custom instruction' })
+
+    const passedMessages = (model.streamAggregated.mock.calls[0] as unknown as [Message[]])[0]
+    const trailing = passedMessages[passedMessages.length - 1]!
+    expect((trailing.content[0] as TextBlock).text).toBe('Custom instruction')
+  })
+
+  it('does not mutate the original messages', async () => {
+    const model = mockModel('Summary')
+    const original = [textMsg('user', 'hello'), textMsg('assistant', 'hi')]
+    await generateSummaryCacheAligned(original, model as any, {})
+    expect(original).toHaveLength(2)
+  })
+
+  it('throws if the model returns no response', async () => {
+    const model = {
+      streamAggregated: vi.fn(() => ({
+        next: vi.fn().mockResolvedValueOnce({ done: true, value: undefined }),
+        [Symbol.asyncIterator]: vi.fn(),
+      })),
+    }
+
+    await expect(generateSummaryCacheAligned([textMsg('user', 'hello')], model as any, {})).rejects.toThrow(
       'Failed to generate summary'
     )
   })

--- a/strands-ts/src/conversation-manager/__tests__/context-compression.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/context-compression.test.ts
@@ -30,6 +30,20 @@ function toolResultMsg(toolUseId: string, text = 'result'): Message {
   })
 }
 
+/** Mock model whose aggregated stream resolves to a single assistant text message. */
+function mockModel(summaryText: string) {
+  const message = new Message({ role: 'assistant', content: [new TextBlock(summaryText)] })
+  return {
+    streamAggregated: vi.fn(() => ({
+      next: vi
+        .fn()
+        .mockResolvedValueOnce({ done: false, value: undefined })
+        .mockResolvedValueOnce({ done: true, value: { message } }),
+      [Symbol.asyncIterator]: vi.fn(),
+    })),
+  }
+}
+
 describe('adjustSplitPointForToolPairs', () => {
   it('returns split point when message is plain text', () => {
     const messages = [textMsg('user', 'hello'), textMsg('assistant', 'hi'), textMsg('user', 'bye')]
@@ -153,19 +167,6 @@ describe('partitionPinned', () => {
 })
 
 describe('generateSummary', () => {
-  function mockModel(summaryText: string) {
-    const message = new Message({ role: 'assistant', content: [new TextBlock(summaryText)] })
-    return {
-      streamAggregated: vi.fn(() => ({
-        next: vi
-          .fn()
-          .mockResolvedValueOnce({ done: false, value: undefined })
-          .mockResolvedValueOnce({ done: true, value: { message } }),
-        [Symbol.asyncIterator]: vi.fn(),
-      })),
-    }
-  }
-
   it('returns a user-role message', async () => {
     const model = mockModel('Summary of conversation')
     const messages = [textMsg('user', 'hello'), textMsg('assistant', 'hi')]
@@ -225,19 +226,6 @@ describe('generateSummary', () => {
 })
 
 describe('generateSummaryCacheAligned', () => {
-  function mockModel(summaryText: string) {
-    const message = new Message({ role: 'assistant', content: [new TextBlock(summaryText)] })
-    return {
-      streamAggregated: vi.fn(() => ({
-        next: vi
-          .fn()
-          .mockResolvedValueOnce({ done: false, value: undefined })
-          .mockResolvedValueOnce({ done: true, value: { message } }),
-        [Symbol.asyncIterator]: vi.fn(),
-      })),
-    }
-  }
-
   const toolSpecs: ToolSpec[] = [{ name: 'search', description: 'search tool', inputSchema: { type: 'object' } }]
 
   it('returns a user-role message', async () => {

--- a/strands-ts/src/conversation-manager/__tests__/context-compression.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/context-compression.test.ts
@@ -340,4 +340,21 @@ describe('generateSummaryCacheAligned', () => {
       'Failed to generate summary'
     )
   })
+
+  it('throws if the model responds with tool use instead of a text summary', async () => {
+    const message = new Message({
+      role: 'assistant',
+      content: [new ToolUseBlock({ toolUseId: 'id-1', name: 'search', input: {} })],
+    })
+    const model = {
+      streamAggregated: vi.fn(() => ({
+        next: vi.fn().mockResolvedValueOnce({ done: true, value: { message } }),
+        [Symbol.asyncIterator]: vi.fn(),
+      })),
+    }
+
+    await expect(generateSummaryCacheAligned([textMsg('user', 'hello')], model as any, { toolSpecs })).rejects.toThrow(
+      'model responded with tool use'
+    )
+  })
 })

--- a/strands-ts/src/conversation-manager/__tests__/summarizing-conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/summarizing-conversation-manager.test.ts
@@ -4,7 +4,7 @@ import { ContextWindowOverflowError, Message, TextBlock, ToolUseBlock, ToolResul
 import { AfterModelCallEvent, BeforeModelCallEvent } from '../../hooks/events.js'
 import { createMockAgent, invokeTrackedHook } from '../../__fixtures__/agent-helpers.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
-import { DEFAULT_SUMMARIZATION_PROMPT } from '../compression/context-compression.js'
+import { DEFAULT_SUMMARIZATION_INSTRUCTION, DEFAULT_SUMMARIZATION_PROMPT } from '../compression/context-compression.js'
 import type { Model, BaseModelConfig, StreamOptions } from '../../models/model.js'
 import type { ToolSpec } from '../../tools/types.js'
 import type { ToolRegistry } from '../../registry/tool-registry.js'
@@ -527,6 +527,123 @@ describe('SummarizingConversationManager', () => {
       expect(mockAgent.messages[0]!.role).toBe('user')
       expect(mockAgent.messages[0]!.content[0]!).toEqual({ type: 'textBlock', text: 'Summary of conversation' })
       expect(mockAgent.messages.slice(-2)).toEqual(lastTwo)
+    })
+
+    it('proactive aligned request carries DEFAULT_SUMMARIZATION_INSTRUCTION as the trailing turn by default', async () => {
+      const model = new MockMessageModel()
+      model.addTurn({ type: 'textBlock', text: 'Summary' })
+      const streamSpy = vi.spyOn(model, 'streamAggregated')
+
+      const manager = new SummarizingConversationManager({
+        summaryRatio: 0.5,
+        preserveRecentMessages: 2,
+        proactiveCompression: true,
+        cacheAligned: true,
+      })
+      // Assistant tail: the instruction is appended as its own user turn
+      const messages = makeMessages(20)
+      const mockAgent = createMockAgent({
+        messages,
+        extra: { systemPrompt: 'Live system prompt', toolRegistry: stubRegistry(toolSpecs) },
+      })
+
+      await manager.reduce({ agent: mockAgent, model: model as unknown as Model })
+
+      const [calledMessages] = streamSpy.mock.calls[0]! as [Message[], StreamOptions]
+      const trailing = calledMessages[calledMessages.length - 1]!
+      expect(trailing.role).toBe('user')
+      expect(trailing.content).toHaveLength(1)
+      // The purpose-built user-turn instruction, not the summarization system prompt
+      expect((trailing.content[0] as TextBlock).text).toBe(DEFAULT_SUMMARIZATION_INSTRUCTION)
+    })
+
+    it('proactive aligned request carries a user-supplied summarizationSystemPrompt as the instruction', async () => {
+      const model = new MockMessageModel()
+      model.addTurn({ type: 'textBlock', text: 'Summary' })
+      const streamSpy = vi.spyOn(model, 'streamAggregated')
+
+      const manager = new SummarizingConversationManager({
+        summaryRatio: 0.5,
+        preserveRecentMessages: 2,
+        proactiveCompression: true,
+        cacheAligned: true,
+        summarizationSystemPrompt: 'Custom summarization override',
+      })
+      const messages = makeMessages(20)
+      const mockAgent = createMockAgent({
+        messages,
+        extra: { systemPrompt: 'Live system prompt', toolRegistry: stubRegistry(toolSpecs) },
+      })
+
+      await manager.reduce({ agent: mockAgent, model: model as unknown as Model })
+
+      const [calledMessages] = streamSpy.mock.calls[0]! as [Message[], StreamOptions]
+      const trailing = calledMessages[calledMessages.length - 1]!
+      expect(trailing.role).toBe('user')
+      expect((trailing.content[0] as TextBlock).text).toBe('Custom summarization override')
+    })
+
+    it('proactive trigger through the BeforeModelCallEvent hook merges the instruction into the user-message tail', async () => {
+      const model = new MockMessageModel()
+      model.updateConfig({ modelId: 'test-model', contextWindowLimit: 1000 })
+      model.addTurn({ type: 'textBlock', text: 'Summary of conversation' })
+      const streamSpy = vi.spyOn(model, 'streamAggregated')
+
+      const manager = new SummarizingConversationManager({
+        summaryRatio: 0.5,
+        preserveRecentMessages: 2,
+        proactiveCompression: { compressionThreshold: 0.7 },
+        cacheAligned: true,
+      })
+      // 21 messages: at the proactive trigger the tail is always the upcoming turn's USER message
+      const messages = makeMessages(21)
+      const liveHistory = [...messages]
+      expect(liveHistory[20]!.role).toBe('user')
+      const mockAgent = createMockAgent({
+        messages,
+        extra: { systemPrompt: 'Live system prompt', toolRegistry: stubRegistry(toolSpecs) },
+      })
+      manager.initAgent(mockAgent)
+
+      const event = new BeforeModelCallEvent({
+        agent: mockAgent,
+        model: model as unknown as Model,
+        invocationState: {},
+        projectedInputTokens: 800,
+      })
+      await invokeTrackedHook(mockAgent, event)
+
+      expect(streamSpy).toHaveBeenCalledOnce()
+      const [calledMessages, calledOptions] = streamSpy.mock.calls[0]! as [Message[], StreamOptions]
+
+      // (a) No consecutive user turns: roles strictly alternate across the built request
+      expect(calledMessages).toHaveLength(21)
+      for (let i = 1; i < calledMessages.length; i++) {
+        expect(calledMessages[i]!.role).not.toBe(calledMessages[i - 1]!.role)
+      }
+
+      // (b) The cached prefix is byte-identical: same message instances as the live history
+      for (let i = 0; i < 20; i++) {
+        expect(calledMessages[i]).toBe(liveHistory[i])
+      }
+
+      // (c) The instruction rides in the final user message, after the original content
+      const finalMessage = calledMessages[20]!
+      expect(finalMessage.role).toBe('user')
+      expect(finalMessage.content).toHaveLength(2)
+      expect((finalMessage.content[0] as TextBlock).text).toBe('Message 21')
+      expect((finalMessage.content[1] as TextBlock).text).toBe(DEFAULT_SUMMARIZATION_INSTRUCTION)
+      // The live history's tail message was cloned, not mutated
+      expect(finalMessage).not.toBe(liveHistory[20])
+      expect(liveHistory[20]!.content).toHaveLength(1)
+
+      // Live prefix reused as-is
+      expect(calledOptions.systemPrompt).toBe('Live system prompt')
+      expect(calledOptions.toolSpecs).toEqual(toolSpecs)
+
+      // 21 * 0.5 = 10 summarized → 1 summary + 11 remaining = 12
+      expect(mockAgent.messages).toHaveLength(12)
+      expect(mockAgent.messages[0]!.content[0]!).toEqual({ type: 'textBlock', text: 'Summary of conversation' })
     })
 
     it('reactive reduce uses the slice-based path even when cacheAligned is set', async () => {

--- a/strands-ts/src/conversation-manager/__tests__/summarizing-conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/summarizing-conversation-manager.test.ts
@@ -5,6 +5,7 @@ import { AfterModelCallEvent, BeforeModelCallEvent } from '../../hooks/events.js
 import { createMockAgent, invokeTrackedHook } from '../../__fixtures__/agent-helpers.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
 import { DEFAULT_SUMMARIZATION_INSTRUCTION, DEFAULT_SUMMARIZATION_PROMPT } from '../compression/context-compression.js'
+import { logger } from '../../logging/logger.js'
 import type { Model, BaseModelConfig, StreamOptions } from '../../models/model.js'
 import type { ToolSpec } from '../../tools/types.js'
 import type { ToolRegistry } from '../../registry/tool-registry.js'
@@ -706,6 +707,128 @@ describe('SummarizingConversationManager', () => {
       expect(calledOptions.systemPrompt).toBe(DEFAULT_SUMMARIZATION_PROMPT)
       expect(calledOptions.toolSpecs).toBeUndefined()
       expect(mockAgent.messages).toHaveLength(11)
+    })
+
+    it('falls back to slice-based summarization when the aligned response contains tool use', async () => {
+      const model = new MockMessageModel()
+      // Aligned request carries live tool specs, so the model may answer with a tool call
+      model.addTurn({ type: 'toolUseBlock', name: 'search', toolUseId: 'id-1', input: {} })
+      model.addTurn({ type: 'textBlock', text: 'Slice summary' })
+      const streamSpy = vi.spyOn(model, 'streamAggregated')
+
+      const manager = new SummarizingConversationManager({
+        summaryRatio: 0.5,
+        preserveRecentMessages: 2,
+        proactiveCompression: true,
+        cacheAligned: true,
+      })
+      const messages = makeMessages(20)
+      const mockAgent = createMockAgent({
+        messages,
+        extra: { systemPrompt: 'Live system prompt', toolRegistry: stubRegistry(toolSpecs) },
+      })
+
+      const result = await manager.reduce({ agent: mockAgent, model: model as unknown as Model })
+
+      expect(result).toBe(true)
+      expect(streamSpy).toHaveBeenCalledTimes(2)
+      // First call: aligned (full history + trailing instruction, live tool specs)
+      const [alignedMessages, alignedOptions] = streamSpy.mock.calls[0]! as [Message[], StreamOptions]
+      expect(alignedMessages).toHaveLength(21)
+      expect(alignedOptions.toolSpecs).toEqual(toolSpecs)
+      // Second call: slice-based fallback
+      const [sliceMessages, sliceOptions] = streamSpy.mock.calls[1]! as [Message[], StreamOptions]
+      expect(sliceMessages).toHaveLength(11)
+      expect(sliceOptions.systemPrompt).toBe(DEFAULT_SUMMARIZATION_PROMPT)
+      expect(sliceOptions.toolSpecs).toBeUndefined()
+      // The slice summary landed; no dangling toolUse was spliced into history
+      expect(mockAgent.messages).toHaveLength(11)
+      expect(mockAgent.messages[0]!.content[0]!).toEqual({ type: 'textBlock', text: 'Slice summary' })
+      expect(mockAgent.messages.every((m) => !m.content.some((b) => b.type === 'toolUseBlock'))).toBe(true)
+    })
+
+    it('falls back to slice-based summarization when the aligned request fails', async () => {
+      const model = new MockMessageModel()
+      model.addTurn(new Error('aligned request failed'))
+      model.addTurn({ type: 'textBlock', text: 'Slice summary' })
+      const streamSpy = vi.spyOn(model, 'streamAggregated')
+
+      const manager = new SummarizingConversationManager({
+        summaryRatio: 0.5,
+        preserveRecentMessages: 2,
+        proactiveCompression: true,
+        cacheAligned: true,
+      })
+      const messages = makeMessages(20)
+      const mockAgent = createMockAgent({
+        messages,
+        extra: { systemPrompt: 'Live system prompt', toolRegistry: stubRegistry(toolSpecs) },
+      })
+
+      const result = await manager.reduce({ agent: mockAgent, model: model as unknown as Model })
+
+      // Compaction still happens via the slice-based path
+      expect(result).toBe(true)
+      expect(streamSpy).toHaveBeenCalledTimes(2)
+      const [sliceMessages, sliceOptions] = streamSpy.mock.calls[1]! as [Message[], StreamOptions]
+      expect(sliceMessages).toHaveLength(11)
+      expect(sliceOptions.systemPrompt).toBe(DEFAULT_SUMMARIZATION_PROMPT)
+      expect(mockAgent.messages).toHaveLength(11)
+      expect(mockAgent.messages[0]!.content[0]!).toEqual({ type: 'textBlock', text: 'Slice summary' })
+    })
+
+    it('uses the slice-based path when a model override is configured, even with cacheAligned set', async () => {
+      const configModel = new MockMessageModel()
+      configModel.addTurn({ type: 'textBlock', text: 'Override summary' })
+      const streamSpy = vi.spyOn(configModel, 'streamAggregated')
+
+      const manager = new SummarizingConversationManager({
+        model: configModel as unknown as Model,
+        summaryRatio: 0.5,
+        preserveRecentMessages: 2,
+        proactiveCompression: true,
+        cacheAligned: true,
+      })
+      const messages = makeMessages(20)
+      const mockAgent = createMockAgent({
+        messages,
+        extra: { systemPrompt: 'Live system prompt', toolRegistry: stubRegistry(toolSpecs) },
+      })
+
+      const result = await manager.reduce({ agent: mockAgent, model: {} as Model })
+
+      expect(result).toBe(true)
+      expect(streamSpy).toHaveBeenCalledOnce()
+      // Slice-based: sending the full live history to a different model guarantees a cache miss
+      const [calledMessages, calledOptions] = streamSpy.mock.calls[0]! as [Message[], StreamOptions]
+      expect(calledMessages).toHaveLength(11)
+      expect(calledOptions.systemPrompt).toBe(DEFAULT_SUMMARIZATION_PROMPT)
+      expect(calledOptions.toolSpecs).toBeUndefined()
+      expect(mockAgent.messages[0]!.content[0]!).toEqual({ type: 'textBlock', text: 'Override summary' })
+    })
+
+    it('warns at construction when cacheAligned is combined with a model override', () => {
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+      try {
+        new SummarizingConversationManager({
+          model: new MockMessageModel() as unknown as Model,
+          proactiveCompression: true,
+          cacheAligned: true,
+        })
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('model override defeats cache alignment'))
+      } finally {
+        warnSpy.mockRestore()
+      }
+    })
+
+    it('warns at construction when cacheAligned is set without proactive compression', () => {
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+      try {
+        new SummarizingConversationManager({ cacheAligned: true })
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('only takes effect on proactive compression'))
+      } finally {
+        warnSpy.mockRestore()
+      }
     })
 
     it('proactive reduce with a dangling tool-use tail falls back to the slice-based path', async () => {

--- a/strands-ts/src/conversation-manager/__tests__/summarizing-conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/summarizing-conversation-manager.test.ts
@@ -4,7 +4,10 @@ import { ContextWindowOverflowError, Message, TextBlock, ToolUseBlock, ToolResul
 import { AfterModelCallEvent, BeforeModelCallEvent } from '../../hooks/events.js'
 import { createMockAgent, invokeTrackedHook } from '../../__fixtures__/agent-helpers.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
-import type { Model, BaseModelConfig } from '../../models/model.js'
+import { DEFAULT_SUMMARIZATION_PROMPT } from '../compression/context-compression.js'
+import type { Model, BaseModelConfig, StreamOptions } from '../../models/model.js'
+import type { ToolSpec } from '../../tools/types.js'
+import type { ToolRegistry } from '../../registry/tool-registry.js'
 
 function textMsg(role: 'user' | 'assistant', text: string): Message {
   return new Message({ role, content: [new TextBlock(text)] })
@@ -475,6 +478,151 @@ describe('SummarizingConversationManager', () => {
 
       const texts = agent.messages.map((m) => (m.content[0] as TextBlock).text)
       expect(texts).toEqual(['pinned-middle', 'Summary', 'old-4', 'recent-1', 'recent-2'])
+    })
+  })
+
+  describe('cacheAligned', () => {
+    const toolSpecs: ToolSpec[] = [{ name: 'search', description: 'search tool', inputSchema: { type: 'object' } }]
+
+    function stubRegistry(specs: ToolSpec[]): ToolRegistry {
+      return {
+        list: () => specs.map((toolSpec) => ({ toolSpec })),
+      } as unknown as ToolRegistry
+    }
+
+    it('proactive reduce sends the live systemPrompt, toolSpecs, and full history with a trailing instruction', async () => {
+      const model = new MockMessageModel()
+      model.addTurn({ type: 'textBlock', text: 'Summary of conversation' })
+      const streamSpy = vi.spyOn(model, 'streamAggregated')
+
+      const manager = new SummarizingConversationManager({
+        summaryRatio: 0.5,
+        preserveRecentMessages: 2,
+        proactiveCompression: true,
+        cacheAligned: true,
+      })
+      const messages = makeMessages(20)
+      const lastTwo = messages.slice(-2)
+      const fullHistory = [...messages]
+      const mockAgent = createMockAgent({
+        messages,
+        extra: { systemPrompt: 'Live system prompt', toolRegistry: stubRegistry(toolSpecs) },
+      })
+
+      // Proactive: no error passed
+      const result = await manager.reduce({ agent: mockAgent, model: model as unknown as Model })
+
+      expect(result).toBe(true)
+      expect(streamSpy).toHaveBeenCalledOnce()
+      const [calledMessages, calledOptions] = streamSpy.mock.calls[0]! as [Message[], StreamOptions]
+      // Full history (20) plus the trailing instruction turn
+      expect(calledMessages).toHaveLength(21)
+      expect(calledMessages.slice(0, 20)).toEqual(fullHistory)
+      expect(calledMessages[20]!.role).toBe('user')
+      expect(calledOptions.systemPrompt).toBe('Live system prompt')
+      expect(calledOptions.toolSpecs).toEqual(toolSpecs)
+
+      // 20 * 0.5 = 10 summarized → 1 summary + 10 remaining = 11; recent messages preserved verbatim
+      expect(mockAgent.messages).toHaveLength(11)
+      expect(mockAgent.messages[0]!.role).toBe('user')
+      expect(mockAgent.messages[0]!.content[0]!).toEqual({ type: 'textBlock', text: 'Summary of conversation' })
+      expect(mockAgent.messages.slice(-2)).toEqual(lastTwo)
+    })
+
+    it('reactive reduce uses the slice-based path even when cacheAligned is set', async () => {
+      const model = new MockMessageModel()
+      model.addTurn({ type: 'textBlock', text: 'Summary' })
+      const streamSpy = vi.spyOn(model, 'streamAggregated')
+
+      const manager = new SummarizingConversationManager({
+        summaryRatio: 0.5,
+        preserveRecentMessages: 2,
+        proactiveCompression: true,
+        cacheAligned: true,
+      })
+      const messages = makeMessages(20)
+      const expectedSlice = messages.slice(0, 10)
+      const mockAgent = createMockAgent({
+        messages,
+        extra: { systemPrompt: 'Live system prompt', toolRegistry: stubRegistry(toolSpecs) },
+      })
+
+      // Reactive: error passed
+      await manager.reduce({
+        agent: mockAgent,
+        model: model as unknown as Model,
+        error: new ContextWindowOverflowError('overflow'),
+      })
+
+      expect(streamSpy).toHaveBeenCalledOnce()
+      const [calledMessages, calledOptions] = streamSpy.mock.calls[0]! as [Message[], StreamOptions]
+      // Slice-based: only the summarize slice + the "Please summarize" request, live tool specs NOT sent
+      expect(calledMessages).toHaveLength(11)
+      expect(calledMessages.slice(0, 10)).toEqual(expectedSlice)
+      expect((calledMessages[10]!.content[0] as TextBlock).text).toBe('Please summarize this conversation.')
+      expect(calledOptions.systemPrompt).toBe(DEFAULT_SUMMARIZATION_PROMPT)
+      expect(calledOptions.toolSpecs).toBeUndefined()
+    })
+
+    it('proactive reduce with cacheAligned off is identical to the slice-based path', async () => {
+      const model = new MockMessageModel()
+      model.addTurn({ type: 'textBlock', text: 'Summary' })
+      const streamSpy = vi.spyOn(model, 'streamAggregated')
+
+      const manager = new SummarizingConversationManager({
+        summaryRatio: 0.5,
+        preserveRecentMessages: 2,
+        proactiveCompression: true,
+      })
+      const messages = makeMessages(20)
+      const expectedSlice = messages.slice(0, 10)
+      const mockAgent = createMockAgent({
+        messages,
+        extra: { systemPrompt: 'Live system prompt', toolRegistry: stubRegistry(toolSpecs) },
+      })
+
+      await manager.reduce({ agent: mockAgent, model: model as unknown as Model })
+
+      const [calledMessages, calledOptions] = streamSpy.mock.calls[0]! as [Message[], StreamOptions]
+      expect(calledMessages).toHaveLength(11)
+      expect(calledMessages.slice(0, 10)).toEqual(expectedSlice)
+      expect(calledOptions.systemPrompt).toBe(DEFAULT_SUMMARIZATION_PROMPT)
+      expect(calledOptions.toolSpecs).toBeUndefined()
+      expect(mockAgent.messages).toHaveLength(11)
+    })
+
+    it('proactive reduce with a dangling tool-use tail falls back to the slice-based path', async () => {
+      const model = new MockMessageModel()
+      model.addTurn({ type: 'textBlock', text: 'Summary' })
+      const streamSpy = vi.spyOn(model, 'streamAggregated')
+
+      const manager = new SummarizingConversationManager({
+        summaryRatio: 0.5,
+        preserveRecentMessages: 2,
+        proactiveCompression: true,
+        cacheAligned: true,
+      })
+      // Last message is an assistant toolUse still awaiting its result — not a valid append tail
+      const messages = [
+        ...makeMessages(19),
+        new Message({
+          role: 'assistant',
+          content: [new ToolUseBlock({ name: 'search', toolUseId: 'id-1', input: {} })],
+        }),
+      ]
+      const originalLength = messages.length
+      const mockAgent = createMockAgent({
+        messages,
+        extra: { systemPrompt: 'Live system prompt', toolRegistry: stubRegistry(toolSpecs) },
+      })
+
+      await manager.reduce({ agent: mockAgent, model: model as unknown as Model })
+
+      const [calledMessages, calledOptions] = streamSpy.mock.calls[0]! as [Message[], StreamOptions]
+      // Slice-based fallback: does not send the full history / live tool specs
+      expect(calledMessages.length).toBeLessThan(originalLength)
+      expect(calledOptions.systemPrompt).toBe(DEFAULT_SUMMARIZATION_PROMPT)
+      expect(calledOptions.toolSpecs).toBeUndefined()
     })
   })
 })

--- a/strands-ts/src/conversation-manager/compression/context-compression.ts
+++ b/strands-ts/src/conversation-manager/compression/context-compression.ts
@@ -199,7 +199,8 @@ export async function generateSummary(
  * with an assistant message, the instruction is appended as a new user turn.
  *
  * @returns A user-role message containing the model-generated summary
- * @throws If the model fails to produce a response
+ * @throws If the model fails to produce a response, or responds with tool use
+ *   instead of a text summary
  */
 export async function generateSummaryCacheAligned(
   allMessages: Message[],
@@ -246,6 +247,13 @@ export async function generateSummaryCacheAligned(
 
   if (!result?.done || !result.value) {
     throw new Error('Failed to generate summary: no response from model')
+  }
+
+  // The aligned request carries the live tool specs, so the model may answer with a tool call
+  // instead of a summary. Splicing that into history would leave a dangling toolUse without a
+  // toolResult — reject it so the caller can fall back to slice-based summarization.
+  if (result.value.message.content.some((block) => block.type === 'toolUseBlock')) {
+    throw new Error('Failed to generate summary: model responded with tool use instead of a summary')
   }
 
   return new Message({

--- a/strands-ts/src/conversation-manager/compression/context-compression.ts
+++ b/strands-ts/src/conversation-manager/compression/context-compression.ts
@@ -1,10 +1,14 @@
 import { Message, TextBlock } from '../../types/messages.js'
-import type { Model } from '../../models/model.js'
+import type { SystemPrompt } from '../../types/messages.js'
+import type { Model, StreamOptions } from '../../models/model.js'
+import type { ToolSpec } from '../../tools/types.js'
 
-export const DEFAULT_SUMMARIZATION_PROMPT = `You are a conversation summarizer. Provide a concise summary of the conversation \
-history.
-
-Format Requirements:
+/**
+ * Requirements shared by {@link DEFAULT_SUMMARIZATION_PROMPT} and
+ * {@link DEFAULT_SUMMARIZATION_INSTRUCTION} — the two texts differ only in
+ * their opening line (persona vs. imperative) and the trailing example block.
+ */
+const SUMMARIZATION_REQUIREMENTS = `Format Requirements:
 - You MUST create a structured and concise summary in bullet-point format.
 - You MUST NOT respond conversationally.
 - You MUST NOT address the user directly.
@@ -19,7 +23,12 @@ Your task is to create a structured summary document:
 - It MUST contain bullet points for all significant tools executed and their results
 - It MUST contain bullet points for any code or technical information shared
 - It MUST contain a section of key insights gained
-- It MUST format the summary in the third person
+- It MUST format the summary in the third person`
+
+export const DEFAULT_SUMMARIZATION_PROMPT = `You are a conversation summarizer. Provide a concise summary of the conversation \
+history.
+
+${SUMMARIZATION_REQUIREMENTS}
 
 Example format:
 
@@ -29,6 +38,22 @@ Example format:
 
 ## Tools Executed
 * Tool X: Result Y`
+
+/**
+ * Default instruction appended as a trailing user turn when generating a
+ * cache-aligned summary.
+ *
+ * Unlike {@link DEFAULT_SUMMARIZATION_PROMPT} (which is delivered as a system
+ * prompt), this text is delivered as a normal user message so the request
+ * prefix — system prompt, tool specs, and message history — stays byte-identical
+ * to the live conversation's request and the provider prompt cache is reused.
+ * It shares {@link SUMMARIZATION_REQUIREMENTS} with the system-prompt variant
+ * rather than relying on a summarization-specific system prompt.
+ */
+export const DEFAULT_SUMMARIZATION_INSTRUCTION = `Summarize the conversation so far so it can be handed off with the recent \
+messages preserved.
+
+${SUMMARIZATION_REQUIREMENTS}`
 
 /**
  * Adjust a split point forward to avoid breaking tool use/result pairs.
@@ -138,6 +163,59 @@ export async function generateSummary(
   const stream = model.streamAggregated(summarizationMessages, {
     systemPrompt: systemPrompt ?? DEFAULT_SUMMARIZATION_PROMPT,
   })
+
+  let result: Awaited<ReturnType<typeof stream.next>> | undefined
+  for (;;) {
+    result = await stream.next()
+    if (result.done) break
+  }
+
+  if (!result?.done || !result.value) {
+    throw new Error('Failed to generate summary: no response from model')
+  }
+
+  return new Message({
+    role: 'user',
+    content: result.value.message.content,
+  })
+}
+
+/**
+ * Generate a summary using a cache-aligned request.
+ *
+ * The request reuses the agent's live system prompt and tool specs and the full
+ * message history, appending the summarization instruction as a trailing user
+ * turn. This keeps the request prefix byte-identical to the live conversation's
+ * request so the provider prompt cache is reused, rather than sending a fresh
+ * summarization-only request that would miss the cache.
+ *
+ * @returns A user-role message containing the model-generated summary
+ * @throws If the model fails to produce a response
+ */
+export async function generateSummaryCacheAligned(
+  allMessages: Message[],
+  model: Model,
+  options: { systemPrompt?: SystemPrompt | undefined; toolSpecs?: ToolSpec[] | undefined; instruction?: string }
+): Promise<Message> {
+  const request = [
+    ...allMessages,
+    new Message({
+      role: 'user',
+      content: [new TextBlock(options.instruction ?? DEFAULT_SUMMARIZATION_INSTRUCTION)],
+    }),
+  ]
+
+  // Only set keys that are defined so the request prefix (system prompt, tool specs) matches the
+  // live turn exactly under exactOptionalPropertyTypes.
+  const streamOptions: StreamOptions = {}
+  if (options.systemPrompt !== undefined) {
+    streamOptions.systemPrompt = options.systemPrompt
+  }
+  if (options.toolSpecs !== undefined) {
+    streamOptions.toolSpecs = options.toolSpecs
+  }
+
+  const stream = model.streamAggregated(request, streamOptions)
 
   let result: Awaited<ReturnType<typeof stream.next>> | undefined
   for (;;) {

--- a/strands-ts/src/conversation-manager/compression/context-compression.ts
+++ b/strands-ts/src/conversation-manager/compression/context-compression.ts
@@ -184,10 +184,19 @@ export async function generateSummary(
  * Generate a summary using a cache-aligned request.
  *
  * The request reuses the agent's live system prompt and tool specs and the full
- * message history, appending the summarization instruction as a trailing user
- * turn. This keeps the request prefix byte-identical to the live conversation's
- * request so the provider prompt cache is reused, rather than sending a fresh
+ * message history, delivering the summarization instruction at the tail. This
+ * keeps the request prefix byte-identical to the live conversation's request so
+ * the provider prompt cache is reused, rather than sending a fresh
  * summarization-only request that would miss the cache.
+ *
+ * When the history ends with a user message (always the case at the proactive
+ * compression trigger — the upcoming turn's input is already appended), the
+ * instruction is merged into a clone of that final user message as an
+ * additional text block. Appending it as a new turn would produce consecutive
+ * user roles, which providers like Bedrock reject for Anthropic models. The
+ * final message lies beyond the previous turn's cache point, so the cached
+ * prefix `messages[0..n-2]` is untouched either way. When the history ends
+ * with an assistant message, the instruction is appended as a new user turn.
  *
  * @returns A user-role message containing the model-generated summary
  * @throws If the model fails to produce a response
@@ -195,15 +204,27 @@ export async function generateSummary(
 export async function generateSummaryCacheAligned(
   allMessages: Message[],
   model: Model,
-  options: { systemPrompt?: SystemPrompt | undefined; toolSpecs?: ToolSpec[] | undefined; instruction?: string }
+  options: {
+    systemPrompt?: SystemPrompt | undefined
+    toolSpecs?: ToolSpec[] | undefined
+    instruction?: string | undefined
+  }
 ): Promise<Message> {
-  const request = [
-    ...allMessages,
-    new Message({
+  const instructionBlock = new TextBlock(options.instruction ?? DEFAULT_SUMMARIZATION_INSTRUCTION)
+
+  const last = allMessages[allMessages.length - 1]
+  let request: Message[]
+  if (last && last.role === 'user') {
+    // Clone rather than mutate: the live history must not carry the instruction.
+    const merged = new Message({
       role: 'user',
-      content: [new TextBlock(options.instruction ?? DEFAULT_SUMMARIZATION_INSTRUCTION)],
-    }),
-  ]
+      content: [...last.content, instructionBlock],
+      ...(last.metadata !== undefined && { metadata: last.metadata }),
+    })
+    request = [...allMessages.slice(0, -1), merged]
+  } else {
+    request = [...allMessages, new Message({ role: 'user', content: [instructionBlock] })]
+  }
 
   // Only set keys that are defined so the request prefix (system prompt, tool specs) matches the
   // live turn exactly under exactOptionalPropertyTypes.

--- a/strands-ts/src/conversation-manager/compression/context-compression.ts
+++ b/strands-ts/src/conversation-manager/compression/context-compression.ts
@@ -40,18 +40,18 @@ Example format:
 * Tool X: Result Y`
 
 /**
- * Default instruction appended as a trailing user turn when generating a
- * cache-aligned summary.
+ * Default instruction delivered at the tail of a cache-aligned summary request
+ * (merged into the final user message, or appended as a new user turn).
  *
  * Unlike {@link DEFAULT_SUMMARIZATION_PROMPT} (which is delivered as a system
- * prompt), this text is delivered as a normal user message so the request
+ * prompt), this text is delivered as normal user content so the request
  * prefix — system prompt, tool specs, and message history — stays byte-identical
  * to the live conversation's request and the provider prompt cache is reused.
  * It shares {@link SUMMARIZATION_REQUIREMENTS} with the system-prompt variant
  * rather than relying on a summarization-specific system prompt.
  */
-export const DEFAULT_SUMMARIZATION_INSTRUCTION = `Summarize the conversation so far so it can be handed off with the recent \
-messages preserved.
+export const DEFAULT_SUMMARIZATION_INSTRUCTION = `Summarize the conversation so far. The most recent messages will be \
+preserved verbatim alongside the summary, so exclude them from the summary and focus on the earlier conversation.
 
 ${SUMMARIZATION_REQUIREMENTS}`
 
@@ -142,6 +142,29 @@ export function findValidTrimPoint(messages: Message[], startIndex: number): num
 }
 
 /**
+ * Drain an aggregated model stream and wrap the final response in a
+ * user-role summary message.
+ *
+ * @throws If the model fails to produce a response
+ */
+async function drainSummaryResponse(stream: ReturnType<Model['streamAggregated']>): Promise<Message> {
+  let result: Awaited<ReturnType<typeof stream.next>> | undefined
+  for (;;) {
+    result = await stream.next()
+    if (result.done) break
+  }
+
+  if (!result?.done || !result.value) {
+    throw new Error('Failed to generate summary: no response from model')
+  }
+
+  return new Message({
+    role: 'user',
+    content: result.value.message.content,
+  })
+}
+
+/**
  * Generate a summary of the provided messages by calling the model.
  *
  * @returns A user-role message containing the model-generated summary
@@ -160,24 +183,34 @@ export async function generateSummary(
     }),
   ]
 
-  const stream = model.streamAggregated(summarizationMessages, {
-    systemPrompt: systemPrompt ?? DEFAULT_SUMMARIZATION_PROMPT,
-  })
+  return await drainSummaryResponse(
+    model.streamAggregated(summarizationMessages, {
+      systemPrompt: systemPrompt ?? DEFAULT_SUMMARIZATION_PROMPT,
+    })
+  )
+}
 
-  let result: Awaited<ReturnType<typeof stream.next>> | undefined
-  for (;;) {
-    result = await stream.next()
-    if (result.done) break
-  }
+/**
+ * Options for {@link generateSummaryCacheAligned}.
+ */
+export interface CacheAlignedSummaryOptions {
+  /**
+   * The agent's live system prompt, reused verbatim so the request prefix
+   * matches the live conversation's request.
+   */
+  systemPrompt?: SystemPrompt | undefined
 
-  if (!result?.done || !result.value) {
-    throw new Error('Failed to generate summary: no response from model')
-  }
+  /**
+   * The agent's live tool specs, reused verbatim so the request prefix
+   * matches the live conversation's request.
+   */
+  toolSpecs?: ToolSpec[] | undefined
 
-  return new Message({
-    role: 'user',
-    content: result.value.message.content,
-  })
+  /**
+   * Summarization instruction delivered at the tail of the request.
+   * Defaults to {@link DEFAULT_SUMMARIZATION_INSTRUCTION}.
+   */
+  instruction?: string | undefined
 }
 
 /**
@@ -205,11 +238,7 @@ export async function generateSummary(
 export async function generateSummaryCacheAligned(
   allMessages: Message[],
   model: Model,
-  options: {
-    systemPrompt?: SystemPrompt | undefined
-    toolSpecs?: ToolSpec[] | undefined
-    instruction?: string | undefined
-  }
+  options: CacheAlignedSummaryOptions
 ): Promise<Message> {
   const instructionBlock = new TextBlock(options.instruction ?? DEFAULT_SUMMARIZATION_INSTRUCTION)
 
@@ -237,29 +266,16 @@ export async function generateSummaryCacheAligned(
     streamOptions.toolSpecs = options.toolSpecs
   }
 
-  const stream = model.streamAggregated(request, streamOptions)
-
-  let result: Awaited<ReturnType<typeof stream.next>> | undefined
-  for (;;) {
-    result = await stream.next()
-    if (result.done) break
-  }
-
-  if (!result?.done || !result.value) {
-    throw new Error('Failed to generate summary: no response from model')
-  }
+  const summary = await drainSummaryResponse(model.streamAggregated(request, streamOptions))
 
   // The aligned request carries the live tool specs, so the model may answer with a tool call
   // instead of a summary. Splicing that into history would leave a dangling toolUse without a
   // toolResult — reject it so the caller can fall back to slice-based summarization.
-  if (result.value.message.content.some((block) => block.type === 'toolUseBlock')) {
+  if (summary.content.some((block) => block.type === 'toolUseBlock')) {
     throw new Error('Failed to generate summary: model responded with tool use instead of a summary')
   }
 
-  return new Message({
-    role: 'user',
-    content: result.value.message.content,
-  })
+  return summary
 }
 
 export type MessageTypeFilter = 'tools' | 'messages' | 'all'

--- a/strands-ts/src/conversation-manager/summarizing-conversation-manager.ts
+++ b/strands-ts/src/conversation-manager/summarizing-conversation-manager.ts
@@ -209,21 +209,33 @@ export class SummarizingConversationManager extends ConversationManager {
     // cache. It only fits under the proactive threshold: the cache-aligned request is a superset of
     // the live request, so on reactive overflow it would overflow again — hence the slice-based
     // fallback there (and when cacheAligned is off, or the tail can't carry the instruction).
-    let summaryMessage: Message
-    if (this._cacheAligned && proactive && this._isValidAppendTail(messages)) {
-      summaryMessage = await generateSummaryCacheAligned(messages, model, {
-        systemPrompt: agent.systemPrompt,
-        toolSpecs: agent.toolRegistry.list().map((tool) => tool.toolSpec),
-        // Only a user-supplied prompt overrides the instruction; otherwise
-        // DEFAULT_SUMMARIZATION_INSTRUCTION applies inside generateSummaryCacheAligned.
-        instruction: this._customSummarizationPrompt,
-      })
-    } else {
-      if (this._cacheAligned && proactive) {
-        logger.debug('cache_aligned=<true> | message tail is not a valid append point, falling back to slice-based')
+    // A configured model override also disables the aligned path: sending the full live history to
+    // a different model guarantees a cache miss, making it strictly worse than slice-based.
+    let summaryMessage: Message | undefined
+    if (this._cacheAligned && proactive && this._model === undefined) {
+      if (this._isValidAppendTail(messages)) {
+        try {
+          summaryMessage = await generateSummaryCacheAligned(messages, model, {
+            systemPrompt: agent.systemPrompt,
+            toolSpecs: agent.toolRegistry.list().map((tool) => tool.toolSpec),
+            // Only a user-supplied prompt overrides the instruction; otherwise
+            // DEFAULT_SUMMARIZATION_INSTRUCTION applies inside generateSummaryCacheAligned.
+            instruction: this._customSummarizationPrompt,
+          })
+        } catch (alignedError) {
+          // Without this fallback no compaction would happen, and a persistently failing aligned
+          // request would repeat on every subsequent turn.
+          logger.warn(
+            `error=<${alignedError}> | cache-aligned summarization failed | falling back to slice-based summarization`
+          )
+        }
+      } else {
+        logger.debug(
+          'cache_aligned=<true> | message tail is not a valid append point | falling back to slice-based summarization'
+        )
       }
-      summaryMessage = await generateSummary(toSummarize, model, this._summarizationSystemPrompt)
     }
+    summaryMessage ??= await generateSummary(toSummarize, model, this._summarizationSystemPrompt)
 
     // Replace summarized range with protected messages + summary. Recent messages stay verbatim;
     // only the oldest range is replaced, regardless of how the summary was generated.

--- a/strands-ts/src/conversation-manager/summarizing-conversation-manager.ts
+++ b/strands-ts/src/conversation-manager/summarizing-conversation-manager.ts
@@ -101,6 +101,13 @@ export class SummarizingConversationManager extends ConversationManager {
   private readonly _summaryRatio: number
   private readonly _preserveRecentMessages: number
   private readonly _summarizationSystemPrompt: string
+  /**
+   * The raw user-supplied `summarizationSystemPrompt`, without the default applied.
+   * The cache-aligned path must distinguish "user configured a prompt" (use it as the
+   * trailing instruction) from "default" (use {@link DEFAULT_SUMMARIZATION_INSTRUCTION},
+   * which is purpose-built for user-turn delivery — the default system prompt is not).
+   */
+  private readonly _customSummarizationPrompt: string | undefined
   private readonly _pinFirst: number | undefined
   private readonly _cacheAligned: boolean
   private _pinFirstApplied = false
@@ -111,6 +118,7 @@ export class SummarizingConversationManager extends ConversationManager {
     // clamped [0.1, 0.8]
     this._summaryRatio = Math.max(0.1, Math.min(0.8, config?.summaryRatio ?? 0.3))
     this._preserveRecentMessages = config?.preserveRecentMessages ?? 10
+    this._customSummarizationPrompt = config?.summarizationSystemPrompt
     this._summarizationSystemPrompt = config?.summarizationSystemPrompt ?? DEFAULT_SUMMARIZATION_PROMPT
     this._pinFirst = config?.pinFirst != null ? Math.max(0, config.pinFirst) : undefined
     this._cacheAligned = config?.cacheAligned ?? false
@@ -200,13 +208,15 @@ export class SummarizingConversationManager extends ConversationManager {
     // system prompt + tool specs so the request prefix matches the live turn and hits the prompt
     // cache. It only fits under the proactive threshold: the cache-aligned request is a superset of
     // the live request, so on reactive overflow it would overflow again — hence the slice-based
-    // fallback there (and when cacheAligned is off, or the tail can't take an appended user turn).
+    // fallback there (and when cacheAligned is off, or the tail can't carry the instruction).
     let summaryMessage: Message
     if (this._cacheAligned && proactive && this._isValidAppendTail(messages)) {
       summaryMessage = await generateSummaryCacheAligned(messages, model, {
         systemPrompt: agent.systemPrompt,
         toolSpecs: agent.toolRegistry.list().map((tool) => tool.toolSpec),
-        instruction: this._summarizationSystemPrompt,
+        // Only a user-supplied prompt overrides the instruction; otherwise
+        // DEFAULT_SUMMARIZATION_INSTRUCTION applies inside generateSummaryCacheAligned.
+        instruction: this._customSummarizationPrompt,
       })
     } else {
       if (this._cacheAligned && proactive) {
@@ -223,9 +233,10 @@ export class SummarizingConversationManager extends ConversationManager {
   }
 
   /**
-   * Returns `true` if a user turn can be appended after the last message without
-   * breaking a tool-use/result pair — i.e. the last message is not an assistant
-   * toolUse still awaiting its toolResult. Empty histories are valid.
+   * Returns `true` if the summarization instruction can be delivered at the tail —
+   * merged into a trailing user message, or appended as a new user turn after an
+   * assistant text message — i.e. the last message is not an assistant toolUse
+   * still awaiting its toolResult. Empty histories are valid.
    */
   private _isValidAppendTail(messages: Message[]): boolean {
     const last = messages[messages.length - 1]

--- a/strands-ts/src/conversation-manager/summarizing-conversation-manager.ts
+++ b/strands-ts/src/conversation-manager/summarizing-conversation-manager.ts
@@ -16,8 +16,10 @@ import { applyPinFirst, partitionPinned } from './compression/pin-message.js'
 import {
   adjustSplitPointForToolPairs,
   generateSummary,
+  generateSummaryCacheAligned,
   DEFAULT_SUMMARIZATION_PROMPT,
 } from './compression/context-compression.js'
+import type { Message } from '../types/messages.js'
 import { logger } from '../logging/logger.js'
 import { normalizeError } from '../errors.js'
 import type { Model } from '../models/model.js'
@@ -65,6 +67,24 @@ export type SummarizingConversationManagerConfig = {
    * Pinned messages are protected from summarization and compacted to the front.
    */
   pinFirst?: number
+
+  /**
+   * Align the summarization request with the live conversation's request so the
+   * provider prompt cache is reused.
+   *
+   * When `true`, proactive summarization reuses the agent's live system prompt
+   * and tool specs and the full message history, appending the summarization
+   * instruction as a trailing user turn. This makes the request prefix
+   * byte-identical to the live conversation's request, so the provider prompt
+   * cache is hit instead of paying to re-read the history.
+   *
+   * Only takes effect on proactive compression. Reactive overflow recovery
+   * always uses slice-based summarization: the cache-aligned request is a
+   * superset of the live request, so it only fits under the proactive threshold —
+   * on overflow it would overflow again. Defaults to `false` (existing
+   * slice-based behavior).
+   */
+  cacheAligned?: boolean
 }
 
 /**
@@ -82,6 +102,7 @@ export class SummarizingConversationManager extends ConversationManager {
   private readonly _preserveRecentMessages: number
   private readonly _summarizationSystemPrompt: string
   private readonly _pinFirst: number | undefined
+  private readonly _cacheAligned: boolean
   private _pinFirstApplied = false
 
   constructor(config?: SummarizingConversationManagerConfig) {
@@ -92,6 +113,16 @@ export class SummarizingConversationManager extends ConversationManager {
     this._preserveRecentMessages = config?.preserveRecentMessages ?? 10
     this._summarizationSystemPrompt = config?.summarizationSystemPrompt ?? DEFAULT_SUMMARIZATION_PROMPT
     this._pinFirst = config?.pinFirst != null ? Math.max(0, config.pinFirst) : undefined
+    this._cacheAligned = config?.cacheAligned ?? false
+
+    if (this._cacheAligned && config?.model) {
+      logger.warn('cache_aligned=<true> | model override defeats cache alignment; summaries will miss the prompt cache')
+    }
+    if (this._cacheAligned && this._compressionThreshold === undefined) {
+      logger.warn(
+        'cache_aligned=<true> | cacheAligned only takes effect on proactive compression; reactive overflow uses slice-based summarization'
+      )
+    }
   }
 
   /**
@@ -108,7 +139,8 @@ export class SummarizingConversationManager extends ConversationManager {
    */
   async reduce({ agent, model, error }: ConversationManagerReduceOptions): Promise<boolean> {
     try {
-      return await this._summarizeOldest(agent, this._model ?? model)
+      // `error === undefined` means proactive compression; a set error means reactive overflow recovery.
+      return await this._summarizeOldest(agent, this._model ?? model, error === undefined)
     } catch (summarizationError) {
       if (error) {
         // Reactive: rethrow so the ContextWindowOverflowError propagates
@@ -128,9 +160,10 @@ export class SummarizingConversationManager extends ConversationManager {
    *
    * @param agent - The agent instance
    * @param model - The model to use for summarization
+   * @param proactive - `true` for proactive compression, `false` for reactive overflow recovery
    * @returns `true` if the history was reduced, `false` otherwise
    */
-  private async _summarizeOldest(agent: LocalAgent, model: Model): Promise<boolean> {
+  private async _summarizeOldest(agent: LocalAgent, model: Model, proactive: boolean): Promise<boolean> {
     const messages = agent.messages
 
     // Calculate how many messages to summarize
@@ -163,12 +196,44 @@ export class SummarizingConversationManager extends ConversationManager {
       return false
     }
 
-    // Generate summary via model call
-    const summaryMessage = await generateSummary(toSummarize, model, this._summarizationSystemPrompt)
+    // Generate the summary. The cache-aligned path sends the full history with the agent's live
+    // system prompt + tool specs so the request prefix matches the live turn and hits the prompt
+    // cache. It only fits under the proactive threshold: the cache-aligned request is a superset of
+    // the live request, so on reactive overflow it would overflow again — hence the slice-based
+    // fallback there (and when cacheAligned is off, or the tail can't take an appended user turn).
+    let summaryMessage: Message
+    if (this._cacheAligned && proactive && this._isValidAppendTail(messages)) {
+      summaryMessage = await generateSummaryCacheAligned(messages, model, {
+        systemPrompt: agent.systemPrompt,
+        toolSpecs: agent.toolRegistry.list().map((tool) => tool.toolSpec),
+        instruction: this._summarizationSystemPrompt,
+      })
+    } else {
+      if (this._cacheAligned && proactive) {
+        logger.debug('cache_aligned=<true> | message tail is not a valid append point, falling back to slice-based')
+      }
+      summaryMessage = await generateSummary(toSummarize, model, this._summarizationSystemPrompt)
+    }
 
-    // Replace summarized range with protected messages + summary
+    // Replace summarized range with protected messages + summary. Recent messages stay verbatim;
+    // only the oldest range is replaced, regardless of how the summary was generated.
     messages.splice(0, messagesToSummarizeCount, ...protectedToPreserve, summaryMessage)
 
     return true
+  }
+
+  /**
+   * Returns `true` if a user turn can be appended after the last message without
+   * breaking a tool-use/result pair — i.e. the last message is not an assistant
+   * toolUse still awaiting its toolResult. Empty histories are valid.
+   */
+  private _isValidAppendTail(messages: Message[]): boolean {
+    const last = messages[messages.length - 1]
+    if (!last) {
+      return true
+    }
+    const hasToolUse = last.content.some((block) => block.type === 'toolUseBlock')
+    const hasToolResult = last.content.some((block) => block.type === 'toolResultBlock')
+    return !(hasToolUse && !hasToolResult)
   }
 }

--- a/strands-ts/src/conversation-manager/summarizing-conversation-manager.ts
+++ b/strands-ts/src/conversation-manager/summarizing-conversation-manager.ts
@@ -73,16 +73,28 @@ export type SummarizingConversationManagerConfig = {
    * provider prompt cache is reused.
    *
    * When `true`, proactive summarization reuses the agent's live system prompt
-   * and tool specs and the full message history, appending the summarization
-   * instruction as a trailing user turn. This makes the request prefix
+   * and tool specs and the full message history, delivering the summarization
+   * instruction at the tail of the request. This makes the request prefix
    * byte-identical to the live conversation's request, so the provider prompt
    * cache is hit instead of paying to re-read the history.
    *
-   * Only takes effect on proactive compression. Reactive overflow recovery
-   * always uses slice-based summarization: the cache-aligned request is a
-   * superset of the live request, so it only fits under the proactive threshold —
-   * on overflow it would overflow again. Defaults to `false` (existing
-   * slice-based behavior).
+   * Only enable this when the model has prompt caching configured (e.g.
+   * `cacheConfig` on `BedrockModel`): the aligned request re-sends the entire
+   * history, so without a cache hit it is strictly more expensive than the
+   * slice-based path.
+   *
+   * Note a semantic difference from the slice-based path: the model sees the
+   * entire history — including the recent messages that are preserved verbatim —
+   * rather than only the oldest slice being summarized. The default instruction
+   * tells the model those recent messages are preserved and should be excluded
+   * from the summary.
+   *
+   * Only takes effect on proactive compression, and is ignored when a `model`
+   * override is configured (a different model cannot reuse the live model's
+   * cache). Reactive overflow recovery always uses slice-based summarization:
+   * the cache-aligned request is a superset of the live request, so it only
+   * fits under the proactive threshold — on overflow it would overflow again.
+   * Defaults to `false` (existing slice-based behavior).
    */
   cacheAligned?: boolean
 }
@@ -124,11 +136,13 @@ export class SummarizingConversationManager extends ConversationManager {
     this._cacheAligned = config?.cacheAligned ?? false
 
     if (this._cacheAligned && config?.model) {
-      logger.warn('cache_aligned=<true> | model override defeats cache alignment; summaries will miss the prompt cache')
+      logger.warn(
+        'cache_aligned=<true> | model override defeats cache alignment | summaries will miss the prompt cache'
+      )
     }
     if (this._cacheAligned && this._compressionThreshold === undefined) {
       logger.warn(
-        'cache_aligned=<true> | cacheAligned only takes effect on proactive compression; reactive overflow uses slice-based summarization'
+        'cache_aligned=<true> | cacheAligned only takes effect on proactive compression | reactive overflow uses slice-based summarization'
       )
     }
   }


### PR DESCRIPTION
Follow-up to #3090 — the runnable example and docs-site page for cache-aligned summarization, split out to keep #3090 under the size limit.

**Depends on #3090. Do not merge until it lands.**

The example imports the `cacheAligned` option added in #3090, so it cannot compile against `main` yet. This PR is a **draft** on purpose:

- While #3090 is open, this branch sits on top of it, so the diff below temporarily includes #3090's commits too.
- Once #3090 merges, this branch is rebased onto `main`, the diff collapses to just the example + docs page (~439 lines, `size/m`), and it's marked ready for review.

Contents:
- `strands-ts/examples/cache-aligned-summarization/` — runnable REPL agent demonstrating `cacheAligned` + the 3-minute idle-summarize-while-cache-warm pattern.
- `site/.../conversation-management.mdx` — Cache-Aligned Summarization section (warm-vs-cold-cache economics, fallbacks, idle pattern) + typechecked snippet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)