### PR TITLE
fix(bedrock): cache system prompt under cache_config auto/anthropic

### DIFF
--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -227,6 +227,36 @@ class BedrockModel(Model):
             return "anthropic"
         return None
 
+    def _resolve_cache_strategy(self) -> str | None:
+        """Resolve the effective cache strategy from ``cache_config``.
+
+        Applies the ``"auto"`` model-support check: an ``"auto"`` strategy resolves to the model's
+        supported strategy (``"anthropic"`` for Claude/Anthropic models) or ``None`` if the model does
+        not support automatic caching. An explicit ``"anthropic"`` strategy is returned as-is.
+
+        Returns:
+            The effective strategy to apply (e.g. ``"anthropic"``), or ``None`` if caching is
+            disabled or unsupported for this model.
+        """
+        cache_config = self.config.get("cache_config")
+        if not cache_config:
+            return None
+        if cache_config.strategy == "auto":
+            return self._cache_strategy
+        return cache_config.strategy
+
+    def _build_cache_point(self) -> dict[str, Any]:
+        """Build a default cache point block, including the ``cache_config`` TTL if set.
+
+        Returns:
+            A cachePoint block, e.g. ``{"cachePoint": {"type": "default"}}``.
+        """
+        cache_point: dict[str, Any] = {"type": "default"}
+        cache_config = self.config.get("cache_config")
+        if cache_config and cache_config.ttl:
+            cache_point["ttl"] = cache_config.ttl
+        return {"cachePoint": cache_point}
+
     @override
     def update_config(self, **model_config: Unpack[BedrockConfig]) -> None:  # type: ignore
         """Update the Bedrock Model configuration with the provided arguments.
@@ -282,6 +312,12 @@ class BedrockModel(Model):
                 "cache_prompt is deprecated. Use SystemContentBlock with cachePoint instead.", UserWarning, stacklevel=3
             )
             system_blocks.append({"cachePoint": {"type": cache_prompt}})
+        # Under cache_config, add a cachePoint at the system-prompt boundary so the static system
+        # prefix is cached at a boundary that repeated calls (which vary only the last user message)
+        # can read-hit. "auto" only adds this when the model supports automatic caching (see #3144).
+        elif system_blocks and self._resolve_cache_strategy() == "anthropic":
+            if not any("cachePoint" in block for block in system_blocks):
+                system_blocks.append(cast(SystemContentBlock, self._build_cache_point()))
 
         return {
             "modelId": self.config["model_id"],
@@ -425,11 +461,7 @@ class BedrockModel(Model):
                 last_user_idx = msg_idx
 
         if last_user_idx is not None and messages[last_user_idx].get("content"):
-            cache_point: dict[str, Any] = {"type": "default"}
-            cache_config = self.config.get("cache_config")
-            if cache_config and cache_config.ttl:
-                cache_point["ttl"] = cache_config.ttl
-            messages[last_user_idx]["content"].append({"cachePoint": cache_point})
+            messages[last_user_idx]["content"].append(self._build_cache_point())
             logger.debug("msg_idx=<%s> | added cache point to last user message", last_user_idx)
 
     def _find_last_user_text_message_index(self, messages: Messages) -> int | None:
@@ -529,14 +561,12 @@ class BedrockModel(Model):
         # Inject cache point into cleaned_messages (not original messages) if cache_config is set
         cache_config = self.config.get("cache_config")
         if cache_config:
-            strategy: str | None = cache_config.strategy
-            if strategy == "auto":
-                strategy = self._cache_strategy
-                if not strategy:
-                    logger.warning(
-                        "model_id=<%s> | cache_config is enabled but this model does not support automatic caching",
-                        self.config.get("model_id"),
-                    )
+            strategy = self._resolve_cache_strategy()
+            if cache_config.strategy == "auto" and not strategy:
+                logger.warning(
+                    "model_id=<%s> | cache_config is enabled but this model does not support automatic caching",
+                    self.config.get("model_id"),
+                )
             if strategy == "anthropic":
                 self._inject_cache_point(cleaned_messages)
 

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -3209,6 +3209,99 @@ def test_inject_cache_point_auto_strategy_resolves_to_anthropic_for_claude(bedro
     assert len(formatted[1]["content"]) == 1
 
 
+def test_format_request_system_cache_point_auto_claude(bedrock_client, messages):
+    """Test that cache_config auto adds a system-prompt cachePoint for a supported (Claude) model."""
+    model = BedrockModel(
+        model_id="us.anthropic.claude-sonnet-4-20250514-v1:0", cache_config=CacheConfig(strategy="auto")
+    )
+    system_prompt_content = [{"text": "You are a helpful assistant."}]
+
+    request = model.format_request(messages, system_prompt_content=system_prompt_content)
+
+    assert request["system"] == [
+        {"text": "You are a helpful assistant."},
+        {"cachePoint": {"type": "default"}},
+    ]
+
+
+def test_format_request_system_cache_point_no_tools(bedrock_client):
+    """Test that the system cachePoint is added even with no tools (the #3144 no-tools bug)."""
+    model = BedrockModel(
+        model_id="us.anthropic.claude-sonnet-4-20250514-v1:0", cache_config=CacheConfig(strategy="auto")
+    )
+    messages = [{"role": "user", "content": [{"text": "extract this candidate"}]}]
+    system_prompt_content = [{"text": "static system prompt"}]
+
+    request = model.format_request(messages, system_prompt_content=system_prompt_content)
+
+    assert "toolConfig" not in request
+    assert request["system"] == [
+        {"text": "static system prompt"},
+        {"cachePoint": {"type": "default"}},
+    ]
+
+
+def test_format_request_system_cache_point_anthropic_strategy(bedrock_client, messages):
+    """Test that explicit anthropic strategy adds a system cachePoint without a model-support check."""
+    model = BedrockModel(model_id="amazon.nova-pro-v1:0", cache_config=CacheConfig(strategy="anthropic"))
+    system_prompt_content = [{"text": "You are a helpful assistant."}]
+
+    request = model.format_request(messages, system_prompt_content=system_prompt_content)
+
+    assert request["system"] == [
+        {"text": "You are a helpful assistant."},
+        {"cachePoint": {"type": "default"}},
+    ]
+
+
+def test_format_request_system_cache_point_skipped_auto_non_claude(bedrock_client, messages):
+    """Test that auto strategy does NOT add a system cachePoint for a model without automatic caching."""
+    model = BedrockModel(model_id="amazon.nova-pro-v1:0", cache_config=CacheConfig(strategy="auto"))
+    system_prompt_content = [{"text": "You are a helpful assistant."}]
+
+    request = model.format_request(messages, system_prompt_content=system_prompt_content)
+
+    assert request["system"] == [{"text": "You are a helpful assistant."}]
+
+
+def test_format_request_system_cache_point_with_ttl(bedrock_client, messages):
+    """Test that the system cachePoint carries the cache_config ttl when set."""
+    model = BedrockModel(
+        model_id="us.anthropic.claude-sonnet-4-20250514-v1:0", cache_config=CacheConfig(strategy="auto", ttl="1h")
+    )
+    system_prompt_content = [{"text": "You are a helpful assistant."}]
+
+    request = model.format_request(messages, system_prompt_content=system_prompt_content)
+
+    assert request["system"] == [
+        {"text": "You are a helpful assistant."},
+        {"cachePoint": {"type": "default", "ttl": "1h"}},
+    ]
+
+
+def test_format_request_system_cache_point_not_duplicated(bedrock_client, messages):
+    """Test that an existing system cachePoint is not duplicated under cache_config auto."""
+    model = BedrockModel(
+        model_id="us.anthropic.claude-sonnet-4-20250514-v1:0", cache_config=CacheConfig(strategy="auto")
+    )
+    system_prompt_content = [{"text": "You are a helpful assistant."}, {"cachePoint": {"type": "default"}}]
+
+    request = model.format_request(messages, system_prompt_content=system_prompt_content)
+
+    assert request["system"] == system_prompt_content
+    assert sum(1 for block in request["system"] if "cachePoint" in block) == 1
+
+
+def test_format_request_system_cache_point_skipped_without_cache_config(bedrock_client, messages):
+    """Test that no system cachePoint is added when cache_config is unset."""
+    model = BedrockModel(model_id="us.anthropic.claude-sonnet-4-20250514-v1:0")
+    system_prompt_content = [{"text": "You are a helpful assistant."}]
+
+    request = model.format_request(messages, system_prompt_content=system_prompt_content)
+
+    assert request["system"] == [{"text": "You are a helpful assistant."}]
+
+
 def test_find_last_user_text_message_index_no_user_messages(bedrock_client):
     """Test _find_last_user_text_message_index returns None when no user text messages exist."""
     model = BedrockModel(model_id="test-model")


### PR DESCRIPTION
## Summary

Fixes the System Prompt CachePoint bug (#3144). `CacheConfig` auto/anthropic only injected a `cachePoint` on the **last user message**, never at the **system-prompt boundary**. For repeated calls that share one static system prompt but vary the final user message (e.g. no-tools structured-output loops), the static system prefix was re-written to cache on almost every call and never read back — defeating the point of prompt caching.

## Changes

- Append a `cachePoint` at the system boundary in `format_request` so the static prefix is cached where repeated calls can read-hit.
- Honours `"auto"`: the system cachePoint is only added when the model supports automatic caching (resolves to `"anthropic"` for Claude/Anthropic models), skipped otherwise.
- Existing system cachePoints are not duplicated; the `cache_config` TTL is propagated.
- Strategy resolution and cache-point construction factored into shared helpers reused by the message-injection path.

## Testing

- `tests/strands/models/test_bedrock.py` — 181 passed (added coverage for the system-prompt cachePoint path).
- `ruff check src/strands/models/bedrock.py` — clean.

Fixes #3144
