### PR TITLE
fix(openai): preserve stateless Responses output items

### DIFF
--- a/strands-py/src/strands/event_loop/_recover_message_on_max_tokens_reached.py
+++ b/strands-py/src/strands/event_loop/_recover_message_on_max_tokens_reached.py
@@ -71,4 +71,13 @@ def recover_message_on_max_tokens_reached(message: Message) -> Message:
     recovered: Message = {"content": valid_content, "role": message["role"]}
     if "metadata" in message:
         recovered["metadata"] = message["metadata"]
+    response_fields = message.get("additionalModelResponseFields")
+    if isinstance(response_fields, dict):
+        output = response_fields.get("openaiResponsesOutput")
+        if isinstance(output, list):
+            # Tool calls can be incomplete at the token boundary and are replaced above.
+            # Keep only reasoning state; recovered visible text remains the canonical answer.
+            reasoning_items = [item for item in output if isinstance(item, dict) and item.get("type") == "reasoning"]
+            if reasoning_items:
+                recovered["additionalModelResponseFields"] = {"openaiResponsesOutput": reasoning_items}
     return recovered

--- a/strands-py/src/strands/event_loop/streaming.py
+++ b/strands-py/src/strands/event_loop/streaming.py
@@ -364,7 +364,6 @@ def handle_message_stop(event: MessageStopEvent, content: list[dict[str, Any]]) 
         The reason for stopping the stream.
     """
     stop_reason = event["stopReason"]
-
     if stop_reason == "end_turn" and any("toolUse" in item for item in content):
         logger.warning(
             "original_stop_reason=<%s>, new_stop_reason=<%s> | "
@@ -386,6 +385,7 @@ def handle_redact_content(event: RedactContentEvent, state: dict[str, Any]) -> N
     """
     if event.get("redactAssistantContentMessage") is not None:
         state["message"]["content"] = [{"text": event["redactAssistantContentMessage"]}]
+        state["message"].pop("additionalModelResponseFields", None)
 
 
 def extract_usage_metrics(event: MetadataEvent, time_to_first_byte_ms: int | None = None) -> tuple[Usage, Metrics]:
@@ -468,6 +468,9 @@ async def process_stream(
         elif "contentBlockStop" in chunk:
             state = handle_content_block_stop(state)
         elif "messageStop" in chunk:
+            additional_fields = chunk["messageStop"].get("additionalModelResponseFields")
+            if additional_fields is not None:
+                state["message"]["additionalModelResponseFields"] = additional_fields
             stop_reason = handle_message_stop(chunk["messageStop"], state["message"].get("content", []))
         elif "metadata" in chunk:
             time_to_first_byte_ms = (
@@ -514,9 +517,15 @@ async def stream_messages(
     logger.debug("model=<%s> | streaming messages", model)
 
     messages = _normalize_messages(messages)
-    # Whitelist only role and content before sending to the model provider.
-    # This ensures metadata (and any future non-model fields) never leak to providers.
-    messages = [Message(role=msg["role"], content=msg["content"]) for msg in messages]
+    # Whitelist model-facing fields before sending to the provider. Provider-specific
+    # response fields are intentionally retained so the originating adapter can replay them.
+    model_messages: Messages = []
+    for msg in messages:
+        model_message = Message(role=msg["role"], content=msg["content"])
+        if "additionalModelResponseFields" in msg:
+            model_message["additionalModelResponseFields"] = msg["additionalModelResponseFields"]
+        model_messages.append(model_message)
+    messages = model_messages
     start_time = time.time()
 
     chunks = model.stream(

--- a/strands-py/src/strands/models/openai_responses.py
+++ b/strands-py/src/strands/models/openai_responses.py
@@ -28,7 +28,7 @@ from types import SimpleNamespace
 from typing import Any, Protocol, TypedDict, TypeVar, cast
 
 from packaging.version import Version
-from pydantic import BaseModel
+from pydantic import BaseModel, TypeAdapter, ValidationError
 from typing_extensions import Unpack, override
 
 # Validate OpenAI SDK version at import time - Responses API requires v2.0.0+
@@ -52,6 +52,7 @@ except Exception as e:
     ) from e
 
 import openai  # noqa: E402 - must import after version check
+from openai.types.responses.response_output_item import ResponseOutputItem  # noqa: E402
 
 from ..types.citations import WebLocationDict  # noqa: E402
 from ..types.content import ContentBlock, Message, Messages, Role, SystemContentBlock  # noqa: E402
@@ -76,33 +77,7 @@ _CONTEXT_WINDOW_OVERFLOW_MSG = "OpenAI Responses API threw context window overfl
 _RATE_LIMIT_MSG = "OpenAI Responses API threw rate limit error"
 _ENCRYPTED_REASONING_INCLUDE = "reasoning.encrypted_content"
 _OPENAI_RESPONSES_OUTPUT_FIELD = "openaiResponsesOutput"
-_RESPONSE_OUTPUT_ITEM_TYPES = {
-    "message",
-    "file_search_call",
-    "function_call",
-    "function_call_output",
-    "web_search_call",
-    "computer_call",
-    "computer_call_output",
-    "reasoning",
-    "tool_search_call",
-    "tool_search_output",
-    "image_generation_call",
-    "code_interpreter_call",
-    "local_shell_call",
-    "local_shell_call_output",
-    "shell_call",
-    "shell_call_output",
-    "apply_patch_call",
-    "apply_patch_call_output",
-    "mcp_call",
-    "mcp_list_tools",
-    "mcp_approval_request",
-    "mcp_approval_response",
-    "custom_tool_call",
-    "custom_tool_call_output",
-    "compaction",
-}
+_RESPONSE_OUTPUT_ITEM_ADAPTER: TypeAdapter[ResponseOutputItem] = TypeAdapter(ResponseOutputItem)
 
 
 def _encode_media_to_data_url(data: bytes, format_ext: str, media_type: str = "image") -> str:
@@ -498,10 +473,10 @@ class OpenAIResponsesModel(Model):
                 yield self._format_chunk({"chunk_type": "content_stop", "data_type": "tool"})
 
             # Determine finish reason: tool_calls > max_tokens (length) > normal stop
-            if tool_calls:
-                finish_reason = "tool_calls"
-            elif stop_reason == "length":
+            if stop_reason == "length":
                 finish_reason = "length"
+            elif tool_calls:
+                finish_reason = "tool_calls"
             else:
                 finish_reason = "stop"
             additional_fields = None
@@ -754,20 +729,10 @@ class OpenAIResponsesModel(Model):
     def _is_responses_output_item(value: Any) -> bool:
         if not isinstance(value, dict):
             return False
-        item_id = value.get("id")
-        item_type = value.get("type")
-        if not isinstance(item_id, str) or item_type not in _RESPONSE_OUTPUT_ITEM_TYPES:
+        try:
+            _RESPONSE_OUTPUT_ITEM_ADAPTER.validate_python(value)
+        except ValidationError:
             return False
-        if item_type == "message":
-            return (
-                value.get("role") == "assistant"
-                and isinstance(value.get("status"), str)
-                and isinstance(value.get("content"), list)
-            )
-        if item_type == "reasoning":
-            return isinstance(value.get("summary"), list)
-        if item_type == "function_call":
-            return all(isinstance(value.get(field), str) for field in ("call_id", "name", "arguments"))
         return True
 
     @classmethod

--- a/strands-py/src/strands/models/openai_responses.py
+++ b/strands-py/src/strands/models/openai_responses.py
@@ -76,6 +76,33 @@ _CONTEXT_WINDOW_OVERFLOW_MSG = "OpenAI Responses API threw context window overfl
 _RATE_LIMIT_MSG = "OpenAI Responses API threw rate limit error"
 _ENCRYPTED_REASONING_INCLUDE = "reasoning.encrypted_content"
 _OPENAI_RESPONSES_OUTPUT_FIELD = "openaiResponsesOutput"
+_RESPONSE_OUTPUT_ITEM_TYPES = {
+    "message",
+    "file_search_call",
+    "function_call",
+    "function_call_output",
+    "web_search_call",
+    "computer_call",
+    "computer_call_output",
+    "reasoning",
+    "tool_search_call",
+    "tool_search_output",
+    "image_generation_call",
+    "code_interpreter_call",
+    "local_shell_call",
+    "local_shell_call_output",
+    "shell_call",
+    "shell_call_output",
+    "apply_patch_call",
+    "apply_patch_call_output",
+    "mcp_call",
+    "mcp_list_tools",
+    "mcp_approval_request",
+    "mcp_approval_response",
+    "custom_tool_call",
+    "custom_tool_call_output",
+    "compaction",
+}
 
 
 def _encode_media_to_data_url(data: bytes, format_ext: str, media_type: str = "image") -> str:
@@ -643,6 +670,12 @@ class OpenAIResponsesModel(Model):
             output_items = cls._get_responses_output_items(message)
             if replay_output_items and role == "assistant" and output_items:
                 formatted_messages.extend(output_items)
+                # Max-token recovery may retain only safe reasoning items after removing an
+                # incomplete tool call. Preserve the recovered visible text in that case.
+                if not any(item.get("type") == "message" for item in output_items):
+                    text = "\n".join(content["text"] for content in contents if "text" in content)
+                    if text:
+                        formatted_messages.append({"role": "assistant", "content": text})
                 continue
 
             if any("reasoningContent" in content for content in contents):
@@ -697,22 +730,45 @@ class OpenAIResponsesModel(Model):
             formatted_messages.extend(formatted_tool_calls)
             formatted_messages.extend(formatted_tool_messages)
 
-        return [
-            message
-            for message in formatted_messages
-            if message.get("content")
-            or message.get("type") in ["function_call", "function_call_output", "reasoning", "message"]
-        ]
+        return formatted_messages
 
-    @staticmethod
-    def _get_responses_output_items(message: Message) -> list[dict[str, Any]] | None:
+    @classmethod
+    def _get_responses_output_items(cls, message: Message) -> list[dict[str, Any]] | None:
         fields = message.get("additionalModelResponseFields")
         if not isinstance(fields, dict):
             return None
         output = fields.get(_OPENAI_RESPONSES_OUTPUT_FIELD)
-        if not isinstance(output, list) or not output or not all(isinstance(item, dict) for item in output):
+        if (
+            not isinstance(output, list)
+            or not output
+            or not all(cls._is_responses_output_item(item) for item in output)
+        ):
+            logger.warning(
+                "field=<%s> | invalid Responses output items | using legacy assistant history",
+                _OPENAI_RESPONSES_OUTPUT_FIELD,
+            )
             return None
-        return output
+        return cast(list[dict[str, Any]], output)
+
+    @staticmethod
+    def _is_responses_output_item(value: Any) -> bool:
+        if not isinstance(value, dict):
+            return False
+        item_id = value.get("id")
+        item_type = value.get("type")
+        if not isinstance(item_id, str) or item_type not in _RESPONSE_OUTPUT_ITEM_TYPES:
+            return False
+        if item_type == "message":
+            return (
+                value.get("role") == "assistant"
+                and isinstance(value.get("status"), str)
+                and isinstance(value.get("content"), list)
+            )
+        if item_type == "reasoning":
+            return isinstance(value.get("summary"), list)
+        if item_type == "function_call":
+            return all(isinstance(value.get(field), str) for field in ("call_id", "name", "arguments"))
+        return True
 
     @classmethod
     def _format_request_message_content(cls, content: ContentBlock, *, role: Role = "user") -> dict[str, Any]:

--- a/strands-py/src/strands/models/openai_responses.py
+++ b/strands-py/src/strands/models/openai_responses.py
@@ -52,7 +52,7 @@ except Exception as e:
     ) from e
 
 import openai  # noqa: E402 - must import after version check
-from openai.types.responses.response_output_item import ResponseOutputItem  # noqa: E402
+from openai.types.responses.response_input_item import ResponseInputItem  # noqa: E402
 
 from ..types.citations import WebLocationDict  # noqa: E402
 from ..types.content import ContentBlock, Message, Messages, Role, SystemContentBlock  # noqa: E402
@@ -77,7 +77,7 @@ _CONTEXT_WINDOW_OVERFLOW_MSG = "OpenAI Responses API threw context window overfl
 _RATE_LIMIT_MSG = "OpenAI Responses API threw rate limit error"
 _ENCRYPTED_REASONING_INCLUDE = "reasoning.encrypted_content"
 _OPENAI_RESPONSES_OUTPUT_FIELD = "openaiResponsesOutput"
-_RESPONSE_OUTPUT_ITEM_ADAPTER: TypeAdapter[ResponseOutputItem] = TypeAdapter(ResponseOutputItem)
+_RESPONSE_INPUT_ITEM_ADAPTER: TypeAdapter[ResponseInputItem] = TypeAdapter(ResponseInputItem)
 
 
 def _encode_media_to_data_url(data: bytes, format_ext: str, media_type: str = "image") -> str:
@@ -730,7 +730,7 @@ class OpenAIResponsesModel(Model):
         if not isinstance(value, dict):
             return False
         try:
-            _RESPONSE_OUTPUT_ITEM_ADAPTER.validate_python(value)
+            _RESPONSE_INPUT_ITEM_ADAPTER.validate_python(value)
         except ValidationError:
             return False
         return True

--- a/strands-py/src/strands/models/openai_responses.py
+++ b/strands-py/src/strands/models/openai_responses.py
@@ -54,10 +54,10 @@ except Exception as e:
 import openai  # noqa: E402 - must import after version check
 
 from ..types.citations import WebLocationDict  # noqa: E402
-from ..types.content import ContentBlock, Messages, Role, SystemContentBlock  # noqa: E402
+from ..types.content import ContentBlock, Message, Messages, Role, SystemContentBlock  # noqa: E402
 from ..types.event_loop import Usage  # noqa: E402
 from ..types.exceptions import ContextWindowOverflowException, ModelThrottledException  # noqa: E402
-from ..types.streaming import StreamEvent  # noqa: E402
+from ..types.streaming import MessageStopEvent, StopReason, StreamEvent  # noqa: E402
 from ..types.tools import ToolChoice, ToolResult, ToolSpec, ToolUse  # noqa: E402
 from ._defaults import resolve_config_metadata  # noqa: E402
 from ._openai_bedrock import BedrockMantleConfig, resolve_bedrock_client_args  # noqa: E402
@@ -74,6 +74,8 @@ _MAX_MEDIA_SIZE_LABEL = "20MB"
 _DEFAULT_MIME_TYPE = "application/octet-stream"
 _CONTEXT_WINDOW_OVERFLOW_MSG = "OpenAI Responses API threw context window overflow error"
 _RATE_LIMIT_MSG = "OpenAI Responses API threw rate limit error"
+_ENCRYPTED_REASONING_INCLUDE = "reasoning.encrypted_content"
+_OPENAI_RESPONSES_OUTPUT_FIELD = "openaiResponsesOutput"
 
 
 def _encode_media_to_data_url(data: bytes, format_ext: str, media_type: str = "image") -> str:
@@ -318,6 +320,7 @@ class OpenAIResponsesModel(Model):
                 yield self._format_chunk({"chunk_type": "message_start"})
 
                 tool_calls: dict[str, _ToolCallInfo] = {}
+                output_items: dict[int, dict[str, Any]] = {}
                 final_usage = None
                 data_type: str | None = None
                 stop_reason: str | None = None
@@ -391,6 +394,12 @@ class OpenAIResponsesModel(Model):
                                     "item_id": getattr(event.item, "id", ""),
                                 }
 
+                        elif event.type == "response.output_item.done":
+                            output_index = getattr(event, "output_index", None)
+                            item = getattr(event, "item", None)
+                            if not self.stateful and isinstance(output_index, int) and item is not None:
+                                output_items[output_index] = self._response_item_to_dict(item)
+
                         elif event.type == "response.function_call_arguments.delta":
                             # Tool arguments streaming - accumulate deltas by item_id
                             if hasattr(event, "delta") and hasattr(event, "item_id"):
@@ -410,6 +419,8 @@ class OpenAIResponsesModel(Model):
                         elif event.type == "response.incomplete":
                             # Response stopped early (e.g., max tokens reached)
                             if hasattr(event, "response"):
+                                if not self.stateful:
+                                    self._capture_response_output(event.response, output_items)
                                 if hasattr(event.response, "usage"):
                                     final_usage = event.response.usage
                                 # Check if stopped due to max_output_tokens
@@ -424,6 +435,9 @@ class OpenAIResponsesModel(Model):
 
                         elif event.type == "response.completed":
                             # Response complete
+                            if hasattr(event, "response"):
+                                if not self.stateful:
+                                    self._capture_response_output(event.response, output_items)
                             if hasattr(event, "response") and hasattr(event.response, "usage"):
                                 final_usage = event.response.usage
                             break
@@ -463,7 +477,18 @@ class OpenAIResponsesModel(Model):
                 finish_reason = "length"
             else:
                 finish_reason = "stop"
-            yield self._format_chunk({"chunk_type": "message_stop", "data": finish_reason})
+            additional_fields = None
+            if output_items:
+                additional_fields = {
+                    _OPENAI_RESPONSES_OUTPUT_FIELD: [output_items[index] for index in sorted(output_items)]
+                }
+            yield self._format_chunk(
+                {
+                    "chunk_type": "message_stop",
+                    "data": finish_reason,
+                    "additional_model_response_fields": additional_fields,
+                }
+            )
 
             if final_usage:
                 yield self._format_chunk({"chunk_type": "metadata", "data": final_usage})
@@ -532,7 +557,7 @@ class OpenAIResponsesModel(Model):
             TypeError: If a message contains a content block type that cannot be converted to an OpenAI-compatible
                 format.
         """
-        input_items = self._format_request_messages(messages)
+        input_items = self._format_request_messages(messages, replay_output_items=not self.stateful)
         request: dict[str, Any] = {
             "model": self.config["model_id"],
             "input": input_items,
@@ -540,6 +565,11 @@ class OpenAIResponsesModel(Model):
             **cast(dict[str, Any], self.config.get("params", {})),
             "store": self.stateful,
         }
+
+        if not self.stateful:
+            configured_include = request.get("include") or []
+            if _ENCRYPTED_REASONING_INCLUDE not in configured_include:
+                request["include"] = [*configured_include, _ENCRYPTED_REASONING_INCLUDE]
 
         response_id = model_state.get("response_id") if model_state else None
         if response_id and self.stateful:
@@ -595,11 +625,12 @@ class OpenAIResponsesModel(Model):
                 return {"tool_choice": "auto"}
 
     @classmethod
-    def _format_request_messages(cls, messages: Messages) -> list[dict[str, Any]]:
+    def _format_request_messages(cls, messages: Messages, *, replay_output_items: bool = True) -> list[dict[str, Any]]:
         """Format an OpenAI compatible messages array.
 
         Args:
             messages: List of message objects to be processed by the model.
+            replay_output_items: Whether to replay preserved Responses output items.
 
         Returns:
             An OpenAI compatible messages array.
@@ -609,6 +640,10 @@ class OpenAIResponsesModel(Model):
         for message in messages:
             role = message["role"]
             contents = message["content"]
+            output_items = cls._get_responses_output_items(message)
+            if replay_output_items and role == "assistant" and output_items:
+                formatted_messages.extend(output_items)
+                continue
 
             if any("reasoningContent" in content for content in contents):
                 logger.warning(
@@ -665,8 +700,19 @@ class OpenAIResponsesModel(Model):
         return [
             message
             for message in formatted_messages
-            if message.get("content") or message.get("type") in ["function_call", "function_call_output"]
+            if message.get("content")
+            or message.get("type") in ["function_call", "function_call_output", "reasoning", "message"]
         ]
+
+    @staticmethod
+    def _get_responses_output_items(message: Message) -> list[dict[str, Any]] | None:
+        fields = message.get("additionalModelResponseFields")
+        if not isinstance(fields, dict):
+            return None
+        output = fields.get(_OPENAI_RESPONSES_OUTPUT_FIELD)
+        if not isinstance(output, list) or not output or not all(isinstance(item, dict) for item in output):
+            return None
+        return output
 
     @classmethod
     def _format_request_message_content(cls, content: ContentBlock, *, role: Role = "user") -> dict[str, Any]:
@@ -772,6 +818,22 @@ class OpenAIResponsesModel(Model):
             "output": output,
         }
 
+    @staticmethod
+    def _response_item_to_dict(item: Any) -> dict[str, Any]:
+        if isinstance(item, dict):
+            return item
+        if hasattr(item, "model_dump"):
+            return cast(dict[str, Any], item.model_dump(mode="json", exclude_unset=True))
+        raise TypeError(f"item_type=<{type(item).__name__}> | unsupported Responses output item")
+
+    @classmethod
+    def _capture_response_output(cls, response: Any, output_items: dict[int, dict[str, Any]]) -> None:
+        output = getattr(response, "output", None)
+        if not isinstance(output, (list, tuple)) or not output:
+            return
+        output_items.clear()
+        output_items.update({index: cls._response_item_to_dict(item) for index, item in enumerate(output)})
+
     def _stream_switch_content(self, data_type: str, prev_data_type: str | None) -> tuple[list[StreamEvent], str]:
         """Handle switching to a new content stream.
 
@@ -854,11 +916,15 @@ class OpenAIResponsesModel(Model):
             case "message_stop":
                 match event["data"]:
                     case "tool_calls":
-                        return {"messageStop": {"stopReason": "tool_use"}}
+                        stop_reason: StopReason = "tool_use"
                     case "length":
-                        return {"messageStop": {"stopReason": "max_tokens"}}
+                        stop_reason = "max_tokens"
                     case _:
-                        return {"messageStop": {"stopReason": "end_turn"}}
+                        stop_reason = "end_turn"
+                message_stop = MessageStopEvent(stopReason=stop_reason)
+                if event.get("additional_model_response_fields") is not None:
+                    message_stop["additionalModelResponseFields"] = event["additional_model_response_fields"]
+                return {"messageStop": message_stop}
 
             case "metadata":
                 # Responses API uses input_tokens/output_tokens naming convention

--- a/strands-py/src/strands/types/content.py
+++ b/strands-py/src/strands/types/content.py
@@ -240,12 +240,14 @@ class Message(TypedDict):
             within a conversation, but the same message carries the same id across sessions (copying
             another agent's messages does not re-key them).
         metadata: Optional metadata, stripped before model calls.
+        additionalModelResponseFields: Provider-specific fields captured from the model response.
     """
 
     content: list[ContentBlock]
     role: Role
     tracking_id: NotRequired[str]
     metadata: NotRequired[MessageMetadata]
+    additionalModelResponseFields: NotRequired[dict | list | int | float | str | bool | None]
 
 
 Messages = list[Message]

--- a/strands-py/tests/strands/event_loop/test_recover_message_on_max_tokens_reached.py
+++ b/strands-py/tests/strands/event_loop/test_recover_message_on_max_tokens_reached.py
@@ -295,3 +295,37 @@ def test_recover_message_on_max_tokens_reached_with_content_without_tool_use():
     assert "text" in result["content"][2]
     assert "calculator" in result["content"][2]["text"]
     assert "incomplete due to maximum token limits" in result["content"][2]["text"]
+
+
+def test_recover_message_on_max_tokens_reached_keeps_only_reasoning_response_items():
+    reasoning = {
+        "id": "rs_1",
+        "type": "reasoning",
+        "summary": [],
+        "encrypted_content": "encrypted",
+    }
+    message = {
+        "role": "assistant",
+        "content": [
+            {"text": "partial"},
+            {"toolUse": {"name": "calculator", "input": {}, "toolUseId": "call_1"}},
+        ],
+        "additionalModelResponseFields": {
+            "openaiResponsesOutput": [
+                reasoning,
+                {
+                    "id": "call_item_1",
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "calculator",
+                    "arguments": "{",
+                },
+            ]
+        },
+    }
+
+    result = recover_message_on_max_tokens_reached(message)
+
+    assert result["additionalModelResponseFields"] == {"openaiResponsesOutput": [reasoning]}
+    assert result["content"][0] == {"text": "partial"}
+    assert "incomplete due to maximum token limits" in result["content"][1]["text"]

--- a/strands-py/tests/strands/event_loop/test_streaming.py
+++ b/strands-py/tests/strands/event_loop/test_streaming.py
@@ -1156,6 +1156,24 @@ async def test_process_stream_with_signature(agenerator, alist):
 
 
 @pytest.mark.asyncio
+async def test_process_stream_persists_provider_response_fields(agenerator, alist):
+    fields = {"openaiResponsesOutput": [{"type": "reasoning", "id": "rs_1", "summary": []}]}
+    response = [
+        {"messageStart": {"role": "assistant"}},
+        {"contentBlockStart": {"start": {}}},
+        {"contentBlockDelta": {"delta": {"text": "answer"}}},
+        {"contentBlockStop": {}},
+        {"messageStop": {"stopReason": "end_turn", "additionalModelResponseFields": fields}},
+    ]
+
+    last_event = cast(
+        ModelStopReason, (await alist(strands.event_loop.streaming.process_stream(agenerator(response))))[-1]
+    )
+
+    assert _get_message_from_event(last_event)["additionalModelResponseFields"] == fields
+
+
+@pytest.mark.asyncio
 async def test_stream_messages(agenerator, alist):
     mock_model = unittest.mock.MagicMock()
     mock_model.stream.return_value = agenerator(
@@ -1215,6 +1233,34 @@ async def test_stream_messages(agenerator, alist):
         invocation_state=None,
         model_state=None,
     )
+
+
+@pytest.mark.asyncio
+async def test_stream_messages_preserves_provider_response_fields(agenerator, alist):
+    mock_model = unittest.mock.MagicMock()
+    mock_model.stream.return_value = agenerator([])
+    fields = {"openaiResponsesOutput": [{"type": "reasoning", "id": "rs_1", "summary": []}]}
+
+    await alist(
+        strands.event_loop.streaming.stream_messages(
+            mock_model,
+            system_prompt_content=None,
+            messages=[
+                {
+                    "role": "assistant",
+                    "content": [{"text": "answer"}],
+                    "tracking_id": "durable-1",
+                    "metadata": {"custom": {"private": True}},
+                    "additionalModelResponseFields": fields,
+                }
+            ],
+            tool_specs=None,
+            system_prompt=None,
+        )
+    )
+
+    sent = mock_model.stream.call_args[0][0]
+    assert sent == [{"role": "assistant", "content": [{"text": "answer"}], "additionalModelResponseFields": fields}]
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests/strands/models/test_openai_responses.py
+++ b/strands-py/tests/strands/models/test_openai_responses.py
@@ -429,6 +429,23 @@ def test_format_request_messages_falls_back_when_output_items_are_invalid(caplog
     assert "invalid Responses output items" in caplog.text
 
 
+def test_format_request_messages_falls_back_when_output_is_not_input_compatible(caplog):
+    messages = [
+        {
+            "role": "assistant",
+            "content": [{"text": "answer"}],
+            "additionalModelResponseFields": {
+                "openaiResponsesOutput": [
+                    {"id": "tools_1", "type": "additional_tools", "role": "assistant", "tools": []}
+                ]
+            },
+        }
+    ]
+
+    assert OpenAIResponsesModel._format_request_messages(messages) == [{"role": "assistant", "content": "answer"}]
+    assert "invalid Responses output items" in caplog.text
+
+
 def test_format_request_does_not_replay_output_items_in_stateful_mode(model_id):
     model = OpenAIResponsesModel(model_id=model_id, stateful=True)
     output = [{"id": "rs_1", "type": "reasoning", "summary": [], "encrypted_content": "encrypted"}]

--- a/strands-py/tests/strands/models/test_openai_responses.py
+++ b/strands-py/tests/strands/models/test_openai_responses.py
@@ -386,6 +386,42 @@ def test_format_request_messages_replays_captured_output_items_verbatim():
     ]
 
 
+def test_format_request_messages_replays_builtin_tool_items_verbatim():
+    output = [
+        {
+            "id": "ws_1",
+            "type": "web_search_call",
+            "status": "completed",
+            "action": {"type": "search", "query": "weather"},
+        }
+    ]
+    messages = [
+        {
+            "role": "assistant",
+            "content": [{"text": "recovered"}],
+            "additionalModelResponseFields": {"openaiResponsesOutput": output},
+        }
+    ]
+
+    assert OpenAIResponsesModel._format_request_messages(messages) == [
+        *output,
+        {"role": "assistant", "content": "recovered"},
+    ]
+
+
+def test_format_request_messages_falls_back_when_output_items_are_invalid(caplog):
+    messages = [
+        {
+            "role": "assistant",
+            "content": [{"text": "answer"}],
+            "additionalModelResponseFields": {"openaiResponsesOutput": [{}]},
+        }
+    ]
+
+    assert OpenAIResponsesModel._format_request_messages(messages) == [{"role": "assistant", "content": "answer"}]
+    assert "invalid Responses output items" in caplog.text
+
+
 def test_format_request_does_not_replay_output_items_in_stateful_mode(model_id):
     model = OpenAIResponsesModel(model_id=model_id, stateful=True)
     output = [{"id": "rs_1", "type": "reasoning", "summary": [], "encrypted_content": "encrypted"}]

--- a/strands-py/tests/strands/models/test_openai_responses.py
+++ b/strands-py/tests/strands/models/test_openai_responses.py
@@ -318,6 +318,100 @@ def test_format_request_messages(system_prompt):
     assert tru_result == exp_result
 
 
+def test_format_request_messages_replays_captured_output_items_verbatim():
+    output = [
+        {
+            "id": "rs_1",
+            "type": "reasoning",
+            "status": "completed",
+            "summary": [{"type": "summary_text", "text": "summary"}],
+            "encrypted_content": "encrypted",
+        },
+        {
+            "id": "fc_1",
+            "type": "function_call",
+            "status": "completed",
+            "call_id": "call_1",
+            "name": "lookup",
+            "arguments": '{"query":"next"}',
+        },
+        {
+            "id": "msg_1",
+            "type": "message",
+            "status": "completed",
+            "role": "assistant",
+            "phase": "final_answer",
+            "content": [
+                {
+                    "type": "output_text",
+                    "text": "answer",
+                    "annotations": [
+                        {
+                            "type": "url_citation",
+                            "url": "https://example.com",
+                            "title": "Example",
+                            "start_index": 0,
+                            "end_index": 6,
+                        }
+                    ],
+                }
+            ],
+        },
+    ]
+    messages = [
+        {"role": "user", "content": [{"text": "question"}]},
+        {
+            "role": "assistant",
+            "content": [{"text": "answer"}],
+            "additionalModelResponseFields": {"openaiResponsesOutput": output},
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "toolUseId": "call_1",
+                        "status": "success",
+                        "content": [{"text": "result"}],
+                    }
+                }
+            ],
+        },
+    ]
+
+    assert OpenAIResponsesModel._format_request_messages(messages) == [
+        {"role": "user", "content": [{"type": "input_text", "text": "question"}]},
+        *output,
+        {"type": "function_call_output", "call_id": "call_1", "output": "result"},
+    ]
+
+
+def test_format_request_does_not_replay_output_items_in_stateful_mode(model_id):
+    model = OpenAIResponsesModel(model_id=model_id, stateful=True)
+    output = [{"id": "rs_1", "type": "reasoning", "summary": [], "encrypted_content": "encrypted"}]
+    messages = [
+        {
+            "role": "assistant",
+            "content": [{"text": "answer"}],
+            "additionalModelResponseFields": {"openaiResponsesOutput": output},
+        }
+    ]
+
+    request = model._format_request(messages, None, None)
+
+    assert request["input"] == [{"role": "assistant", "content": "answer"}]
+    assert "include" not in request
+
+
+def test_format_request_merges_encrypted_reasoning_include(model, messages):
+    model.config["params"] = {"include": ["web_search_call.results"]}
+
+    request = model._format_request(messages, None, None)
+
+    assert request["include"] == ["web_search_call.results", "reasoning.encrypted_content"]
+    assert model.config["params"]["include"] == ["web_search_call.results"]
+
+
 def test_format_request_messages_assistant_text_uses_string_content():
     """Assistant history must use the string EasyInputMessage form.
 
@@ -451,6 +545,7 @@ def test_format_request(model, messages, tool_specs, system_prompt):
         ],
         "stream": True,
         "store": False,
+        "include": ["reasoning.encrypted_content"],
         "instructions": system_prompt,
         "tools": [
             {
@@ -726,6 +821,7 @@ async def test_stream(openai_client, model_id, model, agenerator, alist):
         "input": [{"role": "user", "content": [{"type": "input_text", "text": "test"}]}],
         "stream": True,
         "store": False,
+        "include": ["reasoning.encrypted_content"],
         "max_output_tokens": 100,
     }
     openai_client.responses.create.assert_called_once_with(**expected_request)
@@ -1451,6 +1547,41 @@ def test_stateful(model_id, stateful):
     """Model.stateful reflects the stateful config option."""
     model = OpenAIResponsesModel(model_id=model_id, stateful=stateful)
     assert model.stateful is stateful
+
+
+@pytest.mark.asyncio
+async def test_stream_captures_completed_output_items(openai_client, model, agenerator, alist):
+    reasoning = {
+        "id": "rs_1",
+        "type": "reasoning",
+        "status": "completed",
+        "summary": [{"type": "summary_text", "text": "summary"}],
+        "encrypted_content": "encrypted",
+    }
+    message = {
+        "id": "msg_1",
+        "type": "message",
+        "status": "completed",
+        "role": "assistant",
+        "phase": "commentary",
+        "content": [{"type": "output_text", "text": "answer", "annotations": []}],
+    }
+    events = [
+        unittest.mock.Mock(type="response.output_text.delta", delta="answer"),
+        unittest.mock.Mock(type="response.output_item.done", output_index=1, item=message),
+        unittest.mock.Mock(type="response.output_item.done", output_index=0, item=reasoning),
+        unittest.mock.Mock(type="response.completed", response=unittest.mock.Mock(usage=None, output=None)),
+    ]
+    openai_client.responses.create = unittest.mock.AsyncMock(return_value=agenerator(events))
+
+    streamed = await alist(model.stream([{"role": "user", "content": [{"text": "x"}]}]))
+
+    assert {
+        "messageStop": {
+            "stopReason": "end_turn",
+            "additionalModelResponseFields": {"openaiResponsesOutput": [reasoning, message]},
+        }
+    } in streamed
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests/strands/models/test_openai_responses.py
+++ b/strands-py/tests/strands/models/test_openai_responses.py
@@ -389,11 +389,18 @@ def test_format_request_messages_replays_captured_output_items_verbatim():
 def test_format_request_messages_replays_builtin_tool_items_verbatim():
     output = [
         {
+            "id": "program_1",
+            "type": "program",
+            "call_id": "call_program_1",
+            "code": "print(1)",
+            "fingerprint": "fingerprint",
+        },
+        {
             "id": "ws_1",
             "type": "web_search_call",
             "status": "completed",
             "action": {"type": "search", "query": "weather"},
-        }
+        },
     ]
     messages = [
         {
@@ -1014,6 +1021,32 @@ async def test_stream_response_incomplete(openai_client, model, agenerator, alis
     assert len(metadata_events) == 1
     assert metadata_events[0]["metadata"]["usage"]["inputTokens"] == 10
     assert metadata_events[0]["metadata"]["usage"]["outputTokens"] == 100
+
+
+@pytest.mark.asyncio
+async def test_stream_incomplete_tool_call_preserves_max_tokens(openai_client, model, agenerator, alist):
+    events = [
+        unittest.mock.Mock(
+            type="response.output_item.added",
+            item=unittest.mock.Mock(type="function_call", call_id="call_1", name="calculator", id="item_1"),
+        ),
+        unittest.mock.Mock(
+            type="response.function_call_arguments.done", arguments='{"expression": "2+2"}', item_id="item_1"
+        ),
+        unittest.mock.Mock(
+            type="response.incomplete",
+            response=unittest.mock.Mock(
+                usage=None,
+                output=None,
+                incomplete_details=unittest.mock.Mock(reason="max_output_tokens"),
+            ),
+        ),
+    ]
+    openai_client.responses.create = unittest.mock.AsyncMock(return_value=agenerator(events))
+
+    streamed = await alist(model.stream([{"role": "user", "content": [{"text": "calculate"}]}]))
+
+    assert {"messageStop": {"stopReason": "max_tokens"}} in streamed
 
 
 @pytest.mark.asyncio

--- a/strands-ts/src/models/model.ts
+++ b/strands-ts/src/models/model.ts
@@ -12,6 +12,7 @@ import {
 import { CitationsBlock } from '../types/citations.js'
 import type { Citation, CitationGeneratedContent } from '../types/citations.js'
 import type { StateStore } from '../state-store.js'
+import type { JSONValue } from '../types/json.js'
 import type { ToolChoice, ToolSpec } from '../tools/types.js'
 import {
   ModelContentBlockDeltaEvent,
@@ -348,6 +349,7 @@ export abstract class Model<T extends BaseModelConfig = BaseModelConfig> {
       let stoppedMessage: Message | null = null
       let finalStopReason: StopReason | null = null
       let metadata: ModelMetadataEvent | undefined = undefined
+      let additionalModelResponseFields: JSONValue | undefined = undefined
       let redactionMessage: string | undefined = undefined
       let toolInputParseError: SyntaxError | undefined = undefined
 
@@ -439,9 +441,11 @@ export abstract class Model<T extends BaseModelConfig = BaseModelConfig> {
               const filtered = contentBlocks.filter(
                 (block) => !(block instanceof TextBlock && block.text.trim() === '')
               )
+              additionalModelResponseFields = event.additionalModelResponseFields
               stoppedMessage = new Message({
                 role: messageRole,
                 content: filtered,
+                ...(additionalModelResponseFields !== undefined && { additionalModelResponseFields }),
               })
               finalStopReason = event.stopReason!
             }
@@ -461,6 +465,7 @@ export abstract class Model<T extends BaseModelConfig = BaseModelConfig> {
             if (event.outputRedaction) {
               // Update output message directly with redacted content
               // Redaction event comes after modelMessageStopEvent, so we overwrite stoppedMessage
+              additionalModelResponseFields = undefined
               stoppedMessage = new Message({
                 role: 'assistant',
                 content: [new TextBlock(event.outputRedaction.replaceContent)],
@@ -491,6 +496,7 @@ export abstract class Model<T extends BaseModelConfig = BaseModelConfig> {
           role: stoppedMessage.role,
           content: stoppedMessage.content,
           metadata: messageMetadata,
+          ...(additionalModelResponseFields !== undefined && { additionalModelResponseFields }),
         })
       }
 

--- a/strands-ts/src/models/openai/__tests__/responses.test.ts
+++ b/strands-ts/src/models/openai/__tests__/responses.test.ts
@@ -481,6 +481,20 @@ describe("OpenAIModel (api: 'responses')", () => {
       warnSpy.mockRestore()
     })
 
+    it('replays additional_tools output items', async () => {
+      const output = [{ id: 'tools_1', type: 'additional_tools', role: 'assistant', tools: [] }]
+      const messages = [
+        new Message({
+          role: 'assistant',
+          content: [new TextBlock('answer')],
+          additionalModelResponseFields: { openaiResponsesOutput: output },
+        }),
+      ]
+
+      const req = await runOnce({}, messages)
+      expect(req.input).toEqual([...output, { role: 'assistant', content: 'answer' }])
+    })
+
     it('does not replay captured output items in stateful mode', async () => {
       const messages = [
         new Message({
@@ -738,6 +752,26 @@ describe("OpenAIModel (api: 'responses')", () => {
       expect(stop?.stopReason).toBe('maxTokens')
       const metadata = events.find((e: any) => e.type === 'modelMetadataEvent') as any
       expect(metadata?.usage).toEqual({ inputTokens: 10, outputTokens: 5, totalTokens: 15 })
+    })
+
+    it('preserves maxTokens when an incomplete response also contains a function call', async () => {
+      const client = createMockClient(async function* () {
+        yield { type: 'response.created', response: { id: 'r' } }
+        yield {
+          type: 'response.output_item.added',
+          item: { type: 'function_call', id: 'item_1', call_id: 'call_1', name: 'calc' },
+        }
+        yield { type: 'response.function_call_arguments.done', item_id: 'item_1', arguments: '{"a":1}' }
+        yield {
+          type: 'response.incomplete',
+          response: { incomplete_details: { reason: 'max_output_tokens' } },
+        }
+      })
+      const model = new OpenAIModel({ api: 'responses', client })
+
+      const events = await collectIterator(model.stream([new Message({ role: 'user', content: [new TextBlock('x')] })]))
+
+      expect((events.find((event: any) => event.type === 'modelMessageStopEvent') as any).stopReason).toBe('maxTokens')
     })
 
     it('plumbs prompt-cache reads (input_tokens_details.cached_tokens) into cacheReadInputTokens', async () => {

--- a/strands-ts/src/models/openai/__tests__/responses.test.ts
+++ b/strands-ts/src/models/openai/__tests__/responses.test.ts
@@ -465,6 +465,22 @@ describe("OpenAIModel (api: 'responses')", () => {
       ])
     })
 
+    it('falls back to assistant text when captured output items are invalid', async () => {
+      const warnSpy = vi.spyOn(logger, 'warn')
+      const messages = [
+        new Message({
+          role: 'assistant',
+          content: [new TextBlock('answer')],
+          additionalModelResponseFields: { openaiResponsesOutput: [null] },
+        }),
+      ]
+
+      const req = await runOnce({}, messages)
+      expect(req.input).toEqual([{ role: 'assistant', content: 'answer' }])
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('invalid responses output items'))
+      warnSpy.mockRestore()
+    })
+
     it('does not replay captured output items in stateful mode', async () => {
       const messages = [
         new Message({

--- a/strands-ts/src/models/openai/__tests__/responses.test.ts
+++ b/strands-ts/src/models/openai/__tests__/responses.test.ts
@@ -481,8 +481,8 @@ describe("OpenAIModel (api: 'responses')", () => {
       warnSpy.mockRestore()
     })
 
-    it('replays additional_tools output items', async () => {
-      const output = [{ id: 'tools_1', type: 'additional_tools', role: 'assistant', tools: [] }]
+    it('replays input-compatible additional_tools output items', async () => {
+      const output = [{ id: 'tools_1', type: 'additional_tools', role: 'developer', tools: [] }]
       const messages = [
         new Message({
           role: 'assistant',
@@ -493,6 +493,21 @@ describe("OpenAIModel (api: 'responses')", () => {
 
       const req = await runOnce({}, messages)
       expect(req.input).toEqual([...output, { role: 'assistant', content: 'answer' }])
+    })
+
+    it('falls back when output items are not input-compatible', async () => {
+      const messages = [
+        new Message({
+          role: 'assistant',
+          content: [new TextBlock('answer')],
+          additionalModelResponseFields: {
+            openaiResponsesOutput: [{ id: 'tools_1', type: 'additional_tools', role: 'assistant', tools: [] }],
+          },
+        }),
+      ]
+
+      const req = await runOnce({}, messages)
+      expect(req.input).toEqual([{ role: 'assistant', content: 'answer' }])
     })
 
     it('does not replay captured output items in stateful mode', async () => {

--- a/strands-ts/src/models/openai/__tests__/responses.test.ts
+++ b/strands-ts/src/models/openai/__tests__/responses.test.ts
@@ -173,6 +173,7 @@ describe("OpenAIModel (api: 'responses')", () => {
       expect(req.model).toBe('gpt-5.4')
       expect(req.stream).toBe(true)
       expect(req.store).toBe(false)
+      expect(req.include).toEqual(['reasoning.encrypted_content'])
       expect(Array.isArray(req.input)).toBe(true)
     })
 
@@ -403,6 +404,83 @@ describe("OpenAIModel (api: 'responses')", () => {
       expect(req.input[2]).toEqual({ role: 'user', content: [{ type: 'input_text', text: 'What about 3+3?' }] })
     })
 
+    it('replays captured Responses output items verbatim in order', async () => {
+      const output = [
+        {
+          id: 'rs_1',
+          type: 'reasoning',
+          status: 'completed',
+          summary: [{ type: 'summary_text', text: 'summary' }],
+          encrypted_content: 'encrypted',
+        },
+        {
+          id: 'fc_1',
+          type: 'function_call',
+          status: 'completed',
+          call_id: 'call_1',
+          name: 'lookup',
+          arguments: '{"query":"next"}',
+        },
+        {
+          id: 'msg_1',
+          type: 'message',
+          status: 'completed',
+          role: 'assistant',
+          phase: 'final_answer',
+          content: [
+            {
+              type: 'output_text',
+              text: 'answer',
+              annotations: [
+                { type: 'url_citation', url: 'https://example.com', title: 'Example', start_index: 0, end_index: 6 },
+              ],
+            },
+          ],
+        },
+      ]
+      const messages = [
+        new Message({ role: 'user', content: [new TextBlock('question')] }),
+        new Message({
+          role: 'assistant',
+          content: [new TextBlock('answer')],
+          additionalModelResponseFields: { openaiResponsesOutput: output },
+        }),
+        new Message({
+          role: 'user',
+          content: [
+            new ToolResultBlock({
+              toolUseId: 'call_1',
+              status: 'success',
+              content: [new TextBlock('result')],
+            }),
+          ],
+        }),
+      ]
+
+      const req = await runOnce({}, messages)
+      expect(req.input).toEqual([
+        { role: 'user', content: [{ type: 'input_text', text: 'question' }] },
+        ...output,
+        { type: 'function_call_output', call_id: 'call_1', output: 'result' },
+      ])
+    })
+
+    it('does not replay captured output items in stateful mode', async () => {
+      const messages = [
+        new Message({
+          role: 'assistant',
+          content: [new TextBlock('answer')],
+          additionalModelResponseFields: {
+            openaiResponsesOutput: [{ id: 'rs_1', type: 'reasoning', summary: [], encrypted_content: 'encrypted' }],
+          },
+        }),
+      ]
+
+      const req = await runOnce({ stateful: true }, messages)
+      expect(req.input).toEqual([{ role: 'assistant', content: 'answer' }])
+      expect(req.include).toBeUndefined()
+    })
+
     it('joins multiple assistant text blocks with newlines', async () => {
       const messages = [
         new Message({ role: 'user', content: [new TextBlock('list two words')] }),
@@ -545,6 +623,43 @@ describe("OpenAIModel (api: 'responses')", () => {
         'modelContentBlockStopEvent',
         'modelMessageStopEvent',
       ])
+    })
+
+    it('captures completed output items on the aggregated assistant message', async () => {
+      const reasoning = {
+        id: 'rs_1',
+        type: 'reasoning',
+        status: 'completed',
+        summary: [{ type: 'summary_text', text: 'summary' }],
+        encrypted_content: 'encrypted',
+      }
+      const message = {
+        id: 'msg_1',
+        type: 'message',
+        status: 'completed',
+        role: 'assistant',
+        phase: 'commentary',
+        content: [{ type: 'output_text', text: 'answer', annotations: [] }],
+      }
+      const client = createMockClient(async function* () {
+        yield { type: 'response.created', response: { id: 'r' } }
+        yield { type: 'response.output_text.delta', delta: 'answer' }
+        yield { type: 'response.output_item.done', output_index: 1, item: message }
+        yield { type: 'response.output_item.done', output_index: 0, item: reasoning }
+        yield { type: 'response.completed', response: {} }
+      })
+      const model = new OpenAIModel({ api: 'responses', client })
+
+      const iterator = model.streamAggregated([new Message({ role: 'user', content: [new TextBlock('x')] })])
+      let result = await iterator.next()
+      while (!result.done) result = await iterator.next()
+
+      expect(result.value.message.additionalModelResponseFields).toEqual({
+        openaiResponsesOutput: [reasoning, message],
+      })
+      expect(Message.fromJSON(result.value.message.toJSON()).additionalModelResponseFields).toEqual({
+        openaiResponsesOutput: [reasoning, message],
+      })
     })
 
     it('emits tool call triplet after stream close and sets stopReason=toolUse', async () => {

--- a/strands-ts/src/models/openai/responses-adapter.ts
+++ b/strands-ts/src/models/openai/responses-adapter.ts
@@ -21,8 +21,11 @@ import type {
   ResponseFunctionCallOutputItem,
   ResponseCreateParamsStreaming,
   ResponseUsage,
+  ResponseOutputItem,
+  ResponseIncludable,
 } from 'openai/resources/responses/responses'
 import type { Message, StopReason, ToolResultBlock } from '../../types/messages.js'
+import type { JSONValue } from '../../types/json.js'
 import type { ImageBlock, DocumentBlock } from '../../types/media.js'
 import { encodeBase64 } from '../../types/media.js'
 import { toMimeType } from '../../mime.js'
@@ -37,6 +40,8 @@ import type { OpenAIResponsesConfig } from './types.js'
 export const DEFAULT_RESPONSES_MODEL_ID = MODEL_DEFAULTS.openai.modelId
 
 const MANAGED_PARAMS: ReadonlySet<string> = new Set(['model', 'input', 'stream', 'store'])
+const ENCRYPTED_REASONING_INCLUDE: ResponseIncludable = 'reasoning.encrypted_content'
+const OPENAI_RESPONSES_OUTPUT_FIELD = 'openaiResponsesOutput'
 
 /**
  * Logs a warning for each responses-managed key present in `params`.
@@ -58,7 +63,7 @@ export function formatResponsesRequest(
   options: StreamOptions | undefined,
   stateful: boolean
 ): ResponseCreateParamsStreaming {
-  const input = formatResponsesMessages(messages)
+  const input = formatResponsesMessages(messages, !stateful)
 
   // User `params` are spread first so provider-managed fields (asserted
   // required by `ResponseCreateParamsStreaming` below) always win. The
@@ -70,6 +75,13 @@ export function formatResponsesRequest(
     stream: true as const,
     store: stateful,
   } as ResponseCreateParamsStreaming
+
+  if (!stateful) {
+    const configuredInclude = request.include ?? []
+    request.include = configuredInclude.includes(ENCRYPTED_REASONING_INCLUDE)
+      ? configuredInclude
+      : [...configuredInclude, ENCRYPTED_REASONING_INCLUDE]
+  }
 
   if (stateful) {
     const responseId = options?.modelState?.get('responseId') as string | undefined
@@ -136,11 +148,16 @@ export function formatResponsesRequest(
  * - Tool calls → separate `{ type: 'function_call', ... }` items
  * - Tool results → separate `{ type: 'function_call_output', ... }` items
  */
-function formatResponsesMessages(messages: Message[]): ResponseInputItem[] {
+function formatResponsesMessages(messages: Message[], replayOutputItems: boolean): ResponseInputItem[] {
   const input: ResponseInputItem[] = []
 
   for (const message of messages) {
     const role = message.role === 'assistant' ? 'assistant' : 'user'
+    const outputItems = getResponsesOutputItems(message)
+    if (replayOutputItems && role === 'assistant' && outputItems) {
+      input.push(...outputItems)
+      continue
+    }
     const contentItems: Array<Record<string, unknown>> = []
     const toolCallItems: ResponseInputItem[] = []
     const toolResultItems: ResponseInputItem[] = []
@@ -250,6 +267,14 @@ function formatResponsesMessages(messages: Message[]): ResponseInputItem[] {
   return input
 }
 
+function getResponsesOutputItems(message: Message): ResponseInputItem[] | undefined {
+  const fields = message.additionalModelResponseFields
+  if (!fields || typeof fields !== 'object' || Array.isArray(fields)) return undefined
+  const output = (fields as Record<string, JSONValue>)[OPENAI_RESPONSES_OUTPUT_FIELD]
+  if (!Array.isArray(output) || output.length === 0) return undefined
+  return output as unknown as ResponseInputItem[]
+}
+
 /**
  * Builds a Responses API `function_call_output.output` value from a SDK
  * `toolResultBlock`. Returns a plain string for text-only results (joined with
@@ -350,6 +375,7 @@ function formatDocumentInput(docBlock: DocumentBlock): Record<string, unknown> |
 export interface ResponsesStreamState {
   dataType: string | null
   toolCalls: Map<string, { name: string; arguments: string; callId: string; itemId: string }>
+  outputItems: Map<number, ResponseOutputItem>
   finalUsage: {
     inputTokens: number
     outputTokens: number
@@ -368,6 +394,7 @@ export function createResponsesStreamState(): ResponsesStreamState {
   return {
     dataType: null,
     toolCalls: new Map(),
+    outputItems: new Map(),
     finalUsage: null,
     stopReason: 'endTurn',
   }
@@ -503,6 +530,11 @@ export function mapResponsesEventToSDK(
       break
     }
 
+    case 'response.output_item.done': {
+      if (!stateful) state.outputItems.set(event.output_index, event.item)
+      break
+    }
+
     case 'response.function_call_arguments.delta': {
       const tc = state.toolCalls.get(event.item_id)
       if (tc) {
@@ -521,6 +553,7 @@ export function mapResponsesEventToSDK(
 
     case 'response.incomplete': {
       const resp = event.response
+      if (!stateful) captureResponseOutput(resp.output, state)
       if (resp.usage) {
         state.finalUsage = mapResponsesUsage(resp.usage)
       }
@@ -541,6 +574,7 @@ export function mapResponsesEventToSDK(
 
     case 'response.completed': {
       const resp = event.response
+      if (!stateful) captureResponseOutput(resp.output, state)
       if (resp.usage) {
         state.finalUsage = mapResponsesUsage(resp.usage)
       }
@@ -561,6 +595,12 @@ export function mapResponsesEventToSDK(
  *
  * @internal
  */
+function captureResponseOutput(output: ResponseOutputItem[] | undefined, state: ResponsesStreamState): void {
+  if (!output || output.length === 0) return
+  state.outputItems.clear()
+  output.forEach((item, index) => state.outputItems.set(index, item))
+}
+
 export function finalizeResponsesStream(state: ResponsesStreamState): ModelStreamEvent[] {
   const events: ModelStreamEvent[] = []
 
@@ -589,7 +629,14 @@ export function finalizeResponsesStream(state: ResponsesStreamState): ModelStrea
     events.push({ type: 'modelMetadataEvent', usage: state.finalUsage })
   }
 
-  events.push({ type: 'modelMessageStopEvent', stopReason })
+  const outputItems = [...state.outputItems.entries()].sort(([left], [right]) => left - right).map(([, item]) => item)
+  events.push({
+    type: 'modelMessageStopEvent',
+    stopReason,
+    ...(outputItems.length > 0 && {
+      additionalModelResponseFields: { [OPENAI_RESPONSES_OUTPUT_FIELD]: outputItems } as unknown as JSONValue,
+    }),
+  })
 
   return events
 }

--- a/strands-ts/src/models/openai/responses-adapter.ts
+++ b/strands-ts/src/models/openai/responses-adapter.ts
@@ -42,6 +42,33 @@ export const DEFAULT_RESPONSES_MODEL_ID = MODEL_DEFAULTS.openai.modelId
 const MANAGED_PARAMS: ReadonlySet<string> = new Set(['model', 'input', 'stream', 'store'])
 const ENCRYPTED_REASONING_INCLUDE: ResponseIncludable = 'reasoning.encrypted_content'
 const OPENAI_RESPONSES_OUTPUT_FIELD = 'openaiResponsesOutput'
+const RESPONSE_OUTPUT_ITEM_TYPES = new Set([
+  'message',
+  'file_search_call',
+  'function_call',
+  'function_call_output',
+  'web_search_call',
+  'computer_call',
+  'computer_call_output',
+  'reasoning',
+  'tool_search_call',
+  'tool_search_output',
+  'image_generation_call',
+  'code_interpreter_call',
+  'local_shell_call',
+  'local_shell_call_output',
+  'shell_call',
+  'shell_call_output',
+  'apply_patch_call',
+  'apply_patch_call_output',
+  'mcp_call',
+  'mcp_list_tools',
+  'mcp_approval_request',
+  'mcp_approval_response',
+  'custom_tool_call',
+  'custom_tool_call_output',
+  'compaction',
+])
 
 /**
  * Logs a warning for each responses-managed key present in `params`.
@@ -156,6 +183,11 @@ function formatResponsesMessages(messages: Message[], replayOutputItems: boolean
     const outputItems = getResponsesOutputItems(message)
     if (replayOutputItems && role === 'assistant' && outputItems) {
       input.push(...outputItems)
+      // Max-token recovery may retain only safe reasoning items after removing an
+      // incomplete tool call. Preserve the recovered visible text in that case.
+      if (!outputItems.some((item) => item.type === 'message')) {
+        appendAssistantTextFallback(input, message)
+      }
       continue
     }
     const contentItems: Array<Record<string, unknown>> = []
@@ -272,7 +304,35 @@ function getResponsesOutputItems(message: Message): ResponseInputItem[] | undefi
   if (!fields || typeof fields !== 'object' || Array.isArray(fields)) return undefined
   const output = (fields as Record<string, JSONValue>)[OPENAI_RESPONSES_OUTPUT_FIELD]
   if (!Array.isArray(output) || output.length === 0) return undefined
+  if (!output.every(isResponsesOutputItem)) {
+    logger.warn('field=<openaiResponsesOutput> | invalid responses output items | using legacy assistant history')
+    return undefined
+  }
   return output as unknown as ResponseInputItem[]
+}
+
+function isResponsesOutputItem(value: JSONValue): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const item = value as Record<string, JSONValue>
+  if (typeof item.id !== 'string' || typeof item.type !== 'string' || !RESPONSE_OUTPUT_ITEM_TYPES.has(item.type)) {
+    return false
+  }
+  if (item.type === 'message') {
+    return item.role === 'assistant' && typeof item.status === 'string' && Array.isArray(item.content)
+  }
+  if (item.type === 'reasoning') return Array.isArray(item.summary)
+  if (item.type === 'function_call') {
+    return typeof item.call_id === 'string' && typeof item.name === 'string' && typeof item.arguments === 'string'
+  }
+  return true
+}
+
+function appendAssistantTextFallback(input: ResponseInputItem[], message: Message): void {
+  const text = message.content
+    .filter((block) => block.type === 'textBlock')
+    .map((block) => block.text)
+    .join('\n')
+  if (text) input.push({ role: 'assistant', content: text })
 }
 
 /**

--- a/strands-ts/src/models/openai/responses-adapter.ts
+++ b/strands-ts/src/models/openai/responses-adapter.ts
@@ -334,7 +334,9 @@ function isResponsesOutputItem(value: JSONValue): boolean {
     if (typeof item.call_id !== 'string' || typeof item.name !== 'string' || typeof item.arguments !== 'string')
       return false
   } else if (item.type === 'additional_tools') {
-    if (!Array.isArray(item.tools) || typeof item.role !== 'string') return false
+    if (!Array.isArray(item.tools) || item.role !== 'developer') return false
+  } else if (item.type === 'compaction') {
+    if (typeof item.encrypted_content !== 'string') return false
   }
   return true
 }

--- a/strands-ts/src/models/openai/responses-adapter.ts
+++ b/strands-ts/src/models/openai/responses-adapter.ts
@@ -68,6 +68,7 @@ const RESPONSE_OUTPUT_ITEM_TYPES = new Set([
   'custom_tool_call',
   'custom_tool_call_output',
   'compaction',
+  'additional_tools',
 ])
 
 /**
@@ -317,14 +318,39 @@ function isResponsesOutputItem(value: JSONValue): boolean {
   if (typeof item.id !== 'string' || typeof item.type !== 'string' || !RESPONSE_OUTPUT_ITEM_TYPES.has(item.type)) {
     return false
   }
-  if (item.type === 'message') {
-    return item.role === 'assistant' && typeof item.status === 'string' && Array.isArray(item.content)
+  if (
+    item.status !== undefined &&
+    !['in_progress', 'completed', 'incomplete', 'generating', 'failed'].includes(String(item.status))
+  ) {
+    return false
   }
-  if (item.type === 'reasoning') return Array.isArray(item.summary)
-  if (item.type === 'function_call') {
-    return typeof item.call_id === 'string' && typeof item.name === 'string' && typeof item.arguments === 'string'
+  if (item.type === 'message') {
+    if (item.role !== 'assistant' || !['in_progress', 'completed', 'incomplete'].includes(String(item.status)))
+      return false
+    if (!Array.isArray(item.content) || !item.content.every(isResponseOutputContent)) return false
+  } else if (item.type === 'reasoning') {
+    if (!Array.isArray(item.summary) || !item.summary.every(isReasoningSummaryPart)) return false
+  } else if (item.type === 'function_call') {
+    if (typeof item.call_id !== 'string' || typeof item.name !== 'string' || typeof item.arguments !== 'string')
+      return false
+  } else if (item.type === 'additional_tools') {
+    if (!Array.isArray(item.tools) || typeof item.role !== 'string') return false
   }
   return true
+}
+
+function isResponseOutputContent(value: JSONValue): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const part = value as Record<string, JSONValue>
+  if (part.type === 'output_text') return typeof part.text === 'string' && Array.isArray(part.annotations)
+  if (part.type === 'refusal') return typeof part.refusal === 'string'
+  return false
+}
+
+function isReasoningSummaryPart(value: JSONValue): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const part = value as Record<string, JSONValue>
+  return part.type === 'summary_text' && typeof part.text === 'string'
 }
 
 function appendAssistantTextFallback(input: ResponseInputItem[], message: Message): void {
@@ -681,7 +707,7 @@ export function finalizeResponsesStream(state: ResponsesStreamState): ModelStrea
   }
 
   let stopReason = state.stopReason
-  if (state.toolCalls.size > 0) {
+  if (state.toolCalls.size > 0 && stopReason === 'endTurn') {
     stopReason = 'toolUse'
   }
 

--- a/strands-ts/src/types/messages.ts
+++ b/strands-ts/src/types/messages.ts
@@ -17,8 +17,8 @@ import type { Usage, Metrics } from '../models/streaming.js'
 /**
  * Optional metadata attached to a message.
  *
- * Not sent to model providers — model providers construct their own message format
- * from `role` and `content` only. Persisted alongside the message in session storage.
+ * Not sent directly to model providers — adapters decide whether to use it when
+ * constructing their provider-specific format. Persisted alongside the message in session storage.
  */
 export interface MessageMetadata {
   /** Token usage information from the model response. */
@@ -53,6 +53,12 @@ export interface MessageData {
    * Optional metadata, not sent to model providers.
    */
   metadata?: MessageMetadata
+
+  /**
+   * Provider-specific fields captured from the model response.
+   * Model adapters may use these fields to preserve provider state across turns.
+   */
+  additionalModelResponseFields?: JSONValue
 }
 
 /**
@@ -98,7 +104,18 @@ export class Message implements JSONSerializable<MessageData> {
    */
   metadata?: MessageMetadata
 
-  constructor(data: { role: Role; content: ContentBlock[]; trackingId?: string; metadata?: MessageMetadata }) {
+  /**
+   * Provider-specific fields captured from the model response.
+   */
+  readonly additionalModelResponseFields?: JSONValue
+
+  constructor(data: {
+    role: Role
+    content: ContentBlock[]
+    trackingId?: string
+    metadata?: MessageMetadata
+    additionalModelResponseFields?: JSONValue
+  }) {
     this.role = data.role
     this.content = data.content
     // Mint a durable id when the caller did not supply a usable one, so every Message has one from
@@ -106,6 +123,9 @@ export class Message implements JSONSerializable<MessageData> {
     this.trackingId = data.trackingId || generateTrackingId()
     if (data.metadata !== undefined) {
       this.metadata = data.metadata
+    }
+    if (data.additionalModelResponseFields !== undefined) {
+      this.additionalModelResponseFields = data.additionalModelResponseFields
     }
   }
 
@@ -121,6 +141,9 @@ export class Message implements JSONSerializable<MessageData> {
       // A missing trackingId (e.g. legacy serialized data) is backfilled by the constructor.
       ...(data.trackingId !== undefined && { trackingId: data.trackingId }),
       ...(data.metadata !== undefined && { metadata: data.metadata }),
+      ...(data.additionalModelResponseFields !== undefined && {
+        additionalModelResponseFields: data.additionalModelResponseFields,
+      }),
     })
   }
 
@@ -134,6 +157,9 @@ export class Message implements JSONSerializable<MessageData> {
       content: this.content.map((block) => block.toJSON() as ContentBlockData),
       ...(this.trackingId !== undefined && { trackingId: this.trackingId }),
       ...(this.metadata !== undefined && { metadata: this.metadata }),
+      ...(this.additionalModelResponseFields !== undefined && {
+        additionalModelResponseFields: this.additionalModelResponseFields,
+      }),
     }
   }
 


### PR DESCRIPTION
## Description

Preserve OpenAI Responses output items across stateless turns in both SDKs.

- requests `reasoning.encrypted_content` without replacing configured `include` fields
- captures complete ordered `response.output_item.done` / terminal output items
- persists provider response fields with assistant messages and session serialization
- validates items as replayable Responses input before replaying them verbatim
- keeps the existing string-form fallback for legacy history and stateful behavior
- preserves max-token handling and prevents incomplete tool calls from executing

## Related Issues

Fixes #3389
Related to #3388 and #3399

## Documentation PR

No documentation change needed; this restores adapter round-trip behavior.

## Type of Change

Bug fix

## Testing

- [x] TypeScript pre-commit suite: build, full unit tests with coverage, lint, format check, type check
- [x] Python targeted tests: 200 passed across Responses, streaming, and max-token recovery
- [x] Python full gate from `strands-py`: `hatch run prepare` exited 0
  - formatting and Ruff passed
  - mypy passed across 223 source files
  - Python 3.14: 4,534 passed
  - Python 3.13: 4,534 passed
  - Python 3.12: 4,534 passed
  - Python 3.11: 4,534 passed
  - Python 3.10: 4,529 passed, 5 skipped

Independent review loop:
- Round 1: fixed Python built-in item filtering, max-token state persistence, and unvalidated replay metadata
- Round 2: fixed max-token/tool-call precedence and expanded SDK variant/shape validation
- Round 3: fixed output-vs-input compatibility validation for replay items
- Hard cap reached; all concrete findings were addressed and re-tested

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.