### PR TITLE
feat(python): add HTTP request vended tool

### DIFF
--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -75,7 +75,7 @@ agent("Create a file at /tmp/hello.txt with the contents 'Hello, world!'")
 
 ### HTTP Request
 
-Lets your agent call external APIs and fetch web content. Supports all HTTP methods, custom headers, and request bodies. Default timeout is 30 seconds.
+Lets your agent call external APIs and fetch web content over HTTP or HTTPS. Supports GET, POST, PUT, DELETE, PATCH, HEAD, and OPTIONS, along with custom headers and request bodies. The default timeout is 30 seconds.
 
 _Supported in: Python, Node.js 20+, modern browsers._
 
@@ -107,7 +107,14 @@ from strands.vended_tools import http_request
 </Tab>
 </Tabs>
 
-📖 API Reference: [Python](@api/python/strands.vended_tools.http_request.http_request) | [TypeScript](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/http-request/README.md)
+Python direct calls are asynchronous. `await http_request(...)` returns a dictionary containing `status`, `status_text`, `headers`, and `body`. It raises `ValueError` for invalid inputs, `TimeoutError` when the deadline expires, and `RuntimeError` for network failures or non-2xx responses.
+
+```python
+response = await http_request(method="GET", url="https://api.example.com/users")
+print(response["status"], response["body"])
+```
+
+📖 API Reference: [Python function](@api/python/strands.vended_tools.http_request.http_request) and [Python output type](@api/python/strands.vended_tools.http_request.types#HttpRequestOutput) | [TypeScript](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/http-request/README.md)
 
 ---
 

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -9,6 +9,7 @@ sourceLinks:
   - path: strands-ts/src/vended-tools/file-editor/file-editor.ts
   - path: strands-ts/src/vended-tools/bash/bash.ts
   - path: strands-ts/src/vended-tools/http-request/http-request.ts
+  - path: strands-py/src/strands/vended_tools/http_request/http_request.py
   - path: strands-ts/src/vended-tools/notebook/notebook.ts
 ---
 
@@ -31,7 +32,7 @@ Each tool is imported from its own subpath under `@strands-agents/sdk/vended-too
 | Tool | Description | Supported in |
 |------|-------------|--------------|
 | [File Editor](#file-editor) | View, create, and edit files | Python, TypeScript (Node.js) |
-| [HTTP Request](#http-request) | Make HTTP requests to external APIs | TypeScript (Node.js 20+, browsers) |
+| [HTTP Request](#http-request) | Make HTTP requests to external APIs | Python, TypeScript (Node.js 20+, browsers) |
 | [Notebook](#notebook) | Manage persistent text notebooks | TypeScript (Node.js, browsers) |
 | [Bash](#bash) | Execute shell commands with persistent sessions | Python, TypeScript (Node.js, Unix/Linux/macOS) |
 
@@ -76,18 +77,35 @@ agent("Create a file at /tmp/hello.txt with the contents 'Hello, world!'")
 
 Lets your agent call external APIs and fetch web content. Supports all HTTP methods, custom headers, and request bodies. Default timeout is 30 seconds.
 
-_Supported in: Node.js 20+, modern browsers._
+_Supported in: Python, Node.js 20+, modern browsers._
 
 :::caution[Security Warning]
 This tool makes HTTP requests to arbitrary URLs without restrictions on destination. Only use with trusted input and consider running in a [sandboxed environment](../sandbox/index.mdx) for production.
 :::
 
 **Example:**
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.vended_tools import http_request
+
+--8<-- "user-guide/concepts/tools/vended-tools.py:http_request_example"
+```
+
+</Tab>
+<Tab label="TypeScript">
+
 ```typescript
 --8<-- "user-guide/concepts/tools/vended-tools-imports.ts:http_request_import"
 
 --8<-- "user-guide/concepts/tools/vended-tools.ts:http_request_example"
 ```
+
+</Tab>
+</Tabs>
 
 📖 [Full API Reference](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/http-request/README.md)
 

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -107,7 +107,7 @@ from strands.vended_tools import http_request
 </Tab>
 </Tabs>
 
-📖 [Full API Reference](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/http-request/README.md)
+📖 API Reference: [Python](@api/python/strands.vended_tools.http_request.http_request) | [TypeScript](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/http-request/README.md)
 
 ---
 

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.py
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.py
@@ -1,0 +1,14 @@
+"""Python snippets for the vended tools guide."""
+
+from strands import Agent
+from strands.vended_tools import http_request
+
+
+def http_request_example() -> None:
+    """Show an agent using the HTTP request tool."""
+    # --8<-- [start:http_request_example]
+    agent = Agent(tools=[http_request])
+
+    agent("Get data from https://api.example.com/users")
+    agent('Post {"name": "John"} to https://api.example.com/users')
+    # --8<-- [end:http_request_example]

--- a/strands-py/pyproject.toml
+++ b/strands-py/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "botocore>=1.29.0,<2.0.0",
     "docstring_parser>=0.15,<1.0",
     "jsonschema>=4.0.0,<5.0.0",
+    "httpx>=0.28.1,<1.0.0",
     "mcp>=1.23.0,<2.0.0",
     "pydantic>=2.4.0,<3.0.0",
     "typing-extensions>=4.13.2,<5.0.0",
@@ -70,7 +71,6 @@ a2a = [
     "a2a-sdk>=0.3.0,<0.4.0",
     "a2a-sdk[sql]>=0.3.0,<0.4.0",
     "uvicorn>=0.34.2,<1.0.0",
-    "httpx>=0.28.1,<1.0.0",
     "fastapi>=0.133.0,<1.0.0",
     "starlette>=1.0.0,<2.0.0",
 ]

--- a/strands-py/src/strands/tools/decorator.py
+++ b/strands-py/src/strands/tools/decorator.py
@@ -129,7 +129,9 @@ class FunctionToolMetadata:
 
         if get_origin(annotation) is Annotated:
             args = get_args(annotation)
-            actual_type = args[0]
+            # Preserve validation metadata such as pydantic.Strict while extracting
+            # tool descriptions from the same annotation.
+            actual_type = annotation
 
             # Look through metadata for a string description or a FieldInfo object
             for meta in args[1:]:

--- a/strands-py/src/strands/vended_tools/__init__.py
+++ b/strands-py/src/strands/vended_tools/__init__.py
@@ -1,4 +1,4 @@
-"""Built-in tools for executing commands and editing files.
+"""Built-in tools for commands, file editing, and HTTP requests.
 
 The :data:`bash` tool runs a
 persistent shell on the host; the :func:`make_bash` and :func:`make_file_editor`
@@ -17,10 +17,12 @@ Example Usage:
 
 from .bash import bash, make_bash
 from .file_editor import file_editor, make_file_editor
+from .http_request import http_request
 
 __all__ = [
     "bash",
     "file_editor",
+    "http_request",
     "make_bash",
     "make_file_editor",
 ]

--- a/strands-py/src/strands/vended_tools/http_request/__init__.py
+++ b/strands-py/src/strands/vended_tools/http_request/__init__.py
@@ -1,0 +1,14 @@
+"""HTTP request tool for calling external APIs.
+
+Example Usage:
+    ```python
+    from strands import Agent
+    from strands.vended_tools import http_request
+
+    agent = Agent(tools=[http_request])
+    ```
+"""
+
+from .http_request import http_request
+
+__all__ = ["http_request"]

--- a/strands-py/src/strands/vended_tools/http_request/http_request.py
+++ b/strands-py/src/strands/vended_tools/http_request/http_request.py
@@ -4,19 +4,30 @@ from __future__ import annotations
 
 import asyncio
 import math
-from typing import Annotated, Literal
+from typing import Any, Literal
 
 import httpx
-from pydantic import AnyUrl, Strict, TypeAdapter, ValidationError
+from pydantic import AnyUrl, TypeAdapter, ValidationError
+from pydantic_core import core_schema
 
 from ...tools.decorator import tool
 from ...types.tools import JSONSchema
 from .types import HttpRequestOutput
 
 HttpMethod = Literal["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"]
-Timeout = Annotated[float, Strict()]
+
+
+class Timeout(float):
+    """Strict, finite, positive request timeout in seconds."""
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source_type: Any, handler: Any) -> core_schema.CoreSchema:
+        """Return the validation schema used by the tool decorator."""
+        return core_schema.float_schema(strict=True, allow_inf_nan=False, gt=0)
+
 
 _DEFAULT_TIMEOUT = 30
+_DEFAULT_TIMEOUT_VALUE = Timeout(_DEFAULT_TIMEOUT)
 _HTTP_METHODS = {"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"}
 _HTTP_URL_ADAPTER = TypeAdapter(AnyUrl)
 _HTTP_REQUEST_INPUT_SCHEMA: JSONSchema = {
@@ -60,7 +71,7 @@ async def http_request(
     url: str,
     headers: dict[str, str] | None = None,
     body: str | None = None,
-    timeout: Timeout = _DEFAULT_TIMEOUT,
+    timeout: Timeout = _DEFAULT_TIMEOUT_VALUE,
 ) -> HttpRequestOutput:
     """Make an HTTP request to an external API.
 
@@ -84,9 +95,10 @@ async def http_request(
     """
     if method not in _HTTP_METHODS:
         raise ValueError(f"Unsupported HTTP method: {method}")
-    if isinstance(timeout, bool) or not isinstance(timeout, (int, float)):
+    timeout_value: object = timeout
+    if isinstance(timeout_value, bool) or not isinstance(timeout_value, (int, float)):
         raise ValueError("timeout must be a number")
-    if not math.isfinite(timeout) or timeout <= 0:
+    if not math.isfinite(timeout_value) or timeout_value <= 0:
         raise ValueError("timeout must be a finite number greater than 0")
 
     try:

--- a/strands-py/src/strands/vended_tools/http_request/http_request.py
+++ b/strands-py/src/strands/vended_tools/http_request/http_request.py
@@ -1,0 +1,113 @@
+"""HTTP request tool for calling external APIs."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Literal
+
+import httpx
+from pydantic import AnyUrl, TypeAdapter, ValidationError
+
+from ...tools.decorator import tool
+from ...types.tools import JSONSchema
+from .types import HttpRequestOutput
+
+HttpMethod = Literal["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"]
+
+_DEFAULT_TIMEOUT = 30
+_HTTP_METHODS = {"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"}
+_HTTP_URL_ADAPTER = TypeAdapter(AnyUrl)
+_HTTP_REQUEST_INPUT_SCHEMA: JSONSchema = {
+    "json": {
+        "type": "object",
+        "properties": {
+            "method": {
+                "type": "string",
+                "enum": sorted(_HTTP_METHODS),
+                "description": "HTTP method to use for the request",
+            },
+            "url": {
+                "type": "string",
+                "format": "uri",
+                "description": "URL to send the request to",
+            },
+            "headers": {
+                "type": "object",
+                "additionalProperties": {"type": "string"},
+                "description": "Optional HTTP headers as key-value pairs",
+            },
+            "body": {
+                "type": "string",
+                "description": "Optional request body as a string",
+            },
+            "timeout": {
+                "type": "number",
+                "exclusiveMinimum": 0,
+                "default": _DEFAULT_TIMEOUT,
+                "description": "Optional timeout in seconds (default: 30)",
+            },
+        },
+        "required": ["method", "url"],
+    }
+}
+
+
+@tool(name="http_request", inputSchema=_HTTP_REQUEST_INPUT_SCHEMA)
+async def http_request(
+    method: HttpMethod,
+    url: str,
+    headers: dict[str, str] | None = None,
+    body: str | None = None,
+    timeout: float = _DEFAULT_TIMEOUT,
+) -> HttpRequestOutput:
+    """Make an HTTP request to an external API.
+
+    Supports GET, POST, PUT, DELETE, PATCH, HEAD, and OPTIONS requests. Redirects
+    are followed automatically. The response body is returned as text.
+
+    Args:
+        method: HTTP method to use for the request.
+        url: URL to send the request to.
+        headers: Optional HTTP headers as key-value pairs.
+        body: Optional request body as a string.
+        timeout: Timeout in seconds (default: 30).
+
+    Returns:
+        The response status, status text, headers, and body.
+
+    Raises:
+        ValueError: If the method, URL, or timeout is invalid.
+        TimeoutError: If the request exceeds the timeout.
+        RuntimeError: If the request fails or returns a non-2xx response.
+    """
+    if method not in _HTTP_METHODS:
+        raise ValueError(f"Unsupported HTTP method: {method}")
+    if timeout <= 0:
+        raise ValueError("timeout must be greater than 0")
+
+    try:
+        _HTTP_URL_ADAPTER.validate_python(url)
+    except ValidationError as error:
+        raise ValueError(f"Invalid URL: {url}") from error
+
+    try:
+        async with httpx.AsyncClient(follow_redirects=True, timeout=None) as client:
+            response = await asyncio.wait_for(
+                client.request(method, url, headers=headers, content=body),
+                timeout=timeout,
+            )
+    except (TimeoutError, httpx.TimeoutException) as error:
+        raise TimeoutError(f"Request timed out after {timeout} seconds: {method} {url}") from error
+    except httpx.RequestError as error:
+        raise RuntimeError(str(error)) from error
+
+    response_body = response.content.decode("utf-8", errors="replace")
+    if not 200 <= response.status_code < 300:
+        raise RuntimeError(f"HTTP {response.status_code} {response.reason_phrase}: {method} {url}")
+
+    return {
+        "status": response.status_code,
+        "status_text": response.reason_phrase,
+        "headers": dict(response.headers.items()),
+        "body": response_body,
+    }

--- a/strands-py/src/strands/vended_tools/http_request/http_request.py
+++ b/strands-py/src/strands/vended_tools/http_request/http_request.py
@@ -3,16 +3,18 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Literal
+import math
+from typing import Annotated, Literal
 
 import httpx
-from pydantic import AnyUrl, TypeAdapter, ValidationError
+from pydantic import AnyUrl, Strict, TypeAdapter, ValidationError
 
 from ...tools.decorator import tool
 from ...types.tools import JSONSchema
 from .types import HttpRequestOutput
 
 HttpMethod = Literal["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"]
+Timeout = Annotated[float, Strict()]
 
 _DEFAULT_TIMEOUT = 30
 _HTTP_METHODS = {"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"}
@@ -58,7 +60,7 @@ async def http_request(
     url: str,
     headers: dict[str, str] | None = None,
     body: str | None = None,
-    timeout: float = _DEFAULT_TIMEOUT,
+    timeout: Timeout = _DEFAULT_TIMEOUT,
 ) -> HttpRequestOutput:
     """Make an HTTP request to an external API.
 
@@ -82,8 +84,8 @@ async def http_request(
     """
     if method not in _HTTP_METHODS:
         raise ValueError(f"Unsupported HTTP method: {method}")
-    if timeout <= 0:
-        raise ValueError("timeout must be greater than 0")
+    if not math.isfinite(timeout) or timeout <= 0:
+        raise ValueError("timeout must be a finite number greater than 0")
 
     try:
         _HTTP_URL_ADAPTER.validate_python(url)
@@ -96,7 +98,7 @@ async def http_request(
                 client.request(method, url, headers=headers, content=body),
                 timeout=timeout,
             )
-    except (TimeoutError, httpx.TimeoutException) as error:
+    except (asyncio.TimeoutError, httpx.TimeoutException) as error:
         raise TimeoutError(f"Request timed out after {timeout} seconds: {method} {url}") from error
     except httpx.RequestError as error:
         raise RuntimeError(str(error)) from error

--- a/strands-py/src/strands/vended_tools/http_request/http_request.py
+++ b/strands-py/src/strands/vended_tools/http_request/http_request.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import math
-from typing import Any, Literal
+from typing import Annotated, Literal
 
 import httpx
-from pydantic import AnyUrl, TypeAdapter, ValidationError
-from pydantic_core import core_schema
+from pydantic import AnyUrl, Strict, TypeAdapter, ValidationError
 
 from ...tools.decorator import tool
 from ...types.tools import JSONSchema
@@ -17,17 +16,9 @@ from .types import HttpRequestOutput
 HttpMethod = Literal["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"]
 
 
-class Timeout(float):
-    """Strict, finite, positive request timeout in seconds."""
-
-    @classmethod
-    def __get_pydantic_core_schema__(cls, source_type: Any, handler: Any) -> core_schema.CoreSchema:
-        """Return the validation schema used by the tool decorator."""
-        return core_schema.float_schema(strict=True, allow_inf_nan=False, gt=0)
-
+Timeout = Annotated[float, Strict()]
 
 _DEFAULT_TIMEOUT = 30
-_DEFAULT_TIMEOUT_VALUE = Timeout(_DEFAULT_TIMEOUT)
 _HTTP_METHODS = {"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"}
 _HTTP_URL_ADAPTER = TypeAdapter(AnyUrl)
 _HTTP_REQUEST_INPUT_SCHEMA: JSONSchema = {
@@ -71,7 +62,7 @@ async def http_request(
     url: str,
     headers: dict[str, str] | None = None,
     body: str | None = None,
-    timeout: Timeout = _DEFAULT_TIMEOUT_VALUE,
+    timeout: Timeout = _DEFAULT_TIMEOUT,
 ) -> HttpRequestOutput:
     """Make an HTTP request to an external API.
 

--- a/strands-py/src/strands/vended_tools/http_request/http_request.py
+++ b/strands-py/src/strands/vended_tools/http_request/http_request.py
@@ -84,6 +84,8 @@ async def http_request(
     """
     if method not in _HTTP_METHODS:
         raise ValueError(f"Unsupported HTTP method: {method}")
+    if isinstance(timeout, bool) or not isinstance(timeout, (int, float)):
+        raise ValueError("timeout must be a number")
     if not math.isfinite(timeout) or timeout <= 0:
         raise ValueError("timeout must be a finite number greater than 0")
 

--- a/strands-py/src/strands/vended_tools/http_request/http_request.py
+++ b/strands-py/src/strands/vended_tools/http_request/http_request.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import math
+import re
 from typing import Annotated, Literal
 
 import httpx
-from pydantic import AnyUrl, Strict, TypeAdapter, ValidationError
+from pydantic import AnyHttpUrl, Strict, TypeAdapter, ValidationError
 
 from ...tools.decorator import tool
 from ...types.tools import JSONSchema
@@ -20,7 +21,8 @@ Timeout = Annotated[float, Strict()]
 
 _DEFAULT_TIMEOUT = 30
 _HTTP_METHODS = {"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"}
-_HTTP_URL_ADAPTER = TypeAdapter(AnyUrl)
+_HTTP_URL_ADAPTER = TypeAdapter(AnyHttpUrl)
+_HTTP_URL_PATTERN = re.compile(r"^https?://[^/]", re.IGNORECASE)
 _HTTP_REQUEST_INPUT_SCHEMA: JSONSchema = {
     "json": {
         "type": "object",
@@ -33,7 +35,8 @@ _HTTP_REQUEST_INPUT_SCHEMA: JSONSchema = {
             "url": {
                 "type": "string",
                 "format": "uri",
-                "description": "URL to send the request to",
+                "pattern": r"^[hH][tT][tT][pP][sS]?://[^/]",
+                "description": "HTTP or HTTPS URL without embedded credentials; use headers for authentication",
             },
             "headers": {
                 "type": "object",
@@ -71,7 +74,7 @@ async def http_request(
 
     Args:
         method: HTTP method to use for the request.
-        url: URL to send the request to.
+        url: HTTP or HTTPS URL without embedded credentials. Use headers for authentication.
         headers: Optional HTTP headers as key-value pairs.
         body: Optional request body as a string.
         timeout: Timeout in seconds (default: 30).
@@ -89,18 +92,32 @@ async def http_request(
     timeout_value: object = timeout
     if isinstance(timeout_value, bool) or not isinstance(timeout_value, (int, float)):
         raise ValueError("timeout must be a number")
-    if not math.isfinite(timeout_value) or timeout_value <= 0:
+    try:
+        timeout_is_valid = math.isfinite(timeout_value) and timeout_value > 0
+    except OverflowError:
+        timeout_is_valid = False
+    if not timeout_is_valid:
         raise ValueError("timeout must be a finite number greater than 0")
 
+    if (
+        not isinstance(url, str)
+        or not _HTTP_URL_PATTERN.match(url)
+        or any(ord(char) < 32 or ord(char) == 127 for char in url)
+    ):
+        raise ValueError("Invalid URL: expected an absolute HTTP or HTTPS URL without embedded credentials")
     try:
-        _HTTP_URL_ADAPTER.validate_python(url)
-    except ValidationError as error:
-        raise ValueError(f"Invalid URL: {url}") from error
+        validated_url = _HTTP_URL_ADAPTER.validate_python(url)
+        raw_request_url = httpx.URL(url)
+        request_url = httpx.URL(str(validated_url))
+    except (ValidationError, httpx.InvalidURL):
+        raise ValueError("Invalid URL: expected an absolute HTTP or HTTPS URL without embedded credentials") from None
+    if not raw_request_url.is_absolute_url or raw_request_url.userinfo or request_url.userinfo:
+        raise ValueError("Invalid URL: expected an absolute HTTP or HTTPS URL without embedded credentials")
 
     try:
         async with httpx.AsyncClient(follow_redirects=True, timeout=None) as client:
             response = await asyncio.wait_for(
-                client.request(method, url, headers=headers, content=body),
+                client.request(method, request_url, headers=headers, content=body),
                 timeout=timeout,
             )
     except (asyncio.TimeoutError, httpx.TimeoutException) as error:

--- a/strands-py/src/strands/vended_tools/http_request/types.py
+++ b/strands-py/src/strands/vended_tools/http_request/types.py
@@ -1,0 +1,19 @@
+"""Shared types for the HTTP request tool."""
+
+from typing import TypedDict
+
+
+class HttpRequestOutput(TypedDict):
+    """Output of an HTTP request.
+
+    Attributes:
+        status: HTTP status code.
+        status_text: HTTP status text.
+        headers: Response headers as key-value pairs.
+        body: Response body as text.
+    """
+
+    status: int
+    status_text: str
+    headers: dict[str, str]
+    body: str

--- a/strands-py/tests/strands/tools/test_decorator.py
+++ b/strands-py/tests/strands/tools/test_decorator.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any
 from unittest.mock import MagicMock
 
 import pytest
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, Strict
 
 import strands
 from strands import Agent
@@ -1803,6 +1803,22 @@ def test_tool_decorator_annotated_string_description():
 
     # Verify all are required
     assert set(schema["required"]) == {"name", "age", "city"}
+
+
+@pytest.mark.asyncio
+async def test_tool_decorator_preserves_annotated_validation_metadata(alist):
+    """Annotated validation metadata applies to tool-stream inputs."""
+
+    @strands.tool
+    def strict_tool(value: Annotated[float, Strict()]) -> float:
+        """Return a strictly validated number."""
+        return value
+
+    valid_result = (await alist(strict_tool.stream({"toolUseId": "valid", "input": {"value": 1}}, {})))[-1]
+    invalid_result = (await alist(strict_tool.stream({"toolUseId": "invalid", "input": {"value": "1"}}, {})))[-1]
+
+    assert valid_result["tool_result"]["status"] == "success"
+    assert invalid_result["tool_result"]["status"] == "error"
 
 
 def test_tool_decorator_annotated_pydantic_field_constraints():

--- a/strands-py/tests/strands/vended_tools/http_request/test_http_request.py
+++ b/strands-py/tests/strands/vended_tools/http_request/test_http_request.py
@@ -155,7 +155,7 @@ async def test_rejects_non_positive_timeout(timeout):
         await http_request(method="GET", url=_URL, timeout=timeout)
 
 
-@pytest.mark.parametrize("timeout", ["1", True])
+@pytest.mark.parametrize("timeout", ["1", True, False])
 @pytest.mark.asyncio
 async def test_tool_validation_rejects_coercible_timeout_values(timeout):
     events = [
@@ -167,6 +167,18 @@ async def test_tool_validation_rejects_coercible_timeout_values(timeout):
     ]
 
     assert events[-1].tool_result["status"] == "error"
+
+
+@pytest.mark.parametrize("timeout", ["1", True, False])
+@pytest.mark.asyncio
+async def test_direct_call_rejects_non_numeric_timeout_without_request(timeout):
+    request = AsyncMock(return_value=_response())
+
+    with patch("httpx.AsyncClient.request", new=request):
+        with pytest.raises(ValueError, match="timeout must be a number"):
+            await http_request(method="GET", url=_URL, timeout=timeout)
+
+    request.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests/strands/vended_tools/http_request/test_http_request.py
+++ b/strands-py/tests/strands/vended_tools/http_request/test_http_request.py
@@ -1,10 +1,13 @@
 """Tests for the HTTP request tool."""
 
 import asyncio
+import traceback
 from unittest.mock import AsyncMock, patch
 
 import httpx
+import jsonschema
 import pytest
+from pydantic import AnyHttpUrl, TypeAdapter
 
 from strands.vended_tools import http_request
 
@@ -69,7 +72,7 @@ async def test_sends_custom_headers_and_body():
 
     request.assert_awaited_once_with(
         "POST",
-        "https://api.example.com/users",
+        httpx.URL("https://api.example.com/users"),
         headers={"Content-Type": "application/json"},
         content='{"name":"test"}',
     )
@@ -82,7 +85,7 @@ async def test_uses_none_for_unset_headers_and_body():
     with patch("httpx.AsyncClient.request", new=request):
         await http_request(method="GET", url=_URL)
 
-    request.assert_awaited_once_with("GET", _URL, headers=None, content=None)
+    request.assert_awaited_once_with("GET", httpx.URL(_URL), headers=None, content=None)
 
 
 @pytest.mark.parametrize(("content", "expected"), [(b"", ""), (b"Plain text response", "Plain text response")])
@@ -141,18 +144,134 @@ async def test_wraps_network_failures():
     assert caught.value.__cause__ is error
 
 
-@pytest.mark.parametrize("url", ["not-a-url", "/relative"])
+@pytest.mark.parametrize(
+    "url",
+    [
+        "not-a-url",
+        "/relative",
+        "ftp://example.com/resource",
+        "mailto:user@example.com",
+        "file:///tmp/resource",
+        "http:///path",
+        "http:example.com",
+        "https:/example.com",
+        "http://example.com\nfoo",
+        "http://example.com: ",
+        "http://user:pass@example.com/resource",
+        r"http://good.example\user:secret@evil.example/resource",
+        r"http://example.com\@evil.com",
+        r"http://127.0.0.1:8000\@127.0.0.1:8001/private",
+    ],
+)
 @pytest.mark.asyncio
-async def test_rejects_invalid_http_urls(url):
-    with pytest.raises(ValueError, match="^Invalid URL"):
+async def test_rejects_non_http_urls_without_request(url):
+    with patch("httpx.AsyncClient") as client:
+        with pytest.raises(ValueError, match="^Invalid URL"):
+            await http_request(method="GET", url=url)
+
+    client.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://example.com/resource",
+        "https://example.com/resource",
+        "http://[::1]/health",
+        "http://[0:0:0:0:0:0:0:1]/health",
+        "http://[::FFFF:127.0.0.1]/health",
+        "http://[2001:0db8:0000:0000:0000:ff00:0042:8329]/health",
+        "https://éxample.com/resource",
+        "https://xn--xample-9ua.com/resource",
+    ],
+)
+@pytest.mark.asyncio
+async def test_accepts_http_and_https_urls(url):
+    request = AsyncMock(return_value=_response())
+
+    with patch("httpx.AsyncClient.request", new=request):
         await http_request(method="GET", url=url)
 
+    request.assert_awaited_once()
+    called_url = request.await_args.args[1]
+    assert isinstance(called_url, httpx.URL)
+    assert called_url == httpx.URL(str(TypeAdapter(AnyHttpUrl).validate_python(url)))
 
-@pytest.mark.parametrize("timeout", [0, -1, float("inf"), float("-inf"), float("nan")])
+
+@pytest.mark.parametrize(
+    ("url", "expected_url"),
+    [("HTTP://EXAMPLE.COM/a b", "http://example.com/a%20b")],
+)
+@pytest.mark.asyncio
+async def test_uses_validated_url_for_request_destination(url, expected_url):
+    request = AsyncMock(return_value=_response())
+
+    with patch("httpx.AsyncClient.request", new=request):
+        await http_request(method="GET", url=url)
+
+    request.assert_awaited_once_with(
+        "GET",
+        httpx.URL(expected_url),
+        headers=None,
+        content=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_rejects_credentials_without_disclosing_them():
+    url = r"https://secret-user:secret-password\@example.com/resource"
+
+    with patch("httpx.AsyncClient") as client:
+        with pytest.raises(ValueError) as caught:
+            await http_request(method="GET", url=url)
+
+    assert "secret-user" not in str(caught.value)
+    assert "secret-password" not in str(caught.value)
+    assert "without embedded credentials" in str(caught.value)
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is not None
+    assert caught.value.__suppress_context__ is True
+    formatted = "".join(traceback.format_exception(caught.value))
+    assert "secret-user" not in formatted
+    assert "secret-password" not in formatted
+    client.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_tool_error_does_not_disclose_url_credentials():
+    url = r"https://secret-user:secret-password\\@example.com/resource"
+
+    with patch("httpx.AsyncClient") as client:
+        events = [
+            event
+            async for event in http_request.stream(
+                {"toolUseId": "test", "name": "http_request", "input": {"method": "GET", "url": url}},
+                {},
+            )
+        ]
+
+    result = events[-1].tool_result
+    assert result["status"] == "error"
+    assert "secret-user" not in str(result)
+    assert "secret-password" not in str(result)
+    exception = events[-1].exception
+    assert isinstance(exception, ValueError)
+    assert exception.__cause__ is None
+    assert exception.__suppress_context__ is True
+    formatted = "".join(traceback.format_exception(exception))
+    assert "secret-user" not in formatted
+    assert "secret-password" not in formatted
+    client.assert_not_called()
+
+
+@pytest.mark.parametrize("timeout", [0, -1, 10**309, float("inf"), float("-inf"), float("nan")])
 @pytest.mark.asyncio
 async def test_rejects_non_positive_timeout(timeout):
-    with pytest.raises(ValueError, match="timeout must be a finite number greater than 0"):
-        await http_request(method="GET", url=_URL, timeout=timeout)
+    with patch("httpx.AsyncClient") as client:
+        with pytest.raises(ValueError, match="timeout must be a finite number greater than 0"):
+            await http_request(method="GET", url=_URL, timeout=timeout)
+
+    client.assert_not_called()
 
 
 @pytest.mark.parametrize("timeout", ["1", True, False])
@@ -210,6 +329,11 @@ def test_tool_metadata():
         "OPTIONS",
     }
     assert schema["properties"]["url"]["format"] == "uri"
+    assert schema["properties"]["url"]["pattern"] == r"^[hH][tT][tT][pP][sS]?://[^/]"
+    for url in ("ftp://example.com", "mailto:user@example.com", "file:///tmp/resource"):
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate({"method": "GET", "url": url}, schema)
+    jsonschema.validate({"method": "GET", "url": "https://example.com"}, schema)
     assert schema["properties"]["timeout"]["exclusiveMinimum"] == 0
     assert schema["properties"]["timeout"]["default"] == 30
 

--- a/strands-py/tests/strands/vended_tools/http_request/test_http_request.py
+++ b/strands-py/tests/strands/vended_tools/http_request/test_http_request.py
@@ -1,0 +1,197 @@
+"""Tests for the HTTP request tool."""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from strands.vended_tools import http_request
+
+_URL = "https://api.example.com/resource"
+
+
+def _response(
+    status: int = 200,
+    *,
+    reason: str = "OK",
+    headers: list[tuple[str, str]] | None = None,
+    content: bytes = b'{"success":true}',
+) -> httpx.Response:
+    """Build an HTTPX response with a reason phrase for the tool."""
+    return httpx.Response(
+        status,
+        headers=headers,
+        content=content,
+        extensions={"reason_phrase": reason.encode()},
+        request=httpx.Request("GET", _URL),
+    )
+
+
+@pytest.mark.parametrize(
+    ("method", "status", "reason"),
+    [
+        ("GET", 200, "OK"),
+        ("POST", 201, "Created"),
+        ("PUT", 200, "OK"),
+        ("DELETE", 204, "No Content"),
+        ("PATCH", 200, "OK"),
+        ("HEAD", 200, "OK"),
+        ("OPTIONS", 200, "OK"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_returns_successful_response_for_supported_methods(method, status, reason):
+    response = _response(status, reason=reason, headers=[("content-type", "application/json")])
+
+    with patch("httpx.AsyncClient.request", new=AsyncMock(return_value=response)):
+        result = await http_request(method=method, url=_URL)
+
+    assert result == {
+        "status": status,
+        "status_text": reason,
+        "headers": {"content-type": "application/json", "content-length": str(len(response.content))},
+        "body": '{"success":true}',
+    }
+
+
+@pytest.mark.asyncio
+async def test_sends_custom_headers_and_body():
+    request = AsyncMock(return_value=_response())
+
+    with patch("httpx.AsyncClient.request", new=request):
+        await http_request(
+            method="POST",
+            url="https://api.example.com/users",
+            headers={"Content-Type": "application/json"},
+            body='{"name":"test"}',
+        )
+
+    request.assert_awaited_once_with(
+        "POST",
+        "https://api.example.com/users",
+        headers={"Content-Type": "application/json"},
+        content='{"name":"test"}',
+    )
+
+
+@pytest.mark.asyncio
+async def test_uses_none_for_unset_headers_and_body():
+    request = AsyncMock(return_value=_response())
+
+    with patch("httpx.AsyncClient.request", new=request):
+        await http_request(method="GET", url=_URL)
+
+    request.assert_awaited_once_with("GET", _URL, headers=None, content=None)
+
+
+@pytest.mark.parametrize(("content", "expected"), [(b"", ""), (b"Plain text response", "Plain text response")])
+@pytest.mark.asyncio
+async def test_returns_response_body_as_text(content, expected):
+    with patch("httpx.AsyncClient.request", new=AsyncMock(return_value=_response(content=content))):
+        result = await http_request(method="GET", url=_URL)
+
+    assert result["body"] == expected
+
+
+@pytest.mark.asyncio
+async def test_flattens_response_headers():
+    response = _response(headers=[("content-type", "application/json"), ("x-custom-header", "value")], content=b"{}")
+
+    with patch("httpx.AsyncClient.request", new=AsyncMock(return_value=response)):
+        result = await http_request(method="GET", url=_URL)
+
+    assert result["headers"] == {
+        "content-type": "application/json",
+        "x-custom-header": "value",
+        "content-length": "2",
+    }
+
+
+@pytest.mark.parametrize(
+    ("status", "reason"),
+    [(301, "Moved Permanently"), (404, "Not Found"), (500, "Internal Server Error")],
+)
+@pytest.mark.asyncio
+async def test_raises_for_non_success_statuses(status, reason):
+    with patch("httpx.AsyncClient.request", new=AsyncMock(return_value=_response(status, reason=reason))):
+        with pytest.raises(RuntimeError, match=rf"^HTTP {status} {reason}: GET {_URL}$"):
+            await http_request(method="GET", url=_URL)
+
+
+@pytest.mark.asyncio
+async def test_times_out_after_configured_deadline():
+    async def slow_request(*args, **kwargs):
+        await asyncio.sleep(1)
+        return _response()
+
+    with patch("httpx.AsyncClient.request", new=slow_request):
+        with pytest.raises(TimeoutError, match=rf"^Request timed out after 0.01 seconds: GET {_URL}$"):
+            await http_request(method="GET", url=_URL, timeout=0.01)
+
+
+@pytest.mark.asyncio
+async def test_wraps_network_failures():
+    error = httpx.ConnectError("Failed to connect", request=httpx.Request("GET", _URL))
+
+    with patch("httpx.AsyncClient.request", new=AsyncMock(side_effect=error)):
+        with pytest.raises(RuntimeError, match="^Failed to connect$") as caught:
+            await http_request(method="GET", url=_URL)
+
+    assert caught.value.__cause__ is error
+
+
+@pytest.mark.parametrize("url", ["not-a-url", "/relative"])
+@pytest.mark.asyncio
+async def test_rejects_invalid_http_urls(url):
+    with pytest.raises(ValueError, match="^Invalid URL"):
+        await http_request(method="GET", url=url)
+
+
+@pytest.mark.parametrize("timeout", [0, -1])
+@pytest.mark.asyncio
+async def test_rejects_non_positive_timeout(timeout):
+    with pytest.raises(ValueError, match="timeout must be greater than 0"):
+        await http_request(method="GET", url=_URL, timeout=timeout)
+
+
+@pytest.mark.asyncio
+async def test_rejects_unsupported_method_for_direct_calls():
+    with pytest.raises(ValueError, match="Unsupported HTTP method"):
+        await http_request(method="TRACE", url=_URL)
+
+
+def test_tool_metadata():
+    schema = http_request.tool_spec["inputSchema"]["json"]
+
+    assert http_request.tool_name == "http_request"
+    assert schema["required"] == ["method", "url"]
+    assert set(schema["properties"]["method"]["enum"]) == {
+        "GET",
+        "POST",
+        "PUT",
+        "DELETE",
+        "PATCH",
+        "HEAD",
+        "OPTIONS",
+    }
+    assert schema["properties"]["url"]["format"] == "uri"
+    assert schema["properties"]["timeout"]["exclusiveMinimum"] == 0
+    assert schema["properties"]["timeout"]["default"] == 30
+
+
+@pytest.mark.asyncio
+async def test_client_follows_redirects_and_uses_total_deadline():
+    response = _response()
+
+    with (
+        patch("httpx.AsyncClient.__init__", return_value=None) as init,
+        patch(
+            "httpx.AsyncClient.__aenter__",
+            new=AsyncMock(return_value=AsyncMock(request=AsyncMock(return_value=response))),
+        ),
+        patch("httpx.AsyncClient.__aexit__", new=AsyncMock(return_value=None)),
+    ):
+        await http_request(method="GET", url=_URL)
+
+    init.assert_called_once_with(follow_redirects=True, timeout=None)

--- a/strands-py/tests/strands/vended_tools/http_request/test_http_request.py
+++ b/strands-py/tests/strands/vended_tools/http_request/test_http_request.py
@@ -148,11 +148,25 @@ async def test_rejects_invalid_http_urls(url):
         await http_request(method="GET", url=url)
 
 
-@pytest.mark.parametrize("timeout", [0, -1])
+@pytest.mark.parametrize("timeout", [0, -1, float("inf"), float("-inf"), float("nan")])
 @pytest.mark.asyncio
 async def test_rejects_non_positive_timeout(timeout):
-    with pytest.raises(ValueError, match="timeout must be greater than 0"):
+    with pytest.raises(ValueError, match="timeout must be a finite number greater than 0"):
         await http_request(method="GET", url=_URL, timeout=timeout)
+
+
+@pytest.mark.parametrize("timeout", ["1", True])
+@pytest.mark.asyncio
+async def test_tool_validation_rejects_coercible_timeout_values(timeout):
+    events = [
+        event
+        async for event in http_request.stream(
+            {"toolUseId": "test", "name": "http_request", "input": {"method": "GET", "url": _URL, "timeout": timeout}},
+            {},
+        )
+    ]
+
+    assert events[-1].tool_result["status"] == "error"
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests/strands/vended_tools/http_request/test_http_request.py
+++ b/strands-py/tests/strands/vended_tools/http_request/test_http_request.py
@@ -158,15 +158,23 @@ async def test_rejects_non_positive_timeout(timeout):
 @pytest.mark.parametrize("timeout", ["1", True, False])
 @pytest.mark.asyncio
 async def test_tool_validation_rejects_coercible_timeout_values(timeout):
-    events = [
-        event
-        async for event in http_request.stream(
-            {"toolUseId": "test", "name": "http_request", "input": {"method": "GET", "url": _URL, "timeout": timeout}},
-            {},
-        )
-    ]
+    request = AsyncMock(return_value=_response())
+
+    with patch("httpx.AsyncClient.request", new=request):
+        events = [
+            event
+            async for event in http_request.stream(
+                {
+                    "toolUseId": "test",
+                    "name": "http_request",
+                    "input": {"method": "GET", "url": _URL, "timeout": timeout},
+                },
+                {},
+            )
+        ]
 
     assert events[-1].tool_result["status"] == "error"
+    request.assert_not_awaited()
 
 
 @pytest.mark.parametrize("timeout", ["1", True, False])

--- a/strands-py/tests_integ/tools/__init__.py
+++ b/strands-py/tests_integ/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for vended tools."""

--- a/strands-py/tests_integ/tools/test_http_request.py
+++ b/strands-py/tests_integ/tools/test_http_request.py
@@ -1,0 +1,20 @@
+"""Integration tests for the HTTP request tool."""
+
+from strands import Agent
+from strands.vended_tools import http_request
+from tests_integ.models.providers import bedrock
+
+
+def test_agent_uses_http_request_to_fetch_weather():
+    """An agent can use the tool against a live public API."""
+    agent = Agent(model=bedrock.create_model(), tools=[http_request])
+
+    result = agent(
+        "Use http_request to GET current NYC weather from "
+        "https://api.open-meteo.com/v1/forecast?latitude=40.7128&longitude=-74.0060&current=temperature_2m. "
+        "Then briefly report the temperature."
+    )
+
+    assert any(term in str(result).lower() for term in ("weather", "temperature", "°", "nyc", "new york"))
+    assert result.stop_reason == "end_turn"
+    assert result.message["role"] == "assistant"


### PR DESCRIPTION
## Description

Ports the TypeScript `http_request` vended tool to Python. The async tool supports GET, POST, PUT, DELETE, PATCH, HEAD, and OPTIONS over HTTP(S), follows redirects, applies a total finite-positive timeout, and returns `status`, `status_text`, flattened `headers`, and text `body`.

The port adds `httpx>=0.28.1,<1.0.0` as a core dependency, exports the tool from `strands.vended_tools`, adds unit and live integration coverage, and documents agent-driven and direct async use. It also preserves Pydantic metadata in `Annotated` tool parameters so strict model-originated timeout validation is effective.

URL handling rejects malformed/non-HTTP URLs and embedded credentials before client construction, dispatches only the canonical validated destination, and suppresses credential-bearing parser exception chains.

## Related Issues

Resolves #3154
Parent: #2498

## Documentation PR

Included under `site/`: Python support, runnable agent example, direct async-call contract, output/error behavior, API references, supported methods, and security guidance.

## Type of Change

New feature

## Public API Changes

```python
from strands import Agent
from strands.vended_tools import http_request

agent = Agent(tools=[http_request])
agent("Get current weather from an HTTP API")

response = await http_request(method="GET", url="https://api.example.com/data")
print(response["status"], response["body"])
```

## Testing

- Python 3.10 focused HTTP suite: 57 passed
- Python 3.12 decorator + vended-tool suite: 201 passed
- Fresh-cache Ruff, Ruff format, focused mypy, and `git diff --check`: passed
- Independent translation validator: PASS at `480f38a3`
- Independent correctness reviewer: APPROVE at `480f38a3`
- Independent API bar-raiser: APPROVE at `480f38a3`
- Site unit tests previously run: 453 passed, 2 skipped
- Live Bedrock/Open-Meteo integration was added but not run locally because provider credentials are unavailable

- [ ] I ran `hatch run prepare`

## Port evidence

<details><summary>Source-test → target-test traceability matrix</summary>

| TypeScript source test | Behavior | Python target test | Result |
|---|---|---|---|
| `strands-ts/src/vended-tools/http-request/__tests__/http-request.test.ts:15-43` | GET/POST/PUT/DELETE/PATCH/HEAD/OPTIONS successful responses | `strands-py/tests/strands/vended_tools/http_request/test_http_request.py:34-58` | PASS |
| `strands-ts/src/vended-tools/http-request/__tests__/http-request.test.ts:45-70` | Forward custom headers and string body | `strands-py/tests/strands/vended_tools/http_request/test_http_request.py:61-78` | PASS |
| `strands-ts/src/vended-tools/http-request/__tests__/http-request.test.ts:73-89` | Empty response body | `strands-py/tests/strands/vended_tools/http_request/test_http_request.py:91-97` | PASS |
| `strands-ts/src/vended-tools/http-request/__tests__/http-request.test.ts:91-106` | Plain-text response body | `strands-py/tests/strands/vended_tools/http_request/test_http_request.py:91-97` | PASS |
| `strands-ts/src/vended-tools/http-request/__tests__/http-request.test.ts:108-129` | Flatten response headers | `strands-py/tests/strands/vended_tools/http_request/test_http_request.py:100-111` | PASS |
| `strands-ts/src/vended-tools/http-request/__tests__/http-request.test.ts:132-148` | 2xx response succeeds | `strands-py/tests/strands/vended_tools/http_request/test_http_request.py:34-58` | PASS |
| `strands-ts/src/vended-tools/http-request/__tests__/http-request.test.ts:150-165` | 3xx response raises | `strands-py/tests/strands/vended_tools/http_request/test_http_request.py:114-122` | PASS |
| `strands-ts/src/vended-tools/http-request/__tests__/http-request.test.ts:167-182` | 4xx response raises with reason | `strands-py/tests/strands/vended_tools/http_request/test_http_request.py:114-122` | PASS |
| `strands-ts/src/vended-tools/http-request/__tests__/http-request.test.ts:184-199` | 5xx response raises | `strands-py/tests/strands/vended_tools/http_request/test_http_request.py:114-122` | PASS |
| `strands-ts/src/vended-tools/http-request/__tests__/http-request.test.ts:202-222` | Configured fractional timeout raises contextual error | `strands-py/tests/strands/vended_tools/http_request/test_http_request.py:125-133` | PASS |
| `strands-ts/src/vended-tools/http-request/__tests__/http-request.test.ts:224-233` | Network failure becomes tool error | `strands-py/tests/strands/vended_tools/http_request/test_http_request.py:136-144` | PASS |
| `strands-ts/test/integ/tools/http-request.test.ts:6-22` | Agent calls Open-Meteo and completes | `strands-py/tests_integ/tools/test_http_request.py:8-20` | MAPPED; live run requires credentials |

Python-specific hardening: HTTP(S)/malformed/control/credential validation and no-client assertions at `test_http_request.py:147-172`; HTTP(S), IPv6, and IDNA acceptance at `:175-198`; canonical dispatch at `:201-218`; credential-safe direct/tool exception graphs at `:221-264`; strict/finite timeout validation at `:267-308`; method/schema/client configuration at `:312-355`; strict `Annotated` metadata at `strands-py/tests/strands/tools/test_decorator.py:1808-1821`.

</details>

<details><summary>Structural map and decisions</summary>

- TS `tool({...})` → Python async `@tool`: `strands-py/src/strands/vended_tools/http_request/http_request.py:62-137`
- TS output interface → Python `TypedDict`: `strands-py/src/strands/vended_tools/http_request/types.py:6-19`
- TS barrel exports → Python package/root exports: `strands-py/src/strands/vended_tools/http_request/__init__.py:12-14`, `strands-py/src/strands/vended_tools/__init__.py:18-28`
- Native `fetch` → `httpx.AsyncClient(follow_redirects=True, timeout=None)` plus `asyncio.wait_for` total deadline
- `statusText` → Python-idiomatic `status_text`
- `httpx` moves from the `a2a` extra to core; no new package is introduced
- Python has no public in-flight tool cancellation token. The port follows Python's documented cancellation-safe points rather than coupling to private `Agent._cancel_signal` state.
- Credential-bearing URLs are rejected; callers use headers for authentication. Parser errors are sanitized and their URL-bearing exception context is suppressed.

</details>

<details><summary>Review-loop ledger</summary>

| Round | Review/verdict | Finding | Disposition |
|---|---|---|---|
| 1 | Translation/correctness — CHANGES REQUESTED | Python 3.10 raises `asyncio.TimeoutError`; timeout needed total-deadline semantics | Added explicit compatibility handling and `asyncio.wait_for` tests |
| 2 | Correctness — CHANGES REQUESTED | NaN/infinity/bools/coercible strings and direct decorated calls bypassed intended timeout checks | Added strict, finite-positive runtime/tool validation and no-request tests |
| 3 | Correctness — CHANGES REQUESTED | Decorator stripped `Annotated[..., Strict()]` metadata | Preserved full `Annotated` validation metadata and added decorator regression test |
| 4 | Correctness — CHANGES REQUESTED | Private `float` subtype harmed public call typing | Kept public `Annotated[float, Strict()]`; fresh reviewer APPROVED |
| 5 | Critic — CHANGES REQUESTED | `AnyUrl` accepted `ftp:`, `mailto:`, and `file:` | Switched to HTTP(S)-specific validation and asserted no client construction |
| 6 | Correctness/API — CHANGES REQUESTED | Malformed HTTP forms normalized; schema exposed generic URI; docs overstated methods/omitted direct async contract | Added explicit authority/control checks, HTTP(S) schema pattern, method list, output/error docs |
| 7 | Correctness — CHANGES REQUESTED | Pydantic/HTTPX parser disagreement could change destination or leak `InvalidURL` | Dispatch canonical validated URL; reject malformed raw parse before client; add parser-confusion tests |
| 8 | Translation/API — CHANGES REQUESTED | Host comparison rejected valid IDN/IPv6 and alternate IPv6 spellings | Removed display-host comparison; canonical validated dispatch accepts IDN/IPv6 |
| 9 | Translation — CHANGES REQUESTED | Same-host backslash/port authority confusion | Canonical validated destination is the only dispatched URL; added regression |
| 10 | API — CHANGES REQUESTED | Credential URL errors echoed secrets and contract was undocumented | Added credential prohibition/header guidance and sanitized direct/tool errors |
| 11 | Translation/correctness — CHANGES REQUESTED | Parser exception chain retained credentials; fresh-cache Ruff exposed stale-cache import findings | Raised sanitized error `from None`; asserted traceback/event exception non-disclosure; fresh-cache Ruff run |
| 12 | Correctness — CHANGES REQUESTED | Raw HTTPX userinfo could be ignored after canonicalization | Reject userinfo in both raw and canonical parses; no-client regressions |
| 13 | Correctness — CHANGES REQUESTED | Huge integer timeout could leak `OverflowError` | Map overflow to documented finite-positive `ValueError`; no-client regression |
| 14 | Final translation validator | **PASS** at `480f38a3` | Full source/target matrix and security checks clean |
| 15 | Final correctness reviewer | **APPROVE** at `480f38a3` | No actionable findings |
| 16 | Final API bar-raiser | **APPROVE** at `480f38a3` | Public API accepted |

Two earlier API-bar-raiser spawns failed infrastructurally and produced no verdict; successful fresh API reviews were subsequently completed, including the final approval above.

</details>

<details><summary>Final verbatim local gate output at 480f38a3</summary>

**Python 3.10 focused**

```text
.........................................................                [100%]
57 passed in 0.65s
```

**Python 3.12 decorator + vended tools**

```text
........................................................................ [ 35%]
........................................................................ [ 71%]
.........................................................                [100%]
201 passed in 1.78s
```

**Fresh-cache Ruff, formatting, and focused mypy**

```text
All checks passed!
22 files already formatted
pyproject.toml: note: unused section(s): module = ['cedar_mcp_schema_generator', 'cedarpy']
Success: no issues found in 1 source file
```

**Git**

```text
git diff --check: passed
## agent-tasks/3154...fork/agent-tasks/3154 [ahead 1]
480f38a37816e44901c593e2e679a1d17ad17bb0
```

The `[ahead 1]` line was captured before pushing; `480f38a3` is now on the fork branch.

</details>

<details><summary>Sensitive-surface review</summary>

This feature intentionally adds arbitrary outbound HTTP(S) access. It adds no credential discovery, subprocess execution, filesystem access, or deserialization. Embedded URL credentials are rejected without disclosure; authentication belongs in headers. The docs retain the warning to expose the tool only to trusted input and consider sandboxing.

</details>

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added necessary tests proving the feature and hardening behavior
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate documentation example
- [x] Focused validation generates no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.