### PR TITLE
fix(models/ollama): guard against None token counts in format_chunk metadata

### DIFF
--- a/strands-py/src/strands/models/ollama.py
+++ b/strands-py/src/strands/models/ollama.py
@@ -280,15 +280,21 @@ class OllamaModel(Model):
                 return {"messageStop": {"stopReason": reason}}
 
             case "metadata":
+                # Ollama omits zero-valued counts from the response (Metrics fields are
+                # `json:",omitempty"`), so ollama-python deserializes them to None. Guard the
+                # arithmetic with `or 0`, matching the idiom already used in anthropic.py.
+                prompt_eval_count = event["data"].prompt_eval_count or 0
+                eval_count = event["data"].eval_count or 0
+                total_duration = event["data"].total_duration or 0
                 return {
                     "metadata": {
                         "usage": {
-                            "inputTokens": event["data"].prompt_eval_count,
-                            "outputTokens": event["data"].eval_count,
-                            "totalTokens": event["data"].eval_count + event["data"].prompt_eval_count,
+                            "inputTokens": prompt_eval_count,
+                            "outputTokens": eval_count,
+                            "totalTokens": eval_count + prompt_eval_count,
                         },
                         "metrics": {
-                            "latencyMs": int(event["data"].total_duration / 1e6),
+                            "latencyMs": int(total_duration / 1e6),
                         },
                     },
                 }

--- a/strands-py/tests/strands/models/test_ollama.py
+++ b/strands-py/tests/strands/models/test_ollama.py
@@ -450,6 +450,40 @@ def test_format_chunk_metadata(model):
     assert tru_chunk == exp_chunk
 
 
+@pytest.mark.parametrize(
+    ("omitted_field", "exp_usage", "exp_latency_ms"),
+    [
+        ("prompt_eval_count", {"inputTokens": 0, "outputTokens": 7, "totalTokens": 7}, 1),
+        ("eval_count", {"inputTokens": 11, "outputTokens": 0, "totalTokens": 11}, 1),
+        ("total_duration", {"inputTokens": 11, "outputTokens": 7, "totalTokens": 18}, 0),
+    ],
+)
+def test_format_chunk_metadata_omitted_counts(model, omitted_field, exp_usage, exp_latency_ms):
+    # Ollama omits zero-valued Metrics fields from the response (`json:",omitempty"`), so
+    # ollama-python deserializes them to None. Build a real ChatResponse (not a Mock, which
+    # would supply ints and hide the None contract) with each field omitted in turn.
+    data = {
+        "model": "llama3",
+        "done": True,
+        "message": {"role": "assistant", "content": ""},
+        "prompt_eval_count": 11,
+        "eval_count": 7,
+        "total_duration": 1_000_000,
+    }
+    del data[omitted_field]
+    event = {"chunk_type": "metadata", "data": ollama.ChatResponse.model_validate(data)}
+
+    tru_chunk = model.format_chunk(event)
+    exp_chunk = {
+        "metadata": {
+            "usage": exp_usage,
+            "metrics": {"latencyMs": exp_latency_ms},
+        },
+    }
+
+    assert tru_chunk == exp_chunk
+
+
 def test_format_chunk_other(model):
     event = {"chunk_type": "other"}
 


### PR DESCRIPTION
## Description

On the Ollama streaming path, `OllamaModel.format_chunk` does unguarded arithmetic on the token counts in the `metadata` chunk:

```python
"totalTokens": event["data"].eval_count + event["data"].prompt_eval_count,
...
"latencyMs": int(event["data"].total_duration / 1e6),
```

Those three fields are optional on the wire. Ollama tags them `json:",omitempty"` in its Go `Metrics` struct, so a zero (or absent) value is dropped from the response JSON, and ollama-python declares them `Optional[int] = None`, so a dropped field deserializes to `None`. `format_chunk` then evaluates `int + None` (and `None / float`) and raises `TypeError`, which aborts the stream. `strands` itself declares `inputTokens: Required[int]` on the `Usage` type, so a `None` reaching this chunk also breaks the contract the metadata chunk is meant to satisfy.

The non-streaming path is unaffected: it reads a single fully populated `message.usage`. The Anthropic adapter already guards the identical hazard with `usage.get(...) or 0` (`anthropic.py:377-378`); this change adopts the same idiom for Ollama, so an omitted count reads as `0`.

## Related Issues

None; self-discovered.

## Type of Change

Bug fix

## Testing

Reproduced and verified in a clean `python:3.12-slim` container at this branch's HEAD, driving the real `OllamaModel.format_chunk` with real `ollama.ChatResponse` objects (no mocks), each count omitted in turn:

- Before: omitting `prompt_eval_count`, `eval_count`, or `total_duration` each raises `TypeError`.
- After: each returns integer usage/metrics, with the omitted count read as `0`.

Added `test_format_chunk_metadata_omitted_counts` to `tests/strands/models/test_ollama.py`, parametrized over the three fields; it fails on `main` (`TypeError`) and passes here. It builds a real `ChatResponse` rather than a `Mock`, because a `Mock` supplies integers and hides the `Optional[int]` contract that causes the bug.

Ran in Docker (the gates `hatch run prepare` covers): `ruff check`, `ruff format --check`, `mypy ./src` all clean; `hatch test tests/strands/models/test_ollama.py` = 43 passed.

Not verified: I did not drive a live Ollama server, so this shows that an omitted-count response crashes today and is handled after the fix, not how frequently a given server omits these fields.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added a test that proves the fix is effective (fails before, passes after)
- [x] No documentation change is needed (bug fix, no public API change)
- [x] My changes generate no new warnings
