### PR TITLE
fix(session): guard against duplicate agent ids in TS SessionManager

### DIFF
--- a/strands-ts/src/session/__tests__/session-manager.test.ts
+++ b/strands-ts/src/session/__tests__/session-manager.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, beforeEach, vi } from 'vitest'
 import { SessionManager } from '../session-manager.js'
+import { SessionError } from '../../errors.js'
 import { MockSnapshotStorage, createTestSnapshot } from '../../__fixtures__/mock-storage-provider.js'
 import {
   InitializedEvent,
@@ -106,6 +107,24 @@ describe('SessionManager', () => {
         location: { sessionId: 'test-default', scope: 'agent', scopeId: 'agent' },
       })
       expect(snapshot).not.toBeNull()
+    })
+  })
+
+  describe('duplicate agent id guard', () => {
+    it('throws when two agents share an id in the same session', () => {
+      sessionManager = new SessionManager({ sessionId: 'test-session', storage: { snapshot: storage } })
+      sessionManager.initAgent(createMockAgentWithHooks({ extra: { id: 'shared-id' } }))
+
+      expect(() => sessionManager.initAgent(createMockAgentWithHooks({ extra: { id: 'shared-id' } }))).toThrow(
+        SessionError
+      )
+    })
+
+    it('allows distinct agent ids in the same session', () => {
+      sessionManager = new SessionManager({ sessionId: 'test-session', storage: { snapshot: storage } })
+      sessionManager.initAgent(createMockAgentWithHooks({ extra: { id: 'agent-a' } }))
+
+      expect(() => sessionManager.initAgent(createMockAgentWithHooks({ extra: { id: 'agent-b' } }))).not.toThrow()
     })
   })
 

--- a/strands-ts/src/session/session-manager.ts
+++ b/strands-ts/src/session/session-manager.ts
@@ -3,6 +3,7 @@ import type { Storage } from '../storage/storage.js'
 import { NAMESPACED, namespace } from '../storage/storage.js'
 import { SnapshotStorageAdapter } from './snapshot-storage-adapter.js'
 import { validateIdentifier } from './validation.js'
+import { SessionError } from '../errors.js'
 import type { SnapshotTriggerCallback } from './types.js'
 import type { Plugin } from '../plugins/plugin.js'
 import type { LocalAgent } from '../types/agent.js'
@@ -103,6 +104,7 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
   private readonly _snapshotTrigger?: SnapshotTriggerCallback | undefined
   private readonly _multiAgentSaveLatestOn: MultiAgentSaveLatestStrategy
   private _multiAgentRestoredIds = new Set<string>()
+  private _initializedAgentIds = new Set<string>()
 
   /**
    * Unique identifier for this plugin.
@@ -131,6 +133,15 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
 
   /** Initializes the plugin by registering lifecycle hook callbacks. */
   public initAgent(agent: LocalAgent): void {
+    // Agents share a session storage path keyed by `agent.id` (`scopeId`), so two agents with the
+    // same id in one session would silently overwrite each other's snapshots. Guard against that
+    // in-process; the cross-process case (same sessionId across processes) needs storage-level
+    // uniqueness and is out of scope here.
+    if (this._initializedAgentIds.has(agent.id)) {
+      throw new SessionError(`The agent id '${agent.id}' must be unique within a session.`)
+    }
+    this._initializedAgentIds.add(agent.id)
+
     agent.addHook(InitializedEvent, async (event) => {
       await this._onAgentInitialized(event)
     })


### PR DESCRIPTION
## What does this PR do?

Adds an in-process duplicate-agent-id guard to the TypeScript `SessionManager`.

When two agents share the same `id` within one session, they both resolve to the same storage path (`scopeId: agent.id`) and silently overwrite each other's `snapshot_latest` — data loss with no warning. This can happen with two `new Agent()` using default ids attached to the same session manager.

The Python SDK already guards this in `RepositorySessionManager.initialize` (raises `SessionException` on a re-registered `agent_id`), but the TS `SessionManager.initAgent()` registered hooks without tracking which ids it had already seen. This mirrors the Python semantics: track initialized agent ids and `throw new SessionError(...)` on a duplicate.

## Scope

- ✅ **In-process** case (this PR): two agents sharing an id on the same `SessionManager` instance now throw instead of silently colliding.
- ⛔ **Cross-process** case (same `sessionId` across processes, colliding `agent.id`) is intentionally left out — as noted in the issue, that needs storage-level uniqueness/locking rather than an in-memory guard. Happy to open a follow-up.

## Type of change

- [x] Bug fix

## Testing

- Added two unit tests in `session-manager.test.ts`: duplicate ids throw `SessionError`; distinct ids don't.
- `vitest run --project unit-node` on the session suite: 52 passed (50 existing + 2 new).
- `tsc --noEmit --project src/tsconfig.json`, `eslint`, and `prettier` clean on the changed files.

Refs #2531
