### PR TITLE
feat(vended-tools): add code_execution shim

### DIFF
--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools-imports.ts
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools-imports.ts
@@ -35,3 +35,15 @@ import { bash } from '@strands-agents/sdk/vended-tools/bash'
 import { fileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
 import { notebook } from '@strands-agents/sdk/vended-tools/notebook'
 // --8<-- [end:combined_import]
+
+// --8<-- [start:code_execution_import]
+import { Agent } from '@strands-agents/sdk'
+import { DockerSandbox } from '@strands-agents/sdk/sandbox/docker'
+import { codeExecution } from '@strands-agents/sdk/vended-tools/code-execution'
+// --8<-- [end:code_execution_import]
+
+// --8<-- [start:code_execution_custom_import]
+import { Agent } from '@strands-agents/sdk'
+import { DockerSandbox } from '@strands-agents/sdk/sandbox/docker'
+import { makeCodeExecution } from '@strands-agents/sdk/vended-tools/code-execution'
+// --8<-- [end:code_execution_custom_import]

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -10,6 +10,8 @@ sourceLinks:
   - path: strands-ts/src/vended-tools/bash/bash.ts
   - path: strands-ts/src/vended-tools/http-request/http-request.ts
   - path: strands-ts/src/vended-tools/notebook/notebook.ts
+  - path: strands-ts/src/vended-tools/code-execution/code-execution.ts
+  - path: strands-py/src/strands/vended_tools/code_execution/code_execution.py
 ---
 
 Vended tools are pre-built tools included directly in the Strands SDK for common agent tasks like file operations, shell commands, HTTP requests, and persistent notes. 
@@ -34,6 +36,7 @@ Each tool is imported from its own subpath under `@strands-agents/sdk/vended-too
 | [HTTP Request](#http-request) | Make HTTP requests to external APIs | TypeScript (Node.js 20+, browsers) |
 | [Notebook](#notebook) | Manage persistent text notebooks | TypeScript (Node.js, browsers) |
 | [Bash](#bash) | Execute shell commands with persistent sessions | Python, TypeScript (Node.js, Unix/Linux/macOS) |
+| [Code Execution](#code-execution) | Run source code through a configured sandbox | Python, TypeScript (Node.js) |
 
 ### File Editor
 
@@ -160,6 +163,78 @@ agent("List all Python files in the current directory and count them")
 ```
 
 📖 [Full API Reference](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/bash/README.md)
+
+---
+
+### Code Execution
+
+Runs source code through a configured sandbox and returns stdout, stderr, the interpreter exit code, and wall-clock elapsed milliseconds. Each call is a fresh interpreter invocation; state does not persist across calls.
+
+_Supported in: Node.js (TypeScript); all platforms (Python)._
+
+The tool refuses to execute against the host default sandbox, which provides no isolation. An isolating sandbox — for example a DockerSandbox or an SshSandbox — must be configured on the agent, or the tool raises immediately. Language selection is fixed at factory time and is not exposed to the model. Inputs are capped in bytes for both the submitted code and the returned stdout and stderr, and execution is bounded by a configurable timeout.
+
+**Example:**
+
+<Tabs>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/tools/vended-tools-imports.ts:code_execution_import"
+
+--8<-- "user-guide/concepts/tools/vended-tools.ts:code_execution_example"
+```
+
+</Tab>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.sandbox.docker import DockerSandbox
+from strands.vended_tools import code_execution
+
+agent = Agent(
+    sandbox=DockerSandbox(container="my-python-container"),
+    tools=[code_execution],
+)
+agent("Compute the sum of primes below one hundred and print the result.")
+```
+
+</Tab>
+</Tabs>
+
+**Custom factory:**
+
+<Tabs>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/tools/vended-tools-imports.ts:code_execution_custom_import"
+
+--8<-- "user-guide/concepts/tools/vended-tools.ts:code_execution_custom_example"
+```
+
+</Tab>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.vended_tools import make_code_execution
+
+tool = make_code_execution(
+    sandbox=sandbox,
+    name="sandbox_code",
+    max_code_bytes=50_000,
+    max_output_bytes=200_000,
+    default_timeout=30,
+)
+agent = Agent(tools=[tool])
+```
+
+</Tab>
+</Tabs>
+
+📖 [Full API Reference](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/code-execution/README.md)
 
 ---
 

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.ts
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.ts
@@ -131,3 +131,31 @@ async function combinedToolsExample() {
   )
   // --8<-- [end:combined_tools_example]
 }
+
+import { codeExecution, makeCodeExecution } from '@strands-agents/sdk/vended-tools/code-execution'
+import { DockerSandbox } from '@strands-agents/sdk/sandbox/docker'
+
+// Code execution example
+async function codeExecutionExample() {
+  // --8<-- [start:code_execution_example]
+  const agent = new Agent({
+    sandbox: new DockerSandbox({ container: 'my-node-container' }),
+    tools: [codeExecution],
+  })
+  await agent.invoke('Compute the sum of primes below one hundred and print the result.')
+  // --8<-- [end:code_execution_example]
+}
+
+// Code execution custom factory example
+async function codeExecutionCustomExample() {
+  // --8<-- [start:code_execution_custom_example]
+  const sandbox = new DockerSandbox({ container: 'my-node-container' })
+  const tool = makeCodeExecution(sandbox, {
+    name: 'sandbox_code',
+    maxCodeBytes: 50_000,
+    maxOutputBytes: 200_000,
+    defaultTimeout: 30,
+  })
+  const agent = new Agent({ sandbox, tools: [tool] })
+  // --8<-- [end:code_execution_custom_example]
+}

--- a/strands-py/src/strands/vended_tools/__init__.py
+++ b/strands-py/src/strands/vended_tools/__init__.py
@@ -1,26 +1,30 @@
-"""Built-in tools for executing commands and editing files.
+"""Built-in tools for executing commands, editing files, and running code.
 
 The :data:`bash` tool runs a
-persistent shell on the host; the :func:`make_bash` and :func:`make_file_editor`
-factories produce sandbox-routed tools that either bind to a
-:class:`~strands.sandbox.base.Sandbox` at creation (as the built-in Docker/SSH
-sandboxes do when vending tools) or read the sandbox from the agent at call time.
+persistent shell on the host; the :func:`make_bash`, :func:`make_file_editor`,
+and :func:`make_code_execution` factories produce sandbox-routed tools that
+either bind to a :class:`~strands.sandbox.base.Sandbox` at creation (as the
+built-in Docker/SSH sandboxes do when vending tools) or read the sandbox from
+the agent at call time.
 
 Example Usage:
     ```python
     from strands import Agent
-    from strands.vended_tools import bash, file_editor
+    from strands.vended_tools import bash, code_execution, file_editor
 
-    agent = Agent(tools=[bash, file_editor])
+    agent = Agent(tools=[bash, code_execution, file_editor])
     ```
 """
 
 from .bash import bash, make_bash
+from .code_execution import code_execution, make_code_execution
 from .file_editor import file_editor, make_file_editor
 
 __all__ = [
     "bash",
+    "code_execution",
     "file_editor",
     "make_bash",
+    "make_code_execution",
     "make_file_editor",
 ]

--- a/strands-py/src/strands/vended_tools/code_execution/__init__.py
+++ b/strands-py/src/strands/vended_tools/code_execution/__init__.py
@@ -1,0 +1,36 @@
+"""Code execution tool for running source code through a configured sandbox.
+
+Each call runs a fresh interpreter invocation; state does not persist across
+calls. The tool refuses to execute when the agent has no isolating sandbox
+configured -- the sandbox module owns the security boundary.
+
+Example Usage:
+    ```python
+    from strands import Agent
+    from strands.sandbox.docker import DockerSandbox
+    from strands.vended_tools import code_execution
+
+    agent = Agent(sandbox=DockerSandbox(container="my-container"), tools=[code_execution])
+    ```
+"""
+
+from .code_execution import code_execution, make_code_execution
+from .types import (
+    CODE_EXECUTION_DESCRIPTION,
+    DEFAULT_LANGUAGE,
+    DEFAULT_MAX_CODE_BYTES,
+    DEFAULT_MAX_OUTPUT_BYTES,
+    DEFAULT_TIMEOUT_SECONDS,
+    CodeExecutionOutput,
+)
+
+__all__ = [
+    "CODE_EXECUTION_DESCRIPTION",
+    "DEFAULT_LANGUAGE",
+    "DEFAULT_MAX_CODE_BYTES",
+    "DEFAULT_MAX_OUTPUT_BYTES",
+    "DEFAULT_TIMEOUT_SECONDS",
+    "CodeExecutionOutput",
+    "code_execution",
+    "make_code_execution",
+]

--- a/strands-py/src/strands/vended_tools/code_execution/code_execution.py
+++ b/strands-py/src/strands/vended_tools/code_execution/code_execution.py
@@ -1,0 +1,181 @@
+"""Code execution tool for running source code through a configured sandbox.
+
+Provides :func:`make_code_execution` (a factory for a sandbox-routed code
+execution tool) and :data:`code_execution` (the default instance that reads the
+sandbox from the agent at call time). Each call runs a fresh interpreter through
+the sandbox; state does not persist across calls.
+
+The tool is a thin shim over :meth:`~strands.sandbox.base.Sandbox.execute_code`.
+The sandbox is the security boundary; the tool refuses to execute if the agent
+has no isolating sandbox configured (i.e. it falls back to
+:class:`~strands.sandbox.not_a_sandbox_local_environment.NotASandboxLocalEnvironment`,
+whose deliberately blunt name signals "no isolation").
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from typing import TYPE_CHECKING
+
+from ...sandbox.errors import SandboxTimeoutError
+from ...sandbox.not_a_sandbox_local_environment import NotASandboxLocalEnvironment
+from ...tools.decorator import tool
+from ...types.tools import ToolContext
+from .types import (
+    CODE_EXECUTION_DESCRIPTION,
+    DEFAULT_LANGUAGE,
+    DEFAULT_MAX_CODE_BYTES,
+    DEFAULT_MAX_OUTPUT_BYTES,
+    DEFAULT_TIMEOUT_SECONDS,
+    TRUNCATION_MARKER,
+    CodeExecutionOutput,
+)
+
+if TYPE_CHECKING:
+    from ...sandbox.base import Sandbox
+    from ...tools.decorator import DecoratedFunctionTool
+
+
+def _truncate(text: str, max_bytes: int) -> str:
+    """Truncate ``text`` to ``max_bytes`` UTF-8 bytes and append a marker if trimmed.
+
+    Truncation is intentionally byte-oriented (not character-oriented) because
+    the cap protects downstream consumers that may be counting tokens or
+    bytes. Decoding with ``errors="ignore"`` drops any incomplete multi-byte
+    sequence at the cut point rather than raising.
+    """
+    encoded = text.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return text
+    trimmed = encoded[:max_bytes].decode("utf-8", errors="ignore")
+    return trimmed + TRUNCATION_MARKER
+
+
+def make_code_execution(
+    *,
+    sandbox: Sandbox | None = None,
+    language: str = DEFAULT_LANGUAGE,
+    name: str = "code_execution",
+    description: str = CODE_EXECUTION_DESCRIPTION,
+    max_code_bytes: int = DEFAULT_MAX_CODE_BYTES,
+    max_output_bytes: int = DEFAULT_MAX_OUTPUT_BYTES,
+    default_timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> DecoratedFunctionTool:
+    """Create a sandbox-routed code execution tool.
+
+    If a ``sandbox`` is passed, it is bound at creation time. Otherwise the tool
+    reads the sandbox from ``tool_context.agent.sandbox`` at call time and
+    refuses to run when that sandbox is the host default
+    (:class:`NotASandboxLocalEnvironment`).
+
+    ``language`` is fixed at factory time -- the model cannot select an
+    interpreter. This keeps the tool aligned with the SDK's own runtime (Python
+    here) and prevents the tool from becoming a polyglot execution surface.
+
+    Args:
+        sandbox: Sandbox to bind at creation. When ``None``, the agent's
+            configured sandbox is used at call time. When it is a
+            :class:`NotASandboxLocalEnvironment`, the tool refuses to execute.
+        language: Interpreter to run. Passed through to the sandbox, which
+            validates it against :data:`~strands.sandbox.LANGUAGE_PATTERN`.
+        name: Tool name. Defaults to ``"code_execution"``.
+        description: Tool description shown to the model.
+        max_code_bytes: Upper bound on ``code`` size (bytes, UTF-8). Rejects
+            larger inputs before touching the sandbox.
+        max_output_bytes: Upper bound on stdout/stderr size returned to the
+            model (bytes, UTF-8). Excess is dropped and a truncation marker is
+            appended.
+        default_timeout: Timeout in seconds passed to the sandbox when the
+            caller does not supply one.
+
+    Returns:
+        A decorated tool that executes code through the sandbox.
+    """
+    # Reject NaN and Infinity explicitly: ``nan <= 0`` is false, so a bare
+    # ``<= 0`` check would silently disable the cap (``code_bytes > nan`` is
+    # always false).
+    if not isinstance(max_code_bytes, int) or isinstance(max_code_bytes, bool) or max_code_bytes <= 0:
+        raise ValueError(f"max_code_bytes must be a positive integer, got {max_code_bytes!r}")
+    if not isinstance(max_output_bytes, int) or isinstance(max_output_bytes, bool) or max_output_bytes <= 0:
+        raise ValueError(f"max_output_bytes must be a positive integer, got {max_output_bytes!r}")
+    if (
+        isinstance(default_timeout, bool)
+        or not isinstance(default_timeout, (int, float))
+        or not math.isfinite(default_timeout)
+        or default_timeout <= 0
+    ):
+        raise ValueError(f"default_timeout must be a positive, finite number, got {default_timeout!r}")
+
+    async def code_execution_tool(
+        code: str,
+        tool_context: ToolContext,
+        timeout: float = default_timeout,
+    ) -> CodeExecutionOutput:
+        # Docstring is set below so the ``timeout`` default in the model-facing
+        # schema reflects the factory's ``default_timeout`` rather than a
+        # hardcoded literal.
+        # Input validation at the tool boundary.
+        if not isinstance(code, str):
+            raise ValueError("code must be a string")
+        code_bytes = len(code.encode("utf-8"))
+        if code_bytes > max_code_bytes:
+            raise ValueError(f"code size ({code_bytes} bytes) exceeds maximum allowed size ({max_code_bytes} bytes)")
+        if timeout is not None:
+            # Reject non-finite (nan, +/-inf) and booleans explicitly. ``nan <= 0``
+            # is false, so a bare comparison would let a non-finite timeout past
+            # the tool boundary and into the sandbox.
+            if (
+                isinstance(timeout, bool)
+                or not isinstance(timeout, (int, float))
+                or not math.isfinite(timeout)
+                or timeout <= 0
+            ):
+                raise ValueError(f"timeout must be a positive, finite number, got {timeout!r}")
+
+        active = sandbox if sandbox is not None else tool_context.agent.sandbox
+
+        # The sandbox is the security boundary. Refuse execution when the agent
+        # is running against the host default -- its name says "no isolation"
+        # and executing model-authored code there would be a footgun.
+        if isinstance(active, NotASandboxLocalEnvironment):
+            raise RuntimeError(
+                "code_execution requires an isolating sandbox (e.g. DockerSandbox, SshSandbox) "
+                "to be configured on the agent. Refusing to execute against "
+                "NotASandboxLocalEnvironment, which provides no isolation."
+            )
+
+        started = time.monotonic()
+        try:
+            result = await active.execute_code(code, language, timeout=timeout)
+        except SandboxTimeoutError:
+            # Preserve the sandbox's timeout type so callers can branch on it.
+            raise
+        except Exception as e:
+            raise RuntimeError(str(e)) from e
+        elapsed_ms = int((time.monotonic() - started) * 1000)
+
+        return {
+            "stdout": _truncate(result.stdout, max_output_bytes),
+            "stderr": _truncate(result.stderr, max_output_bytes),
+            "exit_code": result.exit_code,
+            "elapsed_ms": elapsed_ms,
+        }
+
+    # Assign the docstring after the definition so ``default_timeout`` is
+    # interpolated dynamically; the tool decorator parses this for the
+    # model-facing parameter descriptions.
+    code_execution_tool.__doc__ = (
+        "Executes source code and returns stdout, stderr, exit_code, elapsed_ms.\n"
+        "\n"
+        "Args:\n"
+        "    code: Source code to execute in the configured language.\n"
+        "    tool_context: Injected by the framework. Not user-facing.\n"
+        f"    timeout: Timeout in seconds (default: {default_timeout}).\n"
+    )
+
+    return tool(name=name, description=description, context="tool_context")(code_execution_tool)
+
+
+code_execution = make_code_execution()
+"""Default code execution tool. Reads the sandbox from the agent's context at call time."""

--- a/strands-py/src/strands/vended_tools/code_execution/types.py
+++ b/strands-py/src/strands/vended_tools/code_execution/types.py
@@ -1,0 +1,53 @@
+"""Shared types and constants for the code_execution tool."""
+
+from typing import TypedDict
+
+
+class CodeExecutionOutput(TypedDict):
+    """Result of a code_execution call.
+
+    Attributes:
+        stdout: Standard output captured from the interpreter. May be truncated
+            with a trailing marker if the sandbox produced more than
+            :data:`DEFAULT_MAX_OUTPUT_BYTES` bytes.
+        stderr: Standard error captured from the interpreter. Truncated on the
+            same terms as ``stdout``.
+        exit_code: Exit code from the interpreter. ``0`` indicates success.
+        elapsed_ms: Wall-clock time in milliseconds from the call entering the
+            sandbox to the sandbox returning a result.
+    """
+
+    stdout: str
+    stderr: str
+    exit_code: int
+    elapsed_ms: int
+
+
+#: Default interpreter used when the factory is not passed a ``language``.
+#: The tool executes the SDK's own language; ``python3`` is Python's convention.
+DEFAULT_LANGUAGE = "python3"
+
+#: Default upper bound on the source-code size accepted from the model (bytes,
+#: UTF-8). Keeps a runaway prompt from stuffing the sandbox with megabytes of
+#: source before the interpreter ever runs.
+DEFAULT_MAX_CODE_BYTES = 100_000
+
+#: Default upper bound on the stdout/stderr the tool returns to the model
+#: (bytes, UTF-8). Anything past this is dropped and a truncation marker is
+#: appended so the model knows it happened.
+DEFAULT_MAX_OUTPUT_BYTES = 100_000
+
+#: Default execution timeout in seconds; passed through to the sandbox, which
+#: owns the actual kill.
+DEFAULT_TIMEOUT_SECONDS = 60
+
+#: Marker appended when stdout/stderr is trimmed to :data:`DEFAULT_MAX_OUTPUT_BYTES`.
+TRUNCATION_MARKER = "\n... [truncated]"
+
+CODE_EXECUTION_DESCRIPTION = (
+    "Executes source code through a configured sandbox and returns stdout, stderr, "
+    "the exit code, and wall-clock elapsed milliseconds. Each call is a fresh "
+    "interpreter invocation; state does not persist across calls. Requires an "
+    "isolating sandbox to be configured on the agent."
+)
+"""Description shown to the model."""

--- a/strands-py/tests/strands/vended_tools/test_code_execution.py
+++ b/strands-py/tests/strands/vended_tools/test_code_execution.py
@@ -1,0 +1,276 @@
+"""Tests for the code_execution tool.
+
+The tool shims :meth:`~strands.sandbox.base.Sandbox.execute_code`. Security tests
+run against a fake sandbox to exercise the tool boundary; happy-path tests run
+against a :class:`~strands.sandbox.posix_shell.PosixShellSandbox` subclass that
+executes ``python3`` on the host, mirroring the sandbox tests' fixture. These
+spawn ``sh``/``python3`` and require POSIX, so they are skipped on Windows.
+"""
+
+from __future__ import annotations
+
+import shlex
+import sys
+from collections.abc import AsyncGenerator
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from strands.sandbox.base import Sandbox
+from strands.sandbox.errors import SandboxTimeoutError
+from strands.sandbox.not_a_sandbox_local_environment import NotASandboxLocalEnvironment
+from strands.sandbox.posix_shell import PosixShellSandbox, build_shell_env_prefix
+from strands.sandbox.stream_process import _stream_process
+from strands.sandbox.types import ExecutionResult, StreamChunk
+from strands.types.tools import ToolContext
+from strands.vended_tools.code_execution import code_execution, make_code_execution
+from strands.vended_tools.code_execution.types import (
+    CODE_EXECUTION_DESCRIPTION,
+    DEFAULT_MAX_CODE_BYTES,
+    TRUNCATION_MARKER,
+)
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="POSIX shell required")
+
+
+class _ShellTestSandbox(PosixShellSandbox):
+    """Concrete sandbox that runs commands via ``sh -c`` in a working directory."""
+
+    def __init__(self, working_dir: str) -> None:
+        self.working_dir = working_dir
+
+    async def execute_streaming(
+        self,
+        command: str,
+        *,
+        timeout: float | None = None,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> AsyncGenerator[StreamChunk | ExecutionResult, None]:
+        target_cwd = cwd if cwd is not None else self.working_dir
+        env_prefix = build_shell_env_prefix(env)
+        full_command = f"cd {shlex.quote(target_cwd)} && {env_prefix}{command}"
+        async for chunk in _stream_process("sh", ["-c", full_command], timeout=timeout):
+            yield chunk
+
+
+def _tool_context(sandbox: Sandbox | None = None) -> ToolContext:
+    """Build a ToolContext whose agent exposes the given sandbox (or the host default)."""
+    agent = SimpleNamespace(sandbox=sandbox or NotASandboxLocalEnvironment())
+    return ToolContext(
+        tool_use={"name": "code_execution", "toolUseId": "id", "input": {}},
+        agent=agent,
+        invocation_state={},
+    )
+
+
+@pytest.fixture
+def isolating_sandbox(tmp_path) -> _ShellTestSandbox:
+    """A sandbox subclass that is *not* NotASandboxLocalEnvironment.
+
+    The tool treats NotASandboxLocalEnvironment as "no isolation" and refuses to
+    execute; this fixture stands in for a real Docker/SSH sandbox for happy-path
+    tests without requiring one to be provisioned.
+    """
+    return _ShellTestSandbox(str(tmp_path))
+
+
+# ---- Security surface: refuses when no isolating sandbox ----
+
+
+class TestRefusalWithoutSandbox:
+    """The tool must refuse when the agent has no isolating sandbox configured."""
+
+    @pytest.mark.asyncio
+    async def test_refuses_when_agent_sandbox_is_host_default(self):
+        # The default agent sandbox is NotASandboxLocalEnvironment (no isolation).
+        with pytest.raises(RuntimeError, match="requires an isolating sandbox"):
+            await code_execution(code="print('nope')", tool_context=_tool_context())
+
+    @pytest.mark.asyncio
+    async def test_refuses_even_when_bound_at_creation(self):
+        # If someone binds NotASandboxLocalEnvironment at creation, still refuse.
+        t = make_code_execution(sandbox=NotASandboxLocalEnvironment())
+        with pytest.raises(RuntimeError, match="requires an isolating sandbox"):
+            await t(code="print('nope')", tool_context=_tool_context())
+
+
+# ---- Security surface: oversized inputs ----
+
+
+class TestInputCaps:
+    """Oversized code is rejected at the tool boundary before touching the sandbox."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_oversized_code(self, isolating_sandbox):
+        t = make_code_execution(sandbox=isolating_sandbox, max_code_bytes=100)
+        oversized = "x" * 200
+        with pytest.raises(ValueError, match="exceeds maximum"):
+            await t(code=oversized, tool_context=_tool_context())
+
+    @pytest.mark.asyncio
+    async def test_default_cap_is_reasonable(self, isolating_sandbox):
+        # Under the cap: runs. Over the cap: refuses. This locks in the default.
+        t = make_code_execution(sandbox=isolating_sandbox)
+        code = "a" * (DEFAULT_MAX_CODE_BYTES + 1)
+        with pytest.raises(ValueError, match="exceeds maximum"):
+            await t(code=code, tool_context=_tool_context())
+
+    @pytest.mark.asyncio
+    async def test_truncates_stdout_over_limit(self, isolating_sandbox):
+        t = make_code_execution(sandbox=isolating_sandbox, max_output_bytes=32)
+        # Emit more than 32 bytes of output.
+        result = await t(code="print('x' * 200)", tool_context=_tool_context())
+        assert result["stdout"].endswith(TRUNCATION_MARKER)
+        assert len(result["stdout"].encode("utf-8")) <= 32 + len(TRUNCATION_MARKER.encode("utf-8"))
+
+    def test_factory_rejects_nonpositive_caps(self):
+        with pytest.raises(ValueError):
+            make_code_execution(max_code_bytes=0)
+        with pytest.raises(ValueError):
+            make_code_execution(max_output_bytes=-1)
+        with pytest.raises(ValueError):
+            make_code_execution(default_timeout=0)
+
+    def test_factory_rejects_non_finite_default_timeout(self):
+        # Without the finiteness check, ``nan <= 0`` is false and the sandbox
+        # would see a non-finite timeout.
+        with pytest.raises(ValueError):
+            make_code_execution(default_timeout=float("nan"))
+        with pytest.raises(ValueError):
+            make_code_execution(default_timeout=float("inf"))
+
+    def test_factory_rejects_boolean_caps(self):
+        # ``bool`` is a subclass of ``int``; catch it explicitly so a stray
+        # ``True`` cannot be smuggled through as a "positive integer".
+        with pytest.raises(ValueError):
+            make_code_execution(max_code_bytes=True)  # type: ignore[arg-type]
+        with pytest.raises(ValueError):
+            make_code_execution(max_output_bytes=False)  # type: ignore[arg-type]
+
+    @pytest.mark.asyncio
+    async def test_rejects_nonpositive_timeout(self, isolating_sandbox):
+        t = make_code_execution(sandbox=isolating_sandbox)
+        with pytest.raises(ValueError, match="timeout must be"):
+            await t(code="print(1)", tool_context=_tool_context(), timeout=0)
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_finite_timeout(self, isolating_sandbox):
+        t = make_code_execution(sandbox=isolating_sandbox)
+        with pytest.raises(ValueError, match="finite"):
+            await t(code="print(1)", tool_context=_tool_context(), timeout=float("nan"))
+        with pytest.raises(ValueError, match="finite"):
+            await t(code="print(1)", tool_context=_tool_context(), timeout=float("inf"))
+
+
+# ---- Happy path ----
+
+
+class TestHappyPath:
+    """The tool executes code through the sandbox and returns the expected shape."""
+
+    @pytest.mark.asyncio
+    async def test_returns_stdout(self, isolating_sandbox):
+        t = make_code_execution(sandbox=isolating_sandbox)
+        result = await t(code="print(2 + 2)", tool_context=_tool_context())
+        assert result["stdout"].strip() == "4"
+        assert result["stderr"] == ""
+        assert result["exit_code"] == 0
+        assert isinstance(result["elapsed_ms"], int)
+        assert result["elapsed_ms"] >= 0
+
+    @pytest.mark.asyncio
+    async def test_returns_stderr(self, isolating_sandbox):
+        t = make_code_execution(sandbox=isolating_sandbox)
+        result = await t(code="import sys; sys.stderr.write('oops')", tool_context=_tool_context())
+        assert "oops" in result["stderr"]
+
+    @pytest.mark.asyncio
+    async def test_nonzero_exit_code_on_failure(self, isolating_sandbox):
+        t = make_code_execution(sandbox=isolating_sandbox)
+        result = await t(code="import sys; sys.exit(3)", tool_context=_tool_context())
+        assert result["exit_code"] == 3
+
+    @pytest.mark.asyncio
+    async def test_syntax_error_surfaces_as_nonzero_exit(self, isolating_sandbox):
+        t = make_code_execution(sandbox=isolating_sandbox)
+        result = await t(code="def : bad(", tool_context=_tool_context())
+        assert result["exit_code"] != 0
+        assert result["stderr"] != ""
+
+    @pytest.mark.asyncio
+    async def test_reads_sandbox_from_agent_context(self, isolating_sandbox):
+        # Default (unbound) instance falls through to context.agent.sandbox.
+        result = await code_execution(
+            code="print('via-context')",
+            tool_context=_tool_context(isolating_sandbox),
+        )
+        assert result["stdout"].strip() == "via-context"
+
+
+# ---- Timeout ----
+
+
+class TestTimeout:
+    """Timeout is passed through to the sandbox and surfaces as SandboxTimeoutError."""
+
+    @pytest.mark.asyncio
+    async def test_timeout_on_runaway(self, isolating_sandbox):
+        t = make_code_execution(sandbox=isolating_sandbox)
+        with pytest.raises(SandboxTimeoutError):
+            await t(
+                code="import time; time.sleep(10)",
+                tool_context=_tool_context(),
+                timeout=0.2,
+            )
+
+
+# ---- Error passthrough ----
+
+
+class TestSandboxErrorPassthrough:
+    """Non-timeout sandbox errors surface as RuntimeError."""
+
+    @pytest.mark.asyncio
+    async def test_wraps_arbitrary_sandbox_error(self):
+        class _BoomSandbox(_ShellTestSandbox):
+            async def execute_code(self, *args, **kwargs):  # type: ignore[override]
+                raise ValueError("boom")
+
+        t = make_code_execution(sandbox=_BoomSandbox("/tmp"))
+        with pytest.raises(RuntimeError, match="boom"):
+            await t(code="print(1)", tool_context=_tool_context())
+
+
+# ---- Tool metadata ----
+
+
+class TestToolMetadata:
+    """Tool names, descriptions, and input schemas are correct."""
+
+    def test_default_name(self):
+        assert code_execution.tool_name == "code_execution"
+
+    def test_custom_name(self):
+        assert make_code_execution(name="sandbox_code").tool_name == "sandbox_code"
+
+    def test_default_description(self):
+        assert make_code_execution().tool_spec["description"] == CODE_EXECUTION_DESCRIPTION
+
+    def test_custom_description(self):
+        assert make_code_execution(description="custom desc").tool_spec["description"] == "custom desc"
+
+    def test_schema_excludes_context(self):
+        props = code_execution.tool_spec["inputSchema"]["json"]["properties"]
+        assert "code" in props
+        assert "timeout" in props
+        assert "tool_context" not in props
+
+    def test_timeout_description_reflects_default(self):
+        # The model-facing docstring should advertise the factory's configured
+        # default rather than a hardcoded literal.
+        t = make_code_execution(default_timeout=15)
+        props = t.tool_spec["inputSchema"]["json"]["properties"]
+        assert "15" in props["timeout"]["description"]

--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -68,6 +68,10 @@
       "types": "./dist/src/vended-tools/bash/index.d.ts",
       "default": "./dist/src/vended-tools/bash/index.js"
     },
+    "./vended-tools/code-execution": {
+      "types": "./dist/src/vended-tools/code-execution/index.d.ts",
+      "default": "./dist/src/vended-tools/code-execution/index.js"
+    },
     "./a2a": {
       "types": "./dist/src/a2a/index.d.ts",
       "default": "./dist/src/a2a/index.js"

--- a/strands-ts/src/vended-tools/code-execution/README.md
+++ b/strands-ts/src/vended-tools/code-execution/README.md
@@ -1,0 +1,67 @@
+# Code Execution Tool
+
+Runs source code through a configured sandbox and returns stdout, stderr, the interpreter exit code, and wall-clock elapsed milliseconds.
+
+The tool is a thin shim over Sandbox.executeCode. The sandbox is the security boundary; the tool refuses to execute when the agent falls back to NotASandboxLocalEnvironment, whose name signals no isolation. Language selection is fixed at factory time and is not exposed to the model. Every input the model controls is capped: code size, stdout and stderr size returned to the model, and execution time. Timeout and agent cancellation both surface as an Error whose name is AbortError, so callers can branch on error.name.
+
+## Usage
+
+```typescript
+import { Agent } from '@strands-agents/sdk'
+import { DockerSandbox } from '@strands-agents/sdk/sandbox/docker'
+import { codeExecution } from '@strands-agents/sdk/vended-tools/code-execution'
+
+const agent = new Agent({
+  sandbox: new DockerSandbox({ container: 'my-node-container' }),
+  tools: [codeExecution],
+})
+await agent.invoke('Compute the sum of primes below one hundred and print the result.')
+```
+
+Custom factory:
+
+```typescript
+import { makeCodeExecution } from '@strands-agents/sdk/vended-tools/code-execution'
+
+const tool = makeCodeExecution(sandbox, {
+  name: 'sandbox_code',
+  maxCodeBytes: 50_000,
+  maxOutputBytes: 200_000,
+  defaultTimeout: 30,
+})
+```
+
+## API
+
+### `codeExecution`
+
+The default tool, produced by `makeCodeExecution()` with the built-in caps.
+
+### `makeCodeExecution(sandbox?, options?)`
+
+| Option           | Type     | Default          | Description                                                                    |
+| ---------------- | -------- | ---------------- | ------------------------------------------------------------------------------ |
+| `name`           | `string` | `code_execution` | Tool name.                                                                     |
+| `description`    | `string` | (built-in)       | Description shown to the model.                                                |
+| `language`       | `string` | `node`           | Interpreter to run. Fixed at factory time; not exposed to the model.           |
+| `maxCodeBytes`   | `number` | `100000`         | Upper bound on the `code` input in UTF-8 bytes.                                |
+| `maxOutputBytes` | `number` | `100000`         | Upper bound on returned stdout and stderr in UTF-8 bytes. Excess is truncated. |
+| `defaultTimeout` | `number` | `60`             | Timeout in seconds when the caller does not supply one.                        |
+
+Throws if any cap is not a positive number.
+
+### Input
+
+| Property  | Type     | Required | Description                                                       |
+| --------- | -------- | -------- | ----------------------------------------------------------------- |
+| `code`    | `string` | Yes      | Source code to execute in the configured language.                |
+| `timeout` | `number` | No       | Timeout in seconds. Falls back to the factory's `defaultTimeout`. |
+
+### Output
+
+| Field       | Type     | Description                                                  |
+| ----------- | -------- | ------------------------------------------------------------ |
+| `stdout`    | `string` | Standard output. May end with a truncation marker if capped. |
+| `stderr`    | `string` | Standard error. Same truncation rules as stdout.             |
+| `exitCode`  | `number` | Interpreter exit code. Zero indicates success.               |
+| `elapsedMs` | `number` | Wall-clock time from tool entry to sandbox return.           |

--- a/strands-ts/src/vended-tools/code-execution/__tests__/code-execution.test.node.ts
+++ b/strands-ts/src/vended-tools/code-execution/__tests__/code-execution.test.node.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { codeExecution, makeCodeExecution } from '../index.js'
+import {
+  CODE_EXECUTION_DESCRIPTION,
+  CodeSizeExceededError,
+  DEFAULT_MAX_CODE_BYTES,
+  SandboxNotConfiguredError,
+  TRUNCATION_MARKER,
+  type CodeExecutionOutput,
+} from '../types.js'
+import { NotASandboxLocalEnvironment } from '../../../sandbox/not-a-sandbox-local-environment.js'
+import { PosixShellSandbox } from '../../../sandbox/posix-shell.js'
+import type { ExecuteOptions } from '../../../sandbox/base.js'
+import type { ExecutionResult, StreamChunk } from '../../../sandbox/types.js'
+import { buildShellEnvPrefix } from '../../../sandbox/posix-shell.js'
+import { shellQuote } from '../../../sandbox/constants.js'
+import { streamProcess } from '../../../sandbox/stream-process.js'
+import type { ToolContext } from '../../../index.js'
+import { createMockAgent } from '../../../__fixtures__/agent-helpers.js'
+import type { Sandbox } from '../../../sandbox/base.js'
+
+/**
+ * A concrete PosixShellSandbox subclass used as an "isolating sandbox" stand-in.
+ * The tool treats NotASandboxLocalEnvironment as "no isolation" and refuses to
+ * execute; using a different subclass lets the happy-path tests run without
+ * provisioning a real Docker/SSH backend.
+ *
+ * Executes `node`/`python3` in a temp working directory via `sh -c`, mirroring
+ * the shape of the `TestSandbox` fixture used by the sandbox tests.
+ */
+class TestPosixSandbox extends PosixShellSandbox {
+  constructor(readonly workingDir: string) {
+    super()
+  }
+
+  async *executeStreaming(
+    command: string,
+    options?: ExecuteOptions
+  ): AsyncGenerator<StreamChunk | ExecutionResult, void, undefined> {
+    const cwd = options?.cwd ?? this.workingDir
+    const envPrefix = buildShellEnvPrefix(options?.env)
+    const fullCommand = `cd ${shellQuote(cwd)} && ${envPrefix}${command}`
+    yield* streamProcess('sh', ['-c', fullCommand], { timeout: options?.timeout, signal: options?.signal })
+  }
+}
+
+// Skip on Windows — the sandbox stand-in requires POSIX shell.
+describe.skipIf(process.platform === 'win32')('codeExecution tool', () => {
+  let workDir: string
+  let sandbox: TestPosixSandbox
+
+  const createContext = (sandboxOverride?: Sandbox): ToolContext => {
+    const agent = createMockAgent(
+      sandboxOverride
+        ? { extra: { sandbox: sandboxOverride } as unknown as Partial<import('../../../agent/agent.js').Agent> }
+        : undefined
+    )
+    return {
+      toolUse: { name: 'code_execution', toolUseId: 'test-id', input: {} },
+      agent,
+      invocationState: {},
+      interrupt: () => {
+        throw new Error('interrupt not available in mock context')
+      },
+    }
+  }
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), 'code-exec-test-'))
+    sandbox = new TestPosixSandbox(workDir)
+  })
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true })
+  })
+
+  describe('security: refuses when no isolating sandbox', () => {
+    it('refuses when agent sandbox is the host default', async () => {
+      // createMockAgent's sandbox getter returns the registered default,
+      // which is NotASandboxLocalEnvironment (see __fixtures__/register-node-defaults.ts).
+      await expect(codeExecution.invoke({ code: "console.log('nope')" }, createContext())).rejects.toThrow(
+        SandboxNotConfiguredError
+      )
+    })
+
+    it('refuses even when NotASandboxLocalEnvironment is bound at creation', async () => {
+      const t = makeCodeExecution(new NotASandboxLocalEnvironment())
+      await expect(t.invoke({ code: "console.log('nope')" }, createContext())).rejects.toThrow(
+        SandboxNotConfiguredError
+      )
+    })
+  })
+
+  describe('security: input caps', () => {
+    it('rejects oversized code before touching the sandbox', async () => {
+      const t = makeCodeExecution(sandbox, { maxCodeBytes: 100 })
+      const oversized = 'x'.repeat(200)
+      await expect(t.invoke({ code: oversized }, createContext())).rejects.toThrow(CodeSizeExceededError)
+    })
+
+    it('enforces the default cap', async () => {
+      const t = makeCodeExecution(sandbox)
+      const code = 'a'.repeat(DEFAULT_MAX_CODE_BYTES + 1)
+      await expect(t.invoke({ code }, createContext())).rejects.toThrow(CodeSizeExceededError)
+    })
+
+    it('truncates stdout over the output limit and appends the marker', async () => {
+      const t = makeCodeExecution(sandbox, { maxOutputBytes: 32 })
+      const result = (await t.invoke({ code: "console.log('x'.repeat(200))" }, createContext())) as CodeExecutionOutput
+      expect(result.stdout.endsWith(TRUNCATION_MARKER)).toBe(true)
+      expect(new TextEncoder().encode(result.stdout).byteLength).toBeLessThanOrEqual(
+        32 + new TextEncoder().encode(TRUNCATION_MARKER).byteLength
+      )
+    })
+
+    it('factory rejects nonpositive caps', () => {
+      expect(() => makeCodeExecution({ maxCodeBytes: 0 })).toThrow(/maxCodeBytes/)
+      expect(() => makeCodeExecution({ maxOutputBytes: -1 })).toThrow(/maxOutputBytes/)
+      expect(() => makeCodeExecution({ defaultTimeout: 0 })).toThrow(/defaultTimeout/)
+    })
+
+    it('factory rejects non-finite caps and timeouts', () => {
+      // `NaN <= 0` is false, so a bare comparison would silently disable the cap.
+      expect(() => makeCodeExecution({ maxCodeBytes: Number.NaN })).toThrow(/finite/)
+      expect(() => makeCodeExecution({ maxCodeBytes: Number.POSITIVE_INFINITY })).toThrow(/finite/)
+      expect(() => makeCodeExecution({ maxOutputBytes: Number.NaN })).toThrow(/finite/)
+      expect(() => makeCodeExecution({ defaultTimeout: Number.NaN })).toThrow(/finite/)
+      expect(() => makeCodeExecution({ defaultTimeout: Number.POSITIVE_INFINITY })).toThrow(/finite/)
+    })
+
+    it('input schema rejects a nonpositive timeout', async () => {
+      const t = makeCodeExecution(sandbox)
+      // Zod's `.positive()` rejects zero and negative.
+      await expect(t.invoke({ code: 'console.log(1)', timeout: 0 }, createContext())).rejects.toThrow()
+      await expect(t.invoke({ code: 'console.log(1)', timeout: -1 }, createContext())).rejects.toThrow()
+    })
+
+    it('input schema rejects non-finite timeouts', async () => {
+      const t = makeCodeExecution(sandbox)
+      await expect(t.invoke({ code: 'console.log(1)', timeout: Number.NaN }, createContext())).rejects.toThrow()
+      await expect(
+        t.invoke({ code: 'console.log(1)', timeout: Number.POSITIVE_INFINITY }, createContext())
+      ).rejects.toThrow()
+    })
+  })
+
+  describe('happy path', () => {
+    it('returns stdout for a trivial program', async () => {
+      const t = makeCodeExecution(sandbox)
+      const result = (await t.invoke({ code: 'console.log(2 + 2)' }, createContext())) as CodeExecutionOutput
+      expect(result.stdout.trim()).toBe('4')
+      expect(result.stderr).toBe('')
+      expect(result.exitCode).toBe(0)
+      expect(typeof result.elapsedMs).toBe('number')
+      expect(result.elapsedMs).toBeGreaterThanOrEqual(0)
+    })
+
+    it('returns stderr from the interpreter', async () => {
+      const t = makeCodeExecution(sandbox)
+      const result = (await t.invoke({ code: "process.stderr.write('oops')" }, createContext())) as CodeExecutionOutput
+      expect(result.stderr).toContain('oops')
+    })
+
+    it('returns a nonzero exit code when the code fails', async () => {
+      const t = makeCodeExecution(sandbox)
+      const result = (await t.invoke({ code: 'process.exit(3)' }, createContext())) as CodeExecutionOutput
+      expect(result.exitCode).toBe(3)
+    })
+
+    it('surfaces a syntax error as a nonzero exit with stderr', async () => {
+      const t = makeCodeExecution(sandbox)
+      const result = (await t.invoke({ code: 'this is not valid js' }, createContext())) as CodeExecutionOutput
+      expect(result.exitCode).not.toBe(0)
+      expect(result.stderr.length).toBeGreaterThan(0)
+    })
+
+    it('unbound instance reads the sandbox from the agent context', async () => {
+      // The default `codeExecution` reads from context.agent.sandbox at call time.
+      const result = (await codeExecution.invoke(
+        { code: "console.log('via-context')" },
+        createContext(sandbox)
+      )) as CodeExecutionOutput
+      expect(result.stdout.trim()).toBe('via-context')
+    })
+
+    it('a bound-sandbox tool works without a tool context', async () => {
+      // Mirrors the sibling http-request tool, which supports direct .invoke
+      // without a context.
+      const t = makeCodeExecution(sandbox)
+      const result = (await t.invoke({ code: "console.log('no-ctx')" })) as CodeExecutionOutput
+      expect(result.stdout.trim()).toBe('no-ctx')
+    })
+  })
+
+  describe('cancellation', () => {
+    it('surfaces timeout as AbortError on a runaway program', async () => {
+      const t = makeCodeExecution(sandbox)
+      // Loop forever; timeout is 200ms.
+      const error = await t
+        .invoke({ code: 'while (true) {}', timeout: 0.2 }, createContext())
+        .catch((cause: unknown) => cause)
+      expect(error).toBeInstanceOf(Error)
+      expect((error as Error).name).toBe('AbortError')
+      expect((error as Error).message).toMatch(/timed out/)
+    })
+
+    it('surfaces agent cancellation as AbortError', async () => {
+      const controller = new AbortController()
+      const t = makeCodeExecution(sandbox)
+      const context = createContext()
+      Object.defineProperty(context.agent, 'cancelSignal', { value: controller.signal, configurable: true })
+
+      const invocation = t.invoke({ code: 'while (true) {}', timeout: 5 }, context)
+      globalThis.setTimeout(() => controller.abort(), 50)
+      const error = await invocation.catch((cause: unknown) => cause)
+      expect(error).toBeInstanceOf(Error)
+      expect((error as Error).name).toBe('AbortError')
+    })
+  })
+
+  describe('tool metadata', () => {
+    it('has the default name', () => {
+      expect(codeExecution.name).toBe('code_execution')
+    })
+
+    it('accepts a custom name', () => {
+      expect(makeCodeExecution({ name: 'sandbox_code' }).name).toBe('sandbox_code')
+    })
+
+    it('has the default description', () => {
+      expect(makeCodeExecution().description).toBe(CODE_EXECUTION_DESCRIPTION)
+    })
+
+    it('accepts a custom description', () => {
+      expect(makeCodeExecution({ description: 'custom desc' }).description).toBe('custom desc')
+    })
+  })
+})

--- a/strands-ts/src/vended-tools/code-execution/code-execution.ts
+++ b/strands-ts/src/vended-tools/code-execution/code-execution.ts
@@ -1,0 +1,206 @@
+/**
+ * Sandbox-routed code execution tool.
+ *
+ * Provides `makeCodeExecution` (a factory) and `codeExecution` (the default
+ * instance that reads the sandbox from `context.agent.sandbox` at call time).
+ * Each call runs a fresh interpreter through the sandbox; state does not
+ * persist across calls.
+ *
+ * The tool is a thin shim over `Sandbox.executeCode`. The sandbox is the
+ * security boundary; the tool refuses to execute when the agent falls back to
+ * `NotASandboxLocalEnvironment` (whose name signals "no isolation").
+ */
+
+import { tool } from '../../tools/tool-factory.js'
+import { z } from 'zod'
+import { Sandbox } from '../../sandbox/base.js'
+import { SandboxAbortError, SandboxTimeoutError } from '../../sandbox/errors.js'
+import { NotASandboxLocalEnvironment } from '../../sandbox/not-a-sandbox-local-environment.js'
+import {
+  CODE_EXECUTION_DESCRIPTION,
+  CodeSizeExceededError,
+  DEFAULT_LANGUAGE,
+  DEFAULT_MAX_CODE_BYTES,
+  DEFAULT_MAX_OUTPUT_BYTES,
+  DEFAULT_TIMEOUT_SECONDS,
+  SandboxNotConfiguredError,
+  TRUNCATION_MARKER,
+  type CodeExecutionOutput,
+} from './types.js'
+
+/**
+ * Truncate `text` to `maxBytes` UTF-8 bytes and append `TRUNCATION_MARKER` if trimmed.
+ *
+ * Truncation is byte-oriented (not character-oriented) because the cap
+ * protects downstream consumers that may be counting bytes or tokens. If the
+ * cut falls in the middle of a multi-byte code point the default
+ * (non-fatal) `TextDecoder` would emit U+FFFD (`�`) in its place; we
+ * strip a single trailing replacement character to match the Python side,
+ * which uses `errors="ignore"` and genuinely drops the incomplete tail.
+ */
+function truncate(text: string, maxBytes: number): string {
+  const encoded = new TextEncoder().encode(text)
+  if (encoded.byteLength <= maxBytes) return text
+  let trimmed = new TextDecoder('utf-8').decode(encoded.slice(0, maxBytes))
+  if (trimmed.endsWith('�')) {
+    trimmed = trimmed.slice(0, -1)
+  }
+  return trimmed + TRUNCATION_MARKER
+}
+
+/**
+ * Options for {@link makeCodeExecution}.
+ */
+export interface MakeCodeExecutionOptions {
+  /**
+   * Tool name shown to the model. Defaults to `code_execution`.
+   */
+  name?: string
+  /**
+   * Description shown to the model.
+   */
+  description?: string
+  /**
+   * Interpreter to run. Fixed at factory time -- the model cannot select an
+   * interpreter. Defaults to `node`. Passed through to the sandbox, which
+   * validates against `LANGUAGE_PATTERN`.
+   */
+  language?: string
+  /**
+   * Upper bound on `code` size (bytes, UTF-8). Larger inputs are rejected
+   * before touching the sandbox. Defaults to `DEFAULT_MAX_CODE_BYTES`.
+   */
+  maxCodeBytes?: number
+  /**
+   * Upper bound on stdout/stderr size returned to the model (bytes, UTF-8).
+   * Excess is dropped and a truncation marker is appended. Defaults to
+   * `DEFAULT_MAX_OUTPUT_BYTES`.
+   */
+  maxOutputBytes?: number
+  /**
+   * Timeout in seconds passed to the sandbox when the caller does not supply
+   * one. Defaults to `DEFAULT_TIMEOUT_SECONDS`.
+   */
+  defaultTimeout?: number
+}
+
+/**
+ * Create a sandbox-routed code execution tool.
+ *
+ * If a sandbox is passed, it is bound at creation time. Otherwise the tool
+ * reads the sandbox from `context.agent.sandbox` at call time and refuses to
+ * run when that sandbox is the host default (`NotASandboxLocalEnvironment`).
+ */
+export function makeCodeExecution(options?: MakeCodeExecutionOptions): ReturnType<typeof tool>
+export function makeCodeExecution(
+  sandbox: Sandbox | undefined,
+  options?: MakeCodeExecutionOptions
+): ReturnType<typeof tool>
+export function makeCodeExecution(
+  sandboxOrOptions?: Sandbox | MakeCodeExecutionOptions,
+  maybeOptions?: MakeCodeExecutionOptions
+): ReturnType<typeof tool> {
+  const boundSandbox = sandboxOrOptions instanceof Sandbox ? sandboxOrOptions : undefined
+  const options = sandboxOrOptions instanceof Sandbox || maybeOptions ? (maybeOptions ?? {}) : (sandboxOrOptions ?? {})
+
+  const language = options.language ?? DEFAULT_LANGUAGE
+  const maxCodeBytes = options.maxCodeBytes ?? DEFAULT_MAX_CODE_BYTES
+  const maxOutputBytes = options.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES
+  const defaultTimeout = options.defaultTimeout ?? DEFAULT_TIMEOUT_SECONDS
+
+  // Reject NaN and Infinity explicitly: `NaN <= 0` is false, so a bare `<= 0`
+  // check would silently disable the cap (`codeBytes > NaN` is always false).
+  if (!Number.isFinite(maxCodeBytes) || maxCodeBytes <= 0) {
+    throw new Error(`maxCodeBytes must be a positive, finite number, got ${String(maxCodeBytes)}`)
+  }
+  if (!Number.isFinite(maxOutputBytes) || maxOutputBytes <= 0) {
+    throw new Error(`maxOutputBytes must be a positive, finite number, got ${String(maxOutputBytes)}`)
+  }
+  if (!Number.isFinite(defaultTimeout) || defaultTimeout <= 0) {
+    throw new Error(`defaultTimeout must be a positive, finite number, got ${String(defaultTimeout)}`)
+  }
+
+  const inputSchema = z.object({
+    code: z.string().describe('Source code to execute in the configured language.'),
+    timeout: z.number().positive().finite().optional().describe(`Timeout in seconds (default: ${defaultTimeout}).`),
+  })
+
+  return tool({
+    name: options.name ?? 'code_execution',
+    description: options.description ?? CODE_EXECUTION_DESCRIPTION,
+    inputSchema,
+    callback: async (input, context): Promise<CodeExecutionOutput> => {
+      // Input validation at the tool boundary.
+      const codeBytes = new TextEncoder().encode(input.code).byteLength
+      if (codeBytes > maxCodeBytes) {
+        throw new CodeSizeExceededError(
+          `code size (${codeBytes} bytes) exceeds maximum allowed size (${maxCodeBytes} bytes)`
+        )
+      }
+
+      // Prefer the factory-bound sandbox; fall back to the agent's when unbound.
+      // Only require context if we need the agent's sandbox — matches the
+      // sibling httpRequest, which supports direct .invoke() without context.
+      const sandbox = boundSandbox ?? context?.agent.sandbox
+      if (!sandbox) {
+        throw new Error(
+          'code_execution requires either a sandbox bound at factory time or a tool context with an agent.sandbox'
+        )
+      }
+
+      // The sandbox is the security boundary. Refuse execution when the agent
+      // is running against the host default -- its name says "no isolation"
+      // and executing model-authored code there would be a footgun.
+      if (sandbox instanceof NotASandboxLocalEnvironment) {
+        throw new SandboxNotConfiguredError(
+          'code_execution requires an isolating sandbox (e.g. DockerSandbox, SshSandbox) ' +
+            'to be configured on the agent. Refusing to execute against ' +
+            'NotASandboxLocalEnvironment, which provides no isolation.'
+        )
+      }
+
+      // `globalThis.performance.now()` is monotonic; `Date.now()` can jump on NTP
+      // adjustments and yield a misleading (or even negative) elapsed value.
+      // This also matches the Python side's `time.monotonic()`.
+      const started = globalThis.performance.now()
+      let result
+      try {
+        result = await sandbox.executeCode(input.code, language, {
+          timeout: input.timeout ?? defaultTimeout,
+          ...(context ? { signal: context.agent.cancelSignal } : {}),
+        })
+      } catch (err) {
+        // Timeouts and agent cancellation both surface as an Error whose
+        // `name === 'AbortError'`, so callers can distinguish cancellation
+        // from other failures with the standard web-platform check.
+        if (err instanceof SandboxTimeoutError) {
+          throw new DOMException(err.message, 'AbortError')
+        }
+        if (err instanceof SandboxAbortError || (err instanceof Error && err.name === 'AbortError')) {
+          const reason = context?.agent.cancelSignal.reason
+          // `AbortController.abort(reason)` accepts any value; normalize to an
+          // Error subtype so callers can rely on the standard error shape.
+          if (reason instanceof Error) {
+            throw reason
+          }
+          throw new DOMException('code_execution cancelled', 'AbortError')
+        }
+        throw new Error((err as Error).message, { cause: err })
+      }
+      const elapsedMs = Math.round(globalThis.performance.now() - started)
+
+      return {
+        stdout: truncate(result.stdout, maxOutputBytes),
+        stderr: truncate(result.stderr, maxOutputBytes),
+        exitCode: result.exitCode,
+        elapsedMs,
+      }
+    },
+  })
+}
+
+/**
+ * Default code execution tool. Reads the sandbox from the agent's context at
+ * call time and refuses to run when no isolating sandbox is configured.
+ */
+export const codeExecution = makeCodeExecution()

--- a/strands-ts/src/vended-tools/code-execution/index.ts
+++ b/strands-ts/src/vended-tools/code-execution/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Code execution tool for running source code through a configured sandbox.
+ */
+
+export { codeExecution, makeCodeExecution } from './code-execution.js'
+export type { MakeCodeExecutionOptions } from './code-execution.js'
+export {
+  CODE_EXECUTION_DESCRIPTION,
+  DEFAULT_LANGUAGE,
+  DEFAULT_MAX_CODE_BYTES,
+  DEFAULT_MAX_OUTPUT_BYTES,
+  DEFAULT_TIMEOUT_SECONDS,
+  TRUNCATION_MARKER,
+  CodeSizeExceededError,
+  SandboxNotConfiguredError,
+} from './types.js'
+export type { CodeExecutionOutput } from './types.js'

--- a/strands-ts/src/vended-tools/code-execution/types.ts
+++ b/strands-ts/src/vended-tools/code-execution/types.ts
@@ -1,0 +1,91 @@
+/**
+ * Type definitions for the code_execution tool.
+ */
+
+export const CODE_EXECUTION_DESCRIPTION =
+  'Executes source code through a configured sandbox and returns stdout, stderr, ' +
+  'the exit code, and wall-clock elapsed milliseconds. Each call is a fresh ' +
+  'interpreter invocation; state does not persist across calls. Requires an ' +
+  'isolating sandbox to be configured on the agent.'
+
+/**
+ * Default interpreter used when the factory is not passed a `language`.
+ * The tool executes the SDK's own language; `node` is TypeScript/JavaScript's convention.
+ */
+export const DEFAULT_LANGUAGE = 'node'
+
+/**
+ * Default upper bound on the source-code size accepted from the model (bytes,
+ * UTF-8). Keeps a runaway prompt from stuffing the sandbox with megabytes of
+ * source before the interpreter ever runs.
+ */
+export const DEFAULT_MAX_CODE_BYTES = 100_000
+
+/**
+ * Default upper bound on the stdout/stderr the tool returns to the model
+ * (bytes, UTF-8). Anything past this is dropped and a truncation marker is
+ * appended so the model knows it happened.
+ */
+export const DEFAULT_MAX_OUTPUT_BYTES = 100_000
+
+/**
+ * Default execution timeout in seconds; passed through to the sandbox, which
+ * owns the actual kill.
+ */
+export const DEFAULT_TIMEOUT_SECONDS = 60
+
+/**
+ * Marker appended when stdout/stderr is trimmed to `maxOutputBytes`.
+ */
+export const TRUNCATION_MARKER = '\n... [truncated]'
+
+/**
+ * Result of a code_execution call.
+ */
+export interface CodeExecutionOutput {
+  /**
+   * Standard output captured from the interpreter. May be truncated with a
+   * trailing marker if the sandbox produced more than `maxOutputBytes` bytes.
+   */
+  stdout: string
+  /**
+   * Standard error captured from the interpreter. Truncated on the same terms
+   * as `stdout`.
+   */
+  stderr: string
+  /**
+   * Exit code from the interpreter. `0` indicates success.
+   */
+  exitCode: number
+  /**
+   * Wall-clock time in milliseconds from the call entering the sandbox to the
+   * sandbox returning a result.
+   */
+  elapsedMs: number
+
+  /**
+   * Allow indexing with string keys for JSONValue compatibility.
+   */
+  [key: string]: string | number
+}
+
+/**
+ * Thrown when the caller-supplied `code` exceeds the configured `maxCodeBytes`.
+ */
+export class CodeSizeExceededError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'CodeSizeExceededError'
+  }
+}
+
+/**
+ * Thrown when the tool refuses to execute because no isolating sandbox is
+ * configured on the agent.
+ */
+export class SandboxNotConfiguredError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SandboxNotConfiguredError'
+  }
+}

--- a/strands-ts/src/vended-tools/index.ts
+++ b/strands-ts/src/vended-tools/index.ts
@@ -3,7 +3,7 @@
  *
  * Provides a single import path for consumers who want all built-in tools:
  * ```typescript
- * import { bash, fileEditor, httpRequest, notebook } from '@strands-agents/sdk/vended-tools'
+ * import { bash, codeExecution, fileEditor, httpRequest, notebook } from '@strands-agents/sdk/vended-tools'
  * ```
  *
  * Note: This module requires a Node.js environment because the `bash` tool
@@ -12,6 +12,7 @@
  */
 
 export * from './bash/index.js'
+export * from './code-execution/index.js'
 export * from './file-editor/index.js'
 export * from './http-request/index.js'
 export * from './notebook/index.js'


### PR DESCRIPTION
Adds a code_execution vended tool in both SDKs, shimmed onto Sandbox.execute_code in Python and Sandbox.executeCode in TypeScript. Each call runs a fresh interpreter invocation through the agent's sandbox and returns stdout, stderr, the interpreter exit code, and wall-clock elapsed milliseconds. State does not persist across calls. Language is fixed at factory-time and not exposed on the model-facing schema.

The sandbox module owns isolation. The tool enforces boundaries the sandbox cannot see: it refuses to execute when the agent's sandbox is NotASandboxLocalEnvironment, the host-default whose blunt name signals no isolation. Executing model-authored code there would be a footgun, so the tool raises before ever calling into the primitive. Every input the model controls is capped at the tool boundary. Source code larger than max_code_bytes (default 100 KB) is rejected before touching the sandbox. Standard output and standard error returned to the model are trimmed at max_output_bytes (default 100 KB), with a trailing marker so the model knows truncation happened. Timeout and agent cancellation both surface as an AbortError in TypeScript so callers can branch on error.name, matching the sibling http-request convention.

Scope call: stdin was on the original overlay but is not on the SDK's execute_code primitive. Adding a stdin path only in the tool would either duplicate the sandbox's process-management code or shell-pipe input in around it, both of which are the parallel-implementation pattern the brief calls out to avoid. If stdin becomes a real need the right home is a stdin option on Sandbox.execute_code itself. Language is bound at factory time rather than exposed on the input schema so the tool is not a polyglot execution surface; a caller who wants a different interpreter builds a separate tool via the factory.

Nineteen Python tests and eighteen TypeScript tests cover the security surface first and happy path second, running against a PosixShellSandbox stand-in so the whole path is exercised without provisioning Docker or SSH.

https://github.com/strands-agents/harness-sdk/issues/3250