### PR TITLE
feat(plugins): add get_plugin/get_plugins to Agent, Graph, and Swarm

### DIFF
--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -97,6 +97,9 @@ logger = logging.getLogger(__name__)
 # TypeVar for generic structured output
 T = TypeVar("T", bound=BaseModel)
 
+# TypeVar for generic plugin lookup by type
+TPlugin = TypeVar("TPlugin", bound=Plugin)
+
 
 # Sentinel class and object to distinguish between explicit None and default parameter value
 class _DefaultCallbackHandlerSentinel:
@@ -1619,3 +1622,21 @@ class Agent(AgentBase):
             redacted_content = [{"text": redact_message}]
 
         return redacted_content
+
+    def get_plugin(self, plugin_type: type[TPlugin]) -> TPlugin | None:
+        """Return the registered plugin of type ``plugin_type``, or ``None`` if none is registered.
+
+        Args:
+            plugin_type: The plugin class to look up.
+
+        Returns:
+            The matching plugin instance, or ``None`` if no registered plugin matches.
+        """
+        for plugin in self._plugin_registry._plugins.values():
+            if isinstance(plugin, plugin_type):
+                return plugin
+        return None
+
+    def get_plugins(self) -> list[Plugin]:
+        """Return all plugins registered on this agent, in registration order."""
+        return list(self._plugin_registry._plugins.values())

--- a/strands-py/src/strands/multiagent/base.py
+++ b/strands-py/src/strands/multiagent/base.py
@@ -9,15 +9,18 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Union
+from typing import Any, TypeVar, Union
 
 from .._async import run_async
 from ..agent import AgentResult
 from ..hooks.registry import HookCallback, HookOrder
 from ..interrupt import Interrupt
+from ..plugins.multiagent_plugin import MultiAgentPlugin
 from ..types.event_loop import Metrics, Usage
 from ..types.multiagent import MultiAgentInput
 from ..types.traces import AttributeValue
+
+TMultiAgentPlugin = TypeVar("TMultiAgentPlugin", bound=MultiAgentPlugin)
 
 logger = logging.getLogger(__name__)
 
@@ -271,6 +274,28 @@ class MultiAgentBase(ABC):
             order: Execution priority. Lower values execute first.
         """
         raise NotImplementedError(f"{type(self).__name__} must implement add_hook() to support plugins")
+
+    def get_plugin(self, plugin_type: type[TMultiAgentPlugin]) -> TMultiAgentPlugin | None:
+        """Return the registered plugin of type ``plugin_type``, or ``None`` if none is registered.
+
+        Subclasses that support plugins should override this method to look up
+        against their plugin registry.
+
+        Args:
+            plugin_type: The plugin class to look up.
+
+        Returns:
+            The matching plugin instance, or ``None`` if no registered plugin matches.
+        """
+        raise NotImplementedError(f"{type(self).__name__} must implement get_plugin() to support plugins")
+
+    def get_plugins(self) -> list[MultiAgentPlugin]:
+        """Return all plugins registered on this orchestrator, in registration order.
+
+        Subclasses that support plugins should override this method to return
+        their registered plugins.
+        """
+        raise NotImplementedError(f"{type(self).__name__} must implement get_plugins() to support plugins")
 
     def _parse_trace_attributes(
         self, attributes: Mapping[str, AttributeValue] | None = None

--- a/strands-py/src/strands/multiagent/graph.py
+++ b/strands-py/src/strands/multiagent/graph.py
@@ -56,7 +56,7 @@ from ..types.event_loop import Metrics, Usage
 from ..types.multiagent import MultiAgentInput
 from ..types.session import decode_bytes_values, encode_bytes_values
 from ..types.traces import AttributeValue
-from .base import MultiAgentBase, MultiAgentResult, NodeResult, Status
+from .base import MultiAgentBase, MultiAgentResult, NodeResult, Status, TMultiAgentPlugin
 
 logger = logging.getLogger(__name__)
 
@@ -574,6 +574,24 @@ class Graph(MultiAgentBase):
             order: Execution priority. Lower values execute first.
         """
         self.hooks.add_callback(event_type, callback, order=order)
+
+    def get_plugin(self, plugin_type: type[TMultiAgentPlugin]) -> TMultiAgentPlugin | None:
+        """Return the registered plugin of type ``plugin_type``, or ``None`` if none is registered.
+
+        Args:
+            plugin_type: The plugin class to look up.
+
+        Returns:
+            The matching plugin instance, or ``None`` if no registered plugin matches.
+        """
+        for plugin in self._plugin_registry._plugins.values():
+            if isinstance(plugin, plugin_type):
+                return plugin
+        return None
+
+    def get_plugins(self) -> list[MultiAgentPlugin]:
+        """Return all plugins registered on this graph, in registration order."""
+        return list(self._plugin_registry._plugins.values())
 
     def __call__(
         self, task: MultiAgentInput, invocation_state: dict[str, Any] | None = None, **kwargs: Any

--- a/strands-py/src/strands/multiagent/swarm.py
+++ b/strands-py/src/strands/multiagent/swarm.py
@@ -56,7 +56,7 @@ from ..types.event_loop import Metrics, Usage
 from ..types.multiagent import MultiAgentInput
 from ..types.session import decode_bytes_values, encode_bytes_values
 from ..types.traces import AttributeValue
-from .base import MultiAgentBase, MultiAgentResult, NodeResult, Status
+from .base import MultiAgentBase, MultiAgentResult, NodeResult, Status, TMultiAgentPlugin
 
 logger = logging.getLogger(__name__)
 
@@ -328,6 +328,24 @@ class Swarm(MultiAgentBase):
             order: Execution priority. Lower values execute first.
         """
         self.hooks.add_callback(event_type, callback, order=order)
+
+    def get_plugin(self, plugin_type: type[TMultiAgentPlugin]) -> TMultiAgentPlugin | None:
+        """Return the registered plugin of type ``plugin_type``, or ``None`` if none is registered.
+
+        Args:
+            plugin_type: The plugin class to look up.
+
+        Returns:
+            The matching plugin instance, or ``None`` if no registered plugin matches.
+        """
+        for plugin in self._plugin_registry._plugins.values():
+            if isinstance(plugin, plugin_type):
+                return plugin
+        return None
+
+    def get_plugins(self) -> list[MultiAgentPlugin]:
+        """Return all plugins registered on this swarm, in registration order."""
+        return list(self._plugin_registry._plugins.values())
 
     def __call__(
         self, task: MultiAgentInput, invocation_state: dict[str, Any] | None = None, **kwargs: Any

--- a/strands-py/tests/strands/multiagent/test_multiagent_plugins.py
+++ b/strands-py/tests/strands/multiagent/test_multiagent_plugins.py
@@ -281,3 +281,56 @@ def test_graph_add_hook_infers_event_type(mock_graph_agent):
     graph.add_hook(on_before_node)
 
     assert len(graph.hooks._registered_callbacks.get(BeforeNodeCallEvent, [])) == 1
+
+
+# --- get_plugin / get_plugins tests ---
+
+
+class _PluginX(MultiAgentPlugin):
+    name = "plugin-x"
+
+
+class _PluginY(MultiAgentPlugin):
+    name = "plugin-y"
+
+
+def test_swarm_get_plugin_returns_registered_instance_by_type(mock_swarm_agent):
+    plugin = _PluginX()
+    swarm = _make_swarm(mock_swarm_agent, plugins=[plugin])
+
+    assert swarm.get_plugin(_PluginX) is plugin
+
+
+def test_swarm_get_plugin_returns_none_when_type_absent(mock_swarm_agent):
+    swarm = _make_swarm(mock_swarm_agent, plugins=[_PluginX()])
+
+    assert swarm.get_plugin(_PluginY) is None
+
+
+def test_swarm_get_plugins_lists_all_registered_plugins(mock_swarm_agent):
+    first = _PluginX()
+    second = _PluginY()
+    swarm = _make_swarm(mock_swarm_agent, plugins=[first, second])
+
+    assert swarm.get_plugins() == [first, second]
+
+
+def test_graph_get_plugin_returns_registered_instance_by_type(mock_graph_agent):
+    plugin = _PluginX()
+    graph = _make_graph(mock_graph_agent, plugins=[plugin])
+
+    assert graph.get_plugin(_PluginX) is plugin
+
+
+def test_graph_get_plugin_returns_none_when_type_absent(mock_graph_agent):
+    graph = _make_graph(mock_graph_agent, plugins=[_PluginX()])
+
+    assert graph.get_plugin(_PluginY) is None
+
+
+def test_graph_get_plugins_lists_all_registered_plugins(mock_graph_agent):
+    first = _PluginX()
+    second = _PluginY()
+    graph = _make_graph(mock_graph_agent, plugins=[first, second])
+
+    assert graph.get_plugins() == [first, second]

--- a/strands-py/tests/strands/plugins/test_plugins.py
+++ b/strands-py/tests/strands/plugins/test_plugins.py
@@ -207,3 +207,37 @@ def test_plugin_registry_raises_reference_error_after_agent_collected():
 
     with pytest.raises(ReferenceError, match="Agent has been garbage collected"):
         _ = registry._agent
+
+
+# Agent.get_plugin / Agent.get_plugins Tests
+
+
+class _PluginA(Plugin):
+    name = "plugin-a"
+
+
+class _PluginB(Plugin):
+    name = "plugin-b"
+
+
+def test_agent_get_plugin_returns_registered_instance():
+    plugin = _PluginA()
+    agent = Agent(plugins=[plugin])
+
+    assert agent.get_plugin(_PluginA) is plugin
+
+
+def test_agent_get_plugin_returns_none_when_type_absent():
+    agent = Agent(plugins=[_PluginA()])
+
+    assert agent.get_plugin(_PluginB) is None
+
+
+def test_agent_get_plugins_includes_user_plugins_in_registration_order():
+    first = _PluginA()
+    second = _PluginB()
+    agent = Agent(plugins=[first, second])
+
+    tru_plugins = agent.get_plugins()
+    # Built-in plugins (e.g., ModelPlugin) may also be registered; assert order among user plugins.
+    assert tru_plugins.index(first) < tru_plugins.index(second)


### PR DESCRIPTION
## Description

  Adds a public, type-based API for retrieving plugin instances registered on an `Agent`, `Graph`, or `Swarm`. Consumers that need to look up a specific plugin can now
  do so without reaching into private internals.

  ```python
  agent.get_plugin(SomePlugin)  # -> SomePlugin | None
  agent.get_plugins()           # -> list[Plugin]
  ```

  The same methods are declared on `MultiAgentBase` (alongside `add_hook`), so every orchestrator carries the API and concrete subclasses (`Graph`, `Swarm`) override
  with implementations backed by their plugin registry. Subclasses that don't support plugins get a `NotImplementedError` — matching how `add_hook` already works.

  Lookup uses `isinstance`, so subclasses of the queried type also match. Returns `None` when no matching plugin is registered — consistent with how the SDK's other
  typed-lookup methods behave (`SessionRepository.read_*`, `StructuredOutputContext.get_result`, `models._defaults.get_context_window_limit`).

  ## Related Issues

#2951 

  ## Documentation PR

  No documentation changes required — reference docs regenerate from the new methods' docstrings.

  ## Type of Change

  New feature

  ## Testing

  Ran `hatch fmt --formatter --check`, `hatch fmt --linter --check`, and `hatch test` from `strands-py/`: 4239 tests pass, ruff and mypy clean.

  Added unit tests covering:
  - `agent.get_plugin(T)` returns the registered instance
  - `agent.get_plugin(T)` returns `None` when no plugin of type `T` is registered
  - `agent.get_plugins()` includes user plugins in registration order
  - Same coverage for `Graph` and `Swarm`

  - [x] I ran `hatch run prepare`

  ## Checklist
  - [x] I have read the CONTRIBUTING document
  - [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
  - [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
  - [x] I have added any necessary tests that prove my fix is effective or my feature works
  - [x] I have updated the documentation accordingly
  - [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
  - [x] My changes generate no new warnings
  - [x] Any dependent changes have been merged and published

  ----

  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Related to: #2951 