### PR TITLE
fix(a2a): filter executor fallback content

### DIFF
--- a/strands-ts/src/a2a/__tests__/executor.test.ts
+++ b/strands-ts/src/a2a/__tests__/executor.test.ts
@@ -3,12 +3,14 @@ import { A2AExecutor } from '../executor.js'
 import type { AgentExecutionEvent, ExecutionEventBus, RequestContext } from '@a2a-js/sdk/server'
 import type { TaskArtifactUpdateEvent, TaskStatusUpdateEvent } from '@a2a-js/sdk'
 import { Agent } from '../../agent/agent.js'
+import { Interrupt } from '../../interrupt.js'
+import { CitationsBlock } from '../../types/citations.js'
 import type { InvokableAgent } from '../../types/agent.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
 import { createMockAgent } from '../../__fixtures__/agent-helpers.js'
-import { TextBlock } from '../../types/messages.js'
+import { ReasoningBlock, TextBlock } from '../../types/messages.js'
 import { ImageBlock, encodeBase64 } from '../../types/media.js'
-import { ContentBlockEvent, ModelStreamUpdateEvent } from '../../hooks/events.js'
+import { ContentBlockEvent, ModelStreamUpdateEvent, StreamEvent } from '../../hooks/events.js'
 import { AgentResult } from '../../types/agent.js'
 import { Message } from '../../types/messages.js'
 import type { ModelStreamEvent } from '../../models/streaming.js'
@@ -37,6 +39,25 @@ function createRequestContext(text: string, taskId: string = 'task-1'): RequestC
       messageId: 'msg-1',
       role: 'user',
       parts: [{ kind: 'text', text }],
+    },
+  }
+}
+
+class CustomStreamUpdateEvent extends StreamEvent {}
+
+class CustomRenderedAgentResult extends AgentResult {
+  public override toString(): string {
+    return 'SAFE_REDACTED_RESPONSE'
+  }
+}
+
+function createCustomAgent(result: AgentResult): InvokableAgent {
+  return {
+    id: 'custom-agent',
+    invoke: vi.fn(),
+    async *stream() {
+      yield new CustomStreamUpdateEvent()
+      return result
     },
   }
 }
@@ -108,6 +129,127 @@ describe('A2AExecutor', () => {
       expect(artifactEvents).toHaveLength(3)
       expect(artifactEvents.map((e) => e.append)).toStrictEqual([false, true, true])
       expect(artifactEvents[2]!.lastChunk).toBe(true)
+    })
+
+    it('publishes only response-facing content when no text deltas are streamed', async () => {
+      // Regression coverage for #3365: A2A artifacts expose response content without internal reasoning.
+      const mockAgent = createCustomAgent(
+        new CustomRenderedAgentResult({
+          stopReason: 'endTurn',
+          lastMessage: new Message({
+            role: 'assistant',
+            content: [new ReasoningBlock({ text: 'SECRET_INTERNAL_REASONING' }), new TextBlock('PUBLIC_ANSWER')],
+          }),
+          invocationState: {},
+        })
+      )
+      const executor = new A2AExecutor({ agentFactory: () => mockAgent })
+      const eventBus = createMockEventBus()
+
+      await executor.execute(createRequestContext('Hello'), eventBus)
+
+      expect(eventBus.events).toStrictEqual([
+        { kind: 'task', id: 'task-1', contextId: 'ctx-1', status: { state: 'working' } },
+        {
+          kind: 'artifact-update',
+          taskId: 'task-1',
+          contextId: 'ctx-1',
+          artifact: {
+            artifactId: expect.any(String),
+            parts: [{ kind: 'text', text: 'PUBLIC_ANSWER' }],
+          },
+          append: false,
+          lastChunk: true,
+        },
+        {
+          kind: 'status-update',
+          taskId: 'task-1',
+          contextId: 'ctx-1',
+          status: { state: 'completed' },
+          final: true,
+        },
+      ])
+    })
+
+    it.each([
+      {
+        name: 'custom result rendering',
+        result: new CustomRenderedAgentResult({
+          stopReason: 'endTurn',
+          lastMessage: new Message({
+            role: 'assistant',
+            content: [new TextBlock('SENSITIVE_RAW_TEXT')],
+          }),
+          invocationState: {},
+        }),
+        expectedText: 'SAFE_REDACTED_RESPONSE',
+      },
+      {
+        name: 'structured output',
+        result: new CustomRenderedAgentResult({
+          stopReason: 'endTurn',
+          lastMessage: new Message({
+            role: 'assistant',
+            content: [new ReasoningBlock({ text: 'SECRET_INTERNAL_REASONING' })],
+          }),
+          structuredOutput: { answer: 42 },
+          invocationState: {},
+        }),
+        expectedText: '{"answer":42}',
+      },
+      {
+        name: 'interrupts',
+        result: new CustomRenderedAgentResult({
+          stopReason: 'interrupt',
+          lastMessage: new Message({
+            role: 'assistant',
+            content: [new ReasoningBlock({ text: 'SECRET_INTERNAL_REASONING' })],
+          }),
+          interrupts: [new Interrupt({ id: 'interrupt-1', name: 'confirm' })],
+          invocationState: {},
+        }),
+        expectedText: '[{"id":"interrupt-1","name":"confirm","source":"hook"}]',
+      },
+      {
+        name: 'citation text',
+        result: new CustomRenderedAgentResult({
+          stopReason: 'endTurn',
+          lastMessage: new Message({
+            role: 'assistant',
+            content: [
+              new ReasoningBlock({ text: 'SECRET_INTERNAL_REASONING' }),
+              new CitationsBlock({
+                citations: [],
+                content: [{ text: 'CITED_ANSWER' }],
+              }),
+            ],
+          }),
+          invocationState: {},
+        }),
+        expectedText: 'CITED_ANSWER',
+      },
+    ])('preserves $name when no text deltas are streamed', async ({ result, expectedText }) => {
+      const executor = new A2AExecutor({ agentFactory: () => createCustomAgent(result) })
+      const eventBus = createMockEventBus()
+
+      await executor.execute(createRequestContext('Hello'), eventBus)
+
+      const artifactEvents = eventBus.events.filter(
+        (event): event is TaskArtifactUpdateEvent => event.kind === 'artifact-update'
+      )
+      expect(artifactEvents).toStrictEqual([
+        {
+          kind: 'artifact-update',
+          taskId: 'task-1',
+          contextId: 'ctx-1',
+          artifact: {
+            artifactId: expect.any(String),
+            parts: [{ kind: 'text', text: expectedText }],
+          },
+          append: false,
+          lastChunk: true,
+        },
+      ])
     })
 
     it('converts A2A parts to content blocks and passes to stream', async () => {

--- a/strands-ts/src/a2a/executor.ts
+++ b/strands-ts/src/a2a/executor.ts
@@ -8,7 +8,7 @@
 import type { ExecutionEventBus, RequestContext } from '@a2a-js/sdk/server'
 import type { AgentExecutor } from '@a2a-js/sdk/server'
 import { A2AError } from '@a2a-js/sdk/server'
-import type { InvokableAgent, LocalAgent } from '../types/agent.js'
+import type { AgentResult, InvokableAgent, LocalAgent } from '../types/agent.js'
 import type { Snapshot } from '../types/snapshot.js'
 import type { ContentBlock } from '../types/messages.js'
 import { ModelStreamUpdateEvent, ContentBlockEvent } from '../hooks/events.js'
@@ -61,6 +61,37 @@ function asSnapshotAgent(agent: InvokableAgent): SnapshotAgent {
 /** Whether the agent has a configured `sessionManager` (a field not declared on {@link InvokableAgent}). */
 function hasSessionManager(agent: InvokableAgent): boolean {
   return (agent as { sessionManager?: unknown }).sessionManager !== undefined
+}
+
+/** Returns client-facing result text while excluding internal reasoning content. */
+function resultToResponseText(result: AgentResult): string {
+  const hasReasoning = result.lastMessage.content.some((block) => block.type === 'reasoningBlock')
+  if (!hasReasoning) {
+    return result.toString()
+  }
+
+  if (result.interrupts?.length) {
+    return JSON.stringify(result.interrupts)
+  }
+
+  if (result.structuredOutput !== undefined) {
+    return JSON.stringify(result.structuredOutput)
+  }
+
+  const textParts: string[] = []
+  for (const block of result.lastMessage.content) {
+    if (block.type === 'textBlock') {
+      textParts.push(block.text)
+    } else if (block.type === 'citationsBlock') {
+      for (const content of block.content) {
+        if ('text' in content) {
+          textParts.push(content.text)
+        }
+      }
+    }
+  }
+
+  return textParts.join('\n')
 }
 
 /**
@@ -303,8 +334,8 @@ export class A2AExecutor implements AgentExecutor {
         contextId,
         artifact: {
           artifactId,
-          // If no deltas were streamed, publish the full result; otherwise empty to close the artifact
-          parts: [{ kind: 'text', text: isFirstChunk && next.value ? next.value.toString() : '' }],
+          // If no text was streamed, publish response-facing result text; otherwise close the text artifact
+          parts: [{ kind: 'text', text: isFirstChunk && next.value ? resultToResponseText(next.value) : '' }],
         },
         append: !isFirstChunk,
         lastChunk: true,


### PR DESCRIPTION
## Description

`A2AExecutor` previously fell back to `AgentResult.toString()` when an agent stream produced no recognized A2A parts, which could expose internal reasoning in the client-visible artifact. 

With this PR, we now use the existing A2A content adapter for the final assistant message so response-facing content is preserved while unsupported internal blocks are excluded. There is no public API change.

Example: an InvokableAgent returns:

```typescript
lastMessage.content = [
  new ReasoningBlock({ text: 'The user may be vulnerable to this offer...' }),
  new TextBlock('I cannot help with that request.'),
]
```

If its stream emits no A2A-recognized text deltas, A2AExecutor previously used AgentResult.toString(). The resulting A2A response could expose both:
```
The user may be vulnerable to this offer...
I cannot help with that request.
```

With the fix, A2A converts only response-facing content, returning:
```
I cannot help with that request.
```

## Related Issues

Discovered while working on #3365

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

- [x] Ran the A2A executor unit suite in Node.js and Chromium (17/17 each)
- [x] Ran the TypeScript build, type-check, lint, and formatting checks

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR
- [x] My change is focused and reasonably small
- [x] I have added the necessary regression test
- [x] No documentation changes are needed
- [x] My changes generate no new warnings
- [x] There are no dependent changes