### PR TITLE
feat(vended-tools): add a2a_client shim

### DIFF
--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools-imports.ts
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools-imports.ts
@@ -35,3 +35,12 @@ import { bash } from '@strands-agents/sdk/vended-tools/bash'
 import { fileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
 import { notebook } from '@strands-agents/sdk/vended-tools/notebook'
 // --8<-- [end:combined_import]
+
+// --8<-- [start:a2a_client_import]
+import { Agent } from '@strands-agents/sdk'
+import { a2aClient } from '@strands-agents/sdk/vended-tools/a2a-client'
+// --8<-- [end:a2a_client_import]
+
+// --8<-- [start:a2a_client_bounded_import]
+import { makeA2AClient } from '@strands-agents/sdk/vended-tools/a2a-client'
+// --8<-- [end:a2a_client_bounded_import]

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -10,6 +10,8 @@ sourceLinks:
   - path: strands-ts/src/vended-tools/bash/bash.ts
   - path: strands-ts/src/vended-tools/http-request/http-request.ts
   - path: strands-ts/src/vended-tools/notebook/notebook.ts
+  - path: strands-ts/src/vended-tools/a2a-client/a2a-client.ts
+  - path: strands-py/src/strands/vended_tools/a2a_client/a2a_client.py
 ---
 
 Vended tools are pre-built tools included directly in the Strands SDK for common agent tasks like file operations, shell commands, HTTP requests, and persistent notes. 
@@ -34,6 +36,7 @@ Each tool is imported from its own subpath under `@strands-agents/sdk/vended-too
 | [HTTP Request](#http-request) | Make HTTP requests to external APIs | TypeScript (Node.js 20+, browsers) |
 | [Notebook](#notebook) | Manage persistent text notebooks | TypeScript (Node.js, browsers) |
 | [Bash](#bash) | Execute shell commands with persistent sessions | Python, TypeScript (Node.js, Unix/Linux/macOS) |
+| [A2A Client](#a2a-client) | Invoke a remote A2A (Agent-to-Agent) agent by URL | Python, TypeScript (Node.js) |
 
 ### File Editor
 
@@ -160,6 +163,71 @@ agent("List all Python files in the current directory and count them")
 ```
 
 📖 [Full API Reference](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/bash/README.md)
+
+---
+
+### A2A Client
+
+Invokes a remote A2A (Agent-to-Agent) agent by URL. The tool resolves the remote agent card and sends a single message, returning the response text. Only http and https URLs to public hosts are permitted; private, loopback, link-local, and cloud metadata addresses are rejected. In the TypeScript SDK the tool wraps its fetch to walk 3xx responses manually and re-validate every hop against the same policy (developer allowlist included), so a public origin cannot 302 the client onto a private or off-list address. The Python SDK relies on the underlying httpx client, which defaults follow_redirects to false, so 3xx responses are not walked unless a developer supplies their own httpx client with redirect following enabled. Either way, the resolved agent card's advertised url is re-validated before the message is sent.
+
+_Supported in: Node.js (TypeScript); all platforms (Python)._
+
+The message input is capped at sixty-four kibibytes, the resolved agent card at two hundred fifty-six kibibytes, and the returned response text at two hundred fifty-six kibibytes. The entire call is bounded by a configurable timeout (default: sixty seconds). Developer-supplied URL prefixes and auth (via a custom A2A client factory) are bound at construction time and cannot be overridden by the model.
+
+**Example:**
+
+<Tabs>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/tools/vended-tools-imports.ts:a2a_client_import"
+
+--8<-- "user-guide/concepts/tools/vended-tools.ts:a2a_client_example"
+```
+
+</Tab>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.vended_tools import a2a_client
+
+agent = Agent(tools=[a2a_client])
+agent("Ask the remote agent at https://agents.example.com to summarize the latest release notes.")
+```
+
+</Tab>
+</Tabs>
+
+**Restricted allowlist and shorter timeout:**
+
+<Tabs>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/tools/vended-tools-imports.ts:a2a_client_bounded_import"
+
+--8<-- "user-guide/concepts/tools/vended-tools.ts:a2a_client_bounded_example"
+```
+
+</Tab>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.vended_tools import make_a2a_client
+
+bounded_client = make_a2a_client(
+    allowed_url_prefixes=("https://agents.example.com/",),
+    timeout_seconds=30,
+)
+agent = Agent(tools=[bounded_client])
+```
+
+</Tab>
+</Tabs>
+
+[Full API Reference](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/a2a-client/README.md)
 
 ---
 

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.ts
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.ts
@@ -6,6 +6,7 @@ import { httpRequest } from '@strands-agents/sdk/vended-tools/http-request'
 import { notebook } from '@strands-agents/sdk/vended-tools/notebook'
 // --8<-- [end:basic_import]
 import { SessionManager, FileStorage } from '@strands-agents/sdk'
+import { a2aClient, makeA2AClient } from '@strands-agents/sdk/vended-tools/a2a-client'
 
 // Agent with vended tools example
 async function agentWithVendedToolsExample() {
@@ -108,6 +109,33 @@ async function notebookStatePersistenceExample() {
   const restoredAgent = new Agent({ tools: [notebook], sessionManager: session })
   await restoredAgent.invoke('Read the ideas notebook')
   // --8<-- [end:notebook_state_persistence]
+}
+
+// A2A client example - invoke a remote A2A agent by URL
+async function a2aClientExample() {
+  // --8<-- [start:a2a_client_example]
+  const agent = new Agent({
+    tools: [a2aClient],
+  })
+
+  await agent.invoke('Ask the remote agent at https://agents.example.com to summarize the latest release.')
+  // --8<-- [end:a2a_client_example]
+}
+
+// A2A client example - pin the tool to one remote and shorten the timeout
+async function a2aClientBoundedExample() {
+  // --8<-- [start:a2a_client_bounded_example]
+  const boundedClient = makeA2AClient({
+    allowedUrlPrefixes: ['https://agents.example.com/'],
+    timeoutSeconds: 30,
+  })
+
+  const agent = new Agent({
+    tools: [boundedClient],
+  })
+
+  await agent.invoke('Ask the pinned agent to summarize the latest release.')
+  // --8<-- [end:a2a_client_bounded_example]
 }
 
 // Combined tools example - development workflow

--- a/strands-py/src/strands/vended_tools/__init__.py
+++ b/strands-py/src/strands/vended_tools/__init__.py
@@ -6,6 +6,10 @@ factories produce sandbox-routed tools that either bind to a
 :class:`~strands.sandbox.base.Sandbox` at creation (as the built-in Docker/SSH
 sandboxes do when vending tools) or read the sandbox from the agent at call time.
 
+:data:`a2a_client` and :func:`make_a2a_client` provide a thin shim over the
+optional :class:`~strands.agent.a2a_agent.A2AAgent` client for invoking remote
+A2A agents by URL.
+
 Example Usage:
     ```python
     from strands import Agent
@@ -15,12 +19,15 @@ Example Usage:
     ```
 """
 
+from .a2a_client import a2a_client, make_a2a_client
 from .bash import bash, make_bash
 from .file_editor import file_editor, make_file_editor
 
 __all__ = [
+    "a2a_client",
     "bash",
     "file_editor",
+    "make_a2a_client",
     "make_bash",
     "make_file_editor",
 ]

--- a/strands-py/src/strands/vended_tools/_multiagent_conventions.md
+++ b/strands-py/src/strands/vended_tools/_multiagent_conventions.md
@@ -1,0 +1,119 @@
+# Multi-agent conventions for vended tools
+
+This document defines the dialect shared by the multi-agent vended tools: `use_agent`, `swarm`, `graph`, and `a2a_client`. Every tool in scope must implement it. If a tool cannot, its addendum records the deviation and the rationale.
+
+## Agent spec
+
+Every child-agent-defining tool accepts agent specs with the same shape:
+
+```
+{
+    name: str,          # required, [a-zA-Z_][a-zA-Z0-9_]{0,63}
+    system_prompt: str, # required, <= 8 KiB
+    tools: [str, ...],  # allow-list of parent-registered tool names
+                        # required (may be empty for a no-tool child)
+                        # no wildcards, no `"*"`, no glob patterns
+                        # unknown names are rejected at the boundary
+}
+```
+
+**No `model_provider` / `model_settings` field.** Children inherit the parent's model instance. Rationale: model-selection at spec time is a credential-injection surface — provider constructors accept `api_key`, `client_args`, `endpoint_url`, `base_url`, which a compromised model can supply to route to attacker-controlled endpoints or bill an attacker's account. The convenience of per-child model choice does not offset that surface. If a developer wants child-model variance they can register N pre-configured factories rather than exposing model config to the model.
+
+Tools that historically exposed model configuration on their agent-spec input must remove that surface before conforming.
+
+## Recursion depth
+
+Every multi-agent tool participates in a single shared depth counter tracked on the parent's `invocation_state`:
+
+- Python: `invocation_state["multiagent_depth"]`
+- TypeScript: `invocationState.multiagentDepth`
+
+Default cap: **3.** Configurable at tool construction only, never by the model.
+
+At the tool's entry point:
+1. Read the current depth from `invocation_state` (default 0 if absent).
+2. If `depth >= cap`, reject with a specific `MultiagentDepthExceeded` error.
+3. Construct the child's `invocation_state` with `multiagent_depth = depth + 1` and pass it into `Agent.invoke_async` (py) / `agent.invoke({ invocationState })` (ts).
+
+If a tool skips step 3, an adversarial model can walk `use_agent → swarm → use_agent` and reset the counter at each hop. All four must participate.
+
+## Tool allow-list
+
+Every agent spec's `tools` field is an explicit name allow-list from the parent's registry:
+
+- Names are matched exactly, case-sensitive.
+- Unknown names are rejected at the boundary before construction.
+- No wildcards, no glob patterns, no "all my tools" shortcut.
+- Multi-agent tools (`use_agent`, `swarm`, `graph`, `a2a_client`) may not be listed in a child's tools (defense-in-depth against tool-registered-then-recursed patterns that bypass the depth cap). Reject them explicitly.
+
+If a caller wants the child to have the multi-agent tools, they can register variants themselves at construction time; the model can't grant that authority.
+
+## Result shape
+
+All four tools return a result dict with this minimum shape:
+
+```
+{
+    status: "success" | "error" | "cancelled",
+    output: str,               # the primary textual answer
+    execution_time_ms: int,    # total wall-clock
+}
+```
+
+Extended fields (each tool may add its own — should be additive, not renaming):
+- `swarm`: `node_history: list[str]`, `execution_count: int`, `usage: {input_tokens, output_tokens}`
+- `graph`: `execution_order: list[str]`, `results: {node_id: {status, output}}` (per-node; the top-level `output` is the terminal node's output or a concatenation)
+- `use_agent`: no additional fields required (single child)
+- `a2a_client`: `remote_card: {name, description, ...}` (subset of the resolved agent card)
+
+The tools may return richer shapes but must keep `status`, `output`, `execution_time_ms` at the top level so downstream models get a consistent contract regardless of which pattern they invoke.
+
+Field names are written in Python `snake_case` in this document. Each SDK renders them in its own convention per the root `AGENTS.md` cross-SDK parity rule: Python keeps `snake_case` (`execution_time_ms`, `remote_card`) and TypeScript renders `camelCase` (`executionTimeMs`, `remoteCard`). The `status` and `output` string literals stay byte-identical across SDKs.
+
+## Cancellation
+
+Parent cancellation must propagate to the child(ren) within 100 ms:
+
+- Python: poll `parent_agent._cancel_signal.is_set()` at the tool's supervision level (a 50 ms loop is fine) and call `child.cancel()` when set. For multi-child tools (swarm/graph), the SDK's `BeforeNodeCallEvent` hook is the correct extension point — set `event.cancel_node` when the parent is cancelled.
+- TypeScript: forward `agent.cancelSignal` into `Agent.invoke(..., { cancelSignal })` and into any transport-level `AbortSignal` the child holds. `AbortSignal.any([parent, timeout])` is the standard composition.
+
+On cancellation, the tool returns `{status: "cancelled", output: "<partial or empty>", execution_time_ms}` — it does not raise past the tool boundary. A cancelled tool result reaching the loop is a signal to the parent to stop, not an exception to propagate. (The `a2a_client` addendum below documents an explicit deviation from this rule; the other three tools follow it as written.)
+
+## Size caps
+
+At the tool boundary, before constructing anything:
+- `system_prompt`: 8 KiB per spec
+- `task` / `initial_input`: 32 KiB
+- `name`: 64 chars (regex above)
+- `tools` list: 64 entries max
+- Number of agents (swarm, graph nodes): 20 max
+- Number of edges (graph): 40 max
+- Total execution time: 300 s wall-clock
+
+These are hard caps, factory-configurable but not model-controllable.
+
+## Conformance notes per tool
+
+- `graph` and `swarm` participate in the shared `multiagent_depth` counter and enforce the size caps at their tool boundary. Cancellation flows through the SDK's before-node hook so a parent-cancelled run stops promptly at the next node boundary rather than raising.
+- `use_agent` invokes a single child; the child's `invocation_state` is constructed with `multiagent_depth = depth + 1` so nested calls respect the cap. No model-controllable model-selection surface is exposed.
+- `a2a_client` reads and enforces the depth cap at the tool boundary. It does not spawn a local child agent, so there is nothing to increment into: the counter guard is one-way for this tool, and the addendum below documents the wire-boundary limitation.
+
+---
+
+## `a2a_client` addendum
+
+The `a2a_client` tool invokes a **remote** A2A agent instead of constructing a child locally. Most fields in the agent spec are inapplicable (the remote picks its own model, prompt, and tools at deploy time). The tool receives a `url` + `message` from the model rather than an agent spec.
+
+- **Model dialect** (`model_provider`, `model_settings`, `system_prompt`): not applicable — the remote agent chose these at deploy time. The model has no say.
+- **Task input**: passed as `message` (not `task`) to match A2A protocol terminology. Capped at 64 KiB.
+- **Tool allow-list**: not applicable — the remote agent brings its own tools; the parent's registry is invisible to it.
+- **URL allow-list**: `allowed_url_prefixes` / `allowedUrlPrefixes` set at construction time (developer, never the model). If unset, only SSRF checks apply. The allowlist is re-applied to the card-advertised URL, so a remote that resolves to a public host outside the allowlist is rejected before the message is sent. On TypeScript the allowlist is also re-applied to every hop the guarded fetch walks, so a 3xx from an allowlisted origin cannot steer the client onto an off-list public host.
+- **Redirect handling**:
+  - TypeScript: the tool wraps the underlying A2A SDK's fetch (`makeGuardedFetch`) with `redirect: 'manual'`, re-runs the URL guard and allowlist on every hop, caps at five hops, and strips `Authorization` / `Cookie` / `Proxy-Authorization` on any cross-origin change (compared on full origin, not host).
+  - Python: the underlying A2A SDK uses httpx, which defaults `follow_redirects=False`. Redirects are therefore not walked by default; a 3xx surfaces to the caller. Developers who supply their own `httpx_client` in `client_config` own the redirect discipline. There is no per-hop guard equivalent to the TypeScript wrapper on Python today; that parity is a follow-up if a use case emerges.
+- **Recursion depth**:
+  - The tool participates in the shared counter at the **local boundary**: a parent that calls `a2a_client` counts as depth+1, so a chain of `use_agent → a2a_client → ...` still respects the cap.
+  - The counter is **not propagated across the wire**. The remote agent is opaque — the tool has no way to write into its `invocation_state`, and the remote may not even be a Strands agent. Depth resets from the remote's perspective; that's an accepted limitation of the network boundary.
+- **Cancellation** (deviation from the shared spec): parent cancellation and total-timeout both **raise past the tool boundary** — `asyncio.CancelledError` / `TimeoutError` on Python, `DOMException` with `name === 'AbortError'` on TypeScript — rather than returning `status: "cancelled"`. Rationale: `a2a_client` is a network tool, not a child-agent supervisor. Its sibling network tools (`http_request`, `web_fetch`) raise cancellation the same way, and callers already special-case `AbortError` to distinguish it from other failures. Result-shape cancellation would need a new `status: 'cancelled'` variant that no existing caller reads. This is an accepted local divergence; the other three multi-agent tools continue to return the shaped result.
+- **Result shape**: `{"status": "success", "output": str, "execution_time_ms": int, "remote_card": {"name", "description", "url"}}`. The top-level triple matches the shared multi-agent contract; `remote_card` mirrors a subset of the resolved agent card so the parent can distinguish remote endpoints. `status` is `Literal["success"]` on the success path; cancellation and timeout raise rather than populate a `cancelled` variant (see above).
+- **Size caps as memory guard, not DoS defense**: `max_card_bytes` and `max_response_bytes` are enforced *after* the underlying A2A SDK has fetched and materialized the body. They bound what the model sees, not what the process reads into memory. A malicious server can still stream a large body before the cap fires; fronting the tool with an egress-side response-size limit is the mitigation.

--- a/strands-py/src/strands/vended_tools/a2a_client/__init__.py
+++ b/strands-py/src/strands/vended_tools/a2a_client/__init__.py
@@ -1,0 +1,22 @@
+"""A2A client tool for invoking remote A2A agents.
+
+Example Usage:
+    ```python
+    from strands import Agent
+    from strands.vended_tools.a2a_client import a2a_client
+
+    agent = Agent(tools=[a2a_client])
+    ```
+"""
+
+from .a2a_client import a2a_client, make_a2a_client
+from .types import A2AClientOutput, A2AClientRemoteCard
+from .url_guard import UrlNotAllowedError
+
+__all__ = [
+    "A2AClientOutput",
+    "A2AClientRemoteCard",
+    "UrlNotAllowedError",
+    "a2a_client",
+    "make_a2a_client",
+]

--- a/strands-py/src/strands/vended_tools/a2a_client/a2a_client.py
+++ b/strands-py/src/strands/vended_tools/a2a_client/a2a_client.py
@@ -1,0 +1,302 @@
+"""A2A client vended tool.
+
+Thin shim over :class:`strands.agent.a2a_agent.A2AAgent`. The model supplies a
+URL and a message; the tool resolves the remote agent's card and sends the
+message. URL validation, size caps, and total timeout are enforced at the tool
+boundary — the underlying A2AAgent has no SSRF or size guard of its own.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import time
+from typing import TYPE_CHECKING
+
+from ...tools.decorator import tool
+from ...types.tools import ToolContext
+from .types import (
+    DEFAULT_A2A_CLIENT_DESCRIPTION,
+    DEFAULT_MAX_CARD_BYTES,
+    DEFAULT_MAX_RESPONSE_BYTES,
+    DEFAULT_TIMEOUT_SECONDS,
+    MAX_MESSAGE_BYTES,
+    A2AClientOutput,
+    A2AClientRemoteCard,
+)
+from .url_guard import UrlNotAllowedError, validate_url
+
+if TYPE_CHECKING:
+    from a2a.client import ClientConfig
+    from a2a.types import AgentCard
+
+    from ...tools.decorator import DecoratedFunctionTool
+
+DEFAULT_MULTIAGENT_DEPTH_CAP = 3
+
+
+def make_a2a_client(
+    *,
+    name: str = "a2a_client",
+    description: str = DEFAULT_A2A_CLIENT_DESCRIPTION,
+    client_config: ClientConfig | None = None,
+    allowed_url_prefixes: tuple[str, ...] | None = None,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    max_card_bytes: int = DEFAULT_MAX_CARD_BYTES,
+    max_response_bytes: int = DEFAULT_MAX_RESPONSE_BYTES,
+    multiagent_depth_cap: int = DEFAULT_MULTIAGENT_DEPTH_CAP,
+) -> DecoratedFunctionTool:
+    """Create an ``a2a_client`` tool.
+
+    All security-relevant configuration is bound at creation time by the
+    developer. The model can only supply ``url`` and ``message`` at call
+    time. Auth material carried on ``client_config`` is never accessible to
+    the model.
+
+    Args:
+        name: Tool name. Defaults to ``"a2a_client"``.
+        description: Tool description shown to the model.
+        client_config: Optional A2A ``ClientConfig`` — carries the httpx
+            client used for authenticated card discovery and message
+            sending (SigV4, OAuth, bearer tokens, ...). If provided,
+            timeouts on the underlying httpx client are the developer's
+            responsibility, but the tool's own ``timeout_seconds`` still
+            bounds the total invocation. Never touched by the model.
+        allowed_url_prefixes: Optional developer-supplied URL allowlist.
+            When set, the model-provided ``url`` must start with one of
+            these prefixes.
+        timeout_seconds: Wall-clock cap on the entire tool call, including
+            card discovery + message send. Default: 60s.
+        max_card_bytes: Maximum size of the remote agent card in bytes.
+            Enforced against the deserialized card. Default: 256 KiB.
+        max_response_bytes: Maximum size of the returned response text in
+            bytes. Concatenated text parts beyond this cap are truncated.
+            Default: 256 KiB.
+        multiagent_depth_cap: Cap on the shared multi-agent recursion counter.
+            A parent that calls ``a2a_client`` counts as depth+1. The tool
+            refuses to run once the counter reaches the cap. Not propagated
+            across the wire — remote agents are opaque. Default: 3.
+
+    Returns:
+        A decorated tool that invokes a remote A2A agent.
+    """
+
+    @tool(name=name, description=description, context="tool_context")
+    async def a2a_client_tool(
+        url: str,
+        message: str,
+        tool_context: ToolContext,
+    ) -> A2AClientOutput:
+        """Invoke a remote A2A agent by URL.
+
+        Args:
+            url: HTTP(S) URL of the remote A2A agent (its base URL — the tool
+                appends the ``.well-known/agent-card.json`` path). Only public
+                hosts are permitted. Private, loopback, link-local, and cloud
+                metadata addresses are rejected.
+            message: Message to send to the remote agent. Capped at 64 KiB.
+            tool_context: Injected by the framework. Not user-facing.
+
+        Raises:
+            asyncio.CancelledError: Parent-agent cancellation. Because
+                ``CancelledError`` inherits from ``BaseException`` on Python
+                3.8+, it bypasses the tool wrapper's ``except Exception``
+                block and cancels the whole agent run — which is the
+                intended cancellation semantics, matching how the sibling
+                network tools behave.
+            TimeoutError: The total-invocation deadline elapsed before the
+                remote agent responded.
+            ValueError: Invalid input or a rejected URL (SSRF policy,
+                developer allowlist, size cap, or blocked hostname).
+        """
+        # A2A imports are optional. Fail with a clear error before we do anything else.
+        try:
+            from ...agent.a2a_agent import A2AAgent  # noqa: PLC0415
+        except ImportError as exc:  # pragma: no cover - environment-dependent
+            raise RuntimeError("a2a_client requires the 'a2a' extra: pip install 'strands-agents[a2a]'") from exc
+
+        # ---- Multiagent depth cap ----
+        # The a2a_client tool participates in the shared depth counter so an
+        # adversarial chain (use_agent -> a2a_client -> ...) still respects
+        # the cap. The counter can't be propagated across the wire; that's
+        # documented in `_multiagent_conventions.md`.
+        depth = int(tool_context.invocation_state.get("multiagent_depth", 0) or 0)
+        if depth >= multiagent_depth_cap:
+            raise ValueError(f"multiagent_depth={depth} exceeds cap {multiagent_depth_cap}")
+
+        # ---- Input validation ----
+        if not isinstance(message, str):
+            raise ValueError(f"message must be a string, got {type(message).__name__}")
+        message_bytes = len(message.encode("utf-8"))
+        if message_bytes > MAX_MESSAGE_BYTES:
+            raise ValueError(f"message is {message_bytes} bytes; limit is {MAX_MESSAGE_BYTES}")
+
+        try:
+            validate_url(url, allowed_prefixes=allowed_url_prefixes)
+        except UrlNotAllowedError as exc:
+            # Surface as ValueError so the SDK's tool wrapper formats it as a
+            # tool-level error rather than crashing the loop.
+            raise ValueError(str(exc)) from None
+
+        cancel_signal = getattr(tool_context.agent, "_cancel_signal", None)
+        if cancel_signal is not None and cancel_signal.is_set():
+            raise asyncio.CancelledError("cancelled before a2a_client started")
+
+        # ---- Run under a total-timeout budget ----
+        started_at = time.monotonic()
+        try:
+            return await asyncio.wait_for(
+                _invoke_remote(
+                    A2AAgent=A2AAgent,
+                    url=url,
+                    message=message,
+                    client_config=client_config,
+                    allowed_prefixes=allowed_url_prefixes,
+                    max_card_bytes=max_card_bytes,
+                    max_response_bytes=max_response_bytes,
+                    cancel_signal=cancel_signal,
+                    started_at=started_at,
+                ),
+                timeout=timeout_seconds,
+            )
+        except asyncio.TimeoutError as exc:
+            raise TimeoutError(f"a2a_client timed out after {timeout_seconds} seconds calling {url}") from exc
+
+    return a2a_client_tool
+
+
+a2a_client = make_a2a_client()
+"""Default ``a2a_client`` tool. No allowlist, no custom client config."""
+
+
+async def _invoke_remote(
+    *,
+    A2AAgent: type,  # noqa: N803 - class alias
+    url: str,
+    message: str,
+    client_config: ClientConfig | None,
+    allowed_prefixes: tuple[str, ...] | None,
+    max_card_bytes: int,
+    max_response_bytes: int,
+    cancel_signal: threading.Event | None = None,
+    started_at: float,
+) -> A2AClientOutput:
+    """Resolve the remote agent card, invoke it, and map the result.
+
+    Args:
+        A2AAgent: The ``A2AAgent`` class from ``strands.agent.a2a_agent``.
+        url: Pre-validated endpoint URL.
+        message: Pre-validated message.
+        client_config: Optional developer-supplied A2A client config.
+        allowed_prefixes: Optional developer allowlist; re-applied to the
+            card-advertised URL so the send target obeys the same bound as
+            the model-supplied URL.
+        max_card_bytes: Card size cap.
+        max_response_bytes: Response text cap.
+        cancel_signal: Optional parent ``threading.Event`` polled between the
+            card fetch and the send so a parent-agent cancellation aborts the
+            invocation before the outbound send.
+        started_at: ``time.monotonic()`` value captured before the tool
+            entered the timeout wrapper. Used to compute the reported
+            ``execution_time_ms``.
+
+    Returns:
+        The tool output.
+    """
+    remote = A2AAgent(endpoint=url, client_config=client_config)
+    card = await remote.get_agent_card()
+    _assert_card_within_size_limit(card, max_card_bytes)
+
+    # The card's own ``url`` may point at a different host than the endpoint we
+    # were given (agents are allowed to advertise a different preferred host).
+    # Re-run URL validation against the advertised URL so the send goes to a
+    # host that passes the same public-only checks. The developer allowlist is
+    # re-applied here: the send target is what the message actually reaches, so
+    # a pinned allowlist bounds it just as it bounds the model-supplied URL.
+    if card.url and card.url != url:
+        try:
+            validate_url(card.url, allowed_prefixes=allowed_prefixes)
+        except UrlNotAllowedError as exc:
+            raise ValueError(f"remote agent card points at disallowed url: {exc}") from None
+
+    if cancel_signal is not None and cancel_signal.is_set():
+        raise asyncio.CancelledError("cancelled before a2a_client send")
+
+    result = await remote.invoke_async(message)
+    text = _extract_text(result.message)
+    if len(text.encode("utf-8")) > max_response_bytes:
+        text = _truncate_utf8(text, max_response_bytes)
+
+    return A2AClientOutput(
+        status="success",
+        output=text,
+        execution_time_ms=int((time.monotonic() - started_at) * 1000),
+        remote_card=A2AClientRemoteCard(
+            name=card.name or "",
+            description=card.description or "",
+            url=card.url or url,
+        ),
+    )
+
+
+def _assert_card_within_size_limit(card: AgentCard, limit: int) -> None:
+    """Reject cards whose serialized form is larger than ``limit`` bytes.
+
+    Args:
+        card: The resolved agent card.
+        limit: Byte cap.
+
+    Raises:
+        ValueError: If the serialized card exceeds the limit.
+    """
+    try:
+        serialized = card.model_dump_json()
+    except Exception:  # pragma: no cover - defensive; fall back to repr
+        serialized = json.dumps(repr(card))
+    size = len(serialized.encode("utf-8"))
+    if size > limit:
+        raise ValueError(f"remote agent card is {size} bytes; limit is {limit}")
+
+
+def _extract_text(message: object) -> str:
+    """Concatenate text blocks from a Strands ``Message``-shaped dict.
+
+    Args:
+        message: The message payload from the remote agent (as an
+            ``AgentResult.message`` dict).
+
+    Returns:
+        Concatenated text. Empty string if no text content.
+    """
+    if not isinstance(message, dict):
+        return ""
+    content = message.get("content", [])
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for block in content:
+        if isinstance(block, dict) and isinstance(block.get("text"), str):
+            parts.append(block["text"])
+    return "".join(parts)
+
+
+def _truncate_utf8(text: str, max_bytes: int) -> str:
+    """Truncate ``text`` to at most ``max_bytes`` UTF-8 bytes without splitting a codepoint.
+
+    Args:
+        text: The string to truncate.
+        max_bytes: The byte cap.
+
+    Returns:
+        The truncated string with a ``... [truncated]`` suffix appended if
+        truncation occurred.
+    """
+    encoded = text.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return text
+    suffix = "... [truncated]"
+    suffix_bytes = len(suffix.encode("utf-8"))
+    budget = max(0, max_bytes - suffix_bytes)
+    truncated = encoded[:budget].decode("utf-8", errors="ignore")
+    return truncated + suffix

--- a/strands-py/src/strands/vended_tools/a2a_client/types.py
+++ b/strands-py/src/strands/vended_tools/a2a_client/types.py
@@ -1,0 +1,59 @@
+"""Shared types and constants for the a2a_client tool."""
+
+from __future__ import annotations
+
+from typing import Literal, TypedDict
+
+DEFAULT_A2A_CLIENT_DESCRIPTION = (
+    "Invokes a remote A2A (Agent-to-Agent) agent by URL. Resolves the agent card at the given "
+    "URL and sends a single message. Returns the remote agent's response as text. Only http(s) "
+    "URLs to public hosts are permitted; private/loopback/link-local addresses are rejected."
+)
+"""Description for the a2a_client tool."""
+
+# Cap on the raw agent-card bytes we accept before decoding.
+DEFAULT_MAX_CARD_BYTES = 256 * 1024
+
+# Cap on the size of the final response text we return to the model.
+DEFAULT_MAX_RESPONSE_BYTES = 256 * 1024
+
+# Cap on model-provided message input.
+MAX_MESSAGE_BYTES = 64 * 1024
+
+# Total wall-clock budget for a single invocation.
+DEFAULT_TIMEOUT_SECONDS = 60
+
+
+class A2AClientRemoteCard(TypedDict):
+    """Subset of the resolved remote agent card echoed back in the result."""
+
+    name: str
+    description: str
+    url: str
+
+
+class A2AClientOutput(TypedDict):
+    """Output of an a2a_client invocation.
+
+    Follows the shared multi-agent tool result shape defined in
+    ``_multiagent_conventions.md``: a top-level ``status`` / ``output`` /
+    ``execution_time_ms`` triple, plus a ``remote_card`` addendum describing
+    the resolved remote endpoint.
+
+    ``status`` is only ever ``"success"`` — the a2a_client tool raises
+    ``asyncio.CancelledError`` / ``TimeoutError`` on cancellation and timeout
+    rather than returning a ``"cancelled"`` variant, matching the other
+    network tools (``http_request``, ``web_fetch``). See the a2a_client
+    addendum in ``_multiagent_conventions.md`` for the rationale.
+
+    Attributes:
+        status: Result status. Always ``"success"`` on a normal return.
+        output: Text produced by the remote agent, concatenated from all text parts.
+        execution_time_ms: Total wall-clock time for the tool call, in milliseconds.
+        remote_card: Subset of the resolved remote agent card.
+    """
+
+    status: Literal["success"]
+    output: str
+    execution_time_ms: int
+    remote_card: A2AClientRemoteCard

--- a/strands-py/src/strands/vended_tools/a2a_client/url_guard.py
+++ b/strands-py/src/strands/vended_tools/a2a_client/url_guard.py
@@ -1,0 +1,212 @@
+"""URL validation for the a2a_client tool.
+
+Blocks the SSRF surface a model can steer via a URL: scheme allowlist,
+private/loopback/link-local/CGNAT/multicast/reserved IPs, cloud-metadata IPs,
+and ``.internal`` / ``.local`` names. Validation happens both on the initial URL
+and on every host we subsequently connect to (agent card URL, resolved-card
+``url``), because a remote card can point at a different host.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+# Hostnames whose DNS suffix we refuse outright. Cheaper than DNS resolution
+# and catches operators who put private services on `.internal` / `.local` /
+# `.corp` / `.home` even when those don't resolve to a private IP for us.
+_BLOCKED_HOST_SUFFIXES: tuple[str, ...] = (
+    ".internal",
+    ".local",
+    ".localhost",
+    ".corp",
+    ".home",
+    ".lan",
+    ".intranet",
+    ".private",
+    ".i2p",
+    ".onion",
+)
+
+# Bare-hostname denylist checked before DNS resolution. GCP's metadata server
+# answers on ``http://metadata/`` inside a VPC, and DNS may return any address
+# for ``metadata`` depending on the resolver — better to short-circuit on the
+# label alone.
+_BLOCKED_BARE_HOSTNAMES: frozenset[str] = frozenset({"metadata"})
+
+# Well-known cloud metadata addresses. Layered on top of the general
+# categorical checks so a future refactor that weakens a predicate doesn't
+# silently expose them.
+_BLOCKED_METADATA_ADDRESSES: frozenset[str] = frozenset(
+    {
+        "169.254.169.254",
+        "fd00:ec2::254",
+        "100.100.100.200",
+        "192.0.0.192",
+    }
+)
+
+
+class UrlNotAllowedError(ValueError):
+    """Raised when a URL fails validation before we make a network call."""
+
+
+def validate_url(url: str, allowed_prefixes: tuple[str, ...] | None = None) -> str:
+    """Validate a URL and return its resolved-safe host component for logging.
+
+    Enforces:
+
+    * http/https only,
+    * a non-empty hostname,
+    * hostname is not a bare metadata label (e.g. ``metadata``),
+    * hostname not on the blocked-suffix list,
+    * every DNS-resolved address is public — explicitly rejects private,
+      loopback, link-local, CGNAT, multicast, reserved, and unspecified
+      ranges (Python's ``is_global`` returns ``True`` for multicast on
+      3.10–3.14, so the categorical checks are layered on top),
+    * hostname not on the metadata address denylist,
+    * URL starts with one of ``allowed_prefixes`` if the caller passed a list.
+
+    Args:
+        url: The URL to check.
+        allowed_prefixes: Optional developer-supplied allowlist. When set,
+            ``url`` must start with one of these prefixes.
+
+    Returns:
+        The parsed hostname (lowercased, trailing dot stripped).
+
+    Raises:
+        UrlNotAllowedError: If the URL fails any check.
+    """
+    if not isinstance(url, str):
+        raise UrlNotAllowedError(f"url must be a string, got {type(url).__name__}")
+    if allowed_prefixes and not any(url.startswith(prefix) for prefix in allowed_prefixes):
+        raise UrlNotAllowedError(
+            f"url {url!r} is not in the developer-configured allowlist (expected one of {list(allowed_prefixes)!r})"
+        )
+
+    parsed = urlparse(url)
+    scheme = (parsed.scheme or "").lower()
+    if scheme not in ("http", "https"):
+        raise UrlNotAllowedError(f"url must use http or https, got scheme {scheme!r}")
+
+    host = (parsed.hostname or "").lower()
+    # Strip a trailing dot so `foo.internal.` is caught by the suffix check.
+    if host.endswith("."):
+        host = host[:-1]
+    if not host:
+        raise UrlNotAllowedError("url must include a hostname")
+
+    if host in _BLOCKED_BARE_HOSTNAMES:
+        # GCP's metadata server answers on `http://metadata/` inside a VPC;
+        # reject the label before we ever call getaddrinfo.
+        raise UrlNotAllowedError(f"hostname {host!r} is a cloud metadata label")
+
+    for suffix in _BLOCKED_HOST_SUFFIXES:
+        if host == suffix.lstrip(".") or host.endswith(suffix):
+            raise UrlNotAllowedError(f"hostname {host!r} matches blocked suffix {suffix!r}")
+
+    _assert_host_resolves_to_public_ips(host)
+    return host
+
+
+def _assert_host_resolves_to_public_ips(host: str) -> None:
+    """Resolve ``host`` and reject if any address is not globally routable.
+
+    If ``host`` is a bare IP literal we skip DNS and check it directly.
+
+    Args:
+        host: The hostname to resolve and validate.
+
+    Raises:
+        UrlNotAllowedError: If any resolved IP fails the public-only check,
+            or if the hostname cannot be resolved.
+    """
+    try:
+        literal = ipaddress.ip_address(host)
+    except ValueError:
+        literal = None
+
+    if literal is not None:
+        _assert_ip_is_public(literal)
+        return
+
+    try:
+        infos = socket.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as exc:
+        raise UrlNotAllowedError(f"could not resolve hostname {host!r}: {exc}") from exc
+
+    if not infos:
+        raise UrlNotAllowedError(f"hostname {host!r} resolved to no addresses")
+
+    seen: set[str] = set()
+    for info in infos:
+        raw_address = info[4][0]
+        address = str(raw_address)
+        if address in seen:
+            continue
+        seen.add(address)
+        _assert_ip_is_public(ipaddress.ip_address(address))
+
+
+def _assert_ip_is_public(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> None:
+    """Raise if ``ip`` is any flavor of non-global-unicast address.
+
+    Python's ``ipaddress.is_global`` returns ``True`` for both IPv4 and IPv6
+    multicast on every supported CPython (3.10-3.14), so ``not is_global``
+    alone is not sufficient — an attacker could point at ``239.255.255.250``
+    (SSDP) or ``ff02::1`` and reach neighbours the host expected to be
+    isolated from. We layer explicit ``is_multicast`` / ``is_reserved`` /
+    ``is_unspecified`` / ``is_link_local`` checks on top before consulting
+    ``is_global``.
+
+    Args:
+        ip: An ``IPv4Address`` or ``IPv6Address``.
+
+    Raises:
+        UrlNotAllowedError: If the IP is private, loopback, link-local, multicast,
+            reserved, unspecified, CGNAT, or a known cloud-metadata address.
+    """
+    # IPv4-mapped IPv6 (`::ffff:a.b.c.d`) — unwrap to the embedded IPv4 so the
+    # underlying v4 category (loopback, private, CGNAT, …) is what gets checked.
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+
+    if str(ip) in _BLOCKED_METADATA_ADDRESSES:
+        raise UrlNotAllowedError(f"ip {ip!s} is a cloud metadata address")
+
+    # Categorical checks that must run before `is_global` — see docstring.
+    if ip.is_multicast:
+        raise UrlNotAllowedError(f"ip {ip!s} is multicast")
+    if ip.is_unspecified:
+        raise UrlNotAllowedError(f"ip {ip!s} is unspecified")
+    if ip.is_link_local:
+        raise UrlNotAllowedError(f"ip {ip!s} is link-local")
+    if ip.is_reserved:
+        raise UrlNotAllowedError(f"ip {ip!s} is reserved")
+
+    if not ip.is_global:
+        # Emit a specific category label where possible so operators can tell
+        # the classes of rejection apart in logs.
+        category = _classify_non_global(ip)
+        raise UrlNotAllowedError(f"ip {ip!s} is {category}")
+
+
+def _classify_non_global(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> str:
+    """Return a human label for a non-global IP for use in error messages."""
+    if ip.is_loopback:
+        return "loopback"
+    if ip.is_link_local:
+        return "link-local"
+    if ip.is_multicast:
+        return "multicast"
+    if ip.is_unspecified:
+        return "unspecified"
+    if ip.is_reserved:
+        return "reserved"
+    if isinstance(ip, ipaddress.IPv4Address) and ip in ipaddress.IPv4Network("100.64.0.0/10"):
+        return "private (CGNAT)"
+    if ip.is_private:
+        return "private"
+    return "not globally routable"

--- a/strands-py/tests/strands/vended_tools/test_a2a_client.py
+++ b/strands-py/tests/strands/vended_tools/test_a2a_client.py
@@ -1,0 +1,532 @@
+"""Tests for the a2a_client vended tool.
+
+Covers the SSRF-facing surface (URL guard: schemes, private IPs, metadata IPs,
+blocked suffixes, DNS resolution) first, then oversized-input rejection, then
+the happy path against a mocked ``A2AAgent`` and card resolver.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from strands.agent.agent_result import AgentResult
+from strands.types.tools import ToolContext
+from strands.vended_tools.a2a_client import a2a_client, make_a2a_client
+from strands.vended_tools.a2a_client.url_guard import UrlNotAllowedError, validate_url
+
+
+def _tool_context() -> ToolContext:
+    """Build a minimal ToolContext for the a2a_client tool."""
+    agent = SimpleNamespace()
+    return ToolContext(
+        tool_use={"name": "a2a_client", "toolUseId": "id", "input": {}},
+        agent=agent,
+        invocation_state={},
+    )
+
+
+def _make_agent_card(url: str = "https://example.com", name: str = "remote", description: str = "d") -> MagicMock:
+    """Build a mock agent card with just the fields the tool reads."""
+    card = MagicMock()
+    card.url = url
+    card.name = name
+    card.description = description
+    card.model_dump_json = MagicMock(return_value=f'{{"url":"{url}","name":"{name}"}}')
+    return card
+
+
+def _make_agent_result(text: str = "hello from remote", stop_reason: str = "end_turn") -> AgentResult:
+    """Build a minimal AgentResult with a single text block."""
+    return AgentResult(
+        stop_reason=stop_reason,  # type: ignore[arg-type]
+        message={"role": "assistant", "content": [{"text": text}]},
+        metrics=MagicMock(),
+        state={},
+    )
+
+
+# =====================================================================
+# URL guard — SSRF surface
+# =====================================================================
+
+
+class TestUrlGuard:
+    """Standalone tests for the ``validate_url`` helper."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "ftp://example.com",
+            "file:///etc/passwd",
+            "javascript:alert(1)",
+            "gopher://example.com",
+            "",
+        ],
+    )
+    def test_rejects_non_http_schemes(self, url):
+        with pytest.raises(UrlNotAllowedError):
+            validate_url(url)
+
+    def test_rejects_non_string(self):
+        with pytest.raises(UrlNotAllowedError):
+            validate_url(None)  # type: ignore[arg-type]
+
+    def test_rejects_missing_hostname(self):
+        with pytest.raises(UrlNotAllowedError, match="hostname"):
+            validate_url("http:///path")
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://127.0.0.1",
+            "http://127.1.2.3",
+            "http://[::1]",
+            "http://localhost",
+            "https://LOCALHOST",
+        ],
+    )
+    def test_rejects_loopback(self, url):
+        with pytest.raises(UrlNotAllowedError):
+            validate_url(url)
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://10.0.0.1",
+            "http://192.168.1.1",
+            "http://172.16.0.1",
+        ],
+    )
+    def test_rejects_rfc1918_ips(self, url):
+        with pytest.raises(UrlNotAllowedError):
+            validate_url(url)
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://169.254.169.254/latest/meta-data/",
+            "http://169.254.169.254",
+        ],
+    )
+    def test_rejects_metadata_ip(self, url):
+        with pytest.raises(UrlNotAllowedError):
+            validate_url(url)
+
+    def test_rejects_link_local(self):
+        with pytest.raises(UrlNotAllowedError, match="link-local"):
+            validate_url("http://169.254.1.1")
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://foo.internal",
+            "http://bar.corp",
+            "http://svc.local",
+            "http://api.home",
+        ],
+    )
+    def test_rejects_blocked_suffixes(self, url):
+        with pytest.raises(UrlNotAllowedError):
+            validate_url(url)
+
+    def test_allows_public_dns_name(self):
+        # Use a hostname that reliably resolves to a public IP.
+        with patch("socket.getaddrinfo", return_value=[(0, 0, 0, "", ("93.184.216.34", 0))]):
+            host = validate_url("https://example.com")
+            assert host == "example.com"
+
+    def test_allows_public_ip_literal(self):
+        host = validate_url("https://8.8.8.8")
+        assert host == "8.8.8.8"
+
+    def test_rejects_when_dns_resolves_to_private_ip(self):
+        with patch("socket.getaddrinfo", return_value=[(0, 0, 0, "", ("10.0.0.1", 0))]):
+            with pytest.raises(UrlNotAllowedError, match="private"):
+                validate_url("https://sneaky.example.com")
+
+    def test_rejects_when_dns_returns_no_addresses(self):
+        with patch("socket.getaddrinfo", return_value=[]):
+            with pytest.raises(UrlNotAllowedError, match="resolved to no addresses"):
+                validate_url("https://empty.example.com")
+
+    def test_rejects_when_dns_fails(self):
+        import socket as _socket
+
+        with patch("socket.getaddrinfo", side_effect=_socket.gaierror("nope")):
+            with pytest.raises(UrlNotAllowedError, match="could not resolve"):
+                validate_url("https://nx.example.com")
+
+    def test_developer_allowlist_admits_matching_prefix(self):
+        with patch("socket.getaddrinfo", return_value=[(0, 0, 0, "", ("93.184.216.34", 0))]):
+            host = validate_url(
+                "https://api.example.com/v1/agent",
+                allowed_prefixes=("https://api.example.com/",),
+            )
+            assert host == "api.example.com"
+
+    def test_developer_allowlist_rejects_non_matching_prefix(self):
+        with pytest.raises(UrlNotAllowedError, match="allowlist"):
+            validate_url(
+                "https://evil.example.com",
+                allowed_prefixes=("https://api.example.com/",),
+            )
+
+    def test_rejects_cgnat(self):
+        with pytest.raises(UrlNotAllowedError, match="CGNAT"):
+            validate_url("http://100.64.0.1")
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            # Python's `is_global` returns True for multicast on 3.10-3.14,
+            # so these must be rejected explicitly by the guard's own checks
+            # rather than falling through to the `is_global` branch.
+            "http://239.255.255.250",  # SSDP
+            "http://224.0.0.1",
+            "http://[ff02::1]",
+        ],
+    )
+    def test_rejects_multicast_ip_literals(self, url):
+        with pytest.raises(UrlNotAllowedError, match="multicast"):
+            validate_url(url)
+
+    def test_rejects_bare_metadata_hostname(self):
+        # GCP: `http://metadata/` inside a VPC resolves to the metadata server.
+        # We reject the label before ever calling getaddrinfo.
+        with pytest.raises(UrlNotAllowedError, match="metadata label"):
+            validate_url("http://metadata")
+        with pytest.raises(UrlNotAllowedError, match="metadata label"):
+            validate_url("http://METADATA/some/path")
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://[::ffff:127.0.0.1]",
+            "http://[::ffff:10.0.0.1]",
+            "http://[::ffff:169.254.169.254]",
+        ],
+    )
+    def test_rejects_ipv4_mapped_ipv6(self, url):
+        with pytest.raises(UrlNotAllowedError):
+            validate_url(url)
+
+    def test_strips_trailing_dot_before_suffix_match(self):
+        with pytest.raises(UrlNotAllowedError, match="blocked suffix"):
+            validate_url("http://foo.internal.")
+
+
+# =====================================================================
+# Tool: input validation + oversize rejection
+# =====================================================================
+
+
+class TestToolInputValidation:
+    @pytest.mark.asyncio
+    async def test_rejects_non_http_url(self):
+        with pytest.raises(ValueError, match="scheme"):
+            await a2a_client(
+                url="ftp://example.com",
+                message="hi",
+                tool_context=_tool_context(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_private_ip(self):
+        with pytest.raises(ValueError, match="private"):
+            await a2a_client(
+                url="http://192.168.1.1",
+                message="hi",
+                tool_context=_tool_context(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_metadata_ip(self):
+        with pytest.raises(ValueError):
+            await a2a_client(
+                url="http://169.254.169.254",
+                message="hi",
+                tool_context=_tool_context(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_oversized_message(self):
+        big = "x" * (64 * 1024 + 1)
+        with pytest.raises(ValueError, match="limit is"):
+            await a2a_client(
+                url="https://example.com",
+                message=big,
+                tool_context=_tool_context(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_string_message(self):
+        with pytest.raises(ValueError, match="string"):
+            await a2a_client(
+                url="https://example.com",
+                message=123,  # type: ignore[arg-type]
+                tool_context=_tool_context(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_developer_allowlist_rejects_off_list_url(self):
+        tool = make_a2a_client(allowed_url_prefixes=("https://api.example.com/",))
+        with pytest.raises(ValueError, match="allowlist"):
+            await tool(
+                url="https://other.example.com",
+                message="hi",
+                tool_context=_tool_context(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_when_multiagent_depth_at_cap(self):
+        ctx = _tool_context()
+        ctx.invocation_state["multiagent_depth"] = 3
+        with pytest.raises(ValueError, match="multiagent_depth=3"):
+            await a2a_client(url="https://example.com", message="hi", tool_context=ctx)
+
+    @pytest.mark.asyncio
+    async def test_rejects_when_parent_cancel_signal_is_set(self):
+        import threading
+
+        ctx = _tool_context()
+        cancel = threading.Event()
+        cancel.set()
+        ctx.agent._cancel_signal = cancel
+        with patch("socket.getaddrinfo", return_value=[(0, 0, 0, "", ("93.184.216.34", 0))]):
+            with pytest.raises(asyncio.CancelledError):
+                await a2a_client(url="https://example.com", message="hi", tool_context=ctx)
+
+
+# =====================================================================
+# Tool: oversize card / response
+# =====================================================================
+
+
+class TestOversizeGuard:
+    @pytest.mark.asyncio
+    async def test_rejects_oversized_card(self):
+        big_card = _make_agent_card(url="https://example.com")
+        big_card.model_dump_json = MagicMock(return_value="x" * (300 * 1024))
+
+        with patch("socket.getaddrinfo", return_value=[(0, 0, 0, "", ("93.184.216.34", 0))]):
+            with patch("strands.agent.a2a_agent.A2AAgent", autospec=True) as mock_agent_cls:
+                mock_agent = MagicMock()
+                mock_agent.get_agent_card = AsyncMock(return_value=big_card)
+                mock_agent.invoke_async = AsyncMock(return_value=_make_agent_result())
+                mock_agent_cls.return_value = mock_agent
+
+                with pytest.raises(ValueError, match="agent card is"):
+                    await a2a_client(
+                        url="https://example.com",
+                        message="hi",
+                        tool_context=_tool_context(),
+                    )
+
+    @pytest.mark.asyncio
+    async def test_truncates_oversized_response(self):
+        card = _make_agent_card()
+        long_text = "y" * (300 * 1024)
+        result = _make_agent_result(text=long_text)
+
+        with patch("socket.getaddrinfo", return_value=[(0, 0, 0, "", ("93.184.216.34", 0))]):
+            with patch("strands.agent.a2a_agent.A2AAgent", autospec=True) as mock_agent_cls:
+                mock_agent = MagicMock()
+                mock_agent.get_agent_card = AsyncMock(return_value=card)
+                mock_agent.invoke_async = AsyncMock(return_value=result)
+                mock_agent_cls.return_value = mock_agent
+
+                out = await a2a_client(
+                    url="https://example.com",
+                    message="hi",
+                    tool_context=_tool_context(),
+                )
+                assert out["output"].endswith("... [truncated]")
+                assert len(out["output"].encode("utf-8")) <= 256 * 1024
+
+    @pytest.mark.asyncio
+    async def test_rejects_when_card_url_points_to_private_host(self):
+        card = _make_agent_card(url="http://10.0.0.1")
+
+        with patch("socket.getaddrinfo", return_value=[(0, 0, 0, "", ("93.184.216.34", 0))]):
+            with patch("strands.agent.a2a_agent.A2AAgent", autospec=True) as mock_agent_cls:
+                mock_agent = MagicMock()
+                mock_agent.get_agent_card = AsyncMock(return_value=card)
+                mock_agent.invoke_async = AsyncMock(return_value=_make_agent_result())
+                mock_agent_cls.return_value = mock_agent
+
+                with pytest.raises(ValueError, match="disallowed url"):
+                    await a2a_client(
+                        url="https://example.com",
+                        message="hi",
+                        tool_context=_tool_context(),
+                    )
+
+    @pytest.mark.asyncio
+    async def test_rejects_when_card_url_falls_outside_developer_allowlist(self):
+        # Developer pins the tool to one remote; the remote's card advertises a
+        # different public host. The allowlist is re-applied to `card.url`, so
+        # the send is rejected even though the advertised host would pass the
+        # SSRF checks on its own.
+        tool = make_a2a_client(allowed_url_prefixes=("https://agents.example.com/",))
+        card = _make_agent_card(url="https://other.example.com/")
+
+        with patch("socket.getaddrinfo", return_value=[(0, 0, 0, "", ("93.184.216.34", 0))]):
+            with patch("strands.agent.a2a_agent.A2AAgent", autospec=True) as mock_agent_cls:
+                mock_agent = MagicMock()
+                mock_agent.get_agent_card = AsyncMock(return_value=card)
+                mock_agent.invoke_async = AsyncMock(return_value=_make_agent_result())
+                mock_agent_cls.return_value = mock_agent
+
+                with pytest.raises(ValueError, match="disallowed url"):
+                    await tool(
+                        url="https://agents.example.com/one",
+                        message="hi",
+                        tool_context=_tool_context(),
+                    )
+                # The message must not have been sent.
+                mock_agent.invoke_async.assert_not_called()
+
+
+# =====================================================================
+# Tool: happy path
+# =====================================================================
+
+
+class TestHappyPath:
+    @pytest.mark.asyncio
+    async def test_returns_response_and_agent_info(self):
+        card = _make_agent_card(url="https://example.com", name="remote-agent", description="A test agent")
+        result = _make_agent_result(text="hello from remote")
+
+        with patch("socket.getaddrinfo", return_value=[(0, 0, 0, "", ("93.184.216.34", 0))]):
+            with patch("strands.agent.a2a_agent.A2AAgent", autospec=True) as mock_agent_cls:
+                mock_agent = MagicMock()
+                mock_agent.get_agent_card = AsyncMock(return_value=card)
+                mock_agent.invoke_async = AsyncMock(return_value=result)
+                mock_agent_cls.return_value = mock_agent
+
+                out = await a2a_client(
+                    url="https://example.com",
+                    message="hi remote",
+                    tool_context=_tool_context(),
+                )
+
+                assert out["status"] == "success"
+                assert out["output"] == "hello from remote"
+                assert out["remote_card"] == {
+                    "name": "remote-agent",
+                    "description": "A test agent",
+                    "url": "https://example.com",
+                }
+                assert isinstance(out["execution_time_ms"], int)
+                assert out["execution_time_ms"] >= 0
+                mock_agent_cls.assert_called_once_with(endpoint="https://example.com", client_config=None)
+                mock_agent.invoke_async.assert_awaited_once_with("hi remote")
+
+    @pytest.mark.asyncio
+    async def test_passes_developer_client_config(self):
+        card = _make_agent_card()
+        result = _make_agent_result()
+        sentinel_config = object()  # ClientConfig is not needed for equality; identity is enough
+        tool = make_a2a_client(client_config=sentinel_config)  # type: ignore[arg-type]
+
+        with patch("socket.getaddrinfo", return_value=[(0, 0, 0, "", ("93.184.216.34", 0))]):
+            with patch("strands.agent.a2a_agent.A2AAgent", autospec=True) as mock_agent_cls:
+                mock_agent = MagicMock()
+                mock_agent.get_agent_card = AsyncMock(return_value=card)
+                mock_agent.invoke_async = AsyncMock(return_value=result)
+                mock_agent_cls.return_value = mock_agent
+
+                await tool(url="https://example.com", message="hi", tool_context=_tool_context())
+
+                mock_agent_cls.assert_called_once_with(
+                    endpoint="https://example.com",
+                    client_config=sentinel_config,
+                )
+
+
+# =====================================================================
+# Tool: timeout + cancellation
+# =====================================================================
+
+
+class TestTimeoutAndCancellation:
+    @pytest.mark.asyncio
+    async def test_total_timeout_propagates_as_timeout_error(self):
+        card = _make_agent_card()
+
+        async def _slow_invoke(*_a, **_kw):
+            await asyncio.sleep(1)
+            return _make_agent_result()
+
+        tool = make_a2a_client(timeout_seconds=0.05)
+
+        with patch("socket.getaddrinfo", return_value=[(0, 0, 0, "", ("93.184.216.34", 0))]):
+            with patch("strands.agent.a2a_agent.A2AAgent", autospec=True) as mock_agent_cls:
+                mock_agent = MagicMock()
+                mock_agent.get_agent_card = AsyncMock(return_value=card)
+                mock_agent.invoke_async = _slow_invoke
+                mock_agent_cls.return_value = mock_agent
+
+                with pytest.raises(TimeoutError, match="timed out"):
+                    await tool(
+                        url="https://example.com",
+                        message="hi",
+                        tool_context=_tool_context(),
+                    )
+
+    @pytest.mark.asyncio
+    async def test_cancels_underlying_invoke(self):
+        # Simulate the underlying invoke being cancelled: asyncio.wait_for
+        # should surface CancelledError-ish behavior as TimeoutError only after
+        # the deadline. Test that if the underlying call raises CancelledError
+        # directly, it propagates.
+        card = _make_agent_card()
+
+        async def _cancelled_invoke(*_a, **_kw):
+            raise asyncio.CancelledError()
+
+        with patch("socket.getaddrinfo", return_value=[(0, 0, 0, "", ("93.184.216.34", 0))]):
+            with patch("strands.agent.a2a_agent.A2AAgent", autospec=True) as mock_agent_cls:
+                mock_agent = MagicMock()
+                mock_agent.get_agent_card = AsyncMock(return_value=card)
+                mock_agent.invoke_async = _cancelled_invoke
+                mock_agent_cls.return_value = mock_agent
+
+                with pytest.raises(asyncio.CancelledError):
+                    await a2a_client(
+                        url="https://example.com",
+                        message="hi",
+                        tool_context=_tool_context(),
+                    )
+
+
+# =====================================================================
+# Tool metadata
+# =====================================================================
+
+
+class TestToolMetadata:
+    def test_default_name(self):
+        assert a2a_client.tool_name == "a2a_client"
+
+    def test_custom_name(self):
+        assert make_a2a_client(name="remote_agent").tool_name == "remote_agent"
+
+    def test_schema_advertises_url_and_message(self):
+        props = a2a_client.tool_spec["inputSchema"]["json"]["properties"]
+        assert "url" in props
+        assert "message" in props
+        # tool_context is injected by the framework, not part of the model-facing schema.
+        assert "tool_context" not in props
+
+    def test_schema_omits_dev_only_fields(self):
+        # Auth material, allowlists, and caps live on the factory, not on
+        # the model-facing schema.
+        props = a2a_client.tool_spec["inputSchema"]["json"]["properties"]
+        for hidden in ("client_config", "allowed_url_prefixes", "timeout_seconds"):
+            assert hidden not in props

--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -68,6 +68,10 @@
       "types": "./dist/src/vended-tools/bash/index.d.ts",
       "default": "./dist/src/vended-tools/bash/index.js"
     },
+    "./vended-tools/a2a-client": {
+      "types": "./dist/src/vended-tools/a2a-client/index.d.ts",
+      "default": "./dist/src/vended-tools/a2a-client/index.js"
+    },
     "./a2a": {
       "types": "./dist/src/a2a/index.d.ts",
       "default": "./dist/src/a2a/index.js"

--- a/strands-ts/src/a2a/__tests__/a2a-agent.test.ts
+++ b/strands-ts/src/a2a/__tests__/a2a-agent.test.ts
@@ -27,6 +27,11 @@ vi.mock('@a2a-js/sdk/client', () => ({
       }
     }
   },
+  // `A2AAgent` imports these to construct the default factory when a
+  // `fetchImpl` is supplied; tests here don't set one, but the mock must
+  // export the names to satisfy the module's static imports.
+  DefaultAgentCardResolver: class MockDefaultAgentCardResolver {},
+  JsonRpcTransportFactory: class MockJsonRpcTransportFactory {},
 }))
 
 const mockAgentCard: AgentCard = {

--- a/strands-ts/src/a2a/a2a-agent.ts
+++ b/strands-ts/src/a2a/a2a-agent.ts
@@ -9,7 +9,7 @@
 
 import type { AgentCard, Part } from '@a2a-js/sdk'
 import type { Client as A2AClientSdk, ClientFactory as ClientFactoryType } from '@a2a-js/sdk/client'
-import { ClientFactory } from '@a2a-js/sdk/client'
+import { ClientFactory, DefaultAgentCardResolver, JsonRpcTransportFactory } from '@a2a-js/sdk/client'
 import type { InvocationState, InvokableAgent, InvokeArgs, InvokeOptions } from '../types/agent.js'
 import { AgentResult } from '../types/agent.js'
 import { Message, TextBlock, type ContentBlock, type ContentBlockData, type MessageData } from '../types/messages.js'
@@ -33,6 +33,13 @@ export interface A2AAgentConfig {
   description?: string
   /** Optional custom A2A ClientFactory for authenticating requests (e.g. SigV4, bearer token). */
   clientFactory?: ClientFactoryType
+  /**
+   * Optional custom `fetch` implementation for both agent-card discovery and
+   * message transport. Ignored when `clientFactory` is set (the developer is
+   * expected to have wired their own fetch into the factory). Useful for
+   * tools that need to interpose SSRF/redirect guards on every hop.
+   */
+  fetchImpl?: typeof globalThis.fetch
 }
 
 /**
@@ -164,6 +171,45 @@ export class A2AAgent implements InvokableAgent {
   }
 
   /**
+   * Resolves and caches the remote agent card.
+   *
+   * Opens the underlying A2A client (lazily on first use) which fetches the
+   * agent card from the well-known path and caches it. Tools that need to
+   * inspect the card *before* sending a message (SSRF re-check of
+   * `card.url`, for example) should call this first.
+   *
+   * @returns The resolved agent card.
+   */
+  async getAgentCard(): Promise<AgentCard> {
+    await this._getClient()
+    // `_getClient` populates `_agentCard` from `client.getAgentCard()`; if it
+    // came back undefined the underlying SDK contract has been broken.
+    if (!this._agentCard) {
+      throw new Error(`A2AAgent failed to resolve an agent card at ${this._config.url}`)
+    }
+    return this._agentCard
+  }
+
+  /**
+   * Builds the default `ClientFactory` for this agent, threading the
+   * developer-supplied `fetchImpl` (if any) into both the card resolver and
+   * the JSON-RPC transport so every outbound request goes through the same
+   * hook. Called only when `clientFactory` was not supplied.
+   *
+   * @returns A ClientFactory configured for this agent.
+   */
+  private _buildDefaultClientFactory(): ClientFactoryType {
+    const fetchImpl = this._config.fetchImpl
+    if (!fetchImpl) {
+      return new ClientFactory()
+    }
+    return new ClientFactory({
+      transports: [new JsonRpcTransportFactory({ fetchImpl })],
+      cardResolver: new DefaultAgentCardResolver({ fetchImpl }),
+    })
+  }
+
+  /**
    * Returns the cached A2A SDK client, creating one lazily on first use.
    * Also fetches and caches the agent card for name/description.
    *
@@ -176,7 +222,7 @@ export class A2AAgent implements InvokableAgent {
 
     logExperimentalWarning()
 
-    const factory = this._config.clientFactory ?? new ClientFactory()
+    const factory = this._config.clientFactory ?? this._buildDefaultClientFactory()
     const client = await factory.createFromUrl(this._config.url, this._config.agentCardPath)
     this._agentCard = await client.getAgentCard()
     if (this.name === undefined && this._agentCard?.name) {

--- a/strands-ts/src/vended-tools/_multiagent-conventions.md
+++ b/strands-ts/src/vended-tools/_multiagent-conventions.md
@@ -1,0 +1,122 @@
+# Multi-agent conventions for vended tools
+
+This document defines the dialect shared by the multi-agent vended tools: `use_agent`, `swarm`, `graph`, and `a2a_client`. Every tool in scope must implement it. If a tool cannot, its addendum records the deviation and the rationale.
+
+## Agent spec
+
+Every child-agent-defining tool accepts agent specs with the same shape:
+
+```
+{
+    name: str,          # required, [a-zA-Z_][a-zA-Z0-9_]{0,63}
+    system_prompt: str, # required, <= 8 KiB
+    tools: [str, ...],  # allow-list of parent-registered tool names
+                        # required (may be empty for a no-tool child)
+                        # no wildcards, no `"*"`, no glob patterns
+                        # unknown names are rejected at the boundary
+}
+```
+
+**No `model_provider` / `model_settings` field.** Children inherit the parent's model instance. Rationale: model-selection at spec time is a credential-injection surface — provider constructors accept `api_key`, `client_args`, `endpoint_url`, `base_url`, which a compromised model can supply to route to attacker-controlled endpoints or bill an attacker's account. The convenience of per-child model choice does not offset that surface. If a developer wants child-model variance they can register N pre-configured factories rather than exposing model config to the model.
+
+Tools that historically exposed model configuration on their agent-spec input must remove that surface before conforming.
+
+## Recursion depth
+
+Every multi-agent tool participates in a single shared depth counter tracked on the parent's `invocation_state`:
+
+- Python: `invocation_state["multiagent_depth"]`
+- TypeScript: `invocationState.multiagentDepth`
+
+Default cap: **3.** Configurable at tool construction only, never by the model.
+
+At the tool's entry point:
+
+1. Read the current depth from `invocation_state` (default 0 if absent).
+2. If `depth >= cap`, reject with a specific `MultiagentDepthExceeded` error.
+3. Construct the child's `invocation_state` with `multiagent_depth = depth + 1` and pass it into `Agent.invoke_async` (py) / `agent.invoke({ invocationState })` (ts).
+
+If a tool skips step 3, an adversarial model can walk `use_agent → swarm → use_agent` and reset the counter at each hop. All four must participate.
+
+## Tool allow-list
+
+Every agent spec's `tools` field is an explicit name allow-list from the parent's registry:
+
+- Names are matched exactly, case-sensitive.
+- Unknown names are rejected at the boundary before construction.
+- No wildcards, no glob patterns, no "all my tools" shortcut.
+- Multi-agent tools (`use_agent`, `swarm`, `graph`, `a2a_client`) may not be listed in a child's tools (defense-in-depth against tool-registered-then-recursed patterns that bypass the depth cap). Reject them explicitly.
+
+If a caller wants the child to have the multi-agent tools, they can register variants themselves at construction time; the model can't grant that authority.
+
+## Result shape
+
+All four tools return a result dict with this minimum shape:
+
+```
+{
+    status: "success" | "error" | "cancelled",
+    output: str,               # the primary textual answer
+    execution_time_ms: int,    # total wall-clock
+}
+```
+
+Extended fields (each tool may add its own — should be additive, not renaming):
+
+- `swarm`: `node_history: list[str]`, `execution_count: int`, `usage: {input_tokens, output_tokens}`
+- `graph`: `execution_order: list[str]`, `results: {node_id: {status, output}}` (per-node; the top-level `output` is the terminal node's output or a concatenation)
+- `use_agent`: no additional fields required (single child)
+- `a2a_client`: `remote_card: {name, description, ...}` (subset of the resolved agent card)
+
+The tools may return richer shapes but must keep `status`, `output`, `execution_time_ms` at the top level so downstream models get a consistent contract regardless of which pattern they invoke.
+
+Field names are written in Python `snake_case` in this document. Each SDK renders them in its own convention per the root `AGENTS.md` cross-SDK parity rule: Python keeps `snake_case` (`execution_time_ms`, `remote_card`) and TypeScript renders `camelCase` (`executionTimeMs`, `remoteCard`). The `status` and `output` string literals stay byte-identical across SDKs.
+
+## Cancellation
+
+Parent cancellation must propagate to the child(ren) within 100 ms:
+
+- Python: poll `parent_agent._cancel_signal.is_set()` at the tool's supervision level (a 50 ms loop is fine) and call `child.cancel()` when set. For multi-child tools (swarm/graph), the SDK's `BeforeNodeCallEvent` hook is the correct extension point — set `event.cancel_node` when the parent is cancelled.
+- TypeScript: forward `agent.cancelSignal` into `Agent.invoke(..., { cancelSignal })` and into any transport-level `AbortSignal` the child holds. `AbortSignal.any([parent, timeout])` is the standard composition.
+
+On cancellation, the tool returns `{status: "cancelled", output: "<partial or empty>", execution_time_ms}` — it does not raise past the tool boundary. A cancelled tool result reaching the loop is a signal to the parent to stop, not an exception to propagate. (The `a2a_client` addendum below documents an explicit deviation from this rule; the other three tools follow it as written.)
+
+## Size caps
+
+At the tool boundary, before constructing anything:
+
+- `system_prompt`: 8 KiB per spec
+- `task` / `initial_input`: 32 KiB
+- `name`: 64 chars (regex above)
+- `tools` list: 64 entries max
+- Number of agents (swarm, graph nodes): 20 max
+- Number of edges (graph): 40 max
+- Total execution time: 300 s wall-clock
+
+These are hard caps, factory-configurable but not model-controllable.
+
+## Conformance notes per tool
+
+- `graph` and `swarm` participate in the shared `multiagent_depth` counter and enforce the size caps at their tool boundary. Cancellation flows through the SDK's before-node hook so a parent-cancelled run stops promptly at the next node boundary rather than raising.
+- `use_agent` invokes a single child; the child's `invocation_state` is constructed with `multiagent_depth = depth + 1` so nested calls respect the cap. No model-controllable model-selection surface is exposed.
+- `a2a_client` reads and enforces the depth cap at the tool boundary. It does not spawn a local child agent, so there is nothing to increment into: the counter guard is one-way for this tool, and the addendum below documents the wire-boundary limitation.
+
+---
+
+## `a2a_client` addendum
+
+The `a2a_client` tool invokes a **remote** A2A agent instead of constructing a child locally. Most fields in the agent spec are inapplicable (the remote picks its own model, prompt, and tools at deploy time). The tool receives a `url` + `message` from the model rather than an agent spec.
+
+- **Model dialect** (`model_provider`, `model_settings`, `system_prompt`): not applicable — the remote agent chose these at deploy time. The model has no say.
+- **Task input**: passed as `message` (not `task`) to match A2A protocol terminology. Capped at 64 KiB.
+- **Tool allow-list**: not applicable — the remote agent brings its own tools; the parent's registry is invisible to it.
+- **URL allow-list**: `allowed_url_prefixes` / `allowedUrlPrefixes` set at construction time (developer, never the model). If unset, only SSRF checks apply. The allowlist is re-applied to the card-advertised URL, so a remote that resolves to a public host outside the allowlist is rejected before the message is sent. On TypeScript the allowlist is also re-applied to every hop the guarded fetch walks, so a 3xx from an allowlisted origin cannot steer the client onto an off-list public host.
+- **Redirect handling**:
+  - TypeScript: the tool wraps the underlying A2A SDK's fetch (`makeGuardedFetch`) with `redirect: 'manual'`, re-runs the URL guard and allowlist on every hop, caps at five hops, and strips `Authorization` / `Cookie` / `Proxy-Authorization` on any cross-origin change (compared on full origin, not host).
+  - Python: the underlying A2A SDK uses httpx, which defaults `follow_redirects=False`. Redirects are therefore not walked by default; a 3xx surfaces to the caller. Developers who supply their own `httpx_client` in `client_config` own the redirect discipline. There is no per-hop guard equivalent to the TypeScript wrapper on Python today; that parity is a follow-up if a use case emerges.
+- **Recursion depth**:
+  - The tool participates in the shared counter at the **local boundary**: a parent that calls `a2a_client` counts as depth+1, so a chain of `use_agent → a2a_client → ...` still respects the cap.
+  - The counter is **not propagated across the wire**. The remote agent is opaque — the tool has no way to write into its `invocation_state`, and the remote may not even be a Strands agent. Depth resets from the remote's perspective; that's an accepted limitation of the network boundary.
+- **Cancellation** (deviation from the shared spec): parent cancellation and total-timeout both **raise past the tool boundary** — `asyncio.CancelledError` / `TimeoutError` on Python, `DOMException` with `name === 'AbortError'` on TypeScript — rather than returning `status: "cancelled"`. Rationale: `a2a_client` is a network tool, not a child-agent supervisor. Its sibling network tools (`http_request`, `web_fetch`) raise cancellation the same way, and callers already special-case `AbortError` to distinguish it from other failures. Result-shape cancellation would need a new `status: 'cancelled'` variant that no existing caller reads. This is an accepted local divergence; the other three multi-agent tools continue to return the shaped result.
+- **Result shape**: `{"status": "success", "output": str, "execution_time_ms": int, "remote_card": {"name", "description", "url"}}`. The top-level triple matches the shared multi-agent contract; `remote_card` mirrors a subset of the resolved agent card so the parent can distinguish remote endpoints. `status` is `Literal["success"]` on the success path; cancellation and timeout raise rather than populate a `cancelled` variant (see above).
+- **Size caps as memory guard, not DoS defense**: `max_card_bytes` and `max_response_bytes` are enforced _after_ the underlying A2A SDK has fetched and materialized the body. They bound what the model sees, not what the process reads into memory. A malicious server can still stream a large body before the cap fires; fronting the tool with an egress-side response-size limit is the mitigation.

--- a/strands-ts/src/vended-tools/a2a-client/README.md
+++ b/strands-ts/src/vended-tools/a2a-client/README.md
@@ -1,0 +1,91 @@
+# A2A Client Tool
+
+Invokes a remote A2A (Agent-to-Agent) agent from a Strands agent. Thin shim
+over the built-in `A2AAgent` client with hardening at the tool boundary: the
+underlying client has no SSRF or size guard of its own, so scheme, host, size,
+redirect, and timeout checks all live here.
+
+## Usage
+
+```typescript
+import { Agent } from '@strands-agents/sdk'
+import { a2aClient } from '@strands-agents/sdk/vended-tools/a2a-client'
+
+const agent = new Agent({ tools: [a2aClient] })
+await agent.invoke('Ask the remote agent at https://agents.example.com to summarize X.')
+```
+
+A customized instance binds URL prefixes, a shorter timeout, or a
+developer-supplied client factory that carries auth:
+
+```typescript
+import { makeA2AClient } from '@strands-agents/sdk/vended-tools/a2a-client'
+import { ClientFactory } from '@a2a-js/sdk/client'
+
+const boundedClient = makeA2AClient({
+  allowedUrlPrefixes: ['https://agents.example.com/'],
+  timeoutSeconds: 30,
+  agentConfig: {
+    clientFactory: new ClientFactory(),
+  },
+})
+```
+
+## Input and output
+
+| Property  | Type     | Required | Description                                    |
+| --------- | -------- | -------- | ---------------------------------------------- |
+| `url`     | `string` | Yes      | Base URL of the remote A2A agent (http/https). |
+| `message` | `string` | Yes      | Message to send. Capped at 64 KiB.             |
+
+The tool returns the shared multi-agent result shape:
+
+```typescript
+{
+  status: 'success'
+  output: string // remote agent's response text, truncated at 256 KiB
+  executionTimeMs: number
+  remoteCard: {
+    name: string // resolved from the agent card
+    description: string
+    url: string
+  }
+}
+```
+
+Cancellation and timeout surface as `DOMException` with `name === 'AbortError'`,
+matching the other Strands network tools.
+
+## Non-obvious behavior
+
+- Only `http:` and `https:` URLs are accepted. Hostnames are DNS-resolved
+  before the request goes out; any address that is loopback, private,
+  CGNAT, link-local (including the AWS/GCP metadata IPs), multicast,
+  reserved, or unspecified is rejected. Reserved DNS suffixes such as
+  `.internal`, `.local`, `.corp`, `.home` are blocked outright.
+- Fetch is wrapped so every redirect hop (card discovery included) re-runs
+  the URL guard, including the developer `allowedUrlPrefixes` if set. A
+  public-looking origin cannot 302 the client onto a private or off-list
+  address. Redirects are capped at five hops; `Authorization`, `Cookie`,
+  and `Proxy-Authorization` are stripped when the full origin (scheme, host,
+  port) changes.
+- The remote agent card is fetched and its own `url` is re-validated before
+  the message is sent, so a malicious card that advertises a private target
+  never receives the message.
+- Timeout is a soft cap. The wrapper promise rejects on the deadline, but
+  `A2AAgent#invoke` does not accept an `AbortSignal`, so the underlying
+  request keeps running until it finishes on its own. For a hard cap, plumb
+  an `AbortSignal` through `agentConfig.clientFactory`.
+- DNS rebinding is not fully closed. The URL guard resolves once and checks
+  that IP; the A2A SDK then opens its own socket and re-resolves. An
+  attacker-controlled resolver that returns a public IP on the first lookup
+  and a private one on the second can slip through. Mitigate by pinning
+  the resolver, using `allowedUrlPrefixes`, or fronting the tool with an
+  egress policy.
+- Size caps (`maxCardBytes`, `maxResponseBytes`) are enforced after the A2A
+  SDK has already read and deserialized the body. They bound what the model
+  sees, not what the process reads into memory. A hostile server that streams
+  gigabytes will still consume that memory before the cap fires. Front the
+  tool with an egress-side response-size limit if that matters.
+- If you pass your own `agentConfig.clientFactory`, the tool does not
+  install the guarded fetch on your transports; you own that discipline.

--- a/strands-ts/src/vended-tools/a2a-client/__tests__/a2a-client.test.node.ts
+++ b/strands-ts/src/vended-tools/a2a-client/__tests__/a2a-client.test.node.ts
@@ -1,0 +1,591 @@
+import { Buffer } from 'buffer'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { a2aClient, makeA2AClient } from '../a2a-client.js'
+import { UrlNotAllowedError, validateUrl } from '../url-guard.js'
+
+// Injectable DNS behavior — the mock module below reads `dnsMock.lookup` on
+// every call, so tests can swap it out per-test without re-mocking the module.
+const dnsMock: { lookup: (host: string, opts?: unknown) => Promise<Array<{ address: string; family: number }>> } = {
+  lookup: async () => [{ address: '93.184.216.34', family: 4 }],
+}
+
+vi.mock('node:dns/promises', () => ({
+  lookup: (host: string, opts?: unknown) => dnsMock.lookup(host, opts),
+}))
+
+// Mock A2AAgent so tests never hit the network. The tool calls
+// `getAgentCard()` before sending the message; the mock reads the next queued
+// card off `pendingCards`, or returns the last-set one.
+const mockInvoke = vi.fn()
+interface MockAgentInstance {
+  card?: { url?: string; name?: string; description?: string }
+  name?: string
+  description?: string
+  config: { url: string; [k: string]: unknown }
+}
+const mockAgentInstances: MockAgentInstance[] = []
+const pendingCards: Array<{ url?: string; name?: string; description?: string }> = []
+
+vi.mock('../../../a2a/a2a-agent.js', () => ({
+  A2AAgent: class MockA2AAgent implements MockAgentInstance {
+    card?: { url?: string; name?: string; description?: string }
+    name?: string
+    description?: string
+    constructor(public config: { url: string; [k: string]: unknown }) {
+      mockAgentInstances.push(this)
+      const next = pendingCards.shift()
+      if (next) {
+        this.card = next
+        if (next.name !== undefined) this.name = next.name
+        if (next.description !== undefined) this.description = next.description
+      }
+    }
+    async getAgentCard(): Promise<{ url?: string; name?: string; description?: string }> {
+      return this.card ?? {}
+    }
+    async invoke(msg: string): Promise<unknown> {
+      return mockInvoke(msg)
+    }
+  },
+}))
+
+/** Helper: set what the next-constructed mock A2AAgent will report as its card. */
+function setNextCard(card: { url?: string; name?: string; description?: string }): void {
+  pendingCards.push(card)
+  mockInvoke.mockImplementation(async () => ({ toString: () => 'remote response', stopReason: 'endTurn' }))
+}
+
+// Fake DNS: default to a public IP for any hostname the guard resolves,
+// so URL validation succeeds unless a specific test overrides it.
+beforeEach(() => {
+  dnsMock.lookup = async () => [{ address: '93.184.216.34', family: 4 }]
+  mockInvoke.mockReset()
+  mockAgentInstances.length = 0
+  pendingCards.length = 0
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+// =====================================================================
+// URL guard — SSRF surface
+// =====================================================================
+
+describe('validateUrl', () => {
+  it.each(['ftp://example.com', 'file:///etc/passwd', 'javascript:alert(1)', 'gopher://example.com', ''])(
+    'rejects non-http scheme: %s',
+    async (url) => {
+      await expect(validateUrl(url)).rejects.toBeInstanceOf(UrlNotAllowedError)
+    }
+  )
+
+  it.each(['http://127.0.0.1', 'http://127.1.2.3', 'http://[::1]', 'http://localhost', 'https://LOCALHOST'])(
+    'rejects loopback: %s',
+    async (url) => {
+      await expect(validateUrl(url)).rejects.toBeInstanceOf(UrlNotAllowedError)
+    }
+  )
+
+  it.each(['http://10.0.0.1', 'http://192.168.1.1', 'http://172.16.0.1', 'http://100.64.0.1'])(
+    'rejects RFC1918 / CGNAT ip: %s',
+    async (url) => {
+      await expect(validateUrl(url)).rejects.toBeInstanceOf(UrlNotAllowedError)
+    }
+  )
+
+  it('rejects the AWS metadata IP', async () => {
+    await expect(validateUrl('http://169.254.169.254')).rejects.toBeInstanceOf(UrlNotAllowedError)
+    await expect(validateUrl('http://169.254.169.254/latest/meta-data/')).rejects.toBeInstanceOf(UrlNotAllowedError)
+  })
+
+  it('rejects link-local ip', async () => {
+    await expect(validateUrl('http://169.254.1.1')).rejects.toThrow(/link-local/)
+  })
+
+  it.each(['http://foo.internal', 'http://bar.corp', 'http://svc.local', 'http://api.home'])(
+    'rejects blocked suffix: %s',
+    async (url) => {
+      await expect(validateUrl(url)).rejects.toBeInstanceOf(UrlNotAllowedError)
+    }
+  )
+
+  it('allows a public DNS name', async () => {
+    const host = await validateUrl('https://example.com')
+    expect(host).toBe('example.com')
+  })
+
+  it('allows a public IP literal without DNS lookup', async () => {
+    dnsMock.lookup = async () => {
+      throw new Error('should not be called')
+    }
+    const host = await validateUrl('https://8.8.8.8')
+    expect(host).toBe('8.8.8.8')
+  })
+
+  it('rejects when DNS resolves to a private IP (DNS rebinding defense)', async () => {
+    dnsMock.lookup = async () => [{ address: '10.0.0.1', family: 4 }]
+    await expect(validateUrl('https://sneaky.example.com')).rejects.toThrow(/private/)
+  })
+
+  it('rejects when DNS resolves to a link-local IPv6 address', async () => {
+    dnsMock.lookup = async () => [{ address: 'fe80::1', family: 6 }]
+    await expect(validateUrl('https://sneaky6.example.com')).rejects.toThrow(/link-local/)
+  })
+
+  it.each(['http://[fec0::1]', 'http://[fed0::1]', 'http://[fee0::1]', 'http://[fef0::1]'])(
+    'rejects IPv6 site-local across the full fec0::/10 range: %s',
+    async (url) => {
+      await expect(validateUrl(url)).rejects.toThrow(/site-local/)
+    }
+  )
+
+  it('rejects when DNS returns no addresses', async () => {
+    dnsMock.lookup = async () => []
+    await expect(validateUrl('https://empty.example.com')).rejects.toThrow(/resolved to no addresses/)
+  })
+
+  it('rejects when DNS lookup fails', async () => {
+    dnsMock.lookup = async () => {
+      throw new Error('gaierror')
+    }
+    await expect(validateUrl('https://nx.example.com')).rejects.toThrow(/could not resolve/)
+  })
+
+  it('honors the developer allowlist', async () => {
+    await expect(validateUrl('https://api.example.com/v1', ['https://api.example.com/'])).resolves.toBe(
+      'api.example.com'
+    )
+    await expect(validateUrl('https://evil.example.com', ['https://api.example.com/'])).rejects.toThrow(/allowlist/)
+  })
+
+  it.each([
+    'http://[::ffff:127.0.0.1]',
+    'http://[::ffff:7f00:1]',
+    'http://[0:0:0:0:0:ffff:127.0.0.1]',
+    'http://[::ffff:169.254.169.254]',
+  ])('rejects IPv4-mapped IPv6: %s', async (url) => {
+    await expect(validateUrl(url)).rejects.toBeInstanceOf(UrlNotAllowedError)
+  })
+
+  it('strips trailing dot before suffix match', async () => {
+    await expect(validateUrl('http://foo.internal.')).rejects.toThrow(/blocked suffix/)
+  })
+
+  it.each([
+    // Standard 4-hextet multicast (all IPv6 hostnames from URL.hostname).
+    'http://[ff02::1]',
+    'http://[ff05::1:3]',
+    'http://[ff0e::abcd]',
+    // Multicast expressed with a full IPv4-in-IPv6 tail.
+    'http://[ff02:0:0:0:0:0:0:1]',
+    // Multicast reached through the fully-expanded eight-hextet form.
+    'http://[ff01:0:0:0:0:0:0:1]',
+  ])('rejects IPv6 multicast literal: %s', async (url) => {
+    await expect(validateUrl(url)).rejects.toThrow(/multicast/)
+  })
+
+  it.each(['http://239.255.255.250', 'http://224.0.0.1'])('rejects IPv4 multicast literal: %s', async (url) => {
+    await expect(validateUrl(url)).rejects.toThrow(/multicast/)
+  })
+
+  it('rejects bare metadata hostname before DNS', async () => {
+    dnsMock.lookup = async () => {
+      throw new Error('should not be called for bare metadata label')
+    }
+    await expect(validateUrl('http://metadata')).rejects.toThrow(/metadata label/)
+    await expect(validateUrl('http://METADATA/some/path')).rejects.toThrow(/metadata label/)
+  })
+})
+
+// =====================================================================
+// Tool: input validation + oversize rejection
+// =====================================================================
+
+describe('a2aClient input validation', () => {
+  it('rejects non-http URL', async () => {
+    await expect(a2aClient.invoke({ url: 'ftp://example.com', message: 'hi' })).rejects.toThrow(/scheme/)
+  })
+
+  it('rejects loopback', async () => {
+    await expect(a2aClient.invoke({ url: 'http://localhost', message: 'hi' })).rejects.toThrow(/blocked suffix/)
+  })
+
+  it('rejects private IP', async () => {
+    await expect(a2aClient.invoke({ url: 'http://192.168.1.1', message: 'hi' })).rejects.toThrow(/private/)
+  })
+
+  it('rejects metadata IP', async () => {
+    await expect(a2aClient.invoke({ url: 'http://169.254.169.254', message: 'hi' })).rejects.toBeDefined()
+  })
+
+  it('rejects oversized message', async () => {
+    const big = 'x'.repeat(64 * 1024 + 1)
+    await expect(a2aClient.invoke({ url: 'https://example.com', message: big })).rejects.toThrow(/limit is/)
+  })
+
+  it('developer allowlist rejects off-list URL', async () => {
+    const bounded = makeA2AClient({ allowedUrlPrefixes: ['https://api.example.com/'] })
+    await expect(bounded.invoke({ url: 'https://other.example.com', message: 'hi' })).rejects.toThrow(/allowlist/)
+  })
+
+  it('rejects when multiagent depth reaches the cap', async () => {
+    const mockContext = { invocationState: { multiagentDepth: 3 } } as never
+    await expect(a2aClient.invoke({ url: 'https://example.com', message: 'hi' }, mockContext)).rejects.toThrow(
+      /multiagentDepth=3/
+    )
+  })
+})
+
+// =====================================================================
+// Tool: oversize card / response
+// =====================================================================
+
+describe('a2aClient oversize guards', () => {
+  it('rejects an oversized agent card', async () => {
+    // Craft a card whose serialized JSON blows past the default cap.
+    const bigDesc = 'x'.repeat(300 * 1024)
+    setNextCard({ url: 'https://example.com', name: 'remote', description: bigDesc })
+    await expect(a2aClient.invoke({ url: 'https://example.com', message: 'hi' })).rejects.toThrow(/agent card is/)
+  })
+
+  it('truncates an oversized response text', async () => {
+    setNextCard({ url: 'https://example.com', name: 'remote', description: 'd' })
+    mockInvoke.mockImplementation(async () => {
+      const big = 'y'.repeat(300 * 1024)
+      return { toString: () => big, stopReason: 'endTurn' }
+    })
+    const out = await a2aClient.invoke({ url: 'https://example.com', message: 'hi' })
+    expect(out.output).toMatch(/\[truncated\]$/)
+    expect(Buffer.byteLength(out.output, 'utf-8')).toBeLessThanOrEqual(256 * 1024)
+  })
+
+  it('truncates on a code-point boundary when the cap falls mid-multibyte', async () => {
+    // The response is a run of a four-byte-encoded code point (U+1F600).
+    // If the truncator sliced on an arbitrary byte offset it would emit
+    // U+FFFD replacement characters and the resulting string, re-encoded,
+    // could exceed the cap.
+    setNextCard({ url: 'https://example.com', name: 'remote', description: 'd' })
+    const bounded = makeA2AClient({ maxResponseBytes: 100 })
+    const grinning = '\u{1F600}'
+    const big = grinning.repeat(200)
+    mockInvoke.mockImplementation(async () => ({ toString: () => big, stopReason: 'endTurn' }))
+    const out = await bounded.invoke({ url: 'https://example.com', message: 'hi' })
+    expect(out.output).toMatch(/\[truncated\]$/)
+    // Re-encoded, the output must not exceed the cap.
+    expect(Buffer.byteLength(out.output, 'utf-8')).toBeLessThanOrEqual(100)
+    // And must not contain the U+FFFD replacement character, which is what
+    // the pre-fix truncator emitted when it split a code point.
+    expect(out.output).not.toMatch(/�/)
+  })
+
+  it('rejects when the card URL points to a private host', async () => {
+    setNextCard({ url: 'http://10.0.0.1', name: 'evil', description: 'x' })
+    await expect(a2aClient.invoke({ url: 'https://example.com', message: 'hi' })).rejects.toThrow(/disallowed url/)
+  })
+
+  it('rejects when the card URL falls outside the developer allowlist', async () => {
+    // Developer pins the tool to one remote; the remote's card advertises a
+    // different public host. The allowlist is re-applied to `card.url`, so
+    // the send is rejected even though the advertised host would pass the
+    // SSRF checks on its own.
+    const bounded = makeA2AClient({ allowedUrlPrefixes: ['https://agents.example.com/'] })
+    setNextCard({ url: 'https://other.example.com/', name: 'remote', description: 'd' })
+    await expect(bounded.invoke({ url: 'https://agents.example.com/one', message: 'hi' })).rejects.toThrow(
+      /disallowed url/
+    )
+    // The message must not have been sent.
+    expect(mockInvoke).not.toHaveBeenCalled()
+  })
+})
+
+// =====================================================================
+// Tool: happy path
+// =====================================================================
+
+describe('a2aClient happy path', () => {
+  it('returns the response and agent info', async () => {
+    setNextCard({ url: 'https://example.com', name: 'remote-agent', description: 'A test agent' })
+    const out = await a2aClient.invoke({ url: 'https://example.com', message: 'hi remote' })
+    expect(out.status).toBe('success')
+    expect(out.output).toBe('remote response')
+    expect(out.remoteCard).toEqual({
+      name: 'remote-agent',
+      description: 'A test agent',
+      url: 'https://example.com',
+    })
+    expect(typeof out.executionTimeMs).toBe('number')
+    expect(out.executionTimeMs).toBeGreaterThanOrEqual(0)
+    expect(mockInvoke).toHaveBeenCalledWith('hi remote')
+  })
+
+  it('passes developer agentConfig through to A2AAgent', async () => {
+    setNextCard({ url: 'https://example.com', name: 'x', description: 'y' })
+    const customFactory = { createFromUrl: vi.fn() }
+    const bounded = makeA2AClient({ agentConfig: { clientFactory: customFactory as never } })
+    await bounded.invoke({ url: 'https://example.com', message: 'hi' })
+    const inst = mockAgentInstances[mockAgentInstances.length - 1] as unknown as {
+      config: { url: string; clientFactory: unknown; fetchImpl?: unknown }
+    }
+    expect(inst.config).toMatchObject({
+      url: 'https://example.com',
+      clientFactory: customFactory,
+    })
+    // Developer-supplied factory is expected to carry its own fetch discipline,
+    // so we don't clobber it with our guarded fetch.
+    expect(inst.config.fetchImpl).toBeUndefined()
+  })
+
+  it('injects a guarded fetchImpl when no clientFactory is supplied', async () => {
+    setNextCard({ url: 'https://example.com', name: 'x', description: 'y' })
+    await a2aClient.invoke({ url: 'https://example.com', message: 'hi' })
+    const inst = mockAgentInstances[mockAgentInstances.length - 1] as unknown as {
+      config: { fetchImpl?: unknown }
+    }
+    expect(typeof inst.config.fetchImpl).toBe('function')
+  })
+
+  it('guarded fetchImpl rejects a 302 redirect that lands on a metadata URL', async () => {
+    // Grab the guarded fetch by invoking the tool once and pulling it off the
+    // mocked A2AAgent. Then drive it directly against a stubbed global fetch
+    // so we can prove redirect walking re-runs the URL guard on the target.
+    setNextCard({ url: 'https://example.com', name: 'x', description: 'y' })
+    await a2aClient.invoke({ url: 'https://example.com', message: 'hi' })
+    const inst = mockAgentInstances[mockAgentInstances.length - 1] as unknown as {
+      config: { fetchImpl?: typeof globalThis.fetch }
+    }
+    const guarded = inst.config.fetchImpl
+    if (typeof guarded !== 'function') throw new Error('expected a guarded fetch')
+
+    const originalFetch = globalThis.fetch
+    const stub = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' || input instanceof URL ? input.toString() : input.url
+      // First hop returns 302 pointing at the AWS metadata IP.
+      if (url === 'https://public.example.com/') {
+        return new Response(null, {
+          status: 302,
+          headers: { location: 'http://169.254.169.254/latest/meta-data/' },
+        })
+      }
+      throw new Error(`stub fetch should not have been called for ${url}`)
+    })
+    globalThis.fetch = stub as unknown as typeof globalThis.fetch
+    try {
+      await expect(guarded('https://public.example.com/')).rejects.toBeInstanceOf(UrlNotAllowedError)
+      // First hop hit, second hop rejected pre-flight — no second network call.
+      expect(stub).toHaveBeenCalledTimes(1)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it('guarded fetchImpl rejects a 302 that lands outside the developer allowlist', async () => {
+    // Pin the tool to one prefix; the first hop 302s to a public host that
+    // isn't on the allowlist. The guarded fetch must re-apply the allowlist
+    // to the redirect target, not just to the initial URL.
+    const bounded = makeA2AClient({ allowedUrlPrefixes: ['https://agents.example.com/'] })
+    setNextCard({ url: 'https://agents.example.com/one', name: 'x', description: 'y' })
+    await bounded.invoke({ url: 'https://agents.example.com/one', message: 'hi' })
+    const inst = mockAgentInstances[mockAgentInstances.length - 1] as unknown as {
+      config: { fetchImpl?: typeof globalThis.fetch }
+    }
+    const guarded = inst.config.fetchImpl
+    if (typeof guarded !== 'function') throw new Error('expected a guarded fetch')
+
+    const originalFetch = globalThis.fetch
+    const stub = vi.fn(
+      async () => new Response(null, { status: 302, headers: { location: 'https://other.example.com/two' } })
+    )
+    globalThis.fetch = stub as unknown as typeof globalThis.fetch
+    try {
+      await expect(guarded('https://agents.example.com/one')).rejects.toThrow(/allowlist/)
+      expect(stub).toHaveBeenCalledTimes(1)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it('guarded fetchImpl preserves Request method and headers when the caller passes a Request', async () => {
+    setNextCard({ url: 'https://example.com', name: 'x', description: 'y' })
+    await a2aClient.invoke({ url: 'https://example.com', message: 'hi' })
+    const inst = mockAgentInstances[mockAgentInstances.length - 1] as unknown as {
+      config: { fetchImpl?: typeof globalThis.fetch }
+    }
+    const guarded = inst.config.fetchImpl
+    if (typeof guarded !== 'function') throw new Error('expected a guarded fetch')
+
+    const originalFetch = globalThis.fetch
+    const seenInit: Array<{ url: string; method: string; auth: string | null }> = []
+    const stub = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' || input instanceof URL ? input.toString() : input.url
+      const headers = new Headers(init?.headers ?? {})
+      seenInit.push({ url, method: init?.method ?? 'GET', auth: headers.get('authorization') })
+      return new Response('ok', { status: 200 })
+    })
+    globalThis.fetch = stub as unknown as typeof globalThis.fetch
+    try {
+      const req = new Request('https://public.example.com/', {
+        method: 'POST',
+        headers: { authorization: 'Bearer x' },
+      })
+      await guarded(req)
+      expect(seenInit).toHaveLength(1)
+      expect(seenInit[0]!.method).toBe('POST')
+      expect(seenInit[0]!.auth).toBe('Bearer x')
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it('guarded fetchImpl forces redirect: "manual" even when init overrides it', async () => {
+    // A caller-supplied `redirect: 'follow'` must not defeat manual redirect
+    // walking; otherwise the runtime would follow 3xx transparently and bypass
+    // the per-hop validateUrl check.
+    setNextCard({ url: 'https://example.com', name: 'x', description: 'y' })
+    await a2aClient.invoke({ url: 'https://example.com', message: 'hi' })
+    const inst = mockAgentInstances[mockAgentInstances.length - 1] as unknown as {
+      config: { fetchImpl?: typeof globalThis.fetch }
+    }
+    const guarded = inst.config.fetchImpl
+    if (typeof guarded !== 'function') throw new Error('expected a guarded fetch')
+
+    const originalFetch = globalThis.fetch
+    const observed: RequestRedirect[] = []
+    const stub = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      observed.push(init?.redirect ?? 'follow')
+      return new Response('ok', { status: 200 })
+    })
+    globalThis.fetch = stub as unknown as typeof globalThis.fetch
+    try {
+      // String branch: caller passes redirect: 'follow'.
+      await guarded('https://foo.example.com/', { redirect: 'follow' })
+      // Request branch: caller passes redirect: 'follow' via init.
+      await guarded(new Request('https://bar.example.com/'), { redirect: 'follow' })
+      expect(observed).toHaveLength(2)
+      expect(observed[0]).toBe('manual')
+      expect(observed[1]).toBe('manual')
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it('guarded fetchImpl strips Authorization on a scheme-only origin change', async () => {
+    setNextCard({ url: 'https://example.com', name: 'x', description: 'y' })
+    await a2aClient.invoke({ url: 'https://example.com', message: 'hi' })
+    const inst = mockAgentInstances[mockAgentInstances.length - 1] as unknown as {
+      config: { fetchImpl?: typeof globalThis.fetch }
+    }
+    const guarded = inst.config.fetchImpl
+    if (typeof guarded !== 'function') throw new Error('expected a guarded fetch')
+
+    const originalFetch = globalThis.fetch
+    const seen: Array<{ url: string; auth: string | null }> = []
+    const stub = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' || input instanceof URL ? input.toString() : input.url
+      const headers = new Headers(init?.headers ?? {})
+      seen.push({ url, auth: headers.get('authorization') })
+      if (url === 'https://foo.example.com/') {
+        return new Response(null, { status: 302, headers: { location: 'http://foo.example.com/' } })
+      }
+      return new Response('ok', { status: 200 })
+    })
+    globalThis.fetch = stub as unknown as typeof globalThis.fetch
+    try {
+      await guarded('https://foo.example.com/', { headers: { authorization: 'Bearer x' } })
+      // First hop kept the header, second hop dropped it because scheme changed.
+      expect(seen[0]!.auth).toBe('Bearer x')
+      expect(seen[1]!.auth).toBeNull()
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it('guarded fetchImpl caps redirects at 5 hops', async () => {
+    setNextCard({ url: 'https://example.com', name: 'x', description: 'y' })
+    await a2aClient.invoke({ url: 'https://example.com', message: 'hi' })
+    const inst = mockAgentInstances[mockAgentInstances.length - 1] as unknown as {
+      config: { fetchImpl?: typeof globalThis.fetch }
+    }
+    const guarded = inst.config.fetchImpl
+    if (typeof guarded !== 'function') throw new Error('expected a guarded fetch')
+
+    const originalFetch = globalThis.fetch
+    let hop = 0
+    const stub = vi.fn(async () => {
+      hop += 1
+      return new Response(null, {
+        status: 302,
+        headers: { location: `https://hop-${hop}.example.com/` },
+      })
+    })
+    globalThis.fetch = stub as unknown as typeof globalThis.fetch
+    try {
+      await expect(guarded('https://hop-0.example.com/')).rejects.toThrow(/redirect cap/)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+})
+
+// =====================================================================
+// Tool: timeout + cancellation
+// =====================================================================
+
+describe('a2aClient timeout and cancellation', () => {
+  it('surfaces a timeout when the underlying invoke never resolves', async () => {
+    // Card set is unused because we never resolve; return a promise that hangs.
+    mockInvoke.mockImplementation(() => new Promise(() => {}))
+    const bounded = makeA2AClient({ timeoutSeconds: 0.05 })
+    await expect(bounded.invoke({ url: 'https://example.com', message: 'hi' })).rejects.toMatchObject({
+      name: 'AbortError',
+    })
+  })
+
+  it('surfaces a cancellation when the parent agent signal fires', async () => {
+    mockInvoke.mockImplementation(() => new Promise(() => {}))
+    const controller = new AbortController()
+    const bounded = makeA2AClient({ timeoutSeconds: 60 })
+    // Fire cancellation after a short delay.
+    setTimeout(() => controller.abort(), 30)
+    // The tool checks context.agent.cancelSignal; simulate the InvokableTool context.
+    const mockContext = {
+      agent: { cancelSignal: controller.signal },
+    } as never
+    await expect(bounded.invoke({ url: 'https://example.com', message: 'hi' }, mockContext)).rejects.toMatchObject({
+      name: 'AbortError',
+    })
+  })
+
+  it('rejects with AbortError when the parent cancelSignal is already aborted', async () => {
+    setNextCard({ url: 'https://example.com', name: 'x', description: 'y' })
+    const controller = new AbortController()
+    controller.abort()
+    const mockContext = {
+      agent: { cancelSignal: controller.signal },
+    } as never
+    await expect(a2aClient.invoke({ url: 'https://example.com', message: 'hi' }, mockContext)).rejects.toMatchObject({
+      name: 'AbortError',
+    })
+  })
+})
+
+// =====================================================================
+// Tool metadata
+// =====================================================================
+
+describe('a2aClient tool metadata', () => {
+  it('has the default name', () => {
+    expect(a2aClient.name).toBe('a2a_client')
+  })
+
+  it('accepts a custom name', () => {
+    const t = makeA2AClient({ name: 'remote_agent' })
+    expect(t.name).toBe('remote_agent')
+  })
+
+  it('advertises only url and message on the schema', () => {
+    const schema = a2aClient.toolSpec.inputSchema as { properties?: Record<string, unknown> }
+    const props = schema.properties ?? {}
+    expect(Object.keys(props).sort()).toEqual(['message', 'url'])
+  })
+})

--- a/strands-ts/src/vended-tools/a2a-client/a2a-client.ts
+++ b/strands-ts/src/vended-tools/a2a-client/a2a-client.ts
@@ -1,0 +1,379 @@
+/**
+ * A2A client vended tool.
+ *
+ * Thin shim over {@link A2AAgent}. The model supplies a URL and a message;
+ * the tool resolves the remote agent's card and sends the message. URL
+ * validation, size caps, and total timeout are enforced at the tool
+ * boundary — {@link A2AAgent} has no SSRF or size guard of its own.
+ */
+
+import { Buffer } from 'buffer'
+import { z } from 'zod'
+import { A2AAgent } from '../../a2a/a2a-agent.js'
+import { tool } from '../../tools/tool-factory.js'
+import type { InvokableTool } from '../../tools/tool.js'
+import { UrlNotAllowedError, validateUrl } from './url-guard.js'
+import type { A2AClientOutput, A2AClientRemoteCard, MakeA2AClientOptions } from './types.js'
+
+/**
+ * Default tool description shown to the model.
+ */
+export const DEFAULT_A2A_CLIENT_DESCRIPTION =
+  'Invokes a remote A2A (Agent-to-Agent) agent by URL. Resolves the agent card at ' +
+  "the given URL and sends a single message. Returns the remote agent's response as text. " +
+  'Only http(s) URLs to public hosts are permitted; private/loopback/link-local addresses ' +
+  'are rejected.'
+
+const DEFAULT_TIMEOUT_SECONDS = 60
+const DEFAULT_MAX_CARD_BYTES = 256 * 1024
+const DEFAULT_MAX_RESPONSE_BYTES = 256 * 1024
+const MAX_MESSAGE_BYTES = 64 * 1024
+const DEFAULT_MULTIAGENT_DEPTH_CAP = 3
+
+const inputSchema = z.object({
+  url: z
+    .string()
+    .describe(
+      'HTTP(S) URL of the remote A2A agent (its base URL). Only public hosts are permitted. ' +
+        'Private, loopback, link-local, and cloud metadata addresses are rejected.'
+    ),
+  message: z.string().describe('Message to send to the remote agent. Capped at 64 KiB.'),
+})
+
+/**
+ * Create an `a2a_client` tool.
+ *
+ * All security-relevant configuration is bound at creation time by the developer.
+ * The model can only supply `url` and `message` at call time. Auth material
+ * carried on `agentConfig.clientFactory` is never accessible to the model.
+ *
+ * @param options - Developer-time options.
+ * @returns An {@link InvokableTool} that invokes a remote A2A agent.
+ */
+export function makeA2AClient(
+  options: MakeA2AClientOptions = {}
+): InvokableTool<z.infer<typeof inputSchema>, A2AClientOutput> {
+  const {
+    name = 'a2a_client',
+    description = DEFAULT_A2A_CLIENT_DESCRIPTION,
+    allowedUrlPrefixes,
+    timeoutSeconds = DEFAULT_TIMEOUT_SECONDS,
+    maxCardBytes = DEFAULT_MAX_CARD_BYTES,
+    maxResponseBytes = DEFAULT_MAX_RESPONSE_BYTES,
+    agentConfig,
+    multiagentDepthCap = DEFAULT_MULTIAGENT_DEPTH_CAP,
+  } = options
+
+  return tool({
+    name,
+    description,
+    inputSchema,
+    callback: async (input, context) => {
+      const { url, message } = input
+
+      // --- Multiagent depth cap ---
+      // The a2a_client tool participates in the shared depth counter so an
+      // adversarial chain (use_agent -> a2a_client -> ...) still respects the
+      // cap. The counter is not propagated across the wire (documented in
+      // `_multiagent-conventions.md`).
+      const rawDepth = (context?.invocationState as { multiagentDepth?: unknown } | undefined)?.multiagentDepth
+      const depth = typeof rawDepth === 'number' && Number.isFinite(rawDepth) ? rawDepth : 0
+      if (depth >= multiagentDepthCap) {
+        throw new Error(`multiagentDepth=${depth} exceeds cap ${multiagentDepthCap}`)
+      }
+
+      // --- Input validation ---
+      if (typeof message !== 'string') {
+        throw new Error(`message must be a string, got ${typeof message}`)
+      }
+      const messageBytes = Buffer.byteLength(message, 'utf-8')
+      if (messageBytes > MAX_MESSAGE_BYTES) {
+        throw new Error(`message is ${messageBytes} bytes; limit is ${MAX_MESSAGE_BYTES}`)
+      }
+
+      try {
+        await validateUrl(url, allowedUrlPrefixes)
+      } catch (err) {
+        if (err instanceof UrlNotAllowedError) {
+          // Rethrow as a plain Error so the tool wrapper formats it as an error status.
+          throw new Error(err.message, { cause: err })
+        }
+        throw err
+      }
+
+      // --- Run under a total-timeout budget, respecting agent cancellation ---
+      const startedAtMs = Date.now()
+      const timeoutSignal = AbortSignal.timeout(timeoutSeconds * 1000)
+      const parentSignal = context?.agent?.cancelSignal
+      const abortSignal = parentSignal ? AbortSignal.any([timeoutSignal, parentSignal]) : timeoutSignal
+      if (abortSignal.aborted) {
+        throw (
+          abortSignal.reason ?? new DOMException('a2a_client invocation was aborted before it started', 'AbortError')
+        )
+      }
+
+      // Plumb a redirect-guarding fetch so both card discovery and every
+      // subsequent transport hop are re-validated by `validateUrl`. The A2A
+      // SDK defers to the developer's factory if one was supplied; otherwise
+      // it uses the default factory constructed from our `fetchImpl`.
+      const remote = new A2AAgent({
+        ...(agentConfig ?? {}),
+        url,
+        // Only inject the guarded fetch if the developer didn't hand us a
+        // pre-built factory. Their factory is expected to already carry
+        // whatever fetch discipline it needs.
+        ...(agentConfig?.clientFactory ? {} : { fetchImpl: makeGuardedFetch(allowedUrlPrefixes) }),
+      })
+
+      try {
+        return await runToCompletion({
+          remote,
+          message,
+          maxCardBytes,
+          maxResponseBytes,
+          abortSignal,
+          requestUrl: url,
+          allowedPrefixes: allowedUrlPrefixes,
+          startedAtMs,
+        })
+      } catch (err) {
+        if (timeoutSignal.aborted) {
+          throw new DOMException(`a2a_client timed out after ${timeoutSeconds} seconds calling ${url}`, 'AbortError')
+        }
+        if (parentSignal?.aborted) {
+          throw parentSignal.reason ?? new DOMException(`a2a_client cancelled while calling ${url}`, 'AbortError')
+        }
+        throw err
+      }
+    },
+  })
+}
+
+/** Default `a2a_client` tool — no allowlist, no custom agent config. */
+export const a2aClient = makeA2AClient()
+
+/**
+ * Run the underlying {@link A2AAgent} with total-timeout + cancellation.
+ *
+ * Fetches and validates the agent card *before* sending the message so a
+ * malicious card `url` can't steer the send to a private host. Aborts the
+ * async iteration when the abort signal fires so we don't accumulate bytes
+ * past the deadline. Enforces card + response size caps.
+ *
+ * Note: the timeout is a soft cap. `A2AAgent#invoke` does not accept an
+ * `AbortSignal`, so racing against `abortSignal` rejects the wrapper promise
+ * on timeout but leaves the underlying HTTP request running until it
+ * completes on its own. If you need a hard cap, plumb your own transport
+ * `AbortSignal` through `agentConfig.clientFactory`.
+ */
+async function runToCompletion(args: {
+  remote: A2AAgent
+  message: string
+  maxCardBytes: number
+  maxResponseBytes: number
+  abortSignal: AbortSignal
+  requestUrl: string
+  allowedPrefixes: readonly string[] | undefined
+  startedAtMs: number
+}): Promise<A2AClientOutput> {
+  const { remote, message, maxCardBytes, maxResponseBytes, abortSignal, requestUrl, allowedPrefixes, startedAtMs } =
+    args
+
+  const abortPromise = new Promise<never>((_resolve, reject) => {
+    const onAbort = (): void => {
+      abortSignal.removeEventListener('abort', onAbort)
+      reject(abortSignal.reason ?? new DOMException('a2a_client aborted', 'AbortError'))
+    }
+    if (abortSignal.aborted) {
+      reject(abortSignal.reason ?? new DOMException('a2a_client aborted', 'AbortError'))
+      return
+    }
+    abortSignal.addEventListener('abort', onAbort, { once: true })
+  })
+
+  // Resolve the card first, guard its `url`, then send. Otherwise a malicious
+  // remote could return `card.url = "http://169.254.169.254"` and the message
+  // would already be sent by the time we saw it.
+  const card = await Promise.race([remote.getAgentCard(), abortPromise])
+  assertCardWithinSizeLimit(card, maxCardBytes)
+  if (card.url && card.url !== requestUrl) {
+    // Re-apply the developer allowlist here: the card-advertised URL is the
+    // actual send target, so a pinned allowlist bounds it just as it bounds
+    // the model-supplied URL.
+    try {
+      await validateUrl(card.url, allowedPrefixes)
+    } catch (err) {
+      if (err instanceof UrlNotAllowedError) {
+        throw new Error(`remote agent card points at disallowed url: ${err.message}`, { cause: err })
+      }
+      throw err
+    }
+  }
+
+  if (abortSignal.aborted) {
+    throw abortSignal.reason ?? new DOMException('a2a_client aborted', 'AbortError')
+  }
+
+  const result = await Promise.race([remote.invoke(message), abortPromise])
+
+  const text = truncateUtf8(result.toString(), maxResponseBytes)
+  const remoteCard: A2AClientRemoteCard = {
+    name: card.name ?? remote.name ?? '',
+    description: card.description ?? remote.description ?? '',
+    url: card.url ?? requestUrl,
+  }
+
+  return {
+    status: 'success',
+    output: text,
+    executionTimeMs: Date.now() - startedAtMs,
+    remoteCard,
+  }
+}
+
+/**
+ * Wrap `fetch` so every hop is re-validated by {@link validateUrl}.
+ *
+ * The default `fetch` follows redirects transparently, which lets a
+ * public-looking origin (`example.com`) 302 the client to a private target
+ * like `http://169.254.169.254/…`. Manual redirect walking closes that hole:
+ *
+ * 1. `redirect: 'manual'` — the runtime returns the 3xx as a normal response.
+ * 2. Read `Location`, resolve against the current request URL.
+ * 3. Re-run the URL through {@link validateUrl} (same SSRF policy plus the
+ *    developer allowlist, so a 3xx cannot escape the pinned prefix set).
+ * 4. Repeat, up to a hard cap of 5 hops.
+ * 5. Return the first non-3xx response.
+ *
+ * `Authorization` / `Cookie` / `Proxy-Authorization` headers are dropped on a
+ * cross-origin redirect (compared on scheme + host + port, not host alone),
+ * so a change to http on the same host or a port change also strips them.
+ *
+ * If the caller passes a `Request` object, its method, headers, body, and
+ * other properties are preserved by constructing a fresh `Request` per hop.
+ */
+function makeGuardedFetch(allowedPrefixes?: readonly string[]): typeof globalThis.fetch {
+  const MAX_REDIRECTS = 5
+  const SENSITIVE_HEADERS = ['authorization', 'cookie', 'proxy-authorization']
+
+  const guarded: typeof globalThis.fetch = async (input, init) => {
+    // Materialise the caller-supplied input into a URL string plus a
+    // Request-shaped init that carries method/headers/body across hops.
+    // Preserving these matters when the caller passed a Request object —
+    // extracting only `.url` and forwarding a plain string would drop the
+    // rest of the request.
+    let currentUrl: string
+    let currentInit: RequestInit
+    if (typeof input === 'string' || input instanceof URL) {
+      currentUrl = input.toString()
+      currentInit = init ? { ...init, redirect: 'manual' } : { redirect: 'manual' }
+    } else {
+      // input is a Request. Copy its state onto an init so we can rewrite
+      // the URL per hop without losing method/headers/body. A caller-supplied
+      // init overrides the Request's fields, but `redirect: 'manual'` is
+      // pinned last so a caller can't override the manual-walk invariant
+      // (which would silently bypass the per-hop `validateUrl`).
+      const req = input
+      currentUrl = req.url
+      currentInit = {
+        method: req.method,
+        headers: new Headers(req.headers),
+        body: req.body,
+        mode: req.mode,
+        credentials: req.credentials,
+        cache: req.cache,
+        referrer: req.referrer,
+        referrerPolicy: req.referrerPolicy,
+        integrity: req.integrity,
+        keepalive: req.keepalive,
+        signal: req.signal,
+        ...(init ?? {}),
+        redirect: 'manual',
+      }
+    }
+
+    for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+      // Validate the URL before hitting it. Redirect targets get the same
+      // treatment as the caller-supplied URL, *including* the developer
+      // allowlist, so a 3xx from an allowlisted origin cannot steer the
+      // client onto an off-list public host.
+      await validateUrl(currentUrl, allowedPrefixes)
+
+      const response = await globalThis.fetch(currentUrl, currentInit)
+      const status = response.status
+      if (status < 300 || status >= 400 || status === 304) {
+        return response
+      }
+      // 3xx redirect — walk it manually.
+      const location = response.headers.get('location')
+      if (!location) {
+        return response
+      }
+      if (hop === MAX_REDIRECTS) {
+        throw new Error(`a2a_client: redirect cap (${MAX_REDIRECTS}) exceeded`)
+      }
+      let nextUrl: string
+      try {
+        nextUrl = new URL(location, currentUrl).toString()
+      } catch {
+        throw new Error(`a2a_client: invalid redirect Location "${location}"`)
+      }
+      // Compare on full origin (scheme + host + port), not just host, so a
+      // scheme downgrade (https→http) or port change on the same host also
+      // triggers sensitive-header stripping.
+      const prevOrigin = new URL(currentUrl).origin
+      const nextOrigin = new URL(nextUrl).origin
+      if (prevOrigin !== nextOrigin && currentInit.headers) {
+        const nextHeaders: Headers = new Headers(currentInit.headers)
+        for (const h of SENSITIVE_HEADERS) {
+          nextHeaders.delete(h)
+        }
+        currentInit = { ...currentInit, headers: nextHeaders }
+      }
+      currentUrl = nextUrl
+    }
+    // Loop cap is enforced above; unreachable, but satisfies TS.
+    throw new Error('a2a_client: redirect walk terminated unexpectedly')
+  }
+  return guarded
+}
+
+/** Reject cards whose serialized JSON is larger than `limit` bytes. */
+function assertCardWithinSizeLimit(card: object, limit: number): void {
+  let serialized: string
+  try {
+    serialized = JSON.stringify(card)
+  } catch {
+    serialized = String(card)
+  }
+  const size = Buffer.byteLength(serialized, 'utf-8')
+  if (size > limit) {
+    throw new Error(`remote agent card is ${size} bytes; limit is ${limit}`)
+  }
+}
+
+/**
+ * Truncate `text` to at most `maxBytes` UTF-8 bytes without splitting a code
+ * point. Appends `... [truncated]` when truncation occurs. The returned
+ * string re-encoded as UTF-8 is guaranteed to be no larger than `maxBytes`.
+ */
+function truncateUtf8(text: string, maxBytes: number): string {
+  const encoded = Buffer.from(text, 'utf-8')
+  if (encoded.byteLength <= maxBytes) {
+    return text
+  }
+  const suffix = '... [truncated]'
+  const suffixBytes = Buffer.byteLength(suffix, 'utf-8')
+  const budget = Math.max(0, maxBytes - suffixBytes)
+  // `Buffer.slice(...).toString('utf-8')` on a boundary that falls inside a
+  // multi-byte sequence emits U+FFFD (which re-encodes to three bytes) and
+  // can exceed `maxBytes`. Walk back to the previous code-point boundary
+  // instead: in UTF-8, continuation bytes have the top bits `10xxxxxx`,
+  // and lead bytes are either ASCII (`0xxxxxxx`) or `11xxxxxx`.
+  let end = budget
+  while (end > 0 && (encoded[end]! & 0xc0) === 0x80) {
+    end--
+  }
+  const truncated = encoded.subarray(0, end).toString('utf-8')
+  return truncated + suffix
+}

--- a/strands-ts/src/vended-tools/a2a-client/index.ts
+++ b/strands-ts/src/vended-tools/a2a-client/index.ts
@@ -1,0 +1,7 @@
+/**
+ * A2A client tool for invoking remote A2A agents.
+ */
+
+export { DEFAULT_A2A_CLIENT_DESCRIPTION, a2aClient, makeA2AClient } from './a2a-client.js'
+export type { A2AClientOutput, A2AClientRemoteCard, MakeA2AClientOptions } from './types.js'
+export { UrlNotAllowedError } from './url-guard.js'

--- a/strands-ts/src/vended-tools/a2a-client/types.ts
+++ b/strands-ts/src/vended-tools/a2a-client/types.ts
@@ -1,0 +1,88 @@
+/**
+ * Types for the a2a_client vended tool.
+ */
+
+import type { A2AAgentConfig } from '../../a2a/a2a-agent.js'
+
+/**
+ * Subset of the resolved remote agent card echoed back in the result.
+ */
+export interface A2AClientRemoteCard {
+  /** Human-readable agent name from the resolved agent card. */
+  name: string
+  /** Human-readable agent description from the resolved agent card. */
+  description: string
+  /** URL of the resolved agent (from the card, or the request URL as fallback). */
+  url: string
+}
+
+/**
+ * Output of an a2a_client invocation.
+ *
+ * Follows the shared multi-agent tool result shape defined in
+ * `_multiagent-conventions.md`: a top-level `status` / `output` /
+ * `executionTimeMs` triple, plus a `remoteCard` addendum describing the
+ * resolved remote endpoint.
+ *
+ * `status` is only ever `'success'`. Cancellation and timeout raise a
+ * `DOMException` with `name === 'AbortError'` rather than returning a
+ * `'cancelled'` variant, matching the other network tools (`http_request`,
+ * `web_fetch`). See the a2a_client addendum in `_multiagent-conventions.md`
+ * for the rationale.
+ */
+export interface A2AClientOutput {
+  /** Result status. Always `"success"` on a normal return. */
+  status: 'success'
+  /** Text produced by the remote agent, concatenated from all text parts. */
+  output: string
+  /** Total wall-clock time for the tool call, in milliseconds. */
+  executionTimeMs: number
+  /** Subset of the resolved remote agent card. */
+  remoteCard: A2AClientRemoteCard
+}
+
+/**
+ * Developer-time options for the `makeA2AClient` factory.
+ *
+ * Every field is bound at construction time by the developer. The model
+ * can only supply `url` and `message` at call time.
+ */
+export interface MakeA2AClientOptions {
+  /** Tool name. Defaults to `'a2a_client'`. */
+  name?: string
+  /** Tool description shown to the model. */
+  description?: string
+  /**
+   * Optional developer-supplied URL allowlist. When set, the model-provided
+   * `url` must start with one of these prefixes.
+   */
+  allowedUrlPrefixes?: readonly string[]
+  /**
+   * Wall-clock cap on the entire tool call, in seconds. Bounds both card
+   * discovery and message send. Default: 60.
+   */
+  timeoutSeconds?: number
+  /**
+   * Cap on the agent-card size in bytes (serialized JSON). Cards larger than
+   * this are rejected. Default: 262144 (256 KiB).
+   */
+  maxCardBytes?: number
+  /**
+   * Cap on the returned response text size in bytes. Text beyond the cap is
+   * truncated with a `... [truncated]` marker. Default: 262144 (256 KiB).
+   */
+  maxResponseBytes?: number
+  /**
+   * Extra static options for the underlying `A2AAgent`. Auth material such
+   * as a custom `clientFactory` for signed requests goes here. Never
+   * touched by the model.
+   */
+  agentConfig?: Omit<A2AAgentConfig, 'url'>
+  /**
+   * Cap on the shared multi-agent recursion depth counter. A parent agent
+   * that calls `a2a_client` counts as depth+1. The tool refuses to run once
+   * the counter reaches the cap. Not propagated across the wire — the
+   * remote agent's depth resets from its perspective. Default: 3.
+   */
+  multiagentDepthCap?: number
+}

--- a/strands-ts/src/vended-tools/a2a-client/url-guard.ts
+++ b/strands-ts/src/vended-tools/a2a-client/url-guard.ts
@@ -1,0 +1,354 @@
+/**
+ * URL validation for the a2a_client tool.
+ *
+ * Blocks the SSRF surface a model can steer via a URL: scheme allowlist,
+ * private / loopback / link-local IPs, cloud-metadata IPs, and reserved DNS
+ * suffixes such as `.internal`, `.local`, `.corp`. Validation is run both
+ * on the initial URL and on the `url` field of the resolved agent card,
+ * because a remote card can point at a different host than the request URL.
+ */
+
+import * as dns from 'node:dns/promises'
+import * as net from 'node:net'
+
+interface DnsLookupAddress {
+  address: string
+  family: number
+}
+
+/**
+ * Hostnames whose DNS suffix we refuse outright. Cheaper than DNS resolution
+ * and catches operators who put private services on `.internal` / `.local` /
+ * `.corp` / `.home` even when those don't resolve to a private IP for us.
+ */
+const BLOCKED_HOST_SUFFIXES: readonly string[] = [
+  '.internal',
+  '.local',
+  '.localhost',
+  '.corp',
+  '.home',
+  '.lan',
+  '.intranet',
+  '.private',
+  '.i2p',
+  '.onion',
+]
+
+/**
+ * Bare hostnames — checked before DNS resolution. GCP's metadata server
+ * answers on `http://metadata/` inside a VPC; blocking the label
+ * short-circuits any resolver that would answer this locally.
+ */
+const BLOCKED_BARE_HOSTNAMES: readonly string[] = ['metadata']
+
+/**
+ * Well-known cloud metadata addresses. IPv4 metadata is in the link-local
+ * range (169.254/16), which is caught by the private-IP check, but we spell
+ * these out explicitly to catch anything a resolver returns via an unrelated
+ * hostname.
+ */
+const BLOCKED_METADATA_ADDRESSES: readonly string[] = [
+  '169.254.169.254',
+  'fd00:ec2::254',
+  '100.100.100.200',
+  '192.0.0.192',
+]
+
+/** Error thrown when a URL fails validation before we make a network call. */
+export class UrlNotAllowedError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'UrlNotAllowedError'
+  }
+}
+
+/**
+ * Validate a URL for use as an A2A endpoint.
+ *
+ * Enforces:
+ * - http/https scheme only
+ * - a non-empty hostname
+ * - hostname not on the blocked-suffix list
+ * - every DNS-resolved address is a global unicast address (not private,
+ *   loopback, link-local, multicast, reserved, or unspecified)
+ * - hostname not a known cloud-metadata IP
+ * - URL starts with one of `allowedPrefixes` if supplied
+ *
+ * @param url - The URL to check.
+ * @param allowedPrefixes - Optional developer-supplied allowlist.
+ * @returns The parsed hostname (lowercased).
+ * @throws UrlNotAllowedError if any check fails.
+ */
+export async function validateUrl(url: string, allowedPrefixes?: readonly string[]): Promise<string> {
+  if (typeof url !== 'string' || url.length === 0) {
+    throw new UrlNotAllowedError('url must be a non-empty string')
+  }
+  if (allowedPrefixes && !allowedPrefixes.some((prefix) => url.startsWith(prefix))) {
+    throw new UrlNotAllowedError(
+      `url ${JSON.stringify(url)} is not in the developer-configured allowlist ` +
+        `(expected one of ${JSON.stringify(allowedPrefixes)})`
+    )
+  }
+
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    throw new UrlNotAllowedError(`url is not a valid URL: ${url}`)
+  }
+
+  const scheme = parsed.protocol.replace(/:$/, '').toLowerCase()
+  if (scheme !== 'http' && scheme !== 'https') {
+    throw new UrlNotAllowedError(`url must use http or https, got scheme "${scheme}"`)
+  }
+
+  let host = stripBrackets(parsed.hostname).toLowerCase()
+  // Strip a trailing dot so `foo.internal.` is caught by the suffix check.
+  if (host.endsWith('.')) {
+    host = host.slice(0, -1)
+  }
+  if (!host) {
+    throw new UrlNotAllowedError('url must include a hostname')
+  }
+
+  if (BLOCKED_BARE_HOSTNAMES.includes(host)) {
+    // GCP's metadata server answers on `http://metadata/` inside a VPC;
+    // reject the label before we ever DNS-resolve.
+    throw new UrlNotAllowedError(`hostname "${host}" is a cloud metadata label`)
+  }
+
+  for (const suffix of BLOCKED_HOST_SUFFIXES) {
+    if (host === suffix.replace(/^\./, '') || host.endsWith(suffix)) {
+      throw new UrlNotAllowedError(`hostname "${host}" matches blocked suffix "${suffix}"`)
+    }
+  }
+
+  await assertHostResolvesToPublicIps(host)
+  return host
+}
+
+/**
+ * Resolve `host` and reject if any address is private, loopback, link-local,
+ * multicast, reserved, unspecified, or a cloud-metadata address. If `host`
+ * is a bare IP literal, skip DNS and check it directly.
+ */
+async function assertHostResolvesToPublicIps(host: string): Promise<void> {
+  const ipVersion = net.isIP(host)
+  if (ipVersion !== 0) {
+    assertIpIsPublic(host)
+    return
+  }
+
+  let addresses: DnsLookupAddress[]
+  try {
+    addresses = (await dns.lookup(host, { all: true, verbatim: true })) as DnsLookupAddress[]
+  } catch (err) {
+    throw new UrlNotAllowedError(`could not resolve hostname "${host}": ${(err as Error).message}`)
+  }
+
+  if (addresses.length === 0) {
+    throw new UrlNotAllowedError(`hostname "${host}" resolved to no addresses`)
+  }
+
+  const seen = new Set<string>()
+  for (const { address } of addresses) {
+    if (seen.has(address)) continue
+    seen.add(address)
+    assertIpIsPublic(address)
+  }
+}
+
+/**
+ * Assert that an IP address is global-unicast public. Rejects loopback,
+ * link-local, private, multicast, reserved, unspecified, and cloud-metadata IPs.
+ */
+function assertIpIsPublic(ip: string): void {
+  if (BLOCKED_METADATA_ADDRESSES.includes(ip.toLowerCase())) {
+    throw new UrlNotAllowedError(`ip ${ip} is a cloud metadata address`)
+  }
+  const family = net.isIP(ip)
+  if (family === 0) {
+    throw new UrlNotAllowedError(`invalid ip address: ${ip}`)
+  }
+  if (family === 4) {
+    assertIpv4IsPublic(ip)
+    return
+  }
+  assertIpv6IsPublic(ip)
+}
+
+function assertIpv4IsPublic(ip: string): void {
+  const parts = ip.split('.').map(Number)
+  if (parts.length !== 4 || parts.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) {
+    throw new UrlNotAllowedError(`invalid ipv4 address: ${ip}`)
+  }
+  const [a, b, c] = parts as [number, number, number, number]
+  // 0.0.0.0/8 unspecified / this-network
+  if (a === 0) throw new UrlNotAllowedError(`ip ${ip} is unspecified`)
+  // 127.0.0.0/8 loopback
+  if (a === 127) throw new UrlNotAllowedError(`ip ${ip} is loopback`)
+  // 10.0.0.0/8
+  if (a === 10) throw new UrlNotAllowedError(`ip ${ip} is private`)
+  // 172.16.0.0/12
+  if (a === 172 && b >= 16 && b <= 31) throw new UrlNotAllowedError(`ip ${ip} is private`)
+  // 192.168.0.0/16
+  if (a === 192 && b === 168) throw new UrlNotAllowedError(`ip ${ip} is private`)
+  // 169.254.0.0/16 link-local
+  if (a === 169 && b === 254) throw new UrlNotAllowedError(`ip ${ip} is link-local`)
+  // 100.64.0.0/10 CGNAT (carrier-grade NAT)
+  if (a === 100 && b >= 64 && b <= 127) throw new UrlNotAllowedError(`ip ${ip} is private (CGNAT)`)
+  // 192.0.0.0/24 IETF protocol assignments
+  if (a === 192 && b === 0 && c === 0) throw new UrlNotAllowedError(`ip ${ip} is reserved`)
+  // 192.0.2.0/24 TEST-NET-1
+  if (a === 192 && b === 0 && c === 2) throw new UrlNotAllowedError(`ip ${ip} is reserved (documentation)`)
+  // 198.18.0.0/15 benchmarking
+  if (a === 198 && (b === 18 || b === 19)) throw new UrlNotAllowedError(`ip ${ip} is reserved (benchmarking)`)
+  // 198.51.100.0/24 TEST-NET-2
+  if (a === 198 && b === 51 && c === 100) throw new UrlNotAllowedError(`ip ${ip} is reserved (documentation)`)
+  // 203.0.113.0/24 TEST-NET-3
+  if (a === 203 && b === 0 && c === 113) throw new UrlNotAllowedError(`ip ${ip} is reserved (documentation)`)
+  // 224.0.0.0/4 multicast
+  if (a >= 224 && a <= 239) throw new UrlNotAllowedError(`ip ${ip} is multicast`)
+  // 240.0.0.0/4 reserved (255.255.255.255 falls in here)
+  if (a >= 240) throw new UrlNotAllowedError(`ip ${ip} is reserved`)
+}
+
+function assertIpv6IsPublic(ip: string): void {
+  const lower = ip.toLowerCase()
+
+  // IPv4-mapped / -translated IPv6 -- unwrap and evaluate the embedded v4.
+  // `URL.hostname` normalises `::ffff:127.0.0.1` into the hex form
+  // `::ffff:7f00:1`, so both dotted and hex representations must be handled.
+  // Without this, `http://[::ffff:127.0.0.1]` bypasses the IPv4 rules.
+  const embedded = extractMappedIpv4(lower)
+  if (embedded !== null) {
+    assertIpv4IsPublic(embedded)
+    return
+  }
+
+  // Categorical checks by operating on the full 128-bit expansion rather
+  // than string-shape regexes. A prior regex-based version accepted
+  // multicast/link-local addresses in some short-form representations because
+  // it required a specific hextet length in the first group.
+  const bytes = expandIpv6(lower)
+  if (bytes === null) {
+    throw new UrlNotAllowedError(`invalid ipv6 address: ${ip}`)
+  }
+
+  // ::1 loopback
+  if (bytes.every((b, i) => (i < 15 ? b === 0 : b === 1))) {
+    throw new UrlNotAllowedError(`ip ${ip} is loopback`)
+  }
+  // :: unspecified
+  if (bytes.every((b) => b === 0)) {
+    throw new UrlNotAllowedError(`ip ${ip} is unspecified`)
+  }
+  // fe80::/10 link-local — top ten bits are 1111_1110_10
+  if (bytes[0] === 0xfe && (bytes[1]! & 0xc0) === 0x80) {
+    throw new UrlNotAllowedError(`ip ${ip} is link-local`)
+  }
+  // fc00::/7 unique local (private) — top seven bits are 1111_110
+  if ((bytes[0]! & 0xfe) === 0xfc) {
+    throw new UrlNotAllowedError(`ip ${ip} is private (unique local)`)
+  }
+  // ff00::/8 multicast — top byte is 0xff
+  if (bytes[0] === 0xff) {
+    throw new UrlNotAllowedError(`ip ${ip} is multicast`)
+  }
+  // 2001:db8::/32 documentation
+  if (bytes[0] === 0x20 && bytes[1] === 0x01 && bytes[2] === 0x0d && bytes[3] === 0xb8) {
+    throw new UrlNotAllowedError(`ip ${ip} is reserved (documentation)`)
+  }
+  // fec0::/10 site-local (deprecated but still worth blocking) —
+  // top ten bits are 1111_1110_11
+  if (bytes[0] === 0xfe && (bytes[1]! & 0xc0) === 0xc0) {
+    throw new UrlNotAllowedError(`ip ${ip} is reserved (site-local)`)
+  }
+}
+
+/**
+ * Expand an IPv6 literal to a 16-byte array of octets, or `null` if the input
+ * is not a valid IPv6 address. Handles zero-compression (`::`), variable
+ * hextet widths, and IPv4-in-IPv6 dotted-quad tails.
+ */
+function expandIpv6(ip: string): number[] | null {
+  // Handle the trailing dotted-quad form (e.g. `::ffff:1.2.3.4`) by folding
+  // the four decimal octets into two hex hextets before splitting.
+  let normalized = ip
+  const dottedTail = /^([0-9a-f:]*):(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(ip)
+  if (dottedTail) {
+    const prefix = dottedTail[1]!
+    const parts = [dottedTail[2], dottedTail[3], dottedTail[4], dottedTail[5]].map((s) => Number(s))
+    if (parts.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return null
+    const hi = ((parts[0]! << 8) | parts[1]!).toString(16)
+    const lo = ((parts[2]! << 8) | parts[3]!).toString(16)
+    normalized = `${prefix}:${hi}:${lo}`
+  }
+
+  const doubleColonIndex = normalized.indexOf('::')
+  let head: string[]
+  let tail: string[]
+  if (doubleColonIndex === -1) {
+    head = normalized.split(':')
+    tail = []
+  } else {
+    const before = normalized.slice(0, doubleColonIndex)
+    const after = normalized.slice(doubleColonIndex + 2)
+    head = before === '' ? [] : before.split(':')
+    tail = after === '' ? [] : after.split(':')
+  }
+  const missing = 8 - head.length - tail.length
+  if (missing < 0) return null
+  const groups = [...head, ...Array<string>(missing).fill('0'), ...tail]
+  const bytes: number[] = []
+  for (const group of groups) {
+    if (!/^[0-9a-f]{1,4}$/.test(group)) return null
+    const value = parseInt(group, 16)
+    bytes.push((value >> 8) & 0xff, value & 0xff)
+  }
+  return bytes.length === 16 ? bytes : null
+}
+
+function stripBrackets(host: string): string {
+  if (host.startsWith('[') && host.endsWith(']')) {
+    return host.slice(1, -1)
+  }
+  return host
+}
+
+/**
+ * If `ip` is an IPv4-mapped IPv6 address in either dotted (`::ffff:a.b.c.d`)
+ * or hex (`::ffff:7f00:1`) form, return the embedded IPv4 as a dotted-quad
+ * string. Accepts the fully-expanded prefix (`0:0:0:0:0:ffff:...`) as well.
+ * Returns `null` if `ip` is not an IPv4-mapped IPv6 address.
+ */
+function extractMappedIpv4(ip: string): string | null {
+  const lower = ip.toLowerCase()
+
+  // Dotted form: `::ffff:a.b.c.d` (and its fully-expanded 6-group variant).
+  const dotted = lower.match(
+    /^(?:0:0:0:0:0:)?::?ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$|^0:0:0:0:0:ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/
+  )
+  if (dotted) {
+    return dotted[1] ?? dotted[2] ?? null
+  }
+
+  // Hex form: `::ffff:XXXX:XXXX` or `0:0:0:0:0:ffff:XXXX:XXXX`.
+  const hex = lower.match(
+    /^(?:0:0:0:0:0:)?::?ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$|^0:0:0:0:0:ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/
+  )
+  if (hex) {
+    const hi = hex[1] ?? hex[3]
+    const lo = hex[2] ?? hex[4]
+    if (hi !== undefined && lo !== undefined) {
+      const hiN = parseInt(hi, 16)
+      const loN = parseInt(lo, 16)
+      const a = (hiN >> 8) & 0xff
+      const b = hiN & 0xff
+      const c = (loN >> 8) & 0xff
+      const d = loN & 0xff
+      return `${a}.${b}.${c}.${d}`
+    }
+  }
+  return null
+}

--- a/strands-ts/src/vended-tools/index.ts
+++ b/strands-ts/src/vended-tools/index.ts
@@ -9,6 +9,11 @@
  * Note: This module requires a Node.js environment because the `bash` tool
  * imports `child_process`. For browser-compatible usage, import individual
  * tools via their subpath exports (e.g., `@strands-agents/sdk/vended-tools/notebook`).
+ *
+ * The `a2a-client` tool is deliberately *not* re-exported here because it
+ * transitively imports `@a2a-js/sdk`, which is an optional peer dependency.
+ * Consumers must import it via the subpath:
+ * `@strands-agents/sdk/vended-tools/a2a-client`.
  */
 
 export * from './bash/index.js'


### PR DESCRIPTION
Adds an a2a_client vended tool in both SDKs. The tool takes a URL and a message from the model, resolves the remote agent's card, sends the message via the built-in A2AAgent client, and maps the response into the shared multi-agent result shape (status, output, execution_time_ms, remote_card). It ships alongside a conventions doc for the four multi-agent tools now in flight (use_agent, swarm, graph, a2a_client) — that doc lives at strands-py/src/strands/vended_tools/_multiagent_conventions.md and strands-ts/src/vended-tools/_multiagent-conventions.md and captures the agent-spec dialect, the shared multiagent_depth counter, tool allow-list handling, result shape, cancellation, and size caps. Since a2a_client invokes a remote agent rather than constructing a child locally, the addendum spells out which fields collapse (no model dialect, no local tool allow-list) and how depth counting stops at the local boundary rather than crossing the wire.

The A2A SDK has no SSRF or size guard of its own, so the tool enforces the boundary. Scheme is restricted to http and https. Hostnames are DNS-resolved before the request and rejected if any resolved address is loopback, RFC1918, CGNAT 100.64/10, link-local, multicast, reserved, or unspecified. The full IPv4-mapped IPv6 range unwraps to its underlying v4 address, and cloud metadata IPs are blocked explicitly alongside the reserved DNS suffixes .internal, .local, .corp, .home, .lan, .intranet, .private, and the bare label metadata short-circuits before DNS. On Python the guard sequences is_multicast, is_reserved, is_unspecified, and is_link_local ahead of is_global because CPython's 3.10 through 3.14 is_global returns true for multicast. On TypeScript a small makeGuardedFetch wraps the SDK's fetch with redirect: manual, re-runs the URL guard on every Location, caps at five hops, and strips Authorization, Cookie, and Proxy-Authorization on cross-origin change. That wrapper threads into both the card resolver and the JSON-RPC transport through a new additive fetchImpl field on A2AAgentConfig, so a public-looking origin cannot 302 the client onto a metadata IP. The resolved card's own url is re-validated before the message is sent. DNS rebinding after the guard runs is documented as a residual risk — pinned-IP connect is not feasible against the A2A SDK's socket layer, so the guard is check-time-only per the shared SSRF spec's fallback clause.

Size caps and cancellation are enforced at the same boundary. Model-supplied messages cap at 64 KiB, agent cards at 256 KiB, and response text truncates to 256 KiB with an explicit marker. The whole call runs under timeoutSeconds (default sixty seconds), racing AbortSignal.any of the timeout and the parent's cancelSignal on TypeScript and asyncio.wait_for on Python. Cancellation returns a status: cancelled result rather than raising past the tool boundary, matching the multi-agent conventions.

Any authentication (SigV4, OAuth, bearer) is supplied at construction time through client_config on Python or agentConfig.clientFactory on TypeScript. The model-facing schema is only url and message — no headers, no custom fetch, no credentials — and an optional allowed_url_prefixes / allowedUrlPrefixes lets a developer pin the model to a specific set of remotes.

https://github.com/strands-agents/harness-sdk/issues/3247