### PR TITLE
fix(python): convert SageMaker tool results to user messages

### DIFF
--- a/strands-py/src/strands/models/sagemaker.py
+++ b/strands-py/src/strands/models/sagemaker.py
@@ -260,9 +260,10 @@ class SageMakerAIModel(OpenAIModel):
                 message.pop("content", None)
             if message.get("role") == "tool" and self.payload_config.get("tool_results_as_user_messages", False):
                 # Convert tool message to user message
-                tool_call_id = message.get("tool_call_id", "ABCDEF")
+                tool_call_id = message.pop("tool_call_id", "ABCDEF")
                 content = message.get("content", "")
-                message = {"role": "user", "content": f"Tool call ID '{tool_call_id}' returned: {content}"}
+                message["role"] = "user"
+                message["content"] = f"Tool call ID '{tool_call_id}' returned: {content}"
             # Cannot have both reasoning_text and text - if "text", content becomes an array of content["text"]
             for c in message.get("content", []):
                 if "text" in c:

--- a/strands-py/tests/strands/models/test_sagemaker.py
+++ b/strands-py/tests/strands/models/test_sagemaker.py
@@ -260,6 +260,56 @@ class TestSageMakerAIModel:
     #     assert "tools" in payload
     #     assert payload["tools"] == []
 
+    @pytest.mark.parametrize(
+        ("tool_results_as_user_messages", "expected_message"),
+        [
+            (
+                True,
+                {"role": "user", "content": "Tool call ID 'tool-call-1' returned: 72F"},
+            ),
+            (
+                False,
+                {"role": "tool", "tool_call_id": "tool-call-1", "content": "72F"},
+            ),
+        ],
+    )
+    def test_format_request_tool_results_as_user_messages(
+        self,
+        boto_session,
+        endpoint_config,
+        payload_config,
+        tool_results_as_user_messages,
+        expected_message,
+    ):
+        """Test optionally converting tool results to user messages."""
+        model = SageMakerAIModel(
+            endpoint_config=endpoint_config,
+            payload_config={
+                **payload_config,
+                "tool_results_as_user_messages": tool_results_as_user_messages,
+            },
+            boto_session=boto_session,
+        )
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "toolResult": {
+                            "toolUseId": "tool-call-1",
+                            "status": "success",
+                            "content": [{"text": "72F"}],
+                        }
+                    }
+                ],
+            }
+        ]
+
+        payload = json.loads(model.format_request(messages)["Body"])
+
+        assert payload["messages"] == [expected_message]
+        assert "tool_results_as_user_messages" not in payload
+
     def test_format_request_with_additional_args(self, boto_session, endpoint_config, messages, payload_config):
         """Test formatting a request's `additional_args` where provided"""
         endpoint_config_ext = {


### PR DESCRIPTION
## Description

SageMaker's `tool_results_as_user_messages` branch replaced only the loop-local variable, leaving `role="tool"` in the serialized endpoint payload. This fixes the documented option by mutating the formatted message in place: removing `tool_call_id`, changing the role to `user`, and preserving the existing user-facing result text. Endpoints such as TGI and vLLM that reject tool-role messages can now use the option as intended.

## Related Issues

Resolves #3299

## Documentation PR

No documentation change is needed; this restores the already documented behavior.

## Type of Change

Bug fix

## Testing

- [x] I ran `hatch run prepare`

<details>
<summary>Verification evidence</summary>

- Reproduced the issue from the reporter's exact offline script on current `main`; the relevant source was unchanged from the reported commit.
- The same script passes after the fix.
- SageMaker tests: 27 passed.
- Model-provider tests: 839 passed.
- Full Python 3.12 suite: 4,429 passed; the prepare matrix also completed on all configured Python versions.
- Ruff and mypy: clean.
- Independent review round 1: APPROVE, no actionable findings; the reviewer also verified the regression fails on the base revision.

</details>

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.