### PR TITLE
feat(vended-tools): add notebook to strands-py

### DIFF
--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -10,6 +10,7 @@ sourceLinks:
   - path: strands-ts/src/vended-tools/bash/bash.ts
   - path: strands-ts/src/vended-tools/http-request/http-request.ts
   - path: strands-ts/src/vended-tools/notebook/notebook.ts
+  - path: strands-py/src/strands/vended_tools/notebook/notebook.py
 ---
 
 Vended tools are pre-built tools included directly in the Strands SDK for common agent tasks like file operations, shell commands, HTTP requests, and persistent notes. 
@@ -32,7 +33,7 @@ Each tool is imported from its own subpath under `@strands-agents/sdk/vended-too
 |------|-------------|--------------|
 | [File Editor](#file-editor) | View, create, and edit files | Python, TypeScript (Node.js) |
 | [HTTP Request](#http-request) | Make HTTP requests to external APIs | TypeScript (Node.js 20+, browsers) |
-| [Notebook](#notebook) | Manage persistent text notebooks | TypeScript (Node.js, browsers) |
+| [Notebook](#notebook) | Manage persistent text notebooks | Python, TypeScript (Node.js, browsers) |
 | [Bash](#bash) | Execute shell commands with persistent sessions | Python, TypeScript (Node.js, Unix/Linux/macOS) |
 
 ### File Editor
@@ -97,23 +98,62 @@ This tool makes HTTP requests to arbitrary URLs without restrictions on destinat
 
 A scratchpad the agent can read and write across invocations. The most effective use is giving the agent a notebook at the start of a task and instructing it to plan its work there — it can break the task into steps, check things off as it goes, and always have a clear picture of what's left. Notebook state is part of the agent's state, so it persists automatically with [Session Management](../agents/session-management.mdx).
 
-_Supported in: Node.js, browsers._
+_Supported in: Node.js, modern browsers (TypeScript); all platforms (Python)._
 
 **Example - Task Management:**
+
+<Tabs>
+<Tab label="TypeScript">
+
 ```typescript
 --8<-- "user-guide/concepts/tools/vended-tools-imports.ts:notebook_import"
 
 --8<-- "user-guide/concepts/tools/vended-tools.ts:notebook_example"
 ```
 
+</Tab>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.vended_tools import notebook
+
+agent = Agent(tools=[notebook])
+agent('Create a notebook called "tasks" with "# Daily Tasks" and add "- [ ] Review code" to it')
+```
+
+</Tab>
+</Tabs>
+
 **Example - State Persistence:**
+
+<Tabs>
+<Tab label="TypeScript">
+
 ```typescript
 --8<-- "user-guide/concepts/tools/vended-tools-imports.ts:notebook_persistence_import"
 
 --8<-- "user-guide/concepts/tools/vended-tools.ts:notebook_state_persistence"
 ```
 
-📖 [Full API Reference](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/notebook/README.md)
+</Tab>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.vended_tools import notebook
+
+agent = Agent(tools=[notebook])
+agent('Create a notebook called "tasks" with "# Daily Tasks" and add "- [ ] Review code" to it')
+
+# Read the notebook contents directly off agent state.
+print(agent.state.get("notebooks")["tasks"])
+```
+
+</Tab>
+</Tabs>
+
+📖 Full API Reference: [TypeScript](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/notebook/README.md) · [Python](https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/vended_tools/notebook/README.md)
 
 ---
 

--- a/strands-py/src/strands/vended_tools/__init__.py
+++ b/strands-py/src/strands/vended_tools/__init__.py
@@ -1,26 +1,31 @@
-"""Built-in tools for executing commands and editing files.
+"""Built-in tools for executing commands, editing files, and taking notes.
 
 The :data:`bash` tool runs a
 persistent shell on the host; the :func:`make_bash` and :func:`make_file_editor`
 factories produce sandbox-routed tools that either bind to a
 :class:`~strands.sandbox.base.Sandbox` at creation (as the built-in Docker/SSH
 sandboxes do when vending tools) or read the sandbox from the agent at call time.
+The :data:`notebook` tool gives an agent a session-scoped scratchpad backed by
+:attr:`~strands.Agent.state`.
 
 Example Usage:
     ```python
     from strands import Agent
-    from strands.vended_tools import bash, file_editor
+    from strands.vended_tools import bash, file_editor, notebook
 
-    agent = Agent(tools=[bash, file_editor])
+    agent = Agent(tools=[bash, file_editor, notebook])
     ```
 """
 
 from .bash import bash, make_bash
 from .file_editor import file_editor, make_file_editor
+from .notebook import make_notebook, notebook
 
 __all__ = [
     "bash",
     "file_editor",
     "make_bash",
     "make_file_editor",
+    "make_notebook",
+    "notebook",
 ]

--- a/strands-py/src/strands/vended_tools/notebook/README.md
+++ b/strands-py/src/strands/vended_tools/notebook/README.md
@@ -1,0 +1,42 @@
+# Notebook Tool
+
+A session-scoped scratchpad an agent can read, write, and clear. Notebook state lives on `agent.state` under the `notebooks` key, so it persists across invocations within a session and across sessions when the caller wires up a durable state store.
+
+## Usage
+
+```python
+from strands import Agent
+from strands.vended_tools import notebook
+
+agent = Agent(tools=[notebook])
+agent('Create a notebook called "ideas" with "# Project Ideas"')
+agent('Add "- Build a web scraper" to the ideas notebook')
+agent('Read the ideas notebook')
+```
+
+State is accessible directly:
+
+```python
+print(agent.state.get("notebooks"))
+# {'default': '', 'ideas': '# Project Ideas\n- Build a web scraper'}
+```
+
+A `default` notebook is materialized the first time the tool sees empty state so read and list have something to point at. Any `create` that names another notebook keeps the default alongside it.
+
+## Operations
+
+- `create` — create or overwrite a notebook, optionally with initial content.
+- `list` — list all notebooks with line counts.
+- `read` — read a whole notebook or a line range. Ranges are one-indexed and support negative indices.
+- `write` — replace a substring (`old_str` plus `new_str`) or insert a line (`insert_line` plus `new_str`). `insert_line` accepts a line number or a search string.
+- `clear` — empty a notebook without deleting it.
+
+## Session limits
+
+The Python port enforces per-session caps so a prompt injection cannot grow state without bound:
+
+- `MAX_NOTEBOOKS` — sixty-four notebooks per session.
+- `MAX_NOTEBOOK_SIZE_BYTES` — one mebibyte per notebook, measured after UTF-8 encoding.
+- `MAX_TOTAL_SIZE_BYTES` — eight mebibytes total.
+
+Notebook names are validated: path separators, single- and double-dot names, NUL bytes, Windows-reserved device names, and Unicode invisible-format characters are all rejected. Names are NFKC-normalized before checks so fullwidth solidus and similar look-alikes cannot bypass validation.

--- a/strands-py/src/strands/vended_tools/notebook/__init__.py
+++ b/strands-py/src/strands/vended_tools/notebook/__init__.py
@@ -1,0 +1,23 @@
+"""Notebook tool for managing text notebooks within agent invocations.
+
+Notebooks are stored in the agent's :attr:`~strands.Agent.state` under the
+``notebooks`` key and persist within an agent session. Supports create, list,
+read, write (replace/insert), and clear operations.
+
+Example Usage:
+    ```python
+    from strands import Agent
+    from strands.vended_tools import notebook
+
+    agent = Agent(tools=[notebook])
+    ```
+"""
+
+from .notebook import make_notebook, notebook
+from .types import NotebookState
+
+__all__ = [
+    "NotebookState",
+    "make_notebook",
+    "notebook",
+]

--- a/strands-py/src/strands/vended_tools/notebook/notebook.py
+++ b/strands-py/src/strands/vended_tools/notebook/notebook.py
@@ -1,0 +1,353 @@
+"""Notebook tool for managing persistent text notebooks in agent state.
+
+Notebooks are stored on the agent's :attr:`~strands.Agent.state` under the
+``notebooks`` key and persist within the agent session (and, if the caller
+supplies a durable :class:`~strands.agent.state.AgentState`, across sessions).
+The tool is a thin wrapper over ``agent.state`` — persistence, isolation, and
+serialization all follow whatever the caller configured for agent state.
+
+Supported operations: ``create``, ``list``, ``read``, ``write`` (string
+replacement or line insertion), and ``clear``.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from typing import TYPE_CHECKING, Any, Literal
+
+from ...tools.decorator import tool
+from ...types.tools import ToolContext
+from .types import (
+    DEFAULT_NOTEBOOK_DESCRIPTION,
+    DEFAULT_NOTEBOOK_NAME,
+    MAX_NOTEBOOK_NAME_LENGTH,
+    MAX_NOTEBOOK_SIZE_BYTES,
+    MAX_NOTEBOOKS,
+    MAX_TOTAL_SIZE_BYTES,
+)
+
+if TYPE_CHECKING:
+    from ...tools.decorator import DecoratedFunctionTool
+
+_STATE_KEY = "notebooks"
+
+# Modes that alter ``notebooks`` state. Only these persist a write.
+_MUTATING_MODES = frozenset({"create", "write", "clear"})
+
+# Modes that can grow the on-disk footprint. Only these need session-cap enforcement.
+_GROWING_MODES = frozenset({"create", "write"})
+
+# Windows-reserved device names — refuse them regardless of platform so a session
+# state written on Linux does not become un-persistable on Windows. Real Windows
+# strips any extension before comparing against the device-name list, so
+# ``CON.txt`` and ``NUL.log`` are just as broken as ``CON``.
+_WINDOWS_RESERVED = re.compile(r"^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(\..*)?$", re.IGNORECASE)
+
+
+def make_notebook(
+    *,
+    name: str = "notebook",
+    description: str = DEFAULT_NOTEBOOK_DESCRIPTION,
+) -> DecoratedFunctionTool:
+    """Create a notebook tool bound to the agent's state.
+
+    Args:
+        name: Tool name. Defaults to ``"notebook"``.
+        description: Tool description shown to the model.
+
+    Returns:
+        A decorated tool that reads and writes notebooks in ``agent.state``.
+    """
+
+    @tool(name=name, description=description, context="tool_context")
+    def notebook_tool(
+        mode: Literal["create", "list", "read", "write", "clear"],
+        tool_context: ToolContext,
+        name: str | None = None,
+        new_str: str | None = None,
+        old_str: str | None = None,
+        insert_line: int | str | None = None,
+        read_range: list[int] | None = None,
+    ) -> str:
+        """Manages text notebooks for note-taking and documentation.
+
+        Supports `create`, `list`, `read`, `write` (replace or insert), and `clear`
+        operations. Notebooks persist across invocations within a session, and across
+        sessions when the agent has a durable state store.
+
+        Args:
+            mode: The operation to perform: `create`, `list`, `read`, `write`, `clear`.
+            tool_context: Injected by the framework. Not user-facing.
+            name: Name of the notebook to operate on. Defaults to "default".
+            new_str: New string for replacement or insertion operations.
+            old_str: String to replace in write mode when doing text replacement.
+            insert_line: Line number (int) or search text (str) for insertion point in write mode.
+                Supports negative indices.
+            read_range: Optional parameter of `read` command. Line range to show [start, end].
+                Supports negative indices.
+        """
+        state = tool_context.agent.state
+
+        notebooks_obj: Any = state.get(_STATE_KEY)
+        # ``AgentState.get`` deep-copies, so we own the dict. Guard shape strictly —
+        # silent stringification would mask corruption from a sibling tool.
+        if notebooks_obj is None:
+            notebooks: dict[str, str] = {}
+        elif isinstance(notebooks_obj, dict):
+            for k, v in notebooks_obj.items():
+                if not isinstance(k, str) or not isinstance(v, str):
+                    raise ValueError("Malformed notebooks state: keys and values must be strings")
+            notebooks = notebooks_obj
+        else:
+            raise ValueError("Malformed notebooks state: expected a dict")
+
+        # Ensure default notebook exists in-memory when state is empty (matches TS behavior).
+        # Only persisted if this mode actually mutates state.
+        if not notebooks:
+            notebooks[DEFAULT_NOTEBOOK_NAME] = ""
+
+        target = _validate_notebook_name(name if name is not None else DEFAULT_NOTEBOOK_NAME)
+
+        if mode == "create":
+            result = _handle_create(notebooks, target, new_str)
+        elif mode == "list":
+            result = _handle_list(notebooks)
+        elif mode == "read":
+            result = _handle_read(notebooks, target, read_range)
+        elif mode == "write":
+            _validate_write_params(old_str, new_str, insert_line)
+            result = _handle_write(notebooks, target, old_str, new_str, insert_line)
+        elif mode == "clear":
+            result = _handle_clear(notebooks, target)
+        else:  # pragma: no cover - Literal narrows this at type-check time.
+            raise ValueError(f"Unknown mode: {mode}")
+
+        if mode in _GROWING_MODES:
+            _enforce_session_caps(notebooks)
+        if mode in _MUTATING_MODES:
+            state.set(_STATE_KEY, notebooks)
+
+        return result
+
+    return notebook_tool
+
+
+notebook = make_notebook()
+"""Default notebook tool bound to the agent's state at call time."""
+
+
+# ---- Validation ----
+
+
+def _validate_notebook_name(candidate: str) -> str:
+    """Validate a notebook name and return its normalized form.
+
+    Notebook names are opaque keys into agent state; they must not resemble
+    filesystem paths and must fit within a reasonable size. The state layer is
+    memory-only by default, so path traversal is not a direct risk, but a name
+    that looks like a path is a footgun for consumers who later persist state.
+
+    Args:
+        candidate: The proposed notebook name.
+
+    Returns:
+        The NFKC-normalized notebook name.
+
+    Raises:
+        ValueError: If the name is empty, too long, or contains disallowed characters.
+    """
+    if not isinstance(candidate, str) or not candidate:
+        raise ValueError("Notebook name must be a non-empty string")
+    # Normalize BEFORE structural checks so fullwidth solidus (`／`), fullwidth
+    # backslash, etc. are treated as their canonical equivalents.
+    candidate = unicodedata.normalize("NFKC", candidate)
+    if len(candidate) > MAX_NOTEBOOK_NAME_LENGTH:
+        raise ValueError(f"Notebook name exceeds maximum length of {MAX_NOTEBOOK_NAME_LENGTH} characters")
+    # Reject leading/trailing whitespace and whitespace-only names. Windows filename
+    # rules strip trailing spaces and dots before comparing against reserved device
+    # names, so `"CON "`, `"CON."`, or `"  CON"` would otherwise sneak past the
+    # reserved-name regex and land as an unpersistable key on any downstream
+    # consumer that normalizes with Windows semantics.
+    if candidate != candidate.strip():
+        raise ValueError("Notebook name must not have leading or trailing whitespace")
+    if "\0" in candidate:
+        raise ValueError("Notebook name must not contain NUL bytes")
+    # Reject invisible format characters (Unicode category ``Cf``, e.g. U+200B
+    # ZERO WIDTH SPACE, U+200C/D ZERO WIDTH (NON-)JOINER, U+FEFF ZERO WIDTH
+    # NO-BREAK SPACE, U+2060 WORD JOINER). A name like ``..​`` passes the
+    # ``in ("..", ".")`` check, but a downstream persister that strips
+    # invisibles then sees plain ``..``.
+    if any(unicodedata.category(c) == "Cf" for c in candidate):
+        raise ValueError("Notebook name must not contain invisible format characters")
+    if "/" in candidate or "\\" in candidate:
+        raise ValueError("Notebook name must not contain path separators")
+    if candidate in ("..", "."):
+        raise ValueError("Notebook name is not allowed")
+    # Windows strips trailing dots and spaces before comparing against reserved
+    # device names — strip them here too so `"CON."` and `"CON . "` are caught.
+    reserved_check = candidate.rstrip(". ")
+    if _WINDOWS_RESERVED.match(reserved_check):
+        raise ValueError(f"Notebook name '{candidate}' is a reserved device name")
+    return candidate
+
+
+def _validate_write_params(old_str: str | None, new_str: str | None, insert_line: int | str | None) -> None:
+    """Validate the parameter combination for a write operation.
+
+    A write must be either a replacement (``old_str`` + ``new_str``) or an
+    insertion (``insert_line`` + ``new_str``). Anything else is an error.
+
+    Args:
+        old_str: The string to replace, if this is a replacement.
+        new_str: The replacement or inserted text.
+        insert_line: The insertion anchor (line number or search text), if this is an insertion.
+
+    Raises:
+        ValueError: If neither valid combination is present.
+    """
+    has_replacement = old_str is not None and new_str is not None
+    has_insertion = insert_line is not None and new_str is not None
+    if not (has_replacement or has_insertion):
+        raise ValueError(
+            "Write operation requires either (old_str + new_str) for replacement "
+            "or (insert_line + new_str) for insertion"
+        )
+    # Reject ambiguous combos where both a replacement anchor and an insertion
+    # anchor are supplied. Silently preferring one mode over the other lets a
+    # misprompted model corrupt the notebook and get a success back.
+    if old_str is not None and insert_line is not None:
+        raise ValueError(
+            "Write operation is ambiguous: pass either `old_str` (replace) or `insert_line` (insert), not both"
+        )
+
+
+def _enforce_session_caps(notebooks: dict[str, str]) -> None:
+    """Enforce per-session notebook count and size caps.
+
+    Args:
+        notebooks: The in-memory notebooks map about to be persisted.
+
+    Raises:
+        ValueError: If any cap is exceeded.
+    """
+    if len(notebooks) > MAX_NOTEBOOKS:
+        raise ValueError(f"Session notebook count exceeds maximum of {MAX_NOTEBOOKS}")
+    total = 0
+    for nb_name, content in notebooks.items():
+        size = len(content.encode("utf-8"))
+        if size > MAX_NOTEBOOK_SIZE_BYTES:
+            raise ValueError(
+                f"Notebook '{nb_name}' size ({size} bytes) exceeds maximum of {MAX_NOTEBOOK_SIZE_BYTES} bytes"
+            )
+        total += size
+    if total > MAX_TOTAL_SIZE_BYTES:
+        raise ValueError(f"Total notebook size ({total} bytes) exceeds session maximum of {MAX_TOTAL_SIZE_BYTES} bytes")
+
+
+# ---- Handlers ----
+
+
+def _handle_create(notebooks: dict[str, str], name: str, new_str: str | None) -> str:
+    notebooks[name] = new_str if new_str is not None else ""
+    # Match the TypeScript port byte-for-byte: an empty string still labels the notebook
+    # as "(empty)" because TS uses a truthiness check on newStr for the suffix.
+    suffix = " with specified content" if new_str else " (empty)"
+    return f"Created notebook '{name}'{suffix}"
+
+
+def _handle_list(notebooks: dict[str, str]) -> str:
+    lines = []
+    for nb_name, content in notebooks.items():
+        line_count = len(content.split("\n")) if content else 0
+        status = "Empty" if line_count == 0 else f"{line_count} lines"
+        lines.append(f"- {nb_name}: {status}")
+    return "Available notebooks:\n" + "\n".join(lines)
+
+
+def _handle_read(notebooks: dict[str, str], name: str, read_range: list[int] | None) -> str:
+    if name not in notebooks:
+        raise ValueError(f"Notebook '{name}' not found")
+
+    content = notebooks[name]
+
+    if read_range is None:
+        return content if content else f"Notebook '{name}' is empty"
+
+    if len(read_range) != 2:
+        raise ValueError("`read_range` must be a list of two integers: `[start, end]`")
+
+    lines = content.split("\n")
+    start, end = read_range[0], read_range[1]
+
+    if start < 0:
+        start = len(lines) + start + 1
+    if end < 0:
+        end = len(lines) + end + 1
+
+    selected: list[str] = []
+    for line_num in range(start, end + 1):
+        if 1 <= line_num <= len(lines):
+            selected.append(f"{line_num}: {lines[line_num - 1]}")
+
+    return "\n".join(selected) if selected else "No valid lines found in range"
+
+
+def _handle_write(
+    notebooks: dict[str, str],
+    name: str,
+    old_str: str | None,
+    new_str: str | None,
+    insert_line: int | str | None,
+) -> str:
+    if name not in notebooks:
+        raise ValueError(f"Notebook '{name}' not found")
+
+    # String replacement mode.
+    if old_str is not None and new_str is not None:
+        if old_str not in notebooks[name]:
+            raise ValueError(f"String '{old_str}' not found in notebook '{name}'")
+        # str.replace with count=1 replaces only the first occurrence — parity with the
+        # TypeScript port which uses a String replacement (not a RegExp), so dollar
+        # patterns in new_str are preserved literally.
+        notebooks[name] = notebooks[name].replace(old_str, new_str, 1)
+        return f"Replaced text in notebook '{name}'"
+
+    # Line insertion mode.
+    if insert_line is not None and new_str is not None:
+        lines = notebooks[name].split("\n")
+
+        if isinstance(insert_line, str):
+            line_num = -1
+            for i, line in enumerate(lines):
+                if insert_line in line:
+                    line_num = i
+                    break
+            if line_num == -1:
+                raise ValueError(f"Text '{insert_line}' not found in notebook '{name}'")
+        elif isinstance(insert_line, bool):
+            # bool is a subclass of int; reject explicitly to avoid silent coercion.
+            raise ValueError("`insert_line` must be an integer or string")
+        elif isinstance(insert_line, int):
+            if insert_line < 0:
+                line_num = len(lines) + insert_line
+            else:
+                line_num = insert_line - 1
+        else:
+            raise ValueError("`insert_line` must be an integer or string")
+
+        if line_num < -1 or line_num > len(lines):
+            raise ValueError("Line number out of range")
+
+        lines.insert(line_num + 1, new_str)
+        notebooks[name] = "\n".join(lines)
+        return f"Inserted text at line {line_num + 2} in notebook '{name}'"
+
+    raise ValueError("Invalid write operation")
+
+
+def _handle_clear(notebooks: dict[str, str], name: str) -> str:
+    if name not in notebooks:
+        raise ValueError(f"Notebook '{name}' not found")
+    notebooks[name] = ""
+    return f"Cleared notebook '{name}'"

--- a/strands-py/src/strands/vended_tools/notebook/types.py
+++ b/strands-py/src/strands/vended_tools/notebook/types.py
@@ -1,0 +1,39 @@
+"""Shared types and constants for the notebook tool."""
+
+from typing import TypedDict
+
+
+class NotebookState(TypedDict):
+    """State structure for notebook storage.
+
+    Notebooks are stored in the agent's state under the ``notebooks`` key.
+    Each notebook stores plain text content with newline-separated lines.
+    """
+
+    notebooks: dict[str, str]
+
+
+DEFAULT_NOTEBOOK_DESCRIPTION = (
+    "Manages text notebooks for note-taking and documentation. Supports create, list, read, "
+    "write (replace or insert), and clear operations. Notebooks persist across invocations "
+    "within a session, and across sessions when the agent has a durable state store."
+)
+"""Description for the notebook tool."""
+
+DEFAULT_NOTEBOOK_NAME = "default"
+"""Name of the default notebook used when no name is provided."""
+
+# Confinement caps: bound the memory footprint the model can accumulate. These match sane
+# defaults for a session-scoped scratchpad; the TypeScript port has no caps today, but a
+# model-driven store needs an upper bound so a prompt-injection cannot exhaust memory.
+MAX_NOTEBOOKS = 64
+"""Maximum number of notebooks that may exist in a single session."""
+
+MAX_NOTEBOOK_NAME_LENGTH = 128
+"""Maximum length of a notebook name in characters."""
+
+MAX_NOTEBOOK_SIZE_BYTES = 1_048_576  # 1 MiB
+"""Maximum size of any single notebook's content in bytes (UTF-8)."""
+
+MAX_TOTAL_SIZE_BYTES = 8 * 1_048_576  # 8 MiB
+"""Maximum combined size across all notebooks in a session, in bytes (UTF-8)."""

--- a/strands-py/tests/strands/vended_tools/test_notebook.py
+++ b/strands-py/tests/strands/vended_tools/test_notebook.py
@@ -1,0 +1,534 @@
+"""Tests for the notebook tool.
+
+The notebook tool stores state on the agent's :attr:`~strands.Agent.state`
+under the ``notebooks`` key. Tests here mirror the strands-ts suite for the
+same tool (matching ``strands-ts/src/vended-tools/notebook/__tests__``) and
+add coverage for the session confinement / size caps that the Python port
+enforces.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from strands.agent.state import AgentState
+from strands.types.tools import ToolContext
+from strands.vended_tools.notebook import make_notebook, notebook
+from strands.vended_tools.notebook.types import (
+    DEFAULT_NOTEBOOK_DESCRIPTION,
+    MAX_NOTEBOOK_NAME_LENGTH,
+    MAX_NOTEBOOK_SIZE_BYTES,
+    MAX_NOTEBOOKS,
+    MAX_TOTAL_SIZE_BYTES,
+)
+
+
+def _fresh_context(initial_notebooks: dict[str, str] | None = None) -> tuple[AgentState, ToolContext]:
+    """Build a fresh AgentState and ToolContext for a test.
+
+    Args:
+        initial_notebooks: Optional pre-populated notebooks map.
+
+    Returns:
+        A tuple of (state, tool_context).
+    """
+    state = AgentState({"notebooks": initial_notebooks} if initial_notebooks is not None else {"notebooks": {}})
+    agent = SimpleNamespace(state=state)
+    ctx = ToolContext(
+        tool_use={"name": "notebook", "toolUseId": "test-id", "input": {}},
+        agent=agent,
+        invocation_state={},
+    )
+    return state, ctx
+
+
+def _fresh_agent(initial_notebooks: dict[str, str] | None = None) -> tuple[AgentState, SimpleNamespace]:
+    """Build a fresh AgentState and agent stub for stream()-based tests."""
+    state = AgentState({"notebooks": initial_notebooks} if initial_notebooks is not None else {"notebooks": {}})
+    agent = SimpleNamespace(state=state)
+    return state, agent
+
+
+async def _invoke(agent: SimpleNamespace, input_: dict, alist) -> dict:
+    """Invoke the default notebook tool through the async stream() path."""
+    events = await alist(notebook.stream({"toolUseId": "t", "input": input_}, {"agent": agent}))
+    return events[-1]["tool_result"]
+
+
+class TestCreate:
+    """The ``create`` operation."""
+
+    @pytest.mark.asyncio
+    async def test_creates_empty_notebook_with_default_name(self, alist):
+        state, agent = _fresh_agent()
+        result = await _invoke(agent, {"mode": "create"}, alist)
+        assert result == {
+            "toolUseId": "t",
+            "status": "success",
+            "content": [{"text": "Created notebook 'default' (empty)"}],
+        }
+        assert state.get("notebooks")["default"] == ""
+
+    @pytest.mark.asyncio
+    async def test_creates_empty_notebook_with_custom_name(self, alist):
+        state, agent = _fresh_agent()
+        result = await _invoke(agent, {"mode": "create", "name": "notes"}, alist)
+        assert result == {
+            "toolUseId": "t",
+            "status": "success",
+            "content": [{"text": "Created notebook 'notes' (empty)"}],
+        }
+        assert state.get("notebooks")["notes"] == ""
+
+    @pytest.mark.asyncio
+    async def test_creates_notebook_with_initial_content(self):
+        state, ctx = _fresh_context()
+        content = "# My Notes\n\nFirst entry"
+        result = notebook(mode="create", name="notes", new_str=content, tool_context=ctx)
+        assert result == "Created notebook 'notes' with specified content"
+        assert state.get("notebooks")["notes"] == content
+
+    @pytest.mark.asyncio
+    async def test_overwrites_existing_notebook(self):
+        state, ctx = _fresh_context({"notes": "Old content"})
+        result = notebook(mode="create", name="notes", new_str="New content", tool_context=ctx)
+        assert result == "Created notebook 'notes' with specified content"
+        assert state.get("notebooks")["notes"] == "New content"
+
+
+class TestList:
+    """The ``list`` operation."""
+
+    @pytest.mark.asyncio
+    async def test_lists_default_when_initialized(self, alist):
+        _, agent = _fresh_agent({"default": ""})
+        result = await _invoke(agent, {"mode": "list"}, alist)
+        assert result == {
+            "toolUseId": "t",
+            "status": "success",
+            "content": [{"text": "Available notebooks:\n- default: Empty"}],
+        }
+
+    @pytest.mark.asyncio
+    async def test_lists_multiple_with_line_counts(self):
+        _, ctx = _fresh_context(
+            {
+                "default": "",
+                "notes": "Line 1\nLine 2\nLine 3",
+                "todo": "Single line",
+            }
+        )
+        result = notebook(mode="list", tool_context=ctx)
+        assert "default: Empty" in result
+        assert "notes: 3 lines" in result
+        assert "todo: 1 lines" in result
+
+
+class TestRead:
+    """The ``read`` operation."""
+
+    @pytest.mark.asyncio
+    async def test_reads_entire_notebook_default(self, alist):
+        _, agent = _fresh_agent({"default": "Line 1\nLine 2\nLine 3\nLine 4\nLine 5"})
+        result = await _invoke(agent, {"mode": "read"}, alist)
+        assert result == {
+            "toolUseId": "t",
+            "status": "success",
+            "content": [{"text": "Line 1\nLine 2\nLine 3\nLine 4\nLine 5"}],
+        }
+
+    @pytest.mark.asyncio
+    async def test_reads_entire_notebook_custom(self):
+        _, ctx = _fresh_context({"notes": "Content here"})
+        assert notebook(mode="read", name="notes", tool_context=ctx) == "Content here"
+
+    @pytest.mark.asyncio
+    async def test_reads_empty_notebook(self):
+        _, ctx = _fresh_context({"empty": ""})
+        assert notebook(mode="read", name="empty", tool_context=ctx) == "Notebook 'empty' is empty"
+
+    @pytest.mark.asyncio
+    async def test_missing_notebook_raises(self):
+        _, ctx = _fresh_context()
+        with pytest.raises(ValueError, match="Notebook 'missing' not found"):
+            notebook(mode="read", name="missing", tool_context=ctx)
+
+    @pytest.mark.asyncio
+    async def test_reads_specific_line_range(self):
+        _, ctx = _fresh_context({"default": "Line 1\nLine 2\nLine 3\nLine 4\nLine 5"})
+        result = notebook(mode="read", read_range=[2, 4], tool_context=ctx)
+        assert result == "2: Line 2\n3: Line 3\n4: Line 4"
+
+    @pytest.mark.asyncio
+    async def test_reads_range_negative_start(self):
+        _, ctx = _fresh_context({"default": "Line 1\nLine 2\nLine 3\nLine 4\nLine 5"})
+        result = notebook(mode="read", read_range=[-3, 5], tool_context=ctx)
+        assert result == "3: Line 3\n4: Line 4\n5: Line 5"
+
+    @pytest.mark.asyncio
+    async def test_reads_range_negative_end(self):
+        _, ctx = _fresh_context({"default": "Line 1\nLine 2\nLine 3\nLine 4\nLine 5"})
+        result = notebook(mode="read", read_range=[1, -2], tool_context=ctx)
+        assert result == "1: Line 1\n2: Line 2\n3: Line 3\n4: Line 4"
+
+    @pytest.mark.asyncio
+    async def test_reads_range_both_negative(self):
+        _, ctx = _fresh_context({"default": "Line 1\nLine 2\nLine 3\nLine 4\nLine 5"})
+        result = notebook(mode="read", read_range=[-2, -1], tool_context=ctx)
+        assert result == "4: Line 4\n5: Line 5"
+
+    @pytest.mark.asyncio
+    async def test_reads_out_of_range(self):
+        _, ctx = _fresh_context({"default": "Line 1\nLine 2\nLine 3\nLine 4\nLine 5"})
+        result = notebook(mode="read", read_range=[10, 20], tool_context=ctx)
+        assert result == "No valid lines found in range"
+
+
+class TestWriteReplace:
+    """The ``write`` operation in string-replacement mode."""
+
+    @pytest.mark.asyncio
+    async def test_replaces_text_default_notebook(self, alist):
+        state, agent = _fresh_agent({"default": "# Todo List\n\n[ ] Task 1\n[ ] Task 2\n[x] Task 3"})
+        result = await _invoke(
+            agent,
+            {"mode": "write", "old_str": "[ ] Task 1", "new_str": "[x] Task 1"},
+            alist,
+        )
+        assert result == {
+            "toolUseId": "t",
+            "status": "success",
+            "content": [{"text": "Replaced text in notebook 'default'"}],
+        }
+        assert state.get("notebooks")["default"] == "# Todo List\n\n[x] Task 1\n[ ] Task 2\n[x] Task 3"
+
+    @pytest.mark.asyncio
+    async def test_replaces_text_custom_notebook(self):
+        state, ctx = _fresh_context({"notes": "Original text"})
+        result = notebook(mode="write", name="notes", old_str="Original", new_str="Updated", tool_context=ctx)
+        assert result == "Replaced text in notebook 'notes'"
+        assert state.get("notebooks")["notes"] == "Updated text"
+
+    @pytest.mark.asyncio
+    async def test_replaces_multiline_text(self):
+        state, ctx = _fresh_context({"default": "# Todo List\n\n[ ] Task 1\n[ ] Task 2\n[x] Task 3"})
+        result = notebook(
+            mode="write",
+            old_str="[ ] Task 1\n[ ] Task 2",
+            new_str="[x] Task 1\n[x] Task 2",
+            tool_context=ctx,
+        )
+        assert result == "Replaced text in notebook 'default'"
+        assert state.get("notebooks")["default"] == "# Todo List\n\n[x] Task 1\n[x] Task 2\n[x] Task 3"
+
+    @pytest.mark.asyncio
+    async def test_preserves_dollar_sign_patterns_literally(self):
+        state, ctx = _fresh_context({"default": "const value = getPrice()"})
+        result = notebook(mode="write", old_str="getPrice()", new_str="$& is not $1 or $$", tool_context=ctx)
+        assert result == "Replaced text in notebook 'default'"
+        assert state.get("notebooks")["default"] == "const value = $& is not $1 or $$"
+
+    @pytest.mark.asyncio
+    async def test_missing_old_string_raises(self):
+        _, ctx = _fresh_context({"default": "# Todo List\n\n[ ] Task 1"})
+        with pytest.raises(ValueError, match="String 'Nonexistent' not found in notebook 'default'"):
+            notebook(mode="write", old_str="Nonexistent", new_str="New", tool_context=ctx)
+
+    @pytest.mark.asyncio
+    async def test_missing_notebook_raises(self):
+        _, ctx = _fresh_context()
+        with pytest.raises(ValueError, match="Notebook 'missing' not found"):
+            notebook(mode="write", name="missing", old_str="Old", new_str="New", tool_context=ctx)
+
+
+class TestWriteInsert:
+    """The ``write`` operation in line-insertion mode."""
+
+    @pytest.mark.asyncio
+    async def test_inserts_after_line_number(self):
+        state, ctx = _fresh_context({"default": "Line 1\nLine 2\nLine 3"})
+        result = notebook(mode="write", insert_line=2, new_str="Inserted line", tool_context=ctx)
+        assert result == "Inserted text at line 3 in notebook 'default'"
+        assert state.get("notebooks")["default"] == "Line 1\nLine 2\nInserted line\nLine 3"
+
+    @pytest.mark.asyncio
+    async def test_inserts_at_beginning_line_zero(self):
+        state, ctx = _fresh_context({"default": "Line 1\nLine 2\nLine 3"})
+        result = notebook(mode="write", insert_line=0, new_str="First line", tool_context=ctx)
+        assert result == "Inserted text at line 1 in notebook 'default'"
+        assert state.get("notebooks")["default"] == "First line\nLine 1\nLine 2\nLine 3"
+
+    @pytest.mark.asyncio
+    async def test_appends_with_negative_one(self):
+        state, ctx = _fresh_context({"default": "Line 1\nLine 2\nLine 3"})
+        result = notebook(mode="write", insert_line=-1, new_str="Last line", tool_context=ctx)
+        assert result == "Inserted text at line 4 in notebook 'default'"
+        assert state.get("notebooks")["default"] == "Line 1\nLine 2\nLine 3\nLast line"
+
+    @pytest.mark.asyncio
+    async def test_inserts_after_negative_index(self):
+        state, ctx = _fresh_context({"default": "Line 1\nLine 2\nLine 3"})
+        result = notebook(mode="write", insert_line=-2, new_str="Before last", tool_context=ctx)
+        assert result == "Inserted text at line 3 in notebook 'default'"
+        assert state.get("notebooks")["default"] == "Line 1\nLine 2\nBefore last\nLine 3"
+
+    @pytest.mark.asyncio
+    async def test_inserts_after_text_search(self):
+        state, ctx = _fresh_context({"default": "Line 1\nLine 2\nLine 3"})
+        result = notebook(mode="write", insert_line="Line 1", new_str="After Line 1", tool_context=ctx)
+        assert result == "Inserted text at line 2 in notebook 'default'"
+        assert state.get("notebooks")["default"] == "Line 1\nAfter Line 1\nLine 2\nLine 3"
+
+    @pytest.mark.asyncio
+    async def test_inserts_after_partial_text_match(self):
+        state, ctx = _fresh_context({"default": "Line 1\nLine 2\nLine 3"})
+        result = notebook(mode="write", insert_line="2", new_str="After match", tool_context=ctx)
+        assert result == "Inserted text at line 3 in notebook 'default'"
+        assert state.get("notebooks")["default"] == "Line 1\nLine 2\nAfter match\nLine 3"
+
+    @pytest.mark.asyncio
+    async def test_search_not_found_raises(self):
+        _, ctx = _fresh_context({"default": "Line 1\nLine 2\nLine 3"})
+        with pytest.raises(ValueError, match="Text 'Nonexistent' not found in notebook 'default'"):
+            notebook(mode="write", insert_line="Nonexistent", new_str="New line", tool_context=ctx)
+
+    @pytest.mark.asyncio
+    async def test_line_number_out_of_range_raises(self):
+        _, ctx = _fresh_context({"default": "Line 1\nLine 2\nLine 3"})
+        with pytest.raises(ValueError, match="Line number out of range"):
+            notebook(mode="write", insert_line=100, new_str="New line", tool_context=ctx)
+
+    @pytest.mark.asyncio
+    async def test_inserts_into_custom_notebook(self):
+        state, ctx = _fresh_context({"notes": "First\nSecond"})
+        result = notebook(mode="write", name="notes", insert_line=1, new_str="Middle", tool_context=ctx)
+        assert result == "Inserted text at line 2 in notebook 'notes'"
+        assert state.get("notebooks")["notes"] == "First\nMiddle\nSecond"
+
+
+class TestClear:
+    """The ``clear`` operation."""
+
+    @pytest.mark.asyncio
+    async def test_clears_default_notebook(self, alist):
+        state, agent = _fresh_agent({"default": "Some content"})
+        result = await _invoke(agent, {"mode": "clear"}, alist)
+        assert result == {
+            "toolUseId": "t",
+            "status": "success",
+            "content": [{"text": "Cleared notebook 'default'"}],
+        }
+        assert state.get("notebooks")["default"] == ""
+
+    @pytest.mark.asyncio
+    async def test_clears_custom_notebook(self):
+        state, ctx = _fresh_context({"notes": "More content"})
+        result = notebook(mode="clear", name="notes", tool_context=ctx)
+        assert result == "Cleared notebook 'notes'"
+        assert state.get("notebooks")["notes"] == ""
+
+    @pytest.mark.asyncio
+    async def test_missing_notebook_raises(self):
+        _, ctx = _fresh_context()
+        with pytest.raises(ValueError, match="Notebook 'missing' not found"):
+            notebook(mode="clear", name="missing", tool_context=ctx)
+
+    @pytest.mark.asyncio
+    async def test_clearing_does_not_affect_other_notebooks(self):
+        state, ctx = _fresh_context({"default": "Some content", "notes": "More content"})
+        notebook(mode="clear", name="notes", tool_context=ctx)
+        assert state.get("notebooks")["default"] == "Some content"
+
+
+class TestStatePersistence:
+    """Notebook state persists across operations on the same agent."""
+
+    @pytest.mark.asyncio
+    async def test_persists_across_operations(self):
+        state, ctx = _fresh_context()
+        notebook(mode="create", name="notes", new_str="Initial", tool_context=ctx)
+        assert state.get("notebooks")["notes"] == "Initial"
+
+        notebook(mode="write", name="notes", old_str="Initial", new_str="Initial\nAdded", tool_context=ctx)
+        assert state.get("notebooks")["notes"] == "Initial\nAdded"
+
+        content = notebook(mode="read", name="notes", tool_context=ctx)
+        assert content == "Initial\nAdded"
+
+        assert state.get("notebooks")["notes"] == "Initial\nAdded"
+
+    @pytest.mark.asyncio
+    async def test_read_does_not_mutate_state(self):
+        # If a sibling tool grew state past the cap, a pure read must not fail.
+        oversized = {f"nb-{i}": "a" * (MAX_NOTEBOOK_SIZE_BYTES // 2) for i in range(20)}
+        state, ctx = _fresh_context(oversized)
+        version_before = state._get_version()
+        notebook(mode="read", name="nb-0", tool_context=ctx)
+        assert state._get_version() == version_before
+
+    @pytest.mark.asyncio
+    async def test_list_does_not_mutate_state_when_empty(self):
+        # Empty state materializes a default in-memory but must not persist it on `list`.
+        state, ctx = _fresh_context()
+        version_before = state._get_version()
+        notebook(mode="list", tool_context=ctx)
+        assert state._get_version() == version_before
+
+    @pytest.mark.asyncio
+    async def test_rejects_malformed_state(self):
+        state = AgentState({"notebooks": {"good": ["not", "a", "string"]}})
+        agent = SimpleNamespace(state=state)
+        ctx = ToolContext(
+            tool_use={"name": "notebook", "toolUseId": "t", "input": {}},
+            agent=agent,
+            invocation_state={},
+        )
+        with pytest.raises(ValueError, match="Malformed notebooks state"):
+            notebook(mode="read", tool_context=ctx)
+
+
+class TestValidationErrors:
+    """Validation of inputs at the tool boundary."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_write_without_new_str_for_replacement(self):
+        _, ctx = _fresh_context()
+        with pytest.raises(ValueError):
+            notebook(mode="write", old_str="Old", tool_context=ctx)
+
+    @pytest.mark.asyncio
+    async def test_rejects_write_without_new_str_for_insertion(self):
+        _, ctx = _fresh_context()
+        with pytest.raises(ValueError):
+            notebook(mode="write", insert_line=1, tool_context=ctx)
+
+    @pytest.mark.asyncio
+    async def test_rejects_write_without_operation_params(self):
+        _, ctx = _fresh_context()
+        with pytest.raises(ValueError):
+            notebook(mode="write", tool_context=ctx)
+
+    @pytest.mark.asyncio
+    async def test_rejects_write_with_both_old_str_and_insert_line(self):
+        # Ambiguous: replacement anchor and insertion anchor both provided. Reject
+        # rather than silently preferring one mode — the model probably did not
+        # mean to corrupt the notebook.
+        _, ctx = _fresh_context({"default": "Line 1\nLine 2"})
+        with pytest.raises(ValueError, match="ambiguous"):
+            notebook(
+                mode="write",
+                old_str="Line 1",
+                new_str="Replaced",
+                insert_line=0,
+                tool_context=ctx,
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_read_range_wrong_length(self):
+        _, ctx = _fresh_context({"default": "Line 1\nLine 2"})
+        with pytest.raises(ValueError, match="two integers"):
+            notebook(mode="read", read_range=[1], tool_context=ctx)
+
+
+class TestNameConfinement:
+    """Notebook-name validation prevents path-like keys from leaking through state."""
+
+    @pytest.mark.parametrize(
+        "bad_name",
+        [
+            "../etc/passwd",
+            "..\\evil",
+            "/absolute/path",
+            "nested/name",
+            "back\\slash",
+            "..",
+            ".",
+            "notes\x00../etc/passwd",  # NUL-byte smuggling
+            "notes／nested",  # fullwidth solidus — must be normalized then rejected
+            "CON",  # Windows reserved
+            "com1",  # case-insensitive Windows reserved
+            "CON.txt",  # Windows strips extension before reserved-name check
+            "NUL.log",  # same
+            "lpt1.dat",  # lowercase + extension
+            "notes​",  # zero-width space — invisible bypass of `..` check would be `..​`
+            "..​",  # zero-width space after dot-dot
+            "..﻿",  # BOM after dot-dot
+            "..⁠",  # word joiner
+            "notes‌",  # ZWNJ
+            "CON ",  # trailing space — Windows strips it before reserved-name check
+            "CON.",  # trailing dot — Windows strips it too
+            " CON",  # leading whitespace
+            "notes ",  # trailing whitespace
+            "   ",  # whitespace-only
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_rejects_path_like_names(self, bad_name):
+        _, ctx = _fresh_context()
+        with pytest.raises(ValueError):
+            notebook(mode="create", name=bad_name, tool_context=ctx)
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_name(self):
+        _, ctx = _fresh_context()
+        with pytest.raises(ValueError, match="non-empty"):
+            notebook(mode="create", name="", tool_context=ctx)
+
+    @pytest.mark.asyncio
+    async def test_rejects_overly_long_name(self):
+        _, ctx = _fresh_context()
+        long_name = "a" * (MAX_NOTEBOOK_NAME_LENGTH + 1)
+        with pytest.raises(ValueError, match="maximum length"):
+            notebook(mode="create", name=long_name, tool_context=ctx)
+
+
+class TestSessionCaps:
+    """Session-scoped memory caps guard against runaway state growth."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_too_many_notebooks(self):
+        # Pre-fill state right up to the limit, then try to create one more.
+        initial = {f"nb-{i}": "" for i in range(MAX_NOTEBOOKS)}
+        _, ctx = _fresh_context(initial)
+        with pytest.raises(ValueError, match="notebook count"):
+            notebook(mode="create", name="over-the-line", tool_context=ctx)
+
+    @pytest.mark.asyncio
+    async def test_rejects_notebook_content_over_size_limit(self):
+        _, ctx = _fresh_context()
+        oversized = "a" * (MAX_NOTEBOOK_SIZE_BYTES + 1)
+        with pytest.raises(ValueError, match="maximum of"):
+            notebook(mode="create", name="big", new_str=oversized, tool_context=ctx)
+
+    @pytest.mark.asyncio
+    async def test_rejects_total_session_over_size_limit(self):
+        # Each of these is a valid single notebook, but together they overflow the total cap.
+        per_notebook = MAX_NOTEBOOK_SIZE_BYTES
+        count = (MAX_TOTAL_SIZE_BYTES // per_notebook) + 1
+        # Cap ceiling at MAX_NOTEBOOKS to avoid tripping the count cap first.
+        assert count <= MAX_NOTEBOOKS, "Test assumption: total cap trips before count cap"
+        initial = {f"nb-{i}": "a" * per_notebook for i in range(count - 1)}
+        _, ctx = _fresh_context(initial)
+        with pytest.raises(ValueError, match="session maximum"):
+            notebook(mode="create", name="last", new_str="a" * per_notebook, tool_context=ctx)
+
+
+class TestToolMetadata:
+    """Tool names, descriptions, and input schemas."""
+
+    def test_default_name(self):
+        assert notebook.tool_name == "notebook"
+
+    def test_custom_name(self):
+        assert make_notebook(name="scratchpad").tool_name == "scratchpad"
+
+    def test_default_description(self):
+        assert make_notebook().tool_spec["description"] == DEFAULT_NOTEBOOK_DESCRIPTION
+
+    def test_custom_description(self):
+        assert make_notebook(description="custom").tool_spec["description"] == "custom"
+
+    def test_schema_excludes_context(self):
+        props = notebook.tool_spec["inputSchema"]["json"]["properties"]
+        assert "mode" in props
+        assert "tool_context" not in props


### PR DESCRIPTION
Ports the notebook vended tool from the TypeScript SDK to Python. Gives an agent a session-scoped scratchpad it can create, list, read, write, and clear. Notebooks are stored on agent state under the notebooks key, matching the persistence model of the TypeScript port, so anything the caller already does to persist agent state (Session Management, custom state stores) picks the notebook up for free.

The tool is a thin wrapper over agent state and matches the TypeScript port's naming and semantics with Python snake_case parameter names. Registration lives alongside the bash and file editor tools, exposed via strands.vended_tools.notebook and make_notebook.

Two intentional adds beyond a pure port. First, session caps: sixty-four notebooks per session, one mebibyte per notebook, eight mebibytes total. The TypeScript port has no caps today, but a session-persistent model-driven store needs an upper bound so a prompt injection cannot exhaust memory. Second, notebook-name validation: the model-controlled name becomes a dict key on agent state that may later be serialized to disk, so path-shaped keys are rejected (empty names, path separators, single- and double-dot forms, embedded NULs, over 128 characters, Windows-reserved device names, and invisible format characters). Names are NFKC-normalized before checking so look-alike Unicode cannot bypass validation.

The docs page is updated to add a Python tab for the notebook section, mark the tool as available in Python, and add a Python entry to sourceLinks. TypeScript is otherwise untouched.

https://github.com/strands-agents/harness-sdk/issues/3240