### PR TITLE
fix(tools): load tools moved into a watched directory (#264)

### DIFF
--- a/strands-py/src/strands/tools/watcher.py
+++ b/strands-py/src/strands/tools/watcher.py
@@ -95,6 +95,20 @@ class ToolWatcher:
                         except Exception as e:
                             logger.error("exception=<%s> | handler error", str(e))
 
+        def on_created(self, event: Any) -> None:
+            """Reload tools when a new file appears in a watched directory.
+
+            This master handler is the only one scheduled with the Observer, so it must handle on_created too. A file
+            written in place usually raises on_modified as well, which the handler above already catches, but a file
+            moved or renamed into the directory raises on_created alone and would otherwise be dropped - for example
+            the first tool copied into an empty tools directory. reload_tool loads a new file the same as a changed
+            one and is safe to call again for a follow-up on_modified, so route creations through on_modified.
+
+            Args:
+                event: The file system event that triggered this handler.
+            """
+            self.on_modified(event)
+
     def start(self) -> None:
         """Start watching all tools directories for changes."""
         # Initialize shared observer if not already done

--- a/strands-py/tests/strands/tools/test_watcher.py
+++ b/strands-py/tests/strands/tools/test_watcher.py
@@ -96,3 +96,26 @@ def test_on_modified_error_handling(mock_reload_tool):
 
     # Verify that reload_tool was called
     mock_reload_tool.assert_called_once_with("test_tool")
+
+
+@patch.object(ToolRegistry, "reload_tool")
+def test_master_handler_on_created_reloads_new_tool(mock_reload_tool):
+    """Regression for issue #264: the master handler is the one scheduled with the
+    Observer, so it must forward on_created events to the per-registry handlers.
+
+    Without this, a tool file moved into a watched directory - which raises on_created
+    alone, with no follow-up on_modified - is never loaded.
+    """
+    tool_registry = ToolRegistry()
+    watcher = ToolWatcher(tool_registry)
+
+    dir_path = "/path/to/empty_tools_dir"
+    ToolWatcher._registry_handlers.setdefault(dir_path, {})[id(tool_registry)] = watcher.tool_change_handler
+    master_handler = ToolWatcher.MasterChangeHandler(dir_path)
+
+    event = MagicMock()
+    event.src_path = f"{dir_path}/first_tool.py"
+
+    master_handler.on_created(event)
+
+    mock_reload_tool.assert_called_once_with("first_tool")


### PR DESCRIPTION
## Description

The tool hot-reload watcher did not pick up a tool file that was moved or copied into a watched directory. This was most visible when the `./tools` directory was empty at `Agent` initialization: the first tool dropped in never loaded.

Root cause: only the `MasterChangeHandler` is scheduled with the watchdog `Observer` (in `ToolWatcher.start()`), and it implemented only `on_modified`. A file *written in place* inside the directory raises `on_modified` as well as `on_created`, so that path already worked — but a file that *arrives* in the directory, moved or renamed in from elsewhere, raises `on_created` alone, hit the base-class no-op, and was dropped until the file was later edited in place.

An earlier revision of this description said watchdog emits `on_created` *instead of* `on_modified` for any file that did not previously exist. That is wrong on both Linux and macOS, and @ebarkhordar caught it — thank you. The measurements below are the corrected version.

Fix: add `MasterChangeHandler.on_created`, routing through the existing `on_modified` reload path. `reload_tool` loads a new file the same as a changed one, and is safe to call again when a follow-up `on_modified` fires for the same file (hot-reload registration is idempotent), so no double-registration issue.

## Related Issues

Closes #264

## Documentation PR

No docs change needed — this restores documented hot-reload behavior with no API change.

## Type of Change

Bug fix

## Testing

Added a regression test (`test_master_handler_on_created_reloads_new_tool`) that drives the actual production path — the scheduled master handler — and asserts an `on_created` event for a `.py` file triggers `reload_tool`. It fails before the fix (`reload_tool` called 0 times, hitting the base-class no-op) and passes after.

Behaviour measured end-to-end outside the suite, against a real `Observer` scheduling the real `MasterChangeHandler` with `ToolRegistry.reload_tool` stubbed to count calls — macOS 26.5.2, watchdog 6.0.0, `FSEventsObserver`, base `8c3b2102` against this branch:

| how the tool file arrives in the watched dir | before | after |
|---|---|---|
| written in place (`open('w')`, `touch`, `cp`, write + `fsync`) | 1 | 2 |
| **moved / renamed in from outside the directory** | **0** | **1** |
| atomic save: temp file in the same dir, renamed to a new name | 0 | 0 |
| atomic save: temp file in the same dir, renamed over an existing tool | 1 | 1 |

The second row is the bug. Writing in place emits `created` **and** `modified` for the file, which is why the first row already worked before this change; moving a file in emits `created` alone.

Two things that row four hints at, both deliberately out of scope here:

- The reload on the write-in-place path now happens twice (also measured on Linux by @ebarkhordar, ~2ms apart). `reload_tool` is idempotent, so this is redundant work rather than a correctness problem. Happy to add a short same-path debounce if you'd prefer it, but it grows this well past a one-line fix.
- A same-directory atomic save emits `FileMovedEvent`, whose `dest_path` holds the tool path, and no handler here implements `on_moved`. That gap exists before and after this change. It needs `dest_path` rather than `src_path` (which is the temp file, and doesn't even pass the `.py` filter), and macOS and Linux differ on the last row above, so it wants its own tests — happy to open a separate PR for it.

Checks run on this branch:

- `pytest tests/strands/tools/` — 561 passed, no regressions
- `ruff format --check` and `ruff check` — clean; `mypy` (strict) — clean

Note: I don't have `hatch` locally, so I ran the equivalent checks directly (ruff format/lint, mypy strict, pytest) rather than `hatch run prepare`.

- [x] I ran the equivalent of `hatch run prepare` (ruff format + ruff check + mypy + pytest)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
