### PR TITLE
feat(vended-tools): add web_fetch tool

### DIFF
--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -10,6 +10,8 @@ sourceLinks:
   - path: strands-ts/src/vended-tools/bash/bash.ts
   - path: strands-ts/src/vended-tools/http-request/http-request.ts
   - path: strands-ts/src/vended-tools/notebook/notebook.ts
+  - path: strands-ts/src/vended-tools/web-fetch/web-fetch.ts
+  - path: strands-py/src/strands/vended_tools/web_fetch/web_fetch.py
 ---
 
 Vended tools are pre-built tools included directly in the Strands SDK for common agent tasks like file operations, shell commands, HTTP requests, and persistent notes. 
@@ -34,6 +36,7 @@ Each tool is imported from its own subpath under `@strands-agents/sdk/vended-too
 | [HTTP Request](#http-request) | Make HTTP requests to external APIs | TypeScript (Node.js 20+, browsers) |
 | [Notebook](#notebook) | Manage persistent text notebooks | TypeScript (Node.js, browsers) |
 | [Bash](#bash) | Execute shell commands with persistent sessions | Python, TypeScript (Node.js, Unix/Linux/macOS) |
+| [Web Fetch](#web-fetch) | Fetch a URL and return cleaned markdown for a model to read | Python, TypeScript (Node.js) |
 
 ### File Editor
 
@@ -160,6 +163,47 @@ agent("List all Python files in the current directory and count them")
 ```
 
 📖 [Full API Reference](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/bash/README.md)
+
+---
+
+### Web Fetch
+
+Fetches an HTTP(S) URL and returns its readable content as markdown suitable for a model to read. Scripts, styles, and other non-content noise are stripped from the extracted markdown. Distinct from the HTTP Request tool, which returns raw response bodies for API calls.
+
+_Supported in: Node.js (TypeScript); all platforms (Python)._
+
+:::caution[Security Warning]
+The model chooses the fetched URL, so the tool is intentionally strict at that boundary. Only http and https schemes are accepted. Every host is DNS-resolved and every returned address is required to be publicly routable, so private, loopback, link-local, cloud metadata, CGNAT, multicast, and reserved ranges are refused. Redirects are re-validated against the same rules and the tool connects to a specific already-validated IP address so a DNS rebinder cannot substitute a private address between validation and connect. Response bodies are capped at five mebibytes.
+:::
+
+**Example:**
+
+<Tabs>
+<Tab label="TypeScript">
+
+```typescript
+import { Agent } from '@strands-agents/sdk'
+import { webFetch } from '@strands-agents/sdk/vended-tools/web-fetch'
+
+const agent = new Agent({ tools: [webFetch] })
+await agent.invoke('Summarize https://example.com/blog/post')
+```
+
+</Tab>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.vended_tools import web_fetch
+
+agent = Agent(tools=[web_fetch])
+agent("Summarize https://example.com/blog/post")
+```
+
+</Tab>
+</Tabs>
+
+📖 [Full API Reference](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/web-fetch/README.md)
 
 ---
 

--- a/strands-py/src/strands/vended_tools/__init__.py
+++ b/strands-py/src/strands/vended_tools/__init__.py
@@ -1,26 +1,30 @@
-"""Built-in tools for executing commands and editing files.
+"""Built-in tools for executing commands, editing files, and fetching web pages.
 
 The :data:`bash` tool runs a
 persistent shell on the host; the :func:`make_bash` and :func:`make_file_editor`
 factories produce sandbox-routed tools that either bind to a
 :class:`~strands.sandbox.base.Sandbox` at creation (as the built-in Docker/SSH
 sandboxes do when vending tools) or read the sandbox from the agent at call time.
+The :data:`web_fetch` tool fetches an HTTP(S) URL and returns clean markdown.
 
 Example Usage:
     ```python
     from strands import Agent
-    from strands.vended_tools import bash, file_editor
+    from strands.vended_tools import bash, file_editor, web_fetch
 
-    agent = Agent(tools=[bash, file_editor])
+    agent = Agent(tools=[bash, file_editor, web_fetch])
     ```
 """
 
 from .bash import bash, make_bash
 from .file_editor import file_editor, make_file_editor
+from .web_fetch import make_web_fetch, web_fetch
 
 __all__ = [
     "bash",
     "file_editor",
     "make_bash",
     "make_file_editor",
+    "make_web_fetch",
+    "web_fetch",
 ]

--- a/strands-py/src/strands/vended_tools/web_fetch/__init__.py
+++ b/strands-py/src/strands/vended_tools/web_fetch/__init__.py
@@ -1,0 +1,20 @@
+"""Web fetch tool for retrieving a URL and returning clean markdown.
+
+Distinct from ``http_request`` (raw API calls): this tool fetches a page and
+extracts its readable content as markdown suitable for a model to read.
+
+Example Usage:
+    ```python
+    from strands import Agent
+    from strands.vended_tools import web_fetch
+
+    agent = Agent(tools=[web_fetch])
+    ```
+"""
+
+from .web_fetch import make_web_fetch, web_fetch
+
+__all__ = [
+    "make_web_fetch",
+    "web_fetch",
+]

--- a/strands-py/src/strands/vended_tools/web_fetch/_extract.py
+++ b/strands-py/src/strands/vended_tools/web_fetch/_extract.py
@@ -1,0 +1,388 @@
+"""HTML → markdown extraction for the web fetch tool.
+
+The goal is not a perfect readability heuristic — it is producing output that
+is safe and useful for a model to read. We strip script, style, and other
+non-content elements entirely, drop ``data:`` URI images (which can be huge
+blobs), and preserve headings, links, lists, blockquotes, code, and paragraph
+text as GitHub-flavored markdown.
+
+Uses only the standard library (``html.parser``) so this tool adds no runtime
+dependency and no third-party surface to audit.
+"""
+
+from __future__ import annotations
+
+import logging
+from html import unescape
+from html.parser import HTMLParser
+
+logger = logging.getLogger(__name__)
+
+# Elements whose content is discarded entirely, not just unwrapped.
+_DROPPED_ELEMENTS = frozenset(
+    {
+        "script",
+        "style",
+        "noscript",
+        "template",
+        "svg",
+        "canvas",
+        "iframe",
+        "object",
+        "embed",
+        "video",
+        "audio",
+        "form",
+        "input",
+        "button",
+        "select",
+        "textarea",
+        # ``head`` is intentionally NOT dropped -- it contains ``title``, which
+        # we want to extract. Its problematic children (``script``, ``style``)
+        # are already in this set.
+    }
+)
+
+# HTML void elements never fire a matching end tag, so they must not affect
+# the drop-depth counter -- otherwise a void child inside a dropped element
+# would leak the drop state forever (e.g. <form><input></form> would keep the
+# extractor in "dropping" mode after </form>).
+_VOID_ELEMENTS = frozenset(
+    {"area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source", "track", "wbr"}
+)
+
+_HEADING_LEVELS = {"h1": 1, "h2": 2, "h3": 3, "h4": 4, "h5": 5, "h6": 6}
+
+# Sentinel markers used during extraction to record where a blockquote begins
+# and ends. A post-processing pass prefixes every line between the markers with
+# ``> `` so nested block elements (e.g. ``<blockquote><p>...</p></blockquote>``)
+# stay inside the blockquote in the emitted markdown.
+_BQ_OPEN = "\x00BQ_OPEN\x00"
+_BQ_CLOSE = "\x00BQ_CLOSE\x00"
+
+
+class _MarkdownExtractor(HTMLParser):
+    """Streaming HTML→markdown extractor.
+
+    Not a general HTML-to-markdown converter — good enough for feeding a model.
+    """
+
+    def __init__(self) -> None:
+        # convert_charrefs=True → &amp; etc. are decoded before handle_data is called.
+        super().__init__(convert_charrefs=True)
+        self._out: list[str] = []
+        # Stack of currently-open block-level containers we care about. Used to
+        # emit list markers with the right indent and to close blocks cleanly.
+        self._drop_depth = 0  # >0 → inside script/style/etc., discard everything
+        self._list_stack: list[str] = []  # each entry: "ul" or "ol"
+        self._ol_counters: list[int] = []
+        self._pre_depth = 0
+        self._code_depth = 0
+        # For each currently-open <a>, the href we will close with — or ``None`` if
+        # the href was missing or javascript:, in which case we do not emit
+        # markdown link syntax at all.
+        self._link_href: list[str | None] = []
+        self._title_parts: list[str] = []
+        self._in_title = False
+        # Inline text buffer for the current block; flushed on block boundaries.
+        self._inline: list[str] = []
+
+    # ---- Public accessors ----
+
+    @property
+    def title(self) -> str:
+        return "".join(self._title_parts).strip()
+
+    def get_markdown(self) -> str:
+        self._flush_inline()
+        text = "".join(self._out)
+        lines = text.splitlines()
+
+        # Walk lines and prefix everything between _BQ_OPEN/_BQ_CLOSE markers
+        # with "> ". Nesting increases the count so a nested blockquote yields
+        # "> > ".
+        prefixed: list[str] = []
+        bq_depth = 0
+        for line in lines:
+            if line == _BQ_OPEN:
+                bq_depth += 1
+                continue
+            if line == _BQ_CLOSE:
+                if bq_depth > 0:
+                    bq_depth -= 1
+                continue
+            if bq_depth > 0:
+                prefix = "> " * bq_depth
+                # Blank lines inside a blockquote still get the marker so the
+                # block stays visually connected in rendered markdown.
+                if line == "":
+                    prefixed.append(prefix.rstrip())
+                else:
+                    prefixed.append(f"{prefix}{line}")
+            else:
+                prefixed.append(line)
+
+        # Collapse runs of blank lines and trim.
+        collapsed: list[str] = []
+        blank = 0
+        for line in prefixed:
+            if line.strip() == "":
+                blank += 1
+                if blank <= 1:
+                    collapsed.append("")
+            else:
+                blank = 0
+                collapsed.append(line.rstrip())
+        return "\n".join(collapsed).strip() + "\n" if collapsed else ""
+
+    # ---- HTMLParser hooks ----
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        tag = tag.lower()
+
+        if tag == "title":
+            self._in_title = True
+            return
+
+        if self._drop_depth > 0:
+            # Only track nesting for elements that (a) we drop and (b) have a
+            # real end tag. Void tags like <input>/<source> never fire
+            # handle_endtag, so counting them would leak drop-state across
+            # a following close tag of the enclosing dropped element.
+            if tag in _DROPPED_ELEMENTS and tag not in _VOID_ELEMENTS:
+                self._drop_depth += 1
+            return
+
+        if tag in _DROPPED_ELEMENTS and tag not in _VOID_ELEMENTS:
+            self._drop_depth = 1
+            return
+        if tag in _DROPPED_ELEMENTS:
+            # Void + dropped (e.g. <input>) has no body to skip; just ignore it.
+            return
+
+        # Void elements handled here so they don't get pushed onto any stack.
+        if tag == "br":
+            self._inline.append("  \n")
+            return
+        if tag == "hr":
+            self._flush_inline()
+            self._out.append("\n---\n\n")
+            return
+        if tag == "img":
+            self._handle_img(attrs)
+            return
+
+        # Block-level formatting.
+        if tag in _HEADING_LEVELS:
+            self._flush_inline()
+            self._out.append("\n" + "#" * _HEADING_LEVELS[tag] + " ")
+            return
+        if tag == "p":
+            self._flush_inline()
+            self._out.append("\n")
+            return
+        if tag == "blockquote":
+            self._flush_inline()
+            # Emit a sentinel rather than a bare "> " prefix. A post-processing
+            # pass rewrites every line between the sentinels with "> ",
+            # correctly quoting nested block elements like <p> and lists.
+            self._out.append(f"\n{_BQ_OPEN}\n")
+            return
+        if tag == "ul":
+            self._flush_inline()
+            self._list_stack.append("ul")
+            return
+        if tag == "ol":
+            self._flush_inline()
+            self._list_stack.append("ol")
+            self._ol_counters.append(0)
+            return
+        if tag == "li":
+            self._flush_inline()
+            depth = max(0, len(self._list_stack) - 1)
+            indent = "  " * depth
+            if self._list_stack and self._list_stack[-1] == "ol":
+                self._ol_counters[-1] += 1
+                self._out.append(f"{indent}{self._ol_counters[-1]}. ")
+            else:
+                self._out.append(f"{indent}- ")
+            return
+        if tag == "pre":
+            self._flush_inline()
+            self._pre_depth += 1
+            self._out.append("\n```\n")
+            return
+        if tag == "code":
+            self._code_depth += 1
+            if self._pre_depth == 0:
+                self._inline.append("`")
+            return
+        if tag == "a":
+            href = self._attr(attrs, "href") or ""
+            if href and not href.lstrip().lower().startswith("javascript:"):
+                self._link_href.append(href)
+                self._inline.append("[")
+            else:
+                self._link_href.append(None)
+            return
+        if tag in ("strong", "b"):
+            self._inline.append("**")
+            return
+        if tag in ("em", "i"):
+            self._inline.append("*")
+            return
+
+        # Any other tag is treated as a transparent wrapper — its children are
+        # rendered inline. We intentionally do not track it on any stack.
+
+    def handle_endtag(self, tag: str) -> None:
+        tag = tag.lower()
+
+        if tag == "title":
+            self._in_title = False
+            return
+
+        if self._drop_depth > 0:
+            # Mirror handle_starttag exactly: only decrement on end tags of
+            # elements we actually drop AND that have a matching real end tag
+            # (are not void). Otherwise a stray "</input>" or "</embed>"
+            # inside a dropped ancestor would decrement the counter from 1 to
+            # 0 and leak the remaining dropped body.
+            if tag in _DROPPED_ELEMENTS and tag not in _VOID_ELEMENTS:
+                self._drop_depth -= 1
+            return
+
+        if tag in _HEADING_LEVELS:
+            self._flush_inline()
+            self._out.append("\n\n")
+            return
+        if tag == "p":
+            self._flush_inline()
+            self._out.append("\n\n")
+            return
+        if tag == "blockquote":
+            self._flush_inline()
+            self._out.append(f"\n{_BQ_CLOSE}\n\n")
+            return
+        if tag == "ul":
+            self._flush_inline()
+            if self._list_stack and self._list_stack[-1] == "ul":
+                self._list_stack.pop()
+            self._out.append("\n")
+            return
+        if tag == "ol":
+            self._flush_inline()
+            if self._list_stack and self._list_stack[-1] == "ol":
+                self._list_stack.pop()
+                if self._ol_counters:
+                    self._ol_counters.pop()
+            self._out.append("\n")
+            return
+        if tag == "li":
+            self._flush_inline()
+            self._out.append("\n")
+            return
+        if tag == "pre":
+            self._flush_inline()
+            if self._pre_depth > 0:
+                self._pre_depth -= 1
+            self._out.append("```\n\n")
+            return
+        if tag == "code":
+            if self._code_depth > 0:
+                self._code_depth -= 1
+            if self._pre_depth == 0:
+                self._inline.append("`")
+            return
+        if tag == "a":
+            href = self._link_href.pop() if self._link_href else None
+            if href is not None:
+                self._inline.append(f"]({href})")
+            return
+        if tag in ("strong", "b"):
+            self._inline.append("**")
+            return
+        if tag in ("em", "i"):
+            self._inline.append("*")
+            return
+
+    def handle_data(self, data: str) -> None:
+        if self._drop_depth > 0:
+            return
+        if self._in_title:
+            self._title_parts.append(data)
+            return
+        # Discard whitespace-only chunks that appear outside of preformatted blocks
+        # and outside of any current inline content — helps keep output tidy.
+        if self._pre_depth > 0:
+            # Preserve exact whitespace inside <pre>.
+            self._out.append(data)
+            return
+        # Escape backticks inside inline code so they don't unbalance the ``.
+        if self._code_depth > 0:
+            self._inline.append(data.replace("`", ""))
+            return
+        # Collapse internal whitespace to single spaces to match model expectations.
+        normalized = " ".join(data.split())
+        if not normalized:
+            # If we already have some inline text and the raw data had a space,
+            # keep a single separating space.
+            if data and data[0].isspace() and self._inline and not self._inline[-1].endswith(" "):
+                self._inline.append(" ")
+            return
+        # Preserve a leading/trailing space if present in the original chunk.
+        prefix = " " if data and data[0].isspace() and self._inline else ""
+        suffix = " " if data and data[-1].isspace() else ""
+        self._inline.append(f"{prefix}{normalized}{suffix}")
+
+    # ---- Internals ----
+
+    def _flush_inline(self) -> None:
+        if not self._inline:
+            return
+        text = "".join(self._inline).strip()
+        self._inline.clear()
+        if text:
+            self._out.append(text)
+
+    def _handle_img(self, attrs: list[tuple[str, str | None]]) -> None:
+        src = self._attr(attrs, "src") or ""
+        alt = self._attr(attrs, "alt") or ""
+        if not src:
+            return
+        # Data URIs can be enormous blobs — dropping them is a size defense as
+        # well as a noise-reduction one.
+        if src.lstrip().lower().startswith("data:"):
+            if alt:
+                self._inline.append(alt)
+            return
+        if src.lstrip().lower().startswith("javascript:"):
+            return
+        self._inline.append(f"![{alt}]({src})")
+
+    @staticmethod
+    def _attr(attrs: list[tuple[str, str | None]], name: str) -> str | None:
+        name = name.lower()
+        for k, v in attrs:
+            if k.lower() == name:
+                return unescape(v) if v is not None else None
+        return None
+
+
+def html_to_markdown(html: str) -> tuple[str, str]:
+    """Convert HTML to markdown suitable for a model to read.
+
+    Returns:
+        A tuple of (title, markdown). Both are stripped of surrounding whitespace.
+    """
+    parser = _MarkdownExtractor()
+    # HTMLParser tolerates malformed HTML and does not execute anything. Even
+    # so, an unexpected parser bug should not fail the outer fetch -- return
+    # whatever partial output has accumulated -- but leave a debug trace so a
+    # real regression is visible to anyone with debug logging on.
+    try:
+        parser.feed(html)
+        parser.close()
+    except Exception:
+        logger.debug("html_to_markdown parser raised; returning partial output", exc_info=True)
+    return parser.title, parser.get_markdown()

--- a/strands-py/src/strands/vended_tools/web_fetch/_ssrf.py
+++ b/strands-py/src/strands/vended_tools/web_fetch/_ssrf.py
@@ -1,0 +1,170 @@
+"""SSRF defenses for the web fetch tool.
+
+Only ``http`` and ``https`` schemes are allowed. Hostnames are resolved and every
+returned address is checked against a deny list of private, loopback, link-local,
+multicast, reserved, CGNAT, site-local, and unspecified ranges. Named cloud
+metadata endpoints and a DNS suffix denylist are refused before DNS is queried
+at all. Every hop of a redirect chain is re-validated so DNS rebinding cannot
+swap a public address for a private one between the check and the actual
+connect.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urlsplit
+
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+
+# DNS suffix denylist. Common private-network TLDs and anonymized-routing
+# namespaces that must never leak a lookup to the public resolver. Compared
+# case-folded with any trailing "." stripped. Kept in sync with the TypeScript
+# implementation in ``strands-ts/src/vended-tools/web-fetch/ssrf.ts``.
+_DENIED_DNS_SUFFIXES = (
+    ".internal",
+    ".local",
+    ".localhost",
+    ".corp",
+    ".home",
+    ".lan",
+    ".intranet",
+    ".private",
+    ".i2p",
+    ".onion",
+)
+
+# Explicit metadata hostnames. Belt-and-suspenders: every one of these resolves
+# to an address the range checks below would already refuse, but naming them
+# here means a future refactor of those predicates cannot silently expose them
+# without also removing them from this list. Covers AWS/GCP IMDSv1
+# (169.254.169.254), IPv6 EC2 (fd00:ec2::254), Alibaba
+# (100.100.100.200 / 192.0.0.192), and GCP's DNS name.
+_DENIED_METADATA_HOSTS = frozenset(
+    {
+        "169.254.169.254",
+        "fd00:ec2::254",
+        "100.100.100.200",
+        "192.0.0.192",
+        "metadata.google.internal",
+    }
+)
+
+# Site-local IPv6 (deprecated but still commonly deployed internally).
+_IPV6_SITE_LOCAL = ipaddress.IPv6Network("fec0::/10")
+
+
+def validate_url_scheme(url: str) -> None:
+    """Raise ValueError if ``url`` is not an ``http://`` or ``https://`` URL."""
+    parts = urlsplit(url)
+    if parts.scheme.lower() not in _ALLOWED_SCHEMES:
+        raise ValueError(f"Only http:// and https:// URLs are allowed. Got scheme={parts.scheme!r} for URL {url!r}.")
+    if not parts.hostname:
+        raise ValueError(f"URL has no host: {url!r}")
+
+
+def _normalize_host_for_denylist(host: str) -> str:
+    """Lower-case ``host`` and strip a single trailing ``.`` for suffix match."""
+    lower = host.lower()
+    if lower.endswith("."):
+        lower = lower[:-1]
+    return lower
+
+
+def assert_host_is_allowed(host: str) -> None:
+    """Refuse the DNS suffix denylist and named metadata endpoints.
+
+    Runs before DNS resolution -- these hostnames must never generate a lookup
+    at all. Raises :class:`ValueError` on refusal; returns silently on allow.
+    """
+    normalized = _normalize_host_for_denylist(host)
+    if not normalized:
+        return
+    if normalized == "metadata":
+        raise ValueError(f"Refusing to fetch host {host!r}: bare-label metadata endpoint is refused.")
+    if normalized in _DENIED_METADATA_HOSTS:
+        raise ValueError(f"Refusing to fetch host {host!r}: cloud metadata endpoint {normalized!r} is refused.")
+    for suffix in _DENIED_DNS_SUFFIXES:
+        if normalized == suffix[1:] or normalized.endswith(suffix):
+            raise ValueError(f"Refusing to fetch host {host!r}: DNS suffix {suffix!r} is on the denylist.")
+
+
+def _address_is_public(ip_text: str) -> bool:
+    """Return True only for globally routable unicast addresses.
+
+    Layers explicit rejections on top of ``ipaddress.is_global``:
+
+    - ``is_global`` returns ``True`` for **multicast** on every CPython from
+      3.10 through 3.14, so ``is_multicast`` must be checked explicitly.
+    - Site-local IPv6 (``fec0::/10``) is not consistently caught by
+      ``is_global`` either -- reject it explicitly.
+    - ``is_reserved``, ``is_link_local``, and ``is_unspecified`` are layered
+      too, as belt-and-suspenders against any future looseness in
+      ``is_global``.
+
+    IPv4-mapped IPv6 addresses (``::ffff:a.b.c.d``, including the fully expanded
+    ``0:0:0:0:0:ffff:a.b.c.d`` form) are unwrapped first so the underlying IPv4
+    category is what gets checked.
+    """
+    try:
+        ip = ipaddress.ip_address(ip_text)
+    except ValueError:
+        return False
+
+    # Unwrap IPv4-mapped IPv6 addresses so we compare against the mapped IPv4
+    # address's real category.
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+
+    if ip.is_multicast:
+        return False
+    if ip.is_reserved:
+        return False
+    if ip.is_link_local:
+        return False
+    if ip.is_unspecified:
+        return False
+    if isinstance(ip, ipaddress.IPv6Address) and ip in _IPV6_SITE_LOCAL:
+        return False
+    return bool(getattr(ip, "is_global", False))
+
+
+def resolve_and_validate_host(host: str) -> list[str]:
+    """Resolve ``host`` to IP addresses and require every one to be public.
+
+    Returns the resolved addresses on success. Refuses the DNS suffix denylist
+    and named metadata endpoints without querying DNS. If the host is an IP
+    literal it is validated directly. If any resolved address is
+    private/loopback/etc., raises :class:`ValueError`. Every address is
+    re-checked, so a DNS-rebinding attempt that returns multiple A records is
+    rejected.
+
+    The caller is expected to connect using one of these already-validated
+    addresses so the check-time and connect-time addresses agree.
+    """
+    # Refuse .internal / .onion / metadata.google.internal etc. before DNS.
+    assert_host_is_allowed(host)
+
+    # If host is a bracketed IPv6 literal, urlsplit strips the brackets already.
+    try:
+        infos = socket.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as e:
+        raise ValueError(f"Could not resolve host {host!r}: {e}") from e
+
+    addresses: list[str] = []
+    for info in infos:
+        sockaddr = info[4]
+        # sockaddr is (host, port) for AF_INET and (host, port, flow, scope) for AF_INET6.
+        # ``sockaddr[0]`` is typed as ``str | int`` because ``socket.getaddrinfo`` can
+        # return numeric addresses when NUMERICHOST is set; we always want the string.
+        ip_text = str(sockaddr[0])
+        if not _address_is_public(ip_text):
+            raise ValueError(
+                f"Refusing to fetch host {host!r}: resolved address {ip_text!r} is not public "
+                "(private, loopback, link-local, site-local, multicast, CGNAT, or reserved)."
+            )
+        addresses.append(ip_text)
+
+    if not addresses:
+        raise ValueError(f"Could not resolve host {host!r}: no addresses returned")
+    return addresses

--- a/strands-py/src/strands/vended_tools/web_fetch/types.py
+++ b/strands-py/src/strands/vended_tools/web_fetch/types.py
@@ -1,0 +1,30 @@
+"""Shared types and constants for the web fetch tool."""
+
+from typing import TypedDict
+
+
+class WebFetchOutput(TypedDict):
+    """Output of a web fetch.
+
+    Attributes:
+        url: The final URL after redirects.
+        status: HTTP status code of the final response.
+        content_type: Content-Type header of the final response (may be empty).
+        title: Extracted document title, or an empty string when none was found.
+        markdown: Extracted, cleaned markdown suitable for a model to read.
+    """
+
+    url: str
+    status: int
+    content_type: str
+    title: str
+    markdown: str
+
+
+WEB_FETCH_DESCRIPTION = (
+    "Fetches an HTTP(S) URL and returns its readable content as markdown, suitable "
+    "for a model to read. Scripts, styles, and other non-content noise are stripped. "
+    "Only http:// and https:// URLs are allowed. Private, loopback, and link-local "
+    "addresses are refused."
+)
+"""Description for the web fetch tool."""

--- a/strands-py/src/strands/vended_tools/web_fetch/web_fetch.py
+++ b/strands-py/src/strands/vended_tools/web_fetch/web_fetch.py
@@ -1,0 +1,305 @@
+"""Web fetch tool: fetch a URL and return clean markdown for a model to read.
+
+Distinct from the http_request tool, which returns raw response bodies for API
+calls. This tool is intentionally narrow: HTTP(S) GET, decoded body, HTML to
+markdown. It is not a general-purpose scraper.
+
+Only http and https URLs are accepted; every host is resolved and every
+returned address is required to be publicly routable, and IPv4-mapped IPv6
+addresses are unwrapped before the check. Redirects are re-validated against
+the same rules. The tool connects to an already-validated IP address so a DNS
+rebinder cannot substitute a private address between validation and connect.
+Response size is capped and scripts, styles, and data URI images are stripped
+from the extracted markdown. See :mod:`._ssrf` for the address-level defense.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import http.client
+import socket
+import ssl
+from typing import TYPE_CHECKING
+from urllib.parse import urljoin, urlsplit
+
+from ...tools.decorator import tool
+from ._extract import html_to_markdown
+from ._ssrf import resolve_and_validate_host, validate_url_scheme
+from .types import WEB_FETCH_DESCRIPTION, WebFetchOutput
+
+if TYPE_CHECKING:
+    from ...tools.decorator import DecoratedFunctionTool
+
+_DEFAULT_TIMEOUT = 30
+_DEFAULT_MAX_BYTES = 5 * 1024 * 1024  # 5 MiB
+_DEFAULT_MAX_REDIRECTS = 5
+_USER_AGENT = "strands-agents-web-fetch/1.0"
+
+
+class _PinnedHTTPConnection(http.client.HTTPConnection):
+    """HTTPConnection that connects to a caller-chosen IP but sends the original Host header.
+
+    We validate the DNS answer up front and then pin the connect target so a
+    later rebind cannot substitute a private IP. ``host`` is preserved for the
+    Host header and (for HTTPS) SNI/certificate validation.
+    """
+
+    def __init__(self, host: str, pinned_ip: str, port: int, timeout: float) -> None:
+        super().__init__(host, port, timeout=timeout)
+        self._pinned_ip = pinned_ip
+
+    def connect(self) -> None:
+        self.sock = socket.create_connection((self._pinned_ip, self.port), timeout=self.timeout)
+
+
+class _PinnedHTTPSConnection(http.client.HTTPSConnection):
+    """HTTPS variant of :class:`_PinnedHTTPConnection`.
+
+    Preserves ``host`` for SNI and certificate hostname verification while
+    connecting to a pinned IP.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        pinned_ip: str,
+        port: int,
+        timeout: float,
+        context: ssl.SSLContext,
+    ) -> None:
+        # Do NOT pass ``context`` up to ``HTTPSConnection.__init__``. On CPython
+        # 3.11 the parent constructor probes ``context.verify_mode`` and
+        # ``context.check_hostname`` before we get a chance to override
+        # ``connect``. Some callers (and every reasonable test double) don't
+        # want that surface, and we never use ``self._context`` -- ``connect``
+        # below wraps with ``self._ssl_context`` directly.
+        super().__init__(host, port, timeout=timeout)
+        self._pinned_ip = pinned_ip
+        self._ssl_context = context
+
+    def connect(self) -> None:
+        sock = socket.create_connection((self._pinned_ip, self.port), timeout=self.timeout)
+        # Wrap with SNI = self.host so certificate verification still uses the
+        # public hostname (not the pinned IP literal).
+        self.sock = self._ssl_context.wrap_socket(sock, server_hostname=self.host)
+
+
+_REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
+_REDIRECT_BODY_DRAIN_CAP = 4096
+
+
+def _fetch_once(url: str, timeout: float, max_bytes: int) -> tuple[int, dict[str, str], bytes, str]:
+    """Perform one HTTP(S) request with SSRF defenses and no redirect handling.
+
+    Returns:
+        A tuple of (status, headers, body bytes, effective URL). On a 3xx
+        response the body is not buffered beyond a small drain cap: the caller
+        only needs the ``Location`` header.
+    """
+    validate_url_scheme(url)
+    parts = urlsplit(url)
+    host = parts.hostname
+    if host is None:
+        raise ValueError(f"URL has no host: {url!r}")
+
+    addresses = resolve_and_validate_host(host)
+
+    port = parts.port
+    if port is None:
+        port = 443 if parts.scheme.lower() == "https" else 80
+
+    # Build a Host header from hostname (+ optional port) so any userinfo in
+    # the URL is not leaked into the header. IPv6 literals must be bracketed
+    # per RFC 3986 -- otherwise "2001:db8::1:8443" is ambiguous.
+    is_ipv6_literal = ":" in host
+    if is_ipv6_literal:
+        host_header = f"[{host}]" if parts.port is None else f"[{host}]:{parts.port}"
+    else:
+        host_header = host if parts.port is None else f"{host}:{parts.port}"
+
+    path = parts.path or "/"
+    if parts.query:
+        path = f"{path}?{parts.query}"
+
+    # Try each validated address in turn. This matters on hosts where getaddrinfo
+    # returns an AAAA record first but the runtime has no working IPv6, or vice
+    # versa -- every address has already passed the SSRF check, so falling
+    # through does not weaken the security posture.
+    last_error: OSError | None = None
+    for pinned_ip in addresses:
+        conn: http.client.HTTPConnection
+        if parts.scheme.lower() == "https":
+            ctx = ssl.create_default_context()
+            conn = _PinnedHTTPSConnection(host, pinned_ip, port, timeout, ctx)
+        else:
+            conn = _PinnedHTTPConnection(host, pinned_ip, port, timeout)
+
+        try:
+            conn.request(
+                "GET",
+                path,
+                headers={
+                    "Host": host_header,
+                    "User-Agent": _USER_AGENT,
+                    "Accept": "text/html,application/xhtml+xml;q=0.9,*/*;q=0.8",
+                    "Accept-Encoding": "identity",
+                    "Connection": "close",
+                },
+            )
+            response = conn.getresponse()
+            headers = {k.lower(): v for k, v in response.getheaders()}
+            if response.status in _REDIRECT_STATUSES:
+                # We only need the Location header on a redirect -- draining the
+                # body to a small cap is enough to let the connection close
+                # cleanly without buffering the discarded payload.
+                response.read(_REDIRECT_BODY_DRAIN_CAP)
+                return response.status, headers, b"", url
+            # Read up to max_bytes + 1 so we can detect overflow.
+            body = response.read(max_bytes + 1)
+            if len(body) > max_bytes:
+                raise ValueError(f"Response body exceeded max_bytes={max_bytes}. Refusing to buffer more.")
+            return response.status, headers, body, url
+        except OSError as e:
+            # Connect-time or transport-level errors are worth retrying against
+            # the next validated address. ValueError (size cap, etc.) is a
+            # policy decision -- do not retry those.
+            last_error = e
+            continue
+        finally:
+            conn.close()
+
+    # All addresses failed to connect. Surface the last transport error.
+    raise ConnectionError(
+        f"Could not connect to any validated address for host {host!r} (tried {len(addresses)}): {last_error}"
+    ) from last_error
+
+
+def _follow_redirects(
+    url: str,
+    timeout: float,
+    max_bytes: int,
+    max_redirects: int,
+) -> tuple[int, dict[str, str], bytes, str]:
+    """Fetch ``url``, following up to ``max_redirects`` redirects, revalidating each hop."""
+    current = url
+    seen: set[str] = set()
+    for _ in range(max_redirects + 1):
+        if current in seen:
+            raise ValueError(f"Redirect loop detected involving {current!r}")
+        seen.add(current)
+
+        status, headers, body, effective = _fetch_once(current, timeout=timeout, max_bytes=max_bytes)
+        if status in _REDIRECT_STATUSES:
+            location = headers.get("location")
+            if not location:
+                raise ValueError(f"Redirect {status} from {current!r} without a Location header")
+            # Resolve relative Location against the request URL.
+            current = urljoin(current, location)
+            # Re-validate scheme immediately so we do not, for example, follow a
+            # javascript: or file: redirect.
+            validate_url_scheme(current)
+            continue
+        return status, headers, body, effective
+
+    raise ValueError(f"Exceeded max_redirects={max_redirects} following {url!r}")
+
+
+def _decode_body(body: bytes, content_type: str) -> str:
+    """Decode a response body using the charset from Content-Type, defaulting to utf-8."""
+    charset = "utf-8"
+    for part in content_type.split(";"):
+        part = part.strip()
+        if part.lower().startswith("charset="):
+            charset = part.split("=", 1)[1].strip().strip('"').strip("'") or "utf-8"
+            break
+    try:
+        return body.decode(charset, errors="replace")
+    except LookupError:
+        return body.decode("utf-8", errors="replace")
+
+
+def make_web_fetch(
+    *,
+    name: str = "web_fetch",
+    description: str = WEB_FETCH_DESCRIPTION,
+    max_bytes: int = _DEFAULT_MAX_BYTES,
+    max_redirects: int = _DEFAULT_MAX_REDIRECTS,
+) -> DecoratedFunctionTool:
+    """Create a web fetch tool.
+
+    Args:
+        name: Tool name. Defaults to ``"web_fetch"``.
+        description: Tool description shown to the model.
+        max_bytes: Maximum response body size, in bytes. Larger responses are
+            rejected without buffering the entire body.
+        max_redirects: Maximum number of HTTP redirects to follow. Each hop is
+            revalidated against the same SSRF rules as the initial URL.
+
+    Returns:
+        A decorated tool that fetches a URL and returns the extracted markdown.
+    """
+    if max_bytes <= 0:
+        raise ValueError(f"max_bytes must be positive, got {max_bytes}")
+    if max_redirects < 0:
+        raise ValueError(f"max_redirects must be non-negative, got {max_redirects}")
+
+    @tool(name=name, description=description)
+    async def web_fetch_tool(url: str, timeout: int = _DEFAULT_TIMEOUT) -> WebFetchOutput:
+        """Fetches an HTTP(S) URL and returns readable markdown.
+
+        Only ``http://`` and ``https://`` URLs are accepted. Requests to
+        private, loopback, link-local, multicast, or reserved addresses are
+        refused. Response body size is capped and redirects are revalidated.
+
+        Args:
+            url: The URL to fetch. Must be ``http://`` or ``https://``.
+            timeout: Total wall-clock timeout in seconds (default: 30). Enforced
+                as an outer ``asyncio.wait_for`` so a trickling server cannot
+                keep the request open past this cap.
+        """
+        if timeout <= 0:
+            raise ValueError(f"timeout must be positive, got {timeout}")
+
+        try:
+            status, headers, body, effective_url = await asyncio.wait_for(
+                asyncio.to_thread(
+                    _follow_redirects,
+                    url,
+                    float(timeout),
+                    max_bytes,
+                    max_redirects,
+                ),
+                timeout=float(timeout),
+            )
+        except asyncio.TimeoutError as e:
+            raise TimeoutError(f"web_fetch exceeded total timeout of {timeout}s for {url!r}") from e
+
+        content_type = headers.get("content-type", "")
+        text = _decode_body(body, content_type)
+
+        # If the response is not HTML, return the decoded body verbatim (up to
+        # the size cap) so the model can still read plain-text or markdown
+        # responses that were served with a non-HTML Content-Type.
+        if "html" not in content_type.lower() and "xml" not in content_type.lower():
+            return {
+                "url": effective_url,
+                "status": status,
+                "content_type": content_type,
+                "title": "",
+                "markdown": text,
+            }
+
+        title, markdown = html_to_markdown(text)
+        return {
+            "url": effective_url,
+            "status": status,
+            "content_type": content_type,
+            "title": title,
+            "markdown": markdown,
+        }
+
+    return web_fetch_tool
+
+
+web_fetch = make_web_fetch()
+"""Default web fetch tool with conservative size and redirect limits."""

--- a/strands-py/tests/strands/vended_tools/test_web_fetch.py
+++ b/strands-py/tests/strands/vended_tools/test_web_fetch.py
@@ -1,0 +1,706 @@
+"""Tests for the web_fetch tool.
+
+These focus on the security surface -- URL validation, SSRF address checks,
+redirect revalidation, size caps -- and on the HTML-to-markdown extractor.
+The transport layer is exercised in-process by monkeypatching ``_fetch_once``
+so tests do not hit the network.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+# The tool named ``web_fetch`` (re-exported by the package ``__init__``) shadows
+# the submodule of the same name in the package namespace. Load the submodule
+# explicitly so monkeypatch can rebind attributes on it -- and load the ``_ssrf``
+# submodule the same way so it can be monkeypatched even though the shadowing
+# breaks dotted-string lookups through the package.
+web_fetch_module = importlib.import_module("strands.vended_tools.web_fetch.web_fetch")
+ssrf_module = importlib.import_module("strands.vended_tools.web_fetch._ssrf")
+
+from strands.vended_tools.web_fetch import make_web_fetch, web_fetch  # noqa: E402
+from strands.vended_tools.web_fetch._extract import html_to_markdown  # noqa: E402
+from strands.vended_tools.web_fetch._ssrf import (  # noqa: E402
+    assert_host_is_allowed,
+    resolve_and_validate_host,
+    validate_url_scheme,
+)
+from strands.vended_tools.web_fetch.types import WEB_FETCH_DESCRIPTION  # noqa: E402
+
+
+class TestUrlSchemeValidation:
+    """Only http:// and https:// URLs may reach the network layer."""
+
+    def test_accepts_http(self):
+        validate_url_scheme("http://example.com/path")
+
+    def test_accepts_https(self):
+        validate_url_scheme("https://example.com/path")
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "file:///etc/passwd",
+            "ftp://example.com/foo",
+            "gopher://example.com/",
+            "javascript:alert(1)",
+            "data:text/html,<script>1</script>",
+            "chrome-extension://foo/bar",
+        ],
+    )
+    def test_rejects_non_http_schemes(self, url):
+        with pytest.raises(ValueError, match="Only http"):
+            validate_url_scheme(url)
+
+    def test_rejects_missing_host(self):
+        with pytest.raises(ValueError, match="no host"):
+            validate_url_scheme("http:///no-host-here")
+
+
+class TestSsrfAddressValidation:
+    """resolve_and_validate_host rejects private, loopback, link-local, etc."""
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "127.0.0.1",
+            "127.0.0.53",
+            "0.0.0.0",
+            "10.0.0.5",
+            "10.255.255.254",
+            "172.16.0.1",
+            "172.31.255.255",
+            "192.168.1.1",
+            "169.254.169.254",  # AWS/GCP metadata endpoint
+            "169.254.170.2",  # ECS task metadata
+            "100.64.0.1",  # CGNAT (100.64.0.0/10)
+            "100.127.255.254",  # CGNAT (100.64.0.0/10)
+            "::1",
+            "fe80::1",  # link-local IPv6
+            "fc00::1",  # unique-local IPv6
+            "224.0.0.1",  # multicast
+            "255.255.255.255",  # broadcast/reserved
+            "2001:db8::1",  # documentation range (compressed form)
+            "fec0::1",  # site-local (deprecated, filtered anyway)
+        ],
+    )
+    def test_rejects_non_public_addresses(self, host):
+        # Some of these (169.254.169.254, 100.100.100.200 etc.) are refused by
+        # the pre-DNS named-metadata check before they ever hit the address
+        # predicate. Either error is fine as long as it's a hard refusal.
+        with pytest.raises(ValueError, match=r"not public|metadata|denylist"):
+            resolve_and_validate_host(host)
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "::ffff:127.0.0.1",  # dotted-quad form
+            "::ffff:169.254.169.254",  # metadata
+            "::ffff:10.0.0.1",
+            "::ffff:100.64.0.1",  # CGNAT
+        ],
+    )
+    def test_rejects_ipv4_mapped_ipv6_variants(self, host):
+        with pytest.raises(ValueError, match="not public"):
+            resolve_and_validate_host(host)
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "foo.internal",
+            "foo.internal.",  # trailing dot must be stripped before match
+            "FOO.INTERNAL",  # case-insensitive
+            "bar.local",
+            "localhost",
+            "example.corp",
+            "example.home",
+            "example.lan",
+            "example.intranet",
+            "example.private",
+            "site.i2p",
+            "site.onion",
+        ],
+    )
+    def test_dns_suffix_denylist_refused_before_dns(self, host):
+        # These hostnames never even reach a DNS query.
+        with pytest.raises(ValueError, match=r"denylist|metadata"):
+            assert_host_is_allowed(host)
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "metadata",
+            "metadata.google.internal",
+            "169.254.169.254",
+            "fd00:ec2::254",
+            "100.100.100.200",
+            "192.0.0.192",
+        ],
+    )
+    def test_metadata_endpoints_refused_before_dns(self, host):
+        with pytest.raises(ValueError, match=r"metadata|denylist"):
+            assert_host_is_allowed(host)
+
+    def test_rejects_ipv4_mapped_ipv6_loopback(self):
+        # An attacker who can influence DNS could serve ::ffff:127.0.0.1
+        # to bypass a naive IPv4-only private check.
+        with pytest.raises(ValueError, match="not public"):
+            resolve_and_validate_host("::ffff:127.0.0.1")
+
+    def test_accepts_public_ipv4_literal(self):
+        # 8.8.8.8 is a canonical public address; validating a literal does not
+        # cause a real DNS query.
+        addrs = resolve_and_validate_host("8.8.8.8")
+        assert addrs == ["8.8.8.8"]
+
+    def test_rejects_when_any_resolution_is_private(self, monkeypatch):
+        """DNS rebinding defense: if any returned A record is non-public, refuse."""
+
+        def fake_getaddrinfo(host, *a, **kw):
+            return [
+                # 8.8.8.8 is a genuinely public address, so if the validator
+                # short-circuited on the first record this test would pass
+                # spuriously. Using a real public IP first proves the loop
+                # actually walks every record.
+                (0, 0, 0, "", ("8.8.8.8", 0)),
+                (0, 0, 0, "", ("127.0.0.1", 0)),
+            ]
+
+        monkeypatch.setattr(ssrf_module.socket, "getaddrinfo", fake_getaddrinfo)
+        with pytest.raises(ValueError, match="not public"):
+            resolve_and_validate_host("example.invalid")
+
+    def test_dns_failure_surfaces_as_value_error(self, monkeypatch):
+        import socket as _socket
+
+        def boom(*a, **kw):
+            raise _socket.gaierror("no such host")
+
+        monkeypatch.setattr(ssrf_module.socket, "getaddrinfo", boom)
+        with pytest.raises(ValueError, match="Could not resolve host"):
+            resolve_and_validate_host("nonexistent.invalid")
+
+    def test_pinned_https_connect_uses_pinned_ip(self, monkeypatch):
+        """The pinned connection must call socket.create_connection with the pinned IP."""
+        captured: dict[str, tuple[str, int]] = {}
+
+        class _FakeSock:
+            def close(self) -> None:  # pragma: no cover - defensive
+                pass
+
+        def fake_create_connection(address, timeout=None):
+            captured["address"] = address
+            return _FakeSock()
+
+        class _FakeCtx:
+            def wrap_socket(self, sock, server_hostname=None):
+                captured["sni"] = server_hostname
+                return sock
+
+        monkeypatch.setattr(web_fetch_module.socket, "create_connection", fake_create_connection)
+        conn = web_fetch_module._PinnedHTTPSConnection(
+            "example.com", "203.0.113.5", 443, timeout=5.0, context=_FakeCtx()
+        )
+        conn.connect()
+        assert captured["address"] == ("203.0.113.5", 443)
+        assert captured["sni"] == "example.com"
+
+
+class TestHtmlToMarkdown:
+    """Extraction strips noise and preserves structure."""
+
+    def test_strips_script_and_style(self):
+        html = """
+        <html><head><title>Hi</title>
+        <style>body{color:red}</style>
+        </head><body>
+        <p>Hello world.</p>
+        <script>alert('xss')</script>
+        <p>After script.</p>
+        </body></html>
+        """
+        title, md = html_to_markdown(html)
+        assert title == "Hi"
+        assert "alert" not in md
+        assert "color:red" not in md
+        assert "Hello world." in md
+        assert "After script." in md
+
+    def test_strips_data_uri_images(self):
+        # A giant data-URI image blob would blow up model context; drop it.
+        big_blob = "A" * 10000
+        html = f'<p>text</p><img src="data:image/png;base64,{big_blob}" alt="alt text">'
+        _, md = html_to_markdown(html)
+        assert big_blob not in md
+        assert "data:" not in md
+        # Alt text is preserved as a substitute so information is not lost.
+        assert "alt text" in md
+
+    def test_preserves_regular_images(self):
+        html = '<img src="https://example.com/pic.png" alt="pic">'
+        _, md = html_to_markdown(html)
+        assert "![pic](https://example.com/pic.png)" in md
+
+    def test_javascript_href_is_dropped(self):
+        html = '<a href="javascript:alert(1)">click</a>'
+        _, md = html_to_markdown(html)
+        assert "javascript:" not in md
+        assert "click" in md
+
+    def test_javascript_img_src_is_dropped(self):
+        html = '<img src="javascript:alert(1)" alt="x">'
+        _, md = html_to_markdown(html)
+        assert "javascript:" not in md
+
+    def test_preserves_headings_lists_and_links(self):
+        html = """
+        <h1>Title</h1>
+        <p>Intro paragraph with a <a href="https://ex.com/x">link</a>.</p>
+        <ul><li>one</li><li>two</li></ul>
+        <ol><li>first</li><li>second</li></ol>
+        """
+        _, md = html_to_markdown(html)
+        assert "# Title" in md
+        assert "[link](https://ex.com/x)" in md
+        assert "- one" in md
+        assert "- two" in md
+        assert "1. first" in md
+        assert "2. second" in md
+
+    def test_preserves_code_blocks(self):
+        html = "<pre><code>def f():\n    return 1</code></pre>"
+        _, md = html_to_markdown(html)
+        assert "```" in md
+        assert "def f():" in md
+        assert "return 1" in md
+
+    def test_ignores_event_handler_attributes(self):
+        # onclick/onerror never appear as content: HTMLParser only reports
+        # data(), and we render only href/src/alt attributes.
+        html = '<div onclick="alert(1)"><p onmouseover="x()">safe</p></div>'
+        _, md = html_to_markdown(html)
+        assert "alert" not in md
+        assert "onclick" not in md
+        assert "safe" in md
+
+    def test_blockquote_prefixes_nested_block_content(self):
+        # <blockquote> wrapping <p> is the common shape. Every line inside the
+        # blockquote must be prefixed with "> ", including the paragraph that a
+        # naive open-tag-only implementation would emit unquoted.
+        html = "<blockquote><p>quoted line one.</p><p>quoted line two.</p></blockquote>"
+        _, md = html_to_markdown(html)
+        bq_lines = [line for line in md.splitlines() if "quoted line" in line]
+        assert len(bq_lines) == 2
+        for line in bq_lines:
+            assert line.startswith("> "), line
+
+    def test_nested_blockquote_stacks_prefix(self):
+        html = "<blockquote><blockquote><p>deep.</p></blockquote></blockquote>"
+        _, md = html_to_markdown(html)
+        assert "> > deep." in md
+
+    def test_survives_malformed_html(self):
+        html = "<p>ok <b>bold <em>and italic</p>"
+        _, md = html_to_markdown(html)
+        assert "ok" in md
+        assert "bold" in md
+
+    def test_void_tag_inside_dropped_element_does_not_swallow_following_content(self):
+        # <input> is a void tag: it never fires an end tag. A previous bug
+        # incremented _drop_depth on every start tag inside a dropped element,
+        # so <form><input></form> would leave _drop_depth > 0 forever and
+        # discard everything after the </form>.
+        html = "<form><input></form><p>after</p>"
+        _, md = html_to_markdown(html)
+        assert "after" in md
+
+    def test_void_end_tag_inside_dropped_ancestor_does_not_leak(self):
+        # A stray </input> or </embed> inside a dropped ancestor must not
+        # decrement _drop_depth (mirror of the start-tag guard). Otherwise the
+        # dropped element's remaining body leaks into output.
+        html = "<form>secret<input></input>LEAKED</form>tail"
+        _, md = html_to_markdown(html)
+        assert "secret" not in md
+        assert "LEAKED" not in md
+        assert "tail" in md
+
+    def test_javascript_href_with_leading_whitespace_is_dropped(self):
+        # Leading whitespace/tab before "javascript:" was a bypass in the
+        # previous version -- lstrip before the prefix check.
+        html = '<a href="\tjavascript:alert(1)">click</a>'
+        _, md = html_to_markdown(html)
+        assert "javascript:" not in md
+        assert "alert" not in md
+        assert "click" in md
+
+
+class TestMakeWebFetchValidation:
+    """Non-trivial factory behavior."""
+
+    def test_default_description(self):
+        assert web_fetch.tool_spec["description"] == WEB_FETCH_DESCRIPTION
+
+    def test_default_name(self):
+        assert web_fetch.tool_name == "web_fetch"
+
+
+class TestWebFetchToolCall:
+    """End-to-end tool behavior with the network layer stubbed out."""
+
+    @pytest.mark.asyncio
+    async def test_html_response_returns_markdown(self, monkeypatch):
+        html_body = b"<html><head><title>T</title></head><body><h1>Hi</h1></body></html>"
+
+        def stub(url, timeout, max_bytes):
+            return 200, {"content-type": "text/html; charset=utf-8"}, html_body, url
+
+        monkeypatch.setattr(web_fetch_module, "_fetch_once", stub)
+        result = await web_fetch(url="https://example.com/")
+        assert result["status"] == 200
+        assert result["url"] == "https://example.com/"
+        assert result["content_type"].startswith("text/html")
+        assert result["title"] == "T"
+        assert "# Hi" in result["markdown"]
+
+    @pytest.mark.asyncio
+    async def test_non_html_response_returns_body(self, monkeypatch):
+        body = b"plain text response"
+
+        def stub(url, timeout, max_bytes):
+            return 200, {"content-type": "text/plain"}, body, url
+
+        monkeypatch.setattr(web_fetch_module, "_fetch_once", stub)
+        tru_result = await web_fetch(url="https://example.com/robots.txt")
+        exp_result = {
+            "url": "https://example.com/robots.txt",
+            "status": 200,
+            "content_type": "text/plain",
+            "title": "",
+            "markdown": "plain text response",
+        }
+        assert tru_result == exp_result
+
+    @pytest.mark.asyncio
+    async def test_redirect_is_followed_and_revalidated(self, monkeypatch):
+        # Two hops: 302 -> 200. Each hop must go through _fetch_once (which
+        # validates scheme + SSRF), proving revalidation is applied.
+        seen = []
+
+        def stub(url, timeout, max_bytes):
+            seen.append(url)
+            if url == "https://example.com/a":
+                return 302, {"location": "https://example.com/b"}, b"", url
+            return 200, {"content-type": "text/html"}, b"<p>ok</p>", url
+
+        monkeypatch.setattr(web_fetch_module, "_fetch_once", stub)
+        result = await web_fetch(url="https://example.com/a")
+        assert seen == ["https://example.com/a", "https://example.com/b"]
+        assert result["status"] == 200
+        assert "ok" in result["markdown"]
+
+    @pytest.mark.asyncio
+    async def test_redirect_to_javascript_scheme_is_rejected(self, monkeypatch):
+        def stub(url, timeout, max_bytes):
+            return 302, {"location": "javascript:alert(1)"}, b"", url
+
+        monkeypatch.setattr(web_fetch_module, "_fetch_once", stub)
+        with pytest.raises(ValueError, match="Only http"):
+            await web_fetch(url="https://example.com/redir")
+
+    @pytest.mark.asyncio
+    async def test_redirect_cap_is_enforced(self, monkeypatch):
+        counter = {"n": 0}
+
+        def stub(url, timeout, max_bytes):
+            counter["n"] += 1
+            return 302, {"location": f"https://example.com/{counter['n']}"}, b"", url
+
+        monkeypatch.setattr(web_fetch_module, "_fetch_once", stub)
+        fetch = make_web_fetch(max_redirects=2)
+        with pytest.raises(ValueError, match="max_redirects"):
+            await fetch(url="https://example.com/start")
+
+    @pytest.mark.asyncio
+    async def test_redirect_missing_location_errors(self, monkeypatch):
+        def stub(url, timeout, max_bytes):
+            return 302, {}, b"", url
+
+        monkeypatch.setattr(web_fetch_module, "_fetch_once", stub)
+        with pytest.raises(ValueError, match="without a Location"):
+            await web_fetch(url="https://example.com/x")
+
+    @pytest.mark.asyncio
+    async def test_private_ip_rejected_end_to_end(self):
+        # 127.0.0.1 is an IP literal, so resolve_and_validate_host refuses
+        # without any real network call.
+        with pytest.raises(ValueError, match="not public"):
+            await web_fetch(url="http://127.0.0.1/anything")
+
+    @pytest.mark.asyncio
+    async def test_metadata_endpoint_rejected(self):
+        with pytest.raises(ValueError, match=r"not public|metadata"):
+            await web_fetch(url="http://169.254.169.254/latest/meta-data/")
+
+    @pytest.mark.asyncio
+    async def test_non_http_scheme_rejected_end_to_end(self):
+        with pytest.raises(ValueError, match="Only http"):
+            await web_fetch(url="file:///etc/passwd")
+
+    @pytest.mark.asyncio
+    async def test_zero_timeout_rejected(self):
+        with pytest.raises(ValueError, match="timeout"):
+            await web_fetch(url="https://example.com/", timeout=0)
+
+    @pytest.mark.asyncio
+    async def test_total_timeout_wraps_slow_transport(self, monkeypatch):
+        # Simulate a transport that would run past the requested timeout: the
+        # outer asyncio.wait_for must trip regardless.
+        import time
+
+        def slow(url, timeout, max_bytes):
+            time.sleep(2.0)
+            return 200, {"content-type": "text/html"}, b"<p>slow</p>", url
+
+        monkeypatch.setattr(web_fetch_module, "_fetch_once", slow)
+        with pytest.raises(TimeoutError, match="total timeout"):
+            await web_fetch(url="https://example.com/", timeout=1)
+
+
+class TestSizeCap:
+    """Oversized responses are rejected without buffering the excess."""
+
+    def test_fetch_once_rejects_body_over_cap(self, monkeypatch):
+        class _FakeResponse:
+            status = 200
+
+            def __init__(self, body: bytes) -> None:
+                self._body = body
+
+            def getheaders(self):
+                return [("Content-Type", "text/html")]
+
+            def read(self, n):
+                return self._body[:n]
+
+        class _FakeConn:
+            def __init__(self, body: bytes) -> None:
+                self._body = body
+
+            def request(self, *a, **kw):
+                pass
+
+            def getresponse(self):
+                return _FakeResponse(self._body)
+
+            def close(self):
+                pass
+
+        big = b"x" * 100
+
+        def fake_pinned_https(host, pinned_ip, port, timeout, context):
+            return _FakeConn(big)
+
+        # Bypass SSRF for this narrow test -- we are exercising the size cap
+        # only. Real end-to-end SSRF is covered elsewhere.
+        monkeypatch.setattr(web_fetch_module, "_PinnedHTTPSConnection", fake_pinned_https)
+        monkeypatch.setattr(web_fetch_module, "resolve_and_validate_host", lambda h: ["203.0.113.1"])
+
+        with pytest.raises(ValueError, match="max_bytes"):
+            web_fetch_module._fetch_once("https://example.com/", timeout=5.0, max_bytes=50)
+
+
+class TestMultiAddressFallback:
+    """If the first validated address fails to connect, the next is tried."""
+
+    def test_second_address_used_when_first_refuses_connection(self, monkeypatch):
+        # Simulate the common case of "AAAA first, no IPv6 route" -- the first
+        # address raises a transport error, the second succeeds. Every address
+        # in the list has already passed the SSRF check.
+        tried: list[str] = []
+
+        class _FakeResponse:
+            status = 200
+
+            def getheaders(self):
+                return [("Content-Type", "text/plain")]
+
+            def read(self, n):
+                return b"ok"
+
+        class _FakeConn:
+            def __init__(self, host, pinned_ip, port, timeout, *a, **kw):
+                self.pinned_ip = pinned_ip
+
+            def request(self, *a, **kw):
+                tried.append(self.pinned_ip)
+                if self.pinned_ip == "2606:4700:4700::1111":
+                    raise OSError("no route to host")
+
+            def getresponse(self):
+                return _FakeResponse()
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(web_fetch_module, "_PinnedHTTPSConnection", _FakeConn)
+        monkeypatch.setattr(
+            web_fetch_module,
+            "resolve_and_validate_host",
+            lambda h: ["2606:4700:4700::1111", "1.1.1.1"],
+        )
+
+        status, _, body, _ = web_fetch_module._fetch_once("https://example.com/", timeout=5.0, max_bytes=1024)
+        assert status == 200
+        assert body == b"ok"
+        assert tried == ["2606:4700:4700::1111", "1.1.1.1"]
+
+    def test_all_addresses_fail_surfaces_connection_error(self, monkeypatch):
+        class _FakeConn:
+            def __init__(self, host, pinned_ip, port, timeout, *a, **kw):
+                pass
+
+            def request(self, *a, **kw):
+                raise OSError("no route to host")
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(web_fetch_module, "_PinnedHTTPSConnection", _FakeConn)
+        monkeypatch.setattr(
+            web_fetch_module,
+            "resolve_and_validate_host",
+            lambda h: ["2606:4700:4700::1111", "1.1.1.1"],
+        )
+
+        with pytest.raises(ConnectionError, match="Could not connect to any validated address"):
+            web_fetch_module._fetch_once("https://example.com/", timeout=5.0, max_bytes=1024)
+
+
+class TestRequestHeaders:
+    """Outgoing request headers must not leak URL userinfo or port state."""
+
+    def _capture_request(self, monkeypatch, url: str) -> dict:
+        captured: dict = {}
+
+        class _FakeResponse:
+            status = 200
+
+            def getheaders(self):
+                return [("Content-Type", "text/plain")]
+
+            def read(self, n):
+                return b""
+
+        class _FakeConn:
+            def request(self, method, path, headers):
+                captured["headers"] = headers
+                captured["path"] = path
+
+            def getresponse(self):
+                return _FakeResponse()
+
+            def close(self):
+                pass
+
+        def fake_pinned_https(host, pinned_ip, port, timeout, context):
+            return _FakeConn()
+
+        def fake_pinned_http(host, pinned_ip, port, timeout):
+            return _FakeConn()
+
+        monkeypatch.setattr(web_fetch_module, "_PinnedHTTPSConnection", fake_pinned_https)
+        monkeypatch.setattr(web_fetch_module, "_PinnedHTTPConnection", fake_pinned_http)
+        monkeypatch.setattr(web_fetch_module, "resolve_and_validate_host", lambda h: ["203.0.113.1"])
+        web_fetch_module._fetch_once(url, timeout=5.0, max_bytes=1024)
+        return captured
+
+    def test_host_header_omits_userinfo(self, monkeypatch):
+        # A URL with basic-auth credentials must not leak them into the Host header.
+        captured = self._capture_request(monkeypatch, "https://alice:pw@example.com/path")
+        assert captured["headers"]["Host"] == "example.com"
+
+    def test_host_header_includes_port(self, monkeypatch):
+        captured = self._capture_request(monkeypatch, "https://example.com:8443/path")
+        assert captured["headers"]["Host"] == "example.com:8443"
+
+    def test_host_header_hides_userinfo_with_port(self, monkeypatch):
+        captured = self._capture_request(monkeypatch, "https://alice:pw@example.com:8443/path")
+        assert captured["headers"]["Host"] == "example.com:8443"
+
+    def test_host_header_brackets_ipv6_with_port(self, monkeypatch):
+        # RFC 3986 requires IPv6 literals in the Host header to be bracketed.
+        # We stub SSRF because 2606:4700:4700::1111 is genuinely public and
+        # we don't want to depend on DNS in a unit test.
+        captured = self._capture_request(monkeypatch, "https://[2606:4700:4700::1111]:8443/path")
+        assert captured["headers"]["Host"] == "[2606:4700:4700::1111]:8443"
+
+    def test_host_header_brackets_ipv6_without_port(self, monkeypatch):
+        captured = self._capture_request(monkeypatch, "https://[2606:4700:4700::1111]/path")
+        assert captured["headers"]["Host"] == "[2606:4700:4700::1111]"
+
+
+class TestRedirectBodyShortCircuit:
+    """A 3xx response must not buffer the full body -- only the drain cap."""
+
+    def test_redirect_body_is_not_buffered(self, monkeypatch):
+        reads: list[int] = []
+
+        class _FakeResponse:
+            status = 302
+
+            def getheaders(self):
+                return [("Location", "https://example.com/next")]
+
+            def read(self, n):
+                reads.append(n)
+                return b""
+
+        class _FakeConn:
+            def request(self, *a, **kw):
+                pass
+
+            def getresponse(self):
+                return _FakeResponse()
+
+            def close(self):
+                pass
+
+        def fake_pinned_https(host, pinned_ip, port, timeout, context):
+            return _FakeConn()
+
+        monkeypatch.setattr(web_fetch_module, "_PinnedHTTPSConnection", fake_pinned_https)
+        monkeypatch.setattr(web_fetch_module, "resolve_and_validate_host", lambda h: ["203.0.113.1"])
+
+        status, headers, body, _ = web_fetch_module._fetch_once(
+            "https://example.com/redir", timeout=5.0, max_bytes=10_000_000
+        )
+        assert status == 302
+        assert headers["location"] == "https://example.com/next"
+        assert body == b""
+        # We should have asked for the small drain cap, not max_bytes + 1.
+        assert reads == [web_fetch_module._REDIRECT_BODY_DRAIN_CAP]
+
+
+class TestCharsetDecoding:
+    """Content-Type charset -- quoted or unquoted -- is honored."""
+
+    @pytest.mark.parametrize(
+        "header,body,expected",
+        [
+            ("text/html; charset=utf-8", b"hello", "hello"),
+            ('text/html; charset="iso-8859-1"', b"caf\xe9", "café"),
+            ("text/html; charset='windows-1252'", b"\xa9 2026", "© 2026"),
+        ],
+    )
+    def test_decode_body_honors_charset(self, header, body, expected):
+        assert web_fetch_module._decode_body(body, header) == expected
+
+    def test_decode_body_defaults_to_utf8_on_missing_charset(self):
+        assert web_fetch_module._decode_body(b"plain", "text/plain") == "plain"
+
+    def test_decode_body_falls_back_on_unknown_charset(self):
+        # Some fictitious charset the runtime doesn't know -- fall back to utf-8
+        # rather than raising.
+        assert web_fetch_module._decode_body(b"plain", "text/plain; charset=xyz-fake-99") == "plain"

--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -68,6 +68,10 @@
       "types": "./dist/src/vended-tools/bash/index.d.ts",
       "default": "./dist/src/vended-tools/bash/index.js"
     },
+    "./vended-tools/web-fetch": {
+      "types": "./dist/src/vended-tools/web-fetch/index.d.ts",
+      "default": "./dist/src/vended-tools/web-fetch/index.js"
+    },
     "./a2a": {
       "types": "./dist/src/a2a/index.d.ts",
       "default": "./dist/src/a2a/index.js"

--- a/strands-ts/src/vended-tools/index.ts
+++ b/strands-ts/src/vended-tools/index.ts
@@ -3,15 +3,17 @@
  *
  * Provides a single import path for consumers who want all built-in tools:
  * ```typescript
- * import { bash, fileEditor, httpRequest, notebook } from '@strands-agents/sdk/vended-tools'
+ * import { bash, fileEditor, httpRequest, notebook, webFetch } from '@strands-agents/sdk/vended-tools'
  * ```
  *
- * Note: This module requires a Node.js environment because the `bash` tool
- * imports `child_process`. For browser-compatible usage, import individual
- * tools via their subpath exports (e.g., `@strands-agents/sdk/vended-tools/notebook`).
+ * Note: This module requires a Node.js environment because the `bash` and
+ * `webFetch` tools import Node built-ins (`child_process`, `http`/`https`,
+ * `dns`, `net`). For browser-compatible usage, import individual tools via
+ * their subpath exports (e.g., `@strands-agents/sdk/vended-tools/notebook`).
  */
 
 export * from './bash/index.js'
 export * from './file-editor/index.js'
 export * from './http-request/index.js'
 export * from './notebook/index.js'
+export * from './web-fetch/index.js'

--- a/strands-ts/src/vended-tools/web-fetch/README.md
+++ b/strands-ts/src/vended-tools/web-fetch/README.md
@@ -1,0 +1,48 @@
+# Web Fetch Tool
+
+Fetches an HTTP(S) URL and returns its readable content as markdown suitable for a model to read. Distinct from the http-request tool, which returns raw response bodies for API calls.
+
+The tool is intentionally strict at the URL boundary because the model chooses the target. Only http and https schemes are accepted. Every host is DNS-resolved and every returned address is required to be publicly routable, so private, loopback, link-local, cloud metadata, CGNAT, multicast, and reserved ranges are refused; IPv4-mapped IPv6 addresses are unwrapped first. The tool then connects to a specific already-validated IP address, so a DNS rebinder cannot substitute a private address between validation and connect. HTTPS certificate verification still uses the public hostname via SNI. Every hop of a redirect chain goes through the same scheme and address checks, the response body is capped at five mebibytes, and the extracted markdown drops scripts, styles, iframes, and other active elements as well as data URI images and javascript URLs.
+
+## Usage
+
+```typescript
+import { Agent } from '@strands-agents/sdk'
+import { webFetch } from '@strands-agents/sdk/vended-tools/web-fetch'
+
+const agent = new Agent({ tools: [webFetch] })
+await agent.invoke('Summarize https://example.com/blog/post')
+```
+
+Direct invocation:
+
+```typescript
+const result = await webFetch.invoke({ url: 'https://example.com/' })
+console.log(result.title)
+console.log(result.markdown)
+```
+
+## API
+
+### Input
+
+| Property  | Type     | Required | Default | Description                                    |
+| --------- | -------- | -------- | ------- | ---------------------------------------------- |
+| `url`     | `string` | Yes      |         | URL to fetch. Must be `http://` or `https://`. |
+| `timeout` | `number` | No       | 30      | Total request timeout in seconds.              |
+
+### Output
+
+| Property      | Type     | Description                                        |
+| ------------- | -------- | -------------------------------------------------- |
+| `url`         | `string` | Final URL after any redirects.                     |
+| `status`      | `number` | HTTP status code of the final response.            |
+| `contentType` | `string` | `Content-Type` header of the final response.       |
+| `title`       | `string` | Extracted `<title>`, or empty if none was found.   |
+| `markdown`    | `string` | Cleaned markdown extracted from the response body. |
+
+For non-HTML responses (JSON, plain text), `markdown` is the decoded body verbatim and `title` is empty.
+
+## What it does not do
+
+This is a one-shot GET: no caching, cookies, or auth handling. JavaScript is not executed, so dynamic pages that build their content from client-side scripts will return only the initial HTML shell; use a headless browser tool if you need the rendered page. There is no robots.txt handling here either. That policy belongs at a higher level, in agent hooks or the caller's own gating.

--- a/strands-ts/src/vended-tools/web-fetch/__tests__/web-fetch.test.node.ts
+++ b/strands-ts/src/vended-tools/web-fetch/__tests__/web-fetch.test.node.ts
@@ -1,0 +1,551 @@
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest'
+import { Buffer } from 'buffer'
+import { createServer, type Server, type IncomingMessage, type ServerResponse } from 'http'
+import type { AddressInfo } from 'net'
+import { addressIsPublic, assertHostIsAllowed, resolveAndValidateHost, validateUrlScheme } from '../ssrf.js'
+import { htmlToMarkdown } from '../extract.js'
+import { webFetch, makeWebFetch, _fetchOnce, _followRedirects, DEFAULT_MAX_BYTES } from '../web-fetch.js'
+import * as ssrfModule from '../ssrf.js'
+
+describe('validateUrlScheme', () => {
+  it('accepts http', () => {
+    expect(() => validateUrlScheme('http://example.com/foo')).not.toThrow()
+  })
+
+  it('accepts https', () => {
+    expect(() => validateUrlScheme('https://example.com/foo')).not.toThrow()
+  })
+
+  it.each([
+    'file:///etc/passwd',
+    'ftp://example.com/foo',
+    'gopher://example.com/',
+    'javascript:alert(1)',
+    'chrome-extension://foo/bar',
+  ])('rejects scheme: %s', (url) => {
+    expect(() => validateUrlScheme(url)).toThrow(/Only http/)
+  })
+
+  it('rejects malformed URL', () => {
+    expect(() => validateUrlScheme('not a url')).toThrow(/Invalid URL/)
+  })
+})
+
+describe('addressIsPublic', () => {
+  it.each([
+    '127.0.0.1',
+    '127.0.0.53',
+    '0.0.0.0',
+    '10.0.0.5',
+    '172.16.0.1',
+    '172.31.255.255',
+    '192.168.1.1',
+    '169.254.169.254', // AWS/GCP metadata endpoint
+    '169.254.170.2', // ECS task metadata
+    '100.64.0.1', // CGNAT
+    '224.0.0.1', // multicast
+    '240.0.0.1', // reserved
+    '255.255.255.255',
+    '203.0.113.1', // TEST-NET-3
+    '198.51.100.1', // TEST-NET-2
+    '192.0.2.1', // TEST-NET-1
+    '::1',
+    'fe80::1',
+    'fc00::1',
+    'fd00::1',
+    'ff02::1',
+    '2001:db8::1', // documentation (compressed)
+    '2001:0db8:0000:0000:0000:0000:0000:0001', // documentation (fully expanded)
+    '100::1', // 100::/64 discard-only
+    'fec0::1', // site-local (deprecated but filtered)
+    'fed0::1',
+  ])('rejects non-public: %s', (ip) => {
+    expect(addressIsPublic(ip)).toBe(false)
+  })
+
+  it.each(['8.8.8.8', '1.1.1.1', '2606:4700:4700::1111'])('accepts public: %s', (ip) => {
+    expect(addressIsPublic(ip)).toBe(true)
+  })
+
+  it('unwraps IPv4-mapped IPv6 loopback and refuses it', () => {
+    // Without unwrapping, ::ffff:127.0.0.1 could bypass an IPv6-only check.
+    expect(addressIsPublic('::ffff:127.0.0.1')).toBe(false)
+  })
+
+  it('unwraps IPv4-mapped IPv6 public addresses and accepts them', () => {
+    expect(addressIsPublic('::ffff:8.8.8.8')).toBe(true)
+  })
+
+  it.each([
+    // Node's URL parser normalizes bracketed `::ffff:127.0.0.1` to the hex
+    // form `::ffff:7f00:1`. The address predicate must unwrap that too.
+    '::ffff:7f00:1', // 127.0.0.1
+    '::ffff:a9fe:a9fe', // 169.254.169.254 (metadata)
+    '::ffff:a00:1', // 10.0.0.1
+    '::ffff:6440:1', // 100.64.0.1 (CGNAT)
+  ])('unwraps hex-form IPv4-mapped IPv6 and refuses private: %s', (ip) => {
+    expect(addressIsPublic(ip)).toBe(false)
+  })
+
+  it('rejects garbage input', () => {
+    expect(addressIsPublic('not-an-ip')).toBe(false)
+    expect(addressIsPublic('999.999.999.999')).toBe(false)
+  })
+})
+
+describe('assertHostIsAllowed', () => {
+  it.each([
+    'foo.internal',
+    'foo.internal.',
+    'FOO.INTERNAL',
+    'bar.local',
+    'localhost',
+    'foo.corp',
+    'foo.home',
+    'foo.lan',
+    'foo.intranet',
+    'foo.private',
+    'example.i2p',
+    'example.onion',
+  ])('rejects denied DNS suffix: %s', (host) => {
+    expect(() => assertHostIsAllowed(host)).toThrow(/denylist|metadata/)
+  })
+
+  it.each([
+    'metadata',
+    'metadata.google.internal',
+    '169.254.169.254',
+    'fd00:ec2::254',
+    '100.100.100.200',
+    '192.0.0.192',
+  ])('rejects named metadata endpoint: %s', (host) => {
+    expect(() => assertHostIsAllowed(host)).toThrow(/metadata|denylist/)
+  })
+
+  it('accepts ordinary public hostnames', () => {
+    expect(() => assertHostIsAllowed('example.com')).not.toThrow()
+    expect(() => assertHostIsAllowed('cloudflare.com')).not.toThrow()
+  })
+})
+
+describe('resolveAndValidateHost', () => {
+  it('accepts a public IP literal without DNS', async () => {
+    // 8.8.8.8 is a canonical public address; no real DNS query is issued.
+    await expect(resolveAndValidateHost('8.8.8.8')).resolves.toEqual(['8.8.8.8'])
+  })
+
+  it('rejects a private IP literal', async () => {
+    await expect(resolveAndValidateHost('127.0.0.1')).rejects.toThrow(/not public/)
+  })
+
+  it('rejects the AWS/GCP metadata IP literal', async () => {
+    // 169.254.169.254 is refused by the pre-DNS named-metadata check before
+    // the address predicate runs. Either error is fine as long as it's a
+    // hard refusal.
+    await expect(resolveAndValidateHost('169.254.169.254')).rejects.toThrow(/not public|metadata/)
+  })
+
+  it('accepts a bracketed IPv6 URL literal', async () => {
+    // new URL('http://[2606:4700:4700::1111]/').hostname is bracketed; the
+    // resolver must strip the brackets before isIP/DNS lookup.
+    await expect(resolveAndValidateHost('[2606:4700:4700::1111]')).resolves.toEqual(['2606:4700:4700::1111'])
+  })
+
+  it('rejects a bracketed private IPv6 URL literal', async () => {
+    await expect(resolveAndValidateHost('[::1]')).rejects.toThrow(/not public/)
+  })
+})
+
+describe('htmlToMarkdown', () => {
+  it('strips script and style content', () => {
+    const html = `
+      <html><head><title>Hi</title>
+      <style>body{color:red}</style>
+      </head><body>
+      <p>Hello world.</p>
+      <script>alert('xss')</script>
+      <p>After script.</p>
+      </body></html>
+    `
+    const { title, markdown } = htmlToMarkdown(html)
+    expect(title).toBe('Hi')
+    expect(markdown).not.toMatch(/alert/)
+    expect(markdown).not.toMatch(/color:red/)
+    expect(markdown).toMatch(/Hello world\./)
+    expect(markdown).toMatch(/After script\./)
+  })
+
+  it('strips data-URI image blobs', () => {
+    const bigBlob = 'A'.repeat(10000)
+    const html = `<p>text</p><img src="data:image/png;base64,${bigBlob}" alt="alt text">`
+    const { markdown } = htmlToMarkdown(html)
+    expect(markdown).not.toContain(bigBlob)
+    expect(markdown).not.toMatch(/data:/)
+    expect(markdown).toMatch(/alt text/)
+  })
+
+  it('preserves regular images', () => {
+    const { markdown } = htmlToMarkdown('<img src="https://example.com/pic.png" alt="pic">')
+    expect(markdown).toContain('![pic](https://example.com/pic.png)')
+  })
+
+  it('drops javascript: hrefs but keeps link text', () => {
+    const { markdown } = htmlToMarkdown('<a href="javascript:alert(1)">click</a>')
+    expect(markdown).not.toMatch(/javascript:/)
+    expect(markdown).toMatch(/click/)
+  })
+
+  it('drops javascript: img srcs', () => {
+    const { markdown } = htmlToMarkdown('<img src="javascript:alert(1)" alt="x">')
+    expect(markdown).not.toMatch(/javascript:/)
+  })
+
+  it('preserves headings, lists, and links', () => {
+    const html = `
+      <h1>Title</h1>
+      <p>Intro paragraph with a <a href="https://ex.com/x">link</a>.</p>
+      <ul><li>one</li><li>two</li></ul>
+      <ol><li>first</li><li>second</li></ol>
+    `
+    const { markdown } = htmlToMarkdown(html)
+    expect(markdown).toMatch(/# Title/)
+    expect(markdown).toContain('[link](https://ex.com/x)')
+    expect(markdown).toContain('- one')
+    expect(markdown).toContain('- two')
+    expect(markdown).toContain('1. first')
+    expect(markdown).toContain('2. second')
+  })
+
+  it('preserves code blocks', () => {
+    const { markdown } = htmlToMarkdown('<pre><code>def f():\n    return 1</code></pre>')
+    expect(markdown).toContain('```')
+    expect(markdown).toContain('def f():')
+    expect(markdown).toContain('return 1')
+  })
+
+  it('ignores event handler attributes', () => {
+    // onclick/onerror never appear as output text because we only render
+    // href/src/alt attributes, and the raw tokenizer discards everything else.
+    const { markdown } = htmlToMarkdown('<div onclick="alert(1)"><p onmouseover="x()">safe</p></div>')
+    expect(markdown).not.toMatch(/alert/)
+    expect(markdown).not.toMatch(/onclick/)
+    expect(markdown).toMatch(/safe/)
+  })
+
+  it('survives malformed HTML', () => {
+    const { markdown } = htmlToMarkdown('<p>ok <b>bold <em>and italic</p>')
+    expect(markdown).toContain('ok')
+    expect(markdown).toContain('bold')
+  })
+
+  it('preserves blockquote prefix on nested block content', () => {
+    // <blockquote> wrapping <p> is the common shape. Every line inside the
+    // blockquote must be prefixed with "> ", including the paragraph that a
+    // naive open-tag-only implementation would emit unquoted.
+    const { markdown } = htmlToMarkdown('<blockquote><p>quoted line one.</p><p>quoted line two.</p></blockquote>')
+    const bqLines = markdown.split('\n').filter((l) => l.includes('quoted line'))
+    expect(bqLines).toHaveLength(2)
+    for (const line of bqLines) {
+      expect(line.startsWith('> ')).toBe(true)
+    }
+  })
+
+  it('nests blockquote prefixes', () => {
+    const { markdown } = htmlToMarkdown('<blockquote><blockquote><p>deep.</p></blockquote></blockquote>')
+    expect(markdown).toMatch(/> > deep\./)
+  })
+
+  it('void tag inside a dropped element does not swallow following content', () => {
+    // <input> is void: only a start tag ever fires. Previous logic used a
+    // depth counter over every start/end tag inside the drop, which trapped
+    // the parser in "dropping" mode after </form>.
+    const { markdown } = htmlToMarkdown('<form><input></form><p>after</p>')
+    expect(markdown).toContain('after')
+  })
+
+  it('drops javascript: hrefs even with leading whitespace', () => {
+    const { markdown } = htmlToMarkdown('<a href="\tjavascript:alert(1)">click</a>')
+    expect(markdown).not.toMatch(/javascript:/)
+    expect(markdown).not.toMatch(/alert/)
+    expect(markdown).toContain('click')
+  })
+
+  it('decodes HTML entities', () => {
+    const { markdown } = htmlToMarkdown('<p>Rock &amp; roll &lt;3</p>')
+    expect(markdown).toContain('Rock & roll <3')
+  })
+
+  it('discards HTML comments', () => {
+    const { markdown } = htmlToMarkdown('<p>before <!-- SECRET_TOKEN=abc --> after</p>')
+    expect(markdown).not.toContain('SECRET_TOKEN')
+    expect(markdown).toContain('before')
+    expect(markdown).toContain('after')
+  })
+})
+
+describe('webFetch end-to-end (SSRF)', () => {
+  it('rejects http://127.0.0.1', async () => {
+    await expect(webFetch.invoke({ url: 'http://127.0.0.1/anything' })).rejects.toThrow(/not public/)
+  })
+
+  it('rejects the cloud metadata endpoint', async () => {
+    await expect(webFetch.invoke({ url: 'http://169.254.169.254/latest/meta-data/' })).rejects.toThrow(
+      /not public|metadata/
+    )
+  })
+
+  it('rejects file://', async () => {
+    await expect(webFetch.invoke({ url: 'file:///etc/passwd' })).rejects.toThrow(/Only http/)
+  })
+
+  it('rejects malformed URL', async () => {
+    await expect(webFetch.invoke({ url: 'not a url' })).rejects.toThrow(/Invalid URL/)
+  })
+})
+
+describe('makeWebFetch factory', () => {
+  it('overrides maxBytes and maxRedirects via options', () => {
+    // Just proves the factory shape; behavior of the caps is verified below
+    // by the loopback transport tests.
+    expect(() => makeWebFetch({ maxBytes: 1024, maxRedirects: 2 })).not.toThrow()
+  })
+
+  it('rejects non-positive maxBytes', () => {
+    expect(() => makeWebFetch({ maxBytes: 0 })).toThrow(/maxBytes/)
+    expect(() => makeWebFetch({ maxBytes: -1 })).toThrow(/maxBytes/)
+  })
+
+  it('rejects negative maxRedirects', () => {
+    expect(() => makeWebFetch({ maxRedirects: -1 })).toThrow(/maxRedirects/)
+  })
+})
+
+// Real-transport tests using an http.createServer on 127.0.0.1. The SSRF
+// address checker rejects loopback by design, so we stub `resolveAndValidateHost`
+// and `assertHostIsAllowed` for these tests only. Every test asserts on
+// behaviors that are impossible to observe from a pure mock-based test:
+// redirect following and revalidation, the size-cap abort, Host-header
+// construction, and the total-timeout wrapper.
+describe('web-fetch transport (loopback)', () => {
+  let server: Server
+  let port = 0
+  type Handler = (req: IncomingMessage, res: ServerResponse) => void
+  let handler: Handler = () => {
+    /* installed per test */
+  }
+
+  beforeAll(async () => {
+    server = createServer((req, res) => handler(req, res))
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+    port = (server.address() as AddressInfo).port
+    // Force every host through validation as if it were the loopback IP; the
+    // pinned-connect logic uses the returned address as the socket target.
+    vi.spyOn(ssrfModule, 'resolveAndValidateHost').mockImplementation(async () => ['127.0.0.1'])
+    vi.spyOn(ssrfModule, 'assertHostIsAllowed').mockImplementation(() => {
+      /* allow */
+    })
+  })
+
+  afterAll(async () => {
+    vi.restoreAllMocks()
+    await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())))
+  })
+
+  beforeEach(() => {
+    handler = () => {
+      /* overridden per test */
+    }
+  })
+
+  it('follows a redirect and revalidates the hop', async () => {
+    handler = (req, res) => {
+      if (req.url === '/start') {
+        res.writeHead(302, { location: `http://web.local:${port}/next` })
+        res.end()
+      } else if (req.url === '/next') {
+        res.writeHead(200, { 'content-type': 'text/html' })
+        res.end('<html><body><h1>ok</h1></body></html>')
+      } else {
+        res.writeHead(404).end()
+      }
+    }
+    const result = await _followRedirects(`http://web.local:${port}/start`, 5000, DEFAULT_MAX_BYTES, 5)
+    expect(result.status).toBe(200)
+    expect(result.body.toString()).toContain('<h1>ok</h1>')
+  })
+
+  it('rejects a javascript: redirect', async () => {
+    handler = (req, res) => {
+      if (req.url === '/start') {
+        res.writeHead(302, { location: 'javascript:alert(1)' })
+        res.end()
+      } else {
+        res.writeHead(404).end()
+      }
+    }
+    await expect(_followRedirects(`http://web.local:${port}/start`, 5000, DEFAULT_MAX_BYTES, 5)).rejects.toThrow(
+      /Only http/
+    )
+  })
+
+  it('surfaces a redirect without a Location header', async () => {
+    handler = (_req, res) => {
+      res.writeHead(302, {})
+      res.end()
+    }
+    await expect(_followRedirects(`http://web.local:${port}/start`, 5000, DEFAULT_MAX_BYTES, 5)).rejects.toThrow(
+      /without a Location/
+    )
+  })
+
+  it('caps the number of redirects', async () => {
+    let hop = 0
+    handler = (_req, res) => {
+      hop += 1
+      res.writeHead(302, { location: `http://web.local:${port}/hop-${hop}` })
+      res.end()
+    }
+    await expect(_followRedirects(`http://web.local:${port}/start`, 5000, DEFAULT_MAX_BYTES, 2)).rejects.toThrow(
+      /Exceeded max_redirects/
+    )
+  })
+
+  it('aborts as soon as the response body exceeds maxBytes', async () => {
+    handler = (_req, res) => {
+      res.writeHead(200, { 'content-type': 'application/octet-stream' })
+      // Write far more than the cap so at least one chunk trips the check
+      // before the connection's `end` event has a chance to fire.
+      res.end(Buffer.alloc(2 * 1024 * 1024))
+    }
+    await expect(_fetchOnce(`http://web.local:${port}/big`, 5000, 100 * 1024)).rejects.toThrow(/exceeded max_bytes/)
+  })
+
+  it('sends the original hostname in the Host header (not the pinned IP)', async () => {
+    let captured: string | undefined
+    handler = (req, res) => {
+      captured = req.headers.host
+      res.writeHead(200, { 'content-type': 'text/plain' })
+      res.end('ok')
+    }
+    await _fetchOnce(`http://web.local:${port}/`, 5000, DEFAULT_MAX_BYTES)
+    expect(captured).toBe(`web.local:${port}`)
+  })
+
+  it('short-circuits the redirect body drain -- does not buffer the discarded payload', async () => {
+    handler = (req, res) => {
+      if (req.url === '/start') {
+        res.writeHead(302, {
+          location: `http://web.local:${port}/final`,
+        })
+        res.write(Buffer.alloc(4 * 1024 * 1024, 0x41)) // 4 MiB
+        res.end()
+      } else {
+        res.writeHead(200, { 'content-type': 'text/html' })
+        res.end('<p>done</p>')
+      }
+    }
+    const result = await _followRedirects(`http://web.local:${port}/start`, 5000, 200 * 1024, 5)
+    expect(result.status).toBe(200)
+    expect(result.body.toString()).toContain('done')
+  })
+
+  it.each([
+    ['text/html; charset=utf-8', 'utf-8'],
+    ['text/html; charset="iso-8859-1"', 'iso-8859-1'],
+    ["text/html; charset='windows-1252'", 'windows-1252'],
+  ])('honors quoted and unquoted Content-Type charset: %s', async (headerValue, expectedCharset) => {
+    // Ensure the extracted markdown reflects the correct decoding for a
+    // charset the server declares. We use a byte sequence that decodes
+    // differently under the two encodings to prove the quoted charset was
+    // parsed. For utf-8 we just prove the happy path.
+    handler = (_req, res) => {
+      res.writeHead(200, { 'content-type': headerValue })
+      // Latin-1 byte 0xA9 (©) decodes as a copyright sign under iso-8859-1
+      // and windows-1252, but under utf-8 it decodes to the replacement
+      // character. We put the byte in the body verbatim.
+      if (expectedCharset === 'utf-8') {
+        res.end('<p>hello</p>')
+      } else {
+        res.end(Buffer.from('<p>' + String.fromCharCode(0xa9) + '</p>', 'binary'))
+      }
+    }
+    const result = (await webFetch.invoke({ url: `http://web.local:${port}/` })) as {
+      markdown: string
+    }
+    if (expectedCharset === 'utf-8') {
+      expect(result.markdown).toContain('hello')
+    } else {
+      // The regex must have picked up the quoted charset -- otherwise the
+      // 0xA9 byte would end up as the utf-8 replacement char.
+      expect(result.markdown).toContain('©')
+    }
+  })
+})
+
+// Multi-address fallback: if the first validated address refuses the
+// connection, the wrapper tries the next. The Python side has an equivalent
+// unit test that drives the fallback via a mocked http.client. Here we prove
+// the retry logic surfaces a clear ConnectionError when every validated
+// address refuses -- the only shape we can force deterministically from a
+// unit test that must not depend on host-specific routing.
+describe('web-fetch multi-address fallback', () => {
+  it('surfaces a clear error when every validated address refuses the connection', async () => {
+    // Bind and immediately close a server to reserve a port we know is now
+    // closed. Connecting to it fails fast with ECONNREFUSED on any OS.
+    const throwaway = createServer()
+    await new Promise<void>((resolve) => throwaway.listen(0, '127.0.0.1', resolve))
+    const closedPort = (throwaway.address() as AddressInfo).port
+    await new Promise<void>((resolve, reject) => throwaway.close((err) => (err ? reject(err) : resolve())))
+
+    vi.spyOn(ssrfModule, 'resolveAndValidateHost').mockImplementationOnce(async () => [
+      '127.0.0.1', // refuses -- closedPort has no listener
+      '127.0.0.1', // still refuses -- proves both addresses were tried before we give up
+    ])
+    vi.spyOn(ssrfModule, 'assertHostIsAllowed').mockImplementation(() => {
+      /* allow */
+    })
+
+    await expect(_fetchOnce(`http://web.local:${closedPort}/`, 3000, DEFAULT_MAX_BYTES)).rejects.toThrow(
+      /Could not connect to any validated address/
+    )
+
+    vi.restoreAllMocks()
+  }, 10000)
+})
+
+// End-to-end assertion on the invoked tool for a plain-text response. Uses the
+// same loopback server pattern above.
+describe('webFetch tool end-to-end (loopback)', () => {
+  let server: Server
+  let port = 0
+
+  beforeAll(async () => {
+    server = createServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' })
+      res.end('plain text response')
+    })
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+    port = (server.address() as AddressInfo).port
+    vi.spyOn(ssrfModule, 'resolveAndValidateHost').mockImplementation(async () => ['127.0.0.1'])
+    vi.spyOn(ssrfModule, 'assertHostIsAllowed').mockImplementation(() => {
+      /* allow */
+    })
+  })
+
+  afterAll(async () => {
+    vi.restoreAllMocks()
+    await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())))
+  })
+
+  it('returns the full deterministic output object for a plain-text response', async () => {
+    const url = `http://web.local:${port}/robots.txt`
+    const result = await webFetch.invoke({ url })
+    expect(result).toEqual({
+      url,
+      status: 200,
+      contentType: 'text/plain',
+      title: '',
+      markdown: 'plain text response',
+    })
+  })
+})

--- a/strands-ts/src/vended-tools/web-fetch/extract.ts
+++ b/strands-ts/src/vended-tools/web-fetch/extract.ts
@@ -1,0 +1,502 @@
+/**
+ * HTML → markdown extraction for the web fetch tool.
+ *
+ * The goal is not a perfect readability heuristic — it is producing output
+ * that is safe and useful for a model to read. We strip script, style, and
+ * other non-content elements entirely, drop `data:` URI images (which can be
+ * huge blobs), and preserve headings, links, lists, blockquotes, code, and
+ * paragraph text as GitHub-flavored markdown.
+ *
+ * No third-party dependency: we hand-tokenize the input. Because we never
+ * execute anything, the parser is safe against script content, event handler
+ * attributes, and other active HTML features by construction — we simply
+ * ignore anything we don't recognize.
+ */
+
+// Elements whose content is discarded entirely, not just unwrapped.
+const DROPPED_ELEMENTS = new Set([
+  'script',
+  'style',
+  'noscript',
+  'template',
+  'svg',
+  'canvas',
+  'iframe',
+  'object',
+  'embed',
+  'video',
+  'audio',
+  'form',
+  'input',
+  'button',
+  'select',
+  'textarea',
+])
+
+// HTML void elements never emit a close tag; they must not push depth on the
+// drop counter, or a void child inside a dropped element (e.g. <input> inside
+// <form>) would leak the drop state past its enclosing </form>.
+const VOID_ELEMENTS = new Set([
+  'area',
+  'base',
+  'br',
+  'col',
+  'embed',
+  'hr',
+  'img',
+  'input',
+  'link',
+  'meta',
+  'param',
+  'source',
+  'track',
+  'wbr',
+])
+
+const HEADING_LEVELS: Record<string, number> = {
+  h1: 1,
+  h2: 2,
+  h3: 3,
+  h4: 4,
+  h5: 5,
+  h6: 6,
+}
+
+interface Attr {
+  name: string
+  value: string | null
+}
+
+interface TagToken {
+  kind: 'tag'
+  name: string
+  attrs: Attr[]
+  closing: boolean
+  selfClosing: boolean
+}
+
+interface TextToken {
+  kind: 'text'
+  value: string
+}
+
+type Token = TagToken | TextToken
+
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  nbsp: ' ',
+}
+
+function decodeEntities(input: string): string {
+  return input.replace(/&(#x[0-9a-fA-F]+|#[0-9]+|[a-zA-Z]+);/g, (match, body: string) => {
+    if (body.startsWith('#x') || body.startsWith('#X')) {
+      const code = Number.parseInt(body.slice(2), 16)
+      return Number.isFinite(code) ? safeCodePoint(code) : match
+    }
+    if (body.startsWith('#')) {
+      const code = Number.parseInt(body.slice(1), 10)
+      return Number.isFinite(code) ? safeCodePoint(code) : match
+    }
+    const named = NAMED_ENTITIES[body.toLowerCase()]
+    return named ?? match
+  })
+}
+
+function safeCodePoint(code: number): string {
+  if (code < 0 || code > 0x10ffff) return ''
+  try {
+    return String.fromCodePoint(code)
+  } catch {
+    return ''
+  }
+}
+
+/**
+ * Tokenize HTML into a flat stream of `<tag>` and text tokens.
+ *
+ * Not a general HTML5 tokenizer — good enough for the block/inline elements
+ * we render. Script/style bodies are consumed as a single text run and
+ * discarded by the caller, which prevents accidental script text ending up in
+ * the output.
+ */
+function tokenize(html: string): Token[] {
+  const tokens: Token[] = []
+  let i = 0
+  while (i < html.length) {
+    if (html[i] === '<') {
+      // Comment
+      if (html.startsWith('<!--', i)) {
+        const end = html.indexOf('-->', i + 4)
+        i = end === -1 ? html.length : end + 3
+        continue
+      }
+      // Doctype / CDATA / other markup declaration
+      if (html.startsWith('<!', i) || html.startsWith('<?', i)) {
+        const end = html.indexOf('>', i + 2)
+        i = end === -1 ? html.length : end + 1
+        continue
+      }
+      // Tag
+      const closing = html.charAt(i + 1) === '/'
+      const nameStart = i + (closing ? 2 : 1)
+      let nameEnd = nameStart
+      while (nameEnd < html.length && /[A-Za-z0-9]/.test(html.charAt(nameEnd))) {
+        nameEnd += 1
+      }
+      const name = html.slice(nameStart, nameEnd).toLowerCase()
+      if (!name) {
+        // "<" that isn't a real tag — treat as text.
+        tokens.push({ kind: 'text', value: '<' })
+        i += 1
+        continue
+      }
+
+      // Parse attributes until we hit '>' or self-close.
+      let cursor = nameEnd
+      const attrs: Attr[] = []
+      let selfClosing = false
+      while (cursor < html.length && html.charAt(cursor) !== '>') {
+        // Skip whitespace
+        while (cursor < html.length && /\s/.test(html.charAt(cursor))) cursor += 1
+        if (cursor >= html.length || html.charAt(cursor) === '>') break
+        if (html.charAt(cursor) === '/') {
+          selfClosing = true
+          cursor += 1
+          continue
+        }
+        // Attribute name
+        const attrStart = cursor
+        while (cursor < html.length && !/[\s/=>]/.test(html.charAt(cursor))) cursor += 1
+        const attrName = html.slice(attrStart, cursor).toLowerCase()
+        // Skip whitespace, optional '='
+        while (cursor < html.length && /\s/.test(html.charAt(cursor))) cursor += 1
+        let attrValue: string | null = null
+        if (html.charAt(cursor) === '=') {
+          cursor += 1
+          while (cursor < html.length && /\s/.test(html.charAt(cursor))) cursor += 1
+          const quote = html.charAt(cursor)
+          if (quote === '"' || quote === "'") {
+            cursor += 1
+            const valueStart = cursor
+            while (cursor < html.length && html.charAt(cursor) !== quote) cursor += 1
+            attrValue = html.slice(valueStart, cursor)
+            if (cursor < html.length) cursor += 1
+          } else {
+            const valueStart = cursor
+            while (cursor < html.length && !/[\s>]/.test(html.charAt(cursor))) cursor += 1
+            attrValue = html.slice(valueStart, cursor)
+          }
+          attrValue = decodeEntities(attrValue)
+        }
+        if (attrName) attrs.push({ name: attrName, value: attrValue })
+      }
+      // Consume '>'
+      if (html.charAt(cursor) === '>') cursor += 1
+      i = cursor
+
+      tokens.push({ kind: 'tag', name, attrs, closing, selfClosing })
+
+      // For script/style, consume raw content up to matching close tag so we
+      // don't accidentally interpret its contents as HTML.
+      if (!closing && !selfClosing && (name === 'script' || name === 'style')) {
+        const closeTag = `</${name}`
+        const lower = html.toLowerCase()
+        const closeIndex = lower.indexOf(closeTag, i)
+        if (closeIndex === -1) {
+          // Unterminated -- discard the rest.
+          i = html.length
+        } else {
+          // Push the raw content as text so DROPPED_ELEMENTS logic in the
+          // renderer discards it. Do NOT decode entities in <script>/<style>.
+          tokens.push({ kind: 'text', value: html.slice(i, closeIndex) })
+          i = closeIndex
+        }
+      }
+      continue
+    }
+
+    // Text run
+    const next = html.indexOf('<', i)
+    const end = next === -1 ? html.length : next
+    const raw = html.slice(i, end)
+    tokens.push({ kind: 'text', value: decodeEntities(raw) })
+    i = end
+  }
+  return tokens
+}
+
+function attr(attrs: Attr[], name: string): string | null {
+  for (const a of attrs) if (a.name === name) return a.value
+  return null
+}
+
+/**
+ * Convert HTML to markdown suitable for a model to read.
+ *
+ * @returns `{ title, markdown }` — both trimmed of surrounding whitespace.
+ */
+// Sentinel markers used during extraction to record where a blockquote begins
+// and ends. A post-processing pass prefixes every line between the markers
+// with `> ` so nested block elements (e.g. `<blockquote><p>...</p></blockquote>`)
+// stay inside the blockquote in the emitted markdown.
+const BQ_OPEN = '\x00BQ_OPEN\x00'
+const BQ_CLOSE = '\x00BQ_CLOSE\x00'
+
+export function htmlToMarkdown(html: string): { title: string; markdown: string } {
+  const tokens = tokenize(html)
+  const out: string[] = []
+  const inline: string[] = []
+  const listStack: ('ul' | 'ol')[] = []
+  const olCounters: number[] = []
+  const linkHrefs: (string | null)[] = []
+  let dropDepth = 0
+  let preDepth = 0
+  let codeDepth = 0
+  let inTitle = false
+  const titleParts: string[] = []
+
+  const flushInline = (): void => {
+    if (inline.length === 0) return
+    const text = inline.join('').trim()
+    inline.length = 0
+    if (text) out.push(text)
+  }
+
+  const pushImg = (attrs: Attr[]): void => {
+    const src = (attr(attrs, 'src') ?? '').trim()
+    const altText = attr(attrs, 'alt') ?? ''
+    if (!src) return
+    const lower = src.trimStart().toLowerCase()
+    // data: URIs can be enormous blobs — dropping them is a size defense as
+    // well as noise reduction.
+    if (lower.startsWith('data:')) {
+      if (altText) inline.push(altText)
+      return
+    }
+    if (lower.startsWith('javascript:')) return
+    inline.push(`![${altText}](${src})`)
+  }
+
+  for (const tok of tokens) {
+    if (tok.kind === 'text') {
+      if (dropDepth > 0) continue
+      if (inTitle) {
+        titleParts.push(tok.value)
+        continue
+      }
+      if (preDepth > 0) {
+        out.push(tok.value)
+        continue
+      }
+      if (codeDepth > 0) {
+        inline.push(tok.value.replace(/`/g, ''))
+        continue
+      }
+      const raw = tok.value
+      const normalized = raw.replace(/\s+/g, ' ')
+      if (normalized === ' ' || normalized === '') {
+        if (raw.length > 0 && /\s/.test(raw.charAt(0)) && inline.length > 0) {
+          const last = inline[inline.length - 1] ?? ''
+          if (!last.endsWith(' ')) inline.push(' ')
+        }
+        continue
+      }
+      const leading = /^\s/.test(raw) && inline.length > 0 ? ' ' : ''
+      const trailing = /\s$/.test(raw) ? ' ' : ''
+      inline.push(`${leading}${normalized.trim()}${trailing}`)
+      continue
+    }
+
+    // tag token
+    const { name, attrs, closing, selfClosing } = tok
+
+    if (name === 'title') {
+      inTitle = !closing
+      continue
+    }
+
+    if (dropDepth > 0) {
+      // Only adjust depth on non-void dropped elements; a void tag like <input>
+      // never fires a matching close, and self-closing tags are one-shot.
+      if (DROPPED_ELEMENTS.has(name) && !VOID_ELEMENTS.has(name) && !selfClosing) {
+        if (closing) dropDepth -= 1
+        else dropDepth += 1
+      }
+      continue
+    }
+    if (!closing && !selfClosing && DROPPED_ELEMENTS.has(name) && !VOID_ELEMENTS.has(name)) {
+      dropDepth = 1
+      continue
+    }
+    // Void + dropped (e.g. <input>) outside a drop -- nothing to do.
+    if (!closing && DROPPED_ELEMENTS.has(name) && VOID_ELEMENTS.has(name)) {
+      continue
+    }
+
+    if (name === 'br') {
+      if (!closing) inline.push('  \n')
+      continue
+    }
+    if (name === 'hr') {
+      if (!closing) {
+        flushInline()
+        out.push('\n---\n\n')
+      }
+      continue
+    }
+    if (name === 'img') {
+      if (!closing) pushImg(attrs)
+      continue
+    }
+
+    const headingLevel = HEADING_LEVELS[name]
+    if (headingLevel !== undefined) {
+      flushInline()
+      if (!closing) out.push('\n' + '#'.repeat(headingLevel) + ' ')
+      else out.push('\n\n')
+      continue
+    }
+    if (name === 'p') {
+      flushInline()
+      out.push(closing ? '\n\n' : '\n')
+      continue
+    }
+    if (name === 'blockquote') {
+      flushInline()
+      // Emit sentinels rather than a bare `> ` prefix. A post-processing pass
+      // rewrites every line between BQ_OPEN and BQ_CLOSE with a `> ` prefix,
+      // which correctly quotes nested block elements like <p> and lists.
+      out.push(closing ? `\n${BQ_CLOSE}\n\n` : `\n${BQ_OPEN}\n`)
+      continue
+    }
+    if (name === 'ul') {
+      flushInline()
+      if (!closing) listStack.push('ul')
+      else {
+        if (listStack[listStack.length - 1] === 'ul') listStack.pop()
+        out.push('\n')
+      }
+      continue
+    }
+    if (name === 'ol') {
+      flushInline()
+      if (!closing) {
+        listStack.push('ol')
+        olCounters.push(0)
+      } else {
+        if (listStack[listStack.length - 1] === 'ol') {
+          listStack.pop()
+          olCounters.pop()
+        }
+        out.push('\n')
+      }
+      continue
+    }
+    if (name === 'li') {
+      flushInline()
+      if (!closing) {
+        const depth = Math.max(0, listStack.length - 1)
+        const indent = '  '.repeat(depth)
+        if (listStack[listStack.length - 1] === 'ol') {
+          const idx = olCounters.length - 1
+          const next = (olCounters[idx] ?? 0) + 1
+          olCounters[idx] = next
+          out.push(`${indent}${next}. `)
+        } else {
+          out.push(`${indent}- `)
+        }
+      } else {
+        out.push('\n')
+      }
+      continue
+    }
+    if (name === 'pre') {
+      flushInline()
+      if (!closing) {
+        preDepth += 1
+        out.push('\n```\n')
+      } else {
+        if (preDepth > 0) preDepth -= 1
+        out.push('```\n\n')
+      }
+      continue
+    }
+    if (name === 'code') {
+      if (!closing) codeDepth += 1
+      else if (codeDepth > 0) codeDepth -= 1
+      if (preDepth === 0) inline.push('`')
+      continue
+    }
+    if (name === 'a') {
+      if (!closing) {
+        const href = (attr(attrs, 'href') ?? '').trim()
+        if (href && !href.trimStart().toLowerCase().startsWith('javascript:')) {
+          linkHrefs.push(href)
+          inline.push('[')
+        } else {
+          linkHrefs.push(null)
+        }
+      } else {
+        const href = linkHrefs.pop()
+        if (href !== null && href !== undefined) inline.push(`](${href})`)
+      }
+      continue
+    }
+    if (name === 'strong' || name === 'b') {
+      inline.push('**')
+      continue
+    }
+    if (name === 'em' || name === 'i') {
+      inline.push('*')
+      continue
+    }
+    // Unrecognized tag → treat as a transparent wrapper (render children inline).
+  }
+
+  flushInline()
+
+  const rawMd = out.join('')
+
+  // Walk lines and prefix everything between BQ_OPEN/BQ_CLOSE markers with
+  // `> `. Nesting increases the number of prefixes so `<blockquote><blockquote>`
+  // yields `> > `.
+  const prefixed: string[] = []
+  let bqDepth = 0
+  for (const line of rawMd.split('\n')) {
+    if (line === BQ_OPEN) {
+      bqDepth += 1
+      continue
+    }
+    if (line === BQ_CLOSE) {
+      if (bqDepth > 0) bqDepth -= 1
+      continue
+    }
+    if (bqDepth > 0) {
+      const prefix = '> '.repeat(bqDepth)
+      // Blank lines inside a blockquote still get the marker so the block stays
+      // visually connected in rendered markdown.
+      prefixed.push(line === '' ? prefix.trimEnd() : `${prefix}${line}`)
+    } else {
+      prefixed.push(line)
+    }
+  }
+
+  const collapsed: string[] = []
+  let blank = 0
+  for (const line of prefixed) {
+    if (line.trim() === '') {
+      blank += 1
+      if (blank <= 1) collapsed.push('')
+    } else {
+      blank = 0
+      collapsed.push(line.replace(/\s+$/, ''))
+    }
+  }
+  const markdown = collapsed.join('\n').trim()
+  const title = titleParts.join('').trim()
+  return { title, markdown: markdown ? markdown + '\n' : '' }
+}

--- a/strands-ts/src/vended-tools/web-fetch/index.ts
+++ b/strands-ts/src/vended-tools/web-fetch/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Web fetch tool: fetch a URL and return clean markdown suitable for a model to read.
+ *
+ * Distinct from the http-request tool (raw API calls). See {@link webFetch}.
+ */
+
+export { webFetch, makeWebFetch } from './web-fetch.js'
+export type { MakeWebFetchOptions } from './web-fetch.js'
+export type { WebFetchInput, WebFetchOutput } from './types.js'

--- a/strands-ts/src/vended-tools/web-fetch/ssrf.ts
+++ b/strands-ts/src/vended-tools/web-fetch/ssrf.ts
@@ -1,0 +1,310 @@
+/**
+ * SSRF defenses for the web fetch tool.
+ *
+ * Only http and https schemes are allowed. Hostnames are resolved and every
+ * returned address is checked against a deny list of private, loopback,
+ * link-local, multicast, and unspecified ranges. Every hop of a redirect chain
+ * is re-validated so DNS rebinding cannot swap a public address for a private
+ * one between the check and the actual connect. The caller is expected to
+ * connect using one of the already-validated addresses so check-time and
+ * connect-time addresses agree.
+ */
+
+import { promises as dns, type LookupAddress } from 'dns'
+import { isIP } from 'net'
+
+const ALLOWED_SCHEMES = new Set(['http:', 'https:'])
+
+// DNS suffix denylist. Common private-network TLDs and anonymized-routing
+// namespaces that must never leak a lookup to the public resolver. Compared
+// case-folded, with any trailing "." stripped. Cloud metadata bare label
+// "metadata" is checked separately in `assertHostIsAllowed`. Kept in sync with
+// the Python implementation in `strands-py/.../_ssrf.py`.
+const DENIED_DNS_SUFFIXES = [
+  '.internal',
+  '.local',
+  '.localhost',
+  '.corp',
+  '.home',
+  '.lan',
+  '.intranet',
+  '.private',
+  '.i2p',
+  '.onion',
+]
+
+// Explicit metadata endpoints. Belt-and-suspenders: every one of these
+// resolves to an address the range checks below would already refuse, but
+// naming them here means a future refactor of those predicates cannot silently
+// expose them without also removing them from this list. Covers AWS/GCP IMDSv1
+// (169.254.169.254), IPv6 EC2 (fd00:ec2::254), Alibaba
+// (100.100.100.200 / 192.0.0.192), and GCP's DNS name.
+const DENIED_METADATA_HOSTS = new Set([
+  '169.254.169.254',
+  'fd00:ec2::254',
+  '100.100.100.200',
+  '192.0.0.192',
+  'metadata.google.internal',
+  // bare-label metadata is refused before DNS in assertHostIsAllowed
+])
+
+/**
+ * Throw if `url` is not an http:// or https:// URL. Returns the parsed URL.
+ */
+export function validateUrlScheme(url: string): URL {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    throw new Error(`Invalid URL: ${url}`)
+  }
+  if (!ALLOWED_SCHEMES.has(parsed.protocol)) {
+    throw new Error(
+      `Only http:// and https:// URLs are allowed. Got scheme=${JSON.stringify(parsed.protocol)} for URL ${JSON.stringify(url)}.`
+    )
+  }
+  if (!parsed.hostname) {
+    throw new Error(`URL has no host: ${JSON.stringify(url)}`)
+  }
+  return parsed
+}
+
+/**
+ * Normalize a URL hostname for comparison against the DNS denylists:
+ * strip surrounding brackets from IPv6 literals, strip a trailing dot, and
+ * fold to lower case.
+ */
+function normalizeHostForDenylist(host: string): string {
+  let bare = stripIpv6Brackets(host).toLowerCase()
+  if (bare.endsWith('.')) bare = bare.slice(0, -1)
+  return bare
+}
+
+/**
+ * Refuse the DNS suffix denylist and the explicit metadata hostnames before
+ * DNS is even queried. Returns silently on allow; throws on deny.
+ */
+export function assertHostIsAllowed(host: string): void {
+  const normalized = normalizeHostForDenylist(host)
+  if (!normalized) return
+  // GCP bare-label metadata endpoint.
+  if (normalized === 'metadata') {
+    throw new Error(`Refusing to fetch host ${JSON.stringify(host)}: bare-label metadata endpoint is refused.`)
+  }
+  if (DENIED_METADATA_HOSTS.has(normalized)) {
+    throw new Error(
+      `Refusing to fetch host ${JSON.stringify(host)}: cloud metadata endpoint ${JSON.stringify(normalized)} is refused.`
+    )
+  }
+  for (const suffix of DENIED_DNS_SUFFIXES) {
+    if (normalized === suffix.slice(1) || normalized.endsWith(suffix)) {
+      throw new Error(
+        `Refusing to fetch host ${JSON.stringify(host)}: DNS suffix ${JSON.stringify(suffix)} is on the denylist.`
+      )
+    }
+  }
+}
+
+/**
+ * Return true only for globally routable unicast addresses.
+ *
+ * Rejects private, loopback, link-local, multicast, and unspecified ranges.
+ * IPv4-mapped IPv6 addresses (::ffff:a.b.c.d, ::ffff:hex:hex, and the fully
+ * expanded 0:0:0:0:0:ffff:a.b.c.d form) are unwrapped before the check.
+ */
+export function addressIsPublic(ip: string): boolean {
+  const family = isIP(ip)
+  if (family === 0) return false
+
+  if (family === 6) {
+    // Unwrap IPv4-mapped IPv6 (::ffff:a.b.c.d) so we evaluate the real IPv4
+    // category, not the wrapping. Anything else in IPv6 falls through to the
+    // IPv6 checks below.
+    //
+    // We expand to the full 8-hextet form and check whether the first six
+    // hextets are 0000:0000:0000:0000:0000:ffff. This catches both the
+    // dotted-quad form (`::ffff:127.0.0.1`) and the pure-hex form
+    // (`::ffff:7f00:1`) that Node's URL parser normalizes to.
+    const lower = ip.toLowerCase()
+    const expanded = expandIpv6(lower)
+    if (expanded !== null && expanded.startsWith('0000:0000:0000:0000:0000:ffff:')) {
+      const parts = expanded.split(':')
+      const high = parseInt(parts[6] ?? '0', 16)
+      const low = parseInt(parts[7] ?? '0', 16)
+      const a = (high >> 8) & 0xff
+      const b = high & 0xff
+      const c = (low >> 8) & 0xff
+      const d = low & 0xff
+      return addressIsPublic(`${a}.${b}.${c}.${d}`)
+    }
+    return ipv6IsPublic(lower)
+  }
+
+  return ipv4IsPublic(ip)
+}
+
+function ipv4IsPublic(ip: string): boolean {
+  const parts = ip.split('.').map((p) => Number(p))
+  if (parts.length !== 4 || parts.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) {
+    return false
+  }
+  const [a, b, c] = parts as [number, number, number, number]
+  // 0.0.0.0/8 -- unspecified/current network
+  if (a === 0) return false
+  // 10.0.0.0/8 -- private
+  if (a === 10) return false
+  // 100.64.0.0/10 -- CGNAT
+  if (a === 100 && b >= 64 && b <= 127) return false
+  // 127.0.0.0/8 -- loopback
+  if (a === 127) return false
+  // 169.254.0.0/16 -- link-local (incl. cloud metadata endpoints)
+  if (a === 169 && b === 254) return false
+  // 172.16.0.0/12 -- private
+  if (a === 172 && b >= 16 && b <= 31) return false
+  // 192.0.0.0/24 -- IETF protocol assignments
+  if (a === 192 && b === 0 && c === 0) return false
+  // 192.0.2.0/24 -- TEST-NET-1
+  if (a === 192 && b === 0 && c === 2) return false
+  // 192.168.0.0/16 -- private
+  if (a === 192 && b === 168) return false
+  // 198.18.0.0/15 -- benchmarking
+  if (a === 198 && (b === 18 || b === 19)) return false
+  // 198.51.100.0/24 -- TEST-NET-2
+  if (a === 198 && b === 51 && c === 100) return false
+  // 203.0.113.0/24 -- TEST-NET-3
+  if (a === 203 && b === 0 && c === 113) return false
+  // 224.0.0.0/4 -- multicast
+  if (a >= 224 && a <= 239) return false
+  // 240.0.0.0/4 -- reserved / broadcast
+  if (a >= 240) return false
+  return true
+}
+
+function ipv6IsPublic(ip: string): boolean {
+  const lower = ip.toLowerCase()
+  // Unspecified :: and loopback ::1
+  if (lower === '::' || lower === '::1') return false
+  const expanded = expandIpv6(lower)
+  if (expanded === null) return false
+  // Link-local fe80::/10
+  if (
+    expanded.startsWith('fe8') ||
+    expanded.startsWith('fe9') ||
+    expanded.startsWith('fea') ||
+    expanded.startsWith('feb')
+  ) {
+    return false
+  }
+  // Site-local fec0::/10 (deprecated but still filtered).
+  if (
+    expanded.startsWith('fec') ||
+    expanded.startsWith('fed') ||
+    expanded.startsWith('fee') ||
+    expanded.startsWith('fef')
+  ) {
+    return false
+  }
+  // Unique-local fc00::/7 -> fc.. or fd..
+  if (expanded.startsWith('fc') || expanded.startsWith('fd')) return false
+  // Multicast ff00::/8
+  if (expanded.startsWith('ff')) return false
+  // Documentation 2001:db8::/32
+  if (expanded.startsWith('2001:0db8:')) return false
+  // 100::/64 -- discard-only address block (first 64 bits are zero).
+  if (expanded.startsWith('0100:0000:0000:0000:')) return false
+  return true
+}
+
+/**
+ * Expand an IPv6 address to its fully-written 8-group form with each group
+ * zero-padded to 4 hex digits. Returns null if the input is not a valid IPv6
+ * address. Used for prefix matching against reserved ranges and for
+ * IPv4-mapped-IPv6 unwrapping.
+ */
+function expandIpv6(ip: string): string | null {
+  // Reject anything that isn't valid IPv6 up front.
+  if (isIP(ip) !== 6) return null
+  const lower = ip.toLowerCase()
+
+  // Node accepts a trailing dotted-quad form (`::ffff:127.0.0.1`). Convert it
+  // to the equivalent pure-hex form before regular expansion so we can produce
+  // 8 hextets uniformly.
+  const dottedMatch = lower.match(/^(.*:)(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/)
+  let prefix = lower
+  if (dottedMatch) {
+    const nums = [dottedMatch[2], dottedMatch[3], dottedMatch[4], dottedMatch[5]].map((s) => Number(s))
+    if (nums.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return null
+    const hi = ((nums[0] ?? 0) << 8) | (nums[1] ?? 0)
+    const lo = ((nums[2] ?? 0) << 8) | (nums[3] ?? 0)
+    prefix = `${dottedMatch[1] ?? ''}${hi.toString(16)}:${lo.toString(16)}`
+  }
+
+  const parts = prefix.split('::')
+  if (parts.length > 2) return null
+  const head = parts[0] === '' ? [] : (parts[0] ?? '').split(':')
+  const tail = parts.length === 2 ? (parts[1] === '' ? [] : (parts[1] ?? '').split(':')) : []
+  const missing = 8 - head.length - tail.length
+  if (missing < 0) return null
+  const groups = [...head, ...Array<string>(missing).fill('0'), ...tail]
+  if (groups.length !== 8) return null
+  return groups.map((g) => g.padStart(4, '0')).join(':')
+}
+
+/**
+ * Strip the surrounding `[...]` from an IPv6 literal host. `new URL().hostname`
+ * keeps the brackets, but `isIP()` and `dns.lookup()` want the bare address.
+ */
+export function stripIpv6Brackets(host: string): string {
+  if (host.length >= 2 && host.startsWith('[') && host.endsWith(']')) {
+    return host.slice(1, -1)
+  }
+  return host
+}
+
+/**
+ * Resolve `host` to IP addresses and require every one to be public.
+ *
+ * Returns the resolved addresses on success. If the host is an IP literal it is
+ * validated directly and returned as-is. If any resolved address is not
+ * public, throws. The DNS-suffix denylist and named metadata endpoints are
+ * refused *before* DNS is queried.
+ */
+export async function resolveAndValidateHost(host: string): Promise<string[]> {
+  // Refuse .internal / .onion / metadata.google.internal etc. before DNS.
+  assertHostIsAllowed(host)
+
+  // Strip [ ] around IPv6 URL literals so isIP / DNS see the bare address.
+  const bare = stripIpv6Brackets(host)
+  const family = isIP(bare)
+  if (family !== 0) {
+    // Host is an IP literal -- no DNS query, just validate.
+    if (!addressIsPublic(bare)) {
+      throw new Error(
+        `Refusing to fetch host ${JSON.stringify(host)}: address ${JSON.stringify(bare)} is not public (private, loopback, link-local, site-local, multicast, CGNAT, or reserved).`
+      )
+    }
+    return [bare]
+  }
+
+  let records: LookupAddress[]
+  try {
+    records = await dns.lookup(bare, { all: true, verbatim: true })
+  } catch (err) {
+    throw new Error(`Could not resolve host ${JSON.stringify(host)}: ${(err as Error).message}`, {
+      cause: err,
+    })
+  }
+  if (records.length === 0) {
+    throw new Error(`Could not resolve host ${JSON.stringify(host)}: no addresses returned`)
+  }
+  const addresses: string[] = []
+  for (const rec of records) {
+    if (!addressIsPublic(rec.address)) {
+      throw new Error(
+        `Refusing to fetch host ${JSON.stringify(host)}: resolved address ${JSON.stringify(rec.address)} is not public (private, loopback, link-local, site-local, multicast, CGNAT, or reserved).`
+      )
+    }
+    addresses.push(rec.address)
+  }
+  return addresses
+}

--- a/strands-ts/src/vended-tools/web-fetch/types.ts
+++ b/strands-ts/src/vended-tools/web-fetch/types.ts
@@ -1,0 +1,28 @@
+import type { z } from 'zod'
+import type { webFetchInputSchema } from './web-fetch.js'
+
+/**
+ * Input parameters for the web fetch tool.
+ *
+ * Derived from the Zod schema in `web-fetch.ts` so the two cannot drift.
+ */
+export type WebFetchInput = z.infer<typeof webFetchInputSchema>
+
+/**
+ * Output from the web fetch tool.
+ */
+export interface WebFetchOutput {
+  /** Final URL after any redirects. */
+  url: string
+  /** HTTP status code of the final response. */
+  status: number
+  /** Content-Type header of the final response, or an empty string. */
+  contentType: string
+  /** Extracted document title, or an empty string if none was found. */
+  title: string
+  /**
+   * Extracted, cleaned markdown suitable for a model to read. For non-HTML
+   * responses (JSON, plain text), the decoded body is returned verbatim.
+   */
+  markdown: string
+}

--- a/strands-ts/src/vended-tools/web-fetch/web-fetch.ts
+++ b/strands-ts/src/vended-tools/web-fetch/web-fetch.ts
@@ -1,0 +1,357 @@
+import { z } from 'zod'
+import { Buffer } from 'buffer'
+import { request as httpRequest } from 'http'
+import { request as httpsRequest } from 'https'
+
+import { tool } from '../../tools/tool-factory.js'
+import { htmlToMarkdown } from './extract.js'
+import { resolveAndValidateHost, stripIpv6Brackets, validateUrlScheme } from './ssrf.js'
+
+const DEFAULT_TIMEOUT_SECONDS = 30
+export const DEFAULT_MAX_BYTES = 5 * 1024 * 1024 // 5 MiB
+export const DEFAULT_MAX_REDIRECTS = 5
+const USER_AGENT = 'strands-agents-web-fetch/1.0'
+// On a 3xx we only need the `Location` header; buffering the discarded body up
+// to `maxBytes` is a waste of memory and an easy DoS vector. Cap at 4 KiB and
+// tear the request down once we've seen the redirect headers.
+const REDIRECT_BODY_DRAIN_CAP = 4096
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308])
+
+export const webFetchInputSchema = z.object({
+  url: z.string().describe('URL to fetch. Must be http:// or https://.'),
+  timeout: z.number().positive().optional().describe('Total request timeout in seconds (default: 30).'),
+})
+
+interface RawResponse {
+  status: number
+  headers: Record<string, string>
+  body: Buffer
+  effectiveUrl: string
+}
+
+/**
+ * Perform one HTTP(S) request with SSRF defenses, no redirect handling.
+ *
+ * Resolves the hostname, checks that every resolved address is public, then
+ * connects to a pinned already-validated address so a DNS rebinder cannot
+ * substitute a private address between validation and connect. Aborts as
+ * soon as the response body exceeds `maxBytes`.
+ *
+ * Exported for testing against a loopback server; not part of the public API.
+ */
+export async function _fetchOnce(
+  url: string,
+  timeoutMs: number,
+  maxBytes: number,
+  signal?: AbortSignal
+): Promise<RawResponse> {
+  const parsed = validateUrlScheme(url)
+  // parsed.hostname keeps [ ] around IPv6 literals; strip them for the
+  // resolver and for the pinned-connect host below.
+  const bareHost = stripIpv6Brackets(parsed.hostname)
+  const addresses = await resolveAndValidateHost(bareHost)
+  const isHttps = parsed.protocol === 'https:'
+  const port = parsed.port ? Number(parsed.port) : isHttps ? 443 : 80
+
+  // Try each validated address in turn. Every address has already passed the
+  // SSRF check, so falling through does not weaken the security posture.
+  // Callers on hosts where DNS returns an AAAA record first but the runtime
+  // has no IPv6 route (or vice versa) still succeed on the second try.
+  const retryable = new Set(['ECONNREFUSED', 'EHOSTUNREACH', 'ENETUNREACH', 'EADDRNOTAVAIL'])
+  let lastError: (Error & { code?: string }) | undefined
+  for (const pinnedIp of addresses) {
+    try {
+      return await fetchOncePinned(url, parsed, bareHost, pinnedIp, isHttps, port, timeoutMs, maxBytes, signal)
+    } catch (err) {
+      const e = err as Error & { code?: string }
+      if (e && e.name !== 'AbortError' && e.code !== undefined && retryable.has(e.code)) {
+        lastError = e
+        continue
+      }
+      throw err
+    }
+  }
+  throw new Error(
+    `Could not connect to any validated address for host ${JSON.stringify(bareHost)} (tried ${addresses.length}): ${lastError?.message ?? 'unknown'}`,
+    { cause: lastError }
+  )
+}
+
+function fetchOncePinned(
+  url: string,
+  parsed: URL,
+  bareHost: string,
+  pinnedIp: string,
+  isHttps: boolean,
+  port: number,
+  timeoutMs: number,
+  maxBytes: number,
+  signal?: AbortSignal
+): Promise<RawResponse> {
+  return new Promise<RawResponse>((resolve, reject) => {
+    const abortReason = (): Error => {
+      const reason = signal?.reason
+      if (reason instanceof Error) return reason
+      return new DOMException('Request aborted', 'AbortError')
+    }
+    // Reject immediately if the signal was already fired -- no request to make.
+    if (signal?.aborted) {
+      reject(abortReason())
+      return
+    }
+
+    const requestFn = isHttps ? httpsRequest : httpRequest
+    const req = requestFn({
+      // Connect to the validated IP; the Host header + servername keep TLS
+      // and vhost routing pointed at the original hostname.
+      host: pinnedIp,
+      port,
+      method: 'GET',
+      path: `${parsed.pathname || '/'}${parsed.search || ''}`,
+      headers: {
+        Host: parsed.host,
+        'User-Agent': USER_AGENT,
+        Accept: 'text/html,application/xhtml+xml;q=0.9,*/*;q=0.8',
+        'Accept-Encoding': 'identity',
+        Connection: 'close',
+      },
+      timeout: timeoutMs,
+      // For HTTPS, override the certificate check hostname so verification
+      // uses the public hostname (not the pinned IP literal). `servername`
+      // wants the bare form -- no [ ] around IPv6 literals.
+      ...(isHttps ? { servername: bareHost } : {}),
+    })
+
+    // Attach the abort listener AFTER req exists so the handler can never
+    // reference a variable in its temporal dead zone. Re-check `aborted`
+    // after attaching to close the window where the signal could have fired
+    // between the initial check and addEventListener returning.
+    const abortHandler = (): void => {
+      req.destroy(abortReason())
+    }
+    if (signal) {
+      signal.addEventListener('abort', abortHandler, { once: true })
+      if (signal.aborted) {
+        signal.removeEventListener('abort', abortHandler)
+        req.destroy(abortReason())
+        reject(abortReason())
+        return
+      }
+    }
+
+    const chunks: Buffer[] = []
+    let total = 0
+
+    const cleanupSignal = (): void => {
+      if (signal) signal.removeEventListener('abort', abortHandler)
+    }
+
+    req.on('response', (res) => {
+      // On a redirect, we only need the Location header -- resolve immediately
+      // with an empty body and tear the connection down so a hostile server
+      // can't force us to buffer megabytes of garbage on every 3xx hop.
+      const status = res.statusCode ?? 0
+      if (REDIRECT_STATUSES.has(status)) {
+        cleanupSignal()
+        const headers: Record<string, string> = {}
+        for (const [k, v] of Object.entries(res.headers)) {
+          if (Array.isArray(v)) headers[k.toLowerCase()] = v.join(', ')
+          else if (typeof v === 'string') headers[k.toLowerCase()] = v
+        }
+        resolve({
+          status,
+          headers,
+          body: Buffer.alloc(0),
+          effectiveUrl: url,
+        })
+        // After we've resolved, still drain up to a small cap so the socket
+        // can close cleanly, but discard the bytes without accumulating them.
+        let drained = 0
+        res.on('data', (chunk: Buffer) => {
+          drained += chunk.length
+          if (drained > REDIRECT_BODY_DRAIN_CAP) req.destroy()
+        })
+        res.on('error', () => {
+          /* already resolved; ignore */
+        })
+        return
+      }
+
+      res.on('data', (chunk: Buffer) => {
+        total += chunk.length
+        if (total > maxBytes) {
+          req.destroy(new Error(`Response body exceeded max_bytes=${maxBytes}. Refusing to buffer more.`))
+          return
+        }
+        chunks.push(chunk)
+      })
+      res.on('end', () => {
+        cleanupSignal()
+        const headers: Record<string, string> = {}
+        for (const [k, v] of Object.entries(res.headers)) {
+          if (Array.isArray(v)) headers[k.toLowerCase()] = v.join(', ')
+          else if (typeof v === 'string') headers[k.toLowerCase()] = v
+        }
+        resolve({
+          status: res.statusCode ?? 0,
+          headers,
+          body: Buffer.concat(chunks),
+          effectiveUrl: url,
+        })
+      })
+      res.on('error', (err) => {
+        cleanupSignal()
+        reject(err)
+      })
+    })
+    req.on('timeout', () => {
+      req.destroy(new DOMException(`Request timed out after ${timeoutMs}ms`, 'AbortError'))
+    })
+    req.on('error', (err) => {
+      cleanupSignal()
+      reject(err)
+    })
+    req.end()
+  })
+}
+
+// Exported for testing; not part of the public API.
+export async function _followRedirects(
+  url: string,
+  timeoutMs: number,
+  maxBytes: number,
+  maxRedirects: number,
+  signal?: AbortSignal
+): Promise<RawResponse> {
+  let current = url
+  const seen = new Set<string>()
+  for (let hop = 0; hop <= maxRedirects; hop += 1) {
+    if (seen.has(current)) {
+      throw new Error(`Redirect loop detected involving ${JSON.stringify(current)}`)
+    }
+    seen.add(current)
+
+    const res = await _fetchOnce(current, timeoutMs, maxBytes, signal)
+    if (REDIRECT_STATUSES.has(res.status)) {
+      const location = res.headers['location']
+      if (!location) {
+        throw new Error(`Redirect ${res.status} from ${JSON.stringify(current)} without a Location header`)
+      }
+      const next = new URL(location, current).toString()
+      // Re-validate the scheme immediately -- refuse javascript:/file:/etc.
+      validateUrlScheme(next)
+      current = next
+      continue
+    }
+    return res
+  }
+  throw new Error(`Exceeded max_redirects=${maxRedirects} following ${JSON.stringify(url)}`)
+}
+
+function decodeBody(body: Buffer, contentType: string): string {
+  // Accept quoted or unquoted charset values -- e.g. `charset=utf-8`,
+  // `charset="iso-8859-1"`, or `charset='windows-1252'`. Trailing quote is
+  // stripped in the same pass.
+  const match = contentType.match(/charset=(?:"([^"]+)"|'([^']+)'|([^;\s]+))/i)
+  const charset = (match?.[1] ?? match?.[2] ?? match?.[3] ?? 'utf-8').toLowerCase()
+  try {
+    return new TextDecoder(charset, { fatal: false }).decode(body)
+  } catch {
+    return new TextDecoder('utf-8', { fatal: false }).decode(body)
+  }
+}
+
+const DEFAULT_DESCRIPTION =
+  'Fetches an HTTP(S) URL and returns its readable content as markdown, suitable ' +
+  'for a model to read. Scripts, styles, and other non-content noise are stripped. ' +
+  'Only http:// and https:// URLs are allowed. Private, loopback, and link-local ' +
+  'addresses are refused.'
+
+export interface MakeWebFetchOptions {
+  /** Tool name shown to the model. Defaults to `'web_fetch'`. */
+  name?: string
+  /** Tool description shown to the model. Defaults to a security-focused summary. */
+  description?: string
+  /**
+   * Maximum response body size, in bytes. Larger responses are aborted before
+   * the excess is buffered. Defaults to five mebibytes.
+   */
+  maxBytes?: number
+  /**
+   * Maximum number of HTTP redirects to follow. Each hop is revalidated
+   * against the same SSRF rules as the initial URL. Defaults to five.
+   */
+  maxRedirects?: number
+}
+
+/**
+ * Create a web fetch tool. Callers who want to tune the size cap, redirect
+ * cap, or the tool's name/description use this factory; the exported
+ * {@link webFetch} is a default instance with conservative limits.
+ *
+ * Only http and https URLs are accepted; every host is DNS-resolved and every
+ * returned address must be publicly routable. Redirects are re-validated
+ * against the same rules and the tool connects to an already-validated IP
+ * address so a DNS rebinder cannot substitute a private address between
+ * validation and connect. Response size is capped and scripts, styles, and
+ * data URI images are stripped from the extracted markdown.
+ */
+export function makeWebFetch(options: MakeWebFetchOptions = {}): ReturnType<typeof tool> {
+  const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES
+  const maxRedirects = options.maxRedirects ?? DEFAULT_MAX_REDIRECTS
+  if (!Number.isFinite(maxBytes) || maxBytes <= 0) {
+    throw new Error(`maxBytes must be a positive number, got ${maxBytes}`)
+  }
+  if (!Number.isInteger(maxRedirects) || maxRedirects < 0) {
+    throw new Error(`maxRedirects must be a non-negative integer, got ${maxRedirects}`)
+  }
+
+  return tool({
+    name: options.name ?? 'web_fetch',
+    description: options.description ?? DEFAULT_DESCRIPTION,
+    inputSchema: webFetchInputSchema,
+    callback: async (input, context) => {
+      const { url, timeout = DEFAULT_TIMEOUT_SECONDS } = input
+      const timeoutMs = timeout * 1000
+
+      // Wire the agent's cancel signal in so a cancelled invocation kills the
+      // request. The socket timeout catches unresponsive peers separately.
+      const timeoutSignal = AbortSignal.timeout(timeoutMs)
+      const signal = context ? AbortSignal.any([timeoutSignal, context.agent.cancelSignal]) : timeoutSignal
+
+      const res = await _followRedirects(url, timeoutMs, maxBytes, maxRedirects, signal)
+      const contentType = res.headers['content-type'] ?? ''
+      const text = decodeBody(res.body, contentType)
+
+      if (!/html|xml/i.test(contentType)) {
+        return {
+          url: res.effectiveUrl,
+          status: res.status,
+          contentType,
+          title: '',
+          markdown: text,
+        }
+      }
+
+      const { title, markdown } = htmlToMarkdown(text)
+      return {
+        url: res.effectiveUrl,
+        status: res.status,
+        contentType,
+        title,
+        markdown,
+      }
+    },
+  })
+}
+
+/**
+ * Default web fetch tool with conservative size and redirect limits. See
+ * {@link makeWebFetch} for a factory that lets callers tune those limits.
+ *
+ * @example
+ * ```typescript
+ * const agent = new Agent({ tools: [webFetch] })
+ * ```
+ */
+export const webFetch = makeWebFetch()


### PR DESCRIPTION
Vended web_fetch tool in both SDKs. Complements the http_request tool: use web_fetch when the model needs to read a page, use http_request when it needs the body verbatim for an API call. Performs a single HTTP or HTTPS GET, decodes the body per the response's charset, and returns cleaned markdown along with the extracted title. Non-HTML responses fall through with the decoded body in the markdown field and an empty title, so a caller pointed at a JSON or plain-text URL still gets something usable.

The extractor is hand-rolled in both languages against the standard library only. Python uses html.parser, TypeScript uses a small tokenizer. Scripts, styles, iframes, forms and other active elements are dropped along with data URI images and javascript URLs; headings, lists, links, code, blockquotes and paragraph text are preserved. The parser never executes anything, so event handlers and other active features are dead on arrival. The alternatives (readability-lxml plus lxml in Python, or Readability plus jsdom in TypeScript) each bring a much larger transitive surface and ongoing audit cost, and we do not need general readability-quality extraction to serve the model.

Because the model chooses the target URL, the tool boundary is strict. Only http and https are accepted. Every host is DNS-resolved and every returned address is required to be publicly routable; private, loopback, link-local including cloud metadata endpoints, CGNAT, site-local, unique-local, multicast, and reserved ranges are refused. IPv4-mapped IPv6 addresses are unwrapped before the check so ::ffff:127.0.0.1 does not slip past an IPv6-only check. After validation the tool connects to a pinned already-validated IP rather than letting the socket layer re-resolve, which defeats DNS rebinding between check and connect. HTTPS certificate verification still uses the public hostname via SNI. Every redirect hop goes through the same scheme and address checks, the body is capped at five mebibytes without buffering the excess, and the total request has a wall-clock timeout with a thirty-second default.

Not in scope: robots.txt handling. Robots is a courtesy protocol rather than a security boundary, and applying it inside a low-level fetch belongs in an agent hook or the caller's own gating rather than the tool.

https://github.com/strands-agents/harness-sdk/issues/3239