### PR TITLE
feat(vended-tools): add mcp_client shim

### DIFF
--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools-imports.ts
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools-imports.ts
@@ -29,6 +29,11 @@ import { Agent, SessionManager, FileStorage } from '@strands-agents/sdk'
 import { notebook } from '@strands-agents/sdk/vended-tools/notebook'
 // --8<-- [end:notebook_persistence_import]
 
+// --8<-- [start:mcp_client_import]
+import { Agent } from '@strands-agents/sdk'
+import { makeMcpClient } from '@strands-agents/sdk/vended-tools/mcp-client'
+// --8<-- [end:mcp_client_import]
+
 // --8<-- [start:combined_import]
 import { Agent } from '@strands-agents/sdk'
 import { bash } from '@strands-agents/sdk/vended-tools/bash'

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -10,6 +10,8 @@ sourceLinks:
   - path: strands-ts/src/vended-tools/bash/bash.ts
   - path: strands-ts/src/vended-tools/http-request/http-request.ts
   - path: strands-ts/src/vended-tools/notebook/notebook.ts
+  - path: strands-ts/src/vended-tools/mcp-client/mcp-client.ts
+  - path: strands-py/src/strands/vended_tools/mcp_client/mcp_client.py
 ---
 
 Vended tools are pre-built tools included directly in the Strands SDK for common agent tasks like file operations, shell commands, HTTP requests, and persistent notes. 
@@ -34,6 +36,7 @@ Each tool is imported from its own subpath under `@strands-agents/sdk/vended-too
 | [HTTP Request](#http-request) | Make HTTP requests to external APIs | TypeScript (Node.js 20+, browsers) |
 | [Notebook](#notebook) | Manage persistent text notebooks | TypeScript (Node.js, browsers) |
 | [Bash](#bash) | Execute shell commands with persistent sessions | Python, TypeScript (Node.js, Unix/Linux/macOS) |
+| [MCP Client](#mcp-client) | Connect to Model Context Protocol servers on a developer-set allowlist | Python, TypeScript (Node.js) |
 
 ### File Editor
 
@@ -160,6 +163,46 @@ agent("List all Python files in the current directory and count them")
 ```
 
 📖 [Full API Reference](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/bash/README.md)
+
+---
+
+### MCP Client
+
+Lets your agent connect to Model Context Protocol servers at runtime, list the tools they expose, invoke one, and disconnect. The factory takes a developer-set allowlist of exact URLs; the model can only connect to servers on that list, never to an arbitrary URL of its choosing.
+
+_Supported in: Node.js (TypeScript); all platforms (Python)._
+
+:::caution[Security Warning]
+An MCP server is arbitrary code behind a network endpoint. If the model can point the tool at any URL, a prompt-injection attacker can reach out to their own MCP server, run tools there, and route the result back through your agent. The allowlist is mandatory and must be non-empty. The tool also enforces an SSRF guard that rejects hosts resolving to private, loopback, link-local, cloud-metadata, and other non-public addresses, and refuses to follow HTTP redirects, but the allowlist is the primary control. Only allowlist URLs whose DNS you trust.
+:::
+
+**Example:**
+
+<Tabs>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/tools/vended-tools-imports.ts:mcp_client_import"
+
+--8<-- "user-guide/concepts/tools/vended-tools.ts:mcp_client_example"
+```
+
+</Tab>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.vended_tools import make_mcp_client
+
+mcp_client = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+agent = Agent(tools=[mcp_client])
+agent("Connect to the MCP server and list its tools.")
+```
+
+</Tab>
+</Tabs>
+
+📖 [Full API Reference](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/mcp-client/README.md)
 
 ---
 

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.ts
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.ts
@@ -6,6 +6,7 @@ import { httpRequest } from '@strands-agents/sdk/vended-tools/http-request'
 import { notebook } from '@strands-agents/sdk/vended-tools/notebook'
 // --8<-- [end:basic_import]
 import { SessionManager, FileStorage } from '@strands-agents/sdk'
+import { makeMcpClient } from '@strands-agents/sdk/vended-tools/mcp-client'
 
 // Agent with vended tools example
 async function agentWithVendedToolsExample() {
@@ -108,6 +109,17 @@ async function notebookStatePersistenceExample() {
   const restoredAgent = new Agent({ tools: [notebook], sessionManager: session })
   await restoredAgent.invoke('Read the ideas notebook')
   // --8<-- [end:notebook_state_persistence]
+}
+
+// MCP client tool example - connect to an allowlisted server, discover tools, and invoke one
+async function mcpClientExample() {
+  // --8<-- [start:mcp_client_example]
+  const mcpClient = makeMcpClient({
+    allowedUrls: ['https://mcp.example.com/mcp'],
+  })
+  const agent = new Agent({ tools: [mcpClient] })
+  await agent.invoke('Connect to the MCP server and list its tools.')
+  // --8<-- [end:mcp_client_example]
 }
 
 // Combined tools example - development workflow

--- a/strands-py/src/strands/vended_tools/__init__.py
+++ b/strands-py/src/strands/vended_tools/__init__.py
@@ -17,10 +17,12 @@ Example Usage:
 
 from .bash import bash, make_bash
 from .file_editor import file_editor, make_file_editor
+from .mcp_client import make_mcp_client
 
 __all__ = [
     "bash",
     "file_editor",
     "make_bash",
     "make_file_editor",
+    "make_mcp_client",
 ]

--- a/strands-py/src/strands/vended_tools/mcp_client/__init__.py
+++ b/strands-py/src/strands/vended_tools/mcp_client/__init__.py
@@ -1,0 +1,22 @@
+"""Agent-callable MCP client tool for connecting to Model Context Protocol servers at runtime.
+
+Provides :func:`make_mcp_client` (a factory that returns a tool bound to a developer-set
+URL allowlist) for use cases where the agent, not the developer, decides which server to
+talk to at runtime. Developer-wired MCP clients remain the primary path
+(``strands.tools.mcp.MCPClient``); this tool is the agent-facing shim.
+
+Example Usage:
+    ```python
+    from strands import Agent
+    from strands.vended_tools import make_mcp_client
+
+    mcp_client_tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+    agent = Agent(tools=[mcp_client_tool])
+    ```
+"""
+
+from .mcp_client import make_mcp_client
+
+__all__ = [
+    "make_mcp_client",
+]

--- a/strands-py/src/strands/vended_tools/mcp_client/mcp_client.py
+++ b/strands-py/src/strands/vended_tools/mcp_client/mcp_client.py
@@ -1,0 +1,630 @@
+"""Agent-callable MCP client tool.
+
+Exposes a single tool with four operations — ``connect``, ``list_tools``, ``call_tool``,
+``disconnect`` — that lets an agent, at runtime, open a connection to a Model Context
+Protocol server, discover its tools, invoke one, and tear the connection down. The tool
+is a thin shim over :class:`~strands.tools.mcp.MCPClient`; all transport, session, and
+protocol handling lives in that class.
+
+**Security model.** This is one of the highest-risk tools to vend: an MCP server can
+implement arbitrary logic, so the model must never be allowed to point the tool at an
+arbitrary URL. The factory takes a developer-set allowlist of exact URLs at construction;
+the tool rejects every ``connect`` that does not match one. In addition:
+
+- Only ``http://`` and ``https://`` URLs are accepted; the tool uses the streamable-http
+  MCP transport. Stdio, SSE, and WebSocket are out of scope: stdio expands the attack
+  surface substantially (subprocess spawn); SSE is being deprecated by the MCP spec in
+  favour of streamable-http; WebSocket is not a documented MCP client transport.
+- The URL's host is rejected outright when it matches a DNS suffix denylist
+  (``.internal``, ``.local``, ``.localhost``, ``.corp``, ``.home``, ``.lan``,
+  ``.intranet``, ``.private``, ``.i2p``, ``.onion``) before any DNS lookup.
+- The URL's host is then resolved and every returned address is checked with
+  :attr:`ipaddress._BaseAddress.is_global` for the private/loopback/CGNAT/shared-
+  address baseline, layered with **explicit** ``is_multicast``, ``is_reserved``,
+  ``is_unspecified``, ``is_link_local``, and IPv6-site-local (``fec0::/10``)
+  rejections: on all supported CPython versions (3.10–3.14) ``is_global`` is
+  ``True`` for IPv4 and IPv6 multicast, and ``fec0::/10`` slips through on some
+  releases, so ``is_global`` alone is not sufficient. IPv4-mapped IPv6
+  (``::ffff:a.b.c.d``, including the fully expanded form) is unwrapped first so
+  the underlying IPv4 category is what gets checked. A short list of
+  cloud-metadata addresses is also spelt out explicitly for defence in depth.
+- The httpx client that MCP uses under the hood is configured with
+  ``follow_redirects=False`` so an allowlisted URL cannot be 3xx'd to a private
+  endpoint the guard never saw.
+- Session IDs are generated with :mod:`secrets` and scoped to the agent that opened
+  them via a :func:`weakref.ref`; another agent using the same tool instance cannot
+  use a session it did not open, and a garbage-collected agent's sessions become
+  unreachable and are dropped from the session table on the next access or connect.
+- The number of live sessions the tool may hold is capped (default: 8), reserved
+  synchronously at connect entry so racing connects cannot overshoot the cap.
+- Blocking MCP client calls (``start``, ``list_tools_sync``, ``stop``) are pushed
+  off the event loop with :func:`asyncio.to_thread` so a slow handshake does not
+  stall other tools.
+- The tool set exposed by the server is fetched once at connect and cached on
+  the session; ``list_tools`` reads that cache and ``call_tool`` validates the
+  requested name against it locally. The cache can go stale if the server
+  changes its tool set mid-session, which is not a supported MCP flow today.
+- Tool-call text and ``structured_content`` are size-capped before being returned to
+  the model.
+
+**Limits.** The public-host classification is a check-time judgment. Between the
+guard's ``getaddrinfo`` and the MCP transport's own ``getaddrinfo``, an
+attacker-controlled resolver could return a public IP first and a private IP second
+(DNS rebinding). MCP's transport layer does not expose a hook for pinned-IP connects,
+so this shim relies on the allowlist pointing at endpoints whose operator does not
+serve time-varying DNS. Do not allowlist a hostname you do not control DNS for.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import json
+import logging
+import secrets
+import socket
+import weakref
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any, Literal, cast
+from urllib.parse import urlparse
+
+import httpx
+from mcp.client.streamable_http import streamablehttp_client
+
+from ...tools.decorator import tool
+from ...tools.mcp.mcp_client import MCPClient
+from ...types.tools import ToolContext
+
+if TYPE_CHECKING:
+    from ...tools.decorator import DecoratedFunctionTool
+
+logger = logging.getLogger(__name__)
+
+
+_MCP_CLIENT_DESCRIPTION = (
+    "Connects to Model Context Protocol (MCP) servers at runtime. Supports four operations: "
+    "'connect' (open a session to an allowlisted server URL), 'list_tools' (list the tools "
+    "the connected server exposes), 'call_tool' (invoke a tool on a connected server), and "
+    "'disconnect' (close a session). URLs must be on a developer-set allowlist."
+)
+
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+_DEFAULT_SCHEME_PORTS = {"http": 80, "https": 443}
+_DEFAULT_SESSION_LIMIT = 8
+_DEFAULT_STARTUP_TIMEOUT = 30
+_DEFAULT_CALL_TIMEOUT_SECONDS = 60
+_MAX_RESULT_TEXT_CHARS = 100_000
+_MAX_STRUCTURED_CONTENT_BYTES = 100_000
+
+# Hostname suffixes we reject before DNS. Names on these zones are intended for
+# internal use even when they happen to resolve to a public IP for some resolver.
+_BLOCKED_HOST_SUFFIXES: tuple[str, ...] = (
+    ".internal",
+    ".local",
+    ".localhost",
+    ".corp",
+    ".home",
+    ".lan",
+    ".intranet",
+    ".private",
+    ".i2p",
+    ".onion",
+)
+
+# Site-local IPv6 (`fec0::/10`, deprecated in RFC 3879 but not caught by
+# `is_global` on some CPython releases). Layer an explicit rejection.
+_IPV6_SITE_LOCAL = ipaddress.IPv6Network("fec0::/10")
+
+# Cloud-metadata endpoints. `is_global` already rejects link-local (169.254/16) and
+# the unique-local IPv6 space, but naming them explicitly guards against a future
+# refactor that weakens a generic predicate.
+_BLOCKED_METADATA_ADDRESSES: frozenset[str] = frozenset(
+    {
+        "169.254.169.254",  # AWS / Azure / DigitalOcean
+        "fd00:ec2::254",  # AWS IPv6
+        "100.100.100.200",  # Alibaba
+        "192.0.0.192",  # Oracle Cloud
+    }
+)
+
+Op = Literal["connect", "list_tools", "call_tool", "disconnect"]
+
+
+class _Session:
+    """A single live MCP connection owned by exactly one agent."""
+
+    __slots__ = ("client", "url", "owner_ref", "tools")
+
+    def __init__(
+        self,
+        client: MCPClient,
+        url: str,
+        owner_ref: weakref.ref,
+        tools: dict[str, Any],
+    ) -> None:
+        self.client = client
+        self.url = url
+        self.owner_ref = owner_ref
+        # Tool set cached at connect time. Keyed by tool name; the value is the
+        # server-provided metadata used to render `list_tools` and validate the
+        # `tool_name` passed to `call_tool`. Matches the TypeScript side, which
+        # also caches at connect so both SDKs surface an "unknown tool" error
+        # locally instead of forwarding an unadvertised name to the server.
+        self.tools = tools
+
+
+def make_mcp_client(
+    *,
+    allowed_urls: list[str],
+    name: str = "mcp_client",
+    description: str = _MCP_CLIENT_DESCRIPTION,
+    session_limit: int = _DEFAULT_SESSION_LIMIT,
+    startup_timeout: int = _DEFAULT_STARTUP_TIMEOUT,
+) -> DecoratedFunctionTool:
+    """Create an agent-callable MCP client tool bound to a developer-set URL allowlist.
+
+    The returned tool exposes ``connect``, ``list_tools``, ``call_tool``, and ``disconnect``
+    operations under a single tool name. Every ``connect`` is checked against ``allowed_urls``;
+    only URLs that appear verbatim (after normalisation) are accepted.
+
+    Args:
+        allowed_urls: Exact URLs the tool may connect to. The list is normalised (scheme
+            lowercased, trailing slash stripped) and each entry must use ``http`` or
+            ``https``. Must not be empty; the tool is deliberately useless without an
+            explicit allowlist.
+        name: Tool name. Defaults to ``"mcp_client"``.
+        description: Tool description shown to the model.
+        session_limit: Maximum number of concurrent live sessions across all agents using
+            this tool instance. Defaults to 8.
+        startup_timeout: Seconds to wait for the initial MCP handshake before treating a
+            connection as failed. Defaults to 30.
+
+    Returns:
+        A decorated tool that manages MCP sessions.
+
+    Raises:
+        ValueError: If ``allowed_urls`` is empty or contains an entry that is not a
+            valid, http-family URL.
+    """
+    if not isinstance(session_limit, int) or isinstance(session_limit, bool) or session_limit <= 0:
+        raise ValueError(f"`session_limit` must be a positive integer, got {session_limit!r}")
+
+    normalised_allowlist = _normalise_allowlist(allowed_urls)
+    sessions: dict[str, _Session] = {}
+    # Reserved-slot counter. Incremented synchronously before any `await` in
+    # `_handle_connect`, so racing connects can never overshoot the cap even
+    # while the blocking `client.start()` is off the event loop in a worker
+    # thread. Held in a single-element list so nested functions can mutate it.
+    reserved: list[int] = [0]
+
+    @tool(name=name, description=description, context="tool_context")
+    async def mcp_client_tool(
+        op: Op,
+        tool_context: ToolContext,
+        server_url: str | None = None,
+        session_id: str | None = None,
+        tool_name: str | None = None,
+        arguments: dict[str, Any] | None = None,
+        timeout: int = _DEFAULT_CALL_TIMEOUT_SECONDS,
+    ) -> dict[str, Any]:
+        """Manage a runtime MCP client connection.
+
+        Args:
+            op: The operation to perform: ``connect``, ``list_tools``, ``call_tool``, ``disconnect``.
+            tool_context: Injected by the framework. Not user-facing.
+            server_url: Server URL for ``connect``. Must match the developer-set allowlist verbatim.
+            session_id: Session identifier returned by ``connect``, required for the other three ops.
+            tool_name: Tool name to invoke, required for ``call_tool``.
+            arguments: Arguments to pass to the invoked tool, for ``call_tool``.
+            timeout: Per-call timeout in seconds. Defaults to 60. Applies to ``call_tool`` only.
+        """
+        agent = tool_context.agent
+
+        if op == "connect":
+            if not server_url:
+                raise ValueError("`server_url` is required for op='connect'")
+            return await _handle_connect(
+                sessions,
+                reserved,
+                allowlist=normalised_allowlist,
+                session_limit=session_limit,
+                startup_timeout=startup_timeout,
+                server_url=server_url,
+                agent=agent,
+            )
+
+        if op == "list_tools":
+            session = _resolve_session(sessions, session_id, agent)
+            return _handle_list_tools(session)
+
+        if op == "call_tool":
+            if not tool_name:
+                raise ValueError("`tool_name` is required for op='call_tool'")
+            session = _resolve_session(sessions, session_id, agent)
+            return await _handle_call_tool(session, tool_name, arguments, timeout)
+
+        if op == "disconnect":
+            session = _resolve_session(sessions, session_id, agent)
+            return await _handle_disconnect(sessions, cast(str, session_id), session)
+
+        raise ValueError(f"Unknown op: {op}")
+
+    return mcp_client_tool
+
+
+# ---- URL validation ----------------------------------------------------------------
+
+
+def _normalise_allowlist(urls: list[str]) -> frozenset[str]:
+    """Normalise the developer-set allowlist and validate each entry."""
+    if not urls:
+        raise ValueError("`allowed_urls` must not be empty; the mcp_client tool requires an explicit allowlist")
+
+    normalised: set[str] = set()
+    for raw in urls:
+        parsed = urlparse(raw)
+        if parsed.scheme.lower() not in _ALLOWED_SCHEMES:
+            raise ValueError(
+                f"Allowlist entry {raw!r} has unsupported scheme {parsed.scheme!r}; only http and https are supported"
+            )
+        if not parsed.hostname:
+            raise ValueError(f"Allowlist entry {raw!r} has no host")
+        _reject_userinfo_and_fragment(raw, parsed)
+        normalised.add(_canonicalise_url(raw))
+    return frozenset(normalised)
+
+
+def _reject_userinfo_and_fragment(raw: str, parsed: Any) -> None:
+    """Reject URLs carrying credentials or fragments.
+
+    Both are stripped by :func:`_canonicalise_url`, so leaving them accepted would
+    let ``https://user:pass@host/path`` canonicalise to the same string as
+    ``https://host/path`` and bypass the verbatim allowlist match.
+    """
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError(f"URL {raw!r} carries credentials; strip the userinfo before allowlisting or connecting")
+    if parsed.fragment:
+        raise ValueError(f"URL {raw!r} carries a fragment; strip it before allowlisting or connecting")
+
+
+def _canonicalise_url(url: str) -> str:
+    """Canonicalise a URL for allowlist matching.
+
+    Lowercase scheme/host, strip the trailing slash on the path, drop the port when it
+    matches the scheme default (so ``https://host`` and ``https://host:443`` match), and
+    drop the fragment. Userinfo is dropped too; :func:`_reject_userinfo_and_fragment`
+    refuses URLs carrying credentials or fragments before this function ever sees them.
+    """
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+    host = (parsed.hostname or "").lower()
+    default_port = _DEFAULT_SCHEME_PORTS.get(scheme)
+    port = f":{parsed.port}" if parsed.port and parsed.port != default_port else ""
+    path = parsed.path.rstrip("/")
+    query = f"?{parsed.query}" if parsed.query else ""
+    return f"{scheme}://{host}{port}{path}{query}"
+
+
+def _assert_public_host(url: str) -> None:
+    """Reject URLs whose host is on the suffix denylist or resolves to non-public space.
+
+    Applied on top of the allowlist as defence in depth: even if the allowlist entry
+    itself points at an internal address, the guard still refuses.
+
+    The classification is a check-time judgment. A DNS-rebinding resolver can return a
+    different address to the MCP transport's own ``getaddrinfo`` at connect time; the
+    MCP client SDK does not expose a hook for pinned-IP connects, so this guard alone
+    does not close the TOCTOU window. Do not allowlist a hostname whose DNS you do not
+    control.
+    """
+    host = (urlparse(url).hostname or "").lower()
+    if host.endswith("."):
+        host = host[:-1]
+
+    for suffix in _BLOCKED_HOST_SUFFIXES:
+        bare = suffix.lstrip(".")
+        if host == bare or host.endswith(suffix):
+            raise ValueError(f"Refusing to connect to {url!r}: hostname {host!r} matches blocked suffix {suffix!r}")
+
+    try:
+        ip = ipaddress.ip_address(host)
+        addresses: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = [ip]
+    except ValueError:
+        try:
+            infos = socket.getaddrinfo(host, None)
+        except socket.gaierror as e:
+            raise ValueError(f"Could not resolve host {host!r}: {e}") from e
+        addresses = []
+        for info in infos:
+            sockaddr = info[4]
+            try:
+                addresses.append(ipaddress.ip_address(sockaddr[0]))
+            except ValueError:
+                continue
+
+    if not addresses:
+        raise ValueError(f"Could not resolve host {host!r} to any IP address")
+
+    for addr in addresses:
+        # Unwrap IPv4-mapped IPv6 first so subsequent checks apply to the embedded v4.
+        if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped is not None:
+            addr = addr.ipv4_mapped
+        if str(addr) in _BLOCKED_METADATA_ADDRESSES:
+            raise ValueError(f"Refusing to connect to {url!r}: host {host!r} resolves to metadata address {addr}")
+        # `is_global` is True for multicast on every supported CPython (3.10–3.14); the
+        # site-local `fec0::/10` range also slips through on some releases. Layer
+        # explicit rejections on top so the guard doesn't inherit those quirks.
+        if addr.is_multicast or addr.is_reserved or addr.is_unspecified or addr.is_link_local:
+            raise ValueError(f"Refusing to connect to {url!r}: host {host!r} resolves to non-public address {addr}")
+        if isinstance(addr, ipaddress.IPv6Address) and addr in _IPV6_SITE_LOCAL:
+            raise ValueError(f"Refusing to connect to {url!r}: host {host!r} resolves to non-public address {addr}")
+        if not addr.is_global:
+            raise ValueError(f"Refusing to connect to {url!r}: host {host!r} resolves to non-public address {addr}")
+
+
+# ---- Operation handlers ------------------------------------------------------------
+
+
+async def _handle_connect(
+    sessions: dict[str, _Session],
+    reserved: list[int],
+    *,
+    allowlist: frozenset[str],
+    session_limit: int,
+    startup_timeout: int,
+    server_url: str,
+    agent: Any,
+) -> dict[str, Any]:
+    parsed = urlparse(server_url)
+    _reject_userinfo_and_fragment(server_url, parsed)
+
+    canonical = _canonicalise_url(server_url)
+    if canonical not in allowlist:
+        raise ValueError(f"URL {server_url!r} is not on the developer-set allowlist")
+
+    scheme = parsed.scheme.lower()
+    if scheme not in _ALLOWED_SCHEMES:
+        # Defence in depth: the allowlist already screens this.
+        raise ValueError(f"unsupported scheme {scheme!r}")
+
+    _assert_public_host(server_url)
+
+    # Drop sessions whose owning agent has been garbage-collected before enforcing
+    # the cap. Left in place they'd count toward the limit forever and pin the
+    # underlying transport open.
+    _purge_dead_sessions(sessions)
+
+    if len(sessions) + reserved[0] >= session_limit:
+        raise RuntimeError(
+            f"Refusing to open a new MCP session: "
+            f"{len(sessions) + reserved[0]}/{session_limit} concurrent sessions in use"
+        )
+
+    transport_callable = _make_http_transport(server_url)
+
+    # Reserve a slot synchronously before any `await`. Without this a burst of
+    # concurrent connects would all pass the cap check, then race to `start()`
+    # in worker threads and overshoot.
+    reserved[0] += 1
+    client = MCPClient(transport_callable, startup_timeout=startup_timeout)
+    try:
+        # `MCPClient.start()` blocks the calling thread until the MCP handshake
+        # completes or `startup_timeout` elapses. Push it off the event loop so
+        # concurrent invocations of the tool are not serialised.
+        await asyncio.to_thread(client.start)
+        try:
+            # Cache the tool list at connect time. `call_tool` validates the
+            # requested name against this cache so an unadvertised name fails
+            # locally instead of being forwarded to the server. TypeScript
+            # does the same; both SDKs accept that the cache goes stale if
+            # the server changes its tool set mid-session, which is not a
+            # supported MCP flow today.
+            tools = await asyncio.to_thread(_list_tools_via_client, client)
+        except BaseException:
+            # A failure past `start()` leaves the client connected. Tear it down
+            # so we do not leak the transport.
+            try:
+                await asyncio.to_thread(client.stop, None, None, None)
+            except Exception:  # pragma: no cover - best-effort cleanup
+                logger.debug("failed to tear down MCP client after connect failure", exc_info=True)
+            raise
+    finally:
+        reserved[0] -= 1
+
+    session_id = secrets.token_urlsafe(24)
+    sessions[session_id] = _Session(
+        client=client,
+        url=canonical,
+        owner_ref=weakref.ref(agent),
+        tools=tools,
+    )
+    logger.debug("session_id=<%s>, url=<%s> | opened MCP session", session_id, canonical)
+
+    return {"session_id": session_id, "server_url": canonical}
+
+
+def _list_tools_via_client(client: MCPClient) -> dict[str, dict[str, Any]]:
+    """Pull the full tool list from an MCP client and return it keyed by name."""
+    tools: dict[str, dict[str, Any]] = {}
+    pagination_token: str | None = None
+    while True:
+        paginated = client.list_tools_sync(pagination_token)
+        for agent_tool in paginated:
+            mcp_tool = agent_tool.mcp_tool
+            entry: dict[str, Any] = {
+                "name": mcp_tool.name,
+                "description": mcp_tool.description or "",
+                "input_schema": mcp_tool.inputSchema,
+            }
+            if mcp_tool.outputSchema:
+                entry["output_schema"] = mcp_tool.outputSchema
+            tools[mcp_tool.name] = entry
+        pagination_token = paginated.pagination_token
+        if pagination_token is None:
+            break
+    return tools
+
+
+def _handle_list_tools(session: _Session) -> dict[str, Any]:
+    return {"tools": list(session.tools.values())}
+
+
+async def _handle_call_tool(
+    session: _Session,
+    tool_name: str,
+    arguments: dict[str, Any] | None,
+    timeout: int,
+) -> dict[str, Any]:
+    if tool_name not in session.tools:
+        raise ValueError(f"Tool {tool_name!r} is not exposed by the connected server")
+
+    tool_use_id = secrets.token_urlsafe(12)
+    result = await session.client.call_tool_async(
+        tool_use_id=tool_use_id,
+        name=tool_name,
+        arguments=arguments,
+        read_timeout_seconds=timedelta(seconds=timeout),
+    )
+
+    truncated = False
+    text_parts: list[str] = []
+    for content in result.get("content", []):
+        text = content.get("text") if isinstance(content, dict) else None
+        if isinstance(text, str):
+            text_parts.append(text)
+
+    joined = "\n".join(text_parts)
+    if len(joined) > _MAX_RESULT_TEXT_CHARS:
+        joined = joined[:_MAX_RESULT_TEXT_CHARS]
+        truncated = True
+
+    response: dict[str, Any] = {
+        "status": result.get("status", "error"),
+        "text": joined,
+    }
+    if truncated:
+        response["truncated"] = True
+    if "structuredContent" in result:
+        response["structured_content"] = _cap_structured_content(result["structuredContent"], response)
+    if result.get("isError"):
+        response["is_error"] = True
+    return response
+
+
+def _cap_structured_content(value: Any, response: dict[str, Any]) -> Any:
+    """Serialise ``value`` to JSON and, if it exceeds the size cap, return a marker.
+
+    Left as-is when small; when too large, replaced with an object announcing the
+    truncation so the model can see the content was dropped rather than silently
+    receiving a shortened blob.
+    """
+    try:
+        encoded = json.dumps(value)
+    except (TypeError, ValueError):
+        # Non-JSON-serialisable — reject rather than smuggle an opaque object through.
+        response["truncated"] = True
+        return {"__truncated__": True, "reason": "structured_content was not JSON-serialisable"}
+    encoded_bytes = len(encoded.encode("utf-8"))
+    if encoded_bytes <= _MAX_STRUCTURED_CONTENT_BYTES:
+        return value
+    response["truncated"] = True
+    # `size` reports the same unit the cap is measured in (bytes) so a non-ASCII
+    # payload's reported size matches the check.
+    return {"__truncated__": True, "reason": "structured_content exceeded size cap", "size": encoded_bytes}
+
+
+async def _handle_disconnect(
+    sessions: dict[str, _Session],
+    session_id: str,
+    session: _Session,
+) -> dict[str, Any]:
+    try:
+        # `stop` blocks until the transport tears down. Push it off the event loop.
+        await asyncio.to_thread(session.client.stop, None, None, None)
+    finally:
+        sessions.pop(session_id, None)
+    return {"disconnected": True}
+
+
+def _purge_dead_sessions(sessions: dict[str, _Session]) -> None:
+    """Remove sessions whose owning agent has been garbage-collected.
+
+    A dead weakref means the agent that opened the session no longer exists, so
+    the session is permanently unreachable via :func:`_resolve_session`. Left in
+    place these entries would count against the ``session_limit`` forever and
+    pin the underlying MCP transport open. Best-effort ``stop`` for the same
+    reason — failures are logged, not raised.
+    """
+    dead: list[str] = [sid for sid, s in sessions.items() if s.owner_ref() is None]
+    for sid in dead:
+        session = sessions.pop(sid, None)
+        if session is None:
+            continue
+        try:
+            session.client.stop(None, None, None)
+        except Exception:  # pragma: no cover - best-effort cleanup
+            logger.debug("failed to stop MCP client for GC'd session %s", sid, exc_info=True)
+
+
+def _resolve_session(sessions: dict[str, _Session], session_id: str | None, agent: Any) -> _Session:
+    """Look up a session, rejecting missing ids and cross-agent access.
+
+    The owner is held as a weakref: if the agent that opened the session has been
+    garbage-collected, ``owner_ref()`` returns ``None`` and the session is
+    unreachable — the caller gets the same "no active session" error as an
+    unknown id. When we observe a dead owner we also drop the session and
+    best-effort stop its client so the resource doesn't leak.
+    """
+    if not session_id:
+        raise ValueError("`session_id` is required")
+    session = sessions.get(session_id)
+    if session is None:
+        raise ValueError(f"No active session for id {session_id!r}")
+    owner = session.owner_ref()
+    if owner is None:
+        # Dead weakref: reap this specific session as we walk past it. Callers see
+        # the same "no active session" error as an unknown id.
+        sessions.pop(session_id, None)
+        try:
+            session.client.stop(None, None, None)
+        except Exception:  # pragma: no cover - best-effort cleanup
+            logger.debug("failed to stop MCP client for GC'd session %s", session_id, exc_info=True)
+        raise ValueError(f"No active session for id {session_id!r}")
+    if owner is not agent:
+        raise ValueError(f"No active session for id {session_id!r}")
+    return session
+
+
+# ---- Transports --------------------------------------------------------------------
+
+
+def _no_redirect_httpx_client_factory(
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None = None,
+    auth: httpx.Auth | None = None,
+) -> httpx.AsyncClient:
+    """MCP-shaped ``httpx.AsyncClient`` factory that refuses to follow redirects.
+
+    MCP's default factory sets ``follow_redirects=True``, which would allow an
+    allowlisted URL to be 3xx'd to a private endpoint the SSRF guard never saw. We
+    override to ``False`` so a redirect surfaces as an ``httpx.HTTPStatusError`` (or a
+    3xx status the caller can see) instead of a silent hop to the new location.
+    """
+    kwargs: dict[str, Any] = {"follow_redirects": False}
+    if timeout is None:
+        kwargs["timeout"] = httpx.Timeout(30.0, read=300.0)
+    else:
+        kwargs["timeout"] = timeout
+    if headers is not None:
+        kwargs["headers"] = headers
+    if auth is not None:
+        kwargs["auth"] = auth
+    return httpx.AsyncClient(**kwargs)
+
+
+def _make_http_transport(url: str):  # type: ignore[no-untyped-def]
+    """Return a zero-arg callable that opens a streamable-http transport for ``url``."""
+    return lambda: streamablehttp_client(
+        url=url,
+        httpx_client_factory=_no_redirect_httpx_client_factory,
+    )

--- a/strands-py/tests/strands/vended_tools/test_mcp_client.py
+++ b/strands-py/tests/strands/vended_tools/test_mcp_client.py
@@ -1,0 +1,710 @@
+"""Tests for the vended MCP client tool.
+
+The tool is a thin shim over ``strands.tools.mcp.MCPClient``. These tests exercise the
+security surface — allowlist enforcement, SSRF guard, session scoping, session cap — with
+the real code paths, and cover the connect->list->call->disconnect happy path by patching
+``MCPClient`` so no real MCP server is needed.
+"""
+
+from __future__ import annotations
+
+import gc
+import socket
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from strands.types.tools import ToolContext
+from strands.vended_tools import make_mcp_client
+from strands.vended_tools.mcp_client.mcp_client import (
+    _canonicalise_url,
+    _cap_structured_content,
+    _no_redirect_httpx_client_factory,
+    _normalise_allowlist,
+)
+
+
+class _StubAgent:
+    """A minimal agent stand-in that supports weakref (SimpleNamespace does not)."""
+
+    def __init__(self, label: str | None = None) -> None:
+        self.label = label
+
+
+def _tool_context(agent: Any | None = None) -> ToolContext:
+    """Build a ToolContext with a distinct sentinel agent object for identity checks."""
+    if agent is None:
+        agent = _StubAgent()
+    return ToolContext(
+        tool_use={"name": "mcp_client", "toolUseId": "test-id", "input": {}},
+        agent=agent,
+        invocation_state={},
+    )
+
+
+class _FakeMCPTool:
+    def __init__(self, name: str, description: str, input_schema: dict[str, Any]) -> None:
+        self.name = name
+        self.description = description
+        self.inputSchema = input_schema
+        self.outputSchema: dict[str, Any] | None = None
+
+
+class _FakeAgentTool:
+    def __init__(self, tool: _FakeMCPTool) -> None:
+        self.mcp_tool = tool
+
+
+class _FakePaginatedList(list):
+    def __init__(self, items: list[Any], token: str | None = None) -> None:
+        super().__init__(items)
+        self.pagination_token = token
+
+
+def _fake_mcp_client_class(
+    *,
+    list_tools_return: list[_FakeAgentTool] | None = None,
+    call_tool_return: dict[str, Any] | None = None,
+) -> Any:
+    """Return a MagicMock-based MCPClient replacement whose start/stop record calls."""
+    instance = MagicMock()
+    instance.start = MagicMock()
+    instance.stop = MagicMock()
+    instance.list_tools_sync = MagicMock(return_value=_FakePaginatedList(list_tools_return or [], token=None))
+
+    async def _call(*args: Any, **kwargs: Any) -> Any:
+        return call_tool_return or {"status": "success", "content": [{"text": "ok"}]}
+
+    instance.call_tool_async = _call
+    return MagicMock(return_value=instance), instance
+
+
+def _mcp_instance(tools: list[_FakeAgentTool] | None = None) -> MagicMock:
+    """Return a MagicMock configured to look enough like an ``MCPClient`` that connect works.
+
+    ``_list_tools_via_client`` reads ``pagination_token`` off the returned page and
+    iterates it, so a bare ``MagicMock`` (whose ``pagination_token`` is another
+    ``MagicMock`` rather than ``None``) would loop forever.
+    """
+    instance = MagicMock()
+    instance.list_tools_sync = MagicMock(return_value=_FakePaginatedList(tools or [], token=None))
+    return instance
+
+
+class TestAllowlistEnforcement:
+    """URL allowlist rejects anything the developer didn't sign off on."""
+
+    @pytest.mark.asyncio
+    async def test_url_not_on_allowlist_is_rejected(self):
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with pytest.raises(ValueError, match="not on the developer-set allowlist"):
+            await tool(op="connect", server_url="https://evil.example.com/mcp", tool_context=_tool_context())
+
+    @pytest.mark.asyncio
+    async def test_allowlist_match_is_scheme_and_host_case_insensitive(self):
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with (
+            patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai,
+            patch("strands.vended_tools.mcp_client.mcp_client.MCPClient") as client_cls,
+        ):
+            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+            instance = _mcp_instance()
+            client_cls.return_value = instance
+            result = await tool(
+                op="connect",
+                server_url="HTTPS://MCP.EXAMPLE.COM/mcp",
+                tool_context=_tool_context(),
+            )
+        assert "session_id" in result
+        instance.start.assert_called_once()
+
+    def test_empty_allowlist_is_rejected_at_construction(self):
+        with pytest.raises(ValueError, match="must not be empty"):
+            make_mcp_client(allowed_urls=[])
+
+    def test_disallowed_scheme_in_allowlist_is_rejected_at_construction(self):
+        with pytest.raises(ValueError, match="unsupported scheme"):
+            make_mcp_client(allowed_urls=["file:///etc/passwd"])
+
+    def test_missing_host_in_allowlist_is_rejected(self):
+        with pytest.raises(ValueError, match="no host"):
+            make_mcp_client(allowed_urls=["https:///"])
+
+    def test_allowlist_entry_with_userinfo_is_rejected(self):
+        # A canonicaliser that dropped userinfo would let `https://user:pass@host/x`
+        # collide with `https://host/x` on the allowlist. Reject at construction.
+        with pytest.raises(ValueError, match="credentials"):
+            make_mcp_client(allowed_urls=["https://user:pass@mcp.example.com/mcp"])
+
+    def test_allowlist_entry_with_fragment_is_rejected(self):
+        with pytest.raises(ValueError, match="fragment"):
+            make_mcp_client(allowed_urls=["https://mcp.example.com/mcp#anchor"])
+
+    @pytest.mark.asyncio
+    async def test_connect_url_with_userinfo_is_rejected(self):
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with pytest.raises(ValueError, match="credentials"):
+            await tool(
+                op="connect",
+                server_url="https://user:pass@mcp.example.com/mcp",
+                tool_context=_tool_context(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_connect_url_with_fragment_is_rejected(self):
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with pytest.raises(ValueError, match="fragment"):
+            await tool(
+                op="connect",
+                server_url="https://mcp.example.com/mcp#x",
+                tool_context=_tool_context(),
+            )
+
+    @pytest.mark.parametrize("bad", [0, -1, 1.5, True, False, "8"])
+    def test_session_limit_must_be_positive_integer(self, bad):
+        with pytest.raises(ValueError, match="positive integer"):
+            make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"], session_limit=bad)  # type: ignore[arg-type]
+
+
+class TestSSRFGuard:
+    """The SSRF guard rejects hostnames that resolve to non-public addresses."""
+
+    @pytest.mark.asyncio
+    async def test_hostname_resolving_to_private_ip_is_rejected(self):
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai:
+            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("10.0.0.5", 0))]
+            with pytest.raises(ValueError, match="non-public address"):
+                await tool(
+                    op="connect",
+                    server_url="https://mcp.example.com/mcp",
+                    tool_context=_tool_context(),
+                )
+
+    @pytest.mark.asyncio
+    async def test_hostname_resolving_to_loopback_is_rejected(self):
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai:
+            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", 0))]
+            with pytest.raises(ValueError, match="non-public address"):
+                await tool(
+                    op="connect",
+                    server_url="https://mcp.example.com/mcp",
+                    tool_context=_tool_context(),
+                )
+
+    @pytest.mark.asyncio
+    async def test_literal_private_ip_in_url_is_rejected(self):
+        tool = make_mcp_client(allowed_urls=["http://192.168.1.1/mcp"])
+        with pytest.raises(ValueError, match="non-public address"):
+            await tool(op="connect", server_url="http://192.168.1.1/mcp", tool_context=_tool_context())
+
+    @pytest.mark.asyncio
+    async def test_link_local_metadata_ip_is_rejected(self):
+        tool = make_mcp_client(allowed_urls=["http://169.254.169.254/mcp"])
+        with pytest.raises(ValueError, match="metadata address|non-public address"):
+            await tool(op="connect", server_url="http://169.254.169.254/mcp", tool_context=_tool_context())
+
+    @pytest.mark.asyncio
+    async def test_cgnat_ip_is_rejected(self):
+        tool = make_mcp_client(allowed_urls=["http://100.64.0.1/mcp"])
+        with pytest.raises(ValueError, match="non-public address"):
+            await tool(op="connect", server_url="http://100.64.0.1/mcp", tool_context=_tool_context())
+
+    @pytest.mark.asyncio
+    async def test_ipv4_mapped_cgnat_is_rejected(self):
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai:
+            gai.return_value = [(socket.AF_INET6, socket.SOCK_STREAM, 0, "", ("::ffff:100.64.0.1", 0, 0, 0))]
+            with pytest.raises(ValueError, match="non-public address"):
+                await tool(
+                    op="connect",
+                    server_url="https://mcp.example.com/mcp",
+                    tool_context=_tool_context(),
+                )
+
+    @pytest.mark.asyncio
+    async def test_ipv4_mapped_private_is_rejected(self):
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai:
+            gai.return_value = [(socket.AF_INET6, socket.SOCK_STREAM, 0, "", ("::ffff:10.0.0.5", 0, 0, 0))]
+            with pytest.raises(ValueError, match="non-public address"):
+                await tool(
+                    op="connect",
+                    server_url="https://mcp.example.com/mcp",
+                    tool_context=_tool_context(),
+                )
+
+    @pytest.mark.asyncio
+    async def test_ipv4_multicast_is_rejected(self):
+        """`is_global` returns True for multicast on CPython — the guard must layer explicit checks."""
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai:
+            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("239.255.0.1", 0))]
+            with pytest.raises(ValueError, match="non-public address"):
+                await tool(
+                    op="connect",
+                    server_url="https://mcp.example.com/mcp",
+                    tool_context=_tool_context(),
+                )
+
+    @pytest.mark.asyncio
+    async def test_ipv6_multicast_is_rejected(self):
+        """`is_global` also returns True for IPv6 multicast (`ff00::/8`) on CPython."""
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai:
+            gai.return_value = [(socket.AF_INET6, socket.SOCK_STREAM, 0, "", ("ff02::1", 0, 0, 0))]
+            with pytest.raises(ValueError, match="non-public address"):
+                await tool(
+                    op="connect",
+                    server_url="https://mcp.example.com/mcp",
+                    tool_context=_tool_context(),
+                )
+
+    @pytest.mark.asyncio
+    async def test_ipv6_site_local_is_rejected(self):
+        """`fec0::/10` slips through `is_global` on some Python versions — explicit block."""
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai:
+            gai.return_value = [(socket.AF_INET6, socket.SOCK_STREAM, 0, "", ("fec0::1", 0, 0, 0))]
+            with pytest.raises(ValueError, match="non-public address"):
+                await tool(
+                    op="connect",
+                    server_url="https://mcp.example.com/mcp",
+                    tool_context=_tool_context(),
+                )
+
+    @pytest.mark.asyncio
+    async def test_unresolvable_host_is_rejected(self):
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai:
+            gai.side_effect = socket.gaierror("nope")
+            with pytest.raises(ValueError, match="Could not resolve host"):
+                await tool(
+                    op="connect",
+                    server_url="https://mcp.example.com/mcp",
+                    tool_context=_tool_context(),
+                )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "svc.internal",
+            "db.corp",
+            "printer.local",
+            "example.LOCAL",
+            "gateway.home",
+            "onboarding.i2p",
+            "secret.onion",
+            "svc.internal.",  # trailing dot
+        ],
+    )
+    async def test_suffix_denylist_rejects_before_dns(self, host):
+        tool = make_mcp_client(allowed_urls=[f"https://{host}/mcp"])
+        with pytest.raises(ValueError, match="blocked suffix"):
+            await tool(op="connect", server_url=f"https://{host}/mcp", tool_context=_tool_context())
+
+
+class TestSessionScoping:
+    """Sessions are scoped to the agent that opened them."""
+
+    @pytest.mark.asyncio
+    async def test_session_id_from_another_agent_is_rejected(self):
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with (
+            patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai,
+            patch("strands.vended_tools.mcp_client.mcp_client.MCPClient") as client_cls,
+        ):
+            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+            client_cls.return_value = _mcp_instance()
+
+            agent_a = _StubAgent(label="a")
+            agent_b = _StubAgent(label="b")
+
+            connected = await tool(
+                op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context(agent_a)
+            )
+            session_id = connected["session_id"]
+
+            with pytest.raises(ValueError, match="No active session"):
+                await tool(op="list_tools", session_id=session_id, tool_context=_tool_context(agent_b))
+
+    @pytest.mark.asyncio
+    async def test_gc_of_owning_agent_invalidates_sessions(self):
+        """If the owning agent is garbage-collected, its sessions become unreachable.
+
+        The check-that-fresh-agent-cannot-list-sessions branch of this test is not
+        specific to GC — cross-agent rejection would fire whether the tool held an
+        ``id(agent)`` or a ``weakref.ref(agent)``. To exercise the GC-specific path
+        we also keep our own :class:`weakref.ref` to the agent and assert it is
+        dead after :func:`gc.collect`; that assertion fails if GC didn't actually
+        run (e.g. because something held a strong reference), which is what the
+        second-pass reviewer asked us to prove.
+        """
+        import weakref as _weakref
+
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with (
+            patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai,
+            patch("strands.vended_tools.mcp_client.mcp_client.MCPClient") as client_cls,
+        ):
+            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+            client_cls.return_value = _mcp_instance()
+
+            class _Agent:
+                pass
+
+            agent = _Agent()
+            # Independent weakref: dies iff the agent object is GC'd. Distinct from
+            # the tool's internal weakref so it proves GC actually happened.
+            gc_witness = _weakref.ref(agent)
+
+            connected = await tool(
+                op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context(agent)
+            )
+            session_id = connected["session_id"]
+
+            # Sanity: while a strong reference exists, our witness is alive.
+            assert gc_witness() is agent
+
+            # Drop the only strong reference and run GC.
+            del agent
+            gc.collect()
+
+            # This is the GC-specific assertion. If nothing else holds `agent`, this
+            # is None; if it isn't, GC didn't actually clean up and the test fails.
+            assert gc_witness() is None
+
+            # And the enforcement path still returns the shared error string.
+            with pytest.raises(ValueError, match="No active session"):
+                await tool(
+                    op="list_tools",
+                    session_id=session_id,
+                    tool_context=_tool_context(_Agent()),
+                )
+
+    @pytest.mark.asyncio
+    async def test_unknown_session_id_is_rejected(self):
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with pytest.raises(ValueError, match="No active session"):
+            await tool(op="list_tools", session_id="does-not-exist", tool_context=_tool_context())
+
+    @pytest.mark.asyncio
+    async def test_missing_session_id_is_rejected(self):
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with pytest.raises(ValueError, match="required"):
+            await tool(op="list_tools", tool_context=_tool_context())
+
+
+class TestSessionLimit:
+    """The tool refuses to open more than ``session_limit`` sessions concurrently."""
+
+    @pytest.mark.asyncio
+    async def test_session_limit_rejects_further_connects(self):
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"], session_limit=1)
+        # Persistent agents: otherwise the ephemeral `_tool_context()` agents get
+        # garbage-collected between calls and the dead-session purge in connect
+        # frees the slot before the cap check.
+        agent_a = _StubAgent(label="a")
+        agent_b = _StubAgent(label="b")
+        with (
+            patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai,
+            patch("strands.vended_tools.mcp_client.mcp_client.MCPClient") as client_cls,
+        ):
+            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+            client_cls.return_value = _mcp_instance()
+            await tool(op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context(agent_a))
+            with pytest.raises(RuntimeError, match="concurrent sessions"):
+                await tool(
+                    op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context(agent_b)
+                )
+
+    @pytest.mark.asyncio
+    async def test_dead_sessions_are_purged_before_enforcing_cap(self):
+        # If a session's owning agent is garbage-collected, the slot should be
+        # reclaimed automatically at the next connect. Otherwise a stream of
+        # connect-and-forget agents pins the cap at zero forever.
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"], session_limit=1)
+        with (
+            patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai,
+            patch("strands.vended_tools.mcp_client.mcp_client.MCPClient") as client_cls,
+        ):
+            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+            client_cls.return_value = _mcp_instance()
+
+            class _Agent:
+                pass
+
+            ephemeral = _Agent()
+            await tool(
+                op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context(ephemeral)
+            )
+            del ephemeral
+            gc.collect()
+
+            # A second connect from a fresh agent should now succeed: the first
+            # session is unreachable and its slot has been returned to the pool.
+            client_cls.return_value = _mcp_instance()
+            connected = await tool(
+                op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context()
+            )
+            assert "session_id" in connected
+
+
+class TestHappyPath:
+    """A full connect -> list_tools -> call_tool -> disconnect flow."""
+
+    @pytest.mark.asyncio
+    async def test_full_lifecycle(self):
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        fake_tool = _FakeMCPTool(
+            name="echo",
+            description="Echoes input",
+            input_schema={"type": "object", "properties": {"msg": {"type": "string"}}},
+        )
+        client_class, instance = _fake_mcp_client_class(
+            list_tools_return=[_FakeAgentTool(fake_tool)],
+            call_tool_return={
+                "status": "success",
+                "content": [{"text": "hello world"}],
+            },
+        )
+
+        agent = _StubAgent(label="a")
+
+        with (
+            patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai,
+            patch("strands.vended_tools.mcp_client.mcp_client.MCPClient", client_class),
+        ):
+            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+
+            connect_result = await tool(
+                op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context(agent)
+            )
+            assert "session_id" in connect_result
+            assert connect_result["server_url"] == "https://mcp.example.com/mcp"
+            instance.start.assert_called_once()
+
+            list_result = await tool(
+                op="list_tools", session_id=connect_result["session_id"], tool_context=_tool_context(agent)
+            )
+            assert len(list_result["tools"]) == 1
+            assert list_result["tools"][0]["name"] == "echo"
+
+            call_result = await tool(
+                op="call_tool",
+                session_id=connect_result["session_id"],
+                tool_name="echo",
+                arguments={"msg": "hi"},
+                tool_context=_tool_context(agent),
+            )
+            assert call_result["status"] == "success"
+            assert call_result["text"] == "hello world"
+            assert "truncated" not in call_result
+
+            disconnect_result = await tool(
+                op="disconnect", session_id=connect_result["session_id"], tool_context=_tool_context(agent)
+            )
+            assert disconnect_result == {"disconnected": True}
+            instance.stop.assert_called_once()
+
+            with pytest.raises(ValueError, match="No active session"):
+                await tool(op="list_tools", session_id=connect_result["session_id"], tool_context=_tool_context(agent))
+
+    @pytest.mark.asyncio
+    async def test_call_tool_rejects_name_not_advertised_by_server(self):
+        # Both SDKs cache the tool set at connect and reject unadvertised names
+        # locally, so an obvious typo fails with a clear error instead of hitting
+        # the server. Mirror-tested on the TypeScript side.
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        fake_tool = _FakeMCPTool(name="echo", description="", input_schema={"type": "object"})
+        client_class, _ = _fake_mcp_client_class(list_tools_return=[_FakeAgentTool(fake_tool)])
+        agent = _StubAgent()
+        with (
+            patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai,
+            patch("strands.vended_tools.mcp_client.mcp_client.MCPClient", client_class),
+        ):
+            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+            connected = await tool(
+                op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context(agent)
+            )
+            with pytest.raises(ValueError, match="not exposed by the connected server"):
+                await tool(
+                    op="call_tool",
+                    session_id=connected["session_id"],
+                    tool_name="not_a_real_tool",
+                    tool_context=_tool_context(agent),
+                )
+
+
+class TestResultTruncation:
+    """Oversized tool-call results are truncated before being returned to the model."""
+
+    @pytest.mark.asyncio
+    async def test_oversized_text_is_truncated(self):
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        big_text = "x" * 250_000
+        fake_tool = _FakeMCPTool(name="anything", description="", input_schema={"type": "object"})
+        client_class, _ = _fake_mcp_client_class(
+            list_tools_return=[_FakeAgentTool(fake_tool)],
+            call_tool_return={"status": "success", "content": [{"text": big_text}]},
+        )
+        agent = _StubAgent(label="a")
+
+        with (
+            patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai,
+            patch("strands.vended_tools.mcp_client.mcp_client.MCPClient", client_class),
+        ):
+            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+            connect_result = await tool(
+                op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context(agent)
+            )
+            call_result = await tool(
+                op="call_tool",
+                session_id=connect_result["session_id"],
+                tool_name="anything",
+                tool_context=_tool_context(agent),
+            )
+        assert call_result["truncated"] is True
+        assert len(call_result["text"]) < len(big_text)
+
+    @pytest.mark.asyncio
+    async def test_oversized_structured_content_is_capped(self):
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        big_structured = {"payload": "y" * 250_000}
+        fake_tool = _FakeMCPTool(name="anything", description="", input_schema={"type": "object"})
+        client_class, _ = _fake_mcp_client_class(
+            list_tools_return=[_FakeAgentTool(fake_tool)],
+            call_tool_return={
+                "status": "success",
+                "content": [{"text": "ok"}],
+                "structuredContent": big_structured,
+            },
+        )
+        agent = _StubAgent(label="a")
+
+        with (
+            patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai,
+            patch("strands.vended_tools.mcp_client.mcp_client.MCPClient", client_class),
+        ):
+            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+            connect_result = await tool(
+                op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context(agent)
+            )
+            call_result = await tool(
+                op="call_tool",
+                session_id=connect_result["session_id"],
+                tool_name="anything",
+                tool_context=_tool_context(agent),
+            )
+        assert call_result["truncated"] is True
+        assert call_result["structured_content"] != big_structured
+        assert call_result["structured_content"].get("__truncated__") is True
+
+
+class TestUrlNormalisation:
+    """The URL canonicalisation used for allowlist matching."""
+
+    def test_canonicalise_strips_trailing_slash(self):
+        assert _canonicalise_url("https://Example.com/mcp/") == "https://example.com/mcp"
+
+    def test_canonicalise_lowercases_scheme_and_host(self):
+        assert _canonicalise_url("HTTPS://EXAMPLE.COM/PATH") == "https://example.com/PATH"
+
+    def test_canonicalise_preserves_non_default_port_and_query(self):
+        assert _canonicalise_url("https://Example.com:8443/mcp?token=abc") == "https://example.com:8443/mcp?token=abc"
+
+    def test_canonicalise_drops_default_https_port(self):
+        # `https://host` and `https://host:443` must canonicalise identically so an
+        # allowlist entry without the port still matches a connect URL that names it.
+        assert _canonicalise_url("https://mcp.example.com:443/mcp") == "https://mcp.example.com/mcp"
+
+    def test_canonicalise_drops_default_http_port(self):
+        assert _canonicalise_url("http://mcp.example.com:80/mcp") == "http://mcp.example.com/mcp"
+
+    def test_normalise_allowlist_deduplicates(self):
+        allowlist = _normalise_allowlist(["https://example.com/mcp", "HTTPS://EXAMPLE.COM/mcp/"])
+        assert allowlist == frozenset({"https://example.com/mcp"})
+
+    def test_normalise_allowlist_treats_default_port_as_equal(self):
+        allowlist = _normalise_allowlist(["https://example.com/mcp", "https://example.com:443/mcp"])
+        assert allowlist == frozenset({"https://example.com/mcp"})
+
+
+class TestNoRedirect:
+    """The httpx client used by MCP refuses to follow redirects."""
+
+    def test_no_redirect_factory_disables_follow_redirects(self):
+        # `_no_redirect_httpx_client_factory` is the MCP-shaped hook that guarantees
+        # an allowlisted URL cannot be 3xx'd to a private endpoint the SSRF guard
+        # never saw. Assert the resulting client is actually configured that way.
+        client = _no_redirect_httpx_client_factory()
+        assert client.follow_redirects is False
+
+
+class TestStructuredContentCap:
+    """Structured content is size-capped and reports the size in the unit it caps in."""
+
+    def test_non_json_serialisable_structured_content_is_replaced(self):
+        # Sets are not JSON-serialisable; the cap must swap the value for a marker
+        # rather than smuggle an opaque blob through to the model.
+        response: dict[str, Any] = {"status": "success", "text": ""}
+        capped = _cap_structured_content({"key": {1, 2, 3}}, response)
+        assert response.get("truncated") is True
+        assert capped == {"__truncated__": True, "reason": "structured_content was not JSON-serialisable"}
+
+    def test_capped_size_is_reported_in_bytes(self):
+        # A payload of multi-byte characters exceeding the byte cap should report
+        # the byte length in `size`, matching the unit the cap is measured in.
+        multibyte = "é" * 90_000  # each character is two UTF-8 bytes → 180_000 bytes
+        response: dict[str, Any] = {"status": "success", "text": ""}
+        capped = _cap_structured_content({"payload": multibyte}, response)
+        assert response.get("truncated") is True
+        assert isinstance(capped, dict)
+        assert capped["__truncated__"] is True
+        # `size` should be a byte count (>= 180_000), not a character count (~90_000).
+        assert capped["size"] > 100_000
+
+
+class TestToolMetadata:
+    """The tool exposes a sensible name, description, and input schema."""
+
+    def test_custom_name(self):
+        t = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"], name="my_mcp")
+        assert t.tool_name == "my_mcp"
+
+    def test_schema_exposes_op_field_and_hides_context(self):
+        t = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        props = t.tool_spec["inputSchema"]["json"]["properties"]
+        assert "op" in props
+        assert "server_url" in props
+        assert "session_id" in props
+        assert "tool_context" not in props
+
+
+class TestConnectInputValidation:
+    """Connect requires ``server_url``; call_tool requires ``tool_name``."""
+
+    @pytest.mark.asyncio
+    async def test_connect_without_url_is_rejected(self):
+        t = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with pytest.raises(ValueError, match="server_url"):
+            await t(op="connect", tool_context=_tool_context())
+
+    @pytest.mark.asyncio
+    async def test_call_tool_without_name_is_rejected(self):
+        t = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        agent = _StubAgent()
+        with (
+            patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai,
+            patch("strands.vended_tools.mcp_client.mcp_client.MCPClient") as client_cls,
+        ):
+            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+            client_cls.return_value = _mcp_instance()
+            connect_result = await t(
+                op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context(agent)
+            )
+            with pytest.raises(ValueError, match="tool_name"):
+                await t(op="call_tool", session_id=connect_result["session_id"], tool_context=_tool_context(agent))

--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -68,6 +68,10 @@
       "types": "./dist/src/vended-tools/bash/index.d.ts",
       "default": "./dist/src/vended-tools/bash/index.js"
     },
+    "./vended-tools/mcp-client": {
+      "types": "./dist/src/vended-tools/mcp-client/index.d.ts",
+      "default": "./dist/src/vended-tools/mcp-client/index.js"
+    },
     "./a2a": {
       "types": "./dist/src/a2a/index.d.ts",
       "default": "./dist/src/a2a/index.js"

--- a/strands-ts/src/vended-tools/index.ts
+++ b/strands-ts/src/vended-tools/index.ts
@@ -14,4 +14,5 @@
 export * from './bash/index.js'
 export * from './file-editor/index.js'
 export * from './http-request/index.js'
+export * from './mcp-client/index.js'
 export * from './notebook/index.js'

--- a/strands-ts/src/vended-tools/mcp-client/README.md
+++ b/strands-ts/src/vended-tools/mcp-client/README.md
@@ -1,0 +1,128 @@
+# MCP Client Tool
+
+Agent-callable Model Context Protocol (MCP) client. Lets the model, at runtime, open a
+connection to an MCP server on a developer-set allowlist, discover its tools, invoke one,
+and disconnect. Thin shim over the SDK's `McpClient` — all transport and protocol
+handling lives there.
+
+The tool is safe only when the developer has decided, at construction time, which servers
+the model may reach. That decision is made in code — the tool does not, and should not,
+prompt for interactive consent at runtime. If you want a human-in-the-loop confirmation,
+use the SDK's HITL intervention on top of this tool; do not weaken the allowlist.
+
+## Usage
+
+```typescript
+import { Agent } from '@strands-agents/sdk'
+import { makeMcpClient } from '@strands-agents/sdk/vended-tools/mcp-client'
+
+const mcpClient = makeMcpClient({
+  allowedUrls: ['https://mcp.example.com/mcp', 'https://tools.internal-org.com/mcp'],
+})
+
+const agent = new Agent({ tools: [mcpClient] })
+```
+
+## Operations
+
+The tool exposes four operations under a single tool name, selected by an `op` field:
+
+| Op           | Required inputs                                            | Returns                                                            |
+| ------------ | ---------------------------------------------------------- | ------------------------------------------------------------------ |
+| `connect`    | `server_url`                                               | `{ session_id, server_url }`                                       |
+| `list_tools` | `session_id`                                               | `{ tools: [{ name, description, input_schema, output_schema? }] }` |
+| `call_tool`  | `session_id`, `tool_name`, optional `arguments`, `timeout` | `{ status, text, truncated?, is_error?, structured_content? }`     |
+| `disconnect` | `session_id`                                               | `{ disconnected: true }`                                           |
+
+## Security model
+
+The allowlist is the primary control. Each `allowedUrls` entry is canonicalised (scheme
+and host lowercased, trailing slash stripped, default port for the scheme dropped, and
+fragment removed) and each `connect` URL is matched verbatim against that set; anything
+else is rejected before any network I/O. URLs carrying credentials in the userinfo
+section or a `#` fragment are rejected outright so they cannot bypass the verbatim
+match. The allowlist must be non-empty and every entry must use `http:` or `https:`.
+
+Layered on top of the allowlist, an SSRF guard rejects hosts whose name matches a
+denylist of internal-use suffixes (`.internal`, `.local`, `.localhost`, `.corp`,
+`.home`, `.lan`, `.intranet`, `.private`, `.i2p`, `.onion`) before DNS is consulted,
+then resolves the host and rejects any address in private (RFC1918), loopback,
+link-local, site-local (`fec0::/10`), CGNAT (`100.64.0.0/10`), multicast, reserved,
+IPv6 documentation (`2001:db8::/32`), or discard-only (`100::/64`) space. IPv4-mapped
+IPv6 (both compressed `::ffff:a.b.c.d` and fully-expanded forms) is unwrapped before
+classification. Cloud-metadata endpoints (AWS, Azure, Alibaba, Oracle) are spelt out
+explicitly for defence in depth.
+
+The classification is a check-time judgment. A resolver that returns a public IP
+first and a private IP second (DNS rebinding) is not fully closed off — the MCP
+client SDK does not expose a hook for pinned-IP connects. Only allowlist hostnames
+whose DNS you control.
+
+Both SDKs reject HTTP redirects rather than following them. In Python, the httpx
+client MCP uses is constructed with `follow_redirects=False`, so a redirect surfaces
+as an `httpx.HTTPStatusError` or a 3xx status the caller sees. In TypeScript, the
+MCP transport's `fetch` is replaced with a shim that sets `redirect: 'error'`, so
+the platform `fetch` throws on any 3xx. Manual redirect walking is not implemented;
+if you allowlist an origin whose canonical path is a redirect, allowlist the final
+URL instead.
+
+Only `http:` and `https:` (MCP streamable-http transport) are supported. Stdio, SSE,
+and WebSocket transports are deliberately out of scope: stdio would let the model
+choose between developer-approved binaries at runtime, expanding the subprocess attack
+surface for negligible value over the developer-wired path; SSE is being deprecated by
+the MCP spec in favour of streamable-http; WebSocket is not a documented MCP client
+transport in the spec.
+
+Session identifiers are `crypto.randomUUID()` values held in a `WeakRef` keyed on the
+agent that opened them. Another agent using the same tool instance cannot use a
+session it did not open, and a garbage-collected agent's sessions become unreachable
+and are dropped from the session table (with a best-effort disconnect) the next time
+that entry is touched or the next connect walks the table. Both cases produce the
+same "no active session" error, so probing for other agents' ids is not informative.
+The number of concurrent live sessions across all agents sharing the tool instance is
+bounded by `sessionLimit` (default eight), with a pending-slot reservation that bumps
+the count synchronously at connect entry so a burst of concurrent connects cannot
+overshoot the cap.
+
+`sessionLimit` must be a positive integer; zero, negative, or non-integer values are
+rejected at construction. The tool set exposed by the server is fetched once at
+connect and cached on the session — `list_tools` reads that cache, and `call_tool`
+validates the requested name against it locally so an unadvertised name fails with
+a clear error instead of being forwarded to the server. The cache can go stale if
+the server changes its tool set mid-session, which is not a supported MCP flow today.
+
+Tool-call output is size-capped before being returned to the model. Text content is
+concatenated and truncated to 100,000 characters; `structured_content` is
+JSON-serialised and capped at 100,000 bytes, and on overflow is replaced with a
+`{ __truncated__: true }` marker. When any cap fires, the response includes
+`truncated: true`.
+
+## API
+
+### `makeMcpClient(options)`
+
+Returns an `InvokableTool` that manages MCP sessions.
+
+**Options:**
+
+| Field          | Type       | Required | Description                                                    |
+| -------------- | ---------- | -------- | -------------------------------------------------------------- |
+| `allowedUrls`  | `string[]` | Yes      | Exact URLs the tool may connect to. Non-empty, `http`/`https`. |
+| `name`         | `string`   | No       | Tool name. Defaults to `mcp_client`.                           |
+| `description`  | `string`   | No       | Tool description.                                              |
+| `sessionLimit` | `number`   | No       | Maximum concurrent live sessions. Defaults to 8.               |
+
+### Inputs
+
+| Field        | Type                                                       | When required           | Description                                         |
+| ------------ | ---------------------------------------------------------- | ----------------------- | --------------------------------------------------- |
+| `op`         | `'connect' \| 'list_tools' \| 'call_tool' \| 'disconnect'` | always                  | The operation to perform.                           |
+| `server_url` | `string`                                                   | `op='connect'`          | URL on the developer-set allowlist.                 |
+| `session_id` | `string`                                                   | any op except `connect` | Session identifier returned by `connect`.           |
+| `tool_name`  | `string`                                                   | `op='call_tool'`        | Name of the MCP tool to invoke.                     |
+| `arguments`  | `Record<string, unknown>`                                  | optional                | Arguments for the invoked tool.                     |
+| `timeout`    | `number` (seconds)                                         | optional                | Per-call timeout. Defaults to 60. `call_tool` only. |
+
+### Outputs
+
+Discriminated by `op`, see the table above.

--- a/strands-ts/src/vended-tools/mcp-client/__tests__/mcp-client.test.node.ts
+++ b/strands-ts/src/vended-tools/mcp-client/__tests__/mcp-client.test.node.ts
@@ -1,0 +1,579 @@
+import { describe, expect, it, vi } from 'vitest'
+import { makeMcpClient, noRedirectFetch } from '../mcp-client.js'
+import { McpClient } from '../../../mcp/client.js'
+import { McpTool } from '../../../tools/mcp-tool.js'
+import type { ToolContext } from '../../../tools/tool.js'
+import type { McpClientCallToolResult, McpClientConnectResult, McpClientListToolsResult } from '../types.js'
+import { createMockAgent } from '../../../__fixtures__/agent-helpers.js'
+
+type FakeMcpClient = Partial<McpClient> & {
+  connect: ReturnType<typeof vi.fn>
+  disconnect: ReturnType<typeof vi.fn>
+  listTools: ReturnType<typeof vi.fn>
+  callTool: ReturnType<typeof vi.fn>
+}
+
+interface FakeClientOptions {
+  tools?: McpTool[]
+  callToolResult?: unknown
+}
+
+function fakeMcpClient(options: FakeClientOptions = {}): FakeMcpClient {
+  const client: FakeMcpClient = {
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    listTools: vi.fn().mockResolvedValue(options.tools ?? []),
+    callTool: vi.fn().mockResolvedValue(options.callToolResult ?? { content: [{ type: 'text', text: 'ok' }] }),
+  }
+  return client
+}
+
+function makeMcpToolStub(name: string): McpTool {
+  return new McpTool({
+    name,
+    description: `${name} tool`,
+    inputSchema: { type: 'object', properties: { msg: { type: 'string' } } },
+    client: {} as McpClient,
+  })
+}
+
+function buildContext(agent = createMockAgent()): ToolContext {
+  return {
+    toolUse: { name: 'mcp_client', toolUseId: 'test-id', input: {} },
+    agent,
+    invocationState: {},
+    interrupt: () => {
+      throw new Error('interrupt not available in mock context')
+    },
+  } as unknown as ToolContext
+}
+
+const PUBLIC_IP = '93.184.216.34'
+
+describe('makeMcpClient', () => {
+  describe('allowlist enforcement', () => {
+    it('rejects a URL that is not on the allowlist', async () => {
+      const t = makeMcpClient({
+        allowedUrls: ['https://mcp.example.com/mcp'],
+        resolveHost: async () => [PUBLIC_IP],
+        clientFactory: () => fakeMcpClient() as unknown as McpClient,
+      })
+      await expect(
+        t.invoke({ op: 'connect', server_url: 'https://evil.example.com/mcp' }, buildContext())
+      ).rejects.toThrow(/not on the developer-set allowlist/)
+    })
+
+    it('matches allowlist entries case-insensitively on scheme and host', async () => {
+      const fake = fakeMcpClient()
+      const t = makeMcpClient({
+        allowedUrls: ['https://mcp.example.com/mcp'],
+        resolveHost: async () => [PUBLIC_IP],
+        clientFactory: () => fake as unknown as McpClient,
+      })
+      const result = (await t.invoke(
+        { op: 'connect', server_url: 'HTTPS://MCP.EXAMPLE.COM/mcp/' },
+        buildContext()
+      )) as unknown as McpClientConnectResult
+      expect(result.session_id).toBeTruthy()
+      expect(result.server_url).toBe('https://mcp.example.com/mcp')
+      expect(fake.connect).toHaveBeenCalledOnce()
+    })
+
+    it('rejects an empty allowlist at construction time', () => {
+      expect(() => makeMcpClient({ allowedUrls: [] })).toThrow(/must not be empty/)
+    })
+
+    it('rejects an unsupported scheme in the allowlist at construction time', () => {
+      expect(() => makeMcpClient({ allowedUrls: ['file:///etc/passwd'] })).toThrow(/unsupported scheme/)
+    })
+
+    it('rejects a malformed URL in the allowlist at construction time', () => {
+      expect(() => makeMcpClient({ allowedUrls: ['not a url'] })).toThrow(/not a valid URL/)
+    })
+
+    it('rejects an allowlist entry that carries credentials', () => {
+      // A canonicaliser that dropped userinfo would let `https://user:pass@host/x`
+      // collide with `https://host/x` on the allowlist.
+      expect(() => makeMcpClient({ allowedUrls: ['https://user:pass@mcp.example.com/mcp'] })).toThrow(/credentials/)
+    })
+
+    it('rejects an allowlist entry that carries a fragment', () => {
+      expect(() => makeMcpClient({ allowedUrls: ['https://mcp.example.com/mcp#anchor'] })).toThrow(/fragment/)
+    })
+
+    it('rejects a connect URL that carries credentials', async () => {
+      const t = makeMcpClient({
+        allowedUrls: ['https://mcp.example.com/mcp'],
+        resolveHost: async () => [PUBLIC_IP],
+        clientFactory: () => fakeMcpClient() as unknown as McpClient,
+      })
+      await expect(
+        t.invoke({ op: 'connect', server_url: 'https://user:pass@mcp.example.com/mcp' }, buildContext())
+      ).rejects.toThrow(/credentials/)
+    })
+
+    it('rejects a connect URL that carries a fragment', async () => {
+      const t = makeMcpClient({
+        allowedUrls: ['https://mcp.example.com/mcp'],
+        resolveHost: async () => [PUBLIC_IP],
+        clientFactory: () => fakeMcpClient() as unknown as McpClient,
+      })
+      await expect(
+        t.invoke({ op: 'connect', server_url: 'https://mcp.example.com/mcp#x' }, buildContext())
+      ).rejects.toThrow(/fragment/)
+    })
+
+    it('matches an allowlist entry with a default port against a connect URL without one', async () => {
+      // `https://host` and `https://host:443` are the same URL; the canonicaliser
+      // must treat them as equal so a well-known-port allowlist entry still lets
+      // a model connect with the bare form (and vice versa).
+      const fake = fakeMcpClient()
+      const t = makeMcpClient({
+        allowedUrls: ['https://mcp.example.com:443/mcp'],
+        resolveHost: async () => [PUBLIC_IP],
+        clientFactory: () => fake as unknown as McpClient,
+      })
+      const result = (await t.invoke(
+        { op: 'connect', server_url: 'https://mcp.example.com/mcp' },
+        buildContext()
+      )) as unknown as McpClientConnectResult
+      expect(result.session_id).toBeTruthy()
+    })
+  })
+
+  describe('sessionLimit validation', () => {
+    it.each([0, -1, 1.5, Number.NaN])('rejects non-positive-integer sessionLimit %s', (bad) => {
+      expect(() => makeMcpClient({ allowedUrls: ['https://mcp.example.com/mcp'], sessionLimit: bad })).toThrow(
+        /positive integer/
+      )
+    })
+  })
+
+  describe('no-redirect fetch', () => {
+    it('forces redirect: "error" on the outgoing request even when the caller omits it', async () => {
+      // The MCP transport's default `fetch` follows 3xx, which would let an
+      // allowlisted URL be redirected onto a private endpoint the SSRF guard
+      // never saw. Assert the shim we wire into the transport actually flips
+      // the flag on the outgoing request.
+      let observedInit: RequestInit | undefined
+      const originalFetch = globalThis.fetch
+      globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
+        observedInit = init
+        return Promise.resolve(new Response('', { status: 200 }))
+      }) as typeof globalThis.fetch
+      try {
+        await noRedirectFetch('https://mcp.example.com/mcp', { method: 'POST' })
+      } finally {
+        globalThis.fetch = originalFetch
+      }
+      expect(observedInit?.redirect).toBe('error')
+    })
+
+    it('overrides a caller-provided redirect: "follow"', async () => {
+      let observedInit: RequestInit | undefined
+      const originalFetch = globalThis.fetch
+      globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
+        observedInit = init
+        return Promise.resolve(new Response('', { status: 200 }))
+      }) as typeof globalThis.fetch
+      try {
+        await noRedirectFetch('https://mcp.example.com/mcp', { redirect: 'follow' })
+      } finally {
+        globalThis.fetch = originalFetch
+      }
+      expect(observedInit?.redirect).toBe('error')
+    })
+  })
+
+  // Direct end-to-end coverage of dead-session purging lives on the Python side
+  // where `gc.collect()` is deterministic. Node.js has no test hook to force
+  // `WeakRef` targets to be reclaimed. The dead-ref branch in `resolveSession`
+  // is exercised via the type system and mirror-tested in the Python suite.
+
+  describe('SSRF guard', () => {
+    it('rejects a hostname that resolves to a private IPv4', async () => {
+      const t = makeMcpClient({
+        allowedUrls: ['https://mcp.example.com/mcp'],
+        resolveHost: async () => ['10.0.0.5'],
+        clientFactory: () => fakeMcpClient() as unknown as McpClient,
+      })
+      await expect(
+        t.invoke({ op: 'connect', server_url: 'https://mcp.example.com/mcp' }, buildContext())
+      ).rejects.toThrow(/non-public address/)
+    })
+
+    it('rejects a hostname that resolves to loopback', async () => {
+      const t = makeMcpClient({
+        allowedUrls: ['https://mcp.example.com/mcp'],
+        resolveHost: async () => ['127.0.0.1'],
+        clientFactory: () => fakeMcpClient() as unknown as McpClient,
+      })
+      await expect(
+        t.invoke({ op: 'connect', server_url: 'https://mcp.example.com/mcp' }, buildContext())
+      ).rejects.toThrow(/non-public address/)
+    })
+
+    it('rejects a hostname that resolves to link-local (metadata endpoint)', async () => {
+      const t = makeMcpClient({
+        allowedUrls: ['http://169.254.169.254/mcp'],
+        resolveHost: async (host) => [host],
+        clientFactory: () => fakeMcpClient() as unknown as McpClient,
+      })
+      await expect(
+        t.invoke({ op: 'connect', server_url: 'http://169.254.169.254/mcp' }, buildContext())
+      ).rejects.toThrow(/metadata address|non-public address/)
+    })
+
+    it('rejects a hostname that resolves to an IPv6 loopback', async () => {
+      const t = makeMcpClient({
+        allowedUrls: ['https://mcp.example.com/mcp'],
+        resolveHost: async () => ['::1'],
+        clientFactory: () => fakeMcpClient() as unknown as McpClient,
+      })
+      await expect(
+        t.invoke({ op: 'connect', server_url: 'https://mcp.example.com/mcp' }, buildContext())
+      ).rejects.toThrow(/non-public address/)
+    })
+
+    it('rejects a CGNAT IPv4', async () => {
+      const t = makeMcpClient({
+        allowedUrls: ['https://mcp.example.com/mcp'],
+        resolveHost: async () => ['100.64.0.1'],
+        clientFactory: () => fakeMcpClient() as unknown as McpClient,
+      })
+      await expect(
+        t.invoke({ op: 'connect', server_url: 'https://mcp.example.com/mcp' }, buildContext())
+      ).rejects.toThrow(/non-public address/)
+    })
+
+    it('rejects IPv4-mapped IPv6 CGNAT (compressed form)', async () => {
+      const t = makeMcpClient({
+        allowedUrls: ['https://mcp.example.com/mcp'],
+        resolveHost: async () => ['::ffff:100.64.0.1'],
+        clientFactory: () => fakeMcpClient() as unknown as McpClient,
+      })
+      await expect(
+        t.invoke({ op: 'connect', server_url: 'https://mcp.example.com/mcp' }, buildContext())
+      ).rejects.toThrow(/non-public address/)
+    })
+
+    it('rejects IPv4-mapped IPv6 CGNAT (expanded form)', async () => {
+      const t = makeMcpClient({
+        allowedUrls: ['https://mcp.example.com/mcp'],
+        resolveHost: async () => ['0:0:0:0:0:ffff:100.64.0.1'],
+        clientFactory: () => fakeMcpClient() as unknown as McpClient,
+      })
+      await expect(
+        t.invoke({ op: 'connect', server_url: 'https://mcp.example.com/mcp' }, buildContext())
+      ).rejects.toThrow(/non-public address/)
+    })
+
+    it('rejects IPv4-mapped IPv6 private (::ffff:10.0.0.5)', async () => {
+      const t = makeMcpClient({
+        allowedUrls: ['https://mcp.example.com/mcp'],
+        resolveHost: async () => ['::ffff:10.0.0.5'],
+        clientFactory: () => fakeMcpClient() as unknown as McpClient,
+      })
+      await expect(
+        t.invoke({ op: 'connect', server_url: 'https://mcp.example.com/mcp' }, buildContext())
+      ).rejects.toThrow(/non-public address/)
+    })
+
+    it.each([
+      'svc.internal',
+      'db.corp',
+      'printer.local',
+      'gateway.home',
+      'onboarding.i2p',
+      'secret.onion',
+      'svc.internal.',
+    ])('rejects hostname %s on the suffix denylist before DNS', async (host) => {
+      const t = makeMcpClient({
+        allowedUrls: [`https://${host}/mcp`],
+        // resolveHost intentionally omitted — should never be called.
+        clientFactory: () => fakeMcpClient() as unknown as McpClient,
+      })
+      await expect(t.invoke({ op: 'connect', server_url: `https://${host}/mcp` }, buildContext())).rejects.toThrow(
+        /blocked suffix/
+      )
+    })
+
+    it.each([
+      ['IPv6 multicast', 'ff02::1'],
+      ['IPv6 site-local (fec0::/10)', 'fec0::1'],
+      ['IPv6 site-local upper edge (feff::)', 'feff::1'],
+      ['IPv6 documentation (2001:db8::/32) compressed', '2001:db8::1'],
+      ['IPv6 documentation (2001:db8::/32) expanded', '2001:0db8:85a3::8a2e:0370:7334'],
+      ['IPv6 discard-only 100::/64', '100::1'],
+    ])('rejects %s', async (_label, ip) => {
+      const t = makeMcpClient({
+        allowedUrls: ['https://mcp.example.com/mcp'],
+        resolveHost: async () => [ip],
+        clientFactory: () => fakeMcpClient() as unknown as McpClient,
+      })
+      await expect(
+        t.invoke({ op: 'connect', server_url: 'https://mcp.example.com/mcp' }, buildContext())
+      ).rejects.toThrow(/non-public address/)
+    })
+
+    it('rejects an unresolvable host', async () => {
+      const t = makeMcpClient({
+        allowedUrls: ['https://mcp.example.com/mcp'],
+        resolveHost: async () => {
+          throw new Error('ENOTFOUND')
+        },
+        clientFactory: () => fakeMcpClient() as unknown as McpClient,
+      })
+      await expect(
+        t.invoke({ op: 'connect', server_url: 'https://mcp.example.com/mcp' }, buildContext())
+      ).rejects.toThrow(/Could not resolve host/)
+    })
+  })
+
+  describe('session scoping', () => {
+    it('rejects a session id belonging to another agent', async () => {
+      const fake = fakeMcpClient()
+      const t = makeMcpClient({
+        allowedUrls: ['https://mcp.example.com/mcp'],
+        resolveHost: async () => [PUBLIC_IP],
+        clientFactory: () => fake as unknown as McpClient,
+      })
+      const agentA = createMockAgent()
+      const agentB = createMockAgent()
+      const connect = (await t.invoke(
+        { op: 'connect', server_url: 'https://mcp.example.com/mcp' },
+        buildContext(agentA)
+      )) as unknown as McpClientConnectResult
+      await expect(
+        t.invoke({ op: 'list_tools', session_id: connect.session_id }, buildContext(agentB))
+      ).rejects.toThrow(/No active session/)
+    })
+
+    it('rejects a missing session id', async () => {
+      const t = makeMcpClient({ allowedUrls: ['https://mcp.example.com/mcp'] })
+      await expect(t.invoke({ op: 'list_tools' } as never, buildContext())).rejects.toThrow(/session_id/i)
+    })
+
+    it('rejects an unknown session id', async () => {
+      const t = makeMcpClient({ allowedUrls: ['https://mcp.example.com/mcp'] })
+      await expect(t.invoke({ op: 'list_tools', session_id: 'does-not-exist' }, buildContext())).rejects.toThrow(
+        /No active session/
+      )
+    })
+  })
+
+  describe('session limit', () => {
+    it('rejects further connects once the limit is reached', async () => {
+      const t = makeMcpClient({
+        allowedUrls: ['https://mcp.example.com/mcp'],
+        sessionLimit: 1,
+        resolveHost: async () => [PUBLIC_IP],
+        clientFactory: () => fakeMcpClient() as unknown as McpClient,
+      })
+      await t.invoke({ op: 'connect', server_url: 'https://mcp.example.com/mcp' }, buildContext())
+      await expect(
+        t.invoke({ op: 'connect', server_url: 'https://mcp.example.com/mcp' }, buildContext())
+      ).rejects.toThrow(/concurrent sessions/)
+    })
+  })
+
+  describe('full lifecycle', () => {
+    it('supports connect -> list_tools -> call_tool -> disconnect', async () => {
+      const echoTool = makeMcpToolStub('echo')
+      const fake = fakeMcpClient({
+        tools: [echoTool],
+        callToolResult: { content: [{ type: 'text', text: 'hello' }] },
+      })
+      const t = makeMcpClient({
+        allowedUrls: ['https://mcp.example.com/mcp'],
+        resolveHost: async () => [PUBLIC_IP],
+        clientFactory: () => fake as unknown as McpClient,
+      })
+      const agent = createMockAgent()
+
+      const connect = (await t.invoke(
+        { op: 'connect', server_url: 'https://mcp.example.com/mcp' },
+        buildContext(agent)
+      )) as unknown as McpClientConnectResult
+
+      const listed = (await t.invoke(
+        { op: 'list_tools', session_id: connect.session_id },
+        buildContext(agent)
+      )) as unknown as McpClientListToolsResult
+      expect(listed.tools).toHaveLength(1)
+      expect(listed.tools[0]?.name).toBe('echo')
+
+      const called = (await t.invoke(
+        {
+          op: 'call_tool',
+          session_id: connect.session_id,
+          tool_name: 'echo',
+          arguments: { msg: 'hi' },
+        },
+        buildContext(agent)
+      )) as unknown as McpClientCallToolResult
+      expect(called.status).toBe('success')
+      expect(called.text).toBe('hello')
+      expect(fake.callTool).toHaveBeenCalledOnce()
+
+      const disconnected = await t.invoke({ op: 'disconnect', session_id: connect.session_id }, buildContext(agent))
+      expect(disconnected).toEqual({ disconnected: true })
+      expect(fake.disconnect).toHaveBeenCalledOnce()
+
+      // Session is gone after disconnect.
+      await expect(t.invoke({ op: 'list_tools', session_id: connect.session_id }, buildContext(agent))).rejects.toThrow(
+        /No active session/
+      )
+    })
+
+    it('rejects call_tool for a tool the server did not expose', async () => {
+      const fake = fakeMcpClient({ tools: [makeMcpToolStub('echo')] })
+      const t = makeMcpClient({
+        allowedUrls: ['https://mcp.example.com/mcp'],
+        resolveHost: async () => [PUBLIC_IP],
+        clientFactory: () => fake as unknown as McpClient,
+      })
+      const agent = createMockAgent()
+      const connect = (await t.invoke(
+        { op: 'connect', server_url: 'https://mcp.example.com/mcp' },
+        buildContext(agent)
+      )) as unknown as McpClientConnectResult
+      await expect(
+        t.invoke({ op: 'call_tool', session_id: connect.session_id, tool_name: 'unknown' }, buildContext(agent))
+      ).rejects.toThrow(/not exposed by the connected server/)
+    })
+  })
+
+  describe('result truncation', () => {
+    it('truncates oversized text results', async () => {
+      const big = 'x'.repeat(250_000)
+      const fake = fakeMcpClient({
+        tools: [makeMcpToolStub('echo')],
+        callToolResult: { content: [{ type: 'text', text: big }] },
+      })
+      const t = makeMcpClient({
+        allowedUrls: ['https://mcp.example.com/mcp'],
+        resolveHost: async () => [PUBLIC_IP],
+        clientFactory: () => fake as unknown as McpClient,
+      })
+      const agent = createMockAgent()
+      const connect = (await t.invoke(
+        { op: 'connect', server_url: 'https://mcp.example.com/mcp' },
+        buildContext(agent)
+      )) as unknown as McpClientConnectResult
+      const called = (await t.invoke(
+        { op: 'call_tool', session_id: connect.session_id, tool_name: 'echo' },
+        buildContext(agent)
+      )) as unknown as McpClientCallToolResult
+      expect(called.truncated).toBe(true)
+      expect(called.text.length).toBeLessThan(big.length)
+    })
+  })
+
+  describe('call_tool result mapping', () => {
+    it('flags server-reported errors on the result', async () => {
+      const fake = fakeMcpClient({
+        tools: [makeMcpToolStub('echo')],
+        callToolResult: { content: [{ type: 'text', text: 'boom' }], isError: true },
+      })
+      const t = makeMcpClient({
+        allowedUrls: ['https://mcp.example.com/mcp'],
+        resolveHost: async () => [PUBLIC_IP],
+        clientFactory: () => fake as unknown as McpClient,
+      })
+      const agent = createMockAgent()
+      const connect = (await t.invoke(
+        { op: 'connect', server_url: 'https://mcp.example.com/mcp' },
+        buildContext(agent)
+      )) as unknown as McpClientConnectResult
+      const called = (await t.invoke(
+        { op: 'call_tool', session_id: connect.session_id, tool_name: 'echo' },
+        buildContext(agent)
+      )) as unknown as McpClientCallToolResult
+      expect(called.status).toBe('error')
+      expect(called.is_error).toBe(true)
+      expect(called.text).toBe('boom')
+    })
+
+    it('passes structured content through', async () => {
+      const fake = fakeMcpClient({
+        tools: [makeMcpToolStub('echo')],
+        callToolResult: { content: [], structuredContent: { answer: 42 } },
+      })
+      const t = makeMcpClient({
+        allowedUrls: ['https://mcp.example.com/mcp'],
+        resolveHost: async () => [PUBLIC_IP],
+        clientFactory: () => fake as unknown as McpClient,
+      })
+      const agent = createMockAgent()
+      const connect = (await t.invoke(
+        { op: 'connect', server_url: 'https://mcp.example.com/mcp' },
+        buildContext(agent)
+      )) as unknown as McpClientConnectResult
+      const called = (await t.invoke(
+        { op: 'call_tool', session_id: connect.session_id, tool_name: 'echo' },
+        buildContext(agent)
+      )) as unknown as McpClientCallToolResult
+      expect(called.structured_content).toEqual({ answer: 42 })
+    })
+
+    it('caps oversized structured_content and flags truncation', async () => {
+      const big = { payload: 'y'.repeat(250_000) }
+      const fake = fakeMcpClient({
+        tools: [makeMcpToolStub('echo')],
+        callToolResult: { content: [{ type: 'text', text: 'ok' }], structuredContent: big },
+      })
+      const t = makeMcpClient({
+        allowedUrls: ['https://mcp.example.com/mcp'],
+        resolveHost: async () => [PUBLIC_IP],
+        clientFactory: () => fake as unknown as McpClient,
+      })
+      const agent = createMockAgent()
+      const connect = (await t.invoke(
+        { op: 'connect', server_url: 'https://mcp.example.com/mcp' },
+        buildContext(agent)
+      )) as unknown as McpClientConnectResult
+      const called = (await t.invoke(
+        { op: 'call_tool', session_id: connect.session_id, tool_name: 'echo' },
+        buildContext(agent)
+      )) as unknown as McpClientCallToolResult
+      expect(called.truncated).toBe(true)
+      expect(called.structured_content).not.toEqual(big)
+      expect((called.structured_content as { __truncated__?: boolean }).__truncated__).toBe(true)
+    })
+  })
+
+  describe('connect cleanup on failure', () => {
+    it('disconnects the client if listTools throws after connect succeeds', async () => {
+      const fake: FakeMcpClient = {
+        connect: vi.fn().mockResolvedValue(undefined),
+        disconnect: vi.fn().mockResolvedValue(undefined),
+        listTools: vi.fn().mockRejectedValue(new Error('listTools boom')),
+        callTool: vi.fn().mockResolvedValue({}),
+      }
+      const t = makeMcpClient({
+        allowedUrls: ['https://mcp.example.com/mcp'],
+        resolveHost: async () => [PUBLIC_IP],
+        clientFactory: () => fake as unknown as McpClient,
+      })
+      await expect(
+        t.invoke({ op: 'connect', server_url: 'https://mcp.example.com/mcp' }, buildContext())
+      ).rejects.toThrow(/listTools boom/)
+      // Without the cleanup path the client would stay connected forever;
+      // asserting `disconnect` was invoked proves the transport is torn down.
+      expect(fake.disconnect).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('input validation', () => {
+    it('rejects op=connect without server_url', async () => {
+      const t = makeMcpClient({ allowedUrls: ['https://mcp.example.com/mcp'] })
+      await expect(t.invoke({ op: 'connect' } as never, buildContext())).rejects.toThrow()
+    })
+
+    it('rejects op=call_tool without tool_name', async () => {
+      const t = makeMcpClient({ allowedUrls: ['https://mcp.example.com/mcp'] })
+      await expect(t.invoke({ op: 'call_tool', session_id: 'x' } as never, buildContext())).rejects.toThrow()
+    })
+  })
+})

--- a/strands-ts/src/vended-tools/mcp-client/index.ts
+++ b/strands-ts/src/vended-tools/mcp-client/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Agent-callable MCP client tool.
+ *
+ * Lets an agent, at runtime, connect to a Model Context Protocol server on a
+ * developer-set allowlist, list its tools, invoke one, and disconnect. Thin shim over
+ * the SDK's `McpClient` — see `README.md` for the security model.
+ */
+
+export { makeMcpClient } from './mcp-client.js'
+export type { MakeMcpClientOptions } from './mcp-client.js'
+export type {
+  McpClientCallToolResult,
+  McpClientConnectResult,
+  McpClientDisconnectResult,
+  McpClientListToolsResult,
+  McpClientResult,
+  McpClientToolSpec,
+} from './types.js'

--- a/strands-ts/src/vended-tools/mcp-client/mcp-client.ts
+++ b/strands-ts/src/vended-tools/mcp-client/mcp-client.ts
@@ -1,0 +1,634 @@
+import { z } from 'zod'
+import { promises as dns } from 'node:dns'
+import { isIP } from 'node:net'
+import { Buffer } from 'node:buffer'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { tool } from '../../tools/tool-factory.js'
+import { McpClient, type McpTransport } from '../../mcp/client.js'
+import type { McpTool } from '../../tools/mcp-tool.js'
+import type { InvokableTool } from '../../tools/tool.js'
+import type { JSONValue } from '../../types/json.js'
+import type {
+  McpClientCallToolResult,
+  McpClientConnectResult,
+  McpClientDisconnectResult,
+  McpClientListToolsResult,
+  McpClientToolSpec,
+} from './types.js'
+
+const ALLOWED_SCHEMES = new Set(['http:', 'https:'])
+const DEFAULT_SCHEME_PORTS: Readonly<Record<string, string>> = { 'http:': '80', 'https:': '443' }
+const DEFAULT_SESSION_LIMIT = 8
+const DEFAULT_CALL_TIMEOUT_SECONDS = 60
+const MAX_RESULT_TEXT_CHARS = 100_000
+const MAX_STRUCTURED_CONTENT_BYTES = 100_000
+
+// Hostname suffixes rejected before DNS lookup. Names in these zones are intended
+// for internal use even when they happen to resolve to a public IP for some resolver.
+const BLOCKED_HOST_SUFFIXES: readonly string[] = [
+  '.internal',
+  '.local',
+  '.localhost',
+  '.corp',
+  '.home',
+  '.lan',
+  '.intranet',
+  '.private',
+  '.i2p',
+  '.onion',
+] as const
+
+// Well-known cloud-metadata addresses. `isNonPublicIPv4` already rejects link-local
+// (169.254/16) and unique-local IPv6, but naming them explicitly guards against a
+// future refactor that weakens a generic predicate.
+const BLOCKED_METADATA_ADDRESSES: ReadonlySet<string> = new Set([
+  '169.254.169.254', // AWS / Azure / DigitalOcean
+  'fd00:ec2::254', // AWS IPv6
+  '100.100.100.200', // Alibaba
+  '192.0.0.192', // Oracle Cloud
+])
+
+/**
+ * Options for building an agent-callable MCP client tool.
+ */
+export interface MakeMcpClientOptions {
+  /**
+   * Exact URLs the tool may connect to. Each entry must use `http:` or `https:`. Empty
+   * arrays are rejected: the tool is deliberately useless without an explicit allowlist.
+   */
+  allowedUrls: string[]
+  /** Tool name reported to the model. Defaults to `mcp_client`. */
+  name?: string
+  /** Tool description shown to the model. */
+  description?: string
+  /**
+   * Maximum number of concurrent live sessions this tool instance may hold, across all
+   * agents that share it. Defaults to 8.
+   */
+  sessionLimit?: number
+  /**
+   * Hook for injecting a custom MCP client factory in tests. Not part of the public API;
+   * do not use in production code.
+   * @internal
+   */
+  clientFactory?: (url: string) => McpClient
+  /**
+   * Hook for overriding DNS resolution in tests.
+   * @internal
+   */
+  resolveHost?: (host: string) => Promise<string[]>
+}
+
+interface Session {
+  client: McpClient
+  tools: Map<string, McpTool>
+  url: string
+  ownerId: WeakRef<object>
+}
+
+const inputSchema = z
+  .object({
+    op: z
+      .enum(['connect', 'list_tools', 'call_tool', 'disconnect'])
+      .describe(
+        'Operation: "connect" (open a session), "list_tools" (list tools on a connected server), ' +
+          '"call_tool" (invoke a tool), or "disconnect" (close a session).'
+      ),
+    server_url: z
+      .string()
+      .optional()
+      .describe('Server URL for op="connect". Must appear verbatim on the developer-set allowlist.'),
+    session_id: z
+      .string()
+      .optional()
+      .describe('Session identifier returned by op="connect". Required for the other three ops.'),
+    tool_name: z.string().optional().describe('Name of the MCP tool to invoke. Required for op="call_tool".'),
+    arguments: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .describe('Arguments to pass to the MCP tool for op="call_tool".'),
+    timeout: z
+      .number()
+      .positive()
+      .optional()
+      .describe(`Per-call timeout in seconds (default: ${DEFAULT_CALL_TIMEOUT_SECONDS}). Applies to op="call_tool".`),
+  })
+  .refine(
+    (data) => {
+      if (data.op === 'connect') return typeof data.server_url === 'string' && data.server_url.length > 0
+      return true
+    },
+    { message: '`server_url` is required when op="connect"' }
+  )
+  .refine(
+    (data) => {
+      if (data.op === 'call_tool') return typeof data.tool_name === 'string' && data.tool_name.length > 0
+      return true
+    },
+    { message: '`tool_name` is required when op="call_tool"' }
+  )
+  .refine(
+    (data) => {
+      if (data.op === 'list_tools' || data.op === 'call_tool' || data.op === 'disconnect') {
+        return typeof data.session_id === 'string' && data.session_id.length > 0
+      }
+      return true
+    },
+    { message: '`session_id` is required for op="list_tools", "call_tool", and "disconnect"' }
+  )
+
+/**
+ * Creates an agent-callable MCP client tool bound to a developer-set URL allowlist.
+ *
+ * The tool exposes four operations under a single name — `connect`, `list_tools`,
+ * `call_tool`, `disconnect` — selected by the `op` field. It is a thin shim over
+ * {@link McpClient}: URL validation, session lifecycle, and result truncation live here;
+ * every other concern (transport, protocol, tool invocation) is delegated.
+ *
+ * **Security model.** MCP servers can implement arbitrary logic, so the model must never
+ * be able to point the tool at an arbitrary URL:
+ *
+ * - Every `connect` URL must appear verbatim on the developer-set `allowedUrls` list
+ *   (after normalisation).
+ * - Only `http:` and `https:` are supported. Stdio, SSE, and WebSocket transports are
+ *   deliberately out of scope — see the accompanying `README.md` for the rationale.
+ * - The URL's host is rejected outright if it matches a DNS suffix denylist
+ *   (`.internal`, `.local`, `.localhost`, `.corp`, `.home`, `.lan`, `.intranet`,
+ *   `.private`, `.i2p`, `.onion`) before any DNS lookup.
+ * - The URL's host is then resolved and every returned address is checked; hostnames
+ *   that resolve to private, loopback, link-local, site-local, multicast, reserved,
+ *   documentation (`2001:db8::/32`, `100::/64`, `fec0::/10`), CGNAT, or
+ *   IPv4-mapped-into-any-of-those space are rejected.
+ * - The MCP transport's `fetch` is replaced with one that sets `redirect: 'error'`,
+ *   so an allowlisted URL cannot be 3xx'd to a private endpoint the SSRF guard never
+ *   saw. Redirects surface as errors rather than silent hops.
+ * - Session IDs are unguessable (`crypto.randomUUID()`) and scoped to the agent that
+ *   opened them via `WeakRef`; another agent using the same tool instance cannot use
+ *   a session it did not open, and a garbage-collected agent's sessions become
+ *   unreachable and are dropped from the session table on the next access or connect.
+ * - The number of concurrent live sessions is capped (default: 8), reserved atomically
+ *   at connect time so a burst of concurrent connects cannot overshoot the cap.
+ * - Tool-call text and `structured_content` are size-capped before being returned to
+ *   the model.
+ *
+ * **Limits.** The classification is a check-time judgment. Between the guard's
+ * `dns.lookup` and the MCP transport's own resolve, an attacker-controlled resolver
+ * could return a public IP first and a private IP second (DNS rebinding). The MCP
+ * client SDK does not expose a hook for pinned-IP connects, so this shim relies on
+ * the allowlist pointing at endpoints whose operator does not serve time-varying DNS.
+ * Do not allowlist a hostname whose DNS you do not control.
+ *
+ * @example
+ * ```typescript
+ * import { Agent } from '@strands-agents/sdk'
+ * import { makeMcpClient } from '@strands-agents/sdk/vended-tools/mcp-client'
+ *
+ * const mcpClient = makeMcpClient({ allowedUrls: ['https://mcp.example.com/mcp'] })
+ * const agent = new Agent({ tools: [mcpClient] })
+ * ```
+ *
+ * @param options - Factory options; `allowedUrls` is required and must be non-empty.
+ * @returns An {@link InvokableTool} that manages MCP sessions.
+ */
+export function makeMcpClient(options: MakeMcpClientOptions): InvokableTool<z.infer<typeof inputSchema>, JSONValue> {
+  const allowlist = normaliseAllowlist(options.allowedUrls)
+  const sessionLimit = options.sessionLimit ?? DEFAULT_SESSION_LIMIT
+  if (!Number.isInteger(sessionLimit) || sessionLimit <= 0) {
+    throw new Error(`\`sessionLimit\` must be a positive integer, got ${String(options.sessionLimit)}`)
+  }
+  const clientFactory = options.clientFactory ?? defaultClientFactory
+  const resolveHost = options.resolveHost ?? defaultResolveHost
+  const sessions = new Map<string, Session>()
+  // Reserved slot count. Incremented synchronously before any `await`, so racing
+  // connects can never overshoot the cap even while `client.connect()` is in flight.
+  let reserved = 0
+
+  return tool({
+    name: options.name ?? 'mcp_client',
+    description:
+      options.description ??
+      'Connects to Model Context Protocol (MCP) servers at runtime. Supports four operations: ' +
+        '"connect" (open a session to an allowlisted server URL), "list_tools" (list the tools ' +
+        'the connected server exposes), "call_tool" (invoke a tool on a connected server), and ' +
+        '"disconnect" (close a session). URLs must be on a developer-set allowlist.',
+    inputSchema,
+    callback: async (input, context) => {
+      if (!context) {
+        throw new Error('Tool context is required')
+      }
+      const owner = context.agent
+
+      switch (input.op) {
+        case 'connect': {
+          const url = input.server_url!
+          rejectUserinfoAndFragment(url)
+          const canonical = canonicaliseUrl(url)
+          if (!allowlist.has(canonical)) {
+            throw new Error(`URL "${url}" is not on the developer-set allowlist`)
+          }
+          // Drop sessions whose owning agent has been garbage-collected before
+          // enforcing the cap. Left in place they would count against the limit
+          // forever and pin the underlying transport open.
+          purgeDeadSessions(sessions)
+          if (sessions.size + reserved >= sessionLimit) {
+            throw new Error(
+              `Refusing to open a new MCP session: ${sessions.size + reserved}/${sessionLimit} concurrent sessions in use`
+            )
+          }
+          reserved += 1
+          try {
+            await assertPublicHost(url, resolveHost)
+            const client = clientFactory(url)
+            await client.connect()
+            let tools
+            try {
+              tools = await client.listTools()
+            } catch (err) {
+              // `connect()` succeeded but the follow-up threw. Tear the client
+              // down so we don't leak the transport / open socket.
+              await client.disconnect().catch(() => {})
+              throw err
+            }
+            const sessionId = globalThis.crypto.randomUUID()
+            const toolMap = new Map(tools.map((t) => [t.name, t]))
+            sessions.set(sessionId, {
+              client,
+              tools: toolMap,
+              url: canonical,
+              ownerId: new WeakRef(owner as object),
+            })
+            const result: McpClientConnectResult = { session_id: sessionId, server_url: canonical }
+            return result as unknown as JSONValue
+          } finally {
+            reserved -= 1
+          }
+        }
+
+        case 'list_tools': {
+          const session = resolveSession(sessions, input.session_id, owner as object)
+          const specs: McpClientToolSpec[] = []
+          for (const t of session.tools.values()) {
+            const spec: McpClientToolSpec = {
+              name: t.name,
+              description: t.description || '',
+              input_schema: t.toolSpec.inputSchema ?? {},
+            }
+            if (t.toolSpec.outputSchema !== undefined) {
+              spec.output_schema = t.toolSpec.outputSchema
+            }
+            specs.push(spec)
+          }
+          const result: McpClientListToolsResult = { tools: specs }
+          return result as unknown as JSONValue
+        }
+
+        case 'call_tool': {
+          const session = resolveSession(sessions, input.session_id, owner as object)
+          const t = session.tools.get(input.tool_name!)
+          if (!t) {
+            throw new Error(`Tool "${input.tool_name}" is not exposed by the connected server`)
+          }
+          const timeoutSeconds = input.timeout ?? DEFAULT_CALL_TIMEOUT_SECONDS
+          const timeoutSignal = AbortSignal.timeout(timeoutSeconds * 1000)
+          const signal = context.agent ? AbortSignal.any([timeoutSignal, context.agent.cancelSignal]) : timeoutSignal
+          const rawResult = await session.client.callTool(t, (input.arguments ?? {}) as JSONValue, { signal })
+          return summariseCallToolResult(rawResult) as unknown as JSONValue
+        }
+
+        case 'disconnect': {
+          const session = resolveSession(sessions, input.session_id, owner as object)
+          try {
+            await session.client.disconnect()
+          } finally {
+            sessions.delete(input.session_id!)
+          }
+          const result: McpClientDisconnectResult = { disconnected: true }
+          return result as unknown as JSONValue
+        }
+      }
+    },
+  })
+}
+
+function normaliseAllowlist(urls: string[]): Set<string> {
+  if (!urls || urls.length === 0) {
+    throw new Error('`allowedUrls` must not be empty; the mcp_client tool requires an explicit allowlist')
+  }
+  const normalised = new Set<string>()
+  for (const raw of urls) {
+    let parsed: URL
+    try {
+      parsed = new URL(raw)
+    } catch {
+      throw new Error(`Allowlist entry "${raw}" is not a valid URL`)
+    }
+    if (!ALLOWED_SCHEMES.has(parsed.protocol)) {
+      throw new Error(
+        `Allowlist entry "${raw}" has unsupported scheme "${parsed.protocol}"; only http and https are supported`
+      )
+    }
+    if (!parsed.hostname) {
+      throw new Error(`Allowlist entry "${raw}" has no host`)
+    }
+    rejectUserinfoAndFragment(raw, parsed)
+    normalised.add(canonicaliseUrl(raw))
+  }
+  return normalised
+}
+
+/**
+ * Reject URLs that carry credentials in the userinfo section or a `#` fragment.
+ *
+ * Both are stripped by `canonicaliseUrl`, so leaving them accepted would let
+ * `https://user:pass@host/path` canonicalise to the same string as
+ * `https://host/path` and bypass the verbatim allowlist match.
+ */
+function rejectUserinfoAndFragment(raw: string, parsed?: URL): void {
+  let parsedUrl: URL
+  try {
+    parsedUrl = parsed ?? new URL(raw)
+  } catch {
+    // Callers that pass an unparseable URL surface that error elsewhere; nothing
+    // to reject here.
+    return
+  }
+  if (parsedUrl.username || parsedUrl.password) {
+    throw new Error(`URL "${raw}" carries credentials; strip the userinfo before allowlisting or connecting`)
+  }
+  if (parsedUrl.hash) {
+    throw new Error(`URL "${raw}" carries a fragment; strip it before allowlisting or connecting`)
+  }
+}
+
+function canonicaliseUrl(url: string): string {
+  const parsed = new URL(url)
+  const scheme = parsed.protocol.toLowerCase()
+  const host = parsed.hostname.toLowerCase()
+  // Drop the port when it matches the scheme default so `https://host` and
+  // `https://host:443` canonicalise to the same string. Explicit non-default
+  // ports are preserved verbatim.
+  const defaultPort = DEFAULT_SCHEME_PORTS[scheme]
+  const port = parsed.port && parsed.port !== defaultPort ? `:${parsed.port}` : ''
+  const path = parsed.pathname.replace(/\/+$/, '')
+  const query = parsed.search
+  return `${scheme}//${host}${port}${path}${query}`
+}
+
+async function defaultResolveHost(host: string): Promise<string[]> {
+  const literal = isIP(host)
+  if (literal !== 0) return [host]
+  const results = await dns.lookup(host, { all: true })
+  return results.map((r) => r.address)
+}
+
+async function assertPublicHost(url: string, resolveHost: (host: string) => Promise<string[]>): Promise<void> {
+  const parsed = new URL(url)
+  let host = parsed.hostname.toLowerCase()
+  if (host.endsWith('.')) host = host.slice(0, -1)
+
+  for (const suffix of BLOCKED_HOST_SUFFIXES) {
+    const bare = suffix.slice(1)
+    if (host === bare || host.endsWith(suffix)) {
+      throw new Error(`Refusing to connect to "${url}": hostname "${host}" matches blocked suffix "${suffix}"`)
+    }
+  }
+
+  let addresses: string[]
+  try {
+    addresses = await resolveHost(host)
+  } catch (err) {
+    throw new Error(`Could not resolve host "${host}": ${(err as Error).message}`, { cause: err })
+  }
+  if (addresses.length === 0) {
+    throw new Error(`Could not resolve host "${host}" to any IP address`)
+  }
+  for (const addr of addresses) {
+    const canonical = canonicaliseIpForMetadataCheck(addr)
+    if (BLOCKED_METADATA_ADDRESSES.has(canonical)) {
+      throw new Error(`Refusing to connect to "${url}": host "${host}" resolves to metadata address ${addr}`)
+    }
+    if (isNonPublic(addr)) {
+      throw new Error(`Refusing to connect to "${url}": host "${host}" resolves to non-public address ${addr}`)
+    }
+  }
+}
+
+/**
+ * Lowercase an IP literal and unwrap `::ffff:` prefixes so the metadata-address set can
+ * be matched against both bare and mapped forms.
+ */
+function canonicaliseIpForMetadataCheck(address: string): string {
+  const lower = address.toLowerCase()
+  const mapped = extractIpv4Mapped(lower)
+  return mapped ?? lower
+}
+
+/**
+ * Returns true when the address is in RFC1918 private space, loopback, link-local,
+ * multicast, reserved, or the unspecified address. Rough but sufficient for the
+ * defence-in-depth SSRF guard applied on top of the allowlist.
+ */
+function isNonPublic(address: string): boolean {
+  const kind = isIP(address)
+  if (kind === 4) return isNonPublicIPv4(address)
+  if (kind === 6) return isNonPublicIPv6(address)
+  // Unknown format — reject conservatively.
+  return true
+}
+
+function isNonPublicIPv4(address: string): boolean {
+  const parts = address.split('.').map((p) => Number(p))
+  if (parts.length !== 4 || parts.some((p) => Number.isNaN(p) || p < 0 || p > 255)) return true
+  const [a, b, c] = parts as [number, number, number, number]
+  if (a === 10) return true // 10.0.0.0/8
+  if (a === 127) return true // loopback
+  if (a === 0) return true // unspecified / 0.0.0.0/8
+  if (a === 169 && b === 254) return true // link-local
+  if (a === 172 && b >= 16 && b <= 31) return true // 172.16.0.0/12
+  if (a === 192 && b === 168) return true // 192.168.0.0/16
+  if (a >= 224) return true // multicast + reserved (224.0.0.0/4, 240.0.0.0/4)
+  if (a === 100 && b >= 64 && b <= 127) return true // CGNAT 100.64.0.0/10
+  if (a === 192 && b === 0 && c === 0) return true // 192.0.0.0/24 (IETF reserved incl. 192.0.0.192)
+  if (a === 192 && b === 0 && c === 2) return true // 192.0.2.0/24 documentation
+  if (a === 198 && (b === 18 || b === 19)) return true // 198.18.0.0/15 benchmarking
+  if (a === 198 && b === 51 && c === 100) return true // 198.51.100.0/24 documentation
+  if (a === 203 && b === 0 && c === 113) return true // 203.0.113.0/24 documentation
+  return false
+}
+
+function isNonPublicIPv6(address: string): boolean {
+  const normalised = address.toLowerCase()
+  if (normalised === '::' || normalised === '::1') return true
+  // Link-local fe80::/10 → first 10 bits `1111 1110 10`, first hextet `fe80`–`febf`.
+  if (/^fe[89ab][0-9a-f]:/.test(normalised) || /^fe[89ab][0-9a-f]::/.test(normalised)) return true
+  // Site-local fec0::/10 → first 10 bits `1111 1110 11`, first hextet `fec0`–`feff`.
+  // Deprecated by RFC 3879 but still worth blocking as internal namespace.
+  if (/^fe[cdef][0-9a-f]:/.test(normalised) || /^fe[cdef][0-9a-f]::/.test(normalised)) return true
+  // Unique local fc00::/7 → first byte fc or fd.
+  if (/^f[cd][0-9a-f]{2}:/.test(normalised) || /^f[cd]::/.test(normalised)) return true
+  // Multicast ff00::/8.
+  if (normalised.startsWith('ff')) return true
+  // Discard-only 100::/64 — compressed form is `100::` (optionally with a suffix);
+  // fully-expanded form is `0(1)00:0000:0000:0000:...`. Both are rejected.
+  if (normalised === '100::' || normalised.startsWith('100::')) return true
+  if (/^0*100:0+:0+:0+:/.test(normalised)) return true
+  // Documentation range 2001:db8::/32 (compressed `2001:db8:` or expanded `2001:0db8:`).
+  if (normalised.startsWith('2001:db8:') || normalised.startsWith('2001:0db8:')) return true
+  const mapped = extractIpv4Mapped(normalised)
+  if (mapped !== null) {
+    return isIP(mapped) === 4 ? isNonPublicIPv4(mapped) : true
+  }
+  return false
+}
+
+/**
+ * Return the embedded IPv4 dotted-quad from an IPv4-mapped IPv6 literal, in either
+ * compressed (`::ffff:a.b.c.d`) or fully-expanded (`0:0:0:0:0:ffff:a.b.c.d`) form.
+ * Returns `null` when the input is not IPv4-mapped.
+ */
+function extractIpv4Mapped(address: string): string | null {
+  const lower = address.toLowerCase()
+  // Compressed: leading `::ffff:`, optionally with an extra `0:` group (`::ffff:0:0:a.b.c.d`).
+  const compressed = /^::ffff:(?:0:)?(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/.exec(lower)
+  if (compressed) return compressed[1] ?? null
+  // Expanded: seven groups of `0:` (or `0000:`) then `ffff:` then the dotted quad.
+  const expanded = /^(?:0{1,4}:){5}ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/.exec(lower)
+  if (expanded) return expanded[1] ?? null
+  return null
+}
+
+/**
+ * A `fetch` shim that refuses to follow HTTP redirects.
+ *
+ * The MCP SDK's `StreamableHTTPClientTransport` accepts a custom `fetch` in its options
+ * bag. Wiring `redirect: 'error'` there forces the platform `fetch` to throw on any 3xx
+ * response, so an allowlisted URL cannot be redirected to a private endpoint the SSRF
+ * guard never saw. The MCP SDK does not expose a manual redirect walker, so this is
+ * strictly a reject-on-3xx policy.
+ *
+ * @internal exported so tests can assert the redirect flag is actually set.
+ */
+export function noRedirectFetch(input: string | URL | Request, init?: RequestInit): Promise<Response> {
+  const merged: RequestInit = { ...(init ?? {}), redirect: 'error' }
+  return globalThis.fetch(input as Parameters<typeof globalThis.fetch>[0], merged)
+}
+
+/**
+ * Default MCP client factory: constructs a {@link McpClient} whose underlying
+ * `StreamableHTTPClientTransport` uses {@link noRedirectFetch}, so redirects surface as
+ * errors instead of silently landing on a new host.
+ */
+function defaultClientFactory(url: string): McpClient {
+  const parsed = new URL(url)
+  const transport = new StreamableHTTPClientTransport(parsed, {
+    fetch: noRedirectFetch as unknown as (input: string | URL, init?: RequestInit) => Promise<Response>,
+  })
+  return new McpClient({ transport: transport as unknown as McpTransport })
+}
+
+function resolveSession(sessions: Map<string, Session>, sessionId: string | undefined, owner: object): Session {
+  if (!sessionId) {
+    throw new Error('`session_id` is required')
+  }
+  const session = sessions.get(sessionId)
+  if (!session) {
+    throw new Error(`No active session for id "${sessionId}"`)
+  }
+  const ownerRef = session.ownerId.deref()
+  if (ownerRef === undefined) {
+    // Owning agent has been garbage-collected. Reap this specific session so the
+    // slot is returned to the pool and the transport is torn down; callers see
+    // the same "no active session" error as an unknown id.
+    sessions.delete(sessionId)
+    session.client.disconnect().catch(() => {})
+    throw new Error(`No active session for id "${sessionId}"`)
+  }
+  // A foreign agent produces the same "no session" error as a missing id —
+  // probing for other agents' ids is not informative.
+  if (ownerRef !== owner) {
+    throw new Error(`No active session for id "${sessionId}"`)
+  }
+  return session
+}
+
+/**
+ * Drop sessions whose owning agent has been garbage-collected and tear down their
+ * clients on a best-effort basis. Called before enforcing the session cap so a
+ * stream of connect-and-forget agents cannot pin the cap at zero.
+ */
+function purgeDeadSessions(sessions: Map<string, Session>): void {
+  for (const [sid, session] of sessions) {
+    if (session.ownerId.deref() === undefined) {
+      sessions.delete(sid)
+      session.client.disconnect().catch(() => {})
+    }
+  }
+}
+
+function summariseCallToolResult(raw: unknown): McpClientCallToolResult {
+  if (!raw || typeof raw !== 'object') {
+    return { status: 'error', text: '' }
+  }
+  const record = raw as Record<string, unknown>
+  const content = Array.isArray(record.content) ? record.content : []
+  const textParts: string[] = []
+  for (const item of content) {
+    if (item && typeof item === 'object') {
+      const t = (item as Record<string, unknown>).text
+      if (typeof t === 'string') textParts.push(t)
+    }
+  }
+  let text = textParts.join('\n')
+  let truncated = false
+  if (text.length > MAX_RESULT_TEXT_CHARS) {
+    text = text.slice(0, MAX_RESULT_TEXT_CHARS)
+    truncated = true
+  }
+  const result: McpClientCallToolResult = {
+    status: record.isError ? 'error' : 'success',
+    text,
+  }
+  if (record.structuredContent !== undefined) {
+    const capped = capStructuredContent(record.structuredContent)
+    result.structured_content = capped.value
+    if (capped.truncated) truncated = true
+  }
+  if (truncated) result.truncated = true
+  if (record.isError) result.is_error = true
+  return result
+}
+
+/**
+ * Serialise `value` to JSON and, when it exceeds the size cap, swap it for a marker
+ * object announcing the truncation. Non-JSON-serialisable input is also swapped so the
+ * model never receives an opaque or oversized blob.
+ */
+function capStructuredContent(value: unknown): { value: JSONValue; truncated: boolean } {
+  let encoded: string
+  try {
+    encoded = JSON.stringify(value)
+  } catch {
+    return {
+      value: { __truncated__: true, reason: 'structured_content was not JSON-serialisable' } as JSONValue,
+      truncated: true,
+    }
+  }
+  if (encoded === undefined) {
+    return {
+      value: { __truncated__: true, reason: 'structured_content was not JSON-serialisable' } as JSONValue,
+      truncated: true,
+    }
+  }
+  const byteLength = Buffer.byteLength(encoded, 'utf8')
+  if (byteLength <= MAX_STRUCTURED_CONTENT_BYTES) {
+    return { value: value as JSONValue, truncated: false }
+  }
+  return {
+    value: {
+      __truncated__: true,
+      reason: 'structured_content exceeded size cap',
+      size: byteLength,
+    } as JSONValue,
+    truncated: true,
+  }
+}

--- a/strands-ts/src/vended-tools/mcp-client/types.ts
+++ b/strands-ts/src/vended-tools/mcp-client/types.ts
@@ -1,0 +1,58 @@
+import type { JSONSchema, JSONValue } from '../../types/json.js'
+
+/**
+ * A tool exposed by a connected MCP server, as reported by `list_tools`.
+ */
+export interface McpClientToolSpec {
+  /** Server-assigned tool name. */
+  name: string
+  /** Server-provided description shown to the model. Empty string when the server omits it. */
+  description: string
+  /** JSON Schema for the tool's input. */
+  input_schema: JSONSchema
+  /** Optional output schema, when the server publishes one. */
+  output_schema?: JSONSchema
+}
+
+/**
+ * Result of a successful `connect` call.
+ */
+export interface McpClientConnectResult {
+  /** Opaque, unguessable session identifier. */
+  session_id: string
+  /** Canonicalised URL of the connected server. */
+  server_url: string
+}
+
+/**
+ * Result of a `list_tools` call.
+ */
+export interface McpClientListToolsResult {
+  tools: McpClientToolSpec[]
+}
+
+/**
+ * Result of a `call_tool` call.
+ */
+export interface McpClientCallToolResult {
+  /** `'success'` when the server returned a non-error result, `'error'` otherwise. */
+  status: 'success' | 'error'
+  /** Concatenated text content, possibly truncated. */
+  text: string
+  /** Present and true when the returned text was truncated to the size cap. */
+  truncated?: boolean
+  /** Structured content when the server returned any. */
+  structured_content?: JSONValue
+  /** Present and true when the server flagged the tool call as an application-level error. */
+  is_error?: boolean
+}
+
+/**
+ * Result of a `disconnect` call.
+ */
+export interface McpClientDisconnectResult {
+  disconnected: true
+}
+
+export type McpClientResult =
+  McpClientConnectResult | McpClientListToolsResult | McpClientCallToolResult | McpClientDisconnectResult


### PR DESCRIPTION
Adds a vended mcp_client tool in both SDKs. It lets an agent, at runtime, connect to a Model Context Protocol server on a developer-set URL allowlist, list the tools that server exposes, invoke one, and disconnect. The tool is a thin shim over the existing MCP client machinery in each SDK — transport, protocol, and session lifecycle live there — so the surface area unique to this tool is URL validation, the session table, and result truncation.

Four operations are exposed under a single tool name via an op field: connect, list_tools, call_tool, disconnect. Session identifiers are unguessable and scoped to the agent that opened them via a weak reference to the agent object, so another agent using the same tool instance cannot use a session it did not open and a garbage-collected agent's sessions become unreachable. The number of concurrent live sessions across all agents sharing the tool instance is bounded by session_limit (default eight), reserved atomically at connect entry so a burst of concurrent connects cannot overshoot the cap.

The security envelope is deliberately narrow. Only http and https streamable-http servers are supported; stdio, SSE, and WebSocket transports are out of scope. The allowlist is required at construction, must be non-empty, and every connect URL is canonicalised and matched verbatim before any network I/O. Layered on top, an SSRF guard rejects host names on an internal-use suffix denylist before DNS is consulted, then resolves the host and rejects any address in private, loopback, link-local, site-local, multicast, reserved, CGNAT, IPv6 documentation, or discard-only space. IPv4-mapped IPv6 is unwrapped before classification. Cloud-metadata endpoints are named explicitly for defence in depth. Both SDKs refuse to follow HTTP redirects rather than following them, so an allowlisted URL cannot be redirected onto a private endpoint the guard never saw.

DNS rebinding is a known limit and documented as such in the README: the classification is a check-time judgment, and the MCP client SDK does not expose a hook for pinned-IP connects, so operators should only allowlist hostnames whose DNS they control.

https://github.com/strands-agents/harness-sdk/issues/3248