### PR TITLE
feat(context-offloader): auto-namespace unified Storage under offloader

### DIFF
--- a/strands-ts/src/agent/__tests__/agent.context-manager.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.context-manager.test.ts
@@ -5,7 +5,7 @@ import { SlidingWindowConversationManager } from '../../conversation-manager/sli
 import { SummarizingConversationManager } from '../../conversation-manager/summarizing-conversation-manager.js'
 import { ContextOffloader } from '../../vended-plugins/context-offloader/plugin.js'
 import { InMemoryStorage as LegacyInMemoryStorage } from '../../vended-plugins/context-offloader/storage.js'
-import { InMemoryStorage } from '../../storage/in-memory-storage.js'
+import { NAMESPACED } from '../../storage/storage.js'
 import type { ConversationManager } from '../../conversation-manager/conversation-manager.js'
 
 function internals(agent: Agent): any {
@@ -65,7 +65,7 @@ describe('Agent contextManager', () => {
       expect(offloader).toBeDefined()
       expect(offloader._maxResultTokens).toBe(1500)
       expect(offloader._previewTokens).toBe(750)
-      expect(offloader._storage).toBeInstanceOf(InMemoryStorage)
+      expect(NAMESPACED in offloader._storage).toBe(true)
     })
   })
 

--- a/strands-ts/src/storage/local-file-storage.ts
+++ b/strands-ts/src/storage/local-file-storage.ts
@@ -229,7 +229,11 @@ export class LocalFileStorage implements Storage {
     return walk(dir, keyPrefix)
   }
 
-  /** Returns a prefixed view of this storage without mutating the original. */
+  /**
+   * Returns a prefixed view of this storage without mutating the original.
+   * The returned view preserves `forSandbox` for single-level namespacing;
+   * nested `.namespace()` calls on the view do not carry sandbox routing.
+   */
   namespace(prefix: string): Storage & { forSandbox(sandbox: Sandbox): Storage } {
     const view = namespace(this, prefix)
     return {

--- a/strands-ts/src/storage/local-file-storage.ts
+++ b/strands-ts/src/storage/local-file-storage.ts
@@ -230,7 +230,11 @@ export class LocalFileStorage implements Storage {
   }
 
   /** Returns a prefixed view of this storage without mutating the original. */
-  namespace(prefix: string): Storage {
-    return namespace(this, prefix)
+  namespace(prefix: string): Storage & { forSandbox(sandbox: Sandbox): Storage } {
+    const view = namespace(this, prefix)
+    return {
+      ...view,
+      forSandbox: (sandbox: Sandbox): Storage => namespace(this.forSandbox(sandbox), prefix),
+    }
   }
 }

--- a/strands-ts/src/storage/local-file-storage.ts
+++ b/strands-ts/src/storage/local-file-storage.ts
@@ -159,7 +159,7 @@ export class LocalFileStorage implements Storage {
    */
   async list(prefix: string): Promise<string[]> {
     const normalized = normalizePrefix(prefix)
-    const base = this._baseDir.replace(/\/+$/, '')
+    const base = this._baseDir.replace(/\/$/, '')
     // Narrow the walk to the deepest directory the prefix fully specifies
     const lastSlash = normalized.lastIndexOf('/')
     const dirPortion = lastSlash >= 0 ? normalized.slice(0, lastSlash) : ''
@@ -171,7 +171,7 @@ export class LocalFileStorage implements Storage {
   }
 
   private _pathFor(key: string): string {
-    const base = this._baseDir.replace(/\/+$/, '')
+    const base = this._baseDir.replace(/\/$/, '')
     return `${base}/${key}`
   }
 

--- a/strands-ts/src/storage/s3-storage.ts
+++ b/strands-ts/src/storage/s3-storage.ts
@@ -46,7 +46,7 @@ export class S3Storage implements Storage {
       throw new StorageError('Cannot specify both s3Client and region. Configure the region on the S3Client instead.')
     }
     this._bucket = bucket
-    this._prefix = config?.prefix ? config.prefix.replace(/\/+$/, '') + '/' : ''
+    this._prefix = config?.prefix ? config.prefix.split('/').filter(Boolean).join('/') + '/' : ''
     this._region = config?.region
     this._client = config?.s3Client
   }

--- a/strands-ts/src/storage/storage.ts
+++ b/strands-ts/src/storage/storage.ts
@@ -17,14 +17,14 @@ export const NAMESPACED: unique symbol = Symbol.for('strands.storage.namespaced'
  * @throws {@link StorageError} if the key is empty or contains a `..` segment
  */
 export function normalizeKey(key: string): string {
-  const normalized = key.replace(/\/+/g, '/').replace(/^\/+|\/+$/g, '')
-  if (normalized.length === 0) {
+  const segments = key.split('/').filter(Boolean)
+  if (segments.length === 0) {
     throw new StorageError('Storage key must not be empty')
   }
-  if (normalized.split('/').includes('..')) {
+  if (segments.includes('..')) {
     throw new StorageError(`Invalid storage key '${key}': '..' path segments are not allowed`)
   }
-  return normalized
+  return segments.join('/')
 }
 
 /**
@@ -36,10 +36,13 @@ export function normalizeKey(key: string): string {
  * @throws {@link StorageError} if the prefix contains a `..` segment
  */
 export function normalizePrefix(prefix: string): string {
-  const normalized = prefix.replace(/\/+/g, '/').replace(/^\/+/, '')
-  if (normalized.split('/').includes('..')) {
+  const parts = prefix.split('/')
+  const segments = parts.filter(Boolean)
+  if (segments.includes('..')) {
     throw new StorageError(`Invalid storage prefix '${prefix}': '..' path segments are not allowed`)
   }
+  const joined = segments.join('/')
+  const normalized = parts[parts.length - 1] === '' && joined ? joined + '/' : joined
   return normalized
 }
 

--- a/strands-ts/src/vended-plugins/context-offloader/__tests__/plugin.test.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/__tests__/plugin.test.ts
@@ -789,8 +789,7 @@ describe('ContextOffloader', () => {
       await invokeTrackedHook(agent, event)
 
       const keys = await unifiedStorage.list('')
-      expect(keys.length).toBe(1)
-      expect(keys[0]).toMatch(/^offloader\//)
+      expect(keys).toEqual(['offloader/tool-123_0'])
     })
 
     it('does not double-namespace an already-namespaced Storage', async () => {
@@ -811,9 +810,7 @@ describe('ContextOffloader', () => {
       await invokeTrackedHook(agent, event)
 
       const keys = await unifiedStorage.list('')
-      expect(keys.length).toBe(1)
-      expect(keys[0]).toMatch(/^custom\//)
-      expect(keys[0]).not.toMatch(/^offloader\//)
+      expect(keys).toEqual(['custom/tool-123_0'])
     })
 
     it('does not namespace legacy OffloaderStorage', async () => {

--- a/strands-ts/src/vended-plugins/context-offloader/__tests__/plugin.test.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/__tests__/plugin.test.ts
@@ -761,7 +761,7 @@ describe('ContextOffloader', () => {
 
       // Only one key per block — no sidecar .contenttype key
       const keys = await unifiedStorage.list('')
-      expect(keys).toEqual(['tool-123_0'])
+      expect(keys).toEqual(['offloader/tool-123_0'])
 
       const tools = plugin.getTools()
       const retrievalTool = tools[0]!
@@ -769,6 +769,165 @@ describe('ContextOffloader', () => {
         reference: 'tool-123_0',
       })
       expect(result).toBe('hello world '.repeat(100))
+    })
+  })
+
+  describe('auto-namespacing', () => {
+    it('auto-scopes a raw unified Storage under offloader/', async () => {
+      const { InMemoryStorage: UnifiedInMemoryStorage } = await import('../../../storage/in-memory-storage.js')
+      const unifiedStorage = new UnifiedInMemoryStorage()
+
+      const plugin = new ContextOffloader({
+        storage: unifiedStorage,
+        maxResultTokens: 10,
+        previewTokens: 5,
+      })
+      const agent = createMockAgent()
+      plugin.initAgent(agent)
+
+      const event = makeEvent([new TextBlock('x'.repeat(1000))])
+      await invokeTrackedHook(agent, event)
+
+      const keys = await unifiedStorage.list('')
+      expect(keys.length).toBe(1)
+      expect(keys[0]).toMatch(/^offloader\//)
+    })
+
+    it('does not double-namespace an already-namespaced Storage', async () => {
+      const { InMemoryStorage: UnifiedInMemoryStorage } = await import('../../../storage/in-memory-storage.js')
+      const { namespace } = await import('../../../storage/storage.js')
+      const unifiedStorage = new UnifiedInMemoryStorage()
+      const customScoped = namespace(unifiedStorage, 'custom')
+
+      const plugin = new ContextOffloader({
+        storage: customScoped,
+        maxResultTokens: 10,
+        previewTokens: 5,
+      })
+      const agent = createMockAgent()
+      plugin.initAgent(agent)
+
+      const event = makeEvent([new TextBlock('x'.repeat(1000))])
+      await invokeTrackedHook(agent, event)
+
+      const keys = await unifiedStorage.list('')
+      expect(keys.length).toBe(1)
+      expect(keys[0]).toMatch(/^custom\//)
+      expect(keys[0]).not.toMatch(/^offloader\//)
+    })
+
+    it('does not namespace legacy OffloaderStorage', async () => {
+      const storage = new InMemoryStorage()
+      const plugin = new ContextOffloader({
+        storage,
+        maxResultTokens: 10,
+        previewTokens: 5,
+      })
+      const agent = createMockAgent()
+      plugin.initAgent(agent)
+
+      const event = makeEvent([new TextBlock('x'.repeat(1000))])
+      await invokeTrackedHook(agent, event)
+
+      const preview = (event.result.content[0] as TextBlock).text
+      expect(preview).not.toContain('offloader/')
+    })
+  })
+
+  describe('LocalFileStorage sandbox routing', () => {
+    it('auto-routes LocalFileStorage through sandbox and namespaces under offloader/', async () => {
+      const { LocalFileStorage } = await import('../../../storage/local-file-storage.js')
+      const written: Array<{ path: string; data: Uint8Array }> = []
+      const mockSandbox = {
+        writeFile: vi.fn(async (path: string, data: Uint8Array) => {
+          written.push({ path, data })
+        }),
+        readFile: vi.fn(async (path: string) => {
+          const entry = written.find((entry) => entry.path === path)
+          if (!entry) throw Object.assign(new Error('not found'), { code: 'ENOENT' })
+          return entry.data
+        }),
+        removeFile: vi.fn(),
+        listFiles: vi.fn(async () => []),
+        executeStreaming: vi.fn(),
+        executeCodeStreaming: vi.fn(),
+        getTools: vi.fn(() => []),
+      }
+
+      const storage = new LocalFileStorage('./artifacts')
+      const plugin = new ContextOffloader({
+        storage,
+        maxResultTokens: 10,
+        previewTokens: 5,
+      })
+      const agent = createMockAgent({ extra: { model: mockModel, sandbox: mockSandbox } as never })
+      plugin.initAgent(agent)
+
+      const result = new ToolResultBlock({
+        toolUseId: 'tool-123',
+        status: 'success',
+        content: [new TextBlock('large content '.repeat(100))],
+      })
+      const event = new AfterToolCallEvent({
+        agent,
+        toolUse: { name: 'some_tool', toolUseId: 'tool-123', input: {} },
+        tool: undefined,
+        result,
+        invocationState: {},
+      })
+      await invokeTrackedHook(agent, event)
+
+      expect(mockSandbox.writeFile).toHaveBeenCalled()
+      const writtenPath = mockSandbox.writeFile.mock.calls[0]![0] as string
+      expect(writtenPath).toContain('offloader/')
+    })
+
+    it('routes pre-namespaced LocalFileStorage through sandbox with user prefix', async () => {
+      const { LocalFileStorage } = await import('../../../storage/local-file-storage.js')
+      const written: Array<{ path: string; data: Uint8Array }> = []
+      const mockSandbox = {
+        writeFile: vi.fn(async (path: string, data: Uint8Array) => {
+          written.push({ path, data })
+        }),
+        readFile: vi.fn(async (path: string) => {
+          const entry = written.find((entry) => entry.path === path)
+          if (!entry) throw Object.assign(new Error('not found'), { code: 'ENOENT' })
+          return entry.data
+        }),
+        removeFile: vi.fn(),
+        listFiles: vi.fn(async () => []),
+        executeStreaming: vi.fn(),
+        executeCodeStreaming: vi.fn(),
+        getTools: vi.fn(() => []),
+      }
+
+      const storage = new LocalFileStorage('./artifacts').namespace('custom')
+      const plugin = new ContextOffloader({
+        storage,
+        maxResultTokens: 10,
+        previewTokens: 5,
+      })
+      const agent = createMockAgent({ extra: { model: mockModel, sandbox: mockSandbox } as never })
+      plugin.initAgent(agent)
+
+      const result = new ToolResultBlock({
+        toolUseId: 'tool-123',
+        status: 'success',
+        content: [new TextBlock('large content '.repeat(100))],
+      })
+      const event = new AfterToolCallEvent({
+        agent,
+        toolUse: { name: 'some_tool', toolUseId: 'tool-123', input: {} },
+        tool: undefined,
+        result,
+        invocationState: {},
+      })
+      await invokeTrackedHook(agent, event)
+
+      expect(mockSandbox.writeFile).toHaveBeenCalled()
+      const writtenPath = mockSandbox.writeFile.mock.calls[0]![0] as string
+      expect(writtenPath).toContain('custom/')
+      expect(writtenPath).not.toContain('offloader/')
     })
   })
 })

--- a/strands-ts/src/vended-plugins/context-offloader/plugin.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/plugin.ts
@@ -1,6 +1,7 @@
 import type { Plugin } from '../../plugins/plugin.js'
 import type { Tool, ToolContext } from '../../tools/tool.js'
 import type { LocalAgent } from '../../types/agent.js'
+import type { Sandbox } from '../../sandbox/base.js'
 import { AfterToolCallEvent, BeforeModelCallEvent } from '../../hooks/events.js'
 import { TextBlock, JsonBlock, ToolResultBlock, Message } from '../../types/messages.js'
 import type { ToolResultContent } from '../../types/messages.js'
@@ -11,7 +12,7 @@ import { z } from 'zod'
 import { logger } from '../../logging/logger.js'
 import type { JSONValue } from '../../types/json.js'
 import { FileStorage, InMemoryStorage as LegacyInMemoryStorage, type Storage as OffloaderStorage } from './storage.js'
-import type { Storage } from '../../storage/storage.js'
+import { NAMESPACED, namespace, type Storage } from '../../storage/storage.js'
 import { isSearchableContent, searchContent } from './search.js'
 
 function isOffloaderStorage(storage: Storage | OffloaderStorage): storage is OffloaderStorage {
@@ -156,6 +157,10 @@ export interface ContextOffloaderConfig {
    * - A unified `Storage` (from `@strands-agents/sdk/storage`) — each offloaded content block
    *   occupies exactly one key (content-type is framed into the stored bytes).
    * - A legacy offloader `Storage` (deprecated, from this module).
+   *
+   * When a unified `Storage` is provided, the plugin auto-scopes keys under `offloader/`
+   * unless the storage is already namespaced. A `LocalFileStorage` (including one returned
+   * by `.namespace('prefix')`) is also auto-routed through the agent's sandbox.
    */
   storage: Storage | OffloaderStorage
   /** Token threshold above which tool results are offloaded. Defaults to 2,500. */
@@ -202,6 +207,7 @@ export class ContextOffloader implements Plugin {
 
   private static readonly _DEFAULT_EVICT_AFTER_CYCLES = 20
 
+  private readonly _sandboxableStorage: { forSandbox(sandbox: Sandbox): Storage } | undefined
   private readonly _storage: Storage | OffloaderStorage
   private readonly _maxResultTokens: number
   private readonly _previewTokens: number
@@ -225,7 +231,19 @@ export class ContextOffloader implements Plugin {
       throw new Error('evictAfterCycles must be a positive integer')
     }
 
-    this._storage = config.storage
+    if (isOffloaderStorage(config.storage)) {
+      this._storage = config.storage
+    } else if (NAMESPACED in config.storage) {
+      this._storage = config.storage
+    } else if (config.storage.namespace) {
+      this._storage = config.storage.namespace('offloader')
+    } else {
+      this._storage = namespace(config.storage, 'offloader')
+    }
+    this._sandboxableStorage =
+      !isOffloaderStorage(this._storage) && 'forSandbox' in this._storage
+        ? (this._storage as { forSandbox(sandbox: Sandbox): Storage })
+        : undefined
     this._maxResultTokens = maxResultTokens
     this._previewTokens = previewTokens
     this._includeRetrievalTool = config.includeRetrievalTool ?? true
@@ -273,20 +291,24 @@ export class ContextOffloader implements Plugin {
   }
 
   private _storageForAgent(agent: LocalAgent): Storage | OffloaderStorage {
-    if (!(this._storage instanceof FileStorage)) return this._storage!
+    if (!this._sandboxableStorage && !(this._storage instanceof FileStorage)) return this._storage
 
     let storage = this._storageByAgent.get(agent)
     if (!storage) {
-      storage = this._storage.forSandbox(agent.sandbox)
+      if (this._sandboxableStorage) {
+        storage = this._sandboxableStorage.forSandbox(agent.sandbox)
+      } else {
+        storage = (this._storage as FileStorage).forSandbox(agent.sandbox)
+      }
       this._storageByAgent.set(agent, storage)
     }
     return storage
   }
 
   private _storageForToolContext(context?: ToolContext): Storage | OffloaderStorage {
-    if (!(this._storage instanceof FileStorage)) return this._storage!
+    if (!this._sandboxableStorage && !(this._storage instanceof FileStorage)) return this._storage
     if (!context) {
-      throw new Error('FileStorage retrieval requires a tool execution context.')
+      throw new Error('File-based storage retrieval requires a tool execution context.')
     }
     return this._storageForAgent(context.agent)
   }

--- a/strands-ts/src/vended-plugins/context-offloader/plugin.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/plugin.ts
@@ -159,8 +159,9 @@ export interface ContextOffloaderConfig {
    * - A legacy offloader `Storage` (deprecated, from this module).
    *
    * When a unified `Storage` is provided, the plugin auto-scopes keys under `offloader/`
-   * unless the storage is already namespaced. A `LocalFileStorage` (including one returned
-   * by `.namespace('prefix')`) is also auto-routed through the agent's sandbox.
+   * unless the storage is already namespaced. If the resolved storage exposes a
+   * `forSandbox(sandbox)` method (as `LocalFileStorage` and its namespace views do),
+   * the plugin auto-routes I/O through the agent's sandbox.
    */
   storage: Storage | OffloaderStorage
   /** Token threshold above which tool results are offloaded. Defaults to 2,500. */
@@ -262,12 +263,12 @@ export class ContextOffloader implements Plugin {
       if (this._storage instanceof LegacyInMemoryStorage) {
         this._storage._evict(cycleCount)
       } else if (this._evictAfterCycles !== null) {
-        this._evict(cycleCount)
+        this._evict(cycleCount, agent)
       }
     })
   }
 
-  private _evict(currentCycle: number): void {
+  private _evict(currentCycle: number, agent: LocalAgent): void {
     const threshold = currentCycle - this._evictAfterCycles!
     const toEvict: string[] = []
     for (const [key, storedCycle] of this._keyStoredAt) {
@@ -276,7 +277,7 @@ export class ContextOffloader implements Plugin {
       }
     }
     if (toEvict.length === 0) return
-    const storage = this._storage as Storage
+    const storage = this._storageForAgent(agent) as Storage
     for (const key of toEvict) {
       this._keyStoredAt.delete(key)
       storage.delete(key).catch(() => {})


### PR DESCRIPTION
## Description
When a unified Storage is passed to ContextOffloader, keys are now auto-scoped under 'offloader/' to prevent collisions with other constructs sharing the same Storage (e.g. session manager uses 'session/'). Pre-namespaced storage is respected as-is.

LocalFileStorage passed directly is also auto-routed through the agent's sandbox via forSandbox, matching the legacy FileStorage behavior.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [ ] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
