### PR TITLE
feat(mcp): surface structuredContent from MCP tool results

### DIFF
--- a/strands-ts/src/agent/__tests__/agent.hook.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.hook.test.ts
@@ -1513,6 +1513,42 @@ describe('Agent Hooks Integration', () => {
       )
       expect(block!.content).toEqual([new TextBlock('[REDACTED]')])
     })
+
+    it.each([
+      ['object', { temperature: 72 }],
+      ['zero', 0],
+      ['empty string', ''],
+      ['false', false],
+      ['null', null],
+    ])('preserves %s structuredContent when normalizing a mismatched toolUseId', async (_label, structuredContent) => {
+      const tool = createMockTool('tool', () => 'done')
+
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'tool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+
+      const agent = new Agent({ model, tools: [tool] })
+      agent.addHook(AfterToolCallEvent, (event: AfterToolCallEvent) => {
+        // A mismatched toolUseId forces the executor to rebuild the block.
+        event.result = new ToolResultBlock({
+          toolUseId: 'hook-issued-id',
+          status: 'success',
+          content: [new TextBlock('replaced')],
+          structuredContent,
+        })
+      })
+
+      await agent.invoke('Test')
+
+      const toolResultMessage = agent.messages.find((m) =>
+        m.content.some((b) => b.type === 'toolResultBlock' && b.toolUseId === 'tool-1')
+      )
+      expect(toolResultMessage).toBeDefined()
+      const block = toolResultMessage!.content.find(
+        (b): b is ToolResultBlock => b.type === 'toolResultBlock' && b.toolUseId === 'tool-1'
+      )
+      expect(block!.structuredContent).toEqual(structuredContent)
+    })
   })
 
   describe('AfterInvocationEvent resume', () => {

--- a/strands-ts/src/conversation-manager/__tests__/sliding-window-conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/sliding-window-conversation-manager.test.ts
@@ -451,6 +451,42 @@ describe('SlidingWindowConversationManager', () => {
       )
     })
 
+    it.each([
+      ['object', { temperature: 72 }],
+      ['zero', 0],
+      ['empty string', ''],
+      ['false', false],
+      ['null', null],
+    ])('preserves %s structuredContent on truncated tool results', (_label, structuredContent) => {
+      const manager = new SlidingWindowConversationManager({ shouldTruncateResults: true })
+      const messages = [
+        new Message({
+          role: 'user',
+          content: [
+            new ToolResultBlock({
+              toolUseId: 'tool-1',
+              status: 'success',
+              content: [new TextBlock('x'.repeat(500))],
+              structuredContent,
+            }),
+          ],
+        }),
+      ]
+
+      const changed = (manager as any)._truncateToolResults(messages, 0)
+      expect(changed).toBe(true)
+
+      const expectedText = `${'x'.repeat(200)}\n<truncated chars="100"/>\n${'x'.repeat(200)}`
+      expect(messages[0]!.content[0]).toEqual(
+        new ToolResultBlock({
+          toolUseId: 'tool-1',
+          status: 'success',
+          content: [new TextBlock(expectedText)],
+          structuredContent,
+        })
+      )
+    })
+
     it('image placeholder reflects non-bytes source kinds honestly', () => {
       const manager = new SlidingWindowConversationManager({ shouldTruncateResults: true })
       const messages = [

--- a/strands-ts/src/conversation-manager/sliding-window-conversation-manager.ts
+++ b/strands-ts/src/conversation-manager/sliding-window-conversation-manager.ts
@@ -414,10 +414,14 @@ export class SlidingWindowConversationManager extends ConversationManager {
       }
 
       changesMade = true
+      // structuredContent is never sent to the model, so truncation preserves it.
       return new ToolResultBlock({
         toolUseId: toolResultBlock.toolUseId,
         status: toolResultBlock.status,
         content: newItems,
+        ...(toolResultBlock.structuredContent !== undefined
+          ? { structuredContent: toolResultBlock.structuredContent }
+          : {}),
         ...(toolResultBlock.error !== undefined ? { error: toolResultBlock.error } : {}),
       })
     })

--- a/strands-ts/src/mcp/__tests__/client.structured-content.test.node.ts
+++ b/strands-ts/src/mcp/__tests__/client.structured-content.test.node.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import * as z from 'zod/v4'
+import { McpClient } from '../client.js'
+import type { ToolResultBlock } from '../../types/messages.js'
+import type { LocalAgent } from '../../types/agent.js'
+import type { ToolContext } from '../../tools/tool.js'
+
+/**
+ * Transport-boundary coverage for structuredContent: a real MCP server connected
+ * over a linked in-memory transport, so the MCP SDK's result validation runs.
+ * The mocked tests in client.test.ts bypass that validation layer.
+ */
+describe('structuredContent through a real MCP transport', () => {
+  let server: McpServer
+  let client: McpClient
+
+  beforeEach(async () => {
+    server = new McpServer({ name: 'structured-content-test-server', version: '1.0.0' })
+    server.registerTool(
+      'weather',
+      {
+        description: 'Returns weather with structured output',
+        inputSchema: { city: z.string() },
+        outputSchema: { temperature: z.number(), conditions: z.string() },
+      },
+      async ({ city }) => ({
+        content: [{ type: 'text', text: `Weather for ${city}` }],
+        structuredContent: { temperature: 72, conditions: 'sunny' },
+      })
+    )
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+    await server.connect(serverTransport)
+    client = new McpClient({ applicationName: 'structured-content-test', transport: clientTransport })
+    await client.connect()
+  })
+
+  afterEach(async () => {
+    await client.disconnect()
+    await server.close()
+  })
+
+  it('preserves object-valued structuredContent end to end', async () => {
+    const tools = await client.listTools()
+    const weatherTool = tools.find((tool) => tool.name === 'weather')
+    expect(weatherTool).toBeDefined()
+
+    const toolContext: ToolContext = {
+      toolUse: { toolUseId: 'id-123', name: 'weather', input: { city: 'NYC' } },
+      agent: { cancelSignal: new AbortController().signal } as LocalAgent,
+      invocationState: {},
+      interrupt: () => {
+        throw new Error('interrupt not available in test context')
+      },
+    }
+
+    const generator = weatherTool!.stream(toolContext)
+    let iteration = await generator.next()
+    while (!iteration.done) {
+      iteration = await generator.next()
+    }
+    const result = iteration.value as ToolResultBlock
+
+    expect(result.status).toBe('success')
+    expect(result.structuredContent).toEqual({ temperature: 72, conditions: 'sunny' })
+  })
+})

--- a/strands-ts/src/mcp/__tests__/client.test.ts
+++ b/strands-ts/src/mcp/__tests__/client.test.ts
@@ -739,6 +739,42 @@ describe('MCP Integration', () => {
       expect(content.json).toEqual(expect.objectContaining({ value: data }))
     })
 
+    it('surfaces structuredContent on the tool result', async () => {
+      vi.mocked(mockClientWrapper.callTool).mockResolvedValue({
+        content: [{ type: 'text', text: 'Sunny' }],
+        structuredContent: { temperature: 72, conditions: 'sunny' },
+      })
+
+      const result = await runTool<ToolResultBlock>(tool.stream(toolContext))
+
+      expect(result.status).toBe('success')
+      expect(result.structuredContent).toEqual({ temperature: 72, conditions: 'sunny' })
+    })
+
+    it('passes non-object structuredContent through the mapper', async () => {
+      // Mapper-level coverage only: the MCP SDK's transport validation is object-only
+      // today, so a real server cannot deliver non-object values until it implements
+      // SEP-2106. The mapper is ready for that without changes.
+      vi.mocked(mockClientWrapper.callTool).mockResolvedValue({
+        content: [{ type: 'text', text: 'count' }],
+        structuredContent: 42,
+      })
+
+      const result = await runTool<ToolResultBlock>(tool.stream(toolContext))
+
+      expect(result.structuredContent).toBe(42)
+    })
+
+    it('omits structuredContent when the server does not return it', async () => {
+      vi.mocked(mockClientWrapper.callTool).mockResolvedValue({
+        content: [{ type: 'text', text: 'Sunny' }],
+      })
+
+      const result = await runTool<ToolResultBlock>(tool.stream(toolContext))
+
+      expect(result.structuredContent).toBeUndefined()
+    })
+
     it('provides default message for empty output', async () => {
       vi.mocked(mockClientWrapper.callTool).mockResolvedValue({ content: [] })
 

--- a/strands-ts/src/tools/executors/executor.ts
+++ b/strands-ts/src/tools/executors/executor.ts
@@ -162,6 +162,7 @@ export abstract class ToolExecutor {
       toolUseId,
       status: result.status,
       content: result.content,
+      ...(result.structuredContent !== undefined && { structuredContent: result.structuredContent }),
       ...(result.error !== undefined && { error: result.error }),
     })
   }

--- a/strands-ts/src/tools/mcp-tool.ts
+++ b/strands-ts/src/tools/mcp-tool.ts
@@ -70,6 +70,10 @@ export class McpTool extends Tool {
         toolUseId,
         status: rawResult.isError ? 'error' : 'success',
         content,
+        // The field accepts any JSON value (MCP SEP-2106), but the current MCP SDK
+        // validates structuredContent as object-only before this mapper runs, so only
+        // objects can arrive from a real server until the SDK implements SEP-2106.
+        ...(rawResult.structuredContent !== undefined && { structuredContent: rawResult.structuredContent }),
       })
     } catch (error) {
       if (
@@ -190,9 +194,11 @@ export class McpTool extends Tool {
 
   /**
    * Type Guard: Checks if value matches the expected MCP SDK result shape.
-   * \{ content: unknown[]; isError?: boolean \}
+   * \{ content: unknown[]; structuredContent?: JSONValue; isError?: boolean \}
    */
-  private _isMcpToolResult(value: unknown): value is { content: unknown[]; isError?: boolean } {
+  private _isMcpToolResult(
+    value: unknown
+  ): value is { content: unknown[]; structuredContent?: JSONValue; isError?: boolean } {
     if (typeof value !== 'object' || value === null) {
       return false
     }

--- a/strands-ts/src/types/__tests__/messages.test.ts
+++ b/strands-ts/src/types/__tests__/messages.test.ts
@@ -212,6 +212,57 @@ describe('ToolResultBlock', () => {
       content: [new TextBlock('result')],
     })
   })
+
+  test('creates tool result block with structuredContent', () => {
+    const block = new ToolResultBlock({
+      toolUseId: '123',
+      status: 'success',
+      content: [new TextBlock('result')],
+      structuredContent: { temperature: 72 },
+    })
+
+    expect(block).toEqual({
+      type: 'toolResultBlock',
+      toolUseId: '123',
+      status: 'success',
+      content: [new TextBlock('result')],
+      structuredContent: { temperature: 72 },
+    })
+  })
+
+  test('serializes structuredContent in toJSON', () => {
+    const block = new ToolResultBlock({
+      toolUseId: '123',
+      status: 'success',
+      content: [new TextBlock('result')],
+      structuredContent: { temperature: 72 },
+    })
+
+    expect(block.toJSON()).toEqual({
+      toolResult: {
+        toolUseId: '123',
+        status: 'success',
+        content: [{ text: 'result' }],
+        structuredContent: { temperature: 72 },
+      },
+    })
+  })
+
+  test('omits structuredContent in toJSON when not set', () => {
+    const block = new ToolResultBlock({
+      toolUseId: '123',
+      status: 'success',
+      content: [new TextBlock('result')],
+    })
+
+    expect(block.toJSON()).toEqual({
+      toolResult: {
+        toolUseId: '123',
+        status: 'success',
+        content: [{ text: 'result' }],
+      },
+    })
+  })
 })
 
 describe('ReasoningBlock', () => {
@@ -724,6 +775,8 @@ describe('toJSON/fromJSON round-trips', () => {
     ['ToolResultBlock with text content',      () => new ToolResultBlock({ toolUseId: '123', status: 'success', content: [new TextBlock('Result text')] })],
     ['ToolResultBlock with json content',      () => new ToolResultBlock({ toolUseId: '456', status: 'success', content: [new JsonBlock({ json: { result: 'data' } })] })],
     ['ToolResultBlock with error status',      () => new ToolResultBlock({ toolUseId: '789', status: 'error', content: [new TextBlock('Error message')] })],
+    ['ToolResultBlock with structuredContent', () => new ToolResultBlock({ toolUseId: '123', status: 'success', content: [new TextBlock('Result text')], structuredContent: { temperature: 72 } })],
+    ['ToolResultBlock with non-object structuredContent', () => new ToolResultBlock({ toolUseId: '123', status: 'success', content: [new TextBlock('Result text')], structuredContent: [1, 2, 3] })],
     ['ReasoningBlock with text only',          () => new ReasoningBlock({ text: 'Thinking...' })],
     ['ReasoningBlock with signature',          () => new ReasoningBlock({ text: 'Thinking...', signature: 'sig123' })],
     ['ReasoningBlock with redactedContent',    () => new ReasoningBlock({ redactedContent: new Uint8Array([1, 2, 3]) })],

--- a/strands-ts/src/types/messages.ts
+++ b/strands-ts/src/types/messages.ts
@@ -374,6 +374,11 @@ export interface ToolResultBlockData {
   content: ToolResultContentData[]
 
   /**
+   * Optional structured data returned by the tool (e.g. MCP `structuredContent`), any JSON value.
+   */
+  structuredContent?: JSONValue
+
+  /**
    * The original error object when status is 'error'.
    * Available for inspection by hooks, error handlers, and agent loop.
    * Tools must wrap non-Error thrown values into Error objects.
@@ -406,16 +411,30 @@ export class ToolResultBlock implements JSONSerializable<{ toolResult: ToolResul
   readonly content: ToolResultContent[]
 
   /**
+   * Optional structured data returned by the tool (e.g. MCP `structuredContent`), any JSON value.
+   */
+  readonly structuredContent?: JSONValue
+
+  /**
    * The original error object when status is 'error'.
    * Available for inspection by hooks, error handlers, and agent loop.
    * Tools must wrap non-Error thrown values into Error objects.
    */
   readonly error?: Error
 
-  constructor(data: { toolUseId: string; status: 'success' | 'error'; content: ToolResultContent[]; error?: Error }) {
+  constructor(data: {
+    toolUseId: string
+    status: 'success' | 'error'
+    content: ToolResultContent[]
+    structuredContent?: JSONValue
+    error?: Error
+  }) {
     this.toolUseId = data.toolUseId
     this.status = data.status
     this.content = data.content
+    if (data.structuredContent !== undefined) {
+      this.structuredContent = data.structuredContent
+    }
     if (data.error !== undefined) {
       this.error = data.error
     }
@@ -432,6 +451,7 @@ export class ToolResultBlock implements JSONSerializable<{ toolResult: ToolResul
         toolUseId: this.toolUseId,
         status: this.status,
         content: this.content.map((block) => block.toJSON() as ToolResultContentData),
+        ...(this.structuredContent !== undefined && { structuredContent: this.structuredContent }),
       },
     }
   }
@@ -448,6 +468,9 @@ export class ToolResultBlock implements JSONSerializable<{ toolResult: ToolResul
       toolUseId: data.toolResult.toolUseId,
       status: data.toolResult.status,
       content,
+      ...(data.toolResult.structuredContent !== undefined && {
+        structuredContent: data.toolResult.structuredContent,
+      }),
     })
   }
 }

--- a/strands-ts/src/vended-plugins/context-offloader/__tests__/plugin.test.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/__tests__/plugin.test.ts
@@ -3,6 +3,7 @@ import { ContextOffloader } from '../plugin.js'
 import { InMemoryStorage } from '../storage.js'
 import { AfterToolCallEvent, BeforeModelCallEvent } from '../../../hooks/events.js'
 import { TextBlock, JsonBlock, ToolResultBlock } from '../../../types/messages.js'
+import type { JSONValue } from '../../../types/json.js'
 import { ImageBlock, VideoBlock, DocumentBlock } from '../../../types/media.js'
 import { createMockAgent, invokeTrackedHook } from '../../../__fixtures__/agent-helpers.js'
 import { MockMessageModel } from '../../../__fixtures__/mock-message-model.js'
@@ -18,13 +19,16 @@ function makeEvent(
   content: InstanceType<
     typeof TextBlock | typeof JsonBlock | typeof ImageBlock | typeof VideoBlock | typeof DocumentBlock
   >[],
-  overrides?: { status?: 'success' | 'error'; toolName?: string }
+  overrides?: { status?: 'success' | 'error'; toolName?: string; structuredContent?: JSONValue }
 ) {
   const agent = makeMockAgent()
   const result = new ToolResultBlock({
     toolUseId: 'tool-123',
     status: overrides?.status ?? 'success',
     content,
+    ...(overrides !== undefined && 'structuredContent' in overrides
+      ? { structuredContent: overrides.structuredContent }
+      : {}),
   })
   return new AfterToolCallEvent({
     agent,
@@ -145,6 +149,25 @@ describe('ContextOffloader', () => {
       expect(preview).toContain('Tool result was offloaded')
       expect(preview).toContain('[Stored references:]')
       expect(preview).not.toContain(largeText)
+    })
+
+    it.each([
+      ['object', { temperature: 72 }],
+      ['zero', 0],
+      ['empty string', ''],
+      ['false', false],
+      ['null', null],
+    ])('preserves %s structuredContent when offloading', async (_label, structuredContent) => {
+      const storage = new InMemoryStorage()
+      const plugin = new ContextOffloader({ storage, maxResultTokens: 100, previewTokens: 10 })
+      const agent = createMockAgent()
+      plugin.initAgent(agent)
+
+      const event = makeEvent([new TextBlock('a'.repeat(2000))], { structuredContent })
+      await invokeTrackedHook(agent, event)
+
+      expect((event.result.content[0] as TextBlock).text).toContain('[Offloaded:')
+      expect(event.result.structuredContent).toEqual(structuredContent)
     })
 
     it('offloads large JSON results', async () => {

--- a/strands-ts/src/vended-plugins/context-offloader/plugin.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/plugin.ts
@@ -492,10 +492,14 @@ export class ContextOffloader implements Plugin {
       }
     }
 
+    // structuredContent and error are application-side data, never model context,
+    // so offloading the content blocks preserves them.
     event.result = new ToolResultBlock({
       toolUseId: event.result.toolUseId,
       status: event.result.status,
       content: newContent,
+      ...(event.result.structuredContent !== undefined ? { structuredContent: event.result.structuredContent } : {}),
+      ...(event.result.error !== undefined ? { error: event.result.error } : {}),
     })
   }
 }


### PR DESCRIPTION
## Description

  MCP spec revision 2025-06-18 added structured tool output: a server declares `outputSchema` on a tool and returns the typed value as `structuredContent` alongside the human-readable content blocks. 

TypeScript SDK already surfaces `outputSchema` on `ToolSpec`, but the tool-result mapper discarded structuredContent. This PR added `structuredContent` on `ToolResultBlock` and its serialized form, so typed tool results can be validated against `outputSchema` and consumed programmatically.

The field accepts any JSON value, based on [SEP-2106](https://modelcontextprotocol.io/seps/2106-json-schema-2020-12), which shipped in spec revision 2026-07-28.


## Needs API review on the new field [messages.StructuredContent](https://github.com/strands-agents/harness-sdk/pull/3431/changes#diff-aa9e01706a53e921024715e40085d4101c883a5d3d9829bec00f28f0469192f4R415)

One new optional field on three public surfaces, all exported from the package root:
  
1. [`ToolResultBlockData.structuredContent?: JSONValue`](https://github.com/strands-agents/harness-sdk/pull/3431/changes#diff-aa9e01706a53e921024715e40085d4101c883a5d3d9829bec00f28f0469192f4R415)
  (interface). This is the serialized shape, so it is also a wire-format change for persisted sessions.
2. [`ToolResultBlock.structuredContent?: JSONValue`](https://github.com/strands-agents/harness-sdk/pull/3431/changes#diff-aa9e01706a53e921024715e40085d4101c883a5d3d9829bec00f28f0469192f4R416) (readonly class property), plus the widened constructor parameter.
3. The JSON serialization: `toJSON()` now emits an optional `structuredContent` key inside `toolResult`, and `fromJSON()` revives it. This is the session-persistence format, so it carries the most compatibility weight.
  
## Related Issues
Closes #3270
  
## Documentation PR
N/A
  
## Type of Change
New feature
  
## Testing
  
How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.
  
- [x] I ran `hatch run prepare`
  
## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs 
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings 
- [ ] Any dependent changes have been merged and published
  
----
  
  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.