### PR TITLE
feat(vended-tools): add graph shim

### DIFF
--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -10,6 +10,8 @@ sourceLinks:
   - path: strands-ts/src/vended-tools/bash/bash.ts
   - path: strands-ts/src/vended-tools/http-request/http-request.ts
   - path: strands-ts/src/vended-tools/notebook/notebook.ts
+  - path: strands-ts/src/vended-tools/graph/graph.ts
+  - path: strands-py/src/strands/vended_tools/graph/graph.py
 ---
 
 Vended tools are pre-built tools included directly in the Strands SDK for common agent tasks like file operations, shell commands, HTTP requests, and persistent notes. 
@@ -34,6 +36,7 @@ Each tool is imported from its own subpath under `@strands-agents/sdk/vended-too
 | [HTTP Request](#http-request) | Make HTTP requests to external APIs | TypeScript (Node.js 20+, browsers) |
 | [Notebook](#notebook) | Manage persistent text notebooks | TypeScript (Node.js, browsers) |
 | [Bash](#bash) | Execute shell commands with persistent sessions | Python, TypeScript (Node.js, Unix/Linux/macOS) |
+| [Graph](#graph) | Run a deterministic directed acyclic graph of sub-agents | Python, TypeScript |
 
 ### File Editor
 
@@ -160,6 +163,49 @@ agent("List all Python files in the current directory and count them")
 ```
 
 📖 [Full API Reference](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/bash/README.md)
+
+---
+
+### Graph
+
+Runs a deterministic directed acyclic graph of sub-agents. The caller describes the nodes (each with an optional system prompt and a tool allow-list drawn from the parent agent's registry) and the edges (dependency order); the tool builds a sub-agent per node, wires them into a Graph, executes it, and returns per-node text keyed by node id. Use it when a task has a fixed pipeline shape with clear dependencies; use plain tool calls for single-step work.
+
+Sub-agents inherit the parent's model instance, so model configuration is never accepted from the caller. Tool names must resolve in the parent's registry, wildcards are refused, and cycles are rejected before any sub-agent is built. The tool participates in the shared multi-agent recursion depth counter (default cap of three) so chains that cross tool boundaries stay bounded.
+
+**Example:**
+
+<Tabs>
+<Tab label="TypeScript">
+
+```typescript
+import { Agent } from '@strands-agents/sdk'
+import { graph } from '@strands-agents/sdk/vended-tools/graph'
+
+const agent = new Agent({ tools: [graph] })
+await agent.invoke(
+  'Research the top three JS frameworks and summarise them. ' +
+    'Use the graph tool with a researcher and a summariser node.'
+)
+```
+
+</Tab>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.vended_tools import graph
+
+agent = Agent(tools=[graph])
+agent(
+    "Research the top three JS frameworks and summarise them. "
+    "Use the graph tool with a researcher and a summariser node."
+)
+```
+
+</Tab>
+</Tabs>
+
+📖 [Full API Reference](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/graph/README.md)
 
 ---
 

--- a/strands-py/src/strands/vended_tools/__init__.py
+++ b/strands-py/src/strands/vended_tools/__init__.py
@@ -17,10 +17,13 @@ Example Usage:
 
 from .bash import bash, make_bash
 from .file_editor import file_editor, make_file_editor
+from .graph import graph, make_graph
 
 __all__ = [
     "bash",
     "file_editor",
+    "graph",
     "make_bash",
     "make_file_editor",
+    "make_graph",
 ]

--- a/strands-py/src/strands/vended_tools/_multiagent_conventions.md
+++ b/strands-py/src/strands/vended_tools/_multiagent_conventions.md
@@ -1,0 +1,104 @@
+# Multi-agent conventions — vended tools
+
+Reviewer consensus: four PRs (#65 graph, #66 swarm, #69 a2a_client, #73 use_agent) each shipped their own version of `_multiagent_conventions.md` and no two agree. This document is the resolution.
+
+Scope: `use_agent`, `swarm`, `graph`, `a2a_client`. All four must implement this dialect. If a tool can't, its PR body must explain the deviation.
+
+## Agent spec
+
+Every child-agent-defining tool accepts agent specs with the same shape:
+
+```
+{
+    name: str,          # required, [a-zA-Z_][a-zA-Z0-9_]{0,63}
+    system_prompt: str, # required, <= 8 KiB
+    tools: [str, ...],  # allow-list of parent-registered tool names
+                        # required (may be empty for a no-tool child)
+                        # no wildcards, no `"*"`, no glob patterns
+                        # unknown names are rejected at the boundary
+}
+```
+
+**No `model_provider` / `model_settings` field.** Children inherit the parent's model instance. Rationale: model-selection at spec time is a credential-injection surface — provider constructors accept `api_key`, `client_args`, `endpoint_url`, `base_url`, which a compromised model can supply to route to attacker-controlled endpoints or bill an attacker's account. The convenience of per-child model choice does not offset that surface. If a developer wants child-model variance they can register N pre-configured factories rather than exposing model config to the model.
+
+This is a change from the sub-issues and from three of the four PRs. `use_agent` (#73) keeps a `model_settings` field today — that field must be removed as part of this convergence.
+
+## Recursion depth
+
+Every multi-agent tool participates in a single shared depth counter tracked on the parent's `invocation_state`:
+
+- Python: `invocation_state["multiagent_depth"]`
+- TypeScript: `invocationState.multiagentDepth`
+
+Default cap: **3.** Configurable at tool construction only, never by the model.
+
+At the tool's entry point:
+1. Read the current depth from `invocation_state` (default 0 if absent).
+2. If `depth >= cap`, reject with a specific `MultiagentDepthExceeded` error.
+3. Construct the child's `invocation_state` with `multiagent_depth = depth + 1` and pass it into `Agent.invoke_async` (py) / `agent.invoke({ invocationState })` (ts).
+
+If a tool skips step 3, an adversarial model can walk `use_agent → swarm → use_agent` and reset the counter at each hop. All four must participate.
+
+## Tool allow-list
+
+Every agent spec's `tools` field is an explicit name allow-list from the parent's registry:
+
+- Names are matched exactly, case-sensitive.
+- Unknown names are rejected at the boundary before construction.
+- No wildcards, no glob patterns, no "all my tools" shortcut.
+- Multi-agent tools (`use_agent`, `swarm`, `graph`, `a2a_client`) may not be listed in a child's tools (defense-in-depth against tool-registered-then-recursed patterns that bypass the depth cap). Reject them explicitly.
+
+If a caller wants the child to have the multi-agent tools, they can register variants themselves at construction time; the model can't grant that authority.
+
+## Result shape
+
+All four tools return a result dict with this minimum shape:
+
+```
+{
+    status: "completed" | "failed" | "cancelled" | "interrupted",
+    output: str,               # the primary textual answer
+    execution_time_ms: int,    # total wall-clock
+}
+```
+
+Status strings are the lower-cased values of the SDK's `Status` enum, single word, byte-identical across Python and TypeScript. The TypeScript field name is `executionTimeMs` per the SDK's camelCase convention; the string values of `status` itself are byte-identical across the two SDKs.
+
+Extended fields (each tool may add its own — should be additive, not renaming):
+- `swarm`: `node_history: list[str]`, `execution_count: int`, `usage: {input_tokens, output_tokens}`
+- `graph`: `execution_order: list[str]`, `results: {node_id: {status, output}}` (per-node; the top-level `output` is the terminal node's output or a concatenation)
+- `use_agent`: no additional fields required (single child)
+- `a2a_client`: `remote_card: {name, description, ...}` (subset of the resolved agent card)
+
+The tools may return richer shapes but must keep `status`, `output`, `execution_time_ms` at the top level so downstream models get a consistent contract regardless of which pattern they invoke.
+
+## Cancellation
+
+Parent cancellation must propagate to the child(ren) within 100 ms:
+
+- Python: poll `parent_agent._cancel_signal.is_set()` at the tool's supervision level (a 50 ms loop is fine) and call `child.cancel()` when set. For multi-child tools (swarm/graph), the SDK's `BeforeNodeCallEvent` hook is the correct extension point — set `event.cancel_node` when the parent is cancelled.
+- TypeScript: forward `agent.cancelSignal` into `Agent.invoke(..., { cancelSignal })` and into any transport-level `AbortSignal` the child holds. `AbortSignal.any([parent, timeout])` is the standard composition.
+
+On cancellation, the tool returns `{status: "cancelled", output: "<partial or empty>", execution_time_ms}` — it does not raise past the tool boundary. A cancelled tool result reaching the loop is a signal to the parent to stop, not an exception to propagate.
+
+## Size caps
+
+At the tool boundary, before constructing anything:
+- `system_prompt`: 8 KiB per spec
+- `task` / `initial_input`: 32 KiB
+- `name`: 64 chars (regex above)
+- `tools` list: 64 entries max
+- Number of agents (swarm, graph nodes): 20 max
+- Number of edges (graph): 40 max
+- Total execution time: 300 s wall-clock
+
+These are hard caps, factory-configurable but not model-controllable.
+
+## What each PR needs to change to conform
+
+- **#65 graph:** add `multiagent_depth` participation (BLOCK). Replace `finally`-block cancellation with a `BeforeNodeCallEvent` hook (BLOCK — current code is a no-op in py). Rename `execution_order` → `execution_order` (keep) but add top-level `output` and `execution_time_ms` for shape consistency. Ship a copy of this file at `strands-py/src/strands/vended_tools/_multiagent_conventions.md` / `strands-ts/src/vended-tools/_multiagent-conventions.md`.
+- **#66 swarm:** add `multiagent_depth` participation. Add `.strict()` to the top-level Zod schema (contradicts PR body's own claim). Cap `initial_input` and `system_prompt`. Ship the shared conventions doc.
+- **#69 a2a_client:** the tool doesn't spawn child agents so most conventions don't apply, but its addendum currently claims to increment `multiagent_depth` when it doesn't (BLOCK). Either implement or delete the claim. Add BLOCK-level fixes from SSRF spec.
+- **#73 use_agent:** **remove `model_settings` field entirely** (credential injection MAJOR). Align provider list across py/ts, or drop the provider-name field along with `model_settings` and just inherit the parent's model instance (recommended — matches this spec).
+
+The `_multiagent_conventions.md` files across all four PRs will conflict on merge. That's expected. Human resolves to the version in this spec.

--- a/strands-py/src/strands/vended_tools/graph/__init__.py
+++ b/strands-py/src/strands/vended_tools/graph/__init__.py
@@ -1,0 +1,23 @@
+"""Graph tool for deterministic DAG-based multi-agent orchestration.
+
+The tool lets a caller agent describe a directed acyclic graph of sub-agents
+inline (nodes with optional system prompts and per-node tool allow-lists;
+edges giving the dependency order) and executes it via the SDK's
+:class:`~strands.multiagent.graph.Graph` primitive. Sub-agents inherit the
+parent agent's model instance — per-node model overrides are not supported.
+
+Example Usage:
+    ```python
+    from strands import Agent
+    from strands.vended_tools import graph
+
+    agent = Agent(tools=[graph])
+    ```
+"""
+
+from .graph import graph, make_graph
+
+__all__ = [
+    "graph",
+    "make_graph",
+]

--- a/strands-py/src/strands/vended_tools/graph/graph.py
+++ b/strands-py/src/strands/vended_tools/graph/graph.py
@@ -1,0 +1,497 @@
+"""Graph tool: deterministic DAG orchestration over the SDK's Graph primitive.
+
+Shim over :class:`~strands.multiagent.graph.GraphBuilder` /
+:class:`~strands.multiagent.graph.Graph`. The caller agent describes a DAG of
+sub-agents inline; this tool constructs the ``Graph`` and invokes it, returning
+per-node text results.
+
+Design notes:
+    * The tool is a **shim**. All orchestration lives in ``strands.multiagent.graph``.
+      This module only validates the model-supplied topology, builds sub-agents,
+      wires them into a ``Graph``, and formats the result.
+    * **No edge conditions**. Conditional routing would require executing
+      model-supplied code at every edge; that is not appropriate for a vended tool.
+      Users who want conditional routing should build a ``Graph`` directly.
+    * **Tools are name-allow-listed** from the parent agent's registry. The model
+      cannot conjure new tools inside a node — only reference tools the caller
+      already has. This mirrors the ``use_agent`` / ``swarm`` convention.
+    * **Cycles are rejected** at validation time. ``Graph`` supports cycles;
+      the tool does not.
+    * **Recursion depth** participates in the shared ``multiagent_depth`` counter
+      threaded through ``invocation_state``. See ``_multiagent_conventions.md``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import defaultdict, deque
+from typing import TYPE_CHECKING, Any, cast
+
+from ...agent import Agent
+from ...hooks import BeforeNodeCallEvent
+from ...multiagent.base import Status
+from ...multiagent.graph import GraphBuilder
+from ...tools.decorator import tool
+from ...types.tools import ToolContext
+from .types import (
+    DEFAULT_EXECUTION_TIMEOUT_SECONDS,
+    DEFAULT_NODE_TIMEOUT_SECONDS,
+    GRAPH_DESCRIPTION,
+    MAX_EDGES,
+    MAX_ID_LENGTH,
+    MAX_INITIAL_INPUT_LENGTH,
+    MAX_NODE_EXECUTIONS,
+    MAX_NODES,
+    MAX_SYSTEM_PROMPT_LENGTH,
+    MAX_TOOLS_PER_NODE,
+    GraphNodeResult,
+    GraphOutput,
+)
+
+# Shared multi-agent depth counter — see ``_multiagent_conventions.md``. All
+# multi-agent vended tools (`use_agent`, `swarm`, `graph`, `a2a_client`)
+# increment the same key so a chain that crosses tool boundaries is still
+# capped.
+_DEPTH_KEY = "multiagent_depth"
+_DEFAULT_MAX_DEPTH = 3
+
+# Multi-agent tool names that must never appear in a child node's allow-list.
+# Depth-cap participation already blocks unbounded recursion, but the shared
+# convention (``_multiagent_conventions.md``) also mandates an explicit reject
+# at the tool boundary as defense-in-depth — a compromised parent registry could
+# expose these under aliased names, but a reject on the canonical name still
+# catches the common case.
+_MULTIAGENT_TOOL_NAMES = frozenset({"use_agent", "swarm", "graph", "a2a_client"})
+
+if TYPE_CHECKING:
+    from ...tools.decorator import DecoratedFunctionTool
+    from ...types.tools import AgentTool
+
+
+class MultiagentDepthExceeded(RuntimeError):
+    """Raised when the shared multi-agent recursion cap is reached."""
+
+
+# Sentinel embedded in the ``cancel_node`` message. The SDK's ``Graph`` re-raises
+# that message as a ``RuntimeError``, so we need to distinguish "cancelled by
+# our hook" from "some other runtime failure that mentioned cancellation".
+_CANCEL_SENTINEL = "graph-tool-parent-cancel"
+_CANCEL_MESSAGE = f"cancelled by parent agent [{_CANCEL_SENTINEL}]"
+
+
+class _ParentCancelHook:
+    """Cancel each graph node when the parent agent's cancel signal is set.
+
+    The SDK exposes ``BeforeNodeCallEvent.cancel_node``; setting that field
+    stops execution cleanly at the next node boundary. Polling the parent's
+    ``threading.Event`` inside a hook keeps propagation on the same task as
+    the graph itself, which is the only correct place for it — the previous
+    finally-block approach only ran after ``invoke_async`` had already returned.
+    """
+
+    def __init__(self, parent_agent: Any) -> None:
+        self._parent = parent_agent
+
+    def on_before_node_call(self, event: BeforeNodeCallEvent) -> None:
+        cancel_signal = getattr(self._parent, "_cancel_signal", None)
+        if cancel_signal is not None and cancel_signal.is_set():
+            event.cancel_node = _CANCEL_MESSAGE
+
+
+def _current_depth(invocation_state: dict[str, Any]) -> int:
+    raw = invocation_state.get(_DEPTH_KEY, 0)
+    # ``bool`` is a subclass of ``int``; reject it explicitly so ``True`` doesn't
+    # silently count as depth 1. Not exploitable, but a hostile ``invocation_state``
+    # shouldn't be able to confuse the counter.
+    if isinstance(raw, bool) or not isinstance(raw, int) or raw < 0:
+        return 0
+    return int(raw)
+
+
+def _cancelled_output(execution_time_ms: int, partial: str = "") -> GraphOutput:
+    """Build a ``cancelled`` result.
+
+    Spec (see ``_multiagent_conventions.md``) forbids raising past the tool
+    boundary; a cancelled result reaching the loop is a signal to the parent,
+    not an exception to propagate.
+    """
+    return GraphOutput(
+        status="cancelled",
+        output=partial,
+        execution_order=[],
+        results={},
+        execution_time_ms=execution_time_ms,
+    )
+
+
+def _validate_node_id(node_id: Any) -> str:
+    if not isinstance(node_id, str) or not node_id:
+        raise ValueError("Each node must have a non-empty string 'id'.")
+    if len(node_id) > MAX_ID_LENGTH:
+        raise ValueError(f"Node id '{node_id[:16]}...' exceeds {MAX_ID_LENGTH} characters.")
+    if not all(ch.isalnum() or ch in "_-" for ch in node_id):
+        raise ValueError(
+            f"Node id '{node_id}' contains characters outside [A-Za-z0-9_-]. "
+            "Use short identifiers for readability and to avoid collisions."
+        )
+    return node_id
+
+
+def _resolve_tools(names: list[Any] | None, parent_registry: dict[str, AgentTool], node_id: str) -> list[AgentTool]:
+    """Resolve a node's tool allow-list from the parent registry.
+
+    Args:
+        names: List of tool names the model asked for on this node. ``None`` or
+            an empty list means the node runs with no tools.
+        parent_registry: The caller agent's tool registry (name -> tool).
+        node_id: Node id, for error messages.
+
+    Raises:
+        ValueError: If ``names`` is not a list of strings, contains a wildcard,
+            or references a tool the parent registry does not expose.
+    """
+    if names is None:
+        return []
+    if not isinstance(names, list):
+        raise ValueError(f"Node '{node_id}': 'tools' must be a list of tool names.")
+    if len(names) > MAX_TOOLS_PER_NODE:
+        raise ValueError(
+            f"Node '{node_id}': 'tools' has {len(names)} entries (max {MAX_TOOLS_PER_NODE})."
+        )
+
+    resolved: list[AgentTool] = []
+    seen: set[str] = set()
+    for raw in names:
+        if not isinstance(raw, str) or not raw:
+            raise ValueError(f"Node '{node_id}': tool entries must be non-empty strings.")
+        # Reject wildcards explicitly — a name-allow-list, never "all parent tools".
+        if raw == "*" or "*" in raw:
+            raise ValueError(
+                f"Node '{node_id}': tool '{raw}' looks like a wildcard. "
+                "List each tool by name; wildcards are not allowed."
+            )
+        # Reject multi-agent tools by name — defense-in-depth on top of the
+        # shared depth cap. See ``_multiagent_conventions.md``.
+        if raw in _MULTIAGENT_TOOL_NAMES:
+            raise ValueError(
+                f"Node '{node_id}': tool '{raw}' is a multi-agent tool and may not be "
+                "used inside a graph node's allow-list."
+            )
+        if raw in seen:
+            continue
+        seen.add(raw)
+        tool_instance = parent_registry.get(raw)
+        if tool_instance is None:
+            raise ValueError(f"Node '{node_id}': tool '{raw}' is not registered on the parent agent.")
+        resolved.append(tool_instance)
+    return resolved
+
+
+def _validate_nodes_edges(nodes: list[dict[str, Any]], edges: list[dict[str, Any]]) -> None:
+    """Structural checks that must pass before we build any sub-agents.
+
+    Verifies node/edge counts, unique ids, that edges reference known nodes,
+    and that the resulting graph has no cycles. The SDK ``GraphBuilder`` also
+    accepts cycles (they're valid for cyclic multi-agent patterns), so cycle
+    detection is the tool's responsibility.
+    """
+    if not isinstance(nodes, list) or not nodes:
+        raise ValueError("'nodes' must be a non-empty list.")
+    if len(nodes) > MAX_NODES:
+        raise ValueError(f"Too many nodes: {len(nodes)} (max {MAX_NODES}).")
+
+    if not isinstance(edges, list):
+        raise ValueError("'edges' must be a list (may be empty).")
+    if len(edges) > MAX_EDGES:
+        raise ValueError(f"Too many edges: {len(edges)} (max {MAX_EDGES}).")
+
+    ids: set[str] = set()
+    for node in nodes:
+        if not isinstance(node, dict):
+            raise ValueError("Each node must be an object.")
+        node_id = _validate_node_id(node.get("id"))
+        if node_id in ids:
+            raise ValueError(f"Duplicate node id '{node_id}'.")
+        ids.add(node_id)
+
+    adjacency: dict[str, list[str]] = defaultdict(list)
+    indegree: dict[str, int] = {node_id: 0 for node_id in ids}
+    for edge in edges:
+        if not isinstance(edge, dict):
+            raise ValueError("Each edge must be an object with 'from_id' and 'to_id'.")
+        from_id = edge.get("from_id")
+        to_id = edge.get("to_id")
+        if not isinstance(from_id, str) or not isinstance(to_id, str):
+            raise ValueError("Edge 'from_id' and 'to_id' must be strings.")
+        if from_id not in ids:
+            raise ValueError(f"Edge references unknown source node '{from_id}'.")
+        if to_id not in ids:
+            raise ValueError(f"Edge references unknown target node '{to_id}'.")
+        if from_id == to_id:
+            raise ValueError(f"Self-loop on node '{from_id}' is not allowed; the graph must be a DAG.")
+        adjacency[from_id].append(to_id)
+        indegree[to_id] += 1
+
+    # Kahn's algorithm — if we can't peel all nodes off, the remainder is a cycle.
+    queue = deque([node_id for node_id, deg in indegree.items() if deg == 0])
+    processed = 0
+    while queue:
+        current = queue.popleft()
+        processed += 1
+        for neighbor in adjacency[current]:
+            indegree[neighbor] -= 1
+            if indegree[neighbor] == 0:
+                queue.append(neighbor)
+    if processed != len(ids):
+        raise ValueError("Graph contains a cycle; graphs must be acyclic (DAG).")
+
+
+def _build_agent_for_node(
+    node: dict[str, Any],
+    parent_agent: Any,
+    parent_registry: dict[str, AgentTool],
+) -> Agent:
+    """Build one sub-agent for a graph node.
+
+    * ``model`` defaults to the parent agent's model — this keeps sub-agents on a
+      known, working provider without letting the model pick arbitrary strings.
+    * ``system_prompt`` is optional and length-capped.
+    * ``tools`` is a strict allow-list against the parent's registry.
+    """
+    node_id = node["id"]
+
+    system_prompt = node.get("system_prompt")
+    if system_prompt is not None:
+        if not isinstance(system_prompt, str):
+            raise ValueError(f"Node '{node_id}': 'system_prompt' must be a string.")
+        if len(system_prompt) > MAX_SYSTEM_PROMPT_LENGTH:
+            raise ValueError(f"Node '{node_id}': 'system_prompt' exceeds {MAX_SYSTEM_PROMPT_LENGTH} characters.")
+
+    tools = _resolve_tools(node.get("tools"), parent_registry, node_id)
+
+    return Agent(
+        model=parent_agent.model,
+        name=node_id,
+        system_prompt=system_prompt,
+        tools=list(tools),
+    )
+
+
+def _format_result(result: Any) -> tuple[str, int]:
+    """Turn a NodeResult into ``(text, execution_time_ms)``.
+
+    Extracts text blocks explicitly from the underlying ``AgentResult`` rather
+    than delegating to ``AgentResult.__str__``, which stringifies interrupts
+    and structured output ahead of the text content. Explicit extraction keeps
+    the tool byte-parity with the TypeScript side's ``contentToText`` and
+    means a future change to ``__str__`` cannot silently alter tool output.
+
+    Falls back to a short error description when the node failed. The wording
+    matches the TypeScript side ("error: <message>") so a caller consuming
+    either SDK sees byte-identical output for the same failure.
+    """
+    execution_time = int(getattr(result, "execution_time", 0) or 0)
+    inner = getattr(result, "result", None)
+
+    if isinstance(inner, Exception):
+        return f"error: {inner}", execution_time
+
+    if inner is None:
+        return "", execution_time
+
+    # ``AgentResult`` exposes ``.message`` (a ``Message`` dict with ``content``,
+    # a list of content blocks). Extract only text blocks; images, tool uses,
+    # reasoning, and other structured blocks are dropped so the tool result
+    # cannot smuggle non-text bytes back through the graph.
+    message = getattr(inner, "message", None)
+    if isinstance(message, dict):
+        content_blocks = message.get("content", [])
+        parts: list[str] = []
+        if isinstance(content_blocks, list):
+            for block in content_blocks:
+                if isinstance(block, dict) and isinstance(block.get("text"), str):
+                    parts.append(block["text"])
+        return "\n".join(parts).strip(), execution_time
+
+    # Nested ``MultiAgentResult`` or an unrecognised shape: fall back to str().
+    return str(inner), execution_time
+
+
+def make_graph(
+    *,
+    name: str = "graph",
+    description: str = GRAPH_DESCRIPTION,
+    max_depth: int = _DEFAULT_MAX_DEPTH,
+) -> DecoratedFunctionTool:
+    """Create a graph tool bound to no specific parent.
+
+    Args:
+        name: Tool name shown to the model. Defaults to ``"graph"``.
+        description: Tool description shown to the model.
+        max_depth: Shared multi-agent recursion cap. Factory-only; never
+            surfaced to the model.
+
+    Returns:
+        A decorated tool. Register it on an :class:`~strands.agent.Agent` like
+        any other tool.
+    """
+
+    @tool(name=name, description=description, context="tool_context")
+    async def graph_tool(
+        nodes: list[dict[str, Any]],
+        edges: list[dict[str, Any]],
+        initial_input: str,
+        tool_context: ToolContext,
+    ) -> GraphOutput:
+        """Execute a directed acyclic graph of sub-agents.
+
+        Args:
+            nodes: List of node specs. Each entry has:
+
+                * ``id`` (required): unique short identifier (``[A-Za-z0-9_-]``, up to 64 chars).
+                * ``system_prompt`` (optional): sub-agent system prompt.
+                * ``tools`` (optional): list of tool names to expose to this node,
+                  drawn from the parent agent's tool registry. No wildcards.
+            edges: List of ``{"from_id": ..., "to_id": ...}`` entries defining the
+                dependency order. The graph must be acyclic.
+            initial_input: The task passed to entry-point nodes (nodes with no
+                incoming edges).
+            tool_context: Injected by the framework. Not user-facing.
+
+        Raises:
+            ValueError: If the topology is invalid (non-list ``nodes`` / ``edges``,
+                duplicate or malformed node ids, self-loops, cycles, references to
+                unknown nodes), if ``initial_input`` is not a string or exceeds the
+                size cap, if a node's ``system_prompt`` exceeds the size cap, or if
+                its ``tools`` field references an unknown tool, a wildcard, a
+                multi-agent tool name, or exceeds the per-node tool cap.
+            MultiagentDepthExceeded: If the shared multi-agent recursion depth
+                counter (``invocation_state['multiagent_depth']``) is at or above
+                the factory-configured cap on entry.
+        """
+        # Validation (bad-input) errors still raise past the tool boundary —
+        # they signal a bug the model should see. Only cancellation is caught
+        # and mapped to a ``{status: cancelled}`` result per spec.
+        invocation_state = tool_context.invocation_state or {}
+        depth = _current_depth(invocation_state)
+        if depth >= max_depth:
+            raise MultiagentDepthExceeded(
+                f"graph refused: multi-agent recursion depth cap of {max_depth} reached (current depth {depth})"
+            )
+
+        if not isinstance(initial_input, str):
+            raise ValueError("'initial_input' must be a string.")
+        if len(initial_input) > MAX_INITIAL_INPUT_LENGTH:
+            raise ValueError(f"'initial_input' exceeds {MAX_INITIAL_INPUT_LENGTH} characters.")
+
+        _validate_nodes_edges(nodes, edges)
+
+        parent_agent = tool_context.agent
+        parent_registry_container = getattr(parent_agent, "tool_registry", None)
+        parent_registry: dict[str, AgentTool] = (
+            getattr(parent_registry_container, "registry", {}) if parent_registry_container else {}
+        )
+
+        parent_cancel_signal = getattr(parent_agent, "_cancel_signal", None)
+        start_time = time.monotonic()
+        if parent_cancel_signal is not None and parent_cancel_signal.is_set():
+            # Pre-flight cancellation: return the cancelled sentinel instead of
+            # raising. Spec (``_multiagent_conventions.md`` line 80): the tool
+            # returns ``{status: cancelled}``, does not raise.
+            return _cancelled_output(execution_time_ms=int((time.monotonic() - start_time) * 1000))
+
+        builder = GraphBuilder()
+        builder.set_max_node_executions(MAX_NODE_EXECUTIONS)
+        builder.set_execution_timeout(DEFAULT_EXECUTION_TIMEOUT_SECONDS)
+        builder.set_node_timeout(DEFAULT_NODE_TIMEOUT_SECONDS)
+
+        for node in nodes:
+            sub_agent = _build_agent_for_node(node, parent_agent, parent_registry)
+            builder.add_node(sub_agent, node_id=node["id"])
+
+        for edge in edges:
+            builder.add_edge(edge["from_id"], edge["to_id"])
+
+        graph_instance = builder.build()
+        graph_instance.add_hook(_ParentCancelHook(parent_agent).on_before_node_call, BeforeNodeCallEvent)
+
+        child_invocation_state: dict[str, Any] = {_DEPTH_KEY: depth + 1}
+
+        # Hard wall-clock ceiling. ``builder.set_execution_timeout`` is checked
+        # at node boundaries, so an N-node chain can silently exceed the cap.
+        # ``asyncio.wait_for`` gives us a strict upper bound at exactly the
+        # documented cap so the tool's guarantee matches its documentation.
+        hard_ceiling = DEFAULT_EXECUTION_TIMEOUT_SECONDS
+
+        try:
+            result = await asyncio.wait_for(
+                graph_instance.invoke_async(initial_input, invocation_state=child_invocation_state),
+                timeout=hard_ceiling,
+            )
+        except (asyncio.TimeoutError, TimeoutError):
+            # Hard-ceiling exceeded. Surface as cancelled — the tool boundary
+            # doesn't distinguish "cancelled by parent" from "cancelled by the
+            # tool's own hard timeout"; both mean "no useful result".
+            return _cancelled_output(execution_time_ms=int((time.monotonic() - start_time) * 1000))
+        except RuntimeError as exc:
+            # ``Graph.invoke_async`` re-raises ``RuntimeError`` when a hook sets
+            # ``event.cancel_node``. Match on the sentinel embedded in the hook's
+            # message so an unrelated runtime failure that happens to coincide
+            # with parent cancellation still propagates rather than being
+            # silently mapped to a cancelled result.
+            if _CANCEL_SENTINEL not in str(exc):
+                raise
+            return _cancelled_output(execution_time_ms=int((time.monotonic() - start_time) * 1000))
+
+        results: dict[str, GraphNodeResult] = {}
+        for node_id, node_result in result.results.items():
+            text, execution_time_ms = _format_result(node_result)
+            results[node_id] = GraphNodeResult(
+                status=node_result.status.value,
+                output=text,
+                execution_time_ms=execution_time_ms,
+            )
+
+        top_output = _aggregate_terminal_output(nodes, edges, results)
+
+        return GraphOutput(
+            status=result.status.value if isinstance(result.status, Status) else str(result.status),
+            output=top_output,
+            execution_order=[node.node_id for node in result.execution_order],
+            results=results,
+            execution_time_ms=int(result.execution_time),
+        )
+
+    return cast("DecoratedFunctionTool", graph_tool)
+
+
+def _aggregate_terminal_output(
+    nodes: list[dict[str, Any]],
+    edges: list[dict[str, Any]],
+    results: dict[str, GraphNodeResult],
+) -> str:
+    """Return the top-level ``output`` string per the shared multi-agent dialect.
+
+    Rule: concatenate every terminal (leaf) node's ``output`` text, joined by a
+    blank line, in graph declaration order. Terminal nodes are those with no
+    outgoing edges — a graph without a single named sink typically returns
+    multiple final outputs, and dropping any of them would silently truncate
+    the tool's answer.
+    """
+    with_outgoing: set[str] = {edge["from_id"] for edge in edges if isinstance(edge.get("from_id"), str)}
+    parts: list[str] = []
+    for node in nodes:
+        node_id = node["id"]
+        if node_id in with_outgoing:
+            continue
+        node_result = results.get(node_id)
+        if node_result is None:
+            continue
+        text = node_result["output"]
+        if text:
+            parts.append(text)
+    return "\n\n".join(parts)
+
+
+graph = make_graph()

--- a/strands-py/src/strands/vended_tools/graph/types.py
+++ b/strands-py/src/strands/vended_tools/graph/types.py
@@ -1,0 +1,77 @@
+"""Shared types, constants, and validation helpers for the graph tool."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+# Caps sized to keep the DAG a coordination surface, not a job runner.
+# Anything meaningfully larger belongs in a user-authored ``Graph`` outside the tool.
+MAX_NODES = 20
+"""Maximum number of nodes the tool will accept in one call."""
+
+MAX_EDGES = 40
+"""Maximum number of edges the tool will accept in one call."""
+
+MAX_ID_LENGTH = 64
+"""Maximum length for a node id."""
+
+MAX_SYSTEM_PROMPT_LENGTH = 8_000
+"""Maximum length (chars) of any node's ``system_prompt``."""
+
+MAX_INITIAL_INPUT_LENGTH = 32_000
+"""Maximum length (chars) of the ``initial_input`` passed to the graph."""
+
+MAX_NODE_EXECUTIONS = 40
+"""Total node-execution budget passed to the underlying :class:`~strands.multiagent.graph.Graph`."""
+
+MAX_TOOLS_PER_NODE = 64
+"""Maximum number of tool names a single node may list in its allow-list."""
+
+DEFAULT_EXECUTION_TIMEOUT_SECONDS = 300.0
+"""Wall-clock budget for the whole graph invocation, in seconds."""
+
+DEFAULT_NODE_TIMEOUT_SECONDS = 120.0
+"""Wall-clock budget for each node in the graph, in seconds."""
+
+GRAPH_DESCRIPTION = (
+    "Runs a deterministic directed acyclic graph (DAG) of sub-agents. "
+    "You describe the nodes (each with an optional system prompt and tool "
+    "allow-list) and the edges (dependency order); the tool executes the "
+    "graph, feeding each node the outputs of its dependencies, and returns "
+    "the results keyed by node id. Use when a task has a fixed pipeline shape "
+    "with clear dependencies; use plain tool calls for single-step work."
+)
+"""Description shown to the model."""
+
+
+class GraphNodeResult(TypedDict):
+    """One node's result in the aggregated graph output.
+
+    Attributes:
+        status: Node status (``completed``, ``failed``, ``interrupted``, etc.).
+        output: Text output the node produced. Empty when the node failed
+            before producing content.
+        execution_time_ms: Node wall-clock time in milliseconds.
+    """
+
+    status: str
+    output: str
+    execution_time_ms: int
+
+
+class GraphOutput(TypedDict):
+    """Aggregated result of a graph invocation.
+
+    Shape follows the shared multi-agent dialect: ``status``, ``output``, and
+    ``execution_time_ms`` are the common contract; ``execution_order`` and
+    ``results`` are the graph-specific extensions.
+
+    ``output`` is the concatenation of every terminal (leaf) node's text, joined
+    by a blank line — see ``_multiagent_conventions.md`` for the rationale.
+    """
+
+    status: str
+    output: str
+    execution_order: list[str]
+    results: dict[str, GraphNodeResult]
+    execution_time_ms: int

--- a/strands-py/tests/strands/vended_tools/test_graph.py
+++ b/strands-py/tests/strands/vended_tools/test_graph.py
@@ -1,0 +1,411 @@
+"""Tests for the graph vended tool.
+
+The tool is a thin shim over :class:`~strands.multiagent.graph.GraphBuilder`.
+Security-focused tests check validation at the tool boundary (bad topology,
+oversized inputs, unknown tools, wildcards, cycles); happy-path tests exercise
+a small end-to-end graph using ``MockedModelProvider`` sub-agents.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import pytest
+
+from strands import Agent
+from strands.types.tools import ToolContext
+from strands.vended_tools.graph import graph
+from strands.vended_tools.graph.graph import MultiagentDepthExceeded
+from strands.vended_tools.graph.types import (
+    MAX_INITIAL_INPUT_LENGTH,
+    MAX_NODES,
+    MAX_SYSTEM_PROMPT_LENGTH,
+    MAX_TOOLS_PER_NODE,
+)
+from tests.fixtures.mocked_model_provider import MockedModelProvider
+
+
+def _text_response(text: str) -> dict:
+    return {"role": "assistant", "content": [{"text": text}]}
+
+
+def _make_parent(responses_per_node: int = 1, extra_tools: list | None = None) -> Agent:
+    """Build a parent agent with a mocked model.
+
+    The parent isn't actually invoked; the graph tool reuses its ``model``
+    attribute for the sub-agents built inside the graph. Each sub-agent
+    consumes exactly one response from the shared mocked provider, so we
+    provide enough entries for every node we expect to execute.
+    """
+    responses = [_text_response(f"reply {i}") for i in range(responses_per_node)]
+    model = MockedModelProvider(agent_responses=responses)
+    return Agent(model=model, tools=extra_tools or [])
+
+
+def _tool_context(agent: Agent) -> ToolContext:
+    return ToolContext(
+        tool_use={"name": "graph", "toolUseId": "test-id", "input": {}},
+        agent=agent,
+        invocation_state={},
+    )
+
+
+@pytest.mark.asyncio
+async def test_rejects_cycle():
+    """A -> B -> A must be rejected before any sub-agent is built."""
+    agent = _make_parent()
+    with pytest.raises(ValueError, match="cycle"):
+        await graph(
+            nodes=[{"id": "a"}, {"id": "b"}],
+            edges=[
+                {"from_id": "a", "to_id": "b"},
+                {"from_id": "b", "to_id": "a"},
+            ],
+            initial_input="hi",
+            tool_context=_tool_context(agent),
+        )
+
+
+@pytest.mark.asyncio
+async def test_rejects_self_loop():
+    agent = _make_parent()
+    with pytest.raises(ValueError, match="Self-loop"):
+        await graph(
+            nodes=[{"id": "a"}],
+            edges=[{"from_id": "a", "to_id": "a"}],
+            initial_input="hi",
+            tool_context=_tool_context(agent),
+        )
+
+
+@pytest.mark.asyncio
+async def test_rejects_unknown_tool_in_node_allowlist():
+    """A node cannot request a tool the parent's registry does not expose."""
+    agent = _make_parent()
+    with pytest.raises(ValueError, match="not registered on the parent"):
+        await graph(
+            nodes=[{"id": "a", "tools": ["definitely_not_a_real_tool"]}],
+            edges=[],
+            initial_input="hi",
+            tool_context=_tool_context(agent),
+        )
+
+
+@pytest.mark.asyncio
+async def test_rejects_multiagent_tool_in_node_allowlist():
+    """Spec: multi-agent tools (`use_agent`, `swarm`, `graph`, `a2a_client`)
+    may not appear in a child node's allow-list. Defense-in-depth on top of
+    the shared depth cap."""
+    # Register a real graph tool on the parent so its name resolves in the
+    # registry — otherwise the "unknown tool" rejection would fire first and
+    # mask the multi-agent-name rejection this test is exercising.
+    agent = _make_parent(extra_tools=[graph])
+
+    with pytest.raises(ValueError, match="multi-agent tool"):
+        await graph(
+            nodes=[{"id": "a", "tools": ["graph"]}],
+            edges=[],
+            initial_input="hi",
+            tool_context=_tool_context(agent),
+        )
+
+
+@pytest.mark.asyncio
+async def test_rejects_wildcard_in_tool_allowlist():
+    """The allowlist is names-only; wildcards are refused so 'all tools' can't leak in."""
+    agent = _make_parent()
+    with pytest.raises(ValueError, match="wildcard"):
+        await graph(
+            nodes=[{"id": "a", "tools": ["*"]}],
+            edges=[],
+            initial_input="hi",
+            tool_context=_tool_context(agent),
+        )
+
+
+@pytest.mark.asyncio
+async def test_rejects_oversized_tool_allowlist():
+    """Spec: per-node ``tools`` list is capped so a malicious model cannot flood
+    the resolver with a huge repeated list."""
+    agent = _make_parent()
+    over = ["not_a_tool"] * (MAX_TOOLS_PER_NODE + 1)
+    with pytest.raises(ValueError, match="tools"):
+        await graph(
+            nodes=[{"id": "a", "tools": over}],
+            edges=[],
+            initial_input="hi",
+            tool_context=_tool_context(agent),
+        )
+
+
+@pytest.mark.asyncio
+async def test_rejects_too_many_nodes():
+    agent = _make_parent()
+    over = MAX_NODES + 1
+    nodes = [{"id": f"n{i}"} for i in range(over)]
+    with pytest.raises(ValueError, match="Too many nodes"):
+        await graph(
+            nodes=nodes,
+            edges=[],
+            initial_input="hi",
+            tool_context=_tool_context(agent),
+        )
+
+
+@pytest.mark.asyncio
+async def test_rejects_duplicate_node_ids():
+    agent = _make_parent()
+    with pytest.raises(ValueError, match="Duplicate node id"):
+        await graph(
+            nodes=[{"id": "a"}, {"id": "a"}],
+            edges=[],
+            initial_input="hi",
+            tool_context=_tool_context(agent),
+        )
+
+
+@pytest.mark.asyncio
+async def test_rejects_edge_referencing_unknown_node():
+    agent = _make_parent()
+    with pytest.raises(ValueError, match="unknown"):
+        await graph(
+            nodes=[{"id": "a"}],
+            edges=[{"from_id": "a", "to_id": "ghost"}],
+            initial_input="hi",
+            tool_context=_tool_context(agent),
+        )
+
+
+@pytest.mark.asyncio
+async def test_rejects_oversized_initial_input():
+    agent = _make_parent()
+    with pytest.raises(ValueError, match="initial_input"):
+        await graph(
+            nodes=[{"id": "a"}],
+            edges=[],
+            initial_input="x" * (MAX_INITIAL_INPUT_LENGTH + 1),
+            tool_context=_tool_context(agent),
+        )
+
+
+@pytest.mark.asyncio
+async def test_rejects_oversized_system_prompt():
+    agent = _make_parent()
+    with pytest.raises(ValueError, match="system_prompt"):
+        await graph(
+            nodes=[{"id": "a", "system_prompt": "x" * (MAX_SYSTEM_PROMPT_LENGTH + 1)}],
+            edges=[],
+            initial_input="hi",
+            tool_context=_tool_context(agent),
+        )
+
+
+@pytest.mark.asyncio
+async def test_rejects_bad_node_id_characters():
+    agent = _make_parent()
+    with pytest.raises(ValueError, match="characters outside"):
+        await graph(
+            nodes=[{"id": "bad id!"}],
+            edges=[],
+            initial_input="hi",
+            tool_context=_tool_context(agent),
+        )
+
+
+@pytest.mark.asyncio
+async def test_happy_path_linear_chain():
+    """a -> b runs both nodes in order and returns per-node output."""
+    # Two nodes, one response each.
+    responses = [_text_response("first"), _text_response("second")]
+    model = MockedModelProvider(agent_responses=responses)
+    agent = Agent(model=model)
+
+    result = await graph(
+        nodes=[{"id": "a"}, {"id": "b"}],
+        edges=[{"from_id": "a", "to_id": "b"}],
+        initial_input="start",
+        tool_context=_tool_context(agent),
+    )
+
+    assert result["status"] == "completed"
+    assert set(result["results"].keys()) == {"a", "b"}
+    assert result["results"]["a"]["status"] == "completed"
+    assert result["results"]["b"]["status"] == "completed"
+    assert result["execution_order"] == ["a", "b"]
+    # ``output`` is the terminal node's text — ``b`` is the sole leaf here.
+    assert result["output"] == result["results"]["b"]["output"]
+
+
+@pytest.mark.asyncio
+async def test_happy_path_fan_out_fan_in():
+    """a fans out to b and c; both feed into d."""
+    responses = [_text_response(f"node{i}") for i in range(4)]
+    model = MockedModelProvider(agent_responses=responses)
+    agent = Agent(model=model)
+
+    result = await graph(
+        nodes=[{"id": "a"}, {"id": "b"}, {"id": "c"}, {"id": "d"}],
+        edges=[
+            {"from_id": "a", "to_id": "b"},
+            {"from_id": "a", "to_id": "c"},
+            {"from_id": "b", "to_id": "d"},
+            {"from_id": "c", "to_id": "d"},
+        ],
+        initial_input="start",
+        tool_context=_tool_context(agent),
+    )
+
+    assert result["status"] == "completed"
+    assert set(result["results"].keys()) == {"a", "b", "c", "d"}
+    # 'a' must be first, 'd' must be last; b and c can be in either order.
+    order = result["execution_order"]
+    assert order[0] == "a"
+    assert order[-1] == "d"
+
+
+@pytest.mark.asyncio
+async def test_returns_cancelled_when_parent_already_cancelled():
+    """If the parent agent is already cancelled, the tool returns a cancelled
+    result (not an exception). Spec: cancellation never raises past the tool
+    boundary — a cancelled result is a signal to the loop, not an error."""
+    agent = _make_parent()
+    agent._cancel_signal = threading.Event()
+    agent._cancel_signal.set()
+
+    result = await graph(
+        nodes=[{"id": "a"}],
+        edges=[],
+        initial_input="hi",
+        tool_context=_tool_context(agent),
+    )
+    assert result["status"] == "cancelled"
+    assert result["output"] == ""
+    assert result["execution_order"] == []
+    assert result["results"] == {}
+
+
+@pytest.mark.asyncio
+async def test_before_node_call_hook_cancels_mid_flight():
+    """A parent cancel fired *during* execution aborts the next node.
+
+    Exercises the ``BeforeNodeCallEvent`` hook path — not the pre-flight check.
+    A hook is registered on the parent agent that sets ``_cancel_signal`` the
+    first time the hook fires on the graph itself; the tool must then still
+    return ``{status: cancelled}`` from the hook-driven ``RuntimeError`` re-raise.
+
+    This test would fail without the round-3 fix that catches
+    ``RuntimeError("...graph-tool-parent-cancel...")`` and maps it to a cancelled
+    result — the previous code let the exception propagate to the caller.
+    """
+    responses = [_text_response("first"), _text_response("second")]
+    model = MockedModelProvider(agent_responses=responses)
+    agent = Agent(model=model)
+    # Cancel signal starts un-set — we want the hook to trip mid-flight.
+    agent._cancel_signal = threading.Event()
+
+    # Monkeypatch `_ParentCancelHook.on_before_node_call` to arm the signal
+    # *after* the first call has passed through the original (which observes
+    # signal-not-set and does nothing). The second call then sees the armed
+    # signal and sets `event.cancel_node`, which the SDK re-raises as
+    # `RuntimeError` — the round-3 fix must catch that and return
+    # `{status: 'cancelled'}` instead of propagating.
+    from strands.vended_tools.graph.graph import _ParentCancelHook
+
+    original_on_before = _ParentCancelHook.on_before_node_call
+
+    call_counter = {"count": 0}
+
+    def cancel_after_first_call(self, event):  # type: ignore[no-untyped-def]
+        # Call the original first so it can observe the current state, then
+        # arm the signal so the *next* node's invocation trips it.
+        original_on_before(self, event)
+        call_counter["count"] += 1
+        if call_counter["count"] == 1:
+            agent._cancel_signal.set()
+
+    _ParentCancelHook.on_before_node_call = cancel_after_first_call  # type: ignore[assignment]
+    try:
+        result = await graph(
+            nodes=[{"id": "a"}, {"id": "b"}],
+            edges=[{"from_id": "a", "to_id": "b"}],
+            initial_input="start",
+            tool_context=_tool_context(agent),
+        )
+    finally:
+        _ParentCancelHook.on_before_node_call = original_on_before  # type: ignore[assignment]
+
+    # The tool caught the hook-driven RuntimeError and returned cancelled.
+    assert result["status"] == "cancelled"
+    # The hook was invoked at least twice — once for node A (which ran) and
+    # once for node B (where the cancel_node fired). If it were only 1, the
+    # cancellation was happening pre-flight, not mid-flight.
+    assert call_counter["count"] >= 2, (
+        f"hook only fired {call_counter['count']}x — the test isn't exercising the mid-flight branch"
+    )
+
+
+@pytest.mark.asyncio
+async def test_refuses_when_depth_cap_reached():
+    """A parent already at the depth cap must not construct a new graph frame."""
+    agent = _make_parent()
+    ctx = ToolContext(
+        tool_use={"name": "graph", "toolUseId": "test-id", "input": {}},
+        agent=agent,
+        invocation_state={"multiagent_depth": 3},
+    )
+    with pytest.raises(MultiagentDepthExceeded):
+        await graph(
+            nodes=[{"id": "a"}],
+            edges=[],
+            initial_input="hi",
+            tool_context=ctx,
+        )
+
+
+@pytest.mark.asyncio
+async def test_passes_incremented_depth_to_child_graph(monkeypatch):
+    """Child ``invocation_state`` receives ``multiagent_depth = parent + 1``.
+
+    The value threaded into ``Graph.invoke_async`` is what stops sibling
+    multi-agent tools (`use_agent`, `swarm`, `a2a_client`) from resetting the
+    counter at each hop.
+    """
+    responses = [_text_response("only-node")]
+    model = MockedModelProvider(agent_responses=responses)
+    agent = Agent(model=model)
+
+    parent_ctx = ToolContext(
+        tool_use={"name": "graph", "toolUseId": "test-id", "input": {}},
+        agent=agent,
+        invocation_state={"multiagent_depth": 1},
+    )
+
+    from strands.multiagent.graph import Graph
+
+    captured: dict[str, Any] = {}
+    original_invoke = Graph.invoke_async
+
+    async def spy_invoke_async(self, task, invocation_state=None, **kwargs):
+        captured["invocation_state"] = invocation_state
+        return await original_invoke(self, task, invocation_state, **kwargs)
+
+    monkeypatch.setattr(Graph, "invoke_async", spy_invoke_async)
+
+    await graph(
+        nodes=[{"id": "a"}],
+        edges=[],
+        initial_input="hi",
+        tool_context=parent_ctx,
+    )
+
+    assert captured["invocation_state"] is not None
+    assert captured["invocation_state"].get("multiagent_depth") == 2
+
+
+def test_schema_excludes_context():
+    props = graph.tool_spec["inputSchema"]["json"]["properties"]
+    assert "nodes" in props
+    assert "edges" in props
+    assert "initial_input" in props
+    assert "tool_context" not in props

--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -68,6 +68,10 @@
       "types": "./dist/src/vended-tools/bash/index.d.ts",
       "default": "./dist/src/vended-tools/bash/index.js"
     },
+    "./vended-tools/graph": {
+      "types": "./dist/src/vended-tools/graph/index.d.ts",
+      "default": "./dist/src/vended-tools/graph/index.js"
+    },
     "./a2a": {
       "types": "./dist/src/a2a/index.d.ts",
       "default": "./dist/src/a2a/index.js"

--- a/strands-ts/src/vended-tools/_multiagent-conventions.md
+++ b/strands-ts/src/vended-tools/_multiagent-conventions.md
@@ -1,0 +1,107 @@
+# Multi-agent conventions — vended tools
+
+Reviewer consensus: four PRs (#65 graph, #66 swarm, #69 a2a_client, #73 use_agent) each shipped their own version of `_multiagent_conventions.md` and no two agree. This document is the resolution.
+
+Scope: `use_agent`, `swarm`, `graph`, `a2a_client`. All four must implement this dialect. If a tool can't, its PR body must explain the deviation.
+
+## Agent spec
+
+Every child-agent-defining tool accepts agent specs with the same shape:
+
+```
+{
+    name: str,          # required, [a-zA-Z_][a-zA-Z0-9_]{0,63}
+    system_prompt: str, # required, <= 8 KiB
+    tools: [str, ...],  # allow-list of parent-registered tool names
+                        # required (may be empty for a no-tool child)
+                        # no wildcards, no `"*"`, no glob patterns
+                        # unknown names are rejected at the boundary
+}
+```
+
+**No `model_provider` / `model_settings` field.** Children inherit the parent's model instance. Rationale: model-selection at spec time is a credential-injection surface — provider constructors accept `api_key`, `client_args`, `endpoint_url`, `base_url`, which a compromised model can supply to route to attacker-controlled endpoints or bill an attacker's account. The convenience of per-child model choice does not offset that surface. If a developer wants child-model variance they can register N pre-configured factories rather than exposing model config to the model.
+
+This is a change from the sub-issues and from three of the four PRs. `use_agent` (#73) keeps a `model_settings` field today — that field must be removed as part of this convergence.
+
+## Recursion depth
+
+Every multi-agent tool participates in a single shared depth counter tracked on the parent's `invocation_state`:
+
+- Python: `invocation_state["multiagent_depth"]`
+- TypeScript: `invocationState.multiagentDepth`
+
+Default cap: **3.** Configurable at tool construction only, never by the model.
+
+At the tool's entry point:
+
+1. Read the current depth from `invocation_state` (default 0 if absent).
+2. If `depth >= cap`, reject with a specific `MultiagentDepthExceeded` error.
+3. Construct the child's `invocation_state` with `multiagent_depth = depth + 1` and pass it into `Agent.invoke_async` (py) / `agent.invoke({ invocationState })` (ts).
+
+If a tool skips step 3, an adversarial model can walk `use_agent → swarm → use_agent` and reset the counter at each hop. All four must participate.
+
+## Tool allow-list
+
+Every agent spec's `tools` field is an explicit name allow-list from the parent's registry:
+
+- Names are matched exactly, case-sensitive.
+- Unknown names are rejected at the boundary before construction.
+- No wildcards, no glob patterns, no "all my tools" shortcut.
+- Multi-agent tools (`use_agent`, `swarm`, `graph`, `a2a_client`) may not be listed in a child's tools (defense-in-depth against tool-registered-then-recursed patterns that bypass the depth cap). Reject them explicitly.
+
+If a caller wants the child to have the multi-agent tools, they can register variants themselves at construction time; the model can't grant that authority.
+
+## Result shape
+
+All four tools return a result dict with this minimum shape:
+
+```
+{
+    status: "completed" | "failed" | "cancelled" | "interrupted",
+    output: str,               # the primary textual answer
+    execution_time_ms: int,    # total wall-clock
+}
+```
+
+Status strings are the lower-cased values of the SDK's `Status` enum, single word, byte-identical across Python and TypeScript. The TypeScript field name is `executionTimeMs` per the SDK's camelCase convention; the string values of `status` itself are byte-identical across the two SDKs.
+
+Extended fields (each tool may add its own — should be additive, not renaming):
+
+- `swarm`: `node_history: list[str]`, `execution_count: int`, `usage: {input_tokens, output_tokens}`
+- `graph`: `execution_order: list[str]`, `results: {node_id: {status, output}}` (per-node; the top-level `output` is the terminal node's output or a concatenation)
+- `use_agent`: no additional fields required (single child)
+- `a2a_client`: `remote_card: {name, description, ...}` (subset of the resolved agent card)
+
+The tools may return richer shapes but must keep `status`, `output`, `execution_time_ms` at the top level so downstream models get a consistent contract regardless of which pattern they invoke.
+
+## Cancellation
+
+Parent cancellation must propagate to the child(ren) within 100 ms:
+
+- Python: poll `parent_agent._cancel_signal.is_set()` at the tool's supervision level (a 50 ms loop is fine) and call `child.cancel()` when set. For multi-child tools (swarm/graph), the SDK's `BeforeNodeCallEvent` hook is the correct extension point — set `event.cancel_node` when the parent is cancelled.
+- TypeScript: forward `agent.cancelSignal` into `Agent.invoke(..., { cancelSignal })` and into any transport-level `AbortSignal` the child holds. `AbortSignal.any([parent, timeout])` is the standard composition.
+
+On cancellation, the tool returns `{status: "cancelled", output: "<partial or empty>", execution_time_ms}` — it does not raise past the tool boundary. A cancelled tool result reaching the loop is a signal to the parent to stop, not an exception to propagate.
+
+## Size caps
+
+At the tool boundary, before constructing anything:
+
+- `system_prompt`: 8 KiB per spec
+- `task` / `initial_input`: 32 KiB
+- `name`: 64 chars (regex above)
+- `tools` list: 64 entries max
+- Number of agents (swarm, graph nodes): 20 max
+- Number of edges (graph): 40 max
+- Total execution time: 300 s wall-clock
+
+These are hard caps, factory-configurable but not model-controllable.
+
+## What each PR needs to change to conform
+
+- **#65 graph:** add `multiagent_depth` participation (BLOCK). Replace `finally`-block cancellation with a `BeforeNodeCallEvent` hook (BLOCK — current code is a no-op in py). Rename `execution_order` → `execution_order` (keep) but add top-level `output` and `execution_time_ms` for shape consistency. Ship a copy of this file at `strands-py/src/strands/vended_tools/_multiagent_conventions.md` / `strands-ts/src/vended-tools/_multiagent-conventions.md`.
+- **#66 swarm:** add `multiagent_depth` participation. Add `.strict()` to the top-level Zod schema (contradicts PR body's own claim). Cap `initial_input` and `system_prompt`. Ship the shared conventions doc.
+- **#69 a2a_client:** the tool doesn't spawn child agents so most conventions don't apply, but its addendum currently claims to increment `multiagent_depth` when it doesn't (BLOCK). Either implement or delete the claim. Add BLOCK-level fixes from SSRF spec.
+- **#73 use_agent:** **remove `model_settings` field entirely** (credential injection MAJOR). Align provider list across py/ts, or drop the provider-name field along with `model_settings` and just inherit the parent's model instance (recommended — matches this spec).
+
+The `_multiagent_conventions.md` files across all four PRs will conflict on merge. That's expected. Human resolves to the version in this spec.

--- a/strands-ts/src/vended-tools/graph/README.md
+++ b/strands-ts/src/vended-tools/graph/README.md
@@ -1,0 +1,126 @@
+# Graph Tool
+
+Deterministic directed acyclic graph orchestration for multi-agent pipelines. The caller agent describes a graph of sub-agents at tool-call time; the tool constructs a Graph, runs it, and returns per-node text output.
+
+Shim over [Graph](../../multiagent/graph.ts) — all execution semantics live there.
+
+## Usage
+
+```typescript
+import { Agent } from '@strands-agents/sdk'
+import { BedrockModel } from '@strands-agents/sdk/models/bedrock'
+import { graph } from '@strands-agents/sdk/vended-tools/graph'
+import { httpRequest } from '@strands-agents/sdk/vended-tools/http-request'
+
+const agent = new Agent({
+  model: new BedrockModel({ region: 'us-east-1' }),
+  // Any tool listed here is eligible to appear in a node's `tools` allow-list.
+  tools: [graph, httpRequest],
+})
+
+await agent.invoke(
+  'Research the top three JS frameworks and summarise them. ' +
+    'Use the graph tool with a researcher and a summariser node.'
+)
+```
+
+The model produces a call like:
+
+```json
+{
+  "nodes": [
+    { "id": "research", "systemPrompt": "Find recent facts.", "tools": ["http_request"] },
+    { "id": "summarise", "systemPrompt": "Turn findings into 3 bullets." }
+  ],
+  "edges": [{ "fromId": "research", "toId": "summarise" }],
+  "initialInput": "top three JS frameworks"
+}
+```
+
+The tool builds two sub-agents, hooks research to summarise, runs the graph, and returns:
+
+```json
+{
+  "status": "completed",
+  "output": "...",
+  "executionOrder": ["research", "summarise"],
+  "results": {
+    "research": { "status": "completed", "output": "...", "executionTimeMs": 812 },
+    "summarise": { "status": "completed", "output": "...", "executionTimeMs": 604 }
+  },
+  "executionTimeMs": 1430
+}
+```
+
+The top-level `output` is the concatenation of every terminal (leaf) node's text, joined by a blank line, so a graph without a single named sink still returns every final answer. See [the shared multi-agent conventions](../_multiagent-conventions.md) for the wider dialect.
+
+## Input
+
+```typescript
+interface GraphInput {
+  nodes: {
+    id: string // [A-Za-z0-9_-], up to 64 chars, unique
+    systemPrompt?: string // <= 8000 chars
+    tools?: string[] // names from the parent agent's registry; no wildcards
+  }[]
+  edges: { fromId: string; toId: string }[]
+  initialInput: string // <= 32000 chars
+}
+```
+
+Caps:
+
+| Field                     | Cap         |
+| ------------------------- | ----------- |
+| Nodes                     | 20          |
+| Edges                     | 40          |
+| Tools per node allow-list | 64          |
+| Node id length            | 64          |
+| System prompt length      | 8000        |
+| Initial input length      | 32000       |
+| Max node executions       | 40          |
+| Total wall clock          | 300 seconds |
+| Per-node wall clock       | 120 seconds |
+
+The 300-second total is enforced as a hard ceiling: the invocation is wrapped in a timeout so a chain of long-running nodes cannot silently exceed it, even though the underlying Graph's own execution timeout is checked at node boundaries. If the ceiling fires, the tool returns a cancelled result with an empty output.
+
+## Result
+
+```typescript
+interface GraphOutput {
+  status: string // "completed" | "failed" | "cancelled" | "interrupted"
+  output: string // concatenated terminal-node text (blank-line separated)
+  executionOrder: string[] // node ids in completion order
+  results: Record<
+    string,
+    {
+      status: string
+      output: string // text-only; non-text content blocks are dropped
+      executionTimeMs: number
+    }
+  >
+  executionTimeMs: number
+}
+```
+
+Status strings are single-word lower-case values that match the Python side byte-for-byte, per the shared multi-agent dialect.
+
+## Recursion depth
+
+The tool participates in the shared `multiagentDepth` counter threaded through `invocationState`. Chains that cross tool boundaries (`use_agent -> graph -> use_agent`) are all capped at the same limit (default three). See [the shared multi-agent conventions](../_multiagent-conventions.md).
+
+## Customising the tool
+
+Use `makeGraph` when you need a different tool name, description, or depth cap:
+
+```typescript
+import { makeGraph } from '@strands-agents/sdk/vended-tools/graph'
+
+const shallowGraph = makeGraph({ maxDepth: 2 })
+```
+
+The knobs are factory-only — nothing surfaces to the model.
+
+## Non-goals
+
+Conditional edges are not supported: a shim should not evaluate model-supplied predicates at every edge. Per-node model overrides are not supported: sub-agents inherit the parent's model instance so credentials are never accepted from the caller. Node outputs are flattened to text, so nodes returning images or tool-use blocks will not propagate those to the graph result. If you need any of these, author a Graph directly.

--- a/strands-ts/src/vended-tools/graph/__tests__/graph.test.ts
+++ b/strands-ts/src/vended-tools/graph/__tests__/graph.test.ts
@@ -1,0 +1,419 @@
+/**
+ * Tests for the graph vended tool.
+ *
+ * The tool is a thin shim over `Graph`. Security-focused tests hit the
+ * validation surface (bad topology, oversized inputs, unknown tools,
+ * wildcards, cycles); happy-path tests exercise a small end-to-end DAG
+ * against `MockMessageModel` sub-agents.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { Agent } from '../../../agent/agent.js'
+import { MockMessageModel } from '../../../__fixtures__/mock-message-model.js'
+import { Graph } from '../../../multiagent/graph.js'
+import { TextBlock } from '../../../types/messages.js'
+import type { ToolContext } from '../../../tools/tool.js'
+import { graph, makeGraph, MAX_MULTIAGENT_DEPTH, MULTIAGENT_DEPTH_KEY } from '../graph.js'
+import { MAX_NODES, MAX_INITIAL_INPUT_LENGTH, MAX_SYSTEM_PROMPT_LENGTH, MAX_TOOLS_PER_NODE } from '../types.js'
+
+/**
+ * Build a parent agent whose model produces `count` deterministic replies.
+ * Each sub-agent inside the graph will consume one reply from the shared
+ * `MockMessageModel`, so callers pass `count = numberOfNodes` in happy paths.
+ */
+function makeParent(count: number): Agent {
+  const model = new MockMessageModel()
+  for (let i = 0; i < count; i++) {
+    model.addTurn(new TextBlock(`reply ${i}`))
+  }
+  return new Agent({ model, printer: false })
+}
+
+/**
+ * Real tool context so `context.agent.toolRegistry` / `cancelSignal` behave the
+ * same way they do in production.
+ */
+function toolContext(agent: Agent): ToolContext {
+  return {
+    toolUse: { name: 'graph', toolUseId: 'test-id', input: {} },
+    agent,
+    invocationState: {},
+    interrupt: () => {
+      throw new Error('interrupt not available in tool tests')
+    },
+  }
+}
+
+describe('graph tool — validation (security surface)', () => {
+  it('rejects a cycle', async () => {
+    const agent = makeParent(0)
+    await expect(
+      graph.invoke(
+        {
+          nodes: [{ id: 'a' }, { id: 'b' }],
+          edges: [
+            { fromId: 'a', toId: 'b' },
+            { fromId: 'b', toId: 'a' },
+          ],
+          initialInput: 'go',
+        },
+        toolContext(agent)
+      )
+    ).rejects.toThrow(/cycle/i)
+  })
+
+  it('rejects a self-loop', async () => {
+    const agent = makeParent(0)
+    await expect(
+      graph.invoke(
+        {
+          nodes: [{ id: 'a' }],
+          edges: [{ fromId: 'a', toId: 'a' }],
+          initialInput: 'go',
+        },
+        toolContext(agent)
+      )
+    ).rejects.toThrow(/Self-loop/)
+  })
+
+  it('rejects a tool name not registered on the parent', async () => {
+    const agent = makeParent(0)
+    await expect(
+      graph.invoke(
+        {
+          nodes: [{ id: 'a', tools: ['definitely_not_a_real_tool'] }],
+          edges: [],
+          initialInput: 'go',
+        },
+        toolContext(agent)
+      )
+    ).rejects.toThrow(/not registered on the parent/)
+  })
+
+  it('rejects a wildcard in a node tool allow-list', async () => {
+    const agent = makeParent(0)
+    await expect(
+      graph.invoke(
+        {
+          nodes: [{ id: 'a', tools: ['*'] }],
+          edges: [],
+          initialInput: 'go',
+        },
+        toolContext(agent)
+      )
+    ).rejects.toThrow(/wildcard/i)
+  })
+
+  it('rejects an oversized per-node tool allow-list', async () => {
+    const agent = makeParent(0)
+    const tools = Array.from({ length: MAX_TOOLS_PER_NODE + 1 }, () => 'not_a_tool')
+    await expect(
+      graph.invoke(
+        {
+          nodes: [{ id: 'a', tools }],
+          edges: [],
+          initialInput: 'go',
+        },
+        toolContext(agent)
+      )
+    ).rejects.toThrow(/tools/)
+  })
+
+  it('rejects too many nodes', async () => {
+    const agent = makeParent(0)
+    const nodes = Array.from({ length: MAX_NODES + 1 }, (_, i) => ({ id: `n${i}` }))
+    await expect(graph.invoke({ nodes, edges: [], initialInput: 'go' }, toolContext(agent))).rejects.toThrow(
+      /Too many nodes/
+    )
+  })
+
+  it('rejects duplicate node ids', async () => {
+    const agent = makeParent(0)
+    await expect(
+      graph.invoke(
+        {
+          nodes: [{ id: 'a' }, { id: 'a' }],
+          edges: [],
+          initialInput: 'go',
+        },
+        toolContext(agent)
+      )
+    ).rejects.toThrow(/Duplicate node id/)
+  })
+
+  it('rejects edges to unknown nodes', async () => {
+    const agent = makeParent(0)
+    await expect(
+      graph.invoke(
+        {
+          nodes: [{ id: 'a' }],
+          edges: [{ fromId: 'a', toId: 'ghost' }],
+          initialInput: 'go',
+        },
+        toolContext(agent)
+      )
+    ).rejects.toThrow(/unknown/)
+  })
+
+  it('rejects oversized initialInput', async () => {
+    const agent = makeParent(0)
+    await expect(
+      graph.invoke(
+        {
+          nodes: [{ id: 'a' }],
+          edges: [],
+          initialInput: 'x'.repeat(MAX_INITIAL_INPUT_LENGTH + 1),
+        },
+        toolContext(agent)
+      )
+    ).rejects.toThrow(/initialInput/)
+  })
+
+  it('rejects oversized systemPrompt', async () => {
+    const agent = makeParent(0)
+    await expect(
+      graph.invoke(
+        {
+          nodes: [{ id: 'a', systemPrompt: 'x'.repeat(MAX_SYSTEM_PROMPT_LENGTH + 1) }],
+          edges: [],
+          initialInput: 'go',
+        },
+        toolContext(agent)
+      )
+    ).rejects.toThrow(/systemPrompt/)
+  })
+
+  it('rejects a node id containing forbidden characters', async () => {
+    const agent = makeParent(0)
+    await expect(
+      graph.invoke(
+        {
+          nodes: [{ id: 'bad id!' }],
+          edges: [],
+          initialInput: 'go',
+        },
+        toolContext(agent)
+      )
+    ).rejects.toThrow()
+  })
+})
+
+describe('graph tool — happy path', () => {
+  it('runs a linear chain a -> b and returns per-node text', async () => {
+    // Two sub-agents, one model turn each.
+    const agent = makeParent(2)
+    const result = await graph.invoke(
+      {
+        nodes: [{ id: 'a' }, { id: 'b' }],
+        edges: [{ fromId: 'a', toId: 'b' }],
+        initialInput: 'start',
+      },
+      toolContext(agent)
+    )
+
+    expect(result.status).toBe('completed')
+    expect(Object.keys(result.results).sort()).toEqual(['a', 'b'])
+    const nodeA = result.results['a']!
+    const nodeB = result.results['b']!
+    expect(nodeA.status).toBe('completed')
+    expect(nodeB.status).toBe('completed')
+    expect(result.executionOrder).toEqual(['a', 'b'])
+    // `output` is the sole terminal (leaf) node's output — here that's `b`.
+    expect(result.output).toBe(nodeB.output)
+  })
+
+  it('runs a diamond a -> b/c -> d', async () => {
+    // Four sub-agents, one model turn each.
+    const agent = makeParent(4)
+    const result = await graph.invoke(
+      {
+        nodes: [{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }],
+        edges: [
+          { fromId: 'a', toId: 'b' },
+          { fromId: 'a', toId: 'c' },
+          { fromId: 'b', toId: 'd' },
+          { fromId: 'c', toId: 'd' },
+        ],
+        initialInput: 'start',
+      },
+      toolContext(agent)
+    )
+
+    expect(result.status).toBe('completed')
+    expect(Object.keys(result.results).sort()).toEqual(['a', 'b', 'c', 'd'])
+    // a is first, d is last; b and c can be in either order.
+    expect(result.executionOrder[0]).toBe('a')
+    expect(result.executionOrder.at(-1)).toBe('d')
+  })
+})
+
+describe('graph tool — multi-agent depth cap', () => {
+  it('refuses to start when the shared depth cap is reached', async () => {
+    const agent = makeParent(0)
+    const ctx: ToolContext = {
+      toolUse: { name: 'graph', toolUseId: 'test-id', input: {} },
+      agent,
+      invocationState: { [MULTIAGENT_DEPTH_KEY]: MAX_MULTIAGENT_DEPTH },
+      interrupt: () => {
+        throw new Error('interrupt not available in tool tests')
+      },
+    }
+    await expect(graph.invoke({ nodes: [{ id: 'a' }], edges: [], initialInput: 'go' }, ctx)).rejects.toThrow(
+      /recursion depth cap/
+    )
+  })
+
+  it('honours a lower cap set via makeGraph', async () => {
+    // A factory-configured cap is the only way to change the recursion limit
+    // (nothing surfaces to the model). Set it to 1 and start a call already at
+    // depth 1 — the tool must refuse.
+    const shallow = makeGraph({ maxDepth: 1 })
+    const agent = makeParent(0)
+    const ctx: ToolContext = {
+      toolUse: { name: 'graph', toolUseId: 'test-id', input: {} },
+      agent,
+      invocationState: { [MULTIAGENT_DEPTH_KEY]: 1 },
+      interrupt: () => {
+        throw new Error('interrupt not available in tool tests')
+      },
+    }
+    await expect(shallow.invoke({ nodes: [{ id: 'a' }], edges: [], initialInput: 'go' }, ctx)).rejects.toThrow(
+      /recursion depth cap of 1/
+    )
+  })
+
+  it('threads depth + 1 into the child Graph.invoke invocationState', async () => {
+    const agent = makeParent(1)
+    const ctx: ToolContext = {
+      toolUse: { name: 'graph', toolUseId: 'test-id', input: {} },
+      agent,
+      invocationState: { [MULTIAGENT_DEPTH_KEY]: 1 },
+      interrupt: () => {
+        throw new Error('interrupt not available in tool tests')
+      },
+    }
+
+    // Monkeypatch `Graph.prototype.invoke` to capture the options threaded in
+    // by the tool without disturbing execution. Direct patching (rather than
+    // `vi.spyOn`) is necessary because the tool constructs `new Graph(...)` at
+    // call time and the prototype patch must be visible on that instance.
+    const original = Graph.prototype.invoke
+    let capturedOptions: unknown = null
+    Graph.prototype.invoke = async function patched(this: Graph, input, options) {
+      capturedOptions = options
+      return original.call(this, input, options)
+    }
+    try {
+      await graph.invoke({ nodes: [{ id: 'a' }], edges: [], initialInput: 'go' }, ctx)
+    } finally {
+      Graph.prototype.invoke = original
+    }
+
+    expect(capturedOptions).toBeDefined()
+    expect((capturedOptions as { invocationState?: Record<string, unknown> })?.invocationState).toEqual({
+      [MULTIAGENT_DEPTH_KEY]: 2,
+    })
+  })
+})
+
+describe('graph tool — cancellation', () => {
+  it("returns cancelled when the parent agent's cancelSignal is already aborted", async () => {
+    const model = new MockMessageModel().addTurn(new TextBlock('reply'))
+    const agent = new Agent({ model, printer: false })
+    // Reach into the agent internals to pre-abort. The tool must not proceed
+    // — and per spec, it must return `{status: 'cancelled'}` rather than raise.
+
+    ;(agent as any)._abortController.abort()
+
+    ;(agent as any)._abortSignal = (agent as any)._abortController.signal
+
+    const result = await graph.invoke(
+      {
+        nodes: [{ id: 'a' }],
+        edges: [],
+        initialInput: 'go',
+      },
+      toolContext(agent)
+    )
+    expect(result.status).toBe('cancelled')
+    expect(result.output).toBe('')
+    expect(result.executionOrder).toEqual([])
+    expect(result.results).toEqual({})
+  })
+
+  it('returns cancelled when the SDK Graph throws mid-flight and the parent signal is aborted', async () => {
+    // The SDK's Graph throws `graph cancelled by external signal` when its
+    // external cancelSignal aborts mid-flight (see multiagent/graph.ts:343).
+    // The tool must catch that throw and return `{status: 'cancelled'}` per
+    // spec — it must not propagate the exception past the tool boundary.
+    // Monkey-patch `Graph.prototype.invoke` to arm the parent's cancel signal
+    // and throw the SDK's mid-flight cancel error deterministically. Without
+    // the round-3 catch, the tool would re-throw and this test would fail.
+    const model = new MockMessageModel().addTurn(new TextBlock('reply'))
+    const agent = new Agent({ model, printer: false })
+
+    const original = Graph.prototype.invoke
+    Graph.prototype.invoke = async function patchedInvoke(this: Graph) {
+      // Abort the parent so the tool's catch handler observes it and knows the
+      // throw was cancel-caused rather than a real failure.
+      ;(agent as any)._abortController.abort()
+      throw new Error(`graph_id=<${this.id}> | graph cancelled by external signal`)
+    }
+    try {
+      const result = await graph.invoke(
+        {
+          nodes: [{ id: 'a' }, { id: 'b' }],
+          edges: [{ fromId: 'a', toId: 'b' }],
+          initialInput: 'go',
+        },
+        toolContext(agent)
+      )
+      expect(result.status).toBe('cancelled')
+      expect(result.output).toBe('')
+    } finally {
+      Graph.prototype.invoke = original
+    }
+  })
+
+  it('propagates non-cancellation errors from Graph.invoke past the tool boundary', async () => {
+    // Verify the catch is scoped correctly: real failures still propagate.
+    // Without this, the previous test could pass trivially by swallowing all
+    // errors — this pins down that only cancellation-shaped errors turn into
+    // a cancelled result.
+    const model = new MockMessageModel().addTurn(new TextBlock('reply'))
+    const agent = new Agent({ model, printer: false })
+
+    const original = Graph.prototype.invoke
+    Graph.prototype.invoke = async function throwsRealError() {
+      throw new Error('some unrelated failure')
+    }
+    try {
+      await expect(
+        graph.invoke({ nodes: [{ id: 'a' }], edges: [], initialInput: 'go' }, toolContext(agent))
+      ).rejects.toThrow(/some unrelated failure/)
+    } finally {
+      Graph.prototype.invoke = original
+    }
+  })
+})
+
+describe('graph tool — multi-agent tool rejection', () => {
+  it('rejects a graph node that references a multi-agent tool by name', async () => {
+    // Register the graph tool itself on the parent so `graph` resolves in the
+    // registry — otherwise the "unknown tool" check would fire first and mask
+    // this rejection.
+    const model = new MockMessageModel().addTurn(new TextBlock('reply'))
+    const agent = new Agent({ model, printer: false, tools: [graph] })
+
+    await expect(
+      graph.invoke(
+        {
+          nodes: [{ id: 'a', tools: ['graph'] }],
+          edges: [],
+          initialInput: 'go',
+        },
+        toolContext(agent)
+      )
+    ).rejects.toThrow(/multi-agent tool/)
+  })
+})

--- a/strands-ts/src/vended-tools/graph/graph.ts
+++ b/strands-ts/src/vended-tools/graph/graph.ts
@@ -1,0 +1,424 @@
+/**
+ * Graph tool: deterministic DAG orchestration over the SDK's Graph primitive.
+ *
+ * Shim over `Graph` in `@strands-agents/sdk/multiagent`. The caller agent
+ * describes a DAG of sub-agents inline; this tool constructs a `Graph` from
+ * those specs and invokes it, returning per-node text results.
+ *
+ * Design notes:
+ * - **Shim only.** All orchestration lives in `multiagent/graph.ts`. This module
+ *   validates the model-supplied topology, builds sub-agents, wires them into a
+ *   `Graph`, and formats the result.
+ * - **No edge conditions.** Conditional routing would require executing
+ *   model-supplied code at every edge; not appropriate for a vended tool.
+ * - **Tools are name-allow-listed** from the parent agent's registry. The model
+ *   cannot conjure new tools inside a node — only reference tools the caller
+ *   already has. Mirrors the `use_agent` / `swarm` convention.
+ * - **Cycles are rejected** at validation time. `Graph` also requires reachability
+ *   from source nodes; the tool detects cycles explicitly before construction so
+ *   the failure message points at the actual problem.
+ */
+
+import { z } from 'zod'
+import { Agent } from '../../agent/agent.js'
+import { Graph } from '../../multiagent/graph.js'
+import { AgentNode } from '../../multiagent/nodes.js'
+import type { InvokableTool, Tool } from '../../tools/tool.js'
+import { tool } from '../../tools/tool-factory.js'
+import { TextBlock } from '../../types/messages.js'
+import type { ContentBlock } from '../../types/messages.js'
+import {
+  DEFAULT_NODE_TIMEOUT_MS,
+  DEFAULT_TIMEOUT_MS,
+  GRAPH_DESCRIPTION,
+  MAX_EDGES,
+  MAX_ID_LENGTH,
+  MAX_INITIAL_INPUT_LENGTH,
+  MAX_NODES,
+  MAX_STEPS,
+  MAX_SYSTEM_PROMPT_LENGTH,
+  MAX_TOOLS_PER_NODE,
+  type GraphNodeResult,
+  type GraphOutput,
+} from './types.js'
+
+/**
+ * Shared multi-agent recursion depth counter — see `_multiagent-conventions.md`.
+ * Every multi-agent vended tool (`use_agent`, `swarm`, `graph`, `a2a_client`)
+ * reads/increments the same key so a chain crossing tool boundaries is still
+ * capped.
+ */
+export const MULTIAGENT_DEPTH_KEY = 'multiagentDepth'
+export const MAX_MULTIAGENT_DEPTH = 3
+
+/**
+ * Multi-agent tool names that must never appear in a child node's allow-list.
+ * Depth-cap participation already blocks unbounded recursion, but the shared
+ * convention (`_multiagent-conventions.md`) also mandates an explicit reject at
+ * the tool boundary as defense-in-depth.
+ */
+const MULTIAGENT_TOOL_NAMES = new Set(['use_agent', 'swarm', 'graph', 'a2a_client'])
+
+function currentDepth(invocationState: Record<string, unknown> | undefined): number {
+  const raw = invocationState?.[MULTIAGENT_DEPTH_KEY]
+  if (typeof raw !== 'number' || !Number.isInteger(raw) || raw < 0) return 0
+  return raw
+}
+
+/**
+ * Build a `cancelled` result. Spec (`_multiagent-conventions.md`): a cancelled
+ * tool call returns `{status: 'cancelled'}` — it does not raise past the tool
+ * boundary. A cancelled result reaching the loop is a signal to the parent,
+ * not an exception to propagate.
+ */
+function cancelledOutput(startedAt: number, partial = ''): GraphOutput {
+  return {
+    status: 'cancelled',
+    output: partial,
+    executionOrder: [],
+    results: {},
+    executionTimeMs: Date.now() - startedAt,
+  }
+}
+
+const nodeIdPattern = /^[A-Za-z0-9_-]+$/
+
+const nodeSchema = z.object({
+  id: z
+    .string()
+    .min(1, 'Node id must be non-empty.')
+    .max(MAX_ID_LENGTH, `Node id must be at most ${MAX_ID_LENGTH} characters.`)
+    .regex(nodeIdPattern, 'Node id must match [A-Za-z0-9_-].')
+    .describe('Unique short identifier for the node.'),
+  systemPrompt: z
+    .string()
+    .max(MAX_SYSTEM_PROMPT_LENGTH, `systemPrompt must be at most ${MAX_SYSTEM_PROMPT_LENGTH} characters.`)
+    .optional()
+    .describe("Optional system prompt for this node's sub-agent."),
+  tools: z
+    .array(z.string().min(1))
+    .max(MAX_TOOLS_PER_NODE, `tools list must have at most ${MAX_TOOLS_PER_NODE} entries.`)
+    .optional()
+    .describe(
+      "Tool names to expose to this node, drawn from the parent agent's tool " +
+        'registry. Wildcards are not allowed; each tool must be listed by name.'
+    ),
+})
+
+const edgeSchema = z.object({
+  fromId: z.string().min(1).describe('Source node id.'),
+  toId: z.string().min(1).describe('Target node id.'),
+})
+
+const graphInputSchema = z.object({
+  nodes: z
+    .array(nodeSchema)
+    .min(1, "'nodes' must be a non-empty list.")
+    .max(MAX_NODES, `Too many nodes (max ${MAX_NODES}).`)
+    .describe('Nodes in the graph.'),
+  edges: z
+    .array(edgeSchema)
+    .max(MAX_EDGES, `Too many edges (max ${MAX_EDGES}).`)
+    .describe('Directed edges. Each entry declares that toId depends on fromId.'),
+  initialInput: z
+    .string()
+    .max(MAX_INITIAL_INPUT_LENGTH, `initialInput must be at most ${MAX_INITIAL_INPUT_LENGTH} characters.`)
+    .describe('The task passed to entry-point nodes (nodes with no incoming edges).'),
+})
+
+type NodeSpec = z.infer<typeof nodeSchema>
+type EdgeSpec = z.infer<typeof edgeSchema>
+
+/**
+ * Verifies the graph has no cycles using Kahn's algorithm. Returns nothing on
+ * success; throws when a cycle is detected. `Graph` is a DAG by design — cycle
+ * detection at the tool boundary makes the failure message point at the
+ * actual problem instead of a generic "unreachable node" error from the SDK.
+ */
+function assertNoCycle(nodes: NodeSpec[], edges: EdgeSpec[]): void {
+  const ids = new Set(nodes.map((n) => n.id))
+  const adjacency = new Map<string, string[]>()
+  const inDegree = new Map<string, number>()
+  for (const id of ids) inDegree.set(id, 0)
+
+  for (const edge of edges) {
+    if (!ids.has(edge.fromId)) {
+      throw new Error(`Edge references unknown source node '${edge.fromId}'.`)
+    }
+    if (!ids.has(edge.toId)) {
+      throw new Error(`Edge references unknown target node '${edge.toId}'.`)
+    }
+    if (edge.fromId === edge.toId) {
+      throw new Error(`Self-loop on node '${edge.fromId}' is not allowed; the graph must be a DAG.`)
+    }
+    const targets = adjacency.get(edge.fromId) ?? []
+    targets.push(edge.toId)
+    adjacency.set(edge.fromId, targets)
+    inDegree.set(edge.toId, (inDegree.get(edge.toId) ?? 0) + 1)
+  }
+
+  const queue: string[] = []
+  for (const [id, deg] of inDegree.entries()) {
+    if (deg === 0) queue.push(id)
+  }
+  let processed = 0
+  while (queue.length > 0) {
+    const current = queue.shift()!
+    processed++
+    for (const target of adjacency.get(current) ?? []) {
+      const next = (inDegree.get(target) ?? 0) - 1
+      inDegree.set(target, next)
+      if (next === 0) queue.push(target)
+    }
+  }
+  if (processed !== ids.size) {
+    throw new Error('Graph contains a cycle; graphs must be acyclic (DAG).')
+  }
+}
+
+/**
+ * Assert unique ids in the flat `nodes` list. Zod validates each entry
+ * individually but doesn't cross-check.
+ */
+function assertUniqueNodeIds(nodes: NodeSpec[]): void {
+  const seen = new Set<string>()
+  for (const node of nodes) {
+    if (seen.has(node.id)) {
+      throw new Error(`Duplicate node id '${node.id}'.`)
+    }
+    seen.add(node.id)
+  }
+}
+
+/**
+ * Resolve a node's tool allow-list against the parent registry. Rejects
+ * wildcards, empty strings, and unknown names. Deduplicates.
+ */
+function resolveTools(names: string[] | undefined, parentTools: Map<string, Tool>, nodeId: string): Tool[] {
+  if (!names || names.length === 0) return []
+  const resolved: Tool[] = []
+  const seen = new Set<string>()
+  for (const raw of names) {
+    if (raw === '*' || raw.includes('*')) {
+      throw new Error(
+        `Node '${nodeId}': tool '${raw}' looks like a wildcard. ` + 'List each tool by name; wildcards are not allowed.'
+      )
+    }
+    // Reject multi-agent tools by name — defense-in-depth on top of the shared
+    // depth cap. See `_multiagent-conventions.md`.
+    if (MULTIAGENT_TOOL_NAMES.has(raw)) {
+      throw new Error(
+        `Node '${nodeId}': tool '${raw}' is a multi-agent tool and may not be ` +
+          "used inside a graph node's allow-list."
+      )
+    }
+    if (seen.has(raw)) continue
+    seen.add(raw)
+    const t = parentTools.get(raw)
+    if (!t) {
+      throw new Error(`Node '${nodeId}': tool '${raw}' is not registered on the parent agent.`)
+    }
+    resolved.push(t)
+  }
+  return resolved
+}
+
+/**
+ * Coerce a node's ContentBlock output to a single text string. Non-text blocks
+ * (images, tool uses, reasoning) are dropped — the tool's result shape is text
+ * keyed by node id, which is what a downstream model will consume.
+ */
+function contentToText(blocks: ContentBlock[]): string {
+  const parts: string[] = []
+  for (const block of blocks) {
+    if (block instanceof TextBlock) {
+      parts.push(block.text)
+    }
+  }
+  return parts.join('\n').trim()
+}
+
+/**
+ * Options accepted by {@link makeGraph}. All fields are optional; each falls
+ * back to the shared spec's default. Factory-only — none of these knobs are
+ * surfaced to the model.
+ */
+export interface MakeGraphOptions {
+  /** Tool name shown to the model. Defaults to `"graph"`. */
+  name?: string
+  /** Tool description shown to the model. */
+  description?: string
+  /** Shared multi-agent recursion cap. Defaults to {@link MAX_MULTIAGENT_DEPTH}. */
+  maxDepth?: number
+}
+
+/**
+ * Create a graph tool. Mirrors Python's `make_graph`. Use when you want a
+ * different `name`, `description`, or `maxDepth` from the pre-built {@link graph}.
+ *
+ * @example
+ * ```typescript
+ * import { Agent } from '@strands-agents/sdk'
+ * import { makeGraph } from '@strands-agents/sdk/vended-tools/graph'
+ *
+ * const shallowGraph = makeGraph({ maxDepth: 2 })
+ * const agent = new Agent({ tools: [shallowGraph] })
+ * ```
+ */
+export function makeGraph(
+  options: MakeGraphOptions = {}
+): InvokableTool<z.infer<typeof graphInputSchema>, GraphOutput> {
+  const name = options.name ?? 'graph'
+  const description = options.description ?? GRAPH_DESCRIPTION
+  const maxDepth = options.maxDepth ?? MAX_MULTIAGENT_DEPTH
+
+  return tool({
+    name,
+    description,
+    inputSchema: graphInputSchema,
+    callback: async (input, context): Promise<GraphOutput> => {
+      if (!context) {
+        throw new Error('graph tool requires a tool context.')
+      }
+
+      const invocationState = context.invocationState as Record<string, unknown> | undefined
+      const depth = currentDepth(invocationState)
+      if (depth >= maxDepth) {
+        throw new Error(
+          `graph refused: multi-agent recursion depth cap of ${maxDepth} reached (current depth ${depth})`
+        )
+      }
+
+      const { nodes: nodeSpecs, edges: edgeSpecs, initialInput } = input
+
+      assertUniqueNodeIds(nodeSpecs)
+      assertNoCycle(nodeSpecs, edgeSpecs)
+
+      const startedAt = Date.now()
+
+      if (context.agent.cancelSignal.aborted) {
+        // Pre-flight cancellation: return the cancelled sentinel instead of
+        // raising. Spec (`_multiagent-conventions.md`): the tool returns
+        // `{status: 'cancelled'}`, does not raise past the tool boundary.
+        return cancelledOutput(startedAt)
+      }
+
+      const parentToolMap = new Map<string, Tool>()
+      for (const t of context.agent.toolRegistry.list()) {
+        parentToolMap.set(t.name, t)
+      }
+
+      const parentModel = context.agent.model
+
+      const agentNodes: AgentNode[] = nodeSpecs.map((spec) => {
+        const nodeTools = resolveTools(spec.tools, parentToolMap, spec.id)
+        const subAgent = new Agent({
+          id: spec.id,
+          model: parentModel,
+          printer: false,
+          ...(spec.systemPrompt !== undefined && { systemPrompt: spec.systemPrompt }),
+          tools: nodeTools,
+        })
+        return new AgentNode({ agent: subAgent })
+      })
+
+      const g = new Graph({
+        nodes: agentNodes,
+        edges: edgeSpecs.map((e) => ({ source: e.fromId, target: e.toId })),
+        timeout: DEFAULT_TIMEOUT_MS,
+        nodeTimeout: DEFAULT_NODE_TIMEOUT_MS,
+        maxSteps: MAX_STEPS,
+      })
+
+      const childInvocationState: Record<string, unknown> = { [MULTIAGENT_DEPTH_KEY]: depth + 1 }
+
+      // Hard wall-clock ceiling. The SDK `Graph`'s own `timeout` is checked at
+      // node boundaries, so an N-node chain of long-running nodes can silently
+      // exceed the cap. Composing an `AbortSignal.timeout` with the parent's
+      // cancel signal gives a strict upper bound that fires regardless of where
+      // execution is inside the graph — parity with the Python side's
+      // `asyncio.wait_for` guard.
+      const hardCeiling = AbortSignal.timeout(DEFAULT_TIMEOUT_MS)
+      const composedSignal = AbortSignal.any([context.agent.cancelSignal, hardCeiling])
+
+      let result
+      try {
+        result = await g.invoke(initialInput, {
+          cancelSignal: composedSignal,
+          invocationState: childInvocationState,
+        })
+      } catch (err) {
+        // The SDK's `Graph` throws when its `cancelSignal` aborts mid-flight
+        // (see `graph.ts:343`). Map that back to a cancelled result — spec
+        // forbids raising past the tool boundary. Anything else is a real
+        // error and should propagate. The hard-ceiling `AbortSignal.timeout`
+        // is treated the same way: no useful result once the cap fires.
+        if (composedSignal.aborted) {
+          return cancelledOutput(startedAt)
+        }
+        throw err
+      }
+
+      const results: Record<string, GraphNodeResult> = {}
+      const executionOrder: string[] = []
+      for (const nodeResult of result.results) {
+        results[nodeResult.nodeId] = {
+          // Lowercase the SDK enum value so the tool result matches the Python
+          // side and the shared multi-agent dialect (see
+          // `_multiagent-conventions.md`), which specifies single-word lowercase
+          // status strings.
+          status: nodeResult.status.toLowerCase(),
+          output: nodeResult.error ? `error: ${nodeResult.error.message}` : contentToText(nodeResult.content),
+          executionTimeMs: nodeResult.duration,
+        }
+        executionOrder.push(nodeResult.nodeId)
+      }
+
+      const terminalOutput = aggregateTerminalOutput(nodeSpecs, edgeSpecs, results)
+
+      return {
+        status: result.status.toLowerCase(),
+        output: terminalOutput,
+        executionOrder,
+        results,
+        executionTimeMs: result.duration,
+      }
+    },
+  })
+}
+
+/**
+ * Pre-built graph tool. Register on an `Agent` alongside any tools you want
+ * the graph's nodes to be able to call.
+ *
+ * @example
+ * ```typescript
+ * import { Agent } from '@strands-agents/sdk'
+ * import { graph } from '@strands-agents/sdk/vended-tools/graph'
+ *
+ * const agent = new Agent({ tools: [graph] })
+ * ```
+ */
+export const graph = makeGraph()
+
+/**
+ * Concatenate every terminal (leaf) node's output text, joined by a blank
+ * line, in graph declaration order. A graph without a single named sink
+ * typically returns multiple final outputs; dropping any of them would
+ * silently truncate the tool's answer.
+ */
+function aggregateTerminalOutput(
+  nodes: NodeSpec[],
+  edges: EdgeSpec[],
+  results: Record<string, GraphNodeResult>
+): string {
+  const withOutgoing = new Set<string>(edges.map((e) => e.fromId))
+  const parts: string[] = []
+  for (const spec of nodes) {
+    if (withOutgoing.has(spec.id)) continue
+    const nodeResult = results[spec.id]
+    if (!nodeResult) continue
+    if (nodeResult.output) parts.push(nodeResult.output)
+  }
+  return parts.join('\n\n')
+}

--- a/strands-ts/src/vended-tools/graph/index.ts
+++ b/strands-ts/src/vended-tools/graph/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Graph tool for deterministic DAG multi-agent orchestration.
+ */
+
+export { graph, makeGraph } from './graph.js'
+export type { MakeGraphOptions } from './graph.js'
+export {
+  DEFAULT_NODE_TIMEOUT_MS,
+  DEFAULT_TIMEOUT_MS,
+  GRAPH_DESCRIPTION,
+  MAX_EDGES,
+  MAX_ID_LENGTH,
+  MAX_INITIAL_INPUT_LENGTH,
+  MAX_NODES,
+  MAX_STEPS,
+  MAX_SYSTEM_PROMPT_LENGTH,
+  MAX_TOOLS_PER_NODE,
+} from './types.js'
+export type { GraphNodeResult, GraphOutput } from './types.js'

--- a/strands-ts/src/vended-tools/graph/types.ts
+++ b/strands-ts/src/vended-tools/graph/types.ts
@@ -1,0 +1,87 @@
+/**
+ * Type definitions, caps, and description constants for the graph vended tool.
+ */
+
+/**
+ * Maximum number of nodes the tool will accept in one call.
+ * Sized to keep the DAG a coordination surface, not a job runner. Anything
+ * meaningfully larger belongs in a user-authored `Graph` outside the tool.
+ */
+export const MAX_NODES = 20
+
+/** Maximum number of edges the tool will accept in one call. */
+export const MAX_EDGES = 40
+
+/** Maximum length of a node id (characters). */
+export const MAX_ID_LENGTH = 64
+
+/** Maximum length (characters) of any node's `systemPrompt`. */
+export const MAX_SYSTEM_PROMPT_LENGTH = 8_000
+
+/** Maximum length (characters) of the `initialInput` passed to the graph. */
+export const MAX_INITIAL_INPUT_LENGTH = 32_000
+
+/** Wall-clock budget for the whole graph invocation, in milliseconds. */
+export const DEFAULT_TIMEOUT_MS = 300_000
+
+/** Wall-clock budget for each node in the graph, in milliseconds. */
+export const DEFAULT_NODE_TIMEOUT_MS = 120_000
+
+/** Maximum steps (node executions) the underlying `Graph` is allowed to take. */
+export const MAX_STEPS = 40
+
+/** Maximum number of tool names a single node may list in its allow-list. */
+export const MAX_TOOLS_PER_NODE = 64
+
+/** Tool description shown to the model. */
+export const GRAPH_DESCRIPTION =
+  'Runs a deterministic directed acyclic graph (DAG) of sub-agents. ' +
+  'You describe the nodes (each with an optional system prompt and tool allow-list) ' +
+  'and the edges (dependency order); the tool executes the graph, feeding each node ' +
+  'the outputs of its dependencies, and returns the results keyed by node id. ' +
+  'Use when a task has a fixed pipeline shape with clear dependencies; use plain tool ' +
+  'calls for single-step work.'
+
+/**
+ * One node's result in the aggregated graph output.
+ */
+export interface GraphNodeResult {
+  /**
+   * Node status. Lower-case single-word string ("completed", "failed",
+   * "cancelled", "interrupted"). Matches the Python side byte-for-byte per
+   * the shared multi-agent dialect.
+   */
+  status: string
+  /** Text output the node produced. Empty when the node failed before producing content. */
+  output: string
+  /** Node wall-clock time in milliseconds. */
+  executionTimeMs: number
+}
+
+/**
+ * Aggregated result of a graph invocation.
+ *
+ * Shape follows the shared multi-agent dialect: `status`, `output`, and
+ * `executionTimeMs` are the common contract; `executionOrder` and `results`
+ * are the graph-specific extensions.
+ *
+ * `output` is the concatenation of every terminal (leaf) node's text, joined
+ * by a blank line — see `_multiagent-conventions.md` for the rationale.
+ */
+export interface GraphOutput {
+  /**
+   * Overall graph status. Lower-case single-word string ("completed",
+   * "failed", "cancelled", "interrupted") matching the Python side.
+   */
+  status: string
+  /** Concatenated text of every terminal (leaf) node's output. */
+  output: string
+  /** Node ids in the order they completed. */
+  executionOrder: string[]
+  /** Per-node results keyed by node id. */
+  results: Record<string, GraphNodeResult>
+  /** Total wall-clock time for the whole graph, in milliseconds. */
+  executionTimeMs: number
+  /** Allow indexing with string keys for JSONValue compatibility. */
+  [key: string]: unknown
+}

--- a/strands-ts/src/vended-tools/index.ts
+++ b/strands-ts/src/vended-tools/index.ts
@@ -13,5 +13,6 @@
 
 export * from './bash/index.js'
 export * from './file-editor/index.js'
+export * from './graph/index.js'
 export * from './http-request/index.js'
 export * from './notebook/index.js'


### PR DESCRIPTION
Adds a graph vended tool in both SDKs. The caller agent describes a directed acyclic graph of sub-agents inline: nodes with optional system prompts and per-node tool allow-lists, edges giving the dependency order. The tool constructs a Graph via the SDK's GraphBuilder in Python and Graph in TypeScript, runs it, and returns per-node text results keyed by node id. Shim over strands.multiagent.graph on the Python side and multiagent/graph.ts on the TypeScript side, so all execution semantics live in the primitive.

Each node's tools field is a strict name allow-list resolved against the parent agent's tool registry. Wildcards and unknown names are rejected before any sub-agent is built, and the multi-agent tool names use_agent, swarm, graph, and a2a_client are refused inside a node as defense in depth on top of the shared depth cap. Sub-agents inherit the parent's model instance rather than accepting a provider string from the caller, so credentials cannot be injected through the tool. Cycles and self-loops are rejected at the tool boundary via Kahn's algorithm so the failure points at the actual problem rather than surfacing as a generic reachability error from the SDK. Node count, edge count, id length, prompt length, initial input length, and total step count are all capped, and the total wall-clock budget of three hundred seconds is enforced as a hard ceiling in Python via asyncio.wait_for so a chain of long-running nodes cannot silently exceed it.

Parent cancellation is observed at the next BeforeNodeCallEvent boundary via a hook the tool registers on the graph and, on the TypeScript side, by forwarding the parent's cancel signal into Graph.invoke. On cancellation the tool returns a cancelled result rather than raising, per the shared multi-agent conventions doc shipped alongside this PR. Node outputs are flattened to text, so non-text content blocks cannot smuggle model-controlled bytes back through the graph result path.

This PR also ships the shared multi-agent conventions document at strands-py/src/strands/vended_tools/_multiagent_conventions.md and strands-ts/src/vended-tools/_multiagent-conventions.md. The sibling tools swarm, use_agent, and a2a_client reference this dialect. Landing one canonical version keeps the four convergent.

Deliberately not supported: edge conditions (executing model-supplied predicates at every edge is more attack surface than value for a vended tool) and per-node model override (accepting provider strings from the caller reintroduces the credential-injection surface the shared spec rejects). Users who need either can author a Graph directly.

https://github.com/strands-agents/harness-sdk/issues/3246