### PR TITLE
docs(blog): "Strands Robots, six months on" — physical-AI toolkit deep-dive

### DIFF
--- a/site/src/content/authors.yaml
+++ b/site/src/content/authors.yaml
@@ -187,3 +187,8 @@
   name: Panpan Xu
   role: "Principal Applied Scientist, AWS"
   bio: Panpan Xu is a Principal Applied Scientist at AWS Agentic AI working on agent optimization.
+
+- id: sundar-raghavan
+  name: Sundar Raghavan
+  role: "Sr Solutions Architect, AWS"
+  bio: Sundar Raghavan is a Sr Solutions Architect at AWS on the Agentic AI Foundations team. He focuses on how developers build, deploy, and scale production AI agents on AWS, and is extending that into physical AI through Strands Robots.

--- a/site/src/content/blog/strands-robots-since-strands-labs.mdx
+++ b/site/src/content/blog/strands-robots-since-strands-labs.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Strands Robots, six months on: from a Robot class to a full physical-AI toolkit"
 date: 2026-07-20
-description: "Since we introduced Strands Robots in Strands Labs, the package has grown a benchmarking and evaluation system, a locomotion terrain curriculum, whole-body control, teleoperation, ROS 2 support, edge inference, and a LeRobot streaming data loop. Here is what shipped and how to use it."
+description: "Six months after we introduced Strands Robots in Strands Labs, one Robot class and one SO-101 arm have become a registry of 72 robots, three simulation backends, policy scoring, a terrain curriculum, teleoperation, ROS 2, and a human-gated fleet mesh. Here is the big picture of what changed."
 authors:
   - sundar-raghavan
   - cagatay-cali
@@ -16,11 +16,13 @@ draft: true
 
 When we [introduced Strands Labs](/blog/introducing-strands-labs/) in February, Strands Robots shipped with a single headline idea: a `Robot` class you hand to a Strands agent, with an NVIDIA GR00T policy driving an SO-101 arm. That idea still holds, and the five-line agent loop is unchanged. What has changed is everything around it. Over the last six months the package grew from "control one arm with one policy" into a toolkit that records datasets, benchmarks and evaluates policies, trains from scratch, walks robots over generated terrain, coordinates a fleet, and bridges to ROS 2 hardware, without changing the agent code you write on top.
 
-This post is the guided tour of what shipped. It is a companion to the two deep-dives we published on the Hugging Face blog, [From the Hugging Face Hub to robot hardware](/blog/from-hub-to-hardware-strands-lerobot/) and the streaming data loop, and it pulls the thread together: the same `Robot()` factory, more capability behind it.
+This post is the guided tour of what shipped. It is a companion to the two deep-dives we published on the Hugging Face blog, [From the Hugging Face Hub to robot hardware](https://huggingface.co/blog/amazon/strands-lerobot-hub-to-hardware) and the streaming data loop, and it pulls the thread together: the same `Robot()` factory, more capability behind it.
 
 ## The through-line: one interface, more behind it
 
 The design contract from the Labs intro is intact. `Robot("so101")` returns a MuJoCo simulation by default; `mode="real"` returns a hardware robot driven by LeRobot; the agent code is identical across both. Policies are still swapped with a string. Everything below is additive: new actions on the same tool surface, new providers behind the same `create_policy()`, new backends behind the same factory. If you wrote an agent against the February API, it still runs.
+
+The clearest measure of six months is what that one string now accepts. February was one arm. The robot registry is now 72 entries, 23 arms, 18 humanoids, 10 mobile bases, 9 hands, 5 mobile manipulators, 4 bimanual rigs, 2 aerial, each with its assets, joint layout, and camera conventions already described, and three simulation backends behind the same factory, MuJoCo by default with Isaac Sim and Newton available for heavier physics. Adding a robot to your own agent is a registry entry, not an integration project.
 
 ```python
 from strands import Agent
@@ -33,11 +35,11 @@ agent("pick up the red cube")
 
 ## Record, then prove it is real LeRobot data
 
-The simulation tool records a LeRobotDataset in the exact format LeRobot writes on hardware, same parquet schema for joint states and actions, same per-camera MP4 layout. That means a dataset captured in MuJoCo and one captured from a physical SO-101 load through the same loader with no conversion step. `DatasetRecorder` gained an honest `overwrite=` path so re-running a capture into an existing `repo_id` fails with a clear error or forces a fresh dataset, rather than crashing on a bare `FileExistsError`.
+The simulation tool records a LeRobotDataset in the exact format LeRobot writes on hardware, same parquet schema for joint states and actions, same per-camera video layout. A dataset captured in MuJoCo and one captured from a physical SO-101 load through the same loader with no conversion step. That equivalence is the point: it means simulation can generate training data for real hardware, which is the only affordable answer to the data problem in physical AI.
 
-The full record, push, stream, and train loop, including streaming a dataset straight from the Hub with no local download, is the subject of our streaming data loop post on Hugging Face. Strands Robots now tracks `lerobot>=0.6.0` to pick up that streaming path.
+The full record, push, stream, and train loop, including streaming a dataset straight from the Hub with no local download, is the subject of our streaming data loop post on Hugging Face. Strands Robots tracks LeRobot 0.6 to pick up that streaming path.
 
-## Swap the policy with a string, across nine providers
+## Swap the policy with a string
 
 `create_policy()` resolves a growing set of providers behind one interface. The LerobotLocal path handles anything LeRobot's own registry resolves from a `config.json`, ACT, Diffusion Policy, SmolVLA, π0, and π0.5, with Real-Time Chunking turning on automatically for flow-matching policies. GR00T serves over a container. MolmoAct2 checkpoints route through the LerobotLocal path. NVIDIA's Cosmos 3 is available as a provider behind the same interface, alongside whole-body-control, MoveIt2, and cuRobo providers. The agent code does not change when you point it at a different one.
 
@@ -49,7 +51,7 @@ policy = create_policy("lerobot/act_aloha_sim_transfer_cube_human")
 
 ## Benchmark and evaluate policies, not just run them
 
-This is the largest area of new surface since February. Strands Robots grew a declarative benchmark system: `evaluate_benchmark` scores a policy against a task, `register_builtin_benchmarks()` ships canonical velocity-tracking locomotion benchmarks (`go2_walk_forward`, `g1_walk_forward`), and you can author your own benchmark from a file with a predicate/reward DSL, `base_beyond_x`, `base_tipped`, `base_below_z`, velocity-tracking and orientation reward terms, and more. `eval_policy` and `evaluate_benchmark` record a rollout MP4 per episode so you can watch what the score means, and a `verify-dataset` check flags a truncated or partially-encoded video before it poisons training.
+This is the largest area of new surface since February. Running a policy tells you it moved; scoring one tells you whether it worked. Strands Robots grew a declarative benchmark system: `evaluate_benchmark` scores a policy against a task, canonical locomotion benchmarks ship built in for quadrupeds and humanoids, and you can author your own from a file using a predicate and reward vocabulary, forward progress, fall-over, height collapse, yaw, velocity tracking. Every scored rollout records a video per episode, so you can watch what the number means rather than trust it.
 
 ```python
 robot = Robot("go2")
@@ -59,19 +61,19 @@ agent("evaluate the go2_walk_forward benchmark and record a video per episode")
 
 ## Walk robots over generated terrain
 
-Locomotion got a terrain curriculum. `create_world(terrain=..., difficulty=...)` generates heightfields on demand, `stairs`, `slope`, `pyramid`, and `rough` ground, so you can build a difficulty progression for a walking policy without hand-authoring scenes. `get_ground_height(x, y)` queries the local surface height, and a yaw-locomotion vocabulary (`base_yaw_beyond`, a `go2_turn_left` benchmark) lets you score turning behavior.
+Locomotion got a terrain curriculum. `create_world(terrain=..., difficulty=...)` generates heightfields on demand, stairs, slopes, pyramids, and rough ground, so you can build a difficulty progression for a walking policy without hand-authoring a single scene. Rewards measure clearance above the local surface rather than an absolute world height, which is what makes a curriculum meaningful once the ground stops being flat.
 
 ## Tune the physics and randomize the domain
 
-The MuJoCo backend exposes a physics-tuning surface for sim-to-real work: `set_gravity`, `set_timestep`, `set_body_properties`, `set_geom_properties`, `apply_force`, and `set_obs_noise` for sensor-noise parity. Those are the primitives for domain randomization, perturbing mass, friction, and observations across rollouts so a policy trained in sim survives contact with hardware.
+The simulation backends expose gravity, timestep, body and geometry properties, applied force, and sensor noise as tunable surfaces. Those are the primitives for domain randomization: perturb mass, friction, and observations across rollouts so a policy trained in simulation survives contact with hardware. Sim-to-real is the whole game in physical AI, and it is mostly a question of how honestly you can make the simulator lie.
 
 ## Teleoperate, and bridge to ROS 2
 
-Teleoperation is now first-class: `attach_teleop` / `teleoperate` / `stop_teleoperate` and friends let a leader device drive a follower, the same motion you record into a dataset. On the ROS 2 side, `use_ros` runs in-process through `rclpy` and gained action support, including goal-level `navigate_to` (Nav2 `NavigateToPose`) on a `RosBridgedRobot`, so an agent can send a navigation goal to a real ROS 2 base. A pure-DDS path over `cyclonedds` is available for robots without a full ROS 2 install.
+Teleoperation is first-class: a leader device drives a follower, and that motion is the same motion you record into a dataset, which is how you get demonstrations without a policy that works yet. On the ROS 2 side, `use_ros` runs in-process through `rclpy` and gained action support, including goal-level navigation, so an agent can send a navigation goal to a real ROS 2 base. A pure-DDS path is available for robots without a full ROS 2 install.
 
 ## Coordinate a fleet, safely
 
-More than one robot is where the mesh comes in. Every `Robot()` and `Simulation()` joins a Zenoh peer mesh automatically, and the `robot_mesh` tool gives an agent a vocabulary for fleet operations, peer discovery, structured commands, broadcasts, and emergency stop. Every physically-actuating mesh action is gated behind a human-in-the-loop approval delivered out-of-band of the LLM's tool arguments, so a prompt-injection attempt cannot slip an approval past the operator. For production fleets, the same tool dispatches through Device Connect, a device-aware networking layer developed in collaboration with Arm, and falls back to the built-in Zenoh mesh otherwise, so the agent code is unchanged either way.
+More than one robot is where the mesh comes in. Every `Robot()` and `Simulation()` joins a Zenoh peer mesh automatically, and the `robot_mesh` tool gives an agent a vocabulary for fleet operations: peer discovery, structured commands, broadcasts, and emergency stop. The part we would argue matters most is the gate. Every physically-actuating mesh action waits on a human approval delivered out-of-band of the LLM's tool arguments, so a prompt-injection attempt cannot phrase its way past the operator. An agent that can move a robot arm is a different security problem from an agent that can only write text, and the approval path is where that difference has to be answered.
 
 ## Push inference to the edge
 
@@ -83,13 +85,13 @@ Strands Robots is one project in [Strands Labs](/blog/introducing-strands-labs/)
 
 ## Where to go from here
 
-Everything here lives in [`strands-labs/robots`](https://github.com/strands-labs/robots) under Apache 2.0. The `examples/` folder has fifteen numbered walkthroughs, each demonstrating one primitive in under sixty lines, plus a getting-started notebook series that runs CPU-only with no hardware or GPU. Start with the two Hugging Face deep-dives for the end-to-end story, then open an issue with what worked and what did not. The SDK improves fastest when developer feedback lands on the surface that needs it.
+Everything here lives in [`strands-labs/robots`](https://github.com/strands-labs/robots) under Apache 2.0. The `examples/` folder walks through one primitive at a time, and the notebook series runs CPU-only with no hardware and no GPU, so you can get to a moving simulated robot before deciding whether to buy anything. Start with the two Hugging Face deep-dives for the end-to-end story, then open an issue with what worked and what did not. The SDK improves fastest when developer feedback arrives on the surface that needs it.
 
 ## Resources
 
 - [Strands Robots](https://github.com/strands-labs/robots): SDK, AgentTools, `Robot` factory, Apache 2.0
 - [Strands Robots docs](https://strands-labs.github.io/robots): full documentation
 - [Strands Robots Sim](https://github.com/strands-labs/robots-sim): heavier simulation backends
-- [From the Hugging Face Hub to robot hardware](/blog/from-hub-to-hardware-strands-lerobot/): the LeRobot deep-dive
+- [From the Hugging Face Hub to robot hardware](https://huggingface.co/blog/amazon/strands-lerobot-hub-to-hardware): the LeRobot deep-dive
 - [Introducing Strands Labs](/blog/introducing-strands-labs/): where Strands Robots started
 - [LeRobot](https://github.com/huggingface/lerobot): datasets, policies, hardware drivers

--- a/site/src/content/blog/strands-robots-since-strands-labs.mdx
+++ b/site/src/content/blog/strands-robots-since-strands-labs.mdx
@@ -1,0 +1,95 @@
+---
+title: "Strands Robots, six months on: from a Robot class to a full physical-AI toolkit"
+date: 2026-07-20
+description: "Since we introduced Strands Robots in Strands Labs, the package has grown a benchmarking and evaluation system, a locomotion terrain curriculum, whole-body control, teleoperation, ROS 2 support, edge inference, and a LeRobot streaming data loop. Here is what shipped and how to use it."
+authors:
+  - sundar-raghavan
+  - cagatay-cali
+  - arron-bailiss
+  - joy-chakraborty
+tags:
+  - Physical AI
+  - Robotics
+  - Open Source
+draft: true
+---
+
+When we [introduced Strands Labs](/blog/introducing-strands-labs/) in February, Strands Robots shipped with a single headline idea: a `Robot` class you hand to a Strands agent, with an NVIDIA GR00T policy driving an SO-101 arm. That idea still holds, and the five-line agent loop is unchanged. What has changed is everything around it. Over the last six months the package grew from "control one arm with one policy" into a toolkit that records datasets, benchmarks and evaluates policies, trains from scratch, walks robots over generated terrain, coordinates a fleet, and bridges to ROS 2 hardware, without changing the agent code you write on top.
+
+This post is the guided tour of what shipped. It is a companion to the two deep-dives we published on the Hugging Face blog, [From the Hugging Face Hub to robot hardware](/blog/from-hub-to-hardware-strands-lerobot/) and the streaming data loop, and it pulls the thread together: the same `Robot()` factory, more capability behind it.
+
+## The through-line: one interface, more behind it
+
+The design contract from the Labs intro is intact. `Robot("so101")` returns a MuJoCo simulation by default; `mode="real"` returns a hardware robot driven by LeRobot; the agent code is identical across both. Policies are still swapped with a string. Everything below is additive: new actions on the same tool surface, new providers behind the same `create_policy()`, new backends behind the same factory. If you wrote an agent against the February API, it still runs.
+
+```python
+from strands import Agent
+from strands_robots import Robot
+
+robot = Robot("so101")          # sim by default; mode="real" for hardware
+agent = Agent(tools=[robot])
+agent("pick up the red cube")
+```
+
+## Record, then prove it is real LeRobot data
+
+The simulation tool records a LeRobotDataset in the exact format LeRobot writes on hardware, same parquet schema for joint states and actions, same per-camera MP4 layout. That means a dataset captured in MuJoCo and one captured from a physical SO-101 load through the same loader with no conversion step. `DatasetRecorder` gained an honest `overwrite=` path so re-running a capture into an existing `repo_id` fails with a clear error or forces a fresh dataset, rather than crashing on a bare `FileExistsError`.
+
+The full record, push, stream, and train loop, including streaming a dataset straight from the Hub with no local download, is the subject of our streaming data loop post on Hugging Face. Strands Robots now tracks `lerobot>=0.6.0` to pick up that streaming path.
+
+## Swap the policy with a string, across nine providers
+
+`create_policy()` resolves a growing set of providers behind one interface. The LerobotLocal path handles anything LeRobot's own registry resolves from a `config.json`, ACT, Diffusion Policy, SmolVLA, π0, and π0.5, with Real-Time Chunking turning on automatically for flow-matching policies. GR00T serves over a container. MolmoAct2 checkpoints route through the LerobotLocal path. NVIDIA's Cosmos 3 is available as a provider behind the same interface, alongside whole-body-control, MoveIt2, and cuRobo providers. The agent code does not change when you point it at a different one.
+
+```python
+from strands_robots.policies import create_policy
+
+policy = create_policy("lerobot/act_aloha_sim_transfer_cube_human")
+```
+
+## Benchmark and evaluate policies, not just run them
+
+This is the largest area of new surface since February. Strands Robots grew a declarative benchmark system: `evaluate_benchmark` scores a policy against a task, `register_builtin_benchmarks()` ships canonical velocity-tracking locomotion benchmarks (`go2_walk_forward`, `g1_walk_forward`), and you can author your own benchmark from a file with a predicate/reward DSL, `base_beyond_x`, `base_tipped`, `base_below_z`, velocity-tracking and orientation reward terms, and more. `eval_policy` and `evaluate_benchmark` record a rollout MP4 per episode so you can watch what the score means, and a `verify-dataset` check flags a truncated or partially-encoded video before it poisons training.
+
+```python
+robot = Robot("go2")
+agent = Agent(tools=[robot])
+agent("evaluate the go2_walk_forward benchmark and record a video per episode")
+```
+
+## Walk robots over generated terrain
+
+Locomotion got a terrain curriculum. `create_world(terrain=..., difficulty=...)` generates heightfields on demand, `stairs`, `slope`, `pyramid`, and `rough` ground, so you can build a difficulty progression for a walking policy without hand-authoring scenes. `get_ground_height(x, y)` queries the local surface height, and a yaw-locomotion vocabulary (`base_yaw_beyond`, a `go2_turn_left` benchmark) lets you score turning behavior.
+
+## Tune the physics and randomize the domain
+
+The MuJoCo backend exposes a physics-tuning surface for sim-to-real work: `set_gravity`, `set_timestep`, `set_body_properties`, `set_geom_properties`, `apply_force`, and `set_obs_noise` for sensor-noise parity. Those are the primitives for domain randomization, perturbing mass, friction, and observations across rollouts so a policy trained in sim survives contact with hardware.
+
+## Teleoperate, and bridge to ROS 2
+
+Teleoperation is now first-class: `attach_teleop` / `teleoperate` / `stop_teleoperate` and friends let a leader device drive a follower, the same motion you record into a dataset. On the ROS 2 side, `use_ros` runs in-process through `rclpy` and gained action support, including goal-level `navigate_to` (Nav2 `NavigateToPose`) on a `RosBridgedRobot`, so an agent can send a navigation goal to a real ROS 2 base. A pure-DDS path over `cyclonedds` is available for robots without a full ROS 2 install.
+
+## Coordinate a fleet, safely
+
+More than one robot is where the mesh comes in. Every `Robot()` and `Simulation()` joins a Zenoh peer mesh automatically, and the `robot_mesh` tool gives an agent a vocabulary for fleet operations, peer discovery, structured commands, broadcasts, and emergency stop. Every physically-actuating mesh action is gated behind a human-in-the-loop approval delivered out-of-band of the LLM's tool arguments, so a prompt-injection attempt cannot slip an approval past the operator. For production fleets, the same tool dispatches through Device Connect, a device-aware networking layer developed in collaboration with Arm, and falls back to the built-in Zenoh mesh otherwise, so the agent code is unchanged either way.
+
+## Push inference to the edge
+
+For edge robots with a remote GPU, Strands Robots added a client/server split for remote policy inference: the policy runs where the compute is, the robot runs where the robot is, and the agent loop stays the same. This is the pattern behind the edge-cloud continuum, fast, instinctual control at the edge, deliberate reasoning in the cloud, that our Hugging Face physical-AI post explores in depth.
+
+## The broader ecosystem
+
+Strands Robots is one project in [Strands Labs](/blog/introducing-strands-labs/), alongside Robots Sim (heavier simulation backends including Isaac Sim and Newton, plus a LIBERO benchmark) and AI Functions. For NVIDIA Cosmos specifically, [`strands-cosmos`](https://github.com/strands-labs/strands-for-cosmos) is a companion package that exposes Cosmos world models as Strands model providers and tools, video understanding, generation, and edge VLM inference on Jetson. Both plug into the same Strands agent you already write.
+
+## Where to go from here
+
+Everything here lives in [`strands-labs/robots`](https://github.com/strands-labs/robots) under Apache 2.0. The `examples/` folder has fifteen numbered walkthroughs, each demonstrating one primitive in under sixty lines, plus a getting-started notebook series that runs CPU-only with no hardware or GPU. Start with the two Hugging Face deep-dives for the end-to-end story, then open an issue with what worked and what did not. The SDK improves fastest when developer feedback lands on the surface that needs it.
+
+## Resources
+
+- [Strands Robots](https://github.com/strands-labs/robots): SDK, AgentTools, `Robot` factory, Apache 2.0
+- [Strands Robots docs](https://strands-labs.github.io/robots): full documentation
+- [Strands Robots Sim](https://github.com/strands-labs/robots-sim): heavier simulation backends
+- [From the Hugging Face Hub to robot hardware](/blog/from-hub-to-hardware-strands-lerobot/): the LeRobot deep-dive
+- [Introducing Strands Labs](/blog/introducing-strands-labs/): where Strands Robots started
+- [LeRobot](https://github.com/huggingface/lerobot): datasets, policies, hardware drivers


### PR DESCRIPTION
A native Strands-blog post following the February [Strands Labs introduction](/blog/introducing-strands-labs/) with a big-picture look at what changed in `strands-robots` since. Not a fresh introduction, a "how far it has come" tour.

## Why
The Labs post introduced Strands Robots as a `Robot` class plus GR00T on an SO-101. Six months on the package has grown policy scoring and evaluation, a locomotion terrain curriculum, whole-body control, teleoperation, ROS 2 actions, remote edge inference, more policy providers, and the LeRobot 0.6 streaming data loop. The registry has gone from one arm to 72 robots across eight categories. This post pulls that together and links out to the two Hugging Face deep-dives.

## What this adds
- `site/src/content/blog/strands-robots-since-strands-labs.mdx`, the post (`draft: true` pending review).
- `site/src/content/authors.yaml`, a `sundar-raghavan` author entry (co-authors `cagatay-cali`, `arron-bailiss`, `joy-chakraborty` already exist).

## Accuracy basis
Claims are checked against `strands-robots` **v0.5.1**, tagged 2026-08-06. An earlier revision of this description claimed verification against the released 0.4.x history, which was two minor releases and 857 commits stale, and four counts had drifted with it (provider count, the lerobot floor, the example count, and an example line-length claim). `d0813a1f` drops those counts rather than re-pinning them: a "six months on" post is read for the shape of the change, and a number that has to be re-checked every release is both the wrong register for the piece and a standing accuracy risk. Feature-level function inventories came out for the same reason.

## Notes for reviewers
- No `canonicalUrl`, this is original content rather than a syndication.
- Tags: `Physical AI`, `Robotics`, `Open Source` (existing vocabulary).
- Links to the Hugging Face backport point at the HF original rather than `/blog/from-hub-to-hardware-strands-lerobot/`, so this post does not depend on #3358 merging first. That internal path was previously broken here and invisible: `draft: true` excludes the page from the build, so the broken-link checker never read it. With `draft: false` the build fails outright, which is how it was found.
- Verified with `draft: false` locally so the page is actually built: `npm run build` passes with no broken links across 848 pages.
