### PR TITLE
feat(vended-tools): add handoff_to_user shim

### DIFF
--- a/site/src/content/docs/user-guide/concepts/tools/community-tools-package.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/community-tools-package.mdx
@@ -107,7 +107,7 @@ pip install 'strands-agents-tools[use_computer]'
 - [`journal`](https://github.com/strands-agents/tools/blob/main/src/strands_tools/journal.py): Create structured tasks and logs for agents to manage and work from
 - [`swarm`](https://github.com/strands-agents/tools/blob/main/src/strands_tools/swarm.py): Coordinate multiple AI agents in a swarm / network of agents
 - [`stop`](https://github.com/strands-agents/tools/blob/main/src/strands_tools/stop.py): Force stop the agent event loop
-- [`handoff_to_user`](https://github.com/strands-agents/tools/blob/main/src/strands_tools/handoff_to_user.py): Enable human-in-the-loop workflows by pausing agent execution for user input or transferring control entirely to the user
+- [`handoff_to_user`](https://github.com/strands-agents/tools/blob/main/src/strands_tools/handoff_to_user.py): Legacy — replaced by the vended [`handoff_to_user`](vended-tools.mdx#handoff-to-user), which is the recommended integration path
 - [`use_agent`](https://github.com/strands-agents/tools/blob/main/src/strands_tools/use_agent.py): Run a new AI event loop with custom prompts and different model providers
 - [`think`](https://github.com/strands-agents/tools/blob/main/src/strands_tools/think.py): Perform deep thinking by creating parallel branches of agentic reasoning
 - [`use_llm`](https://github.com/strands-agents/tools/blob/main/src/strands_tools/use_llm.py): Run a new AI event loop with custom prompts
@@ -145,7 +145,11 @@ When this variable is set to `true`, tools will execute without asking for confi
 
 ## Human-in-the-Loop with handoff_to_user
 
-The `handoff_to_user` tool enables human-in-the-loop workflows by allowing agents to pause execution for user input or transfer control entirely to a human operator. It offers two modes: Interactive Mode (`breakout_of_loop=False`) which collects input and continues, and Complete Handoff Mode (`breakout_of_loop=True`) which stops the event loop and transfers control to the user.
+:::note[Legacy]
+The community `handoff_to_user` shown below is a terminal-oriented example implementation from `strands-agents-tools`. New code should use the vended [`handoff_to_user`](vended-tools.mdx#handoff-to-user) tool bundled with the SDK — it raises a structured SDK interrupt with a validated payload rather than performing console I/O, and works with any UI (chat frontends, Slack, custom CLIs).
+:::
+
+The community `handoff_to_user` tool enables human-in-the-loop workflows by allowing agents to pause execution for user input or transfer control entirely to a human operator. It offers two modes: Interactive Mode (`breakout_of_loop=False`) which collects input and continues, and Complete Handoff Mode (`breakout_of_loop=True`) which stops the event loop and transfers control to the user.
 
 ```python
 from strands import Agent

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools-imports.ts
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools-imports.ts
@@ -35,3 +35,8 @@ import { bash } from '@strands-agents/sdk/vended-tools/bash'
 import { fileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
 import { notebook } from '@strands-agents/sdk/vended-tools/notebook'
 // --8<-- [end:combined_import]
+
+// --8<-- [start:handoff_to_user_import]
+import { Agent, InterruptResponseContent } from '@strands-agents/sdk'
+import { handoffToUser } from '@strands-agents/sdk/vended-tools/handoff-to-user'
+// --8<-- [end:handoff_to_user_import]

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -10,6 +10,8 @@ sourceLinks:
   - path: strands-ts/src/vended-tools/bash/bash.ts
   - path: strands-ts/src/vended-tools/http-request/http-request.ts
   - path: strands-ts/src/vended-tools/notebook/notebook.ts
+  - path: strands-ts/src/vended-tools/handoff-to-user/handoff-to-user.ts
+  - path: strands-py/src/strands/vended_tools/handoff_to_user/handoff_to_user.py
 ---
 
 Vended tools are pre-built tools included directly in the Strands SDK for common agent tasks like file operations, shell commands, HTTP requests, and persistent notes. 
@@ -34,6 +36,7 @@ Each tool is imported from its own subpath under `@strands-agents/sdk/vended-too
 | [HTTP Request](#http-request) | Make HTTP requests to external APIs | TypeScript (Node.js 20+, browsers) |
 | [Notebook](#notebook) | Manage persistent text notebooks | TypeScript (Node.js, browsers) |
 | [Bash](#bash) | Execute shell commands with persistent sessions | Python, TypeScript (Node.js, Unix/Linux/macOS) |
+| [Handoff to User](#handoff-to-user) | Pause the agent to ask the user a structured question | Python, TypeScript |
 
 ### File Editor
 
@@ -160,6 +163,52 @@ agent("List all Python files in the current directory and count them")
 ```
 
 📖 [Full API Reference](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/bash/README.md)
+
+---
+
+### Handoff to User
+
+Pauses the agent to ask the user a structured question, then resumes with the answer as the tool result. The tool does not render UI or read from the console — it raises a well-shaped SDK interrupt whose `reason` carries the question, optional multiple-choice options, and whether free-text answers are acceptable. Your application (a chat frontend, Slack app, custom CLI handler, etc.) inspects the interrupt, collects the answer, and resumes the agent.
+
+Use it when the next step genuinely depends on information only the user can supply. Not a general-purpose print or chat channel — the agent halts on every call.
+
+**Example:**
+
+<Tabs>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/tools/vended-tools-imports.ts:handoff_to_user_import"
+
+--8<-- "user-guide/concepts/tools/vended-tools.ts:handoff_to_user_example"
+```
+
+</Tab>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.vended_tools import handoff_to_user
+
+agent = Agent(tools=[handoff_to_user])
+result = agent("Ask me which environment to deploy to.")
+
+if result.stop_reason == "interrupt":
+    interrupt = result.interrupts[0]
+    result = agent([
+        {
+            "interruptResponse": {
+                "interruptId": interrupt.id,
+                "response": {"answer": "prod", "chose": "prod"},
+            }
+        }
+    ])
+```
+
+</Tab>
+</Tabs>
+
+📖 [Full API Reference](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/handoff-to-user/README.md)
 
 ---
 

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.ts
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.ts
@@ -5,7 +5,12 @@ import { fileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
 import { httpRequest } from '@strands-agents/sdk/vended-tools/http-request'
 import { notebook } from '@strands-agents/sdk/vended-tools/notebook'
 // --8<-- [end:basic_import]
-import { SessionManager, FileStorage } from '@strands-agents/sdk'
+import {
+  SessionManager,
+  FileStorage,
+  InterruptResponseContent,
+} from '@strands-agents/sdk'
+import { handoffToUser } from '@strands-agents/sdk/vended-tools/handoff-to-user'
 
 // Agent with vended tools example
 async function agentWithVendedToolsExample() {
@@ -108,6 +113,25 @@ async function notebookStatePersistenceExample() {
   const restoredAgent = new Agent({ tools: [notebook], sessionManager: session })
   await restoredAgent.invoke('Read the ideas notebook')
   // --8<-- [end:notebook_state_persistence]
+}
+
+// Handoff-to-user tool example
+async function handoffToUserExample() {
+  // --8<-- [start:handoff_to_user_example]
+  const agent = new Agent({ tools: [handoffToUser] })
+  const result = await agent.invoke('Ask me which environment to deploy to.')
+
+  if (result.stopReason === 'interrupt') {
+    const interrupt = result.interrupts[0]
+    // interrupt.reason = { question, options, allow_free_text }
+    const resumed = await agent.invoke([
+      new InterruptResponseContent({
+        interruptId: interrupt.id,
+        response: { answer: 'prod', chose: 'prod' },
+      }),
+    ])
+  }
+  // --8<-- [end:handoff_to_user_example]
 }
 
 // Combined tools example - development workflow

--- a/strands-py/src/strands/vended_tools/__init__.py
+++ b/strands-py/src/strands/vended_tools/__init__.py
@@ -1,26 +1,30 @@
-"""Built-in tools for executing commands and editing files.
+"""Built-in tools for executing commands, editing files, and handing off to the user.
 
 The :data:`bash` tool runs a
 persistent shell on the host; the :func:`make_bash` and :func:`make_file_editor`
 factories produce sandbox-routed tools that either bind to a
 :class:`~strands.sandbox.base.Sandbox` at creation (as the built-in Docker/SSH
 sandboxes do when vending tools) or read the sandbox from the agent at call time.
+The :data:`handoff_to_user` tool pauses the agent to ask the user a structured
+question via the SDK's interrupt primitive.
 
 Example Usage:
     ```python
     from strands import Agent
-    from strands.vended_tools import bash, file_editor
+    from strands.vended_tools import bash, file_editor, handoff_to_user
 
-    agent = Agent(tools=[bash, file_editor])
+    agent = Agent(tools=[bash, file_editor, handoff_to_user])
     ```
 """
 
 from .bash import bash, make_bash
 from .file_editor import file_editor, make_file_editor
+from .handoff_to_user import handoff_to_user
 
 __all__ = [
     "bash",
     "file_editor",
+    "handoff_to_user",
     "make_bash",
     "make_file_editor",
 ]

--- a/strands-py/src/strands/vended_tools/handoff_to_user/__init__.py
+++ b/strands-py/src/strands/vended_tools/handoff_to_user/__init__.py
@@ -1,0 +1,36 @@
+"""Vended ``handoff_to_user`` tool.
+
+A thin shim over the SDK's interrupt primitive. Lets an agent hand control back
+to the user with a structured question (optionally multiple-choice) and thread
+the user's answer through as the tool result.
+
+Example Usage:
+    ```python
+    from strands import Agent
+    from strands.vended_tools import handoff_to_user
+
+    agent = Agent(tools=[handoff_to_user])
+    ```
+"""
+
+from .handoff_to_user import handoff_to_user
+from .types import (
+    HANDOFF_TO_USER_DESCRIPTION,
+    INTERRUPT_NAME,
+    MAX_OPTION_LENGTH,
+    MAX_OPTIONS_COUNT,
+    MAX_QUESTION_LENGTH,
+    HandoffAnswer,
+    HandoffQuestion,
+)
+
+__all__ = [
+    "HANDOFF_TO_USER_DESCRIPTION",
+    "INTERRUPT_NAME",
+    "MAX_OPTION_LENGTH",
+    "MAX_OPTIONS_COUNT",
+    "MAX_QUESTION_LENGTH",
+    "HandoffAnswer",
+    "HandoffQuestion",
+    "handoff_to_user",
+]

--- a/strands-py/src/strands/vended_tools/handoff_to_user/handoff_to_user.py
+++ b/strands-py/src/strands/vended_tools/handoff_to_user/handoff_to_user.py
@@ -1,0 +1,201 @@
+"""``handoff_to_user`` tool: pause the agent to ask the user a structured question.
+
+A thin shim over :meth:`~strands.types.tools.ToolContext.interrupt`. The tool
+validates its inputs, then raises a single interrupt whose ``reason`` carries a
+:class:`~strands.vended_tools.handoff_to_user.types.HandoffQuestion` payload.
+The SDK halts the agent; the caller resumes with the user's response, which is
+threaded back as the tool result.
+
+No console I/O and no UI. Rendering the question and collecting the answer are
+the consumer's job (a chat frontend, a Slack app, a CLI handler, etc.). If nothing
+is listening the SDK's default interrupt handling applies.
+
+Example:
+    ```python
+    from strands import Agent
+    from strands.vended_tools import handoff_to_user
+
+    agent = Agent(tools=[handoff_to_user])
+    result = agent("Ask me which environment to deploy to.")
+
+    if result.stop_reason == "interrupt":
+        interrupt = result.interrupts[0]
+        # interrupt.reason = {"question": "...", "options": [...], "allow_free_text": ...}
+        responses = [
+            {
+                "interruptResponse": {
+                    "interruptId": interrupt.id,
+                    "response": {"answer": "prod", "chose": "prod"},
+                }
+            }
+        ]
+        result = agent(responses)
+    ```
+"""
+
+from __future__ import annotations
+
+from ...tools.decorator import tool
+from ...types.tools import ToolContext
+from .types import (
+    HANDOFF_TO_USER_DESCRIPTION,
+    INTERRUPT_NAME,
+    MAX_OPTION_LENGTH,
+    MAX_OPTIONS_COUNT,
+    MAX_QUESTION_LENGTH,
+    HandoffAnswer,
+    HandoffQuestion,
+)
+
+
+def _validate_and_build_reason(
+    question: str,
+    options: list[str] | None,
+    allow_free_text: bool,
+) -> HandoffQuestion:
+    """Validate the tool inputs and produce the interrupt payload.
+
+    Args:
+        question: The question the agent wants to ask the user.
+        options: Optional multiple-choice options.
+        allow_free_text: Whether free-text answers are accepted. Ignored when
+            ``options`` is provided (consumers decide whether to also permit
+            free text alongside the choice).
+
+    Returns:
+        A :class:`HandoffQuestion` dict for use as the interrupt's ``reason``.
+
+    Raises:
+        ValueError: If any input violates the size limits, or if the option list
+            contains a non-string or a duplicate entry.
+    """
+    if not isinstance(question, str) or not question.strip():
+        raise ValueError("question must be a non-empty string")
+    if len(question) > MAX_QUESTION_LENGTH:
+        raise ValueError(f"question length ({len(question)}) exceeds maximum allowed length ({MAX_QUESTION_LENGTH})")
+
+    normalized_options: list[str] | None = None
+    if options is not None:
+        if not isinstance(options, list):
+            raise ValueError("options must be a list of strings")
+        if len(options) == 0:
+            raise ValueError("options must contain at least one entry when provided")
+        if len(options) > MAX_OPTIONS_COUNT:
+            raise ValueError(f"options count ({len(options)}) exceeds maximum allowed count ({MAX_OPTIONS_COUNT})")
+        # Compare options on their trimmed value so ``["yes", "yes "]`` is
+        # rejected as a duplicate — the whitespace check above already treats
+        # such entries as equivalent (both are non-empty after strip).
+        seen: set[str] = set()
+        for i, opt in enumerate(options):
+            if not isinstance(opt, str):
+                raise ValueError(f"options[{i}] must be a string")
+            stripped = opt.strip()
+            if not stripped:
+                raise ValueError(f"options[{i}] must be a non-empty string")
+            if len(opt) > MAX_OPTION_LENGTH:
+                raise ValueError(
+                    f"options[{i}] length ({len(opt)}) exceeds maximum allowed length ({MAX_OPTION_LENGTH})"
+                )
+            if stripped in seen:
+                raise ValueError(f"options[{i}] duplicates an earlier entry: {opt!r}")
+            seen.add(stripped)
+        normalized_options = list(options)
+
+    if normalized_options is None and not allow_free_text:
+        raise ValueError("handoff must accept either options or free text; got neither")
+
+    # allow_free_text is meaningful only when there are no options; document that
+    # in the payload rather than mutating the caller's intent so consumers can see
+    # both fields on the wire.
+    return HandoffQuestion(
+        question=question,
+        options=normalized_options,
+        allow_free_text=bool(allow_free_text),
+    )
+
+
+def _coerce_response(response: object) -> HandoffAnswer:
+    """Normalize the resume response into a :class:`HandoffAnswer` shape.
+
+    - A bare string becomes ``{"answer": <string>}``.
+    - A dict with an ``answer`` key (and optionally ``chose``) is passed through
+      after minimal type checks.
+    - Anything else raises: the tool result should be well-typed, not opaque.
+
+    Args:
+        response: Whatever the caller resumed the interrupt with.
+
+    Returns:
+        A :class:`HandoffAnswer` dict.
+
+    Raises:
+        ValueError: If the response cannot be coerced into a well-formed answer.
+    """
+    # The same 4096-char budget bounds the question going out and the answer
+    # coming back — one direction is user prompt, the other is user answer, both
+    # get plumbed into model context, so a single per-turn text budget is enough.
+    if isinstance(response, str):
+        if len(response) > MAX_QUESTION_LENGTH:
+            raise ValueError(
+                f"handoff response 'answer' length ({len(response)}) exceeds maximum allowed length "
+                f"({MAX_QUESTION_LENGTH})"
+            )
+        return {"answer": response}
+    if isinstance(response, dict):
+        answer = response.get("answer")
+        chose = response.get("chose")
+        if not isinstance(answer, str):
+            raise ValueError("handoff response 'answer' must be a string")
+        if len(answer) > MAX_QUESTION_LENGTH:
+            raise ValueError(
+                f"handoff response 'answer' length ({len(answer)}) exceeds maximum allowed length "
+                f"({MAX_QUESTION_LENGTH})"
+            )
+        result: HandoffAnswer = {"answer": answer}
+        if chose is not None:
+            if not isinstance(chose, str):
+                raise ValueError("handoff response 'chose' must be a string when provided")
+            if len(chose) > MAX_OPTION_LENGTH:
+                raise ValueError(
+                    f"handoff response 'chose' length ({len(chose)}) exceeds maximum allowed length "
+                    f"({MAX_OPTION_LENGTH})"
+                )
+            result["chose"] = chose
+        return result
+    raise ValueError(
+        f"handoff response must be a string or an object with an 'answer' key; got {type(response).__name__}"
+    )
+
+
+@tool(name="handoff_to_user", description=HANDOFF_TO_USER_DESCRIPTION, context="tool_context")
+def handoff_to_user(
+    question: str,
+    tool_context: ToolContext,
+    options: list[str] | None = None,
+    allow_free_text: bool = True,
+) -> HandoffAnswer:
+    """Pause the agent and ask the user a structured question.
+
+    Emits an interrupt whose ``reason`` carries the question, optional multiple-choice
+    options, and whether a free-text answer is acceptable. On resume, the caller's
+    response is normalized to a :class:`HandoffAnswer` and returned as the tool
+    result so the model can continue the loop with the user's answer in hand.
+
+    Args:
+        question: The question to ask the user. Must be a non-empty string no longer
+            than 4096 characters.
+        tool_context: Injected by the framework. Not user-facing.
+        options: Optional multiple-choice options (up to 20 entries, each up to 256
+            characters, all distinct). When omitted, the tool asks a free-text
+            question.
+        allow_free_text: Whether the consumer should accept a free-text answer.
+            Defaults to True. When ``options`` is provided this flag is passed
+            through to the consumer as a hint but does not restrict what the
+            consumer resumes with.
+
+    Returns:
+        The user's response as a :class:`HandoffAnswer` dict.
+    """
+    reason = _validate_and_build_reason(question, options, allow_free_text)
+    response = tool_context.interrupt(INTERRUPT_NAME, reason=reason)
+    return _coerce_response(response)

--- a/strands-py/src/strands/vended_tools/handoff_to_user/types.py
+++ b/strands-py/src/strands/vended_tools/handoff_to_user/types.py
@@ -1,0 +1,68 @@
+"""Shared types and constants for the ``handoff_to_user`` tool."""
+
+from typing import TypedDict
+
+from typing_extensions import NotRequired
+
+HANDOFF_TO_USER_DESCRIPTION = (
+    "Hand off to the user with a structured question when you cannot proceed without "
+    "human input. Emits an interrupt carrying the question, optional multiple-choice "
+    "options, and whether free-text answers are accepted. The agent pauses; on resume "
+    "the user's answer is returned as the tool result. Use sparingly and only when the "
+    "next step genuinely depends on information only the user can supply."
+)
+"""Model-facing description for the ``handoff_to_user`` tool."""
+
+
+MAX_QUESTION_LENGTH = 4096
+"""Maximum length of the question string (in characters)."""
+
+MAX_OPTIONS_COUNT = 20
+"""Maximum number of multiple-choice options."""
+
+MAX_OPTION_LENGTH = 256
+"""Maximum length of each option string (in characters)."""
+
+
+INTERRUPT_NAME = "strands:handoff-to-user"
+"""Fixed interrupt name emitted by the tool, so consumers can pattern-match on it."""
+
+
+class HandoffQuestion(TypedDict):
+    """The structured payload carried on the interrupt's ``reason``.
+
+    Consumers reading the interrupt (custom UI, HITL handler) inspect
+    ``interrupt.reason`` and see a dict with this shape.
+
+    Attributes:
+        question: The question the agent is asking the user.
+        options: Multiple-choice options, or ``None`` for a free-text question.
+        allow_free_text: Whether a free-text answer is acceptable. Ignored when
+            ``options`` is provided; the consumer decides whether to also allow
+            free text alongside a choice.
+    """
+
+    question: str
+    options: list[str] | None
+    allow_free_text: bool
+
+
+class HandoffAnswer(TypedDict):
+    """The shape the consumer resumes with, threaded back as the tool result.
+
+    ``answer`` is always present; ``chose`` is optional and, when supplied,
+    reports which option the consumer selected. Bare-string resume responses
+    are coerced into ``{"answer": <string>}``.
+
+    Attributes:
+        answer: The human's response as free text (the primary field, always
+            present).
+        chose: The option string the consumer reports as selected. The tool does
+            **not** validate this against the emitted ``options`` list — a HITL
+            consumer may return any string here. Callers that need canonical
+            matching should compare ``chose`` against their own copy of
+            ``options`` themselves.
+    """
+
+    answer: str
+    chose: NotRequired[str]

--- a/strands-py/tests/strands/vended_tools/test_handoff_to_user.py
+++ b/strands-py/tests/strands/vended_tools/test_handoff_to_user.py
@@ -1,0 +1,350 @@
+"""Tests for the ``handoff_to_user`` tool.
+
+The tool shims over :meth:`ToolContext.interrupt`. On first invocation the SDK
+raises an ``InterruptException`` and the agent halts; on resume, the response
+from the caller flows back through ``ToolContext.interrupt`` and is returned to
+the model as a structured ``HandoffAnswer``.
+
+These tests drive the tool through :meth:`AgentTool.stream` with a mock agent so
+the interrupt/resume plumbing is exercised end-to-end without spinning up a real
+model.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from strands.interrupt import _InterruptState
+from strands.types._events import ToolInterruptEvent, ToolResultEvent
+from strands.vended_tools import handoff_to_user
+from strands.vended_tools.handoff_to_user import (
+    INTERRUPT_NAME,
+    MAX_OPTION_LENGTH,
+    MAX_OPTIONS_COUNT,
+    MAX_QUESTION_LENGTH,
+)
+
+
+async def _alist(agen):
+    """Drain an async iterator into a list (test helper)."""
+    return [item async for item in agen]
+
+
+def _tool_use(input_: dict, tool_use_id: str = "test_tool_id") -> dict:
+    return {"name": "handoff_to_user", "toolUseId": tool_use_id, "input": input_}
+
+
+def _invocation_state(interrupt_state: _InterruptState | None = None) -> dict:
+    mock_agent = MagicMock()
+    mock_agent._interrupt_state = interrupt_state or _InterruptState()
+    return {"agent": mock_agent}
+
+
+class TestToolMetadata:
+    """Tests for the tool's user-facing surface."""
+
+    def test_schema_excludes_context(self):
+        props = handoff_to_user.tool_spec["inputSchema"]["json"]["properties"]
+        assert "question" in props
+        assert "options" in props
+        assert "allow_free_text" in props
+        assert "tool_context" not in props
+
+
+class TestValidation:
+    """Oversized / malformed inputs must be rejected at the tool boundary."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_question(self):
+        events = await _alist(handoff_to_user.stream(_tool_use({"question": ""}), _invocation_state()))
+        assert len(events) == 1
+        assert isinstance(events[0], ToolResultEvent)
+        assert events[0].tool_result["status"] == "error"
+        assert "non-empty" in events[0].tool_result["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_oversized_question(self):
+        events = await _alist(
+            handoff_to_user.stream(_tool_use({"question": "x" * (MAX_QUESTION_LENGTH + 1)}), _invocation_state())
+        )
+        assert events[0].tool_result["status"] == "error"
+        assert "maximum" in events[0].tool_result["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_too_many_options(self):
+        events = await _alist(
+            handoff_to_user.stream(
+                _tool_use({"question": "pick one", "options": [f"o{i}" for i in range(MAX_OPTIONS_COUNT + 1)]}),
+                _invocation_state(),
+            )
+        )
+        assert events[0].tool_result["status"] == "error"
+        assert "options count" in events[0].tool_result["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_oversized_option(self):
+        events = await _alist(
+            handoff_to_user.stream(
+                _tool_use({"question": "pick one", "options": ["ok", "x" * (MAX_OPTION_LENGTH + 1)]}),
+                _invocation_state(),
+            )
+        )
+        assert events[0].tool_result["status"] == "error"
+        assert "options[1] length" in events[0].tool_result["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_option(self):
+        events = await _alist(
+            handoff_to_user.stream(_tool_use({"question": "pick one", "options": ["", "b"]}), _invocation_state())
+        )
+        assert events[0].tool_result["status"] == "error"
+        assert "non-empty" in events[0].tool_result["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_duplicate_options(self):
+        events = await _alist(
+            handoff_to_user.stream(_tool_use({"question": "pick one", "options": ["a", "a"]}), _invocation_state())
+        )
+        assert events[0].tool_result["status"] == "error"
+        assert "duplicates" in events[0].tool_result["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_duplicate_options_whitespace_variant(self):
+        """['yes', 'yes '] should be caught as a duplicate — both trim to 'yes'."""
+        events = await _alist(
+            handoff_to_user.stream(_tool_use({"question": "pick one", "options": ["yes", "yes "]}), _invocation_state())
+        )
+        assert events[0].tool_result["status"] == "error"
+        assert "duplicates" in events[0].tool_result["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_options_list(self):
+        events = await _alist(
+            handoff_to_user.stream(_tool_use({"question": "pick one", "options": []}), _invocation_state())
+        )
+        assert events[0].tool_result["status"] == "error"
+        assert "at least one" in events[0].tool_result["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_whitespace_only_option(self):
+        events = await _alist(
+            handoff_to_user.stream(_tool_use({"question": "pick one", "options": ["   ", "b"]}), _invocation_state())
+        )
+        assert events[0].tool_result["status"] == "error"
+        assert "non-empty" in events[0].tool_result["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_no_answer_channel(self):
+        """No options + free text disabled = question with nowhere to answer."""
+        events = await _alist(
+            handoff_to_user.stream(
+                _tool_use({"question": "Q?", "allow_free_text": False}),
+                _invocation_state(),
+            )
+        )
+        assert events[0].tool_result["status"] == "error"
+        assert "options or free text" in events[0].tool_result["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_string_option(self):
+        """Locks in the ``options[i] must be a string`` guard, mirroring the TS
+        Zod-schema test that rejects a boolean option entry. The tool decorator
+        validates via pydantic before the callback runs, so a boolean surfaces
+        as a "string_type" validation error rather than reaching the manual
+        isinstance check inside ``_validate_and_build_reason``."""
+        events = await _alist(
+            handoff_to_user.stream(
+                _tool_use({"question": "pick one", "options": [True, "b"]}),
+                _invocation_state(),
+            )
+        )
+        assert events[0].tool_result["status"] == "error"
+        assert "valid string" in events[0].tool_result["content"][0]["text"]
+
+
+class TestInterruptEmission:
+    """The tool must emit a well-shaped interrupt via the SDK's interrupt path."""
+
+    @pytest.mark.asyncio
+    async def test_emits_interrupt_with_free_text_question(self):
+        events = await _alist(handoff_to_user.stream(_tool_use({"question": "What's your name?"}), _invocation_state()))
+        assert len(events) == 1
+        assert isinstance(events[0], ToolInterruptEvent)
+        interrupt = events[0].interrupts[0]
+        assert interrupt.name == INTERRUPT_NAME
+        assert interrupt.reason == {
+            "question": "What's your name?",
+            "options": None,
+            "allow_free_text": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_emits_interrupt_with_options(self):
+        events = await _alist(
+            handoff_to_user.stream(
+                _tool_use(
+                    {
+                        "question": "Which environment?",
+                        "options": ["dev", "staging", "prod"],
+                        "allow_free_text": False,
+                    }
+                ),
+                _invocation_state(),
+            )
+        )
+        assert len(events) == 1
+        assert isinstance(events[0], ToolInterruptEvent)
+        interrupt = events[0].interrupts[0]
+        assert interrupt.reason == {
+            "question": "Which environment?",
+            "options": ["dev", "staging", "prod"],
+            "allow_free_text": False,
+        }
+
+    @pytest.mark.asyncio
+    async def test_interrupt_registered_on_agent_state(self):
+        """The interrupt must be visible on the agent's ``_interrupt_state`` so
+        the SDK's stream/session code can serialize and return it."""
+        state = _InterruptState()
+        invocation_state = _invocation_state(state)
+
+        await _alist(handoff_to_user.stream(_tool_use({"question": "Proceed?"}), invocation_state))
+
+        assert len(state.interrupts) == 1
+        interrupt = next(iter(state.interrupts.values()))
+        assert interrupt.name == INTERRUPT_NAME
+        assert interrupt.reason["question"] == "Proceed?"
+
+
+class TestResume:
+    """On resume, the caller's response is threaded back as the tool result."""
+
+    async def _run_first_pass(self, input_: dict, state: _InterruptState) -> str:
+        """Run the tool once to register an interrupt, and return its id."""
+        events = await _alist(handoff_to_user.stream(_tool_use(input_), {"agent": self._mock_agent_from(state)}))
+        assert isinstance(events[0], ToolInterruptEvent)
+        return events[0].interrupts[0].id
+
+    @staticmethod
+    def _mock_agent_from(state: _InterruptState):
+        m = MagicMock()
+        m._interrupt_state = state
+        return m
+
+    @pytest.mark.asyncio
+    async def test_resume_with_bare_string_wraps_as_answer(self):
+        state = _InterruptState()
+        interrupt_id = await self._run_first_pass({"question": "Name?"}, state)
+
+        # Simulate a caller resume: set a response on the registered interrupt.
+        state.interrupts[interrupt_id].response = "Alice"
+
+        events = await _alist(
+            handoff_to_user.stream(_tool_use({"question": "Name?"}), {"agent": self._mock_agent_from(state)})
+        )
+        assert isinstance(events[0], ToolResultEvent)
+        assert events[0].tool_result["status"] == "success"
+        # Tool return values are JSON-serialized into a text block by the decorator.
+        # Deserialize and assert the full shape so an unexpected extra field would
+        # be caught in one check (mirrors the TS ``toEqual`` assertions).
+        text = events[0].tool_result["content"][0]["text"]
+        assert json.loads(text) == {"answer": "Alice"}
+
+    @pytest.mark.asyncio
+    async def test_resume_with_dict_passes_chose_through(self):
+        state = _InterruptState()
+        interrupt_id = await self._run_first_pass({"question": "Which?", "options": ["a", "b"]}, state)
+
+        state.interrupts[interrupt_id].response = {"answer": "b", "chose": "b"}
+
+        events = await _alist(
+            handoff_to_user.stream(
+                _tool_use({"question": "Which?", "options": ["a", "b"]}),
+                {"agent": self._mock_agent_from(state)},
+            )
+        )
+        assert isinstance(events[0], ToolResultEvent)
+        text = events[0].tool_result["content"][0]["text"]
+        assert json.loads(text) == {"answer": "b", "chose": "b"}
+
+    @pytest.mark.asyncio
+    async def test_resume_with_malformed_response_errors(self):
+        state = _InterruptState()
+        interrupt_id = await self._run_first_pass({"question": "Q"}, state)
+
+        # A number is neither a string nor a dict with 'answer' -> must reject.
+        state.interrupts[interrupt_id].response = 42
+
+        events = await _alist(
+            handoff_to_user.stream(_tool_use({"question": "Q"}), {"agent": self._mock_agent_from(state)})
+        )
+        assert isinstance(events[0], ToolResultEvent)
+        assert events[0].tool_result["status"] == "error"
+        assert "answer" in events[0].tool_result["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_resume_rejects_oversized_bare_string(self):
+        """Resume path enforces the same size cap as the outgoing question."""
+        state = _InterruptState()
+        interrupt_id = await self._run_first_pass({"question": "Q"}, state)
+
+        state.interrupts[interrupt_id].response = "x" * (MAX_QUESTION_LENGTH + 1)
+
+        events = await _alist(
+            handoff_to_user.stream(_tool_use({"question": "Q"}), {"agent": self._mock_agent_from(state)})
+        )
+        assert events[0].tool_result["status"] == "error"
+        assert "maximum" in events[0].tool_result["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_resume_rejects_non_string_answer(self):
+        state = _InterruptState()
+        interrupt_id = await self._run_first_pass({"question": "Q"}, state)
+
+        state.interrupts[interrupt_id].response = {"answer": 42}
+
+        events = await _alist(
+            handoff_to_user.stream(_tool_use({"question": "Q"}), {"agent": self._mock_agent_from(state)})
+        )
+        assert events[0].tool_result["status"] == "error"
+        assert "'answer' must be a string" in events[0].tool_result["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_resume_rejects_oversized_answer(self):
+        state = _InterruptState()
+        interrupt_id = await self._run_first_pass({"question": "Q"}, state)
+
+        state.interrupts[interrupt_id].response = {"answer": "x" * (MAX_QUESTION_LENGTH + 1)}
+
+        events = await _alist(
+            handoff_to_user.stream(_tool_use({"question": "Q"}), {"agent": self._mock_agent_from(state)})
+        )
+        assert events[0].tool_result["status"] == "error"
+        assert "maximum" in events[0].tool_result["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_resume_rejects_non_string_chose(self):
+        state = _InterruptState()
+        interrupt_id = await self._run_first_pass({"question": "Q"}, state)
+
+        state.interrupts[interrupt_id].response = {"answer": "ok", "chose": 5}
+
+        events = await _alist(
+            handoff_to_user.stream(_tool_use({"question": "Q"}), {"agent": self._mock_agent_from(state)})
+        )
+        assert events[0].tool_result["status"] == "error"
+        assert "'chose' must be a string" in events[0].tool_result["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_resume_rejects_oversized_chose(self):
+        state = _InterruptState()
+        interrupt_id = await self._run_first_pass({"question": "Q"}, state)
+
+        state.interrupts[interrupt_id].response = {"answer": "ok", "chose": "x" * (MAX_OPTION_LENGTH + 1)}
+
+        events = await _alist(
+            handoff_to_user.stream(_tool_use({"question": "Q"}), {"agent": self._mock_agent_from(state)})
+        )
+        assert events[0].tool_result["status"] == "error"
+        assert "maximum" in events[0].tool_result["content"][0]["text"]

--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -68,6 +68,10 @@
       "types": "./dist/src/vended-tools/bash/index.d.ts",
       "default": "./dist/src/vended-tools/bash/index.js"
     },
+    "./vended-tools/handoff-to-user": {
+      "types": "./dist/src/vended-tools/handoff-to-user/index.d.ts",
+      "default": "./dist/src/vended-tools/handoff-to-user/index.js"
+    },
     "./a2a": {
       "types": "./dist/src/a2a/index.d.ts",
       "default": "./dist/src/a2a/index.js"

--- a/strands-ts/src/vended-tools/handoff-to-user/README.md
+++ b/strands-ts/src/vended-tools/handoff-to-user/README.md
@@ -1,0 +1,94 @@
+# handoff_to_user
+
+Hands off to the user when the agent cannot proceed without human input. A thin
+shim over the SDK's interrupt primitive:
+
+1. The model calls `handoff_to_user` with a question and optional options.
+2. The tool validates the input and raises an `InterruptError`, halting the
+   agent with `stopReason: 'interrupt'`.
+3. The caller inspects `result.interrupts`, renders the question in whatever
+   UI it owns, collects the user's answer, and resumes the agent with an
+   `InterruptResponseContent`.
+4. On resume, the tool normalizes the response into a `HandoffAnswer` and
+   returns it to the model.
+
+The tool does not read from stdin, does not render anything, and does not talk
+to a session store. Presentation is the consumer's job.
+
+## Usage
+
+```typescript
+import { Agent, InterruptResponseContent } from '@strands-agents/sdk'
+import { handoffToUser } from '@strands-agents/sdk/vended-tools/handoff-to-user'
+
+const agent = new Agent({ tools: [handoffToUser] })
+
+const result = await agent.invoke('Ask me which environment to deploy to.')
+
+if (result.stopReason === 'interrupt') {
+  const interrupt = result.interrupts[0]
+  // interrupt.reason is the HandoffQuestion payload:
+  //   { question, options, allow_free_text }
+  const userAnswer = await promptUserSomehow(interrupt.reason)
+
+  await agent.invoke([
+    new InterruptResponseContent({
+      interruptId: interrupt.id,
+      response: { answer: userAnswer, chose: userAnswer },
+    }),
+  ])
+}
+```
+
+## Event schema
+
+The interrupt's `name` is always `strands:handoff-to-user`. Its `reason` field
+carries the question payload:
+
+```typescript
+interface HandoffQuestion {
+  question: string
+  options: string[] | null
+  allow_free_text: boolean
+}
+```
+
+The caller resumes with either a bare string (interpreted as `answer`) or an
+object matching:
+
+```typescript
+interface HandoffAnswer {
+  answer: string
+  chose?: string
+}
+```
+
+Bare-string resumes are wrapped into `{ answer: <string> }` before the model
+sees them. The same shape applies to the Python tool
+(`strands.vended_tools.handoff_to_user`).
+
+## Input schema
+
+```typescript
+interface HandoffToUserInput {
+  question: string
+  options?: string[]
+  allow_free_text?: boolean // defaults to true
+}
+```
+
+Validated at the tool boundary before the interrupt is raised:
+
+- `question`: non-empty, at most 4096 characters.
+- `options`: at most 20 entries, each non-empty (after trimming), at most 256
+  characters, no duplicates (compared on trimmed value).
+- At least one answer channel must be enabled: either `options` is provided,
+  or `allow_free_text` is not explicitly `false`.
+
+## When to reach for something else
+
+- To gate a specific tool call on approval, use the `HumanInTheLoop`
+  intervention (`@strands-agents/sdk/vended-interventions/hitl`). That is a
+  before-tool policy layer, not an in-turn question.
+- For interactive stdin/stdout, wire a consumer around this tool's interrupt.
+  Do not fork the tool to add a readline reader.

--- a/strands-ts/src/vended-tools/handoff-to-user/__tests__/handoff-to-user.test.ts
+++ b/strands-ts/src/vended-tools/handoff-to-user/__tests__/handoff-to-user.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi } from 'vitest'
+import { handoffToUser } from '../handoff-to-user.js'
+import { INTERRUPT_NAME, MAX_OPTION_LENGTH, MAX_OPTIONS_COUNT, MAX_QUESTION_LENGTH } from '../types.js'
+import type { ToolContext } from '../../../tools/tool.js'
+import type { JSONValue } from '../../../types/json.js'
+import { InterruptError, Interrupt } from '../../../interrupt.js'
+import { createMockAgent } from '../../../__fixtures__/agent-helpers.js'
+
+/**
+ * Build a ToolContext whose `interrupt` records every call. If a preloaded
+ * response is present, it is returned; otherwise `interrupt` throws an
+ * InterruptError just like the real SDK does on the halting path.
+ */
+function makeContext(preloadedResponse?: JSONValue): {
+  context: ToolContext
+  calls: Array<{ name: string; reason: unknown }>
+} {
+  const calls: Array<{ name: string; reason: unknown }> = []
+  const interrupt = vi.fn(<T>(params: { name: string; reason?: JSONValue }): T => {
+    calls.push({ name: params.name, reason: params.reason })
+    if (preloadedResponse !== undefined) {
+      return preloadedResponse as T
+    }
+    throw new InterruptError(
+      new Interrupt({
+        id: `tool:test:${params.name}`,
+        name: params.name,
+        ...(params.reason !== undefined && { reason: params.reason }),
+        source: 'tool',
+      })
+    )
+  })
+  const agent = createMockAgent()
+  const context: ToolContext = {
+    toolUse: { name: 'handoff_to_user', toolUseId: 'test-tool-use-id', input: {} },
+    agent,
+    invocationState: {},
+    interrupt: interrupt as ToolContext['interrupt'],
+  }
+  return { context, calls }
+}
+
+describe('handoffToUser', () => {
+  describe('input validation (Zod schema)', () => {
+    it('rejects an empty question', async () => {
+      const { context } = makeContext()
+      await expect(handoffToUser.invoke({ question: '' }, context)).rejects.toThrow(/non-empty/i)
+    })
+
+    it('rejects an oversized question', async () => {
+      const { context } = makeContext()
+      const q = 'x'.repeat(MAX_QUESTION_LENGTH + 1)
+      await expect(handoffToUser.invoke({ question: q }, context)).rejects.toThrow(/maximum/i)
+    })
+
+    it('rejects too many options', async () => {
+      const { context } = makeContext()
+      const options = Array.from({ length: MAX_OPTIONS_COUNT + 1 }, (_, i) => `opt${i}`)
+      await expect(handoffToUser.invoke({ question: 'q', options }, context)).rejects.toThrow(/options count/i)
+    })
+
+    it('rejects an oversized option entry', async () => {
+      const { context } = makeContext()
+      const options = ['ok', 'x'.repeat(MAX_OPTION_LENGTH + 1)]
+      await expect(handoffToUser.invoke({ question: 'q', options }, context)).rejects.toThrow()
+    })
+
+    it('rejects an empty option entry', async () => {
+      const { context } = makeContext()
+      await expect(handoffToUser.invoke({ question: 'q', options: ['', 'b'] }, context)).rejects.toThrow()
+    })
+
+    it('rejects an empty options list', async () => {
+      const { context } = makeContext()
+      await expect(handoffToUser.invoke({ question: 'q', options: [] }, context)).rejects.toThrow(/at least one/i)
+    })
+
+    it('rejects duplicate options', async () => {
+      const { context } = makeContext()
+      await expect(handoffToUser.invoke({ question: 'q', options: ['a', 'a'] }, context)).rejects.toThrow(/duplicates/i)
+    })
+
+    it('rejects duplicate options that differ only by surrounding whitespace', async () => {
+      const { context } = makeContext()
+      await expect(handoffToUser.invoke({ question: 'q', options: ['yes', 'yes '] }, context)).rejects.toThrow(
+        /duplicates/i
+      )
+    })
+
+    it('rejects whitespace-only option entries', async () => {
+      const { context } = makeContext()
+      await expect(handoffToUser.invoke({ question: 'q', options: ['   ', 'b'] }, context)).rejects.toThrow()
+    })
+
+    it('rejects a question with no answer channel (no options, allow_free_text=false)', async () => {
+      const { context } = makeContext()
+      await expect(handoffToUser.invoke({ question: 'Q?', allow_free_text: false }, context)).rejects.toThrow(
+        /options or free text/i
+      )
+    })
+
+    it('rejects a boolean question (guards against future string coercion)', async () => {
+      const { context } = makeContext()
+      // The Python side rejects a bool for `question` because bool is not str;
+      // this test asserts the Zod schema does not silently coerce a boolean
+      // into "true"/"false", so the two sides stay in lockstep.
+      await expect(handoffToUser.invoke({ question: true as unknown as string }, context)).rejects.toThrow()
+    })
+
+    it('rejects a boolean option entry (guards against future string coercion)', async () => {
+      const { context } = makeContext()
+      await expect(
+        handoffToUser.invoke({ question: 'q', options: [true as unknown as string, 'b'] }, context)
+      ).rejects.toThrow()
+    })
+  })
+
+  describe('interrupt emission', () => {
+    it('emits an interrupt with the documented event shape for a free-text question', async () => {
+      const { context, calls } = makeContext()
+      await expect(handoffToUser.invoke({ question: "What's your name?" }, context)).rejects.toBeInstanceOf(
+        InterruptError
+      )
+      expect(calls).toHaveLength(1)
+      expect(calls[0]).toEqual({
+        name: INTERRUPT_NAME,
+        reason: {
+          question: "What's your name?",
+          options: null,
+          allow_free_text: true,
+        },
+      })
+    })
+
+    it('passes options and allow_free_text through on the reason payload', async () => {
+      const { context, calls } = makeContext()
+      await expect(
+        handoffToUser.invoke(
+          { question: 'Which env?', options: ['dev', 'staging', 'prod'], allow_free_text: false },
+          context
+        )
+      ).rejects.toBeInstanceOf(InterruptError)
+      expect(calls[0]!.reason).toEqual({
+        question: 'Which env?',
+        options: ['dev', 'staging', 'prod'],
+        allow_free_text: false,
+      })
+    })
+
+    it('halts execution via InterruptError so the SDK agent loop pauses', async () => {
+      const { context } = makeContext()
+      let raised: unknown = null
+      try {
+        await handoffToUser.invoke({ question: 'Q?' }, context)
+      } catch (err) {
+        raised = err
+      }
+      expect(raised).toBeInstanceOf(InterruptError)
+      expect((raised as InterruptError).interrupts[0]!.name).toBe(INTERRUPT_NAME)
+    })
+  })
+
+  describe('response coercion on resume', () => {
+    it('wraps a bare string as { answer }', async () => {
+      const { context } = makeContext('Alice')
+      const result = await handoffToUser.invoke({ question: 'Name?' }, context)
+      expect(result).toEqual({ answer: 'Alice' })
+    })
+
+    it('passes a well-shaped object through', async () => {
+      const { context } = makeContext({ answer: 'prod', chose: 'prod' })
+      const result = await handoffToUser.invoke({ question: 'Env?', options: ['dev', 'prod'] }, context)
+      expect(result).toEqual({ answer: 'prod', chose: 'prod' })
+    })
+
+    it('rejects a non-string answer', async () => {
+      const { context } = makeContext({ answer: 42 } as unknown as JSONValue)
+      await expect(handoffToUser.invoke({ question: 'Q?' }, context)).rejects.toThrow(/answer/i)
+    })
+
+    it('rejects a non-string chose', async () => {
+      const { context } = makeContext({ answer: 'ok', chose: 5 } as unknown as JSONValue)
+      await expect(handoffToUser.invoke({ question: 'Q?' }, context)).rejects.toThrow(/chose/i)
+    })
+
+    it('rejects a numeric response entirely', async () => {
+      const { context } = makeContext(42 as unknown as JSONValue)
+      await expect(handoffToUser.invoke({ question: 'Q?' }, context)).rejects.toThrow(/string or an object/i)
+    })
+
+    it('rejects a bare-string answer that exceeds the size cap', async () => {
+      const { context } = makeContext('x'.repeat(MAX_QUESTION_LENGTH + 1))
+      await expect(handoffToUser.invoke({ question: 'Q?' }, context)).rejects.toThrow(/maximum/i)
+    })
+
+    it('rejects an oversized answer inside a dict', async () => {
+      const { context } = makeContext({ answer: 'x'.repeat(MAX_QUESTION_LENGTH + 1) })
+      await expect(handoffToUser.invoke({ question: 'Q?' }, context)).rejects.toThrow(/maximum/i)
+    })
+
+    it('rejects an oversized chose inside a dict', async () => {
+      const { context } = makeContext({ answer: 'ok', chose: 'x'.repeat(MAX_OPTION_LENGTH + 1) })
+      await expect(handoffToUser.invoke({ question: 'Q?' }, context)).rejects.toThrow(/maximum/i)
+    })
+  })
+})

--- a/strands-ts/src/vended-tools/handoff-to-user/handoff-to-user.ts
+++ b/strands-ts/src/vended-tools/handoff-to-user/handoff-to-user.ts
@@ -1,0 +1,190 @@
+import { tool } from '../../tools/tool-factory.js'
+import { z } from 'zod'
+import type { JSONValue } from '../../types/json.js'
+import {
+  HANDOFF_TO_USER_DESCRIPTION,
+  INTERRUPT_NAME,
+  MAX_OPTIONS_COUNT,
+  MAX_OPTION_LENGTH,
+  MAX_QUESTION_LENGTH,
+  type HandoffAnswer,
+  type HandoffQuestion,
+} from './types.js'
+
+/**
+ * Zod schema for the tool's input. The schema is the single source of truth
+ * for the validated input shape and its size caps; the exported
+ * `HandoffToUserInput` type is derived from it via `z.input` (the pre-parse
+ * shape, so `allow_free_text` remains optional in the caller-facing type).
+ *
+ * Zod runs before the callback, so oversized or malformed inputs never reach
+ * the interrupt path.
+ */
+export const handoffToUserInputSchema = z
+  .object({
+    question: z
+      .string()
+      .min(1, 'question must be a non-empty string')
+      .max(MAX_QUESTION_LENGTH, `question length exceeds maximum allowed length (${MAX_QUESTION_LENGTH})`)
+      .describe('The question to ask the user.'),
+    options: z
+      .array(
+        z
+          .string()
+          .max(MAX_OPTION_LENGTH, `options entry length exceeds maximum allowed length (${MAX_OPTION_LENGTH})`)
+          .refine((o) => o.trim().length > 0, 'options entries must be non-empty')
+      )
+      .min(1, 'options must contain at least one entry when provided')
+      .max(MAX_OPTIONS_COUNT, `options count exceeds maximum allowed count (${MAX_OPTIONS_COUNT})`)
+      .optional()
+      .describe(`Optional multiple-choice options (up to ${MAX_OPTIONS_COUNT} entries).`),
+    allow_free_text: z
+      .boolean()
+      .optional()
+      .describe('Whether the consumer should accept a free-text answer (defaults to true).'),
+  })
+  .refine((v) => v.options !== undefined || v.allow_free_text !== false, {
+    message: 'handoff must accept either options or free text; got neither',
+  })
+
+/**
+ * Input accepted by the `handoffToUser` tool, derived from the Zod schema so
+ * the type and validation cannot drift.
+ */
+export type HandoffToUserInput = z.input<typeof handoffToUserInputSchema>
+
+/**
+ * Validate the request beyond what Zod covers and build the interrupt payload.
+ *
+ * Zod already checks length caps; we additionally enforce uniqueness of options,
+ * which the schema alone cannot express without pushing the validator surface up.
+ */
+function buildReason(input: z.infer<typeof handoffToUserInputSchema>): HandoffQuestion {
+  const { question, options, allow_free_text } = input
+
+  if (question.trim().length === 0) {
+    throw new Error('question must be a non-empty string')
+  }
+
+  let normalizedOptions: string[] | null = null
+  if (options !== undefined) {
+    // Compare options on their trimmed value so `["yes", "yes "]` is rejected
+    // as a duplicate — the schema-level non-empty refinement already treats
+    // such entries as equivalent (both are non-empty after trim).
+    const seen = new Set<string>()
+    for (const opt of options) {
+      const stripped = opt.trim()
+      if (seen.has(stripped)) {
+        throw new Error(`options duplicates an earlier entry: ${JSON.stringify(opt)}`)
+      }
+      seen.add(stripped)
+    }
+    normalizedOptions = [...options]
+  }
+
+  return {
+    question,
+    options: normalizedOptions,
+    allow_free_text: allow_free_text ?? true,
+  }
+}
+
+/**
+ * Normalize the resume response into a well-shaped HandoffAnswer.
+ *
+ * - A bare string becomes an object of the form &#123; answer: string &#125;.
+ * - An object with a string 'answer' (and optionally string 'chose') passes through.
+ * - Anything else throws: the tool result should be well-typed, not opaque.
+ */
+function coerceResponse(response: JSONValue): HandoffAnswer {
+  // The same 4096-char budget bounds the question going out and the answer
+  // coming back — one direction is user prompt, the other is user answer, both
+  // get plumbed into model context, so a single per-turn text budget is enough.
+  if (typeof response === 'string') {
+    if (response.length > MAX_QUESTION_LENGTH) {
+      throw new Error(
+        `handoff response 'answer' length (${response.length}) exceeds maximum allowed length (${MAX_QUESTION_LENGTH})`
+      )
+    }
+    return { answer: response }
+  }
+  if (response !== null && typeof response === 'object' && !Array.isArray(response)) {
+    const { answer, chose } = response as { answer?: unknown; chose?: unknown }
+    if (typeof answer !== 'string') {
+      throw new Error("handoff response 'answer' must be a string")
+    }
+    if (answer.length > MAX_QUESTION_LENGTH) {
+      throw new Error(
+        `handoff response 'answer' length (${answer.length}) exceeds maximum allowed length (${MAX_QUESTION_LENGTH})`
+      )
+    }
+    const result: HandoffAnswer = { answer }
+    if (chose !== undefined) {
+      if (typeof chose !== 'string') {
+        throw new Error("handoff response 'chose' must be a string when provided")
+      }
+      if (chose.length > MAX_OPTION_LENGTH) {
+        throw new Error(
+          `handoff response 'chose' length (${chose.length}) exceeds maximum allowed length (${MAX_OPTION_LENGTH})`
+        )
+      }
+      result.chose = chose
+    }
+    return result
+  }
+  throw new Error(
+    "handoff response must be a string or an object with an 'answer' key; " +
+      `got ${response === null ? 'null' : typeof response}`
+  )
+}
+
+/**
+ * handoffToUser: pause the agent to ask the user a structured question.
+ *
+ * A thin shim over context.interrupt. Validates the request, then raises
+ * a single interrupt whose 'reason' carries a HandoffQuestion. The SDK
+ * halts the agent; the caller resumes with the user's response, which is
+ * normalized into a HandoffAnswer and returned as the tool result.
+ *
+ * No console I/O and no UI: rendering the question and collecting the answer
+ * belong to the consumer (a chat frontend, Slack, custom CLI intervention).
+ * When nothing is listening, the SDK's default interrupt handling applies.
+ *
+ * @example
+ * ```typescript
+ * import { Agent } from '@strands-agents/sdk'
+ * import { handoffToUser } from '@strands-agents/sdk/vended-tools/handoff-to-user'
+ *
+ * const agent = new Agent({ tools: [handoffToUser] })
+ * const result = await agent.invoke('Ask me which environment to deploy to.')
+ *
+ * if (result.stopReason === 'interrupt') {
+ *   const interrupt = result.interrupts[0]
+ *   // interrupt.reason = { question, options, allow_free_text }
+ *   const resumed = await agent.invoke([
+ *     new InterruptResponseContent({
+ *       interruptId: interrupt.id,
+ *       response: { answer: 'prod', chose: 'prod' },
+ *     }),
+ *   ])
+ * }
+ * ```
+ */
+export const handoffToUser = tool({
+  name: 'handoff_to_user',
+  description: HANDOFF_TO_USER_DESCRIPTION,
+  inputSchema: handoffToUserInputSchema,
+  callback: (input, context): HandoffAnswer => {
+    if (!context) {
+      throw new Error('Tool context is required for handoffToUser')
+    }
+    const reason = buildReason(input)
+    // context.interrupt throws InterruptError on the first call (halting the
+    // agent) and returns the user's response on resume.
+    const response = context.interrupt<JSONValue>({
+      name: INTERRUPT_NAME,
+      reason: reason as unknown as JSONValue,
+    })
+    return coerceResponse(response)
+  },
+})

--- a/strands-ts/src/vended-tools/handoff-to-user/index.ts
+++ b/strands-ts/src/vended-tools/handoff-to-user/index.ts
@@ -1,0 +1,15 @@
+/**
+ * handoff-to-user tool: pause the agent to ask the user a structured question,
+ * shimmed on top of the SDK's interrupt primitive.
+ */
+
+export { handoffToUser } from './handoff-to-user.js'
+export type { HandoffToUserInput } from './handoff-to-user.js'
+export {
+  HANDOFF_TO_USER_DESCRIPTION,
+  INTERRUPT_NAME,
+  MAX_OPTIONS_COUNT,
+  MAX_OPTION_LENGTH,
+  MAX_QUESTION_LENGTH,
+} from './types.js'
+export type { HandoffAnswer, HandoffQuestion } from './types.js'

--- a/strands-ts/src/vended-tools/handoff-to-user/types.ts
+++ b/strands-ts/src/vended-tools/handoff-to-user/types.ts
@@ -1,0 +1,81 @@
+/**
+ * Type definitions and shared constants for the `handoffToUser` tool.
+ */
+
+/**
+ * Model-facing description for the `handoffToUser` tool.
+ */
+export const HANDOFF_TO_USER_DESCRIPTION =
+  'Hand off to the user with a structured question when you cannot proceed without ' +
+  'human input. Emits an interrupt carrying the question, optional multiple-choice ' +
+  'options, and whether free-text answers are accepted. The agent pauses; on resume ' +
+  "the user's answer is returned as the tool result. Use sparingly and only when the " +
+  'next step genuinely depends on information only the user can supply.'
+
+/**
+ * Maximum length of the question string (in characters).
+ */
+export const MAX_QUESTION_LENGTH = 4096
+
+/**
+ * Maximum number of multiple-choice options.
+ */
+export const MAX_OPTIONS_COUNT = 20
+
+/**
+ * Maximum length of each option string (in characters).
+ */
+export const MAX_OPTION_LENGTH = 256
+
+/**
+ * Fixed interrupt name emitted by the tool. Consumers pattern-match on this to
+ * decide whether to render a handoff UI vs. some other interrupt (e.g. HITL
+ * approval).
+ */
+export const INTERRUPT_NAME = 'strands:handoff-to-user'
+
+/**
+ * The structured payload carried on the interrupt's `reason` field.
+ *
+ * Consumers reading the interrupt (custom UI, HITL handler) see
+ * `interrupt.reason` shaped like this.
+ */
+export interface HandoffQuestion {
+  /** The question the agent is asking the user. */
+  question: string
+
+  /** Multiple-choice options, or `null` for a free-text question. */
+  options: string[] | null
+
+  /**
+   * Whether a free-text answer is acceptable. Ignored when `options` is
+   * provided; the consumer decides whether to also allow free text alongside
+   * a choice.
+   */
+  allow_free_text: boolean
+}
+
+/**
+ * The shape the consumer resumes with. `answer` is required; `chose` is
+ * optional and, when present, reports which option the consumer selected.
+ * Bare-string resume responses are coerced into an object of the form
+ * &#123; answer: string &#125;.
+ */
+export interface HandoffAnswer {
+  /** The human's response as free text (the primary field, always present). */
+  answer: string
+
+  /**
+   * The option string the consumer reports as selected. The tool does **not**
+   * validate this against the emitted `options` list — a HITL consumer may
+   * return any string here. Callers that need canonical matching should
+   * compare `chose` against their own copy of `options` themselves.
+   */
+  chose?: string
+}
+
+// The input type for the tool is derived from the Zod schema in
+// `handoff-to-user.ts` (via `z.input` — the pre-parse shape) and re-exported
+// from `index.ts`. Keeping the schema as the single source of truth prevents
+// a hand-written interface here from silently drifting when a field is added
+// or renamed.

--- a/strands-ts/src/vended-tools/index.ts
+++ b/strands-ts/src/vended-tools/index.ts
@@ -13,5 +13,6 @@
 
 export * from './bash/index.js'
 export * from './file-editor/index.js'
+export * from './handoff-to-user/index.js'
 export * from './http-request/index.js'
 export * from './notebook/index.js'


### PR DESCRIPTION
Adds a handoff_to_user vended tool in both the Python and TypeScript SDKs. The tool is a thin shim over the SDK's existing interrupt primitive: the model calls it with a question and optional multiple-choice options, the tool raises a single interrupt whose reason carries a structured HandoffQuestion payload, the agent halts, and the caller resumes with the user's answer. On resume the response is coerced into a HandoffAnswer and returned as the tool result.

Presentation is intentionally not bundled. Rendering the question and collecting the answer belong to the consumer (a chat frontend, a Slack app, a custom CLI handler). If nothing is listening, the SDK's default interrupt handling applies. The interrupt name is fixed as strands:handoff-to-user so consumers can pattern-match, matching the naming style of the existing HITL intervention.

The tool is deliberately one-shot: emit question, receive answer, return. Bidi mid-run chat with the user was flagged as an open design question in the sub-issue and belongs in a separate tool built on the bidi machinery. The existing HumanInTheLoop intervention is a before-tool-call approval policy rather than an in-turn question, so it still governs whether handoff_to_user may run at all, which is the correct layering.

Inputs are validated at the tool boundary before the interrupt is raised: the question is a non-empty string capped at 4096 characters, options are capped at 20 entries with each entry non-empty and capped at 256 characters (duplicates compared on trimmed value), and the schema rejects a question with no answer channel. Resume responses are coerced through the same size caps, so a malformed response surfaces as a tool error rather than being handed opaquely to the model. The TypeScript input type is derived from the Zod schema via z.input so the two cannot drift, and the docs section on vended-tools.mdx uses --8<-- snippet includes for the TypeScript example, matching the sleep precedent.

Sub-issue: https://github.com/strands-agents/harness-sdk/issues/3243