### PR TITLE
feat(vended-tools): add file_read shim over file_editor

### DIFF
--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools-imports.ts
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools-imports.ts
@@ -35,3 +35,8 @@ import { bash } from '@strands-agents/sdk/vended-tools/bash'
 import { fileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
 import { notebook } from '@strands-agents/sdk/vended-tools/notebook'
 // --8<-- [end:combined_import]
+
+// --8<-- [start:file_read_import]
+import { Agent } from '@strands-agents/sdk'
+import { fileRead } from '@strands-agents/sdk/vended-tools/file-read'
+// --8<-- [end:file_read_import]

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -10,6 +10,8 @@ sourceLinks:
   - path: strands-ts/src/vended-tools/bash/bash.ts
   - path: strands-ts/src/vended-tools/http-request/http-request.ts
   - path: strands-ts/src/vended-tools/notebook/notebook.ts
+  - path: strands-ts/src/vended-tools/file-read/file-read.ts
+  - path: strands-py/src/strands/vended_tools/file_read/file_read.py
 ---
 
 Vended tools are pre-built tools included directly in the Strands SDK for common agent tasks like file operations, shell commands, HTTP requests, and persistent notes. 
@@ -34,6 +36,7 @@ Each tool is imported from its own subpath under `@strands-agents/sdk/vended-too
 | [HTTP Request](#http-request) | Make HTTP requests to external APIs | TypeScript (Node.js 20+, browsers) |
 | [Notebook](#notebook) | Manage persistent text notebooks | TypeScript (Node.js, browsers) |
 | [Bash](#bash) | Execute shell commands with persistent sessions | Python, TypeScript (Node.js, Unix/Linux/macOS) |
+| [File Read](#file-read) | Read a file or list a directory (read-only) | Python, TypeScript (Node.js) |
 
 ### File Editor
 
@@ -160,6 +163,43 @@ agent("List all Python files in the current directory and count them")
 ```
 
 📖 [Full API Reference](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/bash/README.md)
+
+---
+
+### File Read
+
+A read-only view of the filesystem. The agent can view a file (optionally with a line range) or list a directory, but cannot create, edit, or delete anything. The tool is a thin shim over the file editor's view command with a two-parameter surface, so a read-only agent's tool schema does not include any write-side parameters.
+
+_Supported in: Node.js (TypeScript); all platforms (Python)._
+
+All validation is delegated to the file editor: paths must be absolute, directory traversal is rejected on the raw input, files above the configured size limit are rejected, and all input and output goes through the agent's sandbox.
+
+**Example:**
+
+<Tabs>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/tools/vended-tools-imports.ts:file_read_import"
+
+--8<-- "user-guide/concepts/tools/vended-tools.ts:file_read_example"
+```
+
+</Tab>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.vended_tools import file_read
+
+agent = Agent(tools=[file_read])
+agent("Read the first twenty lines of /tmp/config.json")
+```
+
+</Tab>
+</Tabs>
+
+📖 [Full API Reference](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/file-read/README.md)
 
 ---
 

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.ts
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.ts
@@ -110,6 +110,18 @@ async function notebookStatePersistenceExample() {
   // --8<-- [end:notebook_state_persistence]
 }
 
+import { fileRead } from '@strands-agents/sdk/vended-tools/file-read'
+
+// File read example
+async function fileReadExample() {
+  // --8<-- [start:file_read_example]
+  const agent = new Agent({
+    tools: [fileRead],
+  })
+  await agent.invoke('Read the first twenty lines of /tmp/config.json')
+  // --8<-- [end:file_read_example]
+}
+
 // Combined tools example - development workflow
 async function combinedToolsExample() {
   // --8<-- [start:combined_tools_example]

--- a/strands-py/src/strands/vended_tools/__init__.py
+++ b/strands-py/src/strands/vended_tools/__init__.py
@@ -1,10 +1,11 @@
 """Built-in tools for executing commands and editing files.
 
 The :data:`bash` tool runs a
-persistent shell on the host; the :func:`make_bash` and :func:`make_file_editor`
-factories produce sandbox-routed tools that either bind to a
-:class:`~strands.sandbox.base.Sandbox` at creation (as the built-in Docker/SSH
-sandboxes do when vending tools) or read the sandbox from the agent at call time.
+persistent shell on the host; the :func:`make_bash`, :func:`make_file_editor`,
+and :func:`make_file_read` factories produce sandbox-routed tools that either
+bind to a :class:`~strands.sandbox.base.Sandbox` at creation (as the built-in
+Docker/SSH sandboxes do when vending tools) or read the sandbox from the agent
+at call time.
 
 Example Usage:
     ```python
@@ -17,10 +18,13 @@ Example Usage:
 
 from .bash import bash, make_bash
 from .file_editor import file_editor, make_file_editor
+from .file_read import file_read, make_file_read
 
 __all__ = [
     "bash",
     "file_editor",
+    "file_read",
     "make_bash",
     "make_file_editor",
+    "make_file_read",
 ]

--- a/strands-py/src/strands/vended_tools/file_read/__init__.py
+++ b/strands-py/src/strands/vended_tools/file_read/__init__.py
@@ -1,0 +1,22 @@
+"""Read-only file tool.
+
+A thin shim over :func:`~strands.vended_tools.file_editor.make_file_editor`'s
+``view`` command with a narrower two-parameter surface (``path`` and
+``view_range``). All validation is delegated to ``file_editor``.
+
+Example Usage:
+    ```python
+    from strands import Agent
+    from strands.vended_tools import file_read
+
+    agent = Agent(tools=[file_read])
+    ```
+"""
+
+from .file_read import DEFAULT_FILE_READ_DESCRIPTION, file_read, make_file_read
+
+__all__ = [
+    "DEFAULT_FILE_READ_DESCRIPTION",
+    "file_read",
+    "make_file_read",
+]

--- a/strands-py/src/strands/vended_tools/file_read/file_read.py
+++ b/strands-py/src/strands/vended_tools/file_read/file_read.py
@@ -1,0 +1,92 @@
+"""Read-only file tool.
+
+A minimal, read-only surface over :func:`~strands.vended_tools.file_editor.make_file_editor`:
+the model sees only ``path`` and ``view_range``, and every call is routed through
+``file_editor``'s ``view`` command. All input validation (absolute path, ``..``
+traversal, size limit, ``view_range`` bounds, sandbox probing) is delegated to
+``file_editor``; this tool intentionally adds no new logic and no new checks.
+
+Use this tool when an agent should be able to read files and list directories
+but must not be able to create or edit them.
+
+Note on schema strictness: the TypeScript tool uses a ``.strict()`` Zod schema
+that rejects any key outside ``{path, view_range}`` with a validation error.
+The Python tool relies on Pydantic's default behavior in ``@tool``, which
+silently strips unknown keys. Both paths are safe -- the shim hard-codes
+``command="view"``, so a smuggled ``command`` or ``file_text`` field cannot
+reach ``file_editor``'s write branches -- but the model receives feedback only
+in the TypeScript path. This mirrors the ``@tool`` decorator's convention for
+all vended Python tools and is intentional.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+from ...tools.decorator import tool
+from ...types.tools import ToolContext
+from ..file_editor import make_file_editor
+
+if TYPE_CHECKING:
+    from ...sandbox.base import Sandbox
+    from ...tools.decorator import DecoratedFunctionTool
+
+DEFAULT_FILE_READ_DESCRIPTION = (
+    "Read-only filesystem tool. View a file (with an optional line range) or list a directory. "
+    "Paths must be absolute. For creating or editing files, use `file_editor`."
+)
+"""Description for the file_read tool."""
+
+
+def make_file_read(
+    *,
+    sandbox: Sandbox | None = None,
+    name: str = "file_read",
+    description: str = DEFAULT_FILE_READ_DESCRIPTION,
+) -> DecoratedFunctionTool:
+    """Create a sandbox-routed, read-only file tool.
+
+    A thin shim over ``file_editor``'s ``view`` command with a narrower input
+    schema. If ``sandbox`` is passed, it is bound at creation time. Otherwise
+    the underlying ``file_editor`` reads the sandbox from
+    ``tool_context.agent.sandbox`` at call time.
+
+    Args:
+        sandbox: Sandbox to bind at creation. When ``None``, the agent's
+            configured sandbox is used at call time.
+        name: Tool name. Defaults to ``"file_read"``.
+        description: Tool description shown to the model.
+
+    Returns:
+        A decorated tool that reads files and lists directories through the sandbox.
+    """
+    editor = make_file_editor(sandbox=sandbox)
+
+    @tool(name=name, description=description, context="tool_context")
+    async def file_read_tool(
+        path: str,
+        tool_context: ToolContext,
+        view_range: tuple[int, int] | None = None,
+    ) -> str:
+        """Read a file or list a directory.
+
+        Args:
+            path: Absolute path to a file or directory.
+            tool_context: Injected by the framework. Not user-facing.
+            view_range: Optional line range ``[start, end]`` to view. 1-indexed;
+                ``end`` may be ``-1`` for end-of-file. Not allowed when ``path``
+                is a directory.
+        """
+        result = await editor(
+            command="view",
+            path=path,
+            tool_context=tool_context,
+            view_range=list(view_range) if view_range is not None else None,
+        )
+        return cast(str, result)
+
+    return file_read_tool
+
+
+file_read = make_file_read()
+"""Default read-only file tool. Reads the sandbox from the agent's context at call time."""

--- a/strands-py/tests/strands/vended_tools/test_file_read.py
+++ b/strands-py/tests/strands/vended_tools/test_file_read.py
@@ -1,0 +1,171 @@
+"""Tests for the sandbox-routed, read-only file tool.
+
+``file_read`` is a thin shim over ``file_editor``'s ``view`` command. The
+security surface (absolute paths, ``..`` traversal, size limit, ``view_range``
+bounds, missing paths) is enforced by ``file_editor`` and must be reachable
+through the shim — these tests confirm that delegation, not re-implementation.
+"""
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from strands.sandbox.not_a_sandbox_local_environment import NotASandboxLocalEnvironment
+from strands.types.tools import ToolContext
+from strands.vended_tools.file_read import DEFAULT_FILE_READ_DESCRIPTION, file_read, make_file_read
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="POSIX path semantics assumed")
+
+
+def _tool_context(sandbox: NotASandboxLocalEnvironment | None = None) -> ToolContext:
+    agent = SimpleNamespace(sandbox=sandbox or NotASandboxLocalEnvironment())
+    return ToolContext(
+        tool_use={"name": "file_read", "toolUseId": "test-id", "input": {}},
+        agent=agent,
+        invocation_state={},
+    )
+
+
+def _write(path, content: str) -> str:
+    path.write_text(content)
+    return str(path)
+
+
+@pytest.fixture
+def reader():
+    return make_file_read(sandbox=NotASandboxLocalEnvironment())
+
+
+@pytest.fixture
+def ctx():
+    return _tool_context()
+
+
+class TestReadFile:
+    """Happy path: read a whole file or a slice of one."""
+
+    @pytest.mark.asyncio
+    async def test_returns_content_with_line_numbers(self, reader, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "Line 1\nLine 2\nLine 3")
+        result = await reader(path=file_path, tool_context=ctx)
+        assert "Here's the result of running `cat -n`" in result
+        assert "     1  Line 1" in result
+        assert "     3  Line 3" in result
+
+    @pytest.mark.asyncio
+    async def test_view_range(self, reader, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "Line 1\nLine 2\nLine 3\nLine 4\nLine 5")
+        result = await reader(path=file_path, tool_context=ctx, view_range=[2, 4])
+        assert "     2  Line 2" in result
+        assert "     4  Line 4" in result
+        assert "     1  " not in result
+        assert "     5  " not in result
+
+    @pytest.mark.asyncio
+    async def test_view_range_negative_end(self, reader, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "Line 1\nLine 2\nLine 3")
+        result = await reader(path=file_path, tool_context=ctx, view_range=[2, -1])
+        assert "     2  Line 2" in result
+        assert "     3  Line 3" in result
+        assert "     1  " not in result
+
+    @pytest.mark.asyncio
+    async def test_lists_directory(self, reader, ctx, tmp_path):
+        d = tmp_path / "testdir"
+        d.mkdir()
+        _write(d / "file1.txt", "content")
+        _write(d / "file2.txt", "content")
+        result = await reader(path=str(d), tool_context=ctx)
+        assert "file1.txt" in result
+        assert "file2.txt" in result
+
+
+class TestViewRangeShape:
+    """The view_range parameter is fixed-length [start, end]; other lengths are rejected."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_single_element_range(self, reader, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "Line 1\nLine 2")
+        agent = SimpleNamespace(sandbox=NotASandboxLocalEnvironment())
+        tool_use = {
+            "name": "file_read",
+            "toolUseId": "malformed",
+            "input": {"path": file_path, "view_range": [2]},
+        }
+        events = [e async for e in reader.stream(tool_use, {"agent": agent})]
+        result = events[-1].tool_result
+        assert result["status"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_rejects_three_element_range(self, reader, ctx, tmp_path):
+        file_path = _write(tmp_path / "test.txt", "Line 1\nLine 2")
+        agent = SimpleNamespace(sandbox=NotASandboxLocalEnvironment())
+        tool_use = {
+            "name": "file_read",
+            "toolUseId": "malformed",
+            "input": {"path": file_path, "view_range": [1, 2, 3]},
+        }
+        events = [e async for e in reader.stream(tool_use, {"agent": agent})]
+        result = events[-1].tool_result
+        assert result["status"] == "error"
+
+
+class TestSecurityDelegation:
+    """The security surface must be inherited from file_editor verbatim.
+
+    The shim adds no validation logic — file_editor owns the security surface
+    (absolute path, ``..`` traversal, size cap, view_range bounds, directory
+    checks). We prove delegation with a single traversal probe; the exhaustive
+    security suite lives with file_editor.
+    """
+
+    @pytest.mark.asyncio
+    async def test_surfaces_file_editor_validation(self, reader, ctx):
+        with pytest.raises(ValueError, match="path traversal"):
+            await reader(path="/tmp/../etc/passwd", tool_context=ctx)
+
+
+class TestToolMetadata:
+    """The tool must expose a narrower, read-only schema — no write parameters."""
+
+    def test_default_name(self):
+        assert file_read.tool_name == "file_read"
+
+    def test_custom_name(self):
+        assert make_file_read(name="reader").tool_name == "reader"
+
+    def test_default_description(self):
+        assert make_file_read().tool_spec["description"] == DEFAULT_FILE_READ_DESCRIPTION
+
+    def test_input_schema_is_read_only(self):
+        props = file_read.tool_spec["inputSchema"]["json"]["properties"]
+        assert set(props.keys()) == {"path", "view_range"}
+        # The write-side surface of file_editor must not leak through.
+        for banned in ("command", "file_text", "old_str", "new_str", "insert_line"):
+            assert banned not in props
+
+    def test_input_schema_excludes_context(self):
+        props = file_read.tool_spec["inputSchema"]["json"]["properties"]
+        assert "tool_context" not in props
+
+    @pytest.mark.asyncio
+    async def test_smuggled_write_params_are_stripped(self, reader, tmp_path):
+        # A model could try to smuggle write-side params through the tool call.
+        # Pydantic strips extras from the validated input, so the shim's
+        # hard-coded command="view" is the only thing that reaches file_editor.
+        file_path = _write(tmp_path / "test.txt", "ok")
+        agent = SimpleNamespace(sandbox=NotASandboxLocalEnvironment())
+        tool_use = {
+            "name": "file_read",
+            "toolUseId": "smuggle",
+            "input": {"path": file_path, "command": "create", "file_text": "pwned"},
+        }
+        events = [e async for e in reader.stream(tool_use, {"agent": agent})]
+        result = events[-1].tool_result
+        assert result["status"] == "success"
+        text = result["content"][0]["text"]
+        assert "Here's the result of running `cat -n`" in text
+        assert "ok" in text
+        # The smuggled write did not happen.
+        assert (tmp_path / "test.txt").read_text() == "ok"

--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -60,6 +60,10 @@
       "types": "./dist/src/vended-tools/file-editor/index.d.ts",
       "default": "./dist/src/vended-tools/file-editor/index.js"
     },
+    "./vended-tools/file-read": {
+      "types": "./dist/src/vended-tools/file-read/index.d.ts",
+      "default": "./dist/src/vended-tools/file-read/index.js"
+    },
     "./vended-tools/http-request": {
       "types": "./dist/src/vended-tools/http-request/index.d.ts",
       "default": "./dist/src/vended-tools/http-request/index.js"

--- a/strands-ts/src/vended-tools/file-read/README.md
+++ b/strands-ts/src/vended-tools/file-read/README.md
@@ -1,0 +1,24 @@
+# File Read Tool
+
+A read-only view of the filesystem: the agent can view a file (with an optional line range) or list a directory. The tool is a thin shim over the file editor's view command with a two-parameter surface (path and view_range), so a read-only agent's tool schema does not include the write-side parameters (file_text, old_str, new_str, insert_line) at all. All validation is delegated to the file editor; updates to its security surface propagate here automatically.
+
+## Usage
+
+```typescript
+import { fileRead } from '@strands-agents/sdk/vended-tools/file-read'
+import { Agent, BedrockModel } from '@strands-agents/sdk'
+
+const agent = new Agent({
+  model: new BedrockModel({ region: 'us-east-1' }),
+  tools: [fileRead],
+})
+
+await agent.invoke('Read the first twenty lines of /tmp/config.json')
+```
+
+## Parameters
+
+- `path` (string, required): Absolute path to a file or directory.
+- `view_range` (`[number, number]`, optional): Line range to view. 1-indexed; `end` may be `-1` for end-of-file. Not allowed when `path` points to a directory.
+
+For any write operation, use [`fileEditor`](../file-editor/README.md).

--- a/strands-ts/src/vended-tools/file-read/__tests__/file-read.test.node.ts
+++ b/strands-ts/src/vended-tools/file-read/__tests__/file-read.test.node.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { fileRead, makeFileRead, DEFAULT_FILE_READ_DESCRIPTION } from '../file-read.js'
+import type { ToolContext } from '../../../index.js'
+import { createMockAgent } from '../../../__fixtures__/agent-helpers.js'
+import { promises as fs } from 'fs'
+import * as path from 'path'
+import { tmpdir } from 'os'
+
+describe('fileRead tool', () => {
+  let testDir: string
+  let context: ToolContext
+
+  const createFreshContext = (): ToolContext => {
+    const agent = createMockAgent()
+    return {
+      toolUse: { name: 'fileRead', toolUseId: 'test-id', input: {} },
+      agent,
+      invocationState: {},
+      interrupt: () => {
+        throw new Error('interrupt not available in mock context')
+      },
+    }
+  }
+
+  const createTestFile = async (filename: string, content: string): Promise<string> => {
+    const filePath = path.join(testDir, filename)
+    const dir = path.dirname(filePath)
+    await fs.mkdir(dir, { recursive: true })
+    await fs.writeFile(filePath, content, 'utf-8')
+    return filePath
+  }
+
+  beforeEach(async () => {
+    testDir = path.join(tmpdir(), `file-read-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    await fs.mkdir(testDir, { recursive: true })
+    context = createFreshContext()
+  })
+
+  afterEach(async () => {
+    try {
+      await fs.rm(testDir, { recursive: true, force: true })
+    } catch {
+      // ignore cleanup errors
+    }
+  })
+
+  describe('happy path', () => {
+    it('reads a file with line numbers', async () => {
+      const filePath = await createTestFile('test.txt', 'Line 1\nLine 2\nLine 3')
+      const result = (await fileRead.invoke({ path: filePath }, context)) as string
+      expect(result).toContain("Here's the result of running `cat -n`")
+      expect(result).toContain('     1  Line 1')
+      expect(result).toContain('     3  Line 3')
+    })
+
+    it('honours view_range', async () => {
+      const filePath = await createTestFile('test.txt', 'Line 1\nLine 2\nLine 3\nLine 4\nLine 5')
+      const result = (await fileRead.invoke({ path: filePath, view_range: [2, 4] }, context)) as string
+      expect(result).toContain('     2  Line 2')
+      expect(result).toContain('     4  Line 4')
+      expect(result).not.toContain('     1  ')
+      expect(result).not.toContain('     5  ')
+    })
+
+    it('supports -1 for end-of-file', async () => {
+      const filePath = await createTestFile('test.txt', 'Line 1\nLine 2\nLine 3')
+      const result = (await fileRead.invoke({ path: filePath, view_range: [2, -1] }, context)) as string
+      expect(result).toContain('     2  Line 2')
+      expect(result).toContain('     3  Line 3')
+      expect(result).not.toContain('     1  ')
+    })
+
+    it('lists a directory', async () => {
+      const dirPath = path.join(testDir, 'sub')
+      await fs.mkdir(dirPath, { recursive: true })
+      await fs.writeFile(path.join(dirPath, 'a.txt'), 'a', 'utf-8')
+      await fs.writeFile(path.join(dirPath, 'b.txt'), 'b', 'utf-8')
+      const result = (await fileRead.invoke({ path: dirPath }, context)) as string
+      expect(result).toContain('a.txt')
+      expect(result).toContain('b.txt')
+    })
+  })
+
+  describe('security delegation', () => {
+    // The shim adds no validation logic — file_editor owns the security surface
+    // (absolute path, `..` traversal, size cap, view_range bounds, directory
+    // checks). We prove delegation with a single traversal probe; the exhaustive
+    // security suite lives with file_editor.
+    it('surfaces file_editor validation through the shim', async () => {
+      await expect(fileRead.invoke({ path: '/tmp/../etc/passwd' }, context)).rejects.toThrow('path traversal')
+    })
+  })
+
+  describe('tool metadata', () => {
+    it('has the default name and description', () => {
+      expect(fileRead.name).toBe('fileRead')
+      expect(fileRead.description).toBe(DEFAULT_FILE_READ_DESCRIPTION)
+    })
+
+    it('allows overriding name and description', () => {
+      const custom = makeFileRead({ name: 'reader', description: 'custom read tool' })
+      expect(custom.name).toBe('reader')
+      expect(custom.description).toBe('custom read tool')
+    })
+
+    it('exposes a strictly read-only schema (no write parameters)', () => {
+      const schema = fileRead.toolSpec.inputSchema as { properties: Record<string, unknown> } | undefined
+      expect(schema).toBeDefined()
+      const props = schema!.properties
+      expect(Object.keys(props).sort()).toEqual(['path', 'view_range'])
+      for (const banned of ['command', 'file_text', 'old_str', 'new_str', 'insert_line']) {
+        expect(props).not.toHaveProperty(banned)
+      }
+    })
+
+    it('rejects unknown schema fields at invocation (write params cannot leak in)', async () => {
+      const filePath = await createTestFile('test.txt', 'ok')
+      // The schema is `.strict()`: any key outside `{ path, view_range }` is a
+      // hard validation error, not a silent strip. This gives the model clear
+      // feedback if it tries to route a write through the read tool, and the
+      // shim's hard-coded `command: 'view'` means even without .strict() the
+      // smuggle would be harmless.
+      const smuggled = { path: filePath, command: 'create', file_text: 'pwned' } as unknown as {
+        path: string
+        view_range?: [number, number]
+      }
+      await expect(fileRead.invoke(smuggled, context)).rejects.toThrow()
+      // The smuggled write did not happen: file content is unchanged.
+      expect(await fs.readFile(filePath, 'utf-8')).toBe('ok')
+    })
+  })
+})

--- a/strands-ts/src/vended-tools/file-read/file-read.ts
+++ b/strands-ts/src/vended-tools/file-read/file-read.ts
@@ -1,0 +1,100 @@
+import { tool } from '../../tools/tool-factory.js'
+import { z } from 'zod'
+import { Sandbox } from '../../sandbox/base.js'
+import { makeFileEditor } from '../file-editor/file-editor.js'
+
+/**
+ * Description shown to the model for the file-read tool.
+ */
+export const DEFAULT_FILE_READ_DESCRIPTION =
+  'Read-only filesystem tool. View a file (with an optional line range) or list a directory. Paths must be absolute. For creating or editing files, use `fileEditor`.'
+
+/**
+ * Zod schema for the read-only file tool.
+ *
+ * Intentionally narrower than `fileEditor`'s schema: only `path` and
+ * `view_range` are exposed. There is no `command` enum, no `file_text`,
+ * no `old_str`/`new_str`, no `insert_line` — a read-only agent cannot
+ * ask this tool to write.
+ *
+ * This schema is the single source of truth for the tool's input shape;
+ * `FileReadInput` below is derived from it via `z.infer` so the two cannot
+ * drift.
+ */
+const fileReadInputSchema = z
+  .object({
+    path: z.string().describe('Absolute path to a file or directory.'),
+    view_range: z
+      .tuple([z.number(), z.number()])
+      .optional()
+      .describe(
+        'Optional line range [start, end] to view. 1-indexed; end can be -1 for end-of-file. Not allowed for directories.'
+      ),
+  })
+  .strict()
+
+/**
+ * Input parameters for the read-only file tool.
+ *
+ * Derived from `fileReadInputSchema` so any schema change flows through
+ * automatically.
+ */
+export type FileReadInput = z.infer<typeof fileReadInputSchema>
+
+export interface MakeFileReadOptions {
+  name?: string
+  description?: string
+}
+
+/**
+ * Create a sandbox-routed, read-only file tool.
+ *
+ * A thin shim over {@link makeFileEditor}'s `view` command with a narrower
+ * input schema. All validation (absolute path, `..` traversal, size limit,
+ * `view_range` bounds, sandbox probing) is delegated to `fileEditor`; this
+ * tool intentionally adds no new logic and no new checks.
+ *
+ * If a sandbox is passed, it is bound at creation time. Otherwise, the
+ * underlying `fileEditor` reads the sandbox from `context.agent.sandbox` at
+ * call time.
+ *
+ * @example
+ * ```typescript
+ * import { fileRead } from '@strands-agents/sdk/vended-tools/file-read'
+ * import { Agent } from '@strands-agents/sdk'
+ *
+ * const agent = new Agent({
+ *   model: new BedrockModel({ region: 'us-east-1' }),
+ *   tools: [fileRead],
+ * })
+ *
+ * await agent.invoke('Read /tmp/config.json')
+ * ```
+ */
+export function makeFileRead(options?: MakeFileReadOptions): ReturnType<typeof tool>
+export function makeFileRead(sandbox: Sandbox | undefined, options?: MakeFileReadOptions): ReturnType<typeof tool>
+export function makeFileRead(
+  sandboxOrOptions?: Sandbox | MakeFileReadOptions,
+  maybeOptions?: MakeFileReadOptions
+): ReturnType<typeof tool> {
+  const boundSandbox = sandboxOrOptions instanceof Sandbox ? sandboxOrOptions : undefined
+  const options = sandboxOrOptions instanceof Sandbox || maybeOptions ? (maybeOptions ?? {}) : (sandboxOrOptions ?? {})
+
+  const editor = boundSandbox ? makeFileEditor(boundSandbox) : makeFileEditor()
+
+  return tool({
+    name: options.name ?? 'fileRead',
+    description: options.description ?? DEFAULT_FILE_READ_DESCRIPTION,
+    inputSchema: fileReadInputSchema,
+    callback: async (input, context) => {
+      if (!context) throw new Error('Tool context is required for fileRead operations')
+      return editor.invoke({ command: 'view', path: input.path, view_range: input.view_range }, context)
+    },
+  })
+}
+
+/**
+ * Default read-only file tool. Reads the sandbox from the agent's context at
+ * call time.
+ */
+export const fileRead = makeFileRead()

--- a/strands-ts/src/vended-tools/file-read/index.ts
+++ b/strands-ts/src/vended-tools/file-read/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Read-only file tool.
+ *
+ * A thin shim over `fileEditor`'s `view` command with a narrower two-parameter
+ * surface (`path` and `view_range`). All validation is delegated to
+ * `fileEditor`.
+ */
+
+export { fileRead, makeFileRead, DEFAULT_FILE_READ_DESCRIPTION } from './file-read.js'
+export type { MakeFileReadOptions, FileReadInput } from './file-read.js'

--- a/strands-ts/src/vended-tools/index.ts
+++ b/strands-ts/src/vended-tools/index.ts
@@ -13,5 +13,6 @@
 
 export * from './bash/index.js'
 export * from './file-editor/index.js'
+export * from './file-read/index.js'
 export * from './http-request/index.js'
 export * from './notebook/index.js'


### PR DESCRIPTION
Adds file_read, a read-only vended tool in both SDKs. The tool exposes a two-parameter surface, path and view_range, and delegates every call to file_editor's view command. There is no new validation, no new I/O, and no new size limit: absolute paths, directory-traversal rejection, size caps, view_range bounds, and sandbox routing all come from file_editor unchanged.

The point of vending this alongside file_editor is a real capability reduction for read-only agents. Instead of exposing the full seven-parameter editor schema and hoping the model does not reach for create, str_replace, or insert, the tool schema itself contains only path and view_range. The TypeScript Zod schema is strict, so a smuggled command or file_text field raises a validation error at invocation rather than being silently stripped, and even without strict the callback hardcodes command view. The narrower schema is also better model UX in practice.

Tests in both SDKs cover the happy paths (whole file, view_range slice, negative-one end, directory listing), a delegation probe that shows file_editor's traversal rejection surfacing through the shim, and metadata assertions that the input schema is exactly path and view_range with no write-side fields and no tool_context leakage. The TypeScript suite adds an end-to-end smuggle test that asserts the strict schema rejects a routed write.

Sibling file_write is intentionally not being vended (see #3371). file_read is a strict subset of view and gives read-only agents a narrower attack surface. A file_write shim over file_editor's create and str_replace would double the write surface with no corresponding narrowing, which is why the two decisions diverge.

https://github.com/strands-agents/harness-sdk/issues/3236
