### PR TITLE
feat(vended-tools): add tool_registry CRUD

### DIFF
--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools-imports.ts
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools-imports.ts
@@ -29,6 +29,11 @@ import { Agent, SessionManager, FileStorage } from '@strands-agents/sdk'
 import { notebook } from '@strands-agents/sdk/vended-tools/notebook'
 // --8<-- [end:notebook_persistence_import]
 
+// --8<-- [start:tool_registry_import]
+import { Agent, McpClient } from '@strands-agents/sdk'
+import { makeToolRegistry } from '@strands-agents/sdk/vended-tools/tool-registry'
+// --8<-- [end:tool_registry_import]
+
 // --8<-- [start:combined_import]
 import { Agent } from '@strands-agents/sdk'
 import { bash } from '@strands-agents/sdk/vended-tools/bash'

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -11,8 +11,10 @@ sourceLinks:
   - path: strands-ts/src/vended-tools/http-request/http-request.ts
   - path: strands-ts/src/vended-tools/notebook/notebook.ts
   - path: strands-ts/src/vended-tools/stop/stop.ts
+  - path: strands-ts/src/vended-tools/tool-registry/tool-registry.ts
   - path: strands-py/src/strands/vended_tools/http_request/http_request.py
   - path: strands-py/src/strands/vended_tools/stop/stop.py
+  - path: strands-py/src/strands/vended_tools/tool_registry/tool_registry.py
 ---
 
 Vended tools are pre-built tools included directly in the Strands SDK for common agent tasks like file operations, shell commands, HTTP requests, and persistent notes. 
@@ -38,6 +40,7 @@ Each tool is imported from its own subpath under `@strands-agents/sdk/vended-too
 | [Notebook](#notebook) | Manage persistent text notebooks | TypeScript (Node.js, browsers) |
 | [Bash](#bash) | Execute shell commands with persistent sessions | Python, TypeScript (Node.js, Unix/Linux/macOS) |
 | [Stop](#stop) | Gracefully end the agent loop when the task is complete | Python, TypeScript (Node.js, browsers) |
+| [Tool Registry](#tool-registry) | Let the agent list, add, re-bind, and remove tools on its own registry at runtime | Python, TypeScript (Node.js, browsers) |
 
 ### File Editor
 
@@ -239,6 +242,57 @@ result = agent("Summarize the changes in ./CHANGELOG.md")
 </Tabs>
 
 📖 [Full API Reference](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/stop/README.md)
+
+---
+
+### Tool Registry
+
+Gives the agent runtime CRUD access to its own tool registry, backed
+exclusively by already-connected MCP clients the developer pre-approved at
+construction time. The model can list every tool currently registered, register
+a new tool that binds to a specific remote tool on one of those clients, re-bind
+an existing entry, and remove entries this tool itself added.
+Developer-registered tools are never mutable through the interface, and there
+is no filesystem or inline-code loading surface.
+
+_Supported in: Node.js, modern browsers (TypeScript); all platforms (Python)._
+
+The pre-approved MCP client set is fixed when the tool is constructed; the
+model chooses among aliases the developer set, never a raw URL. A configurable
+cap (default: thirty-two) bounds the number of tools any one instance may add
+to a given agent.
+
+**Example:**
+
+<Tabs>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/tools/vended-tools-imports.ts:tool_registry_import"
+
+--8<-- "user-guide/concepts/tools/vended-tools.ts:tool_registry_example"
+```
+
+</Tab>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.tools.mcp import MCPClient
+from strands.vended_tools import make_tool_registry
+
+weather = MCPClient(...)
+weather.start()
+
+registry_tool = make_tool_registry(mcp_clients={"weather": weather})
+agent = Agent(tools=[registry_tool])
+agent("List the tools you have, then add the forecast tool from weather.")
+```
+
+</Tab>
+</Tabs>
+
+📖 [Full API Reference](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/tool-registry/README.md)
 
 ---
 

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.ts
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.ts
@@ -5,7 +5,8 @@ import { fileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
 import { httpRequest } from '@strands-agents/sdk/vended-tools/http-request'
 import { notebook } from '@strands-agents/sdk/vended-tools/notebook'
 // --8<-- [end:basic_import]
-import { SessionManager, FileStorage } from '@strands-agents/sdk'
+import { SessionManager, FileStorage, McpClient } from '@strands-agents/sdk'
+import { makeToolRegistry } from '@strands-agents/sdk/vended-tools/tool-registry'
 
 // Agent with vended tools example
 async function agentWithVendedToolsExample() {
@@ -108,6 +109,18 @@ async function notebookStatePersistenceExample() {
   const restoredAgent = new Agent({ tools: [notebook], sessionManager: session })
   await restoredAgent.invoke('Read the ideas notebook')
   // --8<-- [end:notebook_state_persistence]
+}
+
+// Tool registry example
+async function toolRegistryExample() {
+  // --8<-- [start:tool_registry_example]
+  const weather = new McpClient({ url: 'https://weather.example.com/mcp' })
+  await weather.connect()
+
+  const registryTool = makeToolRegistry({ mcpClients: { weather } })
+  const agent = new Agent({ tools: [registryTool] })
+  await agent.invoke('List the tools you have, then add the forecast tool from weather.')
+  // --8<-- [end:tool_registry_example]
 }
 
 // Combined tools example - development workflow

--- a/strands-py/src/strands/vended_tools/__init__.py
+++ b/strands-py/src/strands/vended_tools/__init__.py
@@ -1,4 +1,4 @@
-"""Built-in tools for executing commands, editing files, making HTTP requests, and controlling the agent loop.
+"""Built-in tools for commands, files, HTTP, tool registry, and agent-loop control.
 
 The :data:`bash` tool runs a
 persistent shell on the host; the :func:`make_bash` and :func:`make_file_editor`
@@ -13,6 +13,9 @@ security posture (private-network denial, redirect and body-size caps,
 sensitive-header rejection); use :func:`make_http_request` to relax individual
 controls when needed.
 
+The :func:`make_tool_registry` factory produces a tool that lets the agent
+introspect and mutate its own tool registry at runtime.
+
 Example Usage:
     ```python
     from strands import Agent
@@ -26,6 +29,7 @@ from .bash import bash, make_bash
 from .file_editor import file_editor, make_file_editor
 from .http_request import http_request, make_http_request
 from .stop import make_stop, stop
+from .tool_registry import make_tool_registry
 
 __all__ = [
     "bash",
@@ -35,5 +39,6 @@ __all__ = [
     "make_file_editor",
     "make_http_request",
     "make_stop",
+    "make_tool_registry",
     "stop",
 ]

--- a/strands-py/src/strands/vended_tools/tool_registry/__init__.py
+++ b/strands-py/src/strands/vended_tools/tool_registry/__init__.py
@@ -1,0 +1,40 @@
+"""Runtime tool-registry-management tool (CRUD over the agent's own tools).
+
+Only tools hosted on pre-approved MCP servers may be registered dynamically.
+Loading tools from a file path or inline source is intentionally not supported.
+
+Example Usage:
+    ```python
+    from strands import Agent
+    from strands.tools.mcp import MCPClient
+    from strands.vended_tools.tool_registry import make_tool_registry
+
+    weather = MCPClient(...)
+    weather.start()
+    registry_tool = make_tool_registry(mcp_clients={"weather": weather})
+
+    agent = Agent(tools=[registry_tool])
+    ```
+"""
+
+from .tool_registry import make_tool_registry
+from .types import (
+    MAX_DYNAMIC_TOOLS,
+    TOOL_NAME_PATTERN,
+    TOOL_REGISTRY_DESCRIPTION,
+    ListResult,
+    MutationResult,
+    RegisteredTool,
+    ToolRegistryError,
+)
+
+__all__ = [
+    "MAX_DYNAMIC_TOOLS",
+    "TOOL_NAME_PATTERN",
+    "TOOL_REGISTRY_DESCRIPTION",
+    "ListResult",
+    "MutationResult",
+    "RegisteredTool",
+    "ToolRegistryError",
+    "make_tool_registry",
+]

--- a/strands-py/src/strands/vended_tools/tool_registry/tool_registry.py
+++ b/strands-py/src/strands/vended_tools/tool_registry/tool_registry.py
@@ -27,6 +27,7 @@ is exactly whatever the developer-approved MCP servers already expose.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import weakref
 from typing import TYPE_CHECKING
@@ -93,18 +94,18 @@ async def _resolve_mcp_tool(
 ) -> MCPAgentTool:
     """Look up a specific tool on the MCP client and adapt it to the local name.
 
-    Async so that the caller yields to the event loop across the (potentially
-    network-bound) MCP list-tools call. In production the body runs to
-    completion without suspending; the ``async`` shape exists so tests can
-    swap in a fake that yields with ``await asyncio.sleep(0)`` to exercise
-    concurrency at the tool level.
+    ``list_tools_sync`` is a blocking network call, so it is dispatched to a
+    worker thread with :func:`asyncio.to_thread`; without that the whole event
+    loop would stall on the round-trip. The suspension point is real, which is
+    what makes the reservation and concurrent-delete/update guards reachable in
+    production the same way the tests exercise them.
 
     Raises:
         ToolRegistryError: If ``remote_name`` is not exposed by the MCP server.
     """
     pagination_token: str | None = None
     while True:
-        page = client.list_tools_sync(pagination_token=pagination_token)
+        page = await asyncio.to_thread(client.list_tools_sync, pagination_token=pagination_token)
         for mcp_tool in page:
             # ``list_tools_sync`` returns MCPAgentTool objects; the underlying
             # ``mcp_tool.name`` is the remote-side name, unaffected by any

--- a/strands-py/src/strands/vended_tools/tool_registry/tool_registry.py
+++ b/strands-py/src/strands/vended_tools/tool_registry/tool_registry.py
@@ -1,0 +1,331 @@
+"""Tool for CRUD over the agent's own tool registry.
+
+Provides :func:`make_tool_registry` (a factory that binds the tool to a set of
+already-connected MCP clients from which new tools may be pulled). The tool
+exposes four operations to the model:
+
+- ``list``: enumerate all tools currently on the agent's registry, marking the
+  ones this tool has registered itself.
+- ``create``: register a new tool that is a thin binding to a specific tool
+  hosted on one of the pre-approved MCP clients.
+- ``update``: re-bind a previously registered tool (e.g. to point at a
+  different remote tool, or to change its description). The local name is the
+  lookup key and is not modifiable; delete and re-create to rename.
+- ``delete``: unregister a tool that this same tool_registry instance
+  registered. Developer-registered tools are never removable.
+
+Design decision (see PR body): ``create`` only accepts references to already-
+connected MCP servers pre-provided by the developer via ``mcp_clients``.
+Accepting a filesystem path (loading arbitrary Python from disk) or inline
+source code (executing arbitrary Python or JS) are explicitly out of scope --
+both introduce a filesystem/code-execution attack surface that is
+disproportionate to the value of runtime tool registration for a general-purpose
+agent tool. Consumers that need those flows should build a separate, more
+locked-down tool. This one is a thin shim onto MCPClient, so its blast radius
+is exactly whatever the developer-approved MCP servers already expose.
+"""
+
+from __future__ import annotations
+
+import logging
+import weakref
+from typing import TYPE_CHECKING
+
+from ...tools.decorator import tool
+from ...tools.mcp import MCPAgentTool, MCPClient
+from ...types.tools import ToolContext
+from .types import (
+    MAX_DYNAMIC_TOOLS,
+    TOOL_NAME_PATTERN,
+    TOOL_REGISTRY_DESCRIPTION,
+    ListResult,
+    MutationResult,
+    RegisteredTool,
+    ToolRegistryError,
+)
+
+if TYPE_CHECKING:
+    from ...tools.decorator import DecoratedFunctionTool
+    from ...tools.registry import ToolRegistry
+
+logger = logging.getLogger(__name__)
+
+
+def _get_owned_names(
+    ownership: weakref.WeakKeyDictionary[ToolRegistry, set[str]],
+    registry: ToolRegistry,
+) -> set[str]:
+    owned = ownership.get(registry)
+    if owned is None:
+        owned = set()
+        ownership[registry] = owned
+    return owned
+
+
+def _validate_tool_name(name: str) -> None:
+    if not isinstance(name, str) or not TOOL_NAME_PATTERN.match(name):
+        raise ToolRegistryError(f"invalid tool name '{name}': must match {TOOL_NAME_PATTERN.pattern}")
+
+
+def _find_normalized_conflict(registry: ToolRegistry, name: str) -> str | None:
+    """Return an existing registry name that collides with ``name``.
+
+    The SDK's normalized-name rule treats ``-`` and ``_`` as equivalent.
+    ``ToolRegistry.register_tool`` enforces this rule but
+    ``register_dynamic_tool`` does not, so we replicate the check here to keep
+    the tool_registry surface consistent with ``register_tool`` and to fail
+    with a clear ToolRegistryError rather than a bare ValueError from the SDK.
+    """
+    normalized = name.replace("-", "_")
+    for existing in list(registry.registry.keys()) + list(registry.dynamic_tools.keys()):
+        if existing == name:
+            continue
+        if existing.replace("-", "_") == normalized:
+            return existing
+    return None
+
+
+async def _resolve_mcp_tool(
+    client: MCPClient,
+    remote_name: str,
+    local_name: str,
+    description_override: str | None,
+) -> MCPAgentTool:
+    """Look up a specific tool on the MCP client and adapt it to the local name.
+
+    Async so that the caller yields to the event loop across the (potentially
+    network-bound) MCP list-tools call. In production the body runs to
+    completion without suspending; the ``async`` shape exists so tests can
+    swap in a fake that yields with ``await asyncio.sleep(0)`` to exercise
+    concurrency at the tool level.
+
+    Raises:
+        ToolRegistryError: If ``remote_name`` is not exposed by the MCP server.
+    """
+    pagination_token: str | None = None
+    while True:
+        page = client.list_tools_sync(pagination_token=pagination_token)
+        for mcp_tool in page:
+            # ``list_tools_sync`` returns MCPAgentTool objects; the underlying
+            # ``mcp_tool.name`` is the remote-side name, unaffected by any
+            # client-level prefix. Match on that.
+            if mcp_tool.mcp_tool.name == remote_name:
+                adapted = MCPAgentTool(
+                    mcp_tool.mcp_tool,
+                    client,
+                    name_override=local_name,
+                )
+                adapted.mark_dynamic()
+                if description_override is not None:
+                    # ``MCPAgentTool.tool_spec`` reads from ``mcp_tool.description``
+                    # each call; override by copying the underlying pydantic model.
+                    adapted.mcp_tool = adapted.mcp_tool.model_copy(update={"description": description_override})
+                return adapted
+        pagination_token = page.pagination_token
+        if pagination_token is None:
+            break
+    raise ToolRegistryError(f"tool '{remote_name}' not found on MCP server")
+
+
+def make_tool_registry(
+    *,
+    mcp_clients: dict[str, MCPClient] | None = None,
+    max_dynamic_tools: int = MAX_DYNAMIC_TOOLS,
+    name: str = "tool_registry",
+    description: str = TOOL_REGISTRY_DESCRIPTION,
+) -> DecoratedFunctionTool:
+    """Create a runtime tool-registry-management tool bound to a set of MCP sources.
+
+    Args:
+        mcp_clients: Mapping from a stable, developer-chosen alias to an
+            already-connected :class:`~strands.tools.mcp.MCPClient`. Only tools
+            hosted on these clients may be registered dynamically. When ``None``
+            or empty, ``create`` and ``update`` always fail; the tool degrades to
+            a read-only view.
+        max_dynamic_tools: Upper bound on the number of tools this instance may
+            add to the agent's registry. Defaults to :data:`.types.MAX_DYNAMIC_TOOLS`.
+        name: Tool name. Defaults to ``"tool_registry"``.
+        description: Tool description shown to the model.
+
+    Returns:
+        A decorated tool that performs the four CRUD operations on the agent's
+        tool registry.
+
+    Raises:
+        ValueError: If ``max_dynamic_tools`` is less than one.
+    """
+    clients: dict[str, MCPClient] = dict(mcp_clients or {})
+
+    if max_dynamic_tools < 1:
+        raise ValueError("max_dynamic_tools must be at least 1")
+
+    # Per-factory ownership map: keyed on the agent's ToolRegistry, closed over
+    # by this factory instance. Two `make_tool_registry` factories on one agent
+    # therefore track their own tools independently. `WeakKeyDictionary` lets
+    # the entry disappear when the registry (and its agent) is garbage-collected.
+    ownership: weakref.WeakKeyDictionary[ToolRegistry, set[str]] = weakref.WeakKeyDictionary()
+
+    @tool(name=name, description=description, context="tool_context")
+    async def tool_registry_tool(
+        operation: str,
+        tool_context: ToolContext,
+        tool_name: str | None = None,
+        source: str | None = None,
+        remote_name: str | None = None,
+        description_override: str | None = None,
+    ) -> ListResult | MutationResult:
+        """Manage the agent's tool registry at runtime (MCP-backed).
+
+        Args:
+            operation: One of ``"list"``, ``"create"``, ``"update"``, ``"delete"``.
+            tool_context: Injected by the framework. Not user-facing.
+            tool_name: Local name for the tool on the agent's registry. Required
+                for ``create``, ``update``, and ``delete``. Must match
+                ``^[a-zA-Z_][a-zA-Z0-9_]{0,63}$``.
+            source: For ``create``/``update``, the alias of an MCP client
+                previously registered with this tool via ``mcp_clients``. The
+                set of valid aliases is fixed at tool construction time.
+            remote_name: For ``create``/``update``, the name of the tool on the
+                MCP server pointed at by ``source``. Defaults to ``tool_name``
+                when omitted.
+            description_override: Optional description to expose to the model in
+                place of the MCP server's advertised description. Useful when the
+                remote description is empty or too generic.
+
+        Raises:
+            ToolRegistryError: For any validation failure surfaced by the tool
+                itself: unknown operation, missing or invalid ``tool_name``,
+                unknown ``source``, unknown remote tool, dynamic-tool cap
+                reached, duplicate registration, self-mutation attempt,
+                deletion or update of a tool this instance did not register,
+                or a concurrent-delete race that cancels an in-flight
+                ``create``/``update``.
+        """
+        agent_registry: ToolRegistry = tool_context.agent.tool_registry
+        owned = _get_owned_names(ownership, agent_registry)
+
+        if operation == "list":
+            tools_out: list[RegisteredTool] = []
+            for spec in agent_registry.get_all_tool_specs():
+                entry: RegisteredTool = {
+                    "name": spec["name"],
+                    "description": spec.get("description", ""),
+                    "registered_by_tool_registry": spec["name"] in owned,
+                }
+                # Omit input_schema only when the underlying tool doesn't
+                # declare the key at all, matching the TypeScript SDK's
+                # optional-field convention. An explicit empty dict is a
+                # valid schema and must be preserved.
+                if "inputSchema" in spec:
+                    entry["input_schema"] = spec["inputSchema"]
+                tools_out.append(entry)
+            return ListResult(
+                tools=tools_out,
+                dynamic_count=len(owned),
+                dynamic_limit=max_dynamic_tools,
+            )
+
+        if operation not in ("create", "update", "delete"):
+            raise ToolRegistryError(
+                f"invalid operation '{operation}': must be one of 'list', 'create', 'update', 'delete'"
+            )
+
+        if tool_name is None:
+            raise ToolRegistryError(f"'tool_name' is required for operation '{operation}'")
+        _validate_tool_name(tool_name)
+
+        # Never allow this tool to remove or replace itself.
+        if tool_name == name:
+            raise ToolRegistryError(f"cannot {operation} the tool_registry tool ('{tool_name}') itself")
+
+        if operation == "delete":
+            if tool_name not in owned:
+                raise ToolRegistryError(
+                    f"tool '{tool_name}' was not registered via tool_registry; "
+                    "developer-registered tools cannot be removed"
+                )
+            # Owned ⇒ present in dynamic_tools; belt-and-braces guard against
+            # external tampering with the registry between calls.
+            agent_registry.dynamic_tools.pop(tool_name, None)
+            agent_registry.registry.pop(tool_name, None)
+            owned.discard(tool_name)
+            return MutationResult(operation="delete", name=tool_name, dynamic_count=len(owned))
+
+        # create / update below share the source-resolution logic.
+        if not source:
+            raise ToolRegistryError(f"'source' is required for operation '{operation}'")
+        if source not in clients:
+            allowed = ", ".join(sorted(clients)) or "<none>"
+            raise ToolRegistryError(f"unknown source '{source}': allowed sources are: {allowed}")
+        effective_remote = remote_name or tool_name
+
+        if operation == "create":
+            if (
+                tool_name in agent_registry.registry
+                or tool_name in agent_registry.dynamic_tools
+                or tool_name in owned
+            ):
+                raise ToolRegistryError(f"a tool named '{tool_name}' is already registered")
+            conflict = _find_normalized_conflict(agent_registry, tool_name)
+            if conflict is not None:
+                raise ToolRegistryError(
+                    f"a tool named '{conflict}' is already registered; "
+                    f"tool names cannot differ only by '-' vs '_'"
+                )
+            if len(owned) >= max_dynamic_tools:
+                raise ToolRegistryError(
+                    f"dynamic tool cap reached ({max_dynamic_tools}); "
+                    "delete an existing dynamically-registered tool first"
+                )
+            # Reserve the slot in the owned set before the MCP lookup so
+            # concurrent `create` calls in the same turn can't all pass the
+            # cap check before any of them registers. On failure, release.
+            owned.add(tool_name)
+            try:
+                new_tool = await _resolve_mcp_tool(
+                    clients[source], effective_remote, tool_name, description_override
+                )
+                # A concurrent `delete` could have observed our reservation,
+                # treated it as if the tool were already registered, and cleared
+                # it while we were awaiting. If so, abort rather than write a
+                # tool this instance can no longer track.
+                if tool_name not in owned:
+                    raise ToolRegistryError(
+                        f"create of '{tool_name}' was cancelled by a concurrent delete "
+                        "before the tool could be registered"
+                    )
+                try:
+                    agent_registry.register_dynamic_tool(new_tool)
+                except ValueError as err:
+                    # A concurrent registration (e.g. another tool_registry
+                    # instance) can still land a duplicate between our checks
+                    # and the write. Surface as ToolRegistryError so callers
+                    # get a single exception type from the tool.
+                    raise ToolRegistryError(str(err)) from err
+            except Exception:
+                owned.discard(tool_name)
+                raise
+            return MutationResult(operation="create", name=tool_name, dynamic_count=len(owned))
+
+        # operation == "update"
+        if tool_name not in owned:
+            raise ToolRegistryError(
+                f"tool '{tool_name}' was not registered via tool_registry; developer-registered tools cannot be updated"
+            )
+        new_tool = await _resolve_mcp_tool(clients[source], effective_remote, tool_name, description_override)
+        # A concurrent `delete` could have run during the await above and
+        # cleared this instance's ownership of the tool. If so, abort rather
+        # than resurrect a tool the model believed deleted (mirrors the
+        # create-during-delete guard).
+        if tool_name not in owned:
+            raise ToolRegistryError(
+                f"update of '{tool_name}' was cancelled by a concurrent delete "
+                "before the tool could be re-bound"
+            )
+        # Replace under the same name, keeping ownership.
+        agent_registry.dynamic_tools[tool_name] = new_tool
+        if tool_name in agent_registry.registry:
+            agent_registry.registry[tool_name] = new_tool
+        return MutationResult(operation="update", name=tool_name, dynamic_count=len(owned))
+
+    return tool_registry_tool

--- a/strands-py/src/strands/vended_tools/tool_registry/types.py
+++ b/strands-py/src/strands/vended_tools/tool_registry/types.py
@@ -1,0 +1,65 @@
+"""Shared types and constants for the tool_registry tool."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Literal, TypedDict
+
+from typing_extensions import NotRequired
+
+# Provider-accepted tool name: leading letter/underscore, then letters/digits/underscore,
+# capped at 64 characters. Stricter than the underlying registry (which also allows '-')
+# because the dynamically-registered tool name is echoed into user-visible spec strings
+# and log messages; disallowing '-' keeps every generated identifier a legal Python name.
+TOOL_NAME_PATTERN: re.Pattern[str] = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]{0,63}$")
+"""Regex enforced on all dynamically-registered tool names."""
+
+MAX_DYNAMIC_TOOLS: int = 32
+"""Maximum number of tools a single tool_registry instance may register."""
+
+TOOL_REGISTRY_DESCRIPTION: str = (
+    "Manage the agent's tool registry at runtime. Supports operations to `list` "
+    "currently registered tools, `create` a new binding to an already-connected "
+    "MCP server tool, `update` an existing binding, and `delete` a previously "
+    "registered binding. Registration is limited to remote MCP tools; loading "
+    "tools from a file path or inline source is intentionally not supported."
+)
+
+
+class RegisteredTool(TypedDict):
+    """A tool entry in a `list` response.
+
+    Attributes:
+        name: The tool name as visible to the agent.
+        description: The tool description as visible to the model.
+        input_schema: The tool's JSON input schema. Omitted when the tool
+            does not declare one.
+        registered_by_tool_registry: True when this tool was registered via
+            the tool_registry tool (i.e. it can be updated/deleted by this
+            tool). False for developer-registered tools.
+    """
+
+    name: str
+    description: str
+    input_schema: NotRequired[dict[str, Any]]
+    registered_by_tool_registry: bool
+
+
+class ListResult(TypedDict):
+    """Result payload for the `list` operation."""
+
+    tools: list[RegisteredTool]
+    dynamic_count: int
+    dynamic_limit: int
+
+
+class MutationResult(TypedDict):
+    """Result payload for `create`, `update`, and `delete` operations."""
+
+    operation: Literal["create", "update", "delete"]
+    name: str
+    dynamic_count: int
+
+
+class ToolRegistryError(ValueError):
+    """Raised for validation failures inside the tool_registry tool."""

--- a/strands-py/tests/strands/vended_tools/test_tool_registry.py
+++ b/strands-py/tests/strands/vended_tools/test_tool_registry.py
@@ -1,0 +1,655 @@
+"""Tests for the tool_registry tool.
+
+The tool provides CRUD access to the agent's own tool registry. Only tools
+hosted on a pre-approved MCP client may be registered; developer-registered
+tools are never removable or updatable via the tool. These tests exercise the
+tool as a plain async callable (bypassing the streaming/error-wrapping path);
+validation failures surface as raised ``ToolRegistryError``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from mcp.types import Tool as MCPTool
+
+from strands.tools.decorator import tool as tool_decorator
+from strands.tools.registry import ToolRegistry
+from strands.types import PaginatedList
+from strands.types.tools import ToolContext
+from strands.vended_tools.tool_registry import (
+    MAX_DYNAMIC_TOOLS,
+    ToolRegistryError,
+    make_tool_registry,
+)
+
+
+@dataclass
+class _FakeMCPClient:
+    """Minimal stand-in for ``MCPClient``: pretends to host a fixed set of tools.
+
+    Only the surface the tool_registry tool actually uses is exposed:
+    ``list_tools_sync`` yielding ``MCPAgentTool`` instances (via the real class
+    from the SDK), with the pagination shape the tool expects.
+    """
+
+    tools: list[MCPTool]
+
+    def list_tools_sync(self, pagination_token: str | None = None, **kwargs: Any) -> PaginatedList[Any]:
+        # Import here to avoid a cycle when tests are collected before mcp submodule init.
+        from strands.tools.mcp.mcp_agent_tool import MCPAgentTool
+
+        adapted = [MCPAgentTool(t, self) for t in self.tools]  # type: ignore[arg-type]
+        return PaginatedList(adapted, token=None)
+
+
+def _mcp_tool(name: str, description: str = "a fake tool") -> MCPTool:
+    return MCPTool(
+        name=name,
+        description=description,
+        inputSchema={"type": "object", "properties": {}},
+    )
+
+
+def _tool_context(registry: ToolRegistry) -> ToolContext:
+    agent = SimpleNamespace(tool_registry=registry)
+    return ToolContext(
+        tool_use={"name": "tool_registry", "toolUseId": "id", "input": {}},
+        agent=agent,
+        invocation_state={},
+    )
+
+
+@pytest.fixture
+def registry() -> ToolRegistry:
+    r = ToolRegistry()
+
+    # Two developer-registered tools that must remain untouchable.
+    @tool_decorator(name="dev_echo", description="developer-registered echo")
+    def dev_echo(text: str) -> str:
+        return text
+
+    @tool_decorator(name="dev_ping", description="developer-registered ping")
+    def dev_ping() -> str:
+        return "pong"
+
+    r.register_tool(dev_echo)
+    r.register_tool(dev_ping)
+    return r
+
+
+@pytest.fixture
+def mcp_client() -> _FakeMCPClient:
+    return _FakeMCPClient(
+        tools=[
+            _mcp_tool("remote_alpha"),
+            _mcp_tool("remote_beta"),
+            _mcp_tool("remote_gamma"),
+        ]
+    )
+
+
+@pytest.fixture
+def registry_tool(mcp_client: _FakeMCPClient) -> Any:
+    # Cast MCPClient explicitly via typing.Any to sidestep the isinstance check
+    # in the tool factory; the factory only requires the ``list_tools_sync`` API.
+    return make_tool_registry(mcp_clients={"weather": mcp_client})  # type: ignore[dict-item]
+
+
+class TestListOperation:
+    @pytest.mark.asyncio
+    async def test_lists_developer_registered_tools_as_not_owned(self, registry_tool, registry: ToolRegistry) -> None:
+        result = await registry_tool(operation="list", tool_context=_tool_context(registry))
+        names = {t["name"]: t for t in result["tools"]}
+        assert "dev_echo" in names
+        assert "dev_ping" in names
+        assert names["dev_echo"]["registered_by_tool_registry"] is False
+        assert names["dev_ping"]["registered_by_tool_registry"] is False
+        assert result["dynamic_count"] == 0
+        assert result["dynamic_limit"] == MAX_DYNAMIC_TOOLS
+
+
+class TestCreateOperation:
+    @pytest.mark.asyncio
+    async def test_registers_mcp_tool_and_marks_owned(self, registry_tool, registry: ToolRegistry) -> None:
+        result = await registry_tool(
+            operation="create",
+            tool_name="alpha",
+            source="weather",
+            remote_name="remote_alpha",
+            tool_context=_tool_context(registry),
+        )
+        assert result["operation"] == "create"
+        assert result["name"] == "alpha"
+        assert result["dynamic_count"] == 1
+        assert "alpha" in registry.dynamic_tools
+
+    @pytest.mark.asyncio
+    async def test_uses_tool_name_as_default_remote_name(self, registry_tool, registry: ToolRegistry) -> None:
+        result = await registry_tool(
+            operation="create",
+            tool_name="remote_beta",
+            source="weather",
+            tool_context=_tool_context(registry),
+        )
+        assert result["name"] == "remote_beta"
+        assert "remote_beta" in registry.dynamic_tools
+
+    @pytest.mark.asyncio
+    async def test_description_override_shadowed_on_spec(self, registry_tool, registry: ToolRegistry) -> None:
+        await registry_tool(
+            operation="create",
+            tool_name="alpha",
+            source="weather",
+            remote_name="remote_alpha",
+            description_override="custom text",
+            tool_context=_tool_context(registry),
+        )
+        spec = registry.dynamic_tools["alpha"].tool_spec
+        assert spec["description"] == "custom text"
+
+    @pytest.mark.asyncio
+    async def test_rejects_unknown_source(self, registry_tool, registry: ToolRegistry) -> None:
+        with pytest.raises(ToolRegistryError, match="unknown source"):
+            await registry_tool(
+                operation="create",
+                tool_name="alpha",
+                source="not_a_real_client",
+                tool_context=_tool_context(registry),
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_unknown_remote_tool(self, registry_tool, registry: ToolRegistry) -> None:
+        with pytest.raises(ToolRegistryError, match="not found on MCP server"):
+            await registry_tool(
+                operation="create",
+                tool_name="alpha",
+                source="weather",
+                remote_name="does_not_exist",
+                tool_context=_tool_context(registry),
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_collision_with_developer_tool(self, registry_tool, registry: ToolRegistry) -> None:
+        with pytest.raises(ToolRegistryError, match="already registered"):
+            await registry_tool(
+                operation="create",
+                tool_name="dev_echo",
+                source="weather",
+                remote_name="remote_alpha",
+                tool_context=_tool_context(registry),
+            )
+
+    @pytest.mark.asyncio
+    async def test_cannot_register_over_itself(self, registry_tool, registry: ToolRegistry) -> None:
+        with pytest.raises(ToolRegistryError, match="itself"):
+            await registry_tool(
+                operation="create",
+                tool_name="tool_registry",
+                source="weather",
+                remote_name="remote_alpha",
+                tool_context=_tool_context(registry),
+            )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "bad",
+        ["", "1_starts_with_digit", "has-dash", "has space", "toolname!"],
+    )
+    async def test_rejects_invalid_tool_name(self, registry_tool, registry: ToolRegistry, bad: str) -> None:
+        with pytest.raises(ToolRegistryError, match="invalid tool name"):
+            await registry_tool(
+                operation="create",
+                tool_name=bad,
+                source="weather",
+                remote_name="remote_alpha",
+                tool_context=_tool_context(registry),
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_normalized_name_conflict(self, registry_tool) -> None:
+        """A tool name that only differs by '-' vs '_' from an existing entry is rejected.
+
+        The underlying SDK registry's `register_tool` enforces this rule but
+        `register_dynamic_tool` does not, so the tool has to replicate the check
+        to keep the two surfaces consistent and to fail with a clear error.
+        """
+        reg = ToolRegistry()
+
+        # Insert a developer tool whose name contains a dash. The tool_registry
+        # tool would never allow the model to register such a name (dashes are
+        # rejected by TOOL_NAME_PATTERN), but developer tools can carry them.
+        @tool_decorator(name="my-tool", description="dash-named developer tool")
+        def my_tool() -> str:
+            return "ok"
+
+        reg.register_tool(my_tool)
+
+        # Now the model tries to add `my_tool` — which normalizes to the same
+        # canonical name — and should be rejected before any MCP work happens.
+        with pytest.raises(ToolRegistryError, match="differ only by '-' vs '_'"):
+            await registry_tool(
+                operation="create",
+                tool_name="my_tool",
+                source="weather",
+                remote_name="remote_alpha",
+                tool_context=_tool_context(reg),
+            )
+
+    @pytest.mark.asyncio
+    async def test_wraps_register_dynamic_tool_value_error(
+        self,
+        mcp_client: _FakeMCPClient,
+        registry: ToolRegistry,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A raw `ValueError` from `register_dynamic_tool` is surfaced as `ToolRegistryError`.
+
+        Another `tool_registry` factory could race a duplicate registration
+        between our checks and the write; callers should still see a single
+        exception type from the tool.
+        """
+        registry_tool = make_tool_registry(
+            mcp_clients={"weather": mcp_client},  # type: ignore[dict-item]
+        )
+
+        def raise_duplicate(_tool: Any) -> None:
+            raise ValueError("Tool 'alpha' already exists")
+
+        monkeypatch.setattr(registry, "register_dynamic_tool", raise_duplicate)
+        with pytest.raises(ToolRegistryError, match="already exists"):
+            await registry_tool(
+                operation="create",
+                tool_name="alpha",
+                source="weather",
+                remote_name="remote_alpha",
+                tool_context=_tool_context(registry),
+            )
+        # Reservation released on failure.
+        list_result = await registry_tool(
+            operation="list",
+            tool_context=_tool_context(registry),
+        )
+        assert list_result["dynamic_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_rejects_overly_long_tool_name(self, registry_tool, registry: ToolRegistry) -> None:
+        with pytest.raises(ToolRegistryError, match="invalid tool name"):
+            await registry_tool(
+                operation="create",
+                tool_name="a" * 65,
+                source="weather",
+                remote_name="remote_alpha",
+                tool_context=_tool_context(registry),
+            )
+
+    @pytest.mark.asyncio
+    async def test_enforces_dynamic_tool_cap(self, mcp_client: _FakeMCPClient, registry: ToolRegistry) -> None:
+        # Cap at 2 so we can exhaust it quickly.
+        registry_tool = make_tool_registry(
+            mcp_clients={"weather": mcp_client},  # type: ignore[dict-item]
+            max_dynamic_tools=2,
+        )
+        ctx = _tool_context(registry)
+        for local_name, remote in [("alpha", "remote_alpha"), ("beta", "remote_beta")]:
+            await registry_tool(
+                operation="create",
+                tool_name=local_name,
+                source="weather",
+                remote_name=remote,
+                tool_context=ctx,
+            )
+        with pytest.raises(ToolRegistryError, match="dynamic tool cap reached"):
+            await registry_tool(
+                operation="create",
+                tool_name="gamma",
+                source="weather",
+                remote_name="remote_gamma",
+                tool_context=ctx,
+            )
+
+    @pytest.mark.asyncio
+    async def test_enforces_dynamic_tool_cap_under_concurrent_creates(
+        self,
+        mcp_client: _FakeMCPClient,
+        registry: ToolRegistry,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        cap = 2
+        registry_tool = make_tool_registry(
+            mcp_clients={"weather": mcp_client},  # type: ignore[dict-item]
+            max_dynamic_tools=cap,
+        )
+        ctx = _tool_context(registry)
+
+        # `_resolve_mcp_tool` in production never yields (list_tools_sync is
+        # sync), so gather-scheduled invocations would serialize and the old
+        # check-then-write ordering would also pass this test. Monkey-patch a
+        # yielding fake so each concurrent create actually suspends between
+        # its cap check and its registry write, exercising the race window.
+        from strands.vended_tools.tool_registry import tool_registry as trmod
+
+        real_resolve = trmod._resolve_mcp_tool
+
+        async def yielding_resolve(*args: Any, **kwargs: Any) -> Any:
+            await asyncio.sleep(0)  # force a real suspend point
+            return await real_resolve(*args, **kwargs)
+
+        monkeypatch.setattr(trmod, "_resolve_mcp_tool", yielding_resolve)
+
+        # Fire 2x cap concurrent creates against a shared context. Under a
+        # check-then-await-then-write ordering all N would race past the cap.
+        results = await asyncio.gather(
+            *(
+                registry_tool(
+                    operation="create",
+                    tool_name=f"t{i}",
+                    source="weather",
+                    remote_name="remote_alpha",
+                    tool_context=ctx,
+                )
+                for i in range(cap * 2)
+            ),
+            return_exceptions=True,
+        )
+        successes = [r for r in results if not isinstance(r, BaseException)]
+        failures = [r for r in results if isinstance(r, ToolRegistryError)]
+        assert len(successes) == cap
+        assert len(failures) == cap
+
+    @pytest.mark.asyncio
+    async def test_does_not_orphan_reservation_on_concurrent_delete(
+        self,
+        mcp_client: _FakeMCPClient,
+        registry: ToolRegistry,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A `delete` landing between `create`'s reservation and write must not orphan."""
+        registry_tool = make_tool_registry(
+            mcp_clients={"weather": mcp_client},  # type: ignore[dict-item]
+        )
+        ctx = _tool_context(registry)
+
+        from strands.vended_tools.tool_registry import tool_registry as trmod
+
+        real_resolve = trmod._resolve_mcp_tool
+        gate = asyncio.Event()
+
+        async def gated_resolve(*args: Any, **kwargs: Any) -> Any:
+            # Suspend until the test releases us so a concurrent `delete` can
+            # slip between the synchronous reservation and the post-await
+            # registry write.
+            await gate.wait()
+            return await real_resolve(*args, **kwargs)
+
+        monkeypatch.setattr(trmod, "_resolve_mcp_tool", gated_resolve)
+
+        # Task B: start `create` and let it park on the gate.
+        create_task = asyncio.create_task(
+            registry_tool(
+                operation="create",
+                tool_name="alpha",
+                source="weather",
+                remote_name="remote_alpha",
+                tool_context=ctx,
+            )
+        )
+        for _ in range(3):
+            await asyncio.sleep(0)
+
+        # Task A: delete the reserved-but-not-yet-registered tool.
+        delete_result = await registry_tool(
+            operation="delete",
+            tool_name="alpha",
+            tool_context=ctx,
+        )
+        assert delete_result["operation"] == "delete"
+
+        # Release create; it must abort rather than resurrect an orphan.
+        gate.set()
+        with pytest.raises(ToolRegistryError, match="cancelled by a concurrent delete"):
+            await create_task
+
+        # No orphan in the SDK registry; ownership set is empty.
+        assert "alpha" not in registry.dynamic_tools
+        assert "alpha" not in registry.registry
+        list_result = await registry_tool(operation="list", tool_context=ctx)
+        assert list_result["dynamic_count"] == 0
+
+
+class TestUpdateOperation:
+    @pytest.mark.asyncio
+    async def test_updates_own_tool(self, registry_tool, registry: ToolRegistry) -> None:
+        ctx = _tool_context(registry)
+        await registry_tool(
+            operation="create",
+            tool_name="alpha",
+            source="weather",
+            remote_name="remote_alpha",
+            tool_context=ctx,
+        )
+        result = await registry_tool(
+            operation="update",
+            tool_name="alpha",
+            source="weather",
+            remote_name="remote_beta",
+            tool_context=ctx,
+        )
+        assert result["operation"] == "update"
+        # The adapter points at remote_beta now.
+        assert registry.dynamic_tools["alpha"].mcp_tool.name == "remote_beta"
+
+    @pytest.mark.asyncio
+    async def test_cannot_update_developer_tool(self, registry_tool, registry: ToolRegistry) -> None:
+        with pytest.raises(ToolRegistryError, match="developer-registered"):
+            await registry_tool(
+                operation="update",
+                tool_name="dev_echo",
+                source="weather",
+                remote_name="remote_alpha",
+                tool_context=_tool_context(registry),
+            )
+
+    @pytest.mark.asyncio
+    async def test_does_not_resurrect_on_concurrent_delete(
+        self,
+        mcp_client: _FakeMCPClient,
+        registry: ToolRegistry,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A `delete` landing during `update`'s MCP lookup must not be undone.
+
+        Mirrors the create-during-delete guard: if `update` re-checks ownership
+        only before the await, a delete landing during the await could resurrect
+        a tool the model believed deleted, leaving an orphan this instance can
+        no longer track.
+        """
+        registry_tool = make_tool_registry(
+            mcp_clients={"weather": mcp_client},  # type: ignore[dict-item]
+        )
+        ctx = _tool_context(registry)
+
+        # First register so `update` has something to target.
+        await registry_tool(
+            operation="create",
+            tool_name="alpha",
+            source="weather",
+            remote_name="remote_alpha",
+            tool_context=ctx,
+        )
+
+        from strands.vended_tools.tool_registry import tool_registry as trmod
+
+        real_resolve = trmod._resolve_mcp_tool
+        gate = asyncio.Event()
+
+        async def gated_resolve(*args: Any, **kwargs: Any) -> Any:
+            await gate.wait()
+            return await real_resolve(*args, **kwargs)
+
+        monkeypatch.setattr(trmod, "_resolve_mcp_tool", gated_resolve)
+
+        # Task B: start `update` and let it park on the gate after the
+        # pre-await ownership check.
+        update_task = asyncio.create_task(
+            registry_tool(
+                operation="update",
+                tool_name="alpha",
+                source="weather",
+                remote_name="remote_beta",
+                tool_context=ctx,
+            )
+        )
+        for _ in range(3):
+            await asyncio.sleep(0)
+
+        # Task A: delete the tool while the update is still awaiting.
+        delete_result = await registry_tool(
+            operation="delete",
+            tool_name="alpha",
+            tool_context=ctx,
+        )
+        assert delete_result["operation"] == "delete"
+
+        # Release the update; it must abort rather than resurrect the tool.
+        gate.set()
+        with pytest.raises(ToolRegistryError, match="cancelled by a concurrent delete"):
+            await update_task
+
+        # Deletion stuck; no orphan.
+        assert "alpha" not in registry.dynamic_tools
+        assert "alpha" not in registry.registry
+        list_result = await registry_tool(operation="list", tool_context=ctx)
+        assert list_result["dynamic_count"] == 0
+
+
+class TestDeleteOperation:
+    @pytest.mark.asyncio
+    async def test_deletes_own_tool(self, registry_tool, registry: ToolRegistry) -> None:
+        ctx = _tool_context(registry)
+        await registry_tool(
+            operation="create",
+            tool_name="alpha",
+            source="weather",
+            remote_name="remote_alpha",
+            tool_context=ctx,
+        )
+        result = await registry_tool(operation="delete", tool_name="alpha", tool_context=ctx)
+        assert result["operation"] == "delete"
+        assert result["dynamic_count"] == 0
+        assert "alpha" not in registry.dynamic_tools
+
+    @pytest.mark.asyncio
+    async def test_rejects_deleting_developer_tool(self, registry_tool, registry: ToolRegistry) -> None:
+        with pytest.raises(ToolRegistryError, match="developer-registered"):
+            await registry_tool(
+                operation="delete",
+                tool_name="dev_echo",
+                tool_context=_tool_context(registry),
+            )
+        # Untouched.
+        assert "dev_echo" in registry.registry
+
+    @pytest.mark.asyncio
+    async def test_rejects_deleting_unknown_tool(self, registry_tool, registry: ToolRegistry) -> None:
+        with pytest.raises(ToolRegistryError, match="developer-registered"):
+            await registry_tool(
+                operation="delete",
+                tool_name="never_registered",
+                tool_context=_tool_context(registry),
+            )
+
+    @pytest.mark.asyncio
+    async def test_does_not_leak_ownership_between_registries(self, mcp_client: _FakeMCPClient) -> None:
+        """Two agents sharing a factory bind their own ownership sets."""
+        registry_tool_shared = make_tool_registry(
+            mcp_clients={"weather": mcp_client}  # type: ignore[dict-item]
+        )
+        reg_a = ToolRegistry()
+        reg_b = ToolRegistry()
+
+        await registry_tool_shared(
+            operation="create",
+            tool_name="alpha",
+            source="weather",
+            remote_name="remote_alpha",
+            tool_context=_tool_context(reg_a),
+        )
+
+        # Registry B never registered "alpha", so deletion must be rejected there
+        # even though registry A has it. Ownership is per-registry, not global.
+        with pytest.raises(ToolRegistryError, match="developer-registered"):
+            await registry_tool_shared(
+                operation="delete",
+                tool_name="alpha",
+                tool_context=_tool_context(reg_b),
+            )
+
+    @pytest.mark.asyncio
+    async def test_two_factories_on_one_agent_do_not_collide(self, mcp_client: _FakeMCPClient) -> None:
+        """Two separate factories on one agent track ownership independently."""
+        factory_a = make_tool_registry(mcp_clients={"weather": mcp_client})  # type: ignore[dict-item]
+        factory_b = make_tool_registry(
+            mcp_clients={"weather": mcp_client},  # type: ignore[dict-item]
+            name="tool_registry_b",
+        )
+        reg = ToolRegistry()
+        ctx = _tool_context(reg)
+
+        await factory_a(
+            operation="create",
+            tool_name="alpha",
+            source="weather",
+            remote_name="remote_alpha",
+            tool_context=ctx,
+        )
+        # Factory B never registered "alpha"; it must refuse to delete it,
+        # matching the TS `WeakMap<LocalAgent, Set<string>>` semantics.
+        with pytest.raises(ToolRegistryError, match="developer-registered"):
+            await factory_b(
+                operation="delete",
+                tool_name="alpha",
+                tool_context=ctx,
+            )
+        # Factory A still owns it.
+        assert "alpha" in reg.dynamic_tools
+
+
+class TestOperationDispatch:
+    @pytest.mark.asyncio
+    async def test_rejects_unknown_operation(self, registry_tool, registry: ToolRegistry) -> None:
+        with pytest.raises(ToolRegistryError, match="invalid operation"):
+            await registry_tool(
+                operation="wipe_registry",
+                tool_context=_tool_context(registry),
+            )
+
+    @pytest.mark.asyncio
+    async def test_read_only_when_no_mcp_clients_configured(self, registry: ToolRegistry) -> None:
+        registry_tool = make_tool_registry()  # empty
+        # list still works
+        result = await registry_tool(operation="list", tool_context=_tool_context(registry))
+        assert result["dynamic_limit"] == MAX_DYNAMIC_TOOLS
+        # create fails
+        with pytest.raises(ToolRegistryError, match="unknown source"):
+            await registry_tool(
+                operation="create",
+                tool_name="alpha",
+                source="anything",
+                tool_context=_tool_context(registry),
+            )
+
+
+class TestFactoryValidation:
+    def test_rejects_zero_max_dynamic_tools(self) -> None:
+        with pytest.raises(ValueError, match="at least 1"):
+            make_tool_registry(max_dynamic_tools=0)
+
+    def test_uses_custom_name_and_description(self) -> None:
+        t = make_tool_registry(name="registry_ctl", description="custom desc")
+        assert t.tool_name == "registry_ctl"
+        assert t.tool_spec["description"] == "custom desc"

--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -72,6 +72,10 @@
       "types": "./dist/src/vended-tools/stop/index.d.ts",
       "default": "./dist/src/vended-tools/stop/index.js"
     },
+    "./vended-tools/tool-registry": {
+      "types": "./dist/src/vended-tools/tool-registry/index.d.ts",
+      "default": "./dist/src/vended-tools/tool-registry/index.js"
+    },
     "./a2a": {
       "types": "./dist/src/a2a/index.d.ts",
       "default": "./dist/src/a2a/index.js"

--- a/strands-ts/src/mcp/client.ts
+++ b/strands-ts/src/mcp/client.ts
@@ -410,17 +410,25 @@ export class McpClient {
 
     // When tasksConfig is undefined, call tools directly without task management
     if (this._tasksConfig === undefined) {
-      return (await this._client.callTool({ name: tool.name, arguments: toolArgs }, undefined, options)) as JSONValue
+      return (await this._client.callTool(
+        { name: tool.remoteName, arguments: toolArgs },
+        undefined,
+        options
+      )) as JSONValue
     }
 
     // When tasksConfig is defined (even as empty object), use task-based invocation
     // which supports long-running tools with progress tracking
-    const stream = this._client.experimental.tasks.callToolStream({ name: tool.name, arguments: toolArgs }, undefined, {
-      timeout: this._tasksConfig.ttl ?? McpClient.DEFAULT_TTL,
-      maxTotalTimeout: this._tasksConfig.pollTimeout ?? McpClient.DEFAULT_POLL_TIMEOUT,
-      resetTimeoutOnProgress: true,
-      ...options,
-    })
+    const stream = this._client.experimental.tasks.callToolStream(
+      { name: tool.remoteName, arguments: toolArgs },
+      undefined,
+      {
+        timeout: this._tasksConfig.ttl ?? McpClient.DEFAULT_TTL,
+        maxTotalTimeout: this._tasksConfig.pollTimeout ?? McpClient.DEFAULT_POLL_TIMEOUT,
+        resetTimeoutOnProgress: true,
+        ...options,
+      }
+    )
 
     const result = await takeResult(stream)
     return result as JSONValue

--- a/strands-ts/src/tools/mcp-tool.ts
+++ b/strands-ts/src/tools/mcp-tool.ts
@@ -15,6 +15,13 @@ export interface McpToolConfig {
   inputSchema: JSONSchema
   outputSchema?: JSONSchema
   client: McpClient
+  /**
+   * Optional name to send to the MCP server on the wire. Defaults to `name`.
+   * Set this when the tool is exposed to the agent under a local alias that
+   * differs from the name registered on the remote server (e.g. the vended
+   * tool_registry lets developers pick a local alias).
+   */
+  remoteName?: string
 }
 
 /**
@@ -28,12 +35,14 @@ export class McpTool extends Tool {
   readonly name: string
   readonly description: string
   readonly toolSpec: ToolSpec
+  readonly remoteName: string
   private readonly mcpClient: McpClient
 
   constructor(config: McpToolConfig) {
     super()
     this.name = config.name
     this.description = config.description
+    this.remoteName = config.remoteName ?? config.name
     this.toolSpec = {
       name: config.name,
       description: config.description,

--- a/strands-ts/src/vended-tools/index.ts
+++ b/strands-ts/src/vended-tools/index.ts
@@ -3,7 +3,7 @@
  *
  * Provides a single import path for consumers who want all built-in tools:
  * ```typescript
- * import { bash, fileEditor, httpRequest, notebook } from '@strands-agents/sdk/vended-tools'
+ * import { bash, fileEditor, httpRequest, notebook, stop, makeToolRegistry } from '@strands-agents/sdk/vended-tools'
  * ```
  *
  * Note: This module requires a Node.js environment because the `bash` tool
@@ -16,3 +16,4 @@ export * from './file-editor/index.js'
 export * from './http-request/index.js'
 export * from './notebook/index.js'
 export * from './stop/index.js'
+export * from './tool-registry/index.js'

--- a/strands-ts/src/vended-tools/tool-registry/README.md
+++ b/strands-ts/src/vended-tools/tool-registry/README.md
@@ -1,0 +1,49 @@
+# Tool Registry Tool
+
+A vended tool that lets an agent list, register, re-register, and unregister tools on its own registry at runtime.
+
+Registration is limited to tools hosted on an already-connected `McpClient` the developer explicitly pre-approved when constructing the tool. The model picks servers by alias, never by raw URL; loading tools from disk or inline source is not supported. `update` and `delete` only affect tools this same instance registered, tracked in a per-agent `WeakMap` so two agents sharing one tool instance never see each other's dynamic tools. Tool names must match `/^[a-zA-Z_][a-zA-Z0-9_]{0,63}$/`, and a configurable `maxDynamicTools` cap (default thirty-two) bounds registry growth over a long conversation.
+
+## Usage
+
+```typescript
+import { Agent, BedrockModel, McpClient } from '@strands-agents/sdk'
+import { makeToolRegistry } from '@strands-agents/sdk/vended-tools/tool-registry'
+
+const weather = new McpClient({ url: 'https://weather.example.com/mcp' })
+await weather.connect()
+
+const registryTool = makeToolRegistry({
+  mcpClients: { weather },
+})
+
+const agent = new Agent({
+  model: new BedrockModel({ region: 'us-east-1' }),
+  tools: [registryTool],
+})
+
+// The model can now discover and pull in tools at runtime:
+//   {"operation": "list"}
+//   {"operation": "create", "toolName": "get_forecast",
+//    "source": "weather", "remoteName": "getForecast"}
+//   {"operation": "delete", "toolName": "get_forecast"}
+```
+
+## API
+
+### `makeToolRegistry(options?)`
+
+Options:
+
+- `mcpClients` (`Record<string, McpClient>`, optional): allow-list of MCP servers the tool may pull tools from. Keys are stable aliases the model references in `source`. Values must already be connected. When omitted, the tool degrades to read-only.
+- `maxDynamicTools` (`number`, default thirty-two): upper bound on the number of tools this instance may register on any single agent.
+- `name` (`string`, default `"tool_registry"`), `description` (`string`): passed through to the tool spec.
+
+### Operations
+
+All four operations share a flat input schema; the `operation` field is a discriminator.
+
+- `list`: returns `{ tools: RegisteredTool[]; dynamicCount: number; dynamicLimit: number }`. Each entry includes `registeredByToolRegistry: boolean`.
+- `create`: requires `toolName`, `source`; `remoteName` defaults to `toolName`; `descriptionOverride` optional. Registers the resolved MCP tool under `toolName` on the agent's registry.
+- `update`: same inputs as `create`. Rejects any `toolName` this tool_registry instance did not register.
+- `delete`: requires `toolName`. Rejects any `toolName` this tool_registry instance did not register.

--- a/strands-ts/src/vended-tools/tool-registry/__tests__/tool-registry.test.ts
+++ b/strands-ts/src/vended-tools/tool-registry/__tests__/tool-registry.test.ts
@@ -1,0 +1,472 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { ToolContext } from '../../../tools/tool.js'
+import { FunctionTool } from '../../../tools/function-tool.js'
+import { McpTool } from '../../../tools/mcp-tool.js'
+import type { McpClient } from '../../../mcp/index.js'
+import { ToolRegistry } from '../../../registry/tool-registry.js'
+import { createMockAgent } from '../../../__fixtures__/agent-helpers.js'
+import { makeToolRegistry } from '../tool-registry.js'
+import { MAX_DYNAMIC_TOOLS, type ListResult, type MutationResult } from '../types.js'
+
+/**
+ * Minimal fake of McpClient. The tool_registry tool only calls `listTools()`,
+ * so this stub returns a fixed array of McpTool instances. We construct real
+ * McpTool objects (they don't dial out until the agent invokes them) but hand
+ * them this fake in place of a real client. `unknown as McpClient` is safe
+ * here because callTool is never exercised in these tests.
+ */
+function makeFakeClient(tools: { name: string; description?: string }[]): McpClient {
+  const client = {} as McpClient
+  const mcpTools = tools.map(
+    (t) =>
+      new McpTool({
+        name: t.name,
+        description: t.description ?? `Fake ${t.name}`,
+        inputSchema: { type: 'object', properties: {} },
+        client,
+      })
+  )
+  ;(client as unknown as { listTools: () => Promise<McpTool[]> }).listTools = async () => mcpTools
+  return client
+}
+
+function makeContext(registry: ToolRegistry): ToolContext {
+  const agent = createMockAgent({ toolRegistry: registry })
+  return {
+    toolUse: { name: 'tool_registry', toolUseId: 'test-id', input: {} },
+    agent,
+    invocationState: {},
+    interrupt: () => {
+      throw new Error('interrupt not available in mock context')
+    },
+  }
+}
+
+function makeDevTool(name: string): FunctionTool {
+  return new FunctionTool({
+    name,
+    description: `developer-registered ${name}`,
+    callback: () => 'ok',
+  })
+}
+
+describe('tool_registry tool', () => {
+  let registry: ToolRegistry
+  let context: ToolContext
+  let client: McpClient
+
+  beforeEach(() => {
+    registry = new ToolRegistry([makeDevTool('dev_echo'), makeDevTool('dev_ping')])
+    context = makeContext(registry)
+    client = makeFakeClient([{ name: 'remote_alpha' }, { name: 'remote_beta' }, { name: 'remote_gamma' }])
+  })
+
+  describe('list operation', () => {
+    it('lists developer-registered tools as not owned', async () => {
+      const registryTool = makeToolRegistry({ mcpClients: { weather: client } })
+      const result = (await registryTool.invoke({ operation: 'list' }, context)) as unknown as ListResult
+      const names = Object.fromEntries(result.tools.map((t) => [t.name, t]))
+      expect(names.dev_echo).toBeDefined()
+      expect(names.dev_echo!.registeredByToolRegistry).toBe(false)
+      expect(names.dev_ping!.registeredByToolRegistry).toBe(false)
+      expect(result.dynamicCount).toBe(0)
+      expect(result.dynamicLimit).toBe(MAX_DYNAMIC_TOOLS)
+    })
+  })
+
+  describe('create operation', () => {
+    it('registers an MCP tool and marks it owned', async () => {
+      const registryTool = makeToolRegistry({ mcpClients: { weather: client } })
+      const result = (await registryTool.invoke(
+        {
+          operation: 'create',
+          toolName: 'alpha',
+          source: 'weather',
+          remoteName: 'remote_alpha',
+        },
+        context
+      )) as unknown as MutationResult
+      expect(result.operation).toBe('create')
+      expect(result.name).toBe('alpha')
+      expect(result.dynamicCount).toBe(1)
+      expect(registry.get('alpha')).toBeDefined()
+    })
+
+    it('uses toolName as default remoteName', async () => {
+      const registryTool = makeToolRegistry({ mcpClients: { weather: client } })
+      const result = (await registryTool.invoke(
+        { operation: 'create', toolName: 'remote_beta', source: 'weather' },
+        context
+      )) as unknown as MutationResult
+      expect(result.name).toBe('remote_beta')
+      expect(registry.get('remote_beta')).toBeDefined()
+    })
+
+    it('applies descriptionOverride to the resulting tool spec', async () => {
+      const registryTool = makeToolRegistry({ mcpClients: { weather: client } })
+      await registryTool.invoke(
+        {
+          operation: 'create',
+          toolName: 'alpha',
+          source: 'weather',
+          remoteName: 'remote_alpha',
+          descriptionOverride: 'custom text',
+        },
+        context
+      )
+      expect(registry.get('alpha')!.toolSpec.description).toBe('custom text')
+    })
+
+    it('rejects unknown source', async () => {
+      const registryTool = makeToolRegistry({ mcpClients: { weather: client } })
+      await expect(
+        registryTool.invoke({ operation: 'create', toolName: 'alpha', source: 'not_a_real_client' }, context)
+      ).rejects.toThrow(/unknown source/)
+    })
+
+    it('rejects unknown remote tool', async () => {
+      const registryTool = makeToolRegistry({ mcpClients: { weather: client } })
+      await expect(
+        registryTool.invoke(
+          {
+            operation: 'create',
+            toolName: 'alpha',
+            source: 'weather',
+            remoteName: 'does_not_exist',
+          },
+          context
+        )
+      ).rejects.toThrow(/not found on MCP server/)
+    })
+
+    it('rejects registering over a developer tool', async () => {
+      const registryTool = makeToolRegistry({ mcpClients: { weather: client } })
+      await expect(
+        registryTool.invoke(
+          {
+            operation: 'create',
+            toolName: 'dev_echo',
+            source: 'weather',
+            remoteName: 'remote_alpha',
+          },
+          context
+        )
+      ).rejects.toThrow(/already registered/)
+    })
+
+    it('cannot register a tool with the tool_registry name itself', async () => {
+      const registryTool = makeToolRegistry({ mcpClients: { weather: client } })
+      await expect(
+        registryTool.invoke(
+          {
+            operation: 'create',
+            toolName: 'tool_registry',
+            source: 'weather',
+            remoteName: 'remote_alpha',
+          },
+          context
+        )
+      ).rejects.toThrow(/itself/)
+    })
+
+    describe.each(['1_starts_with_digit', 'has-dash', 'has space', 'toolname!', 'x'.repeat(65)])(
+      'rejects invalid tool name %j',
+      (bad) => {
+        it('throws ToolRegistryError', async () => {
+          const registryTool = makeToolRegistry({ mcpClients: { weather: client } })
+          await expect(
+            registryTool.invoke(
+              { operation: 'create', toolName: bad, source: 'weather', remoteName: 'remote_alpha' },
+              context
+            )
+          ).rejects.toThrow(/invalid tool name/)
+        })
+      }
+    )
+
+    it('enforces the dynamic tool cap', async () => {
+      const registryTool = makeToolRegistry({
+        mcpClients: { weather: client },
+        maxDynamicTools: 2,
+      })
+      await registryTool.invoke(
+        { operation: 'create', toolName: 'alpha', source: 'weather', remoteName: 'remote_alpha' },
+        context
+      )
+      await registryTool.invoke(
+        { operation: 'create', toolName: 'beta', source: 'weather', remoteName: 'remote_beta' },
+        context
+      )
+      await expect(
+        registryTool.invoke(
+          { operation: 'create', toolName: 'gamma', source: 'weather', remoteName: 'remote_gamma' },
+          context
+        )
+      ).rejects.toThrow(/dynamic tool cap reached/)
+    })
+
+    it('enforces the dynamic tool cap under concurrent create calls', async () => {
+      const cap = 2
+      const registryTool = makeToolRegistry({
+        mcpClients: { weather: client },
+        maxDynamicTools: cap,
+      })
+      // Fire 2× cap concurrent creates against a shared context. Under a
+      // check-then-await-then-write ordering all N would race past the cap.
+      const results = await Promise.allSettled(
+        Array.from({ length: cap * 2 }, (_, i) =>
+          registryTool.invoke(
+            { operation: 'create', toolName: `t${i}`, source: 'weather', remoteName: 'remote_alpha' },
+            context
+          )
+        )
+      )
+      const fulfilled = results.filter((r) => r.status === 'fulfilled').length
+      expect(fulfilled).toBe(cap)
+      const rejected = results.filter((r) => r.status === 'rejected') as PromiseRejectedResult[]
+      expect(rejected.length).toBe(cap)
+      for (const r of rejected) {
+        expect(String(r.reason)).toMatch(/dynamic tool cap reached|already registered/)
+      }
+    })
+
+    it('does not orphan a reservation if a concurrent delete lands during create', async () => {
+      // A controllable client: `listTools` blocks until the test resolves the
+      // gate, so we can interleave a `delete` between `create`'s reservation
+      // (synchronous) and its call to `registry.add` (post-await).
+      let releaseListTools!: () => void
+      const gate = new Promise<void>((resolve) => {
+        releaseListTools = resolve
+      })
+      const slowClient = {} as McpClient
+      const remoteTools = [
+        new McpTool({
+          name: 'remote_alpha',
+          description: 'fake',
+          inputSchema: { type: 'object', properties: {} },
+          client: slowClient,
+        }),
+      ]
+      ;(slowClient as unknown as { listTools: () => Promise<McpTool[]> }).listTools = async () => {
+        await gate
+        return remoteTools
+      }
+
+      const registryTool = makeToolRegistry({ mcpClients: { weather: slowClient } })
+
+      // Task B: starts create; reserves 'alpha' synchronously, then awaits.
+      const createPromise = registryTool.invoke(
+        { operation: 'create', toolName: 'alpha', source: 'weather', remoteName: 'remote_alpha' },
+        context
+      )
+
+      // Yield the microtask queue so the create task has actually entered
+      // `resolveMcpTool` and is waiting on `gate`.
+      await Promise.resolve()
+      await Promise.resolve()
+
+      // Task A: delete lands on the reservation and clears it.
+      const deleteResult = (await registryTool.invoke(
+        { operation: 'delete', toolName: 'alpha' },
+        context
+      )) as unknown as MutationResult
+      expect(deleteResult.operation).toBe('delete')
+
+      // Task B resumes. Under the fix it must abort rather than write a tool
+      // it can no longer track.
+      releaseListTools()
+      await expect(createPromise).rejects.toThrow(/cancelled by a concurrent delete/)
+
+      // Final state: no orphan in the SDK registry, and this instance's
+      // ownership set is empty (dynamicCount == 0), proving the reservation
+      // was released.
+      expect(registry.get('alpha')).toBeUndefined()
+      const list = (await registryTool.invoke({ operation: 'list' }, context)) as unknown as ListResult
+      expect(list.dynamicCount).toBe(0)
+    })
+  })
+
+  describe('update operation', () => {
+    it('updates a tool this instance registered', async () => {
+      const registryTool = makeToolRegistry({ mcpClients: { weather: client } })
+      await registryTool.invoke(
+        { operation: 'create', toolName: 'alpha', source: 'weather', remoteName: 'remote_alpha' },
+        context
+      )
+      const result = (await registryTool.invoke(
+        {
+          operation: 'update',
+          toolName: 'alpha',
+          source: 'weather',
+          remoteName: 'remote_beta',
+          descriptionOverride: 'now bound to beta',
+        },
+        context
+      )) as unknown as MutationResult
+      expect(result.operation).toBe('update')
+      // The description confirms the re-binding took effect.
+      expect(registry.get('alpha')!.toolSpec.description).toBe('now bound to beta')
+    })
+
+    it('cannot update a developer-registered tool', async () => {
+      const registryTool = makeToolRegistry({ mcpClients: { weather: client } })
+      await expect(
+        registryTool.invoke(
+          {
+            operation: 'update',
+            toolName: 'dev_echo',
+            source: 'weather',
+            remoteName: 'remote_alpha',
+          },
+          context
+        )
+      ).rejects.toThrow(/developer-registered/)
+    })
+
+    it('does not resurrect a deleted tool if a concurrent delete lands during update', async () => {
+      // Mirror the create-during-delete race for `update`. Without the guard,
+      // a delete landing between `update`'s pre-await ownership check and its
+      // post-await write would resurrect an entry the model believed deleted.
+      let releaseListTools!: () => void
+      const gate = new Promise<void>((resolve) => {
+        releaseListTools = resolve
+      })
+      const slowClient = {} as McpClient
+      const remoteTools = [
+        new McpTool({
+          name: 'remote_alpha',
+          description: 'fake',
+          inputSchema: { type: 'object', properties: {} },
+          client: slowClient,
+        }),
+        new McpTool({
+          name: 'remote_beta',
+          description: 'fake',
+          inputSchema: { type: 'object', properties: {} },
+          client: slowClient,
+        }),
+      ]
+      let gated = false
+      ;(slowClient as unknown as { listTools: () => Promise<McpTool[]> }).listTools = async () => {
+        if (gated) {
+          await gate
+        }
+        return remoteTools
+      }
+
+      const registryTool = makeToolRegistry({ mcpClients: { weather: slowClient } })
+
+      // First create; MCP lookup returns immediately.
+      await registryTool.invoke(
+        { operation: 'create', toolName: 'alpha', source: 'weather', remoteName: 'remote_alpha' },
+        context
+      )
+      expect(registry.get('alpha')).toBeDefined()
+
+      // From now on, listTools blocks.
+      gated = true
+
+      // Task B: start `update`; it passes the pre-await ownership check, then parks.
+      const updatePromise = registryTool.invoke(
+        { operation: 'update', toolName: 'alpha', source: 'weather', remoteName: 'remote_beta' },
+        context
+      )
+
+      // Yield so the update task is actually awaiting on the gate.
+      await Promise.resolve()
+      await Promise.resolve()
+
+      // Task A: delete lands while the update is still awaiting.
+      const deleteResult = (await registryTool.invoke(
+        { operation: 'delete', toolName: 'alpha' },
+        context
+      )) as unknown as MutationResult
+      expect(deleteResult.operation).toBe('delete')
+
+      // Release the update; it must abort rather than resurrect the tool.
+      releaseListTools()
+      await expect(updatePromise).rejects.toThrow(/cancelled by a concurrent delete/)
+
+      // No orphan in the SDK registry; ownership set is empty.
+      expect(registry.get('alpha')).toBeUndefined()
+      const list = (await registryTool.invoke({ operation: 'list' }, context)) as unknown as ListResult
+      expect(list.dynamicCount).toBe(0)
+    })
+  })
+
+  describe('delete operation', () => {
+    it('deletes a tool this instance registered', async () => {
+      const registryTool = makeToolRegistry({ mcpClients: { weather: client } })
+      await registryTool.invoke(
+        { operation: 'create', toolName: 'alpha', source: 'weather', remoteName: 'remote_alpha' },
+        context
+      )
+      const result = (await registryTool.invoke(
+        { operation: 'delete', toolName: 'alpha' },
+        context
+      )) as unknown as MutationResult
+      expect(result.operation).toBe('delete')
+      expect(result.dynamicCount).toBe(0)
+      expect(registry.get('alpha')).toBeUndefined()
+    })
+
+    it('cannot delete a developer-registered tool', async () => {
+      const registryTool = makeToolRegistry({ mcpClients: { weather: client } })
+      await expect(registryTool.invoke({ operation: 'delete', toolName: 'dev_echo' }, context)).rejects.toThrow(
+        /developer-registered/
+      )
+      expect(registry.get('dev_echo')).toBeDefined()
+    })
+
+    it('cannot delete a tool that was never registered', async () => {
+      const registryTool = makeToolRegistry({ mcpClients: { weather: client } })
+      await expect(registryTool.invoke({ operation: 'delete', toolName: 'never_registered' }, context)).rejects.toThrow(
+        /developer-registered/
+      )
+    })
+
+    it('does not leak ownership between agents sharing the tool instance', async () => {
+      const registryTool = makeToolRegistry({ mcpClients: { weather: client } })
+
+      const regA = new ToolRegistry()
+      const regB = new ToolRegistry()
+      const ctxA = makeContext(regA)
+      const ctxB = makeContext(regB)
+
+      await registryTool.invoke(
+        { operation: 'create', toolName: 'alpha', source: 'weather', remoteName: 'remote_alpha' },
+        ctxA
+      )
+
+      // Even though agent A has 'alpha', from agent B's perspective it was
+      // never registered via tool_registry — deletion must be rejected.
+      await expect(registryTool.invoke({ operation: 'delete', toolName: 'alpha' }, ctxB)).rejects.toThrow(
+        /developer-registered/
+      )
+    })
+  })
+
+  describe('operation dispatch', () => {
+    it('degrades to read-only when no MCP clients are configured', async () => {
+      const registryTool = makeToolRegistry()
+      const list = (await registryTool.invoke({ operation: 'list' }, context)) as unknown as ListResult
+      expect(list.dynamicLimit).toBe(MAX_DYNAMIC_TOOLS)
+
+      await expect(
+        registryTool.invoke({ operation: 'create', toolName: 'alpha', source: 'anything' }, context)
+      ).rejects.toThrow(/unknown source/)
+    })
+  })
+
+  describe('factory validation', () => {
+    it('rejects zero maxDynamicTools', () => {
+      expect(() => makeToolRegistry({ maxDynamicTools: 0 })).toThrow(/at least 1/)
+    })
+
+    it('honors custom name and description', () => {
+      const t = makeToolRegistry({ name: 'registry_ctl', description: 'custom desc' })
+      expect(t.name).toBe('registry_ctl')
+      expect(t.toolSpec.description).toBe('custom desc')
+    })
+  })
+})

--- a/strands-ts/src/vended-tools/tool-registry/__tests__/tool-registry.test.ts
+++ b/strands-ts/src/vended-tools/tool-registry/__tests__/tool-registry.test.ts
@@ -13,7 +13,8 @@ import { MAX_DYNAMIC_TOOLS, type ListResult, type MutationResult } from '../type
  * so this stub returns a fixed array of McpTool instances. We construct real
  * McpTool objects (they don't dial out until the agent invokes them) but hand
  * them this fake in place of a real client. `unknown as McpClient` is safe
- * here because callTool is never exercised in these tests.
+ * here because the wire call goes through a separate McpClient instance the
+ * real agent owns.
  */
 function makeFakeClient(tools: { name: string; description?: string }[]): McpClient {
   const client = {} as McpClient
@@ -100,6 +101,20 @@ describe('tool_registry tool', () => {
       )) as unknown as MutationResult
       expect(result.name).toBe('remote_beta')
       expect(registry.get('remote_beta')).toBeDefined()
+    })
+
+    it('binds a local alias to the remote name for the wire call', async () => {
+      // Regression: an earlier implementation set McpTool.name = localName but
+      // callTool sends tool.name on the wire, so aliased tools sent the
+      // wrong name to the server. The bound tool must carry remoteName.
+      const registryTool = makeToolRegistry({ mcpClients: { weather: client } })
+      await registryTool.invoke(
+        { operation: 'create', toolName: 'alpha', source: 'weather', remoteName: 'remote_alpha' },
+        context
+      )
+      const bound = registry.get('alpha') as McpTool
+      expect(bound.name).toBe('alpha')
+      expect(bound.remoteName).toBe('remote_alpha')
     })
 
     it('applies descriptionOverride to the resulting tool spec', async () => {

--- a/strands-ts/src/vended-tools/tool-registry/index.ts
+++ b/strands-ts/src/vended-tools/tool-registry/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Runtime tool-registry-management tool.
+ */
+
+export { makeToolRegistry } from './tool-registry.js'
+export type { MakeToolRegistryOptions } from './tool-registry.js'
+export { MAX_DYNAMIC_TOOLS, TOOL_NAME_PATTERN, TOOL_REGISTRY_DESCRIPTION, ToolRegistryError } from './types.js'
+export type { ListResult, MutationResult, RegisteredTool } from './types.js'

--- a/strands-ts/src/vended-tools/tool-registry/tool-registry.ts
+++ b/strands-ts/src/vended-tools/tool-registry/tool-registry.ts
@@ -1,0 +1,319 @@
+/**
+ * Runtime tool-registry-management tool (CRUD over the agent's own tools).
+ *
+ * Only tools hosted on pre-approved MCP clients may be registered dynamically.
+ * Loading tools from a file path or inline source is intentionally not
+ * supported. See ../README.md for the design rationale.
+ */
+
+import { z } from 'zod'
+import { tool } from '../../tools/tool-factory.js'
+import { McpTool } from '../../tools/mcp-tool.js'
+import { ToolValidationError } from '../../errors.js'
+import type { LocalAgent } from '../../types/agent.js'
+import type { McpClient } from '../../mcp/index.js'
+import type { JSONSchema, JSONValue } from '../../types/json.js'
+import {
+  MAX_DYNAMIC_TOOLS,
+  TOOL_NAME_PATTERN,
+  TOOL_REGISTRY_DESCRIPTION,
+  ToolRegistryError,
+  type ListResult,
+  type MutationResult,
+  type RegisteredTool,
+} from './types.js'
+
+/**
+ * Remembers which tool names this tool_registry instance registered on each
+ * agent's `toolRegistry`. Keyed on the agent instance; each factory closes
+ * over its own map, so:
+ *
+ *  - Two agents using the same tool_registry instance don't share ownership.
+ *  - Two tool_registry factories in the same agent don't collide.
+ *  - The set doesn't leak into the SDK registry's own Tool metadata (which
+ *    other consumers of the registry might introspect).
+ */
+type OwnershipMap = WeakMap<LocalAgent, Set<string>>
+
+function getOwnedNames(map: OwnershipMap, agent: LocalAgent): Set<string> {
+  let owned = map.get(agent)
+  if (!owned) {
+    owned = new Set()
+    map.set(agent, owned)
+  }
+  return owned
+}
+
+function validateToolName(name: string): void {
+  if (typeof name !== 'string' || !TOOL_NAME_PATTERN.test(name)) {
+    throw new ToolRegistryError(`invalid tool name '${name}': must match ${TOOL_NAME_PATTERN.source}`)
+  }
+}
+
+/**
+ * Locate a specific tool on an already-connected MCP client and adapt it to
+ * a local name / description.
+ */
+async function resolveMcpTool(
+  client: McpClient,
+  remoteName: string,
+  localName: string,
+  descriptionOverride?: string
+): Promise<McpTool> {
+  const tools = await client.listTools()
+  const found = tools.find((t) => t.name === remoteName)
+  if (!found) {
+    throw new ToolRegistryError(`tool '${remoteName}' not found on MCP server`)
+  }
+  return new McpTool({
+    name: localName,
+    description: descriptionOverride ?? found.description,
+    // `McpTool`'s constructor requires an inputSchema; fall back to the empty
+    // object schema when the remote tool doesn't declare one, rather than
+    // casting away an `undefined`.
+    inputSchema: (found.toolSpec.inputSchema ?? { type: 'object', properties: {} }) as JSONSchema,
+    ...(found.toolSpec.outputSchema !== undefined && {
+      outputSchema: found.toolSpec.outputSchema as JSONSchema,
+    }),
+    client,
+  })
+}
+
+/**
+ * Zod schema for input validation. The dispatch is enforced by `.refine`
+ * (rather than a discriminated union) so the schema stays flat and the model
+ * has a single, predictable set of parameters to fill in.
+ *
+ * This schema is the single source of truth for the tool's input shape. If a
+ * field is added, renamed, or removed here, update the JSDoc on
+ * `makeToolRegistry` and the README to match.
+ */
+const toolRegistryInputSchema = z
+  .object({
+    operation: z.enum(['list', 'create', 'update', 'delete']).describe('One of "list", "create", "update", "delete".'),
+    toolName: z
+      .string()
+      .optional()
+      .describe(
+        "Local name for the tool on the agent's registry. Required for create, update, delete. " +
+          'Must match ^[a-zA-Z_][a-zA-Z0-9_]{0,63}$.'
+      ),
+    source: z
+      .string()
+      .optional()
+      .describe('Alias of an MCP client pre-approved at tool construction time. Required for create/update.'),
+    remoteName: z
+      .string()
+      .optional()
+      .describe('Name of the tool on the MCP server pointed at by `source`. Defaults to `toolName`.'),
+    descriptionOverride: z
+      .string()
+      .optional()
+      .describe("Optional description to expose to the model in place of the MCP server's advertised description."),
+  })
+  .refine((v) => v.operation === 'list' || v.toolName !== undefined, {
+    message: '`toolName` is required for create, update, and delete',
+  })
+  .refine((v) => (v.operation !== 'create' && v.operation !== 'update') || v.source !== undefined, {
+    message: '`source` is required for create and update',
+  })
+
+/**
+ * Options for {@link makeToolRegistry}.
+ */
+export interface MakeToolRegistryOptions {
+  /**
+   * Mapping from a stable, developer-chosen alias to an already-connected MCP
+   * client. Only tools hosted on these clients may be registered dynamically.
+   * When omitted or empty, `create` and `update` always error (the tool
+   * degrades to a read-only view of the registry).
+   */
+  mcpClients?: Record<string, McpClient>
+  /**
+   * Upper bound on the number of tools this instance may add to the agent's
+   * registry. Defaults to {@link MAX_DYNAMIC_TOOLS}.
+   */
+  maxDynamicTools?: number
+  /** Tool name. Defaults to `"tool_registry"`. */
+  name?: string
+  /** Tool description shown to the model. */
+  description?: string
+}
+
+/**
+ * Create a runtime tool-registry-management tool bound to a set of MCP sources.
+ *
+ * The returned tool exposes four operations to the model:
+ * - `list`: enumerate all tools currently on the agent's registry, flagging
+ *   the ones this instance has registered itself.
+ * - `create`: register a new tool that is a thin binding to a specific tool
+ *   hosted on one of the pre-approved MCP clients.
+ * - `update`: re-bind a previously registered tool.
+ * - `delete`: unregister a tool that this same tool_registry instance
+ *   registered. Developer-registered tools are never removable.
+ *
+ * @example
+ * ```typescript
+ * const weather = new McpClient({ url: 'http://weather.example/mcp' })
+ * await weather.connect()
+ * const registryTool = makeToolRegistry({ mcpClients: { weather } })
+ * const agent = new Agent({ tools: [registryTool] })
+ * ```
+ */
+export function makeToolRegistry(options: MakeToolRegistryOptions = {}): ReturnType<typeof tool> {
+  const clients: Record<string, McpClient> = { ...(options.mcpClients ?? {}) }
+  const maxDynamicTools = options.maxDynamicTools ?? MAX_DYNAMIC_TOOLS
+  const toolName = options.name ?? 'tool_registry'
+  const description = options.description ?? TOOL_REGISTRY_DESCRIPTION
+
+  if (maxDynamicTools < 1) {
+    throw new Error('maxDynamicTools must be at least 1')
+  }
+
+  const ownership: OwnershipMap = new WeakMap()
+
+  return tool({
+    name: toolName,
+    description,
+    inputSchema: toolRegistryInputSchema,
+    callback: async (input, context): Promise<JSONValue> => {
+      if (!context) {
+        throw new Error('Tool context is required for tool_registry operations')
+      }
+
+      const agent = context.agent
+      const registry = agent.toolRegistry
+      const owned = getOwnedNames(ownership, agent)
+
+      if (input.operation === 'list') {
+        const tools: RegisteredTool[] = registry.list().map((t) => {
+          const entry: RegisteredTool = {
+            name: t.name,
+            description: t.description,
+            registeredByToolRegistry: owned.has(t.name),
+          }
+          if (t.toolSpec.inputSchema !== undefined) {
+            entry.inputSchema = t.toolSpec.inputSchema
+          }
+          return entry
+        })
+        const result: ListResult = {
+          tools,
+          dynamicCount: owned.size,
+          dynamicLimit: maxDynamicTools,
+        }
+        return result as unknown as JSONValue
+      }
+
+      // The schema refine guarantees `toolName` is present for create/update/
+      // delete, but it does not reject the empty string. Coalesce to '' for
+      // TS narrowing and let validateToolName reject empty and other
+      // ill-formed names uniformly.
+      const requestedName = input.toolName ?? ''
+      validateToolName(requestedName)
+
+      // Never allow this tool to remove or replace itself.
+      if (requestedName === toolName) {
+        throw new ToolRegistryError(`cannot ${input.operation} the tool_registry tool ('${requestedName}') itself`)
+      }
+
+      if (input.operation === 'delete') {
+        if (!owned.has(requestedName)) {
+          throw new ToolRegistryError(
+            `tool '${requestedName}' was not registered via tool_registry; ` +
+              'developer-registered tools cannot be removed'
+          )
+        }
+        registry.remove(requestedName)
+        owned.delete(requestedName)
+        const result: MutationResult = {
+          operation: 'delete',
+          name: requestedName,
+          dynamicCount: owned.size,
+        }
+        return result as unknown as JSONValue
+      }
+
+      // create / update below share the source-resolution logic.
+      const source = input.source ?? ''
+      if (!(source in clients)) {
+        const allowed = Object.keys(clients).sort().join(', ') || '<none>'
+        throw new ToolRegistryError(`unknown source '${source}': allowed sources are: ${allowed}`)
+      }
+      const client = clients[source]!
+      const effectiveRemoteName = input.remoteName ?? requestedName
+
+      if (input.operation === 'create') {
+        if (registry.get(requestedName) !== undefined || owned.has(requestedName)) {
+          throw new ToolRegistryError(`a tool named '${requestedName}' is already registered`)
+        }
+        if (owned.size >= maxDynamicTools) {
+          throw new ToolRegistryError(
+            `dynamic tool cap reached (${maxDynamicTools}); ` + 'delete an existing dynamically-registered tool first'
+          )
+        }
+        // Reserve the slot synchronously so concurrent `create` calls in one
+        // turn don't all pass the cap check before any of them writes.
+        owned.add(requestedName)
+        try {
+          const newTool = await resolveMcpTool(client, effectiveRemoteName, requestedName, input.descriptionOverride)
+          // A concurrent `delete` could have observed our reservation, treated
+          // it as if the tool were already registered, and cleared it while we
+          // were awaiting. If so, abort rather than resurrect an orphan entry
+          // in the SDK registry that this instance no longer tracks (and thus
+          // could never delete or update again).
+          if (!owned.has(requestedName)) {
+            throw new ToolRegistryError(
+              `create of '${requestedName}' was cancelled by a concurrent delete before the tool could be registered`
+            )
+          }
+          registry.add(newTool)
+        } catch (err) {
+          owned.delete(requestedName)
+          if (err instanceof ToolValidationError) {
+            throw new ToolRegistryError(err.message)
+          }
+          throw err
+        }
+        const result: MutationResult = {
+          operation: 'create',
+          name: requestedName,
+          dynamicCount: owned.size,
+        }
+        return result as unknown as JSONValue
+      }
+
+      // operation === 'update'
+      if (!owned.has(requestedName)) {
+        throw new ToolRegistryError(
+          `tool '${requestedName}' was not registered via tool_registry; ` +
+            'developer-registered tools cannot be updated'
+        )
+      }
+      const replacement = await resolveMcpTool(client, effectiveRemoteName, requestedName, input.descriptionOverride)
+      // A concurrent `delete` could have observed our ownership, cleared it,
+      // and removed the tool from the registry while we were awaiting the
+      // MCP lookup. If so, abort rather than resurrect a tool the model
+      // believed deleted (mirrors the create-during-delete guard).
+      if (!owned.has(requestedName)) {
+        throw new ToolRegistryError(
+          `update of '${requestedName}' was cancelled by a concurrent delete before the tool could be re-bound`
+        )
+      }
+      try {
+        registry.addOrReplace([replacement])
+      } catch (err) {
+        if (err instanceof ToolValidationError) {
+          throw new ToolRegistryError(err.message)
+        }
+        throw err
+      }
+      const result: MutationResult = {
+        operation: 'update',
+        name: requestedName,
+        dynamicCount: owned.size,
+      }
+      return result as unknown as JSONValue
+    },
+  })
+}

--- a/strands-ts/src/vended-tools/tool-registry/tool-registry.ts
+++ b/strands-ts/src/vended-tools/tool-registry/tool-registry.ts
@@ -67,6 +67,8 @@ async function resolveMcpTool(
   }
   return new McpTool({
     name: localName,
+    // The wire call needs the server's tool name, not the local alias.
+    remoteName,
     description: descriptionOverride ?? found.description,
     // `McpTool`'s constructor requires an inputSchema; fall back to the empty
     // object schema when the remote tool doesn't declare one, rather than

--- a/strands-ts/src/vended-tools/tool-registry/types.ts
+++ b/strands-ts/src/vended-tools/tool-registry/types.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared types and constants for the tool_registry tool.
+ */
+
+import type { JSONSchema } from '../../types/json.js'
+
+/**
+ * Provider-accepted tool name: leading letter/underscore, then letters/digits/
+ * underscore, capped at 64 characters. Stricter than the underlying registry
+ * (which also allows `-`) because the dynamically-registered tool name is
+ * echoed into user-visible spec strings; disallowing `-` keeps every generated
+ * identifier a legal JavaScript identifier.
+ */
+export const TOOL_NAME_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]{0,63}$/
+
+/** Maximum number of tools a single tool_registry instance may register. */
+export const MAX_DYNAMIC_TOOLS = 32
+
+export const TOOL_REGISTRY_DESCRIPTION =
+  "Manage the agent's tool registry at runtime. Supports operations to `list` " +
+  'currently registered tools, `create` a new binding to an already-connected ' +
+  'MCP server tool, `update` an existing binding, and `delete` a previously ' +
+  'registered binding. Registration is limited to remote MCP tools; loading ' +
+  'tools from a file path or inline source is intentionally not supported.'
+
+/** A tool entry in a `list` response. */
+export interface RegisteredTool {
+  /** The tool name as visible to the agent. */
+  name: string
+  /** The tool description as visible to the model. */
+  description: string
+  /** The tool's JSON input schema, if any. */
+  inputSchema?: JSONSchema
+  /**
+   * True when this tool was registered via the tool_registry tool
+   * (i.e. it can be updated/deleted by this tool). False for developer-registered tools.
+   */
+  registeredByToolRegistry: boolean
+}
+
+/** Result payload for the `list` operation. */
+export interface ListResult {
+  tools: RegisteredTool[]
+  dynamicCount: number
+  dynamicLimit: number
+}
+
+/** Result payload for `create`, `update`, and `delete` operations. */
+export interface MutationResult {
+  operation: 'create' | 'update' | 'delete'
+  name: string
+  dynamicCount: number
+}
+
+/**
+ * Error thrown for validation failures inside the tool_registry tool.
+ * Distinct class so callers can pattern-match on it separately from generic
+ * ToolValidationError from the SDK registry.
+ */
+export class ToolRegistryError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ToolRegistryError'
+  }
+}


### PR DESCRIPTION
Closes #3249.

Vended tool_registry in both SDKs. Gives an agent CRUD access to its own tool registry at runtime: list currently registered tools, create a new binding to a tool hosted on a pre-approved MCP server, update an existing binding, and delete one previously registered by this same tool instance. The four operations sit behind a single tool with an operation discriminator, so the model sees a small consistent surface. Python shims onto `ToolRegistry.register_dynamic_tool` and `MCPClient.list_tools_sync`; TypeScript shims onto `ToolRegistry.add`/`addOrReplace`/`remove`/`list` and `McpClient.listTools`. No new runtime dependencies.

The design question in the sub-issue was what create should accept. Three shapes were on the table: a filesystem path (loading arbitrary Python from disk), inline source code (executing arbitrary code from a model-authored string), or a reference to an already-connected MCP server. Only the third ships, and it is tightened further: the model does not choose an MCP URL, it picks from an `mcp_clients` allow-list the developer supplied at tool construction, keyed by a stable alias. Consumers who need path-loading or inline-source-execution should build a separate, more locked-down tool.

Tool names must match `^[a-zA-Z_][a-zA-Z0-9_]{0,63}$`. Update and delete only touch tools this same instance registered, tracked per-agent (a `weakref.WeakKeyDictionary` keyed on the `ToolRegistry` in Python, a `WeakMap` keyed on the `LocalAgent` in TypeScript), so two agents sharing one factory cannot see each other's registrations. A configurable cap (default thirty-two) bounds registrations per instance. Under concurrent creates the cap is enforced by a synchronous reservation before the MCP lookup; a concurrent delete that lands on a reservation causes the still-awaiting create to abort rather than resurrect an entry it can no longer track. The same guard also runs on update.
