### PR TITLE
feat(py): add agent-as-tool delegation

### DIFF
--- a/strands-py/src/strands/agent/_agent_as_tool.py
+++ b/strands-py/src/strands/agent/_agent_as_tool.py
@@ -17,7 +17,7 @@ from ..agent.state import AgentState
 from ..types._events import AgentAsToolStreamEvent, ToolInterruptEvent, ToolResultEvent
 from ..types.content import Messages
 from ..types.interrupt import InterruptResponseContent
-from ..types.tools import AgentTool, ToolGenerator, ToolResultContent, ToolSpec, ToolUse
+from ..types.tools import AgentTool, ToolGenerator, ToolSpec, ToolUse
 
 if TYPE_CHECKING:
     from .agent import Agent
@@ -247,22 +247,12 @@ class _AgentAsTool(AgentTool):
                     }
                 )
             elif self._delegate:
-                # Bypass str(result) which appends \n per text block, accumulating with delegation depth.
-                content = result.message.get("content", [])
-                tool_result_content: list[ToolResultContent] = []
-                for block in content:
-                    if isinstance(block, dict):
-                        if "text" in block:
-                            tool_result_content.append(ToolResultContent(text=block["text"]))
-                        elif "json" in block:
-                            tool_result_content.append(ToolResultContent(json=block["json"]))
-                if not tool_result_content:
-                    tool_result_content = [ToolResultContent(text=str(result))]
+                # Strip newline __str__ adds so that content matches the result more closely
                 yield ToolResultEvent(
                     {
                         "toolUseId": tool_use_id,
                         "status": "success",
-                        "content": tool_result_content,
+                        "content": [{"text": str(result).rstrip("\n")}],
                     }
                 )
             else:

--- a/strands-py/src/strands/agent/_agent_as_tool.py
+++ b/strands-py/src/strands/agent/_agent_as_tool.py
@@ -17,7 +17,7 @@ from ..agent.state import AgentState
 from ..types._events import AgentAsToolStreamEvent, ToolInterruptEvent, ToolResultEvent
 from ..types.content import Messages
 from ..types.interrupt import InterruptResponseContent
-from ..types.tools import AgentTool, ToolGenerator, ToolSpec, ToolUse
+from ..types.tools import AgentTool, ToolGenerator, ToolResultContent, ToolSpec, ToolUse
 
 if TYPE_CHECKING:
     from .agent import Agent
@@ -247,12 +247,30 @@ class _AgentAsTool(AgentTool):
                     }
                 )
             elif self._delegate:
-                # Strip newline __str__ adds so that content matches the result more closely
+                # Copy content blocks verbatim; falls back to str(result) minus trailing \n.
+                content = result.message.get("content", [])
+                tool_result_content: list[ToolResultContent] = []
+                for block in content:
+                    if isinstance(block, dict):
+                        if "text" in block:
+                            tool_result_content.append(ToolResultContent(text=block["text"]))
+                        elif "json" in block:
+                            tool_result_content.append(ToolResultContent(json=block["json"]))
+                        elif "citationsContent" in block:
+                            cited = [
+                                inner["text"]
+                                for inner in block["citationsContent"].get("content", [])
+                                if isinstance(inner, dict) and "text" in inner
+                            ]
+                            if cited:
+                                tool_result_content.append(ToolResultContent(text="\n".join(cited)))
+                if not tool_result_content:
+                    tool_result_content = [ToolResultContent(text=str(result).rstrip("\n"))]
                 yield ToolResultEvent(
                     {
                         "toolUseId": tool_use_id,
                         "status": "success",
-                        "content": [{"text": str(result).rstrip("\n")}],
+                        "content": tool_result_content,
                     }
                 )
             else:

--- a/strands-py/src/strands/agent/_agent_as_tool.py
+++ b/strands-py/src/strands/agent/_agent_as_tool.py
@@ -17,7 +17,7 @@ from ..agent.state import AgentState
 from ..types._events import AgentAsToolStreamEvent, ToolInterruptEvent, ToolResultEvent
 from ..types.content import Messages
 from ..types.interrupt import InterruptResponseContent
-from ..types.tools import AgentTool, ToolGenerator, ToolSpec, ToolUse
+from ..types.tools import AgentTool, ToolGenerator, ToolResultContent, ToolSpec, ToolUse
 
 if TYPE_CHECKING:
     from .agent import Agent
@@ -244,6 +244,25 @@ class _AgentAsTool(AgentTool):
                         "toolUseId": tool_use_id,
                         "status": "success",
                         "content": [{"json": result.structured_output.model_dump(mode="json")}],
+                    }
+                )
+            elif self._delegate:
+                # Bypass str(result) which appends \n per text block, accumulating with delegation depth.
+                content = result.message.get("content", [])
+                tool_result_content: list[ToolResultContent] = []
+                for block in content:
+                    if isinstance(block, dict):
+                        if "text" in block:
+                            tool_result_content.append(ToolResultContent(text=block["text"]))
+                        elif "json" in block:
+                            tool_result_content.append(ToolResultContent(json=block["json"]))
+                if not tool_result_content:
+                    tool_result_content = [ToolResultContent(text=str(result))]
+                yield ToolResultEvent(
+                    {
+                        "toolUseId": tool_use_id,
+                        "status": "success",
+                        "content": tool_result_content,
                     }
                 )
             else:

--- a/strands-py/src/strands/agent/_agent_as_tool.py
+++ b/strands-py/src/strands/agent/_agent_as_tool.py
@@ -24,6 +24,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+DELEGATION_DESCRIPTION_SUFFIX = (
+    " Calling this tool will return its response directly to the user as the final answer."
+    " It should be the only tool called in the turn."
+)
+
 
 class _AgentAsTool(AgentTool):
     """Adapter that exposes an Agent as a tool for use by other agents.
@@ -43,6 +48,9 @@ class _AgentAsTool(AgentTool):
         # Preserve context across invocations
         tool = researcher.as_tool(preserve_context=True)
 
+        # Delegation: sub-agent's response becomes the final answer
+        tool = researcher.as_tool(delegate=True)
+
         writer = Agent(name="writer", tools=[tool])
         writer("Write about AI agents")
         ```
@@ -55,6 +63,7 @@ class _AgentAsTool(AgentTool):
         name: str,
         description: str | None = None,
         preserve_context: bool = False,
+        delegate: bool = False,
     ) -> None:
         r"""Initialize the agent-as-tool adapter.
 
@@ -68,13 +77,20 @@ class _AgentAsTool(AgentTool):
                 values they had at construction time before each call, ensuring every
                 invocation starts from the same baseline regardless of any external
                 interactions with the agent. Defaults to False.
+            delegate: When True, the orchestrator treats this tool's result as the final
+                response and exits without an additional model call. The tool's description
+                is automatically suffixed with an instruction telling the model that this
+                tool should be the only tool called in the turn. Defaults to False.
         """
         super().__init__()
         self._agent = agent
         self._tool_name = name
+        self._delegate = delegate
         self._description = (
             description or agent.description or f"Use the {name} agent as a tool by providing a natural language input"
         )
+        if delegate:
+            self._description += DELEGATION_DESCRIPTION_SUFFIX
         self._preserve_context = preserve_context
 
         # When preserve_context=False, we snapshot the agent's initial state so we can
@@ -100,6 +116,15 @@ class _AgentAsTool(AgentTool):
     def agent(self) -> Agent:
         """The wrapped agent instance."""
         return self._agent
+
+    @property
+    def delegate(self) -> bool:
+        """Whether this tool uses delegation semantics.
+
+        When True, the orchestrator treats this tool's result as the final
+        response and exits without an additional model call.
+        """
+        return self._delegate
 
     @property
     def tool_name(self) -> str:
@@ -222,7 +247,7 @@ class _AgentAsTool(AgentTool):
                     {
                         "toolUseId": tool_use_id,
                         "status": "success",
-                        "content": [{"json": result.structured_output.model_dump()}],
+                        "content": [{"json": result.structured_output.model_dump(mode="json")}],
                     }
                 )
             else:

--- a/strands-py/src/strands/agent/_agent_as_tool.py
+++ b/strands-py/src/strands/agent/_agent_as_tool.py
@@ -119,11 +119,7 @@ class _AgentAsTool(AgentTool):
 
     @property
     def delegate(self) -> bool:
-        """Whether this tool uses delegation semantics.
-
-        When True, the orchestrator treats this tool's result as the final
-        response and exits without an additional model call.
-        """
+        """Get whether this tool uses delegation semantics."""
         return self._delegate
 
     @property

--- a/strands-py/src/strands/agent/_agent_delegation.py
+++ b/strands-py/src/strands/agent/_agent_delegation.py
@@ -6,6 +6,10 @@ When a tool is configured with ``delegate=True``, this plugin ensures:
 2. The agent loop exits immediately after a successful delegation (via end_turn)
 3. The AgentResult is transformed with the delegation tool's content as the last message
 4. Streaming events from the delegate agent are surfaced natively in the parent stream
+
+The final delegation message is produced in middleware after the core loop exits.
+``MessageAddedEvent`` subscribers may observe the end_turn placeholder before the
+middleware replaces it with the real delegation content.
 """
 
 from __future__ import annotations
@@ -95,13 +99,6 @@ def _find_delegation_result(messages: list, tool_use_id: str) -> dict | None:
                     return None
                 return dict(tool_result)
     return None
-
-
-class _NativeStreamEvent(TypedEvent):
-    """Promotes a sub-agent's raw event dict to a TypedEvent for native streaming."""
-
-    def __init__(self, data: dict) -> None:
-        super().__init__(data)
 
 
 class AgentDelegation(Plugin):
@@ -293,7 +290,7 @@ class AgentDelegation(Plugin):
             elif isinstance(event, AgentAsToolStreamEvent):
                 inner_data = event.get("tool_stream_event", {}).get("data")
                 if inner_data is not None:
-                    yield _NativeStreamEvent(inner_data)
+                    yield TypedEvent(inner_data)
                 else:
                     yield event
             else:
@@ -353,8 +350,7 @@ class AgentDelegation(Plugin):
         delegation_message: MessageType = {"role": "assistant", "content": delegation_content}
         _ensure_tracking_id(delegation_message)
 
-        # Replace the placeholder message the event loop persisted. Use redact_latest_message
-        # (same pattern as guardrail redaction) to avoid a duplicate append in session managers.
+        # Replace the placeholder message the event loop persisted.
         session_manager = getattr(context.agent, "_session_manager", None)
         if messages and messages[-1].get("role") == "assistant":
             messages[-1] = delegation_message

--- a/strands-py/src/strands/agent/_agent_delegation.py
+++ b/strands-py/src/strands/agent/_agent_delegation.py
@@ -1,0 +1,383 @@
+"""AgentDelegation plugin — enforces delegation semantics for tool routing.
+
+When a tool is configured with ``delegate=True``, this plugin ensures:
+
+1. The delegation tool is the only tool called in the turn (single-call constraint)
+2. The agent loop exits immediately after a successful delegation (via end_turn)
+3. The AgentResult is transformed with the delegation tool's content as the last message
+4. Streaming events from the delegate agent are surfaced natively in the parent stream
+"""
+
+from __future__ import annotations
+
+import json as json_module
+import logging
+import weakref
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from .._middleware.stages import AgentStreamContext, AgentStreamStage, ExecuteToolContext, ExecuteToolStage
+from .._middleware.types import MiddlewareNext
+from ..hooks import (
+    AfterToolCallEvent,
+    AfterToolsEvent,
+    BeforeModelCallEvent,
+    BeforeToolsEvent,
+    HookOrder,
+    MessageAddedEvent,
+)
+from ..plugins import Plugin
+from ..types._events import AgentAsToolStreamEvent, EventLoopStopEvent, ToolResultEvent, TypedEvent
+from ..types.content import ContentBlock, _ensure_tracking_id
+from ..types.content import Message as MessageType
+from ._agent_as_tool import _AgentAsTool
+
+if TYPE_CHECKING:
+    from .agent import Agent
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _DelegationState:
+    """Per-agent state tracked across the delegation lifecycle within a single invocation."""
+
+    tool_use_count: int = 0
+    """Number of tool use blocks in the current batch."""
+
+    tool_use_id: str | None = None
+    """Tool use ID of the delegation tool that succeeded."""
+
+    end_turn_via_delegation: bool = False
+    """Whether this plugin ended turn."""
+
+
+def _is_delegation_tool(agent: Agent, tool_name: str) -> bool:
+    """Check whether a tool registered on the agent is a delegation AgentAsTool."""
+    tool = agent.tool_registry.registry.get(tool_name) or agent.tool_registry.dynamic_tools.get(tool_name)
+    return isinstance(tool, _AgentAsTool) and tool.delegate
+
+
+def _to_content_blocks(tool_result: dict) -> list[ContentBlock]:
+    """Convert ToolResult content into ContentBlocks for an assistant message.
+
+    JSON blocks are serialized to text (matching TS's ``toContentBlocks``).
+    """
+    raw_content = tool_result.get("content", [])
+    result: list[ContentBlock] = []
+    for block in raw_content:
+        if "text" in block:
+            result.append({"text": block["text"]})
+        elif "json" in block:
+            result.append({"text": json_module.dumps(block["json"])})
+        else:
+            result.append(block)
+    return result
+
+
+def _find_delegation_result(messages: list, tool_use_id: str) -> dict | None:
+    """Find the delegation tool's successful result in the agent messages.
+
+    Searches backwards for the last user message containing a successful tool
+    result matching the given tool_use_id. Returns None if not found or errored.
+    """
+    for i in range(len(messages) - 1, -1, -1):
+        msg = messages[i]
+        if msg.get("role") != "user":
+            continue
+        for block in msg.get("content", []):
+            if not isinstance(block, dict) or "toolResult" not in block:
+                continue
+            tool_result = block["toolResult"]
+            if tool_result.get("toolUseId") == tool_use_id:
+                if tool_result.get("status") == "error":
+                    return None
+                return dict(tool_result)
+    return None
+
+
+class _NativeStreamEvent(TypedEvent):
+    """Promotes a sub-agent's raw event dict to a TypedEvent for native streaming."""
+
+    def __init__(self, data: dict) -> None:
+        super().__init__(data)
+
+
+class AgentDelegation(Plugin):
+    """Plugin that enforces delegation semantics for tool routing.
+
+    Automatically registered on every agent. Acts as a no-op when no delegation tools fire.
+    Implements single-call constraint, early loop exit, and result transformation.
+
+    Example:
+        ```python
+        from strands import Agent
+
+        specialist = Agent(name="specialist", description="Handles billing")
+        orchestrator = Agent(
+            tools=[specialist.as_tool(delegate=True)],
+            # AgentDelegation is auto-registered — no manual setup needed
+        )
+        ```
+    """
+
+    name = "strands:agent-delegation"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._state: weakref.WeakKeyDictionary[Agent, _DelegationState] = weakref.WeakKeyDictionary()
+
+    def init_agent(self, agent: Agent) -> None:
+        """Register hooks and middleware for delegation enforcement."""
+        # Delegation is incompatible with stateful models — early exit would leave
+        # an unclosed function call on the server.
+        if agent.model.stateful:
+            has_delegation_tool = any(
+                isinstance(tool, _AgentAsTool) and tool.delegate for tool in agent.tool_registry.registry.values()
+            )
+            if has_delegation_tool:
+                raise ValueError(
+                    "Delegation tools (delegate=True) are not supported with stateful models. "
+                    "Stateful models manage conversation state server-side, and delegation's early loop exit "
+                    "would leave unclosed function calls on the server."
+                )
+
+        agent.add_hook(self._on_before_tools, BeforeToolsEvent)
+        agent.add_hook(self._on_after_tool_call, AfterToolCallEvent)
+        agent.add_hook(self._on_after_tools, AfterToolsEvent, order=HookOrder.SDK_LAST)
+        agent.add_hook(self._on_before_model_call, BeforeModelCallEvent)
+
+        agent._middleware_registry.add_middleware(ExecuteToolStage, self._handle_tool_execution)
+        agent._middleware_registry.add_middleware(AgentStreamStage, self._handle_stream)
+
+    # --- Hooks ---
+
+    def _on_before_tools(self, event: BeforeToolsEvent) -> None:
+        """Initialize batch state; cancel if a delegate is mixed with other tools."""
+        agent = event.agent
+        if agent.model.stateful:
+            return
+
+        message = event.message
+        content = message.get("content", [])
+        tool_use_blocks = [block for block in content if isinstance(block, dict) and "toolUse" in block]
+
+        self._state[agent] = _DelegationState(tool_use_count=len(tool_use_blocks))
+
+        has_delegation = any(_is_delegation_tool(agent, block["toolUse"]["name"]) for block in tool_use_blocks)
+        if has_delegation and len(tool_use_blocks) > 1:
+            event.cancel = (
+                "This tool call was not executed. A delegation tool must be the only "
+                "tool called in a turn. Retry with a single delegation tool call or "
+                "use only non-delegation tools."
+            )
+
+    def _on_before_model_call(self, event: BeforeModelCallEvent) -> None:
+        """Clear stale delegation state when the loop continues past a delegation batch."""
+        self._state.pop(event.agent, None)
+
+    def _on_after_tool_call(self, event: AfterToolCallEvent) -> None:
+        """Mark tool_use_id on delegation success; clear on error or retry-swap."""
+        if event.agent.model.stateful:
+            return
+
+        if not isinstance(event.selected_tool, _AgentAsTool) or not event.selected_tool.delegate:
+            state = self._state.get(event.agent)
+            if state is not None and state.tool_use_id == event.tool_use.get("toolUseId"):
+                state.tool_use_id = None
+            return
+
+        state = self._state.get(event.agent)
+        if state is None:
+            return
+
+        if event.result.get("status") == "error":
+            state.tool_use_id = None
+            return
+
+        state.tool_use_id = event.tool_use.get("toolUseId")
+
+    def _on_after_tools(self, event: AfterToolsEvent) -> None:
+        """Set end_turn when delegation succeeded and the result is still valid."""
+        if event.agent.model.stateful:
+            return
+
+        state = self._state.get(event.agent)
+        if state is None or not state.tool_use_id:
+            return
+
+        # Verify the tool result is still successful in the committed message.
+        message = event.message
+        content = message.get("content", [])
+        result_block = None
+        for block in content:
+            if not isinstance(block, dict) or "toolResult" not in block:
+                continue
+            tool_result = block["toolResult"]
+            if tool_result.get("toolUseId") == state.tool_use_id:
+                result_block = tool_result
+                break
+
+        if result_block is None or result_block.get("status") == "error":
+            state.tool_use_id = None
+            return
+
+        # Skip delegation when the parent expects structured output.
+        has_structured_output = any(
+            getattr(t, "tool_type", None) == "structured_output"
+            for t in event.agent.tool_registry.dynamic_tools.values()
+        )
+        if has_structured_output:
+            return
+
+        event.end_turn = True
+        state.end_turn_via_delegation = True
+
+    # --- Middleware ---
+
+    async def _handle_tool_execution(
+        self,
+        context: ExecuteToolContext,
+        next_fn: MiddlewareNext,
+    ) -> AsyncGenerator[TypedEvent, None]:
+        """ExecuteToolStage middleware: enforce delegation constraints and unwrap events."""
+        # Non-delegation tools pass through unchanged.
+        if not isinstance(context.tool, _AgentAsTool) or not context.tool.delegate:
+            async for event in next_fn(context):
+                yield event
+            return
+
+        # Reject runtime-added delegate on stateful model.
+        if context.agent.model.stateful:
+            yield ToolResultEvent(
+                {
+                    "toolUseId": context.tool_use["toolUseId"],
+                    "status": "error",
+                    "content": [
+                        {
+                            "text": (
+                                "Delegation failed: delegation tools (delegate=True) are not supported "
+                                "with stateful models."
+                            )
+                        }
+                    ],
+                }
+            )
+            return
+
+        # Enforce single-call constraint.
+        state = self._state.get(context.agent)
+        if state and state.tool_use_count > 1:
+            yield ToolResultEvent(
+                {
+                    "toolUseId": context.tool_use["toolUseId"],
+                    "status": "error",
+                    "content": [
+                        {
+                            "text": (
+                                "Delegation failed: a delegation tool must be the only tool "
+                                "called in a turn. Retry with a single delegation tool call "
+                                "or use only non-delegation tools."
+                            )
+                        }
+                    ],
+                }
+            )
+            return
+
+        # Stream the delegation tool, unwrapping inner agent events as native events.
+        async for event in next_fn(context):
+            if isinstance(event, ToolResultEvent):
+                yield event
+            elif isinstance(event, AgentAsToolStreamEvent):
+                inner_data = event.get("tool_stream_event", {}).get("data")
+                if inner_data is not None:
+                    yield _NativeStreamEvent(inner_data)
+                else:
+                    yield event
+            else:
+                yield event
+
+    async def _handle_stream(
+        self,
+        context: AgentStreamContext,
+        next_fn: MiddlewareNext,
+    ) -> AsyncGenerator[TypedEvent, None]:
+        """AgentStreamStage middleware: replace the terminal stop with delegation content.
+
+        Events before the first stop are yielded immediately. Once a stop appears,
+        the tail is buffered and replayed with the stop replaced (or unchanged).
+        """
+        self._state.pop(context.agent, None)
+
+        tail_buffer: list[TypedEvent] = []
+        buffering = False
+
+        try:
+            async for event in next_fn(context):
+                if buffering:
+                    tail_buffer.append(event)
+                elif isinstance(event, EventLoopStopEvent):
+                    buffering = True
+                    tail_buffer.append(event)
+                else:
+                    yield event
+        except Exception:
+            self._state.pop(context.agent, None)
+            for event in tail_buffer:
+                yield event
+            raise
+
+        state = self._state.pop(context.agent, None)
+
+        if state is None or not state.tool_use_id or not state.end_turn_via_delegation:
+            for event in tail_buffer:
+                yield event
+            return
+
+        # Re-verify the delegation result is still successful in committed history.
+        messages = context.agent.messages
+        tool_result = _find_delegation_result(messages, state.tool_use_id)
+        if tool_result is None:
+            logger.debug(
+                "tool_use_id=<%s> | delegation result no longer successful in history, "
+                "skipping delegation transformation",
+                state.tool_use_id,
+            )
+            for event in tail_buffer:
+                yield event
+            return
+
+        delegation_content = _to_content_blocks(tool_result)
+        delegation_message: MessageType = {"role": "assistant", "content": delegation_content}
+        _ensure_tracking_id(delegation_message)
+
+        # Replace the placeholder message the event loop persisted. Use redact_latest_message
+        # (same pattern as guardrail redaction) to avoid a duplicate append in session managers.
+        session_manager = getattr(context.agent, "_session_manager", None)
+        if messages and messages[-1].get("role") == "assistant":
+            messages[-1] = delegation_message
+            if session_manager is not None:
+                session_manager.redact_latest_message(delegation_message, context.agent)
+            else:
+                await context.agent.hooks.invoke_callbacks_async(
+                    MessageAddedEvent(agent=context.agent, message=delegation_message)
+                )
+        else:
+            messages.append(delegation_message)
+            await context.agent.hooks.invoke_callbacks_async(
+                MessageAddedEvent(agent=context.agent, message=delegation_message)
+            )
+
+        # Replay tail with stop replaced by delegation terminal.
+        for event in tail_buffer:
+            if isinstance(event, EventLoopStopEvent):
+                yield EventLoopStopEvent(
+                    "end_turn",
+                    delegation_message,
+                    context.agent.event_loop_metrics,
+                    context.invocation_state.get("request_state", {}),
+                )
+            else:
+                yield event

--- a/strands-py/src/strands/agent/_agent_delegation.py
+++ b/strands-py/src/strands/agent/_agent_delegation.py
@@ -197,7 +197,14 @@ class AgentDelegation(Plugin):
         state.tool_use_id = event.tool_use.get("toolUseId")
 
     def _on_after_tools(self, event: AfterToolsEvent) -> None:
-        """Set end_turn when delegation succeeded and the result is still valid."""
+        """Set end_turn when delegation succeeded and the result is still valid.
+
+        This hook runs at ``HookOrder.SDK_LAST`` (100). If a hook with a higher numeric order
+        mutates a tool result's status from success to error, the end_turn signal has already
+        been committed and the loop will still exit; ``_handle_stream`` re-verifies the result
+        as defence in depth. No SDK or vended plugin registers AfterToolsEvent hooks above
+        SDK_LAST, and mutating a committed tool result's status there is not a supported pattern.
+        """
         if event.agent.model.stateful:
             return
 

--- a/strands-py/src/strands/agent/_agent_delegation.py
+++ b/strands-py/src/strands/agent/_agent_delegation.py
@@ -8,8 +8,9 @@ When a tool is configured with ``delegate=True``, this plugin ensures:
 4. Streaming events from the delegate agent are surfaced natively in the parent stream
 
 The final delegation message is produced in middleware after the core loop exits.
-``MessageAddedEvent`` subscribers may observe the end_turn placeholder before the
-middleware replaces it with the real delegation content.
+``MessageAddedEvent`` subscribers will see the end_turn placeholder followed by a second
+event with the real delegation content (no session manager), or no event for the real
+content at all (session manager attached).
 """
 
 from __future__ import annotations
@@ -226,6 +227,10 @@ class AgentDelegation(Plugin):
             for t in event.agent.tool_registry.dynamic_tools.values()
         )
         if has_structured_output:
+            logger.debug(
+                "tool_use_id=<%s> | parent requires structured output, skipping delegation",
+                state.tool_use_id,
+            )
             return
 
         event.end_turn = True
@@ -254,8 +259,8 @@ class AgentDelegation(Plugin):
                     "content": [
                         {
                             "text": (
-                                "Delegation failed: delegation tools (delegate=True) are not supported "
-                                "with stateful models."
+                                "Delegation failed: this tool is not supported with stateful models. "
+                                "Respond to the user directly instead of delegating."
                             )
                         }
                     ],

--- a/strands-py/src/strands/agent/_agent_delegation.py
+++ b/strands-py/src/strands/agent/_agent_delegation.py
@@ -259,6 +259,10 @@ class AgentDelegation(Plugin):
 
         # Stateful model: skip delegation, execute as a normal tool.
         if context.agent.model.stateful:
+            logger.debug(
+                "tool_use_id=<%s> | stateful model, skipping delegation and running as a normal tool",
+                context.tool_use["toolUseId"],
+            )
             async for event in next_fn(context):
                 yield event
             return

--- a/strands-py/src/strands/agent/_agent_delegation.py
+++ b/strands-py/src/strands/agent/_agent_delegation.py
@@ -257,22 +257,10 @@ class AgentDelegation(Plugin):
                 yield event
             return
 
-        # Reject runtime-added delegate on stateful model.
+        # Stateful model: skip delegation, execute as a normal tool.
         if context.agent.model.stateful:
-            yield ToolResultEvent(
-                {
-                    "toolUseId": context.tool_use["toolUseId"],
-                    "status": "error",
-                    "content": [
-                        {
-                            "text": (
-                                "Delegation failed: this tool is not supported with stateful models. "
-                                "Respond to the user directly instead of delegating."
-                            )
-                        }
-                    ],
-                }
-            )
+            async for event in next_fn(context):
+                yield event
             return
 
         # Enforce single-call constraint.

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -526,6 +526,15 @@ class Agent(AgentBase):
             for plugin in plugins_to_register:
                 self._plugin_registry.add_and_init(plugin)
 
+        # Always register AgentDelegation so delegation semantics work regardless of
+        # when a delegate tool is added (construction, plugin getTools, MCP, runtime).
+        # The plugin is a no-op when no delegation tools fire.
+        has_agent_delegation = any(plugin.name == "strands:agent-delegation" for plugin in (plugins_to_register or []))
+        if not has_agent_delegation:
+            from ._agent_delegation import AgentDelegation
+
+            self._plugin_registry.add_and_init(AgentDelegation())
+
         # Resolve and register the memory manager (a Plugin); keep a reference so the
         # synchronous entry point can flush pending extraction writes.
         self.memory_manager = self._resolve_memory_manager(memory_manager)
@@ -1008,6 +1017,7 @@ class Agent(AgentBase):
         name: str | None = None,
         description: str | None = None,
         preserve_context: bool = False,
+        delegate: bool = False,
     ) -> AgentTool:
         r"""Convert this agent into a tool for use by another agent.
 
@@ -1021,6 +1031,10 @@ class Agent(AgentBase):
                 values they had at construction time before each call, ensuring every
                 invocation starts from the same baseline regardless of any external
                 interactions with the agent. Defaults to False.
+            delegate: When True, the orchestrator treats this tool's result as the final
+                response and exits without an additional model call. The tool's description
+                is automatically suffixed with an instruction telling the model that this
+                tool should be the only tool called in the turn. Defaults to False.
 
         Returns:
             A tool wrapping this agent.
@@ -1030,11 +1044,18 @@ class Agent(AgentBase):
             researcher = Agent(name="researcher", description="Finds information")
             writer = Agent(name="writer", tools=[researcher.as_tool()])
             writer("Write about AI agents")
+
+            # Delegation: sub-agent response is returned directly as the final answer
+            billing = Agent(name="billing", description="Handles billing questions")
+            orchestrator = Agent(tools=[billing.as_tool(delegate=True)])
+            orchestrator("What is my balance?")
             ```
         """
         if not name:
             name = self.name
-        return _AgentAsTool(self, name=name, description=description, preserve_context=preserve_context)
+        return _AgentAsTool(
+            self, name=name, description=description, preserve_context=preserve_context, delegate=delegate
+        )
 
     def cleanup(self) -> None:
         """Clean up resources used by the agent.

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -526,9 +526,6 @@ class Agent(AgentBase):
             for plugin in plugins_to_register:
                 self._plugin_registry.add_and_init(plugin)
 
-        # Always register AgentDelegation so delegation semantics work regardless of
-        # when a delegate tool is added (construction, plugin getTools, MCP, runtime).
-        # The plugin is a no-op when no delegation tools fire.
         has_agent_delegation = any(plugin.name == "strands:agent-delegation" for plugin in (plugins_to_register or []))
         if not has_agent_delegation:
             from ._agent_delegation import AgentDelegation

--- a/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
@@ -51,6 +51,7 @@ from typing import TYPE_CHECKING, Any, Protocol
 
 from typing_extensions import TypedDict
 
+from ...agent._agent_as_tool import _AgentAsTool
 from ...hooks.events import AfterToolCallEvent, BeforeModelCallEvent
 from ...plugins import Plugin, hook
 from ...storage import Storage
@@ -471,6 +472,11 @@ class ContextOffloader(Plugin):
             return
 
         if self._include_retrieval_tool and event.tool_use.get("name") == self.retrieve_offloaded_content.tool_name:
+            return
+
+        # Never offload delegation tool results — they become the final user-facing answer
+        # and no subsequent model call can retrieve the offloaded content.
+        if isinstance(event.selected_tool, _AgentAsTool) and event.selected_tool.delegate:
             return
 
         result = event.result

--- a/strands-py/tests/strands/agent/test_agent_delegation.py
+++ b/strands-py/tests/strands/agent/test_agent_delegation.py
@@ -272,7 +272,7 @@ class TestStreamOrdering:
             agent=parent,
             messages=[],
             invocation_state={"request_state": {}},
-            _interrupt_state=parent._interrupt_state,
+            _interrupts={},
         )
 
         a = TypedEvent({"a": 1})
@@ -298,7 +298,7 @@ class TestStreamOrdering:
             agent=parent,
             messages=[],
             invocation_state={"request_state": {}},
-            _interrupt_state=parent._interrupt_state,
+            _interrupts={},
         )
 
         s1 = EventLoopStopEvent("end_turn", {"role": "assistant", "content": []}, parent.event_loop_metrics, {})
@@ -340,7 +340,7 @@ class TestStreamOrdering:
             agent=parent,
             messages=[],
             invocation_state={"request_state": {}},
-            _interrupt_state=parent._interrupt_state,
+            _interrupts={},
         )
 
         pre = TypedEvent({"pre": 1})
@@ -390,7 +390,7 @@ class TestStreamOrdering:
             agent=parent,
             messages=[],
             invocation_state={"request_state": {}},
-            _interrupt_state=parent._interrupt_state,
+            _interrupts={},
         )
 
         original_stop = EventLoopStopEvent("end_turn", parent.messages[-1], parent.event_loop_metrics, {})
@@ -623,6 +623,157 @@ class TestSessionPersistence:
         # The final message is the delegation content, not the placeholder
         assert orch_2.messages[-1]["role"] == "assistant"
         assert any("$42" in str(b.get("text", "")) for b in orch_2.messages[-1]["content"])
+
+
+class TestDelegationWithContextOffloader:
+    """ContextOffloader must not offload delegation tool results."""
+
+    @pytest.mark.asyncio
+    async def test_large_delegation_result_not_offloaded(self):
+        """A delegation result exceeding the offloader threshold stays in context."""
+        from strands.vended_plugins.context_offloader import ContextOffloader, InMemoryStorage
+        from tests.fixtures.mocked_model_provider import MockedModelProvider
+
+        storage = InMemoryStorage()
+        offloader = ContextOffloader(storage=storage, max_result_tokens=25, preview_tokens=10)
+
+        large_answer = "x" * 500  # well above 25-token threshold
+        sub = Agent(
+            model=MockedModelProvider([{"role": "assistant", "content": [{"text": large_answer}]}]),
+            name="billing",
+            callback_handler=None,
+        )
+
+        orch = Agent(
+            model=MockedModelProvider(
+                [
+                    {
+                        "role": "assistant",
+                        "content": [{"toolUse": {"toolUseId": "c1", "name": "billing", "input": {"input": "check"}}}],
+                    }
+                ]
+            ),
+            name="orch",
+            tools=[sub.as_tool(delegate=True)],
+            plugins=[offloader],
+            callback_handler=None,
+        )
+
+        result = await orch.invoke_async("Check balance")
+
+        # The delegation result must appear in the final message unmodified
+        assert result.stop_reason == "end_turn"
+        final_text = "".join(block.get("text", "") for block in result.message["content"] if isinstance(block, dict))
+        assert large_answer in final_text
+
+        # Nothing was stored in the offloader
+        assert len(storage._store) == 0
+
+
+class TestAfterToolsOrderingGuard:
+    """SDK_LAST on AfterToolsEvent ensures delegation sees the committed result before other hooks."""
+
+    @pytest.mark.asyncio
+    async def test_late_hook_flipping_result_prevents_end_turn(self):
+        """A default-order AfterToolsEvent hook that flips the result to error prevents delegation end_turn.
+
+        Because AfterToolsEvent uses reverse ordering, SDK_LAST (100) runs first, DEFAULT (0) runs after.
+        Delegation reads the result first. But _handle_stream re-verifies the result from committed history,
+        so a late-hook mutation (at DEFAULT) that changes the committed message is caught.
+        This test verifies that if the committed message is mutated to error between _on_after_tools and
+        _handle_stream, the agent loop continues rather than ending the turn.
+        """
+        from tests.fixtures.mocked_model_provider import MockedModelProvider
+
+        sub = Agent(
+            model=MockedModelProvider([{"role": "assistant", "content": [{"text": "answer"}]}]),
+            name="specialist",
+            callback_handler=None,
+        )
+
+        orch = Agent(
+            model=MockedModelProvider(
+                [
+                    {
+                        "role": "assistant",
+                        "content": [{"toolUse": {"toolUseId": "c1", "name": "specialist", "input": {"input": "go"}}}],
+                    },
+                    # After recovery from the flipped result, the model responds with text
+                    {"role": "assistant", "content": [{"text": "I continued after flip."}]},
+                ]
+            ),
+            name="orch",
+            tools=[sub.as_tool(delegate=True)],
+            callback_handler=None,
+        )
+
+        from strands.hooks import AfterToolsEvent
+
+        def flip_result_to_error(event: AfterToolsEvent):
+            """Simulate a hook that mutates the tool result to error after delegation saw it."""
+            content = event.message.get("content", [])
+            for block in content:
+                if isinstance(block, dict) and "toolResult" in block:
+                    block["toolResult"]["status"] = "error"
+
+        # Register at DEFAULT order — in reverse ordering this runs AFTER SDK_LAST (delegation)
+        orch.add_hook(flip_result_to_error, AfterToolsEvent)
+
+        result = await orch.invoke_async("Do it")
+
+        # The agent must have continued (not stopped at the flipped delegation) and produced a second reply
+        assert result.stop_reason == "end_turn"
+        assert "continued" in str(result.message["content"]).lower()
+
+
+class TestMessageAddedEventDuringDelegation:
+    """Delegation fires MessageAddedEvent for the delegation message."""
+
+    @pytest.mark.asyncio
+    async def test_message_added_event_fires_for_delegation_message(self):
+        """MessageAddedEvent must fire with the delegation content message during a successful delegation."""
+        from strands.hooks import MessageAddedEvent
+        from tests.fixtures.mocked_model_provider import MockedModelProvider
+
+        sub = Agent(
+            model=MockedModelProvider([{"role": "assistant", "content": [{"text": "Balance: $42"}]}]),
+            name="billing",
+            callback_handler=None,
+        )
+
+        orch = Agent(
+            model=MockedModelProvider(
+                [
+                    {
+                        "role": "assistant",
+                        "content": [{"toolUse": {"toolUseId": "c1", "name": "billing", "input": {"input": "check"}}}],
+                    }
+                ]
+            ),
+            name="orch",
+            tools=[sub.as_tool(delegate=True)],
+            callback_handler=None,
+        )
+
+        received_messages = []
+
+        def on_message_added(event: MessageAddedEvent):
+            received_messages.append(event.message)
+
+        orch.add_hook(on_message_added, MessageAddedEvent)
+
+        await orch.invoke_async("Check balance")
+
+        # At minimum: user prompt, assistant tool_use, tool_result, delegation final message
+        assert len(received_messages) >= 3
+
+        # The delegation message (containing the sub-agent's answer) must be among them
+        delegation_messages = [
+            m
+            for m in received_messages
+            if m["role"] == "assistant" and any("$42" in str(b.get("text", "")) for b in m.get("content", []))
+        ]
+        assert len(delegation_messages) == 1
 
 
 class TestMiddlewareSingleCallGuard:

--- a/strands-py/tests/strands/agent/test_agent_delegation.py
+++ b/strands-py/tests/strands/agent/test_agent_delegation.py
@@ -1,15 +1,28 @@
 """Tests for AgentDelegation plugin — verifies delegation semantics with agent-as-tool."""
 
+import json as json_module
+from datetime import datetime
 from unittest.mock import MagicMock, PropertyMock
 
 import pytest
 
+from strands._middleware.stages import AgentStreamContext, ExecuteToolContext
 from strands.agent._agent_as_tool import DELEGATION_DESCRIPTION_SUFFIX, _AgentAsTool
 from strands.agent._agent_delegation import AgentDelegation, _DelegationState, _to_content_blocks
 from strands.agent.agent import Agent
 from strands.agent.agent_result import AgentResult
+from strands.hooks import (
+    AfterToolCallEvent,
+    AfterToolsEvent,
+    BeforeToolsEvent,
+    MessageAddedEvent,
+)
 from strands.interrupt import _InterruptState
 from strands.telemetry.metrics import EventLoopMetrics
+from strands.types._events import EventLoopStopEvent, ToolResultEvent, TypedEvent
+from tests.fixtures.mocked_model_provider import MockedModelProvider
+
+# --- Helpers ---
 
 
 def _mock_sub_agent(name="sub"):
@@ -27,880 +40,408 @@ def _get_plugin(agent):
     return agent._plugin_registry._plugins["strands:agent-delegation"]
 
 
-class TestDelegationFlag:
-    def test_delegate_defaults_false(self):
-        tool = Agent(name="sub", callback_handler=None).as_tool()
-        assert tool.delegate is False
-
-    def test_delegate_true_adds_suffix(self):
-        tool = Agent(name="sub", description="Billing", callback_handler=None).as_tool(delegate=True)
-        assert tool.delegate is True
-        assert tool._description == "Billing" + DELEGATION_DESCRIPTION_SUFFIX
-
-    def test_delegate_false_no_suffix(self):
-        tool = Agent(name="sub", description="Billing", callback_handler=None).as_tool()
-        assert DELEGATION_DESCRIPTION_SUFFIX not in tool._description
-
-    def test_custom_description_with_delegate(self):
-        tool = Agent(name="sub", callback_handler=None).as_tool(delegate=True, description="Custom")
-        assert tool._description == "Custom" + DELEGATION_DESCRIPTION_SUFFIX
-
-
-class TestToolDoesNotOwnStop:
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("delegate", [True, False])
-    async def test_tool_never_sets_stop_event_loop(self, delegate):
-        """_AgentAsTool defers all stop decisions to the plugin."""
-        mock_agent = _mock_sub_agent()
-        result = AgentResult(
-            stop_reason="end_turn",
-            message={"role": "assistant", "content": [{"text": "ok"}]},
-            metrics=EventLoopMetrics(),
-            state={},
-        )
-
-        async def mock_stream(prompt):
-            yield {"result": result}
-
-        mock_agent.stream_async = mock_stream
-        tool = _AgentAsTool(mock_agent, name="sub", delegate=delegate, preserve_context=True)
-
-        invocation_state = {"request_state": {}}
-        async for _ in tool.stream({"toolUseId": "t1", "name": "sub", "input": {"input": "hi"}}, invocation_state):
-            pass
-
-        assert "stop_event_loop" not in invocation_state["request_state"]
-
-    @pytest.mark.asyncio
-    async def test_tool_error_does_not_set_stop(self):
-        mock_agent = _mock_sub_agent()
-
-        async def failing(prompt):
-            raise RuntimeError("crash")
-            yield  # noqa: RET503
-
-        mock_agent.stream_async = failing
-        tool = _AgentAsTool(mock_agent, name="sub", delegate=True, preserve_context=True)
-
-        invocation_state = {"request_state": {}}
-        async for _ in tool.stream({"toolUseId": "t1", "name": "sub", "input": {"input": "hi"}}, invocation_state):
-            pass
-
-        assert invocation_state["request_state"].get("stop_event_loop") is not True
-
-
-class TestSingleCallConstraint:
-    """BeforeToolsEvent cancels the batch when a delegate is mixed with other tools."""
-
-    @pytest.mark.parametrize(
-        "tool_names,expect_cancel",
-        [
-            (["specialist", "other_tool"], True),
-            (["billing", "tech"], True),  # two delegates
-            (["specialist"], False),  # single delegate OK
-            (["tool_a", "tool_b"], False),  # no delegates
-        ],
-        ids=["delegate+other", "two-delegates", "single-delegate", "no-delegates"],
+def _fire_after_tool_call(parent, plugin, tool, tool_use_id, status, selected_tool=None):
+    return AfterToolCallEvent(
+        agent=parent,
+        selected_tool=selected_tool or tool,
+        tool_use={"toolUseId": tool_use_id, "name": "sub", "input": {}},
+        invocation_state={"request_state": {}},
+        result={"toolUseId": tool_use_id, "status": status, "content": [{"text": "x"}]},
     )
-    def test_cancel_decision(self, tool_names, expect_cancel):
-        from strands.hooks import BeforeToolsEvent
-
-        sub = Agent(name="specialist", description="S", callback_handler=None)
-        tools = [sub.as_tool(delegate=True)]
-        # Add a second delegate if needed
-        if "tech" in tool_names or "billing" in tool_names:
-            sub2 = Agent(name="billing" if "billing" in tool_names else "tech", callback_handler=None)
-            tools.append(sub2.as_tool(delegate=True))
-
-        parent = Agent(name="parent", tools=tools, callback_handler=None)
-
-        message = {
-            "role": "assistant",
-            "content": [
-                {"toolUse": {"toolUseId": f"t{i}", "name": name, "input": {}}} for i, name in enumerate(tool_names)
-            ],
-        }
-
-        plugin = AgentDelegation()
-        event = BeforeToolsEvent(agent=parent, message=message, invocation_state={})
-        plugin._on_before_tools(event)
-
-        assert bool(event.cancel) == expect_cancel
-
-
-class TestAfterToolCallState:
-    """_on_after_tool_call marks/clears tool_use_id correctly."""
-
-    def _fire(self, parent, plugin, tool, tool_use_id, status, selected_tool=None):
-        from strands.hooks import AfterToolCallEvent
-
-        return AfterToolCallEvent(
-            agent=parent,
-            selected_tool=selected_tool or tool,
-            tool_use={"toolUseId": tool_use_id, "name": "sub", "input": {}},
-            invocation_state={"request_state": {}},
-            result={"toolUseId": tool_use_id, "status": status, "content": [{"text": "x"}]},
-        )
-
-    def test_marks_on_success(self):
-        tool = _make_delegation_tool()
-        parent = Agent(name="p", tools=[tool], callback_handler=None)
-        plugin = _get_plugin(parent)
-        plugin._state[parent] = _DelegationState(tool_use_count=1)
-
-        event = self._fire(parent, plugin, tool, "t1", "success")
-        plugin._on_after_tool_call(event)
-        assert plugin._state[parent].tool_use_id == "t1"
-
-    def test_clears_on_error(self):
-        tool = _make_delegation_tool()
-        parent = Agent(name="p", tools=[tool], callback_handler=None)
-        plugin = _get_plugin(parent)
-        plugin._state[parent] = _DelegationState(tool_use_id="t1", tool_use_count=1)
-
-        event = self._fire(parent, plugin, tool, "t1", "error")
-        plugin._on_after_tool_call(event)
-        assert plugin._state[parent].tool_use_id is None
-
-    def test_retry_swap_clears_matching_id(self):
-        tool = _make_delegation_tool()
-        parent = Agent(name="p", tools=[tool], callback_handler=None)
-        plugin = _get_plugin(parent)
-        plugin._state[parent] = _DelegationState(tool_use_id="t1", tool_use_count=1)
-
-        ordinary = MagicMock()
-        ordinary.delegate = False
-        event = self._fire(parent, plugin, tool, "t1", "success", selected_tool=ordinary)
-        plugin._on_after_tool_call(event)
-        assert plugin._state[parent].tool_use_id is None
-
-    def test_retry_swap_preserves_different_id(self):
-        tool = _make_delegation_tool()
-        parent = Agent(name="p", tools=[tool], callback_handler=None)
-        plugin = _get_plugin(parent)
-        plugin._state[parent] = _DelegationState(tool_use_id="t1", tool_use_count=1)
-
-        ordinary = MagicMock()
-        ordinary.delegate = False
-        event = self._fire(parent, plugin, tool, "t2", "success", selected_tool=ordinary)
-        plugin._on_after_tool_call(event)
-        assert plugin._state[parent].tool_use_id == "t1"
-
-    def test_foreign_stop_not_touched(self):
-        """Delegation never clears stop_event_loop it didn't set."""
-        tool = _make_delegation_tool()
-        parent = Agent(name="p", tools=[tool], callback_handler=None)
-        plugin = _get_plugin(parent)
-        plugin._state[parent] = _DelegationState(tool_use_id="other", tool_use_count=1)
-
-        invocation_state = {"request_state": {"stop_event_loop": True}}
-        from strands.hooks import AfterToolCallEvent
-
-        event = AfterToolCallEvent(
-            agent=parent,
-            selected_tool=tool,
-            tool_use={"toolUseId": "t99", "name": "sub", "input": {}},
-            invocation_state=invocation_state,
-            result={"toolUseId": "t99", "status": "success", "content": [{"text": "ok"}]},
-        )
-        plugin._on_after_tool_call(event)
-        assert invocation_state["request_state"]["stop_event_loop"] is True
-
-
-class TestAfterToolsEndTurn:
-    """_on_after_tools sets end_turn only when delegation result is valid."""
-
-    def _fire(self, parent, plugin, status="success"):
-        from strands.hooks import AfterToolsEvent
-
-        message = {
-            "role": "user",
-            "content": [{"toolResult": {"toolUseId": "t1", "status": status, "content": [{"text": "x"}]}}],
-        }
-        event = AfterToolsEvent(agent=parent, message=message, invocation_state={"request_state": {}})
-        plugin._on_after_tools(event)
-        return event
-
-    def test_sets_end_turn_on_success(self):
-        tool = _make_delegation_tool()
-        parent = Agent(name="p", tools=[tool], callback_handler=None)
-        plugin = _get_plugin(parent)
-        plugin._state[parent] = _DelegationState(tool_use_id="t1", tool_use_count=1)
-
-        event = self._fire(parent, plugin)
-        assert event.end_turn is True
-
-    def test_skips_when_result_is_error(self):
-        tool = _make_delegation_tool()
-        parent = Agent(name="p", tools=[tool], callback_handler=None)
-        plugin = _get_plugin(parent)
-        plugin._state[parent] = _DelegationState(tool_use_id="t1", tool_use_count=1)
-
-        event = self._fire(parent, plugin, status="error")
-        assert not event.end_turn
-        assert plugin._state[parent].tool_use_id is None
-
-    def test_suppressed_with_structured_output(self):
-        from pydantic import BaseModel
-
-        from strands.tools.structured_output.structured_output_tool import StructuredOutputTool
-
-        class R(BaseModel):
-            x: int
-
-        tool = _make_delegation_tool()
-        parent = Agent(name="p", tools=[tool], callback_handler=None)
-        plugin = _get_plugin(parent)
-        plugin._state[parent] = _DelegationState(tool_use_id="t1", tool_use_count=1)
-        parent.tool_registry.register_dynamic_tool(StructuredOutputTool(R))
-
-        event = self._fire(parent, plugin)
-        assert not event.end_turn
-
-
-class TestStreamOrdering:
-    """_handle_stream preserves ordering and emits exactly one terminal."""
-
-    @pytest.mark.asyncio
-    async def test_non_delegation_preserves_trailing_after_stop(self):
-        from strands._middleware.stages import AgentStreamContext
-        from strands.types._events import EventLoopStopEvent, TypedEvent
-
-        parent = Agent(name="p", callback_handler=None)
-        plugin = _get_plugin(parent)
-        ctx = AgentStreamContext(
-            agent=parent,
-            messages=[],
-            invocation_state={"request_state": {}},
-            _interrupts={},
-        )
-
-        a = TypedEvent({"a": 1})
-        stop = EventLoopStopEvent("end_turn", {"role": "assistant", "content": []}, parent.event_loop_metrics, {})
-        b = TypedEvent({"b": 2})
-
-        async def inner(c):
-            yield a
-            yield stop
-            yield b
-
-        events = [e async for e in plugin._handle_stream(ctx, inner)]
-        assert events == [a, stop, b]
-
-    @pytest.mark.asyncio
-    async def test_non_delegation_multiple_stops_preserved(self):
-        from strands._middleware.stages import AgentStreamContext
-        from strands.types._events import EventLoopStopEvent, TypedEvent
-
-        parent = Agent(name="p", callback_handler=None)
-        plugin = _get_plugin(parent)
-        ctx = AgentStreamContext(
-            agent=parent,
-            messages=[],
-            invocation_state={"request_state": {}},
-            _interrupts={},
-        )
-
-        s1 = EventLoopStopEvent("end_turn", {"role": "assistant", "content": []}, parent.event_loop_metrics, {})
-        mid = TypedEvent({"mid": 1})
-        s2 = EventLoopStopEvent("end_turn", {"role": "assistant", "content": []}, parent.event_loop_metrics, {})
-
-        async def inner(c):
-            yield s1
-            yield mid
-            yield s2
-
-        events = [e async for e in plugin._handle_stream(ctx, inner)]
-        assert events == [s1, mid, s2]
-
-    @pytest.mark.asyncio
-    async def test_delegation_single_terminal_with_trailing(self):
-        """Delegation replaces stop; trailing events keep position; exactly one terminal."""
-        from strands._middleware.stages import AgentStreamContext
-        from strands.types._events import EventLoopStopEvent, TypedEvent
-
-        tool = _make_delegation_tool()
-        parent = Agent(name="p", tools=[tool], callback_handler=None)
-        plugin = _get_plugin(parent)
-
-        parent.messages.extend(
-            [
-                {"role": "assistant", "content": [{"toolUse": {"toolUseId": "t1", "name": "sub", "input": {}}}]},
-                {
-                    "role": "user",
-                    "content": [
-                        {"toolResult": {"toolUseId": "t1", "status": "success", "content": [{"text": "answer"}]}}
-                    ],
-                },
-                {"role": "assistant", "content": [{"text": "placeholder"}]},
-            ]
-        )
-
-        ctx = AgentStreamContext(
-            agent=parent,
-            messages=[],
-            invocation_state={"request_state": {}},
-            _interrupts={},
-        )
-
-        pre = TypedEvent({"pre": 1})
-        stop = EventLoopStopEvent("end_turn", parent.messages[-1], parent.event_loop_metrics, {})
-        trail = TypedEvent({"trail": 1})
-
-        async def inner(c):
-            plugin._state[parent] = _DelegationState(tool_use_id="t1", end_turn_via_delegation=True, tool_use_count=1)
-            yield pre
-            yield stop
-            yield trail
-
-        events = [e async for e in plugin._handle_stream(ctx, inner)]
-
-        assert events[0] is pre
-        stops = [e for e in events if isinstance(e, EventLoopStopEvent)]
-        assert len(stops) == 1
-        assert stops[0]["stop"][1]["content"][0]["text"] == "answer"
-        assert events[-1] is trail
-        assert "tracking_id" in parent.messages[-1]
-
-    @pytest.mark.asyncio
-    async def test_delegation_reverify_failure_replays_original(self):
-        """If the tool result is mutated to error after _on_after_tools, original stop replays."""
-        from strands._middleware.stages import AgentStreamContext
-        from strands.types._events import EventLoopStopEvent
-
-        tool = _make_delegation_tool()
-        parent = Agent(name="p", tools=[tool], callback_handler=None)
-        plugin = _get_plugin(parent)
-
-        # History where the tool result is an error (simulating late mutation)
-        parent.messages.extend(
-            [
-                {"role": "assistant", "content": [{"toolUse": {"toolUseId": "t1", "name": "sub", "input": {}}}]},
-                {
-                    "role": "user",
-                    "content": [
-                        {"toolResult": {"toolUseId": "t1", "status": "error", "content": [{"text": "failed"}]}}
-                    ],
-                },
-                {"role": "assistant", "content": [{"text": "placeholder"}]},
-            ]
-        )
-
-        ctx = AgentStreamContext(
-            agent=parent,
-            messages=[],
-            invocation_state={"request_state": {}},
-            _interrupts={},
-        )
-
-        original_stop = EventLoopStopEvent("end_turn", parent.messages[-1], parent.event_loop_metrics, {})
-
-        async def inner(c):
-            # Delegation state was set (as if _on_after_tools saw success), but history
-            # was mutated to error by a late hook before _handle_stream runs.
-            plugin._state[parent] = _DelegationState(tool_use_id="t1", end_turn_via_delegation=True, tool_use_count=1)
-            yield original_stop
-
-        events = [e async for e in plugin._handle_stream(ctx, inner)]
-
-        # Re-verify fails → original stop replays unchanged, no delegation transformation
-        assert len(events) == 1
-        assert events[0] is original_stop
-
-    @pytest.mark.asyncio
-    async def test_absent_tool_result_skips_delegation(self):
-        """When the tool result for the delegation toolUseId is absent from history, delegation is skipped."""
-        from strands._middleware.stages import AgentStreamContext
-        from strands.types._events import EventLoopStopEvent
-
-        tool = _make_delegation_tool()
-        parent = Agent(name="p", tools=[tool], callback_handler=None)
-        plugin = _get_plugin(parent)
-
-        # History has no tool result at all for the delegation toolUseId
-        parent.messages.extend(
-            [
-                {"role": "assistant", "content": [{"toolUse": {"toolUseId": "t1", "name": "sub", "input": {}}}]},
-                {"role": "assistant", "content": [{"text": "placeholder"}]},
-            ]
-        )
-
-        ctx = AgentStreamContext(
-            agent=parent,
-            messages=[],
-            invocation_state={"request_state": {}},
-            _interrupts={},
-        )
-
-        original_stop = EventLoopStopEvent("end_turn", parent.messages[-1], parent.event_loop_metrics, {})
-
-        async def inner(c):
-            plugin._state[parent] = _DelegationState(tool_use_id="t1", end_turn_via_delegation=True, tool_use_count=1)
-            yield original_stop
-
-        events = [e async for e in plugin._handle_stream(ctx, inner)]
-
-        # Result absent → original stop replays unchanged
-        assert len(events) == 1
-        assert events[0] is original_stop
-
-
-class TestStatefulModel:
-    """Delegation tools are rejected on stateful models at init and runtime."""
-
-    def test_init_raises_with_delegation_on_stateful(self):
-        tool = _make_delegation_tool()
-        stateful = MagicMock()
-        type(stateful).stateful = PropertyMock(return_value=True)
-
-        with pytest.raises(ValueError, match="not supported with stateful models"):
-            Agent(name="p", model=stateful, tools=[tool], callback_handler=None)
-
-    def test_init_ok_without_delegation_on_stateful(self):
-        stateful = MagicMock()
-        type(stateful).stateful = PropertyMock(return_value=True)
-        Agent(name="p", model=stateful, callback_handler=None)
-
-    @pytest.mark.asyncio
-    async def test_runtime_stateful_delegate_returns_error(self):
-        from strands._middleware.stages import ExecuteToolContext
-        from strands.types._events import ToolResultEvent
-
-        tool = _make_delegation_tool()
-        parent = Agent(name="p", callback_handler=None)
-        plugin = _get_plugin(parent)
-        type(parent.model).stateful = PropertyMock(return_value=True)
-
-        try:
-            ctx = ExecuteToolContext(
-                agent=parent,
-                tool=tool,
-                tool_use={"toolUseId": "t1", "name": "sub", "input": {"input": "hi"}},
-                invocation_state={"request_state": {}},
-                _interrupt_state=parent._interrupt_state,
-            )
-
-            async def unreachable(c):
-                yield ToolResultEvent({"toolUseId": "t1", "status": "success", "content": [{"text": "nope"}]})
-
-            events = [e async for e in plugin._handle_tool_execution(ctx, unreachable)]
-            assert len(events) == 1
-            assert events[0].tool_result["status"] == "error"
-            assert "stateful" in events[0].tool_result["content"][0]["text"].lower()
-        finally:
-            del type(parent.model).stateful
-
-
-class TestAutoRegistration:
-    def test_auto_registered(self):
-        assert "strands:agent-delegation" in Agent(name="t", callback_handler=None)._plugin_registry._plugins
-
-    def test_not_duplicated(self):
-        p = AgentDelegation()
-        agent = Agent(name="t", plugins=[p], callback_handler=None)
-        assert agent._plugin_registry._plugins.get("strands:agent-delegation") is p
-
-
-class TestJsonContentConversion:
-    def test_converts_text_json_and_passthrough(self):
-        import json
-
-        blocks = _to_content_blocks(
+
+
+def _fire_after_tools(parent, plugin, status="success"):
+    message = {
+        "role": "user",
+        "content": [{"toolResult": {"toolUseId": "t1", "status": status, "content": [{"text": "x"}]}}],
+    }
+    event = AfterToolsEvent(agent=parent, message=message, invocation_state={"request_state": {}})
+    plugin._on_after_tools(event)
+    return event
+
+
+# --- Delegation flag ---
+
+
+def test_as_tool_delegate_defaults_false():
+    tru_delegate = Agent(name="sub", callback_handler=None).as_tool().delegate
+    assert tru_delegate is False
+
+
+def test_as_tool_delegate_true_adds_suffix():
+    tool = Agent(name="sub", description="Billing", callback_handler=None).as_tool(delegate=True)
+    assert tool.delegate is True
+    assert tool._description == "Billing" + DELEGATION_DESCRIPTION_SUFFIX
+
+
+def test_as_tool_delegate_false_no_suffix():
+    tool = Agent(name="sub", description="Billing", callback_handler=None).as_tool()
+    assert DELEGATION_DESCRIPTION_SUFFIX not in tool._description
+
+
+def test_as_tool_custom_description_with_delegate():
+    tool = Agent(name="sub", callback_handler=None).as_tool(delegate=True, description="Custom")
+    exp_description = "Custom" + DELEGATION_DESCRIPTION_SUFFIX
+    assert tool._description == exp_description
+
+
+# --- Tool does not own stop ---
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("delegate", [True, False])
+async def test_tool_stream_never_sets_stop_event_loop(delegate):
+    """_AgentAsTool defers all stop decisions to the plugin."""
+    mock_agent = _mock_sub_agent()
+    result = AgentResult(
+        stop_reason="end_turn",
+        message={"role": "assistant", "content": [{"text": "ok"}]},
+        metrics=EventLoopMetrics(),
+        state={},
+    )
+
+    async def mock_stream(prompt):
+        yield {"result": result}
+
+    mock_agent.stream_async = mock_stream
+    tool = _AgentAsTool(mock_agent, name="sub", delegate=delegate, preserve_context=True)
+
+    invocation_state = {"request_state": {}}
+    async for _ in tool.stream({"toolUseId": "t1", "name": "sub", "input": {"input": "hi"}}, invocation_state):
+        pass
+
+    assert "stop_event_loop" not in invocation_state["request_state"]
+
+
+@pytest.mark.asyncio
+async def test_tool_stream_error_does_not_set_stop():
+    mock_agent = _mock_sub_agent()
+
+    async def failing(prompt):
+        raise RuntimeError("crash")
+        yield  # noqa: RET503
+
+    mock_agent.stream_async = failing
+    tool = _AgentAsTool(mock_agent, name="sub", delegate=True, preserve_context=True)
+
+    invocation_state = {"request_state": {}}
+    async for _ in tool.stream({"toolUseId": "t1", "name": "sub", "input": {"input": "hi"}}, invocation_state):
+        pass
+
+    assert invocation_state["request_state"].get("stop_event_loop") is not True
+
+
+# --- Single-call constraint (BeforeToolsEvent) ---
+
+
+@pytest.mark.parametrize(
+    "tool_names,expect_cancel",
+    [
+        (["specialist", "other_tool"], True),
+        (["billing", "tech"], True),
+        (["specialist"], False),
+        (["tool_a", "tool_b"], False),
+    ],
+    ids=["delegate+other", "two-delegates", "single-delegate", "no-delegates"],
+)
+def test_on_before_tools_cancel_decision(tool_names, expect_cancel):
+    sub = Agent(name="specialist", description="S", callback_handler=None)
+    tools = [sub.as_tool(delegate=True)]
+    if "tech" in tool_names or "billing" in tool_names:
+        sub2 = Agent(name="billing" if "billing" in tool_names else "tech", callback_handler=None)
+        tools.append(sub2.as_tool(delegate=True))
+
+    parent = Agent(name="parent", tools=tools, callback_handler=None)
+    message = {
+        "role": "assistant",
+        "content": [
+            {"toolUse": {"toolUseId": f"t{i}", "name": name, "input": {}}} for i, name in enumerate(tool_names)
+        ],
+    }
+
+    plugin = AgentDelegation()
+    event = BeforeToolsEvent(agent=parent, message=message, invocation_state={})
+    plugin._on_before_tools(event)
+
+    assert bool(event.cancel) == expect_cancel
+
+
+# --- AfterToolCallEvent state tracking ---
+
+
+def test_on_after_tool_call_marks_on_success():
+    tool = _make_delegation_tool()
+    parent = Agent(name="p", tools=[tool], callback_handler=None)
+    plugin = _get_plugin(parent)
+    plugin._state[parent] = _DelegationState(tool_use_count=1)
+
+    event = _fire_after_tool_call(parent, plugin, tool, "t1", "success")
+    plugin._on_after_tool_call(event)
+    assert plugin._state[parent].tool_use_id == "t1"
+
+
+def test_on_after_tool_call_clears_on_error():
+    tool = _make_delegation_tool()
+    parent = Agent(name="p", tools=[tool], callback_handler=None)
+    plugin = _get_plugin(parent)
+    plugin._state[parent] = _DelegationState(tool_use_id="t1", tool_use_count=1)
+
+    event = _fire_after_tool_call(parent, plugin, tool, "t1", "error")
+    plugin._on_after_tool_call(event)
+    assert plugin._state[parent].tool_use_id is None
+
+
+def test_on_after_tool_call_retry_swap_clears_matching_id():
+    tool = _make_delegation_tool()
+    parent = Agent(name="p", tools=[tool], callback_handler=None)
+    plugin = _get_plugin(parent)
+    plugin._state[parent] = _DelegationState(tool_use_id="t1", tool_use_count=1)
+
+    ordinary = MagicMock()
+    ordinary.delegate = False
+    event = _fire_after_tool_call(parent, plugin, tool, "t1", "success", selected_tool=ordinary)
+    plugin._on_after_tool_call(event)
+    assert plugin._state[parent].tool_use_id is None
+
+
+def test_on_after_tool_call_retry_swap_preserves_different_id():
+    tool = _make_delegation_tool()
+    parent = Agent(name="p", tools=[tool], callback_handler=None)
+    plugin = _get_plugin(parent)
+    plugin._state[parent] = _DelegationState(tool_use_id="t1", tool_use_count=1)
+
+    ordinary = MagicMock()
+    ordinary.delegate = False
+    event = _fire_after_tool_call(parent, plugin, tool, "t2", "success", selected_tool=ordinary)
+    plugin._on_after_tool_call(event)
+    assert plugin._state[parent].tool_use_id == "t1"
+
+
+def test_on_after_tool_call_foreign_stop_not_touched():
+    """Delegation never clears stop_event_loop it didn't set."""
+    tool = _make_delegation_tool()
+    parent = Agent(name="p", tools=[tool], callback_handler=None)
+    plugin = _get_plugin(parent)
+    plugin._state[parent] = _DelegationState(tool_use_id="other", tool_use_count=1)
+
+    invocation_state = {"request_state": {"stop_event_loop": True}}
+    event = AfterToolCallEvent(
+        agent=parent,
+        selected_tool=tool,
+        tool_use={"toolUseId": "t99", "name": "sub", "input": {}},
+        invocation_state=invocation_state,
+        result={"toolUseId": "t99", "status": "success", "content": [{"text": "ok"}]},
+    )
+    plugin._on_after_tool_call(event)
+    assert invocation_state["request_state"]["stop_event_loop"] is True
+
+
+# --- AfterToolsEvent end_turn ---
+
+
+def test_on_after_tools_sets_end_turn_on_success():
+    tool = _make_delegation_tool()
+    parent = Agent(name="p", tools=[tool], callback_handler=None)
+    plugin = _get_plugin(parent)
+    plugin._state[parent] = _DelegationState(tool_use_id="t1", tool_use_count=1)
+
+    tru_event = _fire_after_tools(parent, plugin)
+    assert tru_event.end_turn is True
+
+
+def test_on_after_tools_skips_when_result_is_error():
+    tool = _make_delegation_tool()
+    parent = Agent(name="p", tools=[tool], callback_handler=None)
+    plugin = _get_plugin(parent)
+    plugin._state[parent] = _DelegationState(tool_use_id="t1", tool_use_count=1)
+
+    tru_event = _fire_after_tools(parent, plugin, status="error")
+    assert not tru_event.end_turn
+    assert plugin._state[parent].tool_use_id is None
+
+
+def test_on_after_tools_suppressed_with_structured_output():
+    from pydantic import BaseModel
+
+    from strands.tools.structured_output.structured_output_tool import StructuredOutputTool
+
+    class R(BaseModel):
+        x: int
+
+    tool = _make_delegation_tool()
+    parent = Agent(name="p", tools=[tool], callback_handler=None)
+    plugin = _get_plugin(parent)
+    plugin._state[parent] = _DelegationState(tool_use_id="t1", tool_use_count=1)
+    parent.tool_registry.register_dynamic_tool(StructuredOutputTool(R))
+
+    tru_event = _fire_after_tools(parent, plugin)
+    assert not tru_event.end_turn
+
+
+# --- _handle_stream ordering ---
+
+
+@pytest.mark.asyncio
+async def test_handle_stream_non_delegation_preserves_trailing():
+    parent = Agent(name="p", callback_handler=None)
+    plugin = _get_plugin(parent)
+    ctx = AgentStreamContext(agent=parent, messages=[], invocation_state={"request_state": {}}, _interrupts={})
+
+    a = TypedEvent({"a": 1})
+    stop = EventLoopStopEvent("end_turn", {"role": "assistant", "content": []}, parent.event_loop_metrics, {})
+    b = TypedEvent({"b": 2})
+
+    async def inner(c):
+        yield a
+        yield stop
+        yield b
+
+    tru_events = [e async for e in plugin._handle_stream(ctx, inner)]
+    exp_events = [a, stop, b]
+    assert tru_events == exp_events
+
+
+@pytest.mark.asyncio
+async def test_handle_stream_non_delegation_multiple_stops_preserved():
+    parent = Agent(name="p", callback_handler=None)
+    plugin = _get_plugin(parent)
+    ctx = AgentStreamContext(agent=parent, messages=[], invocation_state={"request_state": {}}, _interrupts={})
+
+    s1 = EventLoopStopEvent("end_turn", {"role": "assistant", "content": []}, parent.event_loop_metrics, {})
+    mid = TypedEvent({"mid": 1})
+    s2 = EventLoopStopEvent("end_turn", {"role": "assistant", "content": []}, parent.event_loop_metrics, {})
+
+    async def inner(c):
+        yield s1
+        yield mid
+        yield s2
+
+    tru_events = [e async for e in plugin._handle_stream(ctx, inner)]
+    exp_events = [s1, mid, s2]
+    assert tru_events == exp_events
+
+
+@pytest.mark.asyncio
+async def test_handle_stream_delegation_replaces_stop_with_trailing():
+    """Delegation replaces stop; trailing events keep position; exactly one terminal."""
+    tool = _make_delegation_tool()
+    parent = Agent(name="p", tools=[tool], callback_handler=None)
+    plugin = _get_plugin(parent)
+
+    parent.messages.extend(
+        [
+            {"role": "assistant", "content": [{"toolUse": {"toolUseId": "t1", "name": "sub", "input": {}}}]},
             {
-                "content": [
-                    {"text": "hi"},
-                    {"json": {"k": 1}},
-                    {"image": {"format": "png", "source": {"bytes": b"x"}}},
-                ]
-            }
-        )
-        assert blocks[0] == {"text": "hi"}
-        assert json.loads(blocks[1]["text"]) == {"k": 1}
-        assert blocks[2] == {"image": {"format": "png", "source": {"bytes": b"x"}}}
-
-
-class TestChildStructuredOutputSerialization:
-    @pytest.mark.asyncio
-    async def test_datetime_serializes_cleanly(self):
-        import json
-        from datetime import datetime
-
-        from pydantic import BaseModel
-
-        from strands.types._events import ToolResultEvent
-
-        class S(BaseModel):
-            at: datetime
-
-        mock_agent = _mock_sub_agent("sched")
-        result = AgentResult(
-            stop_reason="end_turn",
-            message={"role": "assistant", "content": [{"text": "done"}]},
-            metrics=EventLoopMetrics(),
-            state={},
-            structured_output=S(at=datetime(2025, 1, 15, 9, 0)),
-        )
-
-        async def stream(prompt):
-            yield {"result": result}
-
-        mock_agent.stream_async = stream
-        tool = _AgentAsTool(mock_agent, name="sched", delegate=True, preserve_context=True)
-
-        events = [e async for e in tool.stream({"toolUseId": "t1", "name": "sched", "input": {"input": "x"}}, {})]
-        results = [e for e in events if isinstance(e, ToolResultEvent)]
-        assert results[0].tool_result["status"] == "success"
-        assert "2025-01-15" in json.dumps(results[0].tool_result["content"][0]["json"])
-
-
-class TestFullDelegationFlow:
-    @pytest.mark.asyncio
-    async def test_routes_to_specialist(self):
-        from tests.fixtures.mocked_model_provider import MockedModelProvider
-
-        sub = Agent(
-            model=MockedModelProvider([{"role": "assistant", "content": [{"text": "Balance: $42"}]}]),
-            name="billing",
-            callback_handler=None,
-        )
-        orch = Agent(
-            model=MockedModelProvider(
-                [
-                    {
-                        "role": "assistant",
-                        "content": [{"toolUse": {"toolUseId": "c1", "name": "billing", "input": {"input": "check"}}}],
-                    }
-                ]
-            ),
-            name="orch",
-            tools=[sub.as_tool(delegate=True)],
-            callback_handler=None,
-        )
-
-        result = await orch.invoke_async("Check balance")
-        assert result.stop_reason == "end_turn"
-        assert any("$42" in str(b.get("text", "")) for b in result.message["content"])
-
-        # The placeholder must not remain stranded in history
-        for msg in orch.messages:
-            for block in msg.get("content", []):
-                if isinstance(block, dict) and "text" in block:
-                    assert "Turn ended early" not in block["text"]
-
-    @pytest.mark.asyncio
-    async def test_error_recovery(self):
-        from tests.fixtures.mocked_model_provider import MockedModelProvider
-
-        err = _mock_sub_agent("failing")
-
-        async def fail(prompt):
-            raise RuntimeError("crash")
-            yield  # noqa: RET503
-
-        err.stream_async = fail
-        tool = _AgentAsTool(err, name="failing", delegate=True, preserve_context=True)
-
-        orch = Agent(
-            model=MockedModelProvider(
-                [
-                    {
-                        "role": "assistant",
-                        "content": [{"toolUse": {"toolUseId": "c1", "name": "failing", "input": {"input": "x"}}}],
-                    },
-                    {"role": "assistant", "content": [{"text": "I recovered."}]},
-                ]
-            ),
-            name="orch",
-            tools=[tool],
-            callback_handler=None,
-        )
-
-        result = await orch.invoke_async("Do it")
-        assert result.stop_reason == "end_turn"
-        assert "recovered" in str(result.message["content"]).lower()
-
-
-class TestSessionPersistence:
-    """Persisted history after delegation matches in-memory history."""
-
-    @pytest.mark.asyncio
-    async def test_persisted_matches_in_memory_after_delegation(self):
-        from strands.session.repository_session_manager import RepositorySessionManager
-        from tests.fixtures.mock_session_repository import MockedSessionRepository
-        from tests.fixtures.mocked_model_provider import MockedModelProvider
-
-        repo = MockedSessionRepository()
-        session_mgr = RepositorySessionManager(session_id="s1", session_repository=repo)
-
-        sub_model = MockedModelProvider([{"role": "assistant", "content": [{"text": "Balance: $42"}]}])
-        sub = Agent(model=sub_model, name="billing", callback_handler=None)
-
-        orch_model = MockedModelProvider(
-            [
-                {
-                    "role": "assistant",
-                    "content": [{"toolUse": {"toolUseId": "c1", "name": "billing", "input": {"input": "check"}}}],
-                }
-            ]
-        )
-        orch = Agent(
-            model=orch_model,
-            name="orchestrator",
-            tools=[sub.as_tool(delegate=True)],
-            session_manager=session_mgr,
-            callback_handler=None,
-        )
-
-        await orch.invoke_async("Check balance")
-
-        # Restore from the same repo into a fresh agent
-        session_mgr_2 = RepositorySessionManager(session_id="s1", session_repository=repo)
-        orch_2 = Agent(model=orch_model, name="orchestrator", session_manager=session_mgr_2, callback_handler=None)
-
-        # Persisted messages must match in-memory messages exactly
-        assert len(orch_2.messages) == len(orch.messages)
-        for restored, live in zip(orch_2.messages, orch.messages, strict=True):
-            assert restored["role"] == live["role"]
-            # Content comparison (ignore metadata/tracking_id differences)
-            assert restored["content"] == live["content"]
-
-        # The final message is the delegation content, not the placeholder
-        assert orch_2.messages[-1]["role"] == "assistant"
-        assert any("$42" in str(b.get("text", "")) for b in orch_2.messages[-1]["content"])
-
-
-class TestDelegationWithContextOffloader:
-    """ContextOffloader must not offload delegation tool results."""
-
-    @pytest.mark.asyncio
-    async def test_large_delegation_result_not_offloaded(self):
-        """A delegation result exceeding the offloader threshold stays in context."""
-        from strands.vended_plugins.context_offloader import ContextOffloader, InMemoryStorage
-        from tests.fixtures.mocked_model_provider import MockedModelProvider
-
-        storage = InMemoryStorage()
-        offloader = ContextOffloader(storage=storage, max_result_tokens=25, preview_tokens=10)
-
-        large_answer = "x" * 500  # well above 25-token threshold
-        sub = Agent(
-            model=MockedModelProvider([{"role": "assistant", "content": [{"text": large_answer}]}]),
-            name="billing",
-            callback_handler=None,
-        )
-
-        orch = Agent(
-            model=MockedModelProvider(
-                [
-                    {
-                        "role": "assistant",
-                        "content": [{"toolUse": {"toolUseId": "c1", "name": "billing", "input": {"input": "check"}}}],
-                    }
-                ]
-            ),
-            name="orch",
-            tools=[sub.as_tool(delegate=True)],
-            plugins=[offloader],
-            callback_handler=None,
-        )
-
-        result = await orch.invoke_async("Check balance")
-
-        # The delegation result must appear in the final message unmodified
-        assert result.stop_reason == "end_turn"
-        final_text = "".join(block.get("text", "") for block in result.message["content"] if isinstance(block, dict))
-        assert large_answer in final_text
-
-        # Nothing was stored in the offloader
-        assert len(storage._store) == 0
-
-
-class TestAfterToolsOrderingGuard:
-    """SDK_LAST on AfterToolsEvent makes delegation read the result after other hooks have mutated it."""
-
-    @pytest.mark.asyncio
-    async def test_late_hook_flipping_result_prevents_end_turn(self):
-        """A default-order AfterToolsEvent hook that flips the result to error prevents delegation end_turn.
-
-        Order priority always wins: DEFAULT (0) runs before SDK_LAST (100). Reverse ordering only flips
-        registration order *within* one order tier, so delegation's SDK_LAST hook runs last and reads the
-        already-mutated committed message. Its own check in _on_after_tools is what declines to set
-        end_turn here; _handle_stream's re-verification is a second line of defence that does not fire in
-        this scenario. This test verifies the agent loop continues rather than ending the turn.
-        """
-        from tests.fixtures.mocked_model_provider import MockedModelProvider
-
-        sub = Agent(
-            model=MockedModelProvider([{"role": "assistant", "content": [{"text": "answer"}]}]),
-            name="specialist",
-            callback_handler=None,
-        )
-
-        orch = Agent(
-            model=MockedModelProvider(
-                [
-                    {
-                        "role": "assistant",
-                        "content": [{"toolUse": {"toolUseId": "c1", "name": "specialist", "input": {"input": "go"}}}],
-                    },
-                    # After recovery from the flipped result, the model responds with text
-                    {"role": "assistant", "content": [{"text": "I continued after flip."}]},
-                ]
-            ),
-            name="orch",
-            tools=[sub.as_tool(delegate=True)],
-            callback_handler=None,
-        )
-
-        from strands.hooks import AfterToolsEvent
-
-        def flip_result_to_error(event: AfterToolsEvent):
-            """Simulate a hook that mutates the tool result to error after delegation saw it."""
-            content = event.message.get("content", [])
-            for block in content:
-                if isinstance(block, dict) and "toolResult" in block:
-                    block["toolResult"]["status"] = "error"
-
-        # Register at DEFAULT order — in reverse ordering this runs AFTER SDK_LAST (delegation)
-        orch.add_hook(flip_result_to_error, AfterToolsEvent)
-
-        result = await orch.invoke_async("Do it")
-
-        # The agent must have continued (not stopped at the flipped delegation) and produced a second reply
-        assert result.stop_reason == "end_turn"
-        assert "continued" in str(result.message["content"]).lower()
-
-
-class TestMessageAddedEventDuringDelegation:
-    """Delegation fires MessageAddedEvent for the delegation message."""
-
-    @pytest.mark.asyncio
-    async def test_message_added_event_fires_for_delegation_message(self):
-        """MessageAddedEvent fires for the placeholder and then the real delegation content."""
-        from strands.hooks import MessageAddedEvent
-        from tests.fixtures.mocked_model_provider import MockedModelProvider
-
-        sub = Agent(
-            model=MockedModelProvider([{"role": "assistant", "content": [{"text": "Balance: $42"}]}]),
-            name="billing",
-            callback_handler=None,
-        )
-
-        orch = Agent(
-            model=MockedModelProvider(
-                [
-                    {
-                        "role": "assistant",
-                        "content": [{"toolUse": {"toolUseId": "c1", "name": "billing", "input": {"input": "check"}}}],
-                    }
-                ]
-            ),
-            name="orch",
-            tools=[sub.as_tool(delegate=True)],
-            callback_handler=None,
-        )
-
-        received_messages = []
-
-        def on_message_added(event: MessageAddedEvent):
-            received_messages.append(event.message)
-
-        orch.add_hook(on_message_added, MessageAddedEvent)
-
-        await orch.invoke_async("Check balance")
-
-        # Expected events: user prompt, assistant tool_use, tool_result, end_turn placeholder, delegation content
-        assert len(received_messages) == 5
-
-        # The placeholder fires before the delegation content
-        placeholder_msgs = [
-            m
-            for m in received_messages
-            if m["role"] == "assistant"
-            and any("Turn ended early" in str(b.get("text", "")) for b in m.get("content", []))
+                "role": "user",
+                "content": [{"toolResult": {"toolUseId": "t1", "status": "success", "content": [{"text": "answer"}]}}],
+            },
+            {"role": "assistant", "content": [{"text": "placeholder"}]},
         ]
-        assert len(placeholder_msgs) == 1
+    )
 
-        # The delegation message (containing the sub-agent's answer) fires exactly once
-        delegation_msgs = [
-            m
-            for m in received_messages
-            if m["role"] == "assistant" and any("$42" in str(b.get("text", "")) for b in m.get("content", []))
+    ctx = AgentStreamContext(agent=parent, messages=[], invocation_state={"request_state": {}}, _interrupts={})
+    pre = TypedEvent({"pre": 1})
+    stop = EventLoopStopEvent("end_turn", parent.messages[-1], parent.event_loop_metrics, {})
+    trail = TypedEvent({"trail": 1})
+
+    async def inner(c):
+        plugin._state[parent] = _DelegationState(tool_use_id="t1", end_turn_via_delegation=True, tool_use_count=1)
+        yield pre
+        yield stop
+        yield trail
+
+    tru_events = [e async for e in plugin._handle_stream(ctx, inner)]
+
+    assert tru_events[0] is pre
+    tru_stops = [e for e in tru_events if isinstance(e, EventLoopStopEvent)]
+    assert len(tru_stops) == 1
+    assert tru_stops[0]["stop"][1]["content"][0]["text"] == "answer"
+    assert tru_events[-1] is trail
+    assert "tracking_id" in parent.messages[-1]
+
+
+@pytest.mark.asyncio
+async def test_handle_stream_reverify_failure_replays_original():
+    """If the tool result is mutated to error after _on_after_tools, original stop replays."""
+    tool = _make_delegation_tool()
+    parent = Agent(name="p", tools=[tool], callback_handler=None)
+    plugin = _get_plugin(parent)
+
+    parent.messages.extend(
+        [
+            {"role": "assistant", "content": [{"toolUse": {"toolUseId": "t1", "name": "sub", "input": {}}}]},
+            {
+                "role": "user",
+                "content": [{"toolResult": {"toolUseId": "t1", "status": "error", "content": [{"text": "failed"}]}}],
+            },
+            {"role": "assistant", "content": [{"text": "placeholder"}]},
         ]
-        assert len(delegation_msgs) == 1
+    )
 
-        # Placeholder comes before delegation content
-        placeholder_idx = received_messages.index(placeholder_msgs[0])
-        delegation_idx = received_messages.index(delegation_msgs[0])
-        assert placeholder_idx < delegation_idx
+    ctx = AgentStreamContext(agent=parent, messages=[], invocation_state={"request_state": {}}, _interrupts={})
+    original_stop = EventLoopStopEvent("end_turn", parent.messages[-1], parent.event_loop_metrics, {})
 
-    @pytest.mark.asyncio
-    async def test_session_manager_suppresses_delegation_event(self):
-        """With a session manager, subscribers see the placeholder but not the delegation content event."""
-        from strands.hooks import MessageAddedEvent
-        from strands.session.repository_session_manager import RepositorySessionManager
-        from tests.fixtures.mock_session_repository import MockedSessionRepository
-        from tests.fixtures.mocked_model_provider import MockedModelProvider
+    async def inner(c):
+        plugin._state[parent] = _DelegationState(tool_use_id="t1", end_turn_via_delegation=True, tool_use_count=1)
+        yield original_stop
 
-        repo = MockedSessionRepository()
-        session_mgr = RepositorySessionManager(session_id="s1", session_repository=repo)
+    tru_events = [e async for e in plugin._handle_stream(ctx, inner)]
+    assert len(tru_events) == 1
+    assert tru_events[0] is original_stop
 
-        sub = Agent(
-            model=MockedModelProvider([{"role": "assistant", "content": [{"text": "Balance: $42"}]}]),
-            name="billing",
-            callback_handler=None,
-        )
 
-        orch = Agent(
-            model=MockedModelProvider(
-                [
-                    {
-                        "role": "assistant",
-                        "content": [{"toolUse": {"toolUseId": "c1", "name": "billing", "input": {"input": "check"}}}],
-                    }
-                ]
-            ),
-            name="orch",
-            tools=[sub.as_tool(delegate=True)],
-            session_manager=session_mgr,
-            callback_handler=None,
-        )
+@pytest.mark.asyncio
+async def test_handle_stream_absent_tool_result_skips_delegation():
+    """When the tool result for the delegation toolUseId is absent from history, delegation is skipped."""
+    tool = _make_delegation_tool()
+    parent = Agent(name="p", tools=[tool], callback_handler=None)
+    plugin = _get_plugin(parent)
 
-        received_messages = []
-
-        def on_message_added(event: MessageAddedEvent):
-            received_messages.append(event.message)
-
-        orch.add_hook(on_message_added, MessageAddedEvent)
-
-        await orch.invoke_async("Check balance")
-
-        # With session manager: no MessageAddedEvent fires for the delegation content
-        delegation_msgs = [
-            m
-            for m in received_messages
-            if m["role"] == "assistant" and any("$42" in str(b.get("text", "")) for b in m.get("content", []))
+    parent.messages.extend(
+        [
+            {"role": "assistant", "content": [{"toolUse": {"toolUseId": "t1", "name": "sub", "input": {}}}]},
+            {"role": "assistant", "content": [{"text": "placeholder"}]},
         ]
-        assert len(delegation_msgs) == 0
+    )
 
-        # But agent.messages still reflects the delegation content
-        assert any("$42" in str(b.get("text", "")) for b in orch.messages[-1].get("content", []))
+    ctx = AgentStreamContext(agent=parent, messages=[], invocation_state={"request_state": {}}, _interrupts={})
+    original_stop = EventLoopStopEvent("end_turn", parent.messages[-1], parent.event_loop_metrics, {})
+
+    async def inner(c):
+        plugin._state[parent] = _DelegationState(tool_use_id="t1", end_turn_via_delegation=True, tool_use_count=1)
+        yield original_stop
+
+    tru_events = [e async for e in plugin._handle_stream(ctx, inner)]
+    assert len(tru_events) == 1
+    assert tru_events[0] is original_stop
 
 
-class TestMiddlewareSingleCallGuard:
-    """ExecuteToolStage middleware rejects delegation in multi-tool batch."""
+# --- Stateful model rejection ---
 
-    @pytest.mark.asyncio
-    async def test_middleware_rejects_when_batch_count_exceeds_one(self):
-        from strands._middleware.stages import ExecuteToolContext
-        from strands.types._events import ToolResultEvent
 
-        tool = _make_delegation_tool()
-        parent = Agent(name="p", tools=[tool], callback_handler=None)
-        plugin = _get_plugin(parent)
+def test_init_raises_with_delegation_on_stateful():
+    tool = _make_delegation_tool()
+    stateful = MagicMock()
+    type(stateful).stateful = PropertyMock(return_value=True)
 
-        # Simulate BeforeToolsEvent having already set batch count > 1
-        plugin._state[parent] = _DelegationState(tool_use_count=2)
+    with pytest.raises(ValueError, match="not supported with stateful models"):
+        Agent(name="p", model=stateful, tools=[tool], callback_handler=None)
 
+
+def test_init_ok_without_delegation_on_stateful():
+    stateful = MagicMock()
+    type(stateful).stateful = PropertyMock(return_value=True)
+    Agent(name="p", model=stateful, callback_handler=None)
+
+
+@pytest.mark.asyncio
+async def test_runtime_stateful_delegate_returns_error():
+    tool = _make_delegation_tool()
+    parent = Agent(name="p", callback_handler=None)
+    plugin = _get_plugin(parent)
+    type(parent.model).stateful = PropertyMock(return_value=True)
+
+    try:
         ctx = ExecuteToolContext(
             agent=parent,
             tool=tool,
@@ -912,8 +453,399 @@ class TestMiddlewareSingleCallGuard:
         async def unreachable(c):
             yield ToolResultEvent({"toolUseId": "t1", "status": "success", "content": [{"text": "nope"}]})
 
-        events = [e async for e in plugin._handle_tool_execution(ctx, unreachable)]
+        tru_events = [e async for e in plugin._handle_tool_execution(ctx, unreachable)]
+        assert len(tru_events) == 1
+        assert tru_events[0].tool_result["status"] == "error"
+        assert "stateful" in tru_events[0].tool_result["content"][0]["text"].lower()
+    finally:
+        del type(parent.model).stateful
 
-        assert len(events) == 1
-        assert events[0].tool_result["status"] == "error"
-        assert "only tool" in events[0].tool_result["content"][0]["text"].lower()
+
+# --- Auto-registration ---
+
+
+def test_auto_registered():
+    assert "strands:agent-delegation" in Agent(name="t", callback_handler=None)._plugin_registry._plugins
+
+
+def test_auto_registration_not_duplicated():
+    p = AgentDelegation()
+    agent = Agent(name="t", plugins=[p], callback_handler=None)
+    assert agent._plugin_registry._plugins.get("strands:agent-delegation") is p
+
+
+# --- Content conversion ---
+
+
+def test_to_content_blocks_converts_text_json_and_passthrough():
+    tru_blocks = _to_content_blocks(
+        {
+            "content": [
+                {"text": "hi"},
+                {"json": {"k": 1}},
+                {"image": {"format": "png", "source": {"bytes": b"x"}}},
+            ]
+        }
+    )
+    assert tru_blocks[0] == {"text": "hi"}
+    assert json_module.loads(tru_blocks[1]["text"]) == {"k": 1}
+    assert tru_blocks[2] == {"image": {"format": "png", "source": {"bytes": b"x"}}}
+
+
+# --- Child structured output serialization ---
+
+
+@pytest.mark.asyncio
+async def test_child_structured_output_datetime_serializes_cleanly():
+    from pydantic import BaseModel
+
+    class S(BaseModel):
+        at: datetime
+
+    mock_agent = _mock_sub_agent("sched")
+    result = AgentResult(
+        stop_reason="end_turn",
+        message={"role": "assistant", "content": [{"text": "done"}]},
+        metrics=EventLoopMetrics(),
+        state={},
+        structured_output=S(at=datetime(2025, 1, 15, 9, 0)),
+    )
+
+    async def stream(prompt):
+        yield {"result": result}
+
+    mock_agent.stream_async = stream
+    tool = _AgentAsTool(mock_agent, name="sched", delegate=True, preserve_context=True)
+
+    tru_events = [e async for e in tool.stream({"toolUseId": "t1", "name": "sched", "input": {"input": "x"}}, {})]
+    tru_results = [e for e in tru_events if isinstance(e, ToolResultEvent)]
+    assert tru_results[0].tool_result["status"] == "success"
+    assert "2025-01-15" in json_module.dumps(tru_results[0].tool_result["content"][0]["json"])
+
+
+# --- Full delegation flow ---
+
+
+@pytest.mark.asyncio
+async def test_full_delegation_routes_to_specialist():
+    sub = Agent(
+        model=MockedModelProvider([{"role": "assistant", "content": [{"text": "Balance: $42"}]}]),
+        name="billing",
+        callback_handler=None,
+    )
+    orch = Agent(
+        model=MockedModelProvider(
+            [
+                {
+                    "role": "assistant",
+                    "content": [{"toolUse": {"toolUseId": "c1", "name": "billing", "input": {"input": "check"}}}],
+                }
+            ]
+        ),
+        name="orch",
+        tools=[sub.as_tool(delegate=True)],
+        callback_handler=None,
+    )
+
+    tru_result = await orch.invoke_async("Check balance")
+    assert tru_result.stop_reason == "end_turn"
+    assert any("$42" in str(b.get("text", "")) for b in tru_result.message["content"])
+
+    # The placeholder must not remain stranded in history
+    for msg in orch.messages:
+        for block in msg.get("content", []):
+            if isinstance(block, dict) and "text" in block:
+                assert "Turn ended early" not in block["text"]
+
+
+@pytest.mark.asyncio
+async def test_full_delegation_error_recovery():
+    err = _mock_sub_agent("failing")
+
+    async def fail(prompt):
+        raise RuntimeError("crash")
+        yield  # noqa: RET503
+
+    err.stream_async = fail
+    tool = _AgentAsTool(err, name="failing", delegate=True, preserve_context=True)
+
+    orch = Agent(
+        model=MockedModelProvider(
+            [
+                {
+                    "role": "assistant",
+                    "content": [{"toolUse": {"toolUseId": "c1", "name": "failing", "input": {"input": "x"}}}],
+                },
+                {"role": "assistant", "content": [{"text": "I recovered."}]},
+            ]
+        ),
+        name="orch",
+        tools=[tool],
+        callback_handler=None,
+    )
+
+    tru_result = await orch.invoke_async("Do it")
+    assert tru_result.stop_reason == "end_turn"
+    assert "recovered" in str(tru_result.message["content"]).lower()
+
+
+# --- Session persistence ---
+
+
+@pytest.mark.asyncio
+async def test_persisted_matches_in_memory_after_delegation():
+    from strands.session.repository_session_manager import RepositorySessionManager
+    from tests.fixtures.mock_session_repository import MockedSessionRepository
+
+    repo = MockedSessionRepository()
+    session_mgr = RepositorySessionManager(session_id="s1", session_repository=repo)
+
+    sub_model = MockedModelProvider([{"role": "assistant", "content": [{"text": "Balance: $42"}]}])
+    sub = Agent(model=sub_model, name="billing", callback_handler=None)
+
+    orch_model = MockedModelProvider(
+        [
+            {
+                "role": "assistant",
+                "content": [{"toolUse": {"toolUseId": "c1", "name": "billing", "input": {"input": "check"}}}],
+            }
+        ]
+    )
+    orch = Agent(
+        model=orch_model,
+        name="orchestrator",
+        tools=[sub.as_tool(delegate=True)],
+        session_manager=session_mgr,
+        callback_handler=None,
+    )
+
+    await orch.invoke_async("Check balance")
+
+    session_mgr_2 = RepositorySessionManager(session_id="s1", session_repository=repo)
+    orch_2 = Agent(model=orch_model, name="orchestrator", session_manager=session_mgr_2, callback_handler=None)
+
+    assert len(orch_2.messages) == len(orch.messages)
+    for restored, live in zip(orch_2.messages, orch.messages, strict=True):
+        assert restored["role"] == live["role"]
+        assert restored["content"] == live["content"]
+
+    assert orch_2.messages[-1]["role"] == "assistant"
+    assert any("$42" in str(b.get("text", "")) for b in orch_2.messages[-1]["content"])
+
+
+# --- Context offloader integration ---
+
+
+@pytest.mark.asyncio
+async def test_large_delegation_result_not_offloaded():
+    """A delegation result exceeding the offloader threshold stays in context."""
+    from strands.vended_plugins.context_offloader import ContextOffloader, InMemoryStorage
+
+    storage = InMemoryStorage()
+    offloader = ContextOffloader(storage=storage, max_result_tokens=25, preview_tokens=10)
+
+    large_answer = "x" * 500
+    sub = Agent(
+        model=MockedModelProvider([{"role": "assistant", "content": [{"text": large_answer}]}]),
+        name="billing",
+        callback_handler=None,
+    )
+
+    orch = Agent(
+        model=MockedModelProvider(
+            [
+                {
+                    "role": "assistant",
+                    "content": [{"toolUse": {"toolUseId": "c1", "name": "billing", "input": {"input": "check"}}}],
+                }
+            ]
+        ),
+        name="orch",
+        tools=[sub.as_tool(delegate=True)],
+        plugins=[offloader],
+        callback_handler=None,
+    )
+
+    tru_result = await orch.invoke_async("Check balance")
+    assert tru_result.stop_reason == "end_turn"
+    tru_text = "".join(block.get("text", "") for block in tru_result.message["content"] if isinstance(block, dict))
+    assert large_answer in tru_text
+    assert len(storage._store) == 0
+
+
+# --- AfterToolsEvent ordering guard ---
+
+
+@pytest.mark.asyncio
+async def test_ordering_guard_late_hook_flipping_result_prevents_end_turn():
+    """A default-order AfterToolsEvent hook that flips the result to error prevents delegation end_turn.
+
+    Order priority always wins: DEFAULT (0) runs before SDK_LAST (100). Reverse ordering only flips
+    registration order *within* one order tier, so delegation's SDK_LAST hook runs last and reads the
+    already-mutated committed message. Its own check in _on_after_tools is what declines to set
+    end_turn here; _handle_stream's re-verification is a second line of defence that does not fire in
+    this scenario.
+    """
+    sub = Agent(
+        model=MockedModelProvider([{"role": "assistant", "content": [{"text": "answer"}]}]),
+        name="specialist",
+        callback_handler=None,
+    )
+
+    orch = Agent(
+        model=MockedModelProvider(
+            [
+                {
+                    "role": "assistant",
+                    "content": [{"toolUse": {"toolUseId": "c1", "name": "specialist", "input": {"input": "go"}}}],
+                },
+                {"role": "assistant", "content": [{"text": "I continued after flip."}]},
+            ]
+        ),
+        name="orch",
+        tools=[sub.as_tool(delegate=True)],
+        callback_handler=None,
+    )
+
+    def flip_result_to_error(event: AfterToolsEvent):
+        content = event.message.get("content", [])
+        for block in content:
+            if isinstance(block, dict) and "toolResult" in block:
+                block["toolResult"]["status"] = "error"
+
+    orch.add_hook(flip_result_to_error, AfterToolsEvent)
+
+    tru_result = await orch.invoke_async("Do it")
+    assert tru_result.stop_reason == "end_turn"
+    assert "continued" in str(tru_result.message["content"]).lower()
+
+
+# --- MessageAddedEvent during delegation ---
+
+
+@pytest.mark.asyncio
+async def test_message_added_event_fires_for_delegation_message():
+    """MessageAddedEvent fires for the placeholder and then the real delegation content."""
+    sub = Agent(
+        model=MockedModelProvider([{"role": "assistant", "content": [{"text": "Balance: $42"}]}]),
+        name="billing",
+        callback_handler=None,
+    )
+
+    orch = Agent(
+        model=MockedModelProvider(
+            [
+                {
+                    "role": "assistant",
+                    "content": [{"toolUse": {"toolUseId": "c1", "name": "billing", "input": {"input": "check"}}}],
+                }
+            ]
+        ),
+        name="orch",
+        tools=[sub.as_tool(delegate=True)],
+        callback_handler=None,
+    )
+
+    received_messages = []
+
+    def on_message_added(event: MessageAddedEvent):
+        received_messages.append(event.message)
+
+    orch.add_hook(on_message_added, MessageAddedEvent)
+    await orch.invoke_async("Check balance")
+
+    # Expected: user prompt, assistant tool_use, tool_result, end_turn placeholder, delegation content
+    assert len(received_messages) == 5
+
+    tru_placeholders = [
+        m
+        for m in received_messages
+        if m["role"] == "assistant" and any("Turn ended early" in str(b.get("text", "")) for b in m.get("content", []))
+    ]
+    assert len(tru_placeholders) == 1
+
+    tru_delegation = [
+        m
+        for m in received_messages
+        if m["role"] == "assistant" and any("$42" in str(b.get("text", "")) for b in m.get("content", []))
+    ]
+    assert len(tru_delegation) == 1
+
+    # Placeholder comes before delegation content
+    assert received_messages.index(tru_placeholders[0]) < received_messages.index(tru_delegation[0])
+
+
+@pytest.mark.asyncio
+async def test_session_manager_suppresses_delegation_message_added_event():
+    """With a session manager, subscribers see the placeholder but not the delegation content event."""
+    from strands.session.repository_session_manager import RepositorySessionManager
+    from tests.fixtures.mock_session_repository import MockedSessionRepository
+
+    repo = MockedSessionRepository()
+    session_mgr = RepositorySessionManager(session_id="s1", session_repository=repo)
+
+    sub = Agent(
+        model=MockedModelProvider([{"role": "assistant", "content": [{"text": "Balance: $42"}]}]),
+        name="billing",
+        callback_handler=None,
+    )
+
+    orch = Agent(
+        model=MockedModelProvider(
+            [
+                {
+                    "role": "assistant",
+                    "content": [{"toolUse": {"toolUseId": "c1", "name": "billing", "input": {"input": "check"}}}],
+                }
+            ]
+        ),
+        name="orch",
+        tools=[sub.as_tool(delegate=True)],
+        session_manager=session_mgr,
+        callback_handler=None,
+    )
+
+    received_messages = []
+
+    def on_message_added(event: MessageAddedEvent):
+        received_messages.append(event.message)
+
+    orch.add_hook(on_message_added, MessageAddedEvent)
+    await orch.invoke_async("Check balance")
+
+    tru_delegation = [
+        m
+        for m in received_messages
+        if m["role"] == "assistant" and any("$42" in str(b.get("text", "")) for b in m.get("content", []))
+    ]
+    assert len(tru_delegation) == 0
+
+    # But agent.messages still reflects the delegation content
+    assert any("$42" in str(b.get("text", "")) for b in orch.messages[-1].get("content", []))
+
+
+# --- Middleware single-call guard ---
+
+
+@pytest.mark.asyncio
+async def test_middleware_rejects_delegation_when_batch_count_exceeds_one():
+    tool = _make_delegation_tool()
+    parent = Agent(name="p", tools=[tool], callback_handler=None)
+    plugin = _get_plugin(parent)
+    plugin._state[parent] = _DelegationState(tool_use_count=2)
+
+    ctx = ExecuteToolContext(
+        agent=parent,
+        tool=tool,
+        tool_use={"toolUseId": "t1", "name": "sub", "input": {"input": "hi"}},
+        invocation_state={"request_state": {}},
+        _interrupt_state=parent._interrupt_state,
+    )
+
+    async def unreachable(c):
+        yield ToolResultEvent({"toolUseId": "t1", "status": "success", "content": [{"text": "nope"}]})
+
+    tru_events = [e async for e in plugin._handle_tool_execution(ctx, unreachable)]
+    assert len(tru_events) == 1
+    assert tru_events[0].tool_result["status"] == "error"
+    assert "only tool" in tru_events[0].tool_result["content"][0]["text"].lower()

--- a/strands-py/tests/strands/agent/test_agent_delegation.py
+++ b/strands-py/tests/strands/agent/test_agent_delegation.py
@@ -872,3 +872,49 @@ async def test_middleware_rejects_delegation_when_batch_count_exceeds_one():
     assert len(tru_events) == 1
     assert tru_events[0].tool_result["status"] == "error"
     assert "only tool" in tru_events[0].tool_result["content"][0]["text"].lower()
+
+
+# --- Byte-verbatim fidelity ---
+
+
+@pytest.mark.asyncio
+async def test_delegation_preserves_content_verbatim_across_hops():
+    """Delegated content must be byte-identical across a multi-level chain."""
+    exact_payload = '{"name": "User", "roles": ["admin"]}'
+
+    leaf = Agent(
+        model=MockedModelProvider([{"role": "assistant", "content": [{"text": exact_payload}]}]),
+        name="leaf",
+        callback_handler=None,
+    )
+    mid = Agent(
+        model=MockedModelProvider(
+            [
+                {
+                    "role": "assistant",
+                    "content": [{"toolUse": {"toolUseId": "m1", "name": "leaf", "input": {"input": "go"}}}],
+                }
+            ]
+        ),
+        name="mid",
+        tools=[leaf.as_tool(delegate=True)],
+        callback_handler=None,
+    )
+    top = Agent(
+        model=MockedModelProvider(
+            [
+                {
+                    "role": "assistant",
+                    "content": [{"toolUse": {"toolUseId": "t1", "name": "mid", "input": {"input": "go"}}}],
+                }
+            ]
+        ),
+        name="top",
+        tools=[mid.as_tool(delegate=True)],
+        callback_handler=None,
+    )
+
+    result = await top.invoke_async("run")
+
+    delivered_text = result.message["content"][0]["text"]
+    assert delivered_text == exact_payload, f"Expected verbatim {exact_payload!r}, got {delivered_text!r}"

--- a/strands-py/tests/strands/agent/test_agent_delegation.py
+++ b/strands-py/tests/strands/agent/test_agent_delegation.py
@@ -919,3 +919,80 @@ async def test_delegation_preserves_content_verbatim_across_hops():
     assert len(result.message["content"]) == 1
     delivered_text = result.message["content"][0]["text"]
     assert delivered_text == exact_payload, f"Expected verbatim {exact_payload!r}, got {delivered_text!r}"
+
+
+@pytest.mark.asyncio
+async def test_delegation_preserves_json_block_verbatim():
+    """A child returning a json content block in the tool result is serialized to text by _to_content_blocks."""
+
+    json_payload = {"status": "ok", "count": 3}
+
+    # Unit-test the delegation branch directly: simulate a sub-agent result with a json block.
+    sub = Agent(
+        model=MockedModelProvider([{"role": "assistant", "content": [{"text": "unused"}]}]),
+        name="leaf",
+        callback_handler=None,
+    )
+    tool = sub.as_tool(delegate=True)
+
+    # Patch the agent's invoke to return a result with a json content block.
+    from strands.agent.agent_result import AgentResult
+    from strands.telemetry.metrics import EventLoopMetrics
+
+    fake_result = AgentResult(
+        stop_reason="end_turn",
+        message={"role": "assistant", "content": [{"json": json_payload}]},
+        metrics=EventLoopMetrics(),
+        state={},
+    )
+
+    async def fake_stream(prompt):
+        yield {"result": fake_result}
+
+    tool._agent.stream_async = fake_stream
+
+    tool_use = {"toolUseId": "t1", "name": "leaf", "input": {"input": "go"}}
+    events = [e async for e in tool.stream(tool_use, {})]
+    result_events = [e for e in events if isinstance(e, ToolResultEvent)]
+
+    assert len(result_events) == 1
+    content = result_events[0]["tool_result"]["content"]
+    assert len(content) == 1
+    assert content[0]["json"] == json_payload
+
+
+@pytest.mark.asyncio
+async def test_delegation_citations_only_no_trailing_newline():
+    """A child returning only citationsContent must not inject a trailing newline."""
+    from strands.agent.agent_result import AgentResult
+    from strands.telemetry.metrics import EventLoopMetrics
+
+    cited_text = "cited fact"
+
+    sub = Agent(
+        model=MockedModelProvider([{"role": "assistant", "content": [{"text": "unused"}]}]),
+        name="leaf",
+        callback_handler=None,
+    )
+    tool = sub.as_tool(delegate=True)
+
+    fake_result = AgentResult(
+        stop_reason="end_turn",
+        message={"role": "assistant", "content": [{"citationsContent": {"content": [{"text": cited_text}]}}]},
+        metrics=EventLoopMetrics(),
+        state={},
+    )
+
+    async def fake_stream(prompt):
+        yield {"result": fake_result}
+
+    tool._agent.stream_async = fake_stream
+
+    tool_use = {"toolUseId": "t1", "name": "leaf", "input": {"input": "go"}}
+    events = [e async for e in tool.stream(tool_use, {})]
+    result_events = [e for e in events if isinstance(e, ToolResultEvent)]
+
+    assert len(result_events) == 1
+    content = result_events[0]["tool_result"]["content"]
+    assert len(content) == 1
+    assert content[0]["text"] == cited_text

--- a/strands-py/tests/strands/agent/test_agent_delegation.py
+++ b/strands-py/tests/strands/agent/test_agent_delegation.py
@@ -407,6 +407,43 @@ class TestStreamOrdering:
         assert len(events) == 1
         assert events[0] is original_stop
 
+    @pytest.mark.asyncio
+    async def test_absent_tool_result_skips_delegation(self):
+        """When the tool result for the delegation toolUseId is absent from history, delegation is skipped."""
+        from strands._middleware.stages import AgentStreamContext
+        from strands.types._events import EventLoopStopEvent
+
+        tool = _make_delegation_tool()
+        parent = Agent(name="p", tools=[tool], callback_handler=None)
+        plugin = _get_plugin(parent)
+
+        # History has no tool result at all for the delegation toolUseId
+        parent.messages.extend(
+            [
+                {"role": "assistant", "content": [{"toolUse": {"toolUseId": "t1", "name": "sub", "input": {}}}]},
+                {"role": "assistant", "content": [{"text": "placeholder"}]},
+            ]
+        )
+
+        ctx = AgentStreamContext(
+            agent=parent,
+            messages=[],
+            invocation_state={"request_state": {}},
+            _interrupts={},
+        )
+
+        original_stop = EventLoopStopEvent("end_turn", parent.messages[-1], parent.event_loop_metrics, {})
+
+        async def inner(c):
+            plugin._state[parent] = _DelegationState(tool_use_id="t1", end_turn_via_delegation=True, tool_use_count=1)
+            yield original_stop
+
+        events = [e async for e in plugin._handle_stream(ctx, inner)]
+
+        # Result absent → original stop replays unchanged
+        assert len(events) == 1
+        assert events[0] is original_stop
+
 
 class TestStatefulModel:
     """Delegation tools are rejected on stateful models at init and runtime."""
@@ -434,23 +471,24 @@ class TestStatefulModel:
         plugin = _get_plugin(parent)
         type(parent.model).stateful = PropertyMock(return_value=True)
 
-        ctx = ExecuteToolContext(
-            agent=parent,
-            tool=tool,
-            tool_use={"toolUseId": "t1", "name": "sub", "input": {"input": "hi"}},
-            invocation_state={"request_state": {}},
-            _interrupt_state=parent._interrupt_state,
-        )
+        try:
+            ctx = ExecuteToolContext(
+                agent=parent,
+                tool=tool,
+                tool_use={"toolUseId": "t1", "name": "sub", "input": {"input": "hi"}},
+                invocation_state={"request_state": {}},
+                _interrupt_state=parent._interrupt_state,
+            )
 
-        async def unreachable(c):
-            yield ToolResultEvent({"toolUseId": "t1", "status": "success", "content": [{"text": "nope"}]})
+            async def unreachable(c):
+                yield ToolResultEvent({"toolUseId": "t1", "status": "success", "content": [{"text": "nope"}]})
 
-        events = [e async for e in plugin._handle_tool_execution(ctx, unreachable)]
-        assert len(events) == 1
-        assert events[0].tool_result["status"] == "error"
-        assert "stateful" in events[0].tool_result["content"][0]["text"].lower()
-
-        del type(parent.model).stateful
+            events = [e async for e in plugin._handle_tool_execution(ctx, unreachable)]
+            assert len(events) == 1
+            assert events[0].tool_result["status"] == "error"
+            assert "stateful" in events[0].tool_result["content"][0]["text"].lower()
+        finally:
+            del type(parent.model).stateful
 
 
 class TestAutoRegistration:
@@ -542,6 +580,12 @@ class TestFullDelegationFlow:
         result = await orch.invoke_async("Check balance")
         assert result.stop_reason == "end_turn"
         assert any("$42" in str(b.get("text", "")) for b in result.message["content"])
+
+        # The placeholder must not remain stranded in history
+        for msg in orch.messages:
+            for block in msg.get("content", []):
+                if isinstance(block, dict) and "text" in block:
+                    assert "Turn ended early" not in block["text"]
 
     @pytest.mark.asyncio
     async def test_error_recovery(self):
@@ -671,17 +715,17 @@ class TestDelegationWithContextOffloader:
 
 
 class TestAfterToolsOrderingGuard:
-    """SDK_LAST on AfterToolsEvent ensures delegation sees the committed result before other hooks."""
+    """SDK_LAST on AfterToolsEvent makes delegation read the result after other hooks have mutated it."""
 
     @pytest.mark.asyncio
     async def test_late_hook_flipping_result_prevents_end_turn(self):
         """A default-order AfterToolsEvent hook that flips the result to error prevents delegation end_turn.
 
-        Because AfterToolsEvent uses reverse ordering, SDK_LAST (100) runs first, DEFAULT (0) runs after.
-        Delegation reads the result first. But _handle_stream re-verifies the result from committed history,
-        so a late-hook mutation (at DEFAULT) that changes the committed message is caught.
-        This test verifies that if the committed message is mutated to error between _on_after_tools and
-        _handle_stream, the agent loop continues rather than ending the turn.
+        Order priority always wins: DEFAULT (0) runs before SDK_LAST (100). Reverse ordering only flips
+        registration order *within* one order tier, so delegation's SDK_LAST hook runs last and reads the
+        already-mutated committed message. Its own check in _on_after_tools is what declines to set
+        end_turn here; _handle_stream's re-verification is a second line of defence that does not fire in
+        this scenario. This test verifies the agent loop continues rather than ending the turn.
         """
         from tests.fixtures.mocked_model_provider import MockedModelProvider
 
@@ -731,7 +775,7 @@ class TestMessageAddedEventDuringDelegation:
 
     @pytest.mark.asyncio
     async def test_message_added_event_fires_for_delegation_message(self):
-        """MessageAddedEvent must fire with the delegation content message during a successful delegation."""
+        """MessageAddedEvent fires for the placeholder and then the real delegation content."""
         from strands.hooks import MessageAddedEvent
         from tests.fixtures.mocked_model_provider import MockedModelProvider
 
@@ -764,16 +808,82 @@ class TestMessageAddedEventDuringDelegation:
 
         await orch.invoke_async("Check balance")
 
-        # At minimum: user prompt, assistant tool_use, tool_result, delegation final message
-        assert len(received_messages) >= 3
+        # Expected events: user prompt, assistant tool_use, tool_result, end_turn placeholder, delegation content
+        assert len(received_messages) == 5
 
-        # The delegation message (containing the sub-agent's answer) must be among them
-        delegation_messages = [
+        # The placeholder fires before the delegation content
+        placeholder_msgs = [
+            m
+            for m in received_messages
+            if m["role"] == "assistant"
+            and any("Turn ended early" in str(b.get("text", "")) for b in m.get("content", []))
+        ]
+        assert len(placeholder_msgs) == 1
+
+        # The delegation message (containing the sub-agent's answer) fires exactly once
+        delegation_msgs = [
             m
             for m in received_messages
             if m["role"] == "assistant" and any("$42" in str(b.get("text", "")) for b in m.get("content", []))
         ]
-        assert len(delegation_messages) == 1
+        assert len(delegation_msgs) == 1
+
+        # Placeholder comes before delegation content
+        placeholder_idx = received_messages.index(placeholder_msgs[0])
+        delegation_idx = received_messages.index(delegation_msgs[0])
+        assert placeholder_idx < delegation_idx
+
+    @pytest.mark.asyncio
+    async def test_session_manager_suppresses_delegation_event(self):
+        """With a session manager, subscribers see the placeholder but not the delegation content event."""
+        from strands.hooks import MessageAddedEvent
+        from strands.session.repository_session_manager import RepositorySessionManager
+        from tests.fixtures.mock_session_repository import MockedSessionRepository
+        from tests.fixtures.mocked_model_provider import MockedModelProvider
+
+        repo = MockedSessionRepository()
+        session_mgr = RepositorySessionManager(session_id="s1", session_repository=repo)
+
+        sub = Agent(
+            model=MockedModelProvider([{"role": "assistant", "content": [{"text": "Balance: $42"}]}]),
+            name="billing",
+            callback_handler=None,
+        )
+
+        orch = Agent(
+            model=MockedModelProvider(
+                [
+                    {
+                        "role": "assistant",
+                        "content": [{"toolUse": {"toolUseId": "c1", "name": "billing", "input": {"input": "check"}}}],
+                    }
+                ]
+            ),
+            name="orch",
+            tools=[sub.as_tool(delegate=True)],
+            session_manager=session_mgr,
+            callback_handler=None,
+        )
+
+        received_messages = []
+
+        def on_message_added(event: MessageAddedEvent):
+            received_messages.append(event.message)
+
+        orch.add_hook(on_message_added, MessageAddedEvent)
+
+        await orch.invoke_async("Check balance")
+
+        # With session manager: no MessageAddedEvent fires for the delegation content
+        delegation_msgs = [
+            m
+            for m in received_messages
+            if m["role"] == "assistant" and any("$42" in str(b.get("text", "")) for b in m.get("content", []))
+        ]
+        assert len(delegation_msgs) == 0
+
+        # But agent.messages still reflects the delegation content
+        assert any("$42" in str(b.get("text", "")) for b in orch.messages[-1].get("content", []))
 
 
 class TestMiddlewareSingleCallGuard:

--- a/strands-py/tests/strands/agent/test_agent_delegation.py
+++ b/strands-py/tests/strands/agent/test_agent_delegation.py
@@ -458,7 +458,8 @@ def test_init_ok_without_delegation_on_stateful():
 
 
 @pytest.mark.asyncio
-async def test_runtime_stateful_delegate_returns_error():
+async def test_runtime_stateful_delegate_passes_through():
+    """A delegation tool on a stateful model silently behaves as a normal tool (TS parity)."""
     tool = _make_delegation_tool()
     parent = Agent(name="p", callback_handler=None)
     plugin = _get_plugin(parent)
@@ -473,13 +474,13 @@ async def test_runtime_stateful_delegate_returns_error():
             _interrupt_state=parent._interrupt_state,
         )
 
-        async def unreachable(c):
-            yield ToolResultEvent({"toolUseId": "t1", "status": "success", "content": [{"text": "nope"}]})
+        async def normal_execution(c):
+            yield ToolResultEvent({"toolUseId": "t1", "status": "success", "content": [{"text": "normal result"}]})
 
-        tru_events = [e async for e in plugin._handle_tool_execution(ctx, unreachable)]
+        tru_events = [e async for e in plugin._handle_tool_execution(ctx, normal_execution)]
         assert len(tru_events) == 1
-        assert tru_events[0].tool_result["status"] == "error"
-        assert "stateful" in tru_events[0].tool_result["content"][0]["text"].lower()
+        assert tru_events[0].tool_result["status"] == "success"
+        assert tru_events[0].tool_result["content"][0]["text"] == "normal result"
     finally:
         del type(parent.model).stateful
 

--- a/strands-py/tests/strands/agent/test_agent_delegation.py
+++ b/strands-py/tests/strands/agent/test_agent_delegation.py
@@ -924,7 +924,7 @@ async def test_delegation_preserves_content_verbatim_across_hops():
 
 @pytest.mark.asyncio
 async def test_delegation_preserves_json_block_verbatim():
-    """A child returning a json content block in the tool result is serialized to text by _to_content_blocks."""
+    """A child returning a json content block has it copied verbatim into the tool result."""
 
     json_payload = {"status": "ok", "count": 3}
 
@@ -935,10 +935,6 @@ async def test_delegation_preserves_json_block_verbatim():
         callback_handler=None,
     )
     tool = sub.as_tool(delegate=True)
-
-    # Patch the agent's invoke to return a result with a json content block.
-    from strands.agent.agent_result import AgentResult
-    from strands.telemetry.metrics import EventLoopMetrics
 
     fake_result = AgentResult(
         stop_reason="end_turn",
@@ -963,11 +959,9 @@ async def test_delegation_preserves_json_block_verbatim():
 
 
 @pytest.mark.asyncio
-async def test_delegation_citations_only_no_trailing_newline():
-    """A child returning only citationsContent must not inject a trailing newline."""
-    from strands.agent.agent_result import AgentResult
-    from strands.telemetry.metrics import EventLoopMetrics
-
+async def test_delegation_preserves_citations_alongside_text():
+    """Mixed text + citationsContent: both must appear in the tool result without trailing newlines."""
+    plain_text = "Here is the answer."
     cited_text = "cited fact"
 
     sub = Agent(
@@ -979,7 +973,13 @@ async def test_delegation_citations_only_no_trailing_newline():
 
     fake_result = AgentResult(
         stop_reason="end_turn",
-        message={"role": "assistant", "content": [{"citationsContent": {"content": [{"text": cited_text}]}}]},
+        message={
+            "role": "assistant",
+            "content": [
+                {"text": plain_text},
+                {"citationsContent": {"content": [{"text": cited_text}]}},
+            ],
+        },
         metrics=EventLoopMetrics(),
         state={},
     )
@@ -995,5 +995,6 @@ async def test_delegation_citations_only_no_trailing_newline():
 
     assert len(result_events) == 1
     content = result_events[0]["tool_result"]["content"]
-    assert len(content) == 1
-    assert content[0]["text"] == cited_text
+    assert len(content) == 2
+    assert content[0]["text"] == plain_text
+    assert content[1]["text"] == cited_text

--- a/strands-py/tests/strands/agent/test_agent_delegation.py
+++ b/strands-py/tests/strands/agent/test_agent_delegation.py
@@ -278,6 +278,29 @@ def test_on_after_tools_suppressed_with_structured_output():
     assert not tru_event.end_turn
 
 
+@pytest.mark.parametrize(
+    "content",
+    [
+        [{"toolResult": {"toolUseId": "t_other", "status": "success", "content": [{"text": "x"}]}}],
+        [],
+    ],
+    ids=["mismatched-id", "empty-content"],
+)
+def test_on_after_tools_skips_when_result_absent(content):
+    """When the message has no toolResult matching state.tool_use_id, end_turn is not set."""
+    tool = _make_delegation_tool()
+    parent = Agent(name="p", tools=[tool], callback_handler=None)
+    plugin = _get_plugin(parent)
+    plugin._state[parent] = _DelegationState(tool_use_id="t1", tool_use_count=1)
+
+    message = {"role": "user", "content": content}
+    event = AfterToolsEvent(agent=parent, message=message, invocation_state={"request_state": {}})
+    plugin._on_after_tools(event)
+
+    assert not event.end_turn
+    assert plugin._state[parent].tool_use_id is None
+
+
 # --- _handle_stream ordering ---
 
 

--- a/strands-py/tests/strands/agent/test_agent_delegation.py
+++ b/strands-py/tests/strands/agent/test_agent_delegation.py
@@ -1,0 +1,658 @@
+"""Tests for AgentDelegation plugin — verifies delegation semantics with agent-as-tool."""
+
+from unittest.mock import MagicMock, PropertyMock
+
+import pytest
+
+from strands.agent._agent_as_tool import DELEGATION_DESCRIPTION_SUFFIX, _AgentAsTool
+from strands.agent._agent_delegation import AgentDelegation, _DelegationState, _to_content_blocks
+from strands.agent.agent import Agent
+from strands.agent.agent_result import AgentResult
+from strands.interrupt import _InterruptState
+from strands.telemetry.metrics import EventLoopMetrics
+
+
+def _mock_sub_agent(name="sub"):
+    agent = MagicMock()
+    agent.name = name
+    agent._interrupt_state = _InterruptState()
+    return agent
+
+
+def _make_delegation_tool(name="sub", **kwargs):
+    return _AgentAsTool(_mock_sub_agent(name), name=name, delegate=True, preserve_context=True, **kwargs)
+
+
+def _get_plugin(agent):
+    return agent._plugin_registry._plugins["strands:agent-delegation"]
+
+
+class TestDelegationFlag:
+    def test_delegate_defaults_false(self):
+        tool = Agent(name="sub", callback_handler=None).as_tool()
+        assert tool.delegate is False
+
+    def test_delegate_true_adds_suffix(self):
+        tool = Agent(name="sub", description="Billing", callback_handler=None).as_tool(delegate=True)
+        assert tool.delegate is True
+        assert tool._description == "Billing" + DELEGATION_DESCRIPTION_SUFFIX
+
+    def test_delegate_false_no_suffix(self):
+        tool = Agent(name="sub", description="Billing", callback_handler=None).as_tool()
+        assert DELEGATION_DESCRIPTION_SUFFIX not in tool._description
+
+    def test_custom_description_with_delegate(self):
+        tool = Agent(name="sub", callback_handler=None).as_tool(delegate=True, description="Custom")
+        assert tool._description == "Custom" + DELEGATION_DESCRIPTION_SUFFIX
+
+
+class TestToolDoesNotOwnStop:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("delegate", [True, False])
+    async def test_tool_never_sets_stop_event_loop(self, delegate):
+        """_AgentAsTool defers all stop decisions to the plugin."""
+        mock_agent = _mock_sub_agent()
+        result = AgentResult(
+            stop_reason="end_turn",
+            message={"role": "assistant", "content": [{"text": "ok"}]},
+            metrics=EventLoopMetrics(),
+            state={},
+        )
+
+        async def mock_stream(prompt):
+            yield {"result": result}
+
+        mock_agent.stream_async = mock_stream
+        tool = _AgentAsTool(mock_agent, name="sub", delegate=delegate, preserve_context=True)
+
+        invocation_state = {"request_state": {}}
+        async for _ in tool.stream({"toolUseId": "t1", "name": "sub", "input": {"input": "hi"}}, invocation_state):
+            pass
+
+        assert "stop_event_loop" not in invocation_state["request_state"]
+
+    @pytest.mark.asyncio
+    async def test_tool_error_does_not_set_stop(self):
+        mock_agent = _mock_sub_agent()
+
+        async def failing(prompt):
+            raise RuntimeError("crash")
+            yield  # noqa: RET503
+
+        mock_agent.stream_async = failing
+        tool = _AgentAsTool(mock_agent, name="sub", delegate=True, preserve_context=True)
+
+        invocation_state = {"request_state": {}}
+        async for _ in tool.stream({"toolUseId": "t1", "name": "sub", "input": {"input": "hi"}}, invocation_state):
+            pass
+
+        assert invocation_state["request_state"].get("stop_event_loop") is not True
+
+
+class TestSingleCallConstraint:
+    """BeforeToolsEvent cancels the batch when a delegate is mixed with other tools."""
+
+    @pytest.mark.parametrize(
+        "tool_names,expect_cancel",
+        [
+            (["specialist", "other_tool"], True),
+            (["billing", "tech"], True),  # two delegates
+            (["specialist"], False),  # single delegate OK
+            (["tool_a", "tool_b"], False),  # no delegates
+        ],
+        ids=["delegate+other", "two-delegates", "single-delegate", "no-delegates"],
+    )
+    def test_cancel_decision(self, tool_names, expect_cancel):
+        from strands.hooks import BeforeToolsEvent
+
+        sub = Agent(name="specialist", description="S", callback_handler=None)
+        tools = [sub.as_tool(delegate=True)]
+        # Add a second delegate if needed
+        if "tech" in tool_names or "billing" in tool_names:
+            sub2 = Agent(name="billing" if "billing" in tool_names else "tech", callback_handler=None)
+            tools.append(sub2.as_tool(delegate=True))
+
+        parent = Agent(name="parent", tools=tools, callback_handler=None)
+
+        message = {
+            "role": "assistant",
+            "content": [
+                {"toolUse": {"toolUseId": f"t{i}", "name": name, "input": {}}} for i, name in enumerate(tool_names)
+            ],
+        }
+
+        plugin = AgentDelegation()
+        event = BeforeToolsEvent(agent=parent, message=message, invocation_state={})
+        plugin._on_before_tools(event)
+
+        assert bool(event.cancel) == expect_cancel
+
+
+class TestAfterToolCallState:
+    """_on_after_tool_call marks/clears tool_use_id correctly."""
+
+    def _fire(self, parent, plugin, tool, tool_use_id, status, selected_tool=None):
+        from strands.hooks import AfterToolCallEvent
+
+        return AfterToolCallEvent(
+            agent=parent,
+            selected_tool=selected_tool or tool,
+            tool_use={"toolUseId": tool_use_id, "name": "sub", "input": {}},
+            invocation_state={"request_state": {}},
+            result={"toolUseId": tool_use_id, "status": status, "content": [{"text": "x"}]},
+        )
+
+    def test_marks_on_success(self):
+        tool = _make_delegation_tool()
+        parent = Agent(name="p", tools=[tool], callback_handler=None)
+        plugin = _get_plugin(parent)
+        plugin._state[parent] = _DelegationState(tool_use_count=1)
+
+        event = self._fire(parent, plugin, tool, "t1", "success")
+        plugin._on_after_tool_call(event)
+        assert plugin._state[parent].tool_use_id == "t1"
+
+    def test_clears_on_error(self):
+        tool = _make_delegation_tool()
+        parent = Agent(name="p", tools=[tool], callback_handler=None)
+        plugin = _get_plugin(parent)
+        plugin._state[parent] = _DelegationState(tool_use_id="t1", tool_use_count=1)
+
+        event = self._fire(parent, plugin, tool, "t1", "error")
+        plugin._on_after_tool_call(event)
+        assert plugin._state[parent].tool_use_id is None
+
+    def test_retry_swap_clears_matching_id(self):
+        tool = _make_delegation_tool()
+        parent = Agent(name="p", tools=[tool], callback_handler=None)
+        plugin = _get_plugin(parent)
+        plugin._state[parent] = _DelegationState(tool_use_id="t1", tool_use_count=1)
+
+        ordinary = MagicMock()
+        ordinary.delegate = False
+        event = self._fire(parent, plugin, tool, "t1", "success", selected_tool=ordinary)
+        plugin._on_after_tool_call(event)
+        assert plugin._state[parent].tool_use_id is None
+
+    def test_retry_swap_preserves_different_id(self):
+        tool = _make_delegation_tool()
+        parent = Agent(name="p", tools=[tool], callback_handler=None)
+        plugin = _get_plugin(parent)
+        plugin._state[parent] = _DelegationState(tool_use_id="t1", tool_use_count=1)
+
+        ordinary = MagicMock()
+        ordinary.delegate = False
+        event = self._fire(parent, plugin, tool, "t2", "success", selected_tool=ordinary)
+        plugin._on_after_tool_call(event)
+        assert plugin._state[parent].tool_use_id == "t1"
+
+    def test_foreign_stop_not_touched(self):
+        """Delegation never clears stop_event_loop it didn't set."""
+        tool = _make_delegation_tool()
+        parent = Agent(name="p", tools=[tool], callback_handler=None)
+        plugin = _get_plugin(parent)
+        plugin._state[parent] = _DelegationState(tool_use_id="other", tool_use_count=1)
+
+        invocation_state = {"request_state": {"stop_event_loop": True}}
+        from strands.hooks import AfterToolCallEvent
+
+        event = AfterToolCallEvent(
+            agent=parent,
+            selected_tool=tool,
+            tool_use={"toolUseId": "t99", "name": "sub", "input": {}},
+            invocation_state=invocation_state,
+            result={"toolUseId": "t99", "status": "success", "content": [{"text": "ok"}]},
+        )
+        plugin._on_after_tool_call(event)
+        assert invocation_state["request_state"]["stop_event_loop"] is True
+
+
+class TestAfterToolsEndTurn:
+    """_on_after_tools sets end_turn only when delegation result is valid."""
+
+    def _fire(self, parent, plugin, status="success"):
+        from strands.hooks import AfterToolsEvent
+
+        message = {
+            "role": "user",
+            "content": [{"toolResult": {"toolUseId": "t1", "status": status, "content": [{"text": "x"}]}}],
+        }
+        event = AfterToolsEvent(agent=parent, message=message, invocation_state={"request_state": {}})
+        plugin._on_after_tools(event)
+        return event
+
+    def test_sets_end_turn_on_success(self):
+        tool = _make_delegation_tool()
+        parent = Agent(name="p", tools=[tool], callback_handler=None)
+        plugin = _get_plugin(parent)
+        plugin._state[parent] = _DelegationState(tool_use_id="t1", tool_use_count=1)
+
+        event = self._fire(parent, plugin)
+        assert event.end_turn is True
+
+    def test_skips_when_result_is_error(self):
+        tool = _make_delegation_tool()
+        parent = Agent(name="p", tools=[tool], callback_handler=None)
+        plugin = _get_plugin(parent)
+        plugin._state[parent] = _DelegationState(tool_use_id="t1", tool_use_count=1)
+
+        event = self._fire(parent, plugin, status="error")
+        assert not event.end_turn
+        assert plugin._state[parent].tool_use_id is None
+
+    def test_suppressed_with_structured_output(self):
+        from pydantic import BaseModel
+
+        from strands.tools.structured_output.structured_output_tool import StructuredOutputTool
+
+        class R(BaseModel):
+            x: int
+
+        tool = _make_delegation_tool()
+        parent = Agent(name="p", tools=[tool], callback_handler=None)
+        plugin = _get_plugin(parent)
+        plugin._state[parent] = _DelegationState(tool_use_id="t1", tool_use_count=1)
+        parent.tool_registry.register_dynamic_tool(StructuredOutputTool(R))
+
+        event = self._fire(parent, plugin)
+        assert not event.end_turn
+
+
+class TestStreamOrdering:
+    """_handle_stream preserves ordering and emits exactly one terminal."""
+
+    @pytest.mark.asyncio
+    async def test_non_delegation_preserves_trailing_after_stop(self):
+        from strands._middleware.stages import AgentStreamContext
+        from strands.types._events import EventLoopStopEvent, TypedEvent
+
+        parent = Agent(name="p", callback_handler=None)
+        plugin = _get_plugin(parent)
+        ctx = AgentStreamContext(
+            agent=parent,
+            messages=[],
+            invocation_state={"request_state": {}},
+            _interrupt_state=parent._interrupt_state,
+        )
+
+        a = TypedEvent({"a": 1})
+        stop = EventLoopStopEvent("end_turn", {"role": "assistant", "content": []}, parent.event_loop_metrics, {})
+        b = TypedEvent({"b": 2})
+
+        async def inner(c):
+            yield a
+            yield stop
+            yield b
+
+        events = [e async for e in plugin._handle_stream(ctx, inner)]
+        assert events == [a, stop, b]
+
+    @pytest.mark.asyncio
+    async def test_non_delegation_multiple_stops_preserved(self):
+        from strands._middleware.stages import AgentStreamContext
+        from strands.types._events import EventLoopStopEvent, TypedEvent
+
+        parent = Agent(name="p", callback_handler=None)
+        plugin = _get_plugin(parent)
+        ctx = AgentStreamContext(
+            agent=parent,
+            messages=[],
+            invocation_state={"request_state": {}},
+            _interrupt_state=parent._interrupt_state,
+        )
+
+        s1 = EventLoopStopEvent("end_turn", {"role": "assistant", "content": []}, parent.event_loop_metrics, {})
+        mid = TypedEvent({"mid": 1})
+        s2 = EventLoopStopEvent("end_turn", {"role": "assistant", "content": []}, parent.event_loop_metrics, {})
+
+        async def inner(c):
+            yield s1
+            yield mid
+            yield s2
+
+        events = [e async for e in plugin._handle_stream(ctx, inner)]
+        assert events == [s1, mid, s2]
+
+    @pytest.mark.asyncio
+    async def test_delegation_single_terminal_with_trailing(self):
+        """Delegation replaces stop; trailing events keep position; exactly one terminal."""
+        from strands._middleware.stages import AgentStreamContext
+        from strands.types._events import EventLoopStopEvent, TypedEvent
+
+        tool = _make_delegation_tool()
+        parent = Agent(name="p", tools=[tool], callback_handler=None)
+        plugin = _get_plugin(parent)
+
+        parent.messages.extend(
+            [
+                {"role": "assistant", "content": [{"toolUse": {"toolUseId": "t1", "name": "sub", "input": {}}}]},
+                {
+                    "role": "user",
+                    "content": [
+                        {"toolResult": {"toolUseId": "t1", "status": "success", "content": [{"text": "answer"}]}}
+                    ],
+                },
+                {"role": "assistant", "content": [{"text": "placeholder"}]},
+            ]
+        )
+
+        ctx = AgentStreamContext(
+            agent=parent,
+            messages=[],
+            invocation_state={"request_state": {}},
+            _interrupt_state=parent._interrupt_state,
+        )
+
+        pre = TypedEvent({"pre": 1})
+        stop = EventLoopStopEvent("end_turn", parent.messages[-1], parent.event_loop_metrics, {})
+        trail = TypedEvent({"trail": 1})
+
+        async def inner(c):
+            plugin._state[parent] = _DelegationState(tool_use_id="t1", end_turn_via_delegation=True, tool_use_count=1)
+            yield pre
+            yield stop
+            yield trail
+
+        events = [e async for e in plugin._handle_stream(ctx, inner)]
+
+        assert events[0] is pre
+        stops = [e for e in events if isinstance(e, EventLoopStopEvent)]
+        assert len(stops) == 1
+        assert stops[0]["stop"][1]["content"][0]["text"] == "answer"
+        assert events[-1] is trail
+        assert "tracking_id" in parent.messages[-1]
+
+    @pytest.mark.asyncio
+    async def test_delegation_reverify_failure_replays_original(self):
+        """If the tool result is mutated to error after _on_after_tools, original stop replays."""
+        from strands._middleware.stages import AgentStreamContext
+        from strands.types._events import EventLoopStopEvent
+
+        tool = _make_delegation_tool()
+        parent = Agent(name="p", tools=[tool], callback_handler=None)
+        plugin = _get_plugin(parent)
+
+        # History where the tool result is an error (simulating late mutation)
+        parent.messages.extend(
+            [
+                {"role": "assistant", "content": [{"toolUse": {"toolUseId": "t1", "name": "sub", "input": {}}}]},
+                {
+                    "role": "user",
+                    "content": [
+                        {"toolResult": {"toolUseId": "t1", "status": "error", "content": [{"text": "failed"}]}}
+                    ],
+                },
+                {"role": "assistant", "content": [{"text": "placeholder"}]},
+            ]
+        )
+
+        ctx = AgentStreamContext(
+            agent=parent,
+            messages=[],
+            invocation_state={"request_state": {}},
+            _interrupt_state=parent._interrupt_state,
+        )
+
+        original_stop = EventLoopStopEvent("end_turn", parent.messages[-1], parent.event_loop_metrics, {})
+
+        async def inner(c):
+            # Delegation state was set (as if _on_after_tools saw success), but history
+            # was mutated to error by a late hook before _handle_stream runs.
+            plugin._state[parent] = _DelegationState(tool_use_id="t1", end_turn_via_delegation=True, tool_use_count=1)
+            yield original_stop
+
+        events = [e async for e in plugin._handle_stream(ctx, inner)]
+
+        # Re-verify fails → original stop replays unchanged, no delegation transformation
+        assert len(events) == 1
+        assert events[0] is original_stop
+
+
+class TestStatefulModel:
+    """Delegation tools are rejected on stateful models at init and runtime."""
+
+    def test_init_raises_with_delegation_on_stateful(self):
+        tool = _make_delegation_tool()
+        stateful = MagicMock()
+        type(stateful).stateful = PropertyMock(return_value=True)
+
+        with pytest.raises(ValueError, match="not supported with stateful models"):
+            Agent(name="p", model=stateful, tools=[tool], callback_handler=None)
+
+    def test_init_ok_without_delegation_on_stateful(self):
+        stateful = MagicMock()
+        type(stateful).stateful = PropertyMock(return_value=True)
+        Agent(name="p", model=stateful, callback_handler=None)
+
+    @pytest.mark.asyncio
+    async def test_runtime_stateful_delegate_returns_error(self):
+        from strands._middleware.stages import ExecuteToolContext
+        from strands.types._events import ToolResultEvent
+
+        tool = _make_delegation_tool()
+        parent = Agent(name="p", callback_handler=None)
+        plugin = _get_plugin(parent)
+        type(parent.model).stateful = PropertyMock(return_value=True)
+
+        ctx = ExecuteToolContext(
+            agent=parent,
+            tool=tool,
+            tool_use={"toolUseId": "t1", "name": "sub", "input": {"input": "hi"}},
+            invocation_state={"request_state": {}},
+            _interrupt_state=parent._interrupt_state,
+        )
+
+        async def unreachable(c):
+            yield ToolResultEvent({"toolUseId": "t1", "status": "success", "content": [{"text": "nope"}]})
+
+        events = [e async for e in plugin._handle_tool_execution(ctx, unreachable)]
+        assert len(events) == 1
+        assert events[0].tool_result["status"] == "error"
+        assert "stateful" in events[0].tool_result["content"][0]["text"].lower()
+
+        del type(parent.model).stateful
+
+
+class TestAutoRegistration:
+    def test_auto_registered(self):
+        assert "strands:agent-delegation" in Agent(name="t", callback_handler=None)._plugin_registry._plugins
+
+    def test_not_duplicated(self):
+        p = AgentDelegation()
+        agent = Agent(name="t", plugins=[p], callback_handler=None)
+        assert agent._plugin_registry._plugins.get("strands:agent-delegation") is p
+
+
+class TestJsonContentConversion:
+    def test_converts_text_json_and_passthrough(self):
+        import json
+
+        blocks = _to_content_blocks(
+            {
+                "content": [
+                    {"text": "hi"},
+                    {"json": {"k": 1}},
+                    {"image": {"format": "png", "source": {"bytes": b"x"}}},
+                ]
+            }
+        )
+        assert blocks[0] == {"text": "hi"}
+        assert json.loads(blocks[1]["text"]) == {"k": 1}
+        assert blocks[2] == {"image": {"format": "png", "source": {"bytes": b"x"}}}
+
+
+class TestChildStructuredOutputSerialization:
+    @pytest.mark.asyncio
+    async def test_datetime_serializes_cleanly(self):
+        import json
+        from datetime import datetime
+
+        from pydantic import BaseModel
+
+        from strands.types._events import ToolResultEvent
+
+        class S(BaseModel):
+            at: datetime
+
+        mock_agent = _mock_sub_agent("sched")
+        result = AgentResult(
+            stop_reason="end_turn",
+            message={"role": "assistant", "content": [{"text": "done"}]},
+            metrics=EventLoopMetrics(),
+            state={},
+            structured_output=S(at=datetime(2025, 1, 15, 9, 0)),
+        )
+
+        async def stream(prompt):
+            yield {"result": result}
+
+        mock_agent.stream_async = stream
+        tool = _AgentAsTool(mock_agent, name="sched", delegate=True, preserve_context=True)
+
+        events = [e async for e in tool.stream({"toolUseId": "t1", "name": "sched", "input": {"input": "x"}}, {})]
+        results = [e for e in events if isinstance(e, ToolResultEvent)]
+        assert results[0].tool_result["status"] == "success"
+        assert "2025-01-15" in json.dumps(results[0].tool_result["content"][0]["json"])
+
+
+class TestFullDelegationFlow:
+    @pytest.mark.asyncio
+    async def test_routes_to_specialist(self):
+        from tests.fixtures.mocked_model_provider import MockedModelProvider
+
+        sub = Agent(
+            model=MockedModelProvider([{"role": "assistant", "content": [{"text": "Balance: $42"}]}]),
+            name="billing",
+            callback_handler=None,
+        )
+        orch = Agent(
+            model=MockedModelProvider(
+                [
+                    {
+                        "role": "assistant",
+                        "content": [{"toolUse": {"toolUseId": "c1", "name": "billing", "input": {"input": "check"}}}],
+                    }
+                ]
+            ),
+            name="orch",
+            tools=[sub.as_tool(delegate=True)],
+            callback_handler=None,
+        )
+
+        result = await orch.invoke_async("Check balance")
+        assert result.stop_reason == "end_turn"
+        assert any("$42" in str(b.get("text", "")) for b in result.message["content"])
+
+    @pytest.mark.asyncio
+    async def test_error_recovery(self):
+        from tests.fixtures.mocked_model_provider import MockedModelProvider
+
+        err = _mock_sub_agent("failing")
+
+        async def fail(prompt):
+            raise RuntimeError("crash")
+            yield  # noqa: RET503
+
+        err.stream_async = fail
+        tool = _AgentAsTool(err, name="failing", delegate=True, preserve_context=True)
+
+        orch = Agent(
+            model=MockedModelProvider(
+                [
+                    {
+                        "role": "assistant",
+                        "content": [{"toolUse": {"toolUseId": "c1", "name": "failing", "input": {"input": "x"}}}],
+                    },
+                    {"role": "assistant", "content": [{"text": "I recovered."}]},
+                ]
+            ),
+            name="orch",
+            tools=[tool],
+            callback_handler=None,
+        )
+
+        result = await orch.invoke_async("Do it")
+        assert result.stop_reason == "end_turn"
+        assert "recovered" in str(result.message["content"]).lower()
+
+
+class TestSessionPersistence:
+    """Persisted history after delegation matches in-memory history."""
+
+    @pytest.mark.asyncio
+    async def test_persisted_matches_in_memory_after_delegation(self):
+        from strands.session.repository_session_manager import RepositorySessionManager
+        from tests.fixtures.mock_session_repository import MockedSessionRepository
+        from tests.fixtures.mocked_model_provider import MockedModelProvider
+
+        repo = MockedSessionRepository()
+        session_mgr = RepositorySessionManager(session_id="s1", session_repository=repo)
+
+        sub_model = MockedModelProvider([{"role": "assistant", "content": [{"text": "Balance: $42"}]}])
+        sub = Agent(model=sub_model, name="billing", callback_handler=None)
+
+        orch_model = MockedModelProvider(
+            [
+                {
+                    "role": "assistant",
+                    "content": [{"toolUse": {"toolUseId": "c1", "name": "billing", "input": {"input": "check"}}}],
+                }
+            ]
+        )
+        orch = Agent(
+            model=orch_model,
+            name="orchestrator",
+            tools=[sub.as_tool(delegate=True)],
+            session_manager=session_mgr,
+            callback_handler=None,
+        )
+
+        await orch.invoke_async("Check balance")
+
+        # Restore from the same repo into a fresh agent
+        session_mgr_2 = RepositorySessionManager(session_id="s1", session_repository=repo)
+        orch_2 = Agent(model=orch_model, name="orchestrator", session_manager=session_mgr_2, callback_handler=None)
+
+        # Persisted messages must match in-memory messages exactly
+        assert len(orch_2.messages) == len(orch.messages)
+        for restored, live in zip(orch_2.messages, orch.messages, strict=True):
+            assert restored["role"] == live["role"]
+            # Content comparison (ignore metadata/tracking_id differences)
+            assert restored["content"] == live["content"]
+
+        # The final message is the delegation content, not the placeholder
+        assert orch_2.messages[-1]["role"] == "assistant"
+        assert any("$42" in str(b.get("text", "")) for b in orch_2.messages[-1]["content"])
+
+
+class TestMiddlewareSingleCallGuard:
+    """ExecuteToolStage middleware rejects delegation in multi-tool batch."""
+
+    @pytest.mark.asyncio
+    async def test_middleware_rejects_when_batch_count_exceeds_one(self):
+        from strands._middleware.stages import ExecuteToolContext
+        from strands.types._events import ToolResultEvent
+
+        tool = _make_delegation_tool()
+        parent = Agent(name="p", tools=[tool], callback_handler=None)
+        plugin = _get_plugin(parent)
+
+        # Simulate BeforeToolsEvent having already set batch count > 1
+        plugin._state[parent] = _DelegationState(tool_use_count=2)
+
+        ctx = ExecuteToolContext(
+            agent=parent,
+            tool=tool,
+            tool_use={"toolUseId": "t1", "name": "sub", "input": {"input": "hi"}},
+            invocation_state={"request_state": {}},
+            _interrupt_state=parent._interrupt_state,
+        )
+
+        async def unreachable(c):
+            yield ToolResultEvent({"toolUseId": "t1", "status": "success", "content": [{"text": "nope"}]})
+
+        events = [e async for e in plugin._handle_tool_execution(ctx, unreachable)]
+
+        assert len(events) == 1
+        assert events[0].tool_result["status"] == "error"
+        assert "only tool" in events[0].tool_result["content"][0]["text"].lower()

--- a/strands-py/tests/strands/agent/test_agent_delegation.py
+++ b/strands-py/tests/strands/agent/test_agent_delegation.py
@@ -916,5 +916,6 @@ async def test_delegation_preserves_content_verbatim_across_hops():
 
     result = await top.invoke_async("run")
 
+    assert len(result.message["content"]) == 1
     delivered_text = result.message["content"][0]["text"]
     assert delivered_text == exact_payload, f"Expected verbatim {exact_payload!r}, got {delivered_text!r}"


### PR DESCRIPTION
## Description

Python-side implementation of agent-as-tool delegation, matching the TypeScript SDK (#3265). When using agent-as-tools for routing, the orchestrator currently always makes an additional model call to post-process the sub-agent's response, adding latency, token cost, and risking paraphrasing structured output. The `delegate=True` option on `as_tool()` short-circuits this: the sub-agent's response is returned verbatim as the `AgentResult` with `stop_reason='end_turn'`.

```python
from strands import Agent

customer_service = Agent(name="CustomerService", description="Handles billing questions")
technical_support = Agent(name="TechnicalSupport", description="Provides technical support")

orchestrator = Agent(
    tools=[
        customer_service.as_tool(delegate=True),
        technical_support.as_tool(delegate=True),
    ],
)

result = orchestrator("My wifi does not work")
# result.stop_reason == 'end_turn'
# result.message contains the TechnicalSupport agent's response directly
```

## Related Issues

Closes #3479
Related: #3265 (TypeScript implementation), #911 (parent)

## Documentation PR

https://github.com/strands-agents/harness-sdk/pull/3484 (site docs)

#3197 (design doc)

## Type of Change

New feature

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
