### PR TITLE
docs(mcp): use streamable_http_client instead of deprecated name

### DIFF
--- a/site/docs/examples/python/mcp_calculator.py
+++ b/site/docs/examples/python/mcp_calculator.py
@@ -10,7 +10,7 @@ This example demonstrates how to:
 import threading
 import time
 
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 from mcp.server import FastMCP
 from strands import Agent
 from strands.tools.mcp.mcp_client import MCPClient
@@ -110,7 +110,7 @@ def main():
     print("Connecting to MCP server...")
 
     def create_streamable_http_transport():
-        return streamablehttp_client("http://localhost:8000/mcp/")
+        return streamable_http_client("http://localhost:8000/mcp/")
 
     streamable_http_mcp_client = MCPClient(create_streamable_http_transport)
 

--- a/site/src/content/docs/examples/python/mcp_calculator.mdx
+++ b/site/src/content/docs/examples/python/mcp_calculator.mdx
@@ -45,12 +45,12 @@ mcp.run(transport="streamable-http")
 Now let's walk through how to connect a Strands agent to our MCP server:
 
 ```python
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 from strands import Agent
 from strands.tools.mcp.mcp_client import MCPClient
 
 def create_streamable_http_transport():
-   return streamablehttp_client("http://localhost:8000/mcp/")
+   return streamable_http_client("http://localhost:8000/mcp/")
 
 streamable_http_mcp_client = MCPClient(create_streamable_http_transport)
 

--- a/site/src/content/docs/user-guide/concepts/tools/mcp-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/mcp-tools.mdx
@@ -158,12 +158,12 @@ For HTTP-based MCP servers that use Streamable HTTP transport:
 <Tab label="Python">
 
 ```python
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 from strands import Agent
 from strands.tools.mcp import MCPClient
 
 streamable_http_mcp_client = MCPClient(
-    lambda: streamablehttp_client("http://localhost:8000/mcp")
+    lambda: streamable_http_client("http://localhost:8000/mcp")
 )
 
 with streamable_http_mcp_client:
@@ -175,11 +175,11 @@ Additional properties like authentication can be configured:
 
 ```python
 import os
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 from strands.tools.mcp import MCPClient
 
 github_mcp_client = MCPClient(
-    lambda: streamablehttp_client(
+    lambda: streamable_http_client(
         url="https://api.githubcopilot.com/mcp/",
         headers={"Authorization": f"Bearer {os.getenv('MCP_PAT')}"}
     )

--- a/site/src/content/docs/user-guide/deploy/deploy_to_aws_lambda.mdx
+++ b/site/src/content/docs/user-guide/deploy/deploy_to_aws_lambda.mdx
@@ -232,13 +232,13 @@ When using [Model Context Protocol (MCP)](../concepts/tools/mcp-tools.md) tools 
 **Establish a new MCP connection for each Lambda invocation.** Creating the `MCPClient` object itself is inexpensive - the costly operation is establishing the actual connection to the server. Use context managers to ensure connections are properly opened and closed:
 
 ```python
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 from strands import Agent
 from strands.tools.mcp import MCPClient
 
 def handler(event, context):
     mcp_client = MCPClient(
-        lambda: streamablehttp_client("https://your-mcp-server.example.com/mcp")
+        lambda: streamable_http_client("https://your-mcp-server.example.com/mcp")
     )
 
     # Context manager ensures connection is opened and closed safely
@@ -255,13 +255,13 @@ def handler(event, context):
 For optimization, you can establish the connection at module level using `start()` to reuse it across Lambda warm invocations:
 
 ```python
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 from strands import Agent
 from strands.tools.mcp import MCPClient
 
 # Create and start connection at module level (reused across warm invocations)
 mcp_client = MCPClient(
-    lambda: streamablehttp_client("https://your-mcp-server.example.com/mcp")
+    lambda: streamable_http_client("https://your-mcp-server.example.com/mcp")
 )
 mcp_client.start()
 


### PR DESCRIPTION
## Summary
MCP Python SDK ≥1.24.0 deprecated `streamablehttp_client` in favor of `streamable_http_client` (modelcontextprotocol/python-sdk#1177). Docs still showed the old name.

## Change
- Update Streamable HTTP examples to `streamable_http_client`
- Leave `aws_iam_streamablehttp_client` (different package) unchanged

Closes #3349.
