### PR TITLE
fix(ts): abort in-flight Bedrock requests on cancellation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6755,6 +6755,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.1097.0",
+        "@smithy/fetch-http-handler": "^5.6.10",
         "@types/json-schema": "^7.0.15",
         "uuid": "^14.0.1",
         "yaml": "^2.8.3"

--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -243,6 +243,7 @@
   },
   "homepage": "https://github.com/strands-agents/harness-sdk#readme",
   "dependencies": {
+    "@smithy/fetch-http-handler": "^5.6.10",
     "@aws-sdk/client-bedrock-runtime": "^3.1097.0",
     "@types/json-schema": "^7.0.15",
     "uuid": "^14.0.1",

--- a/strands-ts/src/agent/__tests__/agent.cancel.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.cancel.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { Agent } from '../agent.js'
 import { AfterInvocationEvent, AfterModelCallEvent, BeforeModelCallEvent } from '../../hooks/index.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
@@ -213,6 +213,55 @@ describe('Agent Cancellation', () => {
       const result = await agent.invoke('Hi', { cancelSignal: controller.signal })
 
       expect(result.stopReason).toBe('cancelled')
+    })
+
+    it('aborts the in-flight model stream and returns cancelled', async () => {
+      const model = new MockMessageModel()
+      let modelSignal: AbortSignal | undefined
+      let resolveTransportPending!: () => void
+      const transportPending = new Promise<void>((resolve) => {
+        resolveTransportPending = resolve
+      })
+      vi.spyOn(model, 'stream').mockImplementation(async function* (_messages, options) {
+        const signal = options?.signal
+        modelSignal = signal
+
+        yield { type: 'modelMessageStartEvent', role: 'assistant' }
+        resolveTransportPending()
+        if (!signal) {
+          yield { type: 'modelMessageStopEvent', stopReason: 'endTurn' }
+          return
+        }
+
+        await new Promise<void>((_resolve, reject) => {
+          const rejectWithAbort = (): void => {
+            const error = new Error('transport aborted')
+            error.name = 'AbortError'
+            reject(error)
+          }
+
+          if (signal.aborted) {
+            rejectWithAbort()
+          } else {
+            signal.addEventListener('abort', rejectWithAbort, { once: true })
+          }
+        })
+      })
+      const agent = new Agent({ model, printer: false })
+      const controller = new AbortController()
+
+      const invocation = agent.invoke('Hi', { cancelSignal: controller.signal })
+
+      await transportPending
+      expect(modelSignal).toBeDefined()
+      expect(modelSignal).not.toBe(controller.signal)
+      expect(modelSignal?.aborted).toBe(false)
+
+      controller.abort()
+      const result = await invocation
+
+      expect(result.stopReason).toBe('cancelled')
+      expect(modelSignal?.aborted).toBe(true)
     })
   })
 

--- a/strands-ts/src/agent/__tests__/agent.cancel.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.cancel.test.ts
@@ -223,7 +223,7 @@ describe('Agent Cancellation', () => {
         resolveTransportPending = resolve
       })
       vi.spyOn(model, 'stream').mockImplementation(async function* (_messages, options) {
-        const signal = options?.signal
+        const signal = options?.cancelSignal
         modelSignal = signal
 
         yield { type: 'modelMessageStartEvent', role: 'assistant' }

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -2127,6 +2127,7 @@ export class Agent implements LocalAgent, InvokableAgent {
           // get/set methods.
           tempModelState = new StateStore(modelStateSnapshot)
           const streamOptions: StreamOptions = {
+            signal: self._abortSignal,
             toolSpecs: ctx.toolSpecs as ToolSpec[],
             modelState: tempModelState,
             ...(ctx.systemPrompt !== undefined && { systemPrompt: ctx.systemPrompt }),
@@ -2189,25 +2190,32 @@ export class Agent implements LocalAgent, InvokableAgent {
   ): AsyncGenerator<AgentStreamEvent, StreamAggregatedResult, undefined> {
     messages = normalizeToolUseNames(messages)
     const streamGenerator = this.model.streamAggregated(messages, streamOptions)
-    let result = await streamGenerator.next()
+    try {
+      let result = await streamGenerator.next()
 
-    while (!result.done) {
-      this._throwIfCancelled()
+      while (!result.done) {
+        this._throwIfCancelled()
 
-      const event = result.value
+        const event = result.value
 
-      if (isModelStreamEvent(event)) {
-        // ModelStreamEvent: wrap in ModelStreamUpdateEvent
-        yield new ModelStreamUpdateEvent({ agent: this, event, invocationState })
-      } else {
-        // ContentBlock: wrap in ContentBlockEvent
-        yield new ContentBlockEvent({ agent: this, contentBlock: event, invocationState })
+        if (isModelStreamEvent(event)) {
+          // ModelStreamEvent: wrap in ModelStreamUpdateEvent
+          yield new ModelStreamUpdateEvent({ agent: this, event, invocationState })
+        } else {
+          // ContentBlock: wrap in ContentBlockEvent
+          yield new ContentBlockEvent({ agent: this, contentBlock: event, invocationState })
+        }
+        result = await streamGenerator.next()
       }
-      result = await streamGenerator.next()
-    }
 
-    // result.done is true, result.value contains the return value
-    return result.value
+      // result.done is true, result.value contains the return value
+      return result.value
+    } catch (error) {
+      // Provider transports typically surface cancellation as AbortError.
+      // Preserve the Agent cancellation contract when the shared signal fired.
+      this._throwIfCancelled()
+      throw error
+    }
   }
 
   /**

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -2127,7 +2127,7 @@ export class Agent implements LocalAgent, InvokableAgent {
           // get/set methods.
           tempModelState = new StateStore(modelStateSnapshot)
           const streamOptions: StreamOptions = {
-            signal: self._abortSignal,
+            cancelSignal: self._abortSignal,
             toolSpecs: ctx.toolSpecs as ToolSpec[],
             modelState: tempModelState,
             ...(ctx.systemPrompt !== undefined && { systemPrompt: ctx.systemPrompt }),

--- a/strands-ts/src/models/__tests__/bedrock.test.ts
+++ b/strands-ts/src/models/__tests__/bedrock.test.ts
@@ -1231,7 +1231,7 @@ describe('BedrockModel', () => {
       const provider = new BedrockModel({ stream })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
 
-      await collectIterator(provider.stream(messages, { signal: controller.signal }))
+      await collectIterator(provider.stream(messages, { cancelSignal: controller.signal }))
 
       expect(mockSend).toHaveBeenCalledWith(expect.anything(), { abortSignal: controller.signal })
     })
@@ -1271,7 +1271,7 @@ describe('BedrockModel', () => {
       const provider = new BedrockModel()
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
 
-      const streamResult = collectIterator(provider.stream(messages, { signal: controller.signal }))
+      const streamResult = collectIterator(provider.stream(messages, { cancelSignal: controller.signal }))
       await firstTokenProduced
       const tokensAtCancel = producedTokens
       controller.abort()

--- a/strands-ts/src/models/__tests__/bedrock.test.ts
+++ b/strands-ts/src/models/__tests__/bedrock.test.ts
@@ -1206,6 +1206,81 @@ describe('BedrockModel', () => {
   })
 
   describe('stream', () => {
+    it.each([
+      { mode: 'streaming', stream: true },
+      { mode: 'non-streaming', stream: false },
+    ])('passes the cancellation signal to the $mode Bedrock request', async ({ stream }) => {
+      const mockSend = vi.fn(async () => {
+        if (stream) {
+          return {
+            stream: (async function* (): AsyncGenerator<unknown> {
+              yield { messageStart: { role: 'assistant' } }
+              yield { messageStop: { stopReason: 'end_turn' } }
+            })(),
+          }
+        }
+        return {
+          output: { message: { role: 'assistant', content: [{ text: 'Hello' }] } },
+          stopReason: 'end_turn',
+          usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+          metrics: { latencyMs: 100 },
+        }
+      })
+      mockBedrockClientImplementation({ send: mockSend })
+      const controller = new AbortController()
+      const provider = new BedrockModel({ stream })
+      const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
+
+      await collectIterator(provider.stream(messages, { signal: controller.signal }))
+
+      expect(mockSend).toHaveBeenCalledWith(expect.anything(), { abortSignal: controller.signal })
+    })
+
+    it('stops a fake in-flight Bedrock producer when the signal aborts', async () => {
+      let producedTokens = 0
+      let producerStopped = false
+      let resolveFirstToken!: () => void
+      const firstTokenProduced = new Promise<void>((resolve) => {
+        resolveFirstToken = resolve
+      })
+      const mockSend = vi.fn(async (_command: unknown, sendOptions?: unknown) => {
+        const signal = (sendOptions as { abortSignal?: AbortSignal } | undefined)?.abortSignal
+        return {
+          stream: (async function* (): AsyncGenerator<unknown> {
+            yield { messageStart: { role: 'assistant' } }
+            yield { contentBlockStart: { start: {}, contentBlockIndex: 0 } }
+            while (producedTokens < 20) {
+              if (signal?.aborted) {
+                producerStopped = true
+                break
+              }
+              producedTokens += 1
+              if (producedTokens === 1) {
+                resolveFirstToken()
+              }
+              yield { contentBlockDelta: { delta: { text: 'token ' }, contentBlockIndex: 0 } }
+              await new Promise<void>((resolve) => setTimeout(resolve, 1))
+            }
+            yield { contentBlockStop: { contentBlockIndex: 0 } }
+            yield { messageStop: { stopReason: 'end_turn' } }
+          })(),
+        }
+      })
+      mockBedrockClientImplementation({ send: mockSend })
+      const controller = new AbortController()
+      const provider = new BedrockModel()
+      const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
+
+      const streamResult = collectIterator(provider.stream(messages, { signal: controller.signal }))
+      await firstTokenProduced
+      const tokensAtCancel = producedTokens
+      controller.abort()
+      await streamResult
+
+      expect(producerStopped).toBe(true)
+      expect(producedTokens).toBe(tokensAtCancel)
+    })
+
     it('handles tool use input delta', async () => {
       setupMockSend(async function* () {
         yield { messageStart: { role: 'assistant' } }

--- a/strands-ts/src/models/__tests__/bedrock.transport.test.browser.ts
+++ b/strands-ts/src/models/__tests__/bedrock.transport.test.browser.ts
@@ -35,7 +35,7 @@ describe('BedrockModel browser transport cancellation', () => {
       })
       const controller = new AbortController()
       const output = model.stream([new Message({ role: 'user', content: [new TextBlock('Hello')] })], {
-        signal: controller.signal,
+        cancelSignal: controller.signal,
       })
       const iterator = output[Symbol.asyncIterator]()
 

--- a/strands-ts/src/models/__tests__/bedrock.transport.test.browser.ts
+++ b/strands-ts/src/models/__tests__/bedrock.transport.test.browser.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { BedrockRuntimeClientConfig } from '@aws-sdk/client-bedrock-runtime'
+import { BedrockModel } from '../bedrock.js'
+import { Message, TextBlock } from '../../types/messages.js'
+
+describe('BedrockModel browser transport cancellation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  for (const stream of [true, false]) {
+    it(`aborts the default ${stream ? 'streaming' : 'non-streaming'} fetch transport`, async () => {
+      const fetchMock = vi.fn((input: RequestInfo | URL) => {
+        const request = input as Request
+        return new Promise<Response>((_, reject) => {
+          request.signal.addEventListener(
+            'abort',
+            () => reject(new DOMException('The operation was aborted.', 'AbortError')),
+            { once: true }
+          )
+        })
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      const model = new BedrockModel({
+        region: 'us-east-1',
+        modelId: 'test-model',
+        stream,
+        clientConfig: {
+          credentials: {
+            accessKeyId: 'test-access-key',
+            secretAccessKey: 'test-secret-key',
+          },
+        },
+      })
+      const controller = new AbortController()
+      const output = model.stream([new Message({ role: 'user', content: [new TextBlock('Hello')] })], {
+        signal: controller.signal,
+      })
+      const iterator = output[Symbol.asyncIterator]()
+
+      const result = iterator.next()
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce())
+      controller.abort()
+
+      await expect(result).rejects.toMatchObject({ name: 'AbortError' })
+    })
+  }
+
+  it('preserves a caller-provided request handler', () => {
+    const requestHandler = {
+      metadata: { handlerProtocol: 'custom' },
+      handle: vi.fn(),
+      updateHttpClientConfig: vi.fn(),
+      httpHandlerConfigs: vi.fn(() => ({})),
+    }
+
+    const model = new BedrockModel({
+      region: 'us-east-1',
+      modelId: 'test-model',
+      clientConfig: {
+        requestHandler: requestHandler as NonNullable<BedrockRuntimeClientConfig['requestHandler']>,
+      },
+    })
+
+    expect(model['_client'].config.requestHandler).toBe(requestHandler)
+  })
+})

--- a/strands-ts/src/models/bedrock.ts
+++ b/strands-ts/src/models/bedrock.ts
@@ -630,8 +630,8 @@ export class BedrockModel extends Model<BedrockModelConfig> {
       if (this._config.stream !== false) {
         // Create and send the command
         const command = new ConverseStreamCommand(request)
-        const response = options?.signal
-          ? await this._client.send(command, { abortSignal: options.signal })
+        const response = options?.cancelSignal
+          ? await this._client.send(command, { abortSignal: options.cancelSignal })
           : await this._client.send(command)
         // Stream the response
         if (response.stream) {
@@ -647,8 +647,8 @@ export class BedrockModel extends Model<BedrockModelConfig> {
         }
       } else {
         const command = new ConverseCommand(request)
-        const response = options?.signal
-          ? await this._client.send(command, { abortSignal: options.signal })
+        const response = options?.cancelSignal
+          ? await this._client.send(command, { abortSignal: options.cancelSignal })
           : await this._client.send(command)
         for (const event of this._mapBedrockEventToSDKEvent(response)) {
           yield event

--- a/strands-ts/src/models/bedrock.ts
+++ b/strands-ts/src/models/bedrock.ts
@@ -627,7 +627,9 @@ export class BedrockModel extends Model<BedrockModelConfig> {
       if (this._config.stream !== false) {
         // Create and send the command
         const command = new ConverseStreamCommand(request)
-        const response = await this._client.send(command)
+        const response = options?.signal
+          ? await this._client.send(command, { abortSignal: options.signal })
+          : await this._client.send(command)
         // Stream the response
         if (response.stream) {
           let lastStopReason: string | undefined
@@ -642,7 +644,9 @@ export class BedrockModel extends Model<BedrockModelConfig> {
         }
       } else {
         const command = new ConverseCommand(request)
-        const response = await this._client.send(command)
+        const response = options?.signal
+          ? await this._client.send(command, { abortSignal: options.signal })
+          : await this._client.send(command)
         for (const event of this._mapBedrockEventToSDKEvent(response)) {
           yield event
         }

--- a/strands-ts/src/models/bedrock.ts
+++ b/strands-ts/src/models/bedrock.ts
@@ -45,6 +45,7 @@ import {
   type CitationsDelta as BedrockCitationsDelta,
   type GuardrailTraceAssessment,
 } from '@aws-sdk/client-bedrock-runtime'
+import { FetchHttpHandler, type FetchHttpHandlerOptions } from '@smithy/fetch-http-handler'
 import {
   type BaseModelConfig,
   type CacheConfig,
@@ -438,13 +439,15 @@ export class BedrockModel extends Model<BedrockModelConfig> {
       ? `${clientConfig.customUserAgent} strands-agents-ts-sdk`
       : 'strands-agents-ts-sdk'
 
+    const requestHandler = withDefaultRequestTimeout(clientConfig?.requestHandler)
     this._client = new BedrockRuntimeClient({
       ...(clientConfig ?? {}),
-      requestHandler: withDefaultRequestTimeout(clientConfig?.requestHandler),
+      requestHandler,
       // region takes precedence over clientConfig
       ...(region ? { region: region } : {}),
       customUserAgent,
     })
+    applyAbortAwareBrowserRequestHandler(this._client.config, requestHandler)
 
     if (apiKey) {
       applyApiKey(this._client, apiKey)
@@ -1805,6 +1808,25 @@ function withDefaultRequestTimeout(
   // Use `??` rather than spread order so an explicit `requestTimeout: undefined` still gets
   // the default (spread would otherwise overwrite the default with `undefined`, disabling it).
   return { ...options, requestTimeout: options.requestTimeout ?? DEFAULT_REQUEST_TIMEOUT_MS }
+}
+
+/**
+ * Replaces the AWS browser default WebSocket wrapper for this model's HTTPS
+ * requests. The wrapper drops HttpHandlerOptions when delegating to fetch, so
+ * abortSignal never reaches the transport. Node defaults and caller-provided
+ * handler instances are left unchanged.
+ */
+function applyAbortAwareBrowserRequestHandler(
+  config: BedrockRuntimeClientResolvedConfig,
+  requestHandler: NonNullable<BedrockRuntimeClientConfig['requestHandler']>
+): void {
+  if (typeof (requestHandler as { handle?: unknown }).handle === 'function') {
+    return
+  }
+  if (config.requestHandler?.metadata?.handlerProtocol !== 'websocket/h1.1') {
+    return
+  }
+  config.requestHandler = new FetchHttpHandler(requestHandler as FetchHttpHandlerOptions)
 }
 
 /**

--- a/strands-ts/src/models/model.ts
+++ b/strands-ts/src/models/model.ts
@@ -130,6 +130,11 @@ export interface BaseModelConfig {
  */
 export interface StreamOptions {
   /**
+   * Signal used to abort an in-flight model provider request.
+   */
+  signal?: AbortSignal
+
+  /**
    * System prompt to guide the model's behavior.
    * Can be a simple string or an array of content blocks for advanced caching.
    */

--- a/strands-ts/src/models/model.ts
+++ b/strands-ts/src/models/model.ts
@@ -130,10 +130,10 @@ export interface BaseModelConfig {
  */
 export interface StreamOptions {
   /**
-   * Optional signal that a provider implementation can forward to abort an in-flight request.
+   * Optional cancellation signal that a provider implementation can forward to abort an in-flight request.
    * Support is provider-dependent.
    */
-  signal?: AbortSignal
+  cancelSignal?: AbortSignal
 
   /**
    * System prompt to guide the model's behavior.

--- a/strands-ts/src/models/model.ts
+++ b/strands-ts/src/models/model.ts
@@ -130,7 +130,8 @@ export interface BaseModelConfig {
  */
 export interface StreamOptions {
   /**
-   * Signal used to abort an in-flight model provider request.
+   * Optional signal that a provider implementation can forward to abort an in-flight request.
+   * Support is provider-dependent.
    */
   signal?: AbortSignal
 


### PR DESCRIPTION
## Description

Cancelling an Agent invocation currently stops local event processing, but the
composed cancellation signal never reaches the Bedrock transport. An in-flight
Converse request can therefore continue generating after the caller has
cancelled the turn.

This change:

- adds an optional cancellation signal to `StreamOptions` and passes the
  Agent's composed per-invocation signal to the model stream;
- forwards that signal to both streaming and non-streaming Bedrock requests via
  the AWS SDK `abortSignal` request option;
- replaces the AWS browser default WebSocket wrapper for this model's HTTPS
  requests with the abort-aware Smithy fetch handler, while preserving Node and
  caller-provided request handlers;
- preserves the existing Agent cancellation result when the provider transport
  reports the abort as `AbortError`;
- adds regressions for both Bedrock request modes, active transport abortion,
  a fake producer that stops emitting after cancellation, and the real default
  Chromium transport boundary.

The new option is optional and provider-dependent, other model providers are
unchanged, and Bedrock keeps its existing one-argument `send(command)` path
when no signal is present.

## Related Issues

Fixes #3224

## Documentation PR

No documentation change is needed. This makes the existing `cancelSignal`
contract apply to the in-flight Bedrock request.

## Type of Change

Bug fix

## Testing

- `npm test -- src/agent/__tests__/agent.cancel.test.ts src/models/__tests__/bedrock.test.ts` (194 tests)
- `npm test` (3789 tests)
- `npm run test:browser` (3086 passed, 5 skipped, including 3 browser transport-boundary tests)
- `npm run type-check`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run check:browser-bundle`
- `npm run test:integ:selective` was attempted locally; provider-backed suites
  could not complete because repository AWS/Bedrock test credentials were not
  available. Credential-independent tests passed, and Bedrock-backed tests were
  skipped or failed during provider setup.

- [ ] I ran `hatch run prepare` (not applicable to this TypeScript-only change)

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
