### PR TITLE
fix(ts): complete aggregated streams without message start

### DIFF
--- a/strands-ts/src/models/__tests__/model.test.ts
+++ b/strands-ts/src/models/__tests__/model.test.ts
@@ -122,6 +122,43 @@ describe('Model', () => {
           'Model reached maximum token limit. This is an unrecoverable state that requires intervention.'
         )
       })
+
+      it('defaults to assistant when stream content arrives without a message start event', async () => {
+        const provider = new TestModelProvider(async function* () {
+          yield { type: 'modelContentBlockStartEvent' }
+          yield {
+            type: 'modelContentBlockDeltaEvent',
+            delta: { type: 'textDelta', text: 'Hello from a provider without stream-start' },
+          }
+          yield { type: 'modelContentBlockStopEvent' }
+          yield { type: 'modelMessageStopEvent', stopReason: 'endTurn' }
+        })
+
+        const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
+
+        const { items, result } = await collectGenerator(provider.streamAggregated(messages))
+
+        expect(items).toEqual([
+          { type: 'modelContentBlockStartEvent' },
+          {
+            type: 'modelContentBlockDeltaEvent',
+            delta: { type: 'textDelta', text: 'Hello from a provider without stream-start' },
+          },
+          { type: 'modelContentBlockStopEvent' },
+          { type: 'textBlock', text: 'Hello from a provider without stream-start' },
+          { type: 'modelMessageStopEvent', stopReason: 'endTurn' },
+        ])
+        expect(result).toEqual({
+          message: {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'textBlock', text: 'Hello from a provider without stream-start' }],
+            trackingId: anyTrackingId,
+          },
+          stopReason: 'endTurn',
+          metadata: undefined,
+        })
+      })
     })
 
     describe('when streaming multiple text blocks', () => {

--- a/strands-ts/src/models/model.ts
+++ b/strands-ts/src/models/model.ts
@@ -435,12 +435,12 @@ export abstract class Model<T extends BaseModelConfig = BaseModelConfig> {
 
           case 'modelMessageStopEvent':
             // Store message and stop reason
-            if (messageRole) {
+            if (messageRole || contentBlocks.length > 0) {
               const filtered = contentBlocks.filter(
                 (block) => !(block instanceof TextBlock && block.text.trim() === '')
               )
               stoppedMessage = new Message({
-                role: messageRole,
+                role: messageRole ?? 'assistant',
                 content: filtered,
               })
               finalStopReason = event.stopReason!


### PR DESCRIPTION
﻿## Summary
- Default `streamAggregated()` to an assistant role when a provider emits content blocks and a message stop event without an earlier `modelMessageStartEvent`.
- Preserve the existing hard failure for streams that end without both a completed message and aggregated content.
- Add a regression test for the missing `stream-start` / missing message-start path from #3189.

## Root cause
Some Vercel-compatible providers can stream valid content without a leading `stream-start` part, so `VercelModel` may never emit `modelMessageStartEvent`. Content blocks are still delivered, but `streamAggregated()` previously threw `Stream ended without completing a message` after the stream ended.

This PR intentionally keeps the change in the aggregation layer and does not change `VercelModel.stream()`. #3206 covers the separate #3185 tool-use stop-reason path.

## Validation
- `npm run test -w strands-ts -- src/models/__tests__/model.test.ts`
- `npm run test -w strands-ts -- src/models/__tests__/vercel.test.ts`
- `npm run build -w strands-ts`
- `npm run type-check -w strands-ts`
- `npm run format:check -w strands-ts -- src/models/model.ts src/models/__tests__/model.test.ts`
- `npm run lint -w strands-ts -- src/models/model.ts src/models/__tests__/model.test.ts`

Fixes #3189
