### PR TITLE
feat(gemini): add canonical built_in_tools config

### DIFF
--- a/site/src/content/docs/user-guide/concepts/model-providers/google.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/google.mdx
@@ -176,7 +176,10 @@ For a complete list of supported models, see the [Gemini API documentation](http
 <Tabs>
 <Tab label="Python">
 
-Google's built-in tools (Google Search, Code Execution, URL Context) can be passed via the `gemini_tools` config option. These are appended alongside any function tools registered on the agent.
+Configure Google's built-in tools (Google Search, Code Execution, URL Context) with
+`built_in_tools`. These tools are appended alongside any tools registered on the agent.
+The deprecated `gemini_tools` alias remains available for backward compatibility but
+emits a `DeprecationWarning`.
 
 ```python
 from google import genai
@@ -186,7 +189,7 @@ from strands.models.gemini import GeminiModel
 model = GeminiModel(
     client_args={"api_key": "<KEY>"},
     model_id="gemini-2.5-flash",
-    gemini_tools=[
+    built_in_tools=[
         genai.types.Tool(google_search=genai.types.GoogleSearch()),
     ],
 )

--- a/strands-py/src/strands/models/gemini.py
+++ b/strands-py/src/strands/models/gemini.py
@@ -659,7 +659,7 @@ class GeminiModel(Model):
 
         if "gemini_tools" in model_config:
             warnings.warn(
-                "gemini_tools is deprecated; use built_in_tools instead.",
+                "gemini_tools is deprecated and will be removed in v2.0.0. Use built_in_tools instead.",
                 DeprecationWarning,
                 stacklevel=3,
             )

--- a/strands-py/src/strands/models/gemini.py
+++ b/strands-py/src/strands/models/gemini.py
@@ -8,6 +8,7 @@ import json
 import logging
 import mimetypes
 import secrets
+import warnings
 from collections.abc import AsyncGenerator
 from typing import Any, TypeVar, cast
 
@@ -45,11 +46,12 @@ class GeminiModel(Model):
             params: Additional model parameters (e.g., temperature).
                 For a complete list of supported parameters, see
                 https://ai.google.dev/api/generate-content#generationconfig.
-            gemini_tools: Gemini-specific tools that are not FunctionDeclarations
+            built_in_tools: Gemini-specific tools that are not FunctionDeclarations
                 (e.g., GoogleSearch, CodeExecution, ComputerUse, UrlContext, FileSearch).
                 Use the standard tools interface for function calling tools.
                 For a complete list of supported tools, see
                 https://ai.google.dev/api/caching#Tool
+            gemini_tools: Deprecated alias for built_in_tools.
             use_native_token_count: Whether to use the native Gemini count_tokens API.
                 When True, count_tokens() calls the Gemini API for accurate counts.
                 When False (default), skips the API call and uses the local estimator.
@@ -57,6 +59,7 @@ class GeminiModel(Model):
 
         model_id: Required[str]
         params: dict[str, Any]
+        built_in_tools: list[genai.types.Tool]
         gemini_tools: list[genai.types.Tool]
         use_native_token_count: bool
 
@@ -83,9 +86,11 @@ class GeminiModel(Model):
             **model_config: Configuration options for the Gemini model.
 
         Raises:
-            ValueError: If both `client` and `client_args` are provided.
+            ValueError: If both `client` and `client_args` are provided, if both `built_in_tools` and
+                `gemini_tools` are configured, or if built-in tools contain function declarations.
         """
         validate_config_keys(model_config, GeminiModel.GeminiConfig)
+        model_config = self._normalize_built_in_tools(model_config)
         self.config = GeminiModel.GeminiConfig(**model_config)
 
         # Validate that only one client configuration method is provided
@@ -95,9 +100,8 @@ class GeminiModel(Model):
         self._custom_client = client
         self.client_args = client_args or {}
 
-        # Validate gemini_tools if provided
-        if "gemini_tools" in self.config:
-            self._validate_gemini_tools(self.config["gemini_tools"])
+        if "built_in_tools" in self.config:
+            self._validate_built_in_tools(self.config["built_in_tools"])
 
         logger.debug("config=<%s> | initializing", self.config)
 
@@ -107,10 +111,14 @@ class GeminiModel(Model):
 
         Args:
             **model_config: Configuration overrides.
+
+        Raises:
+            ValueError: If both `built_in_tools` and `gemini_tools` are configured, or if built-in tools contain
+                function declarations.
         """
-        # Validate gemini_tools if provided
-        if "gemini_tools" in model_config:
-            self._validate_gemini_tools(model_config["gemini_tools"])
+        model_config = self._normalize_built_in_tools(model_config)
+        if "built_in_tools" in model_config:
+            self._validate_built_in_tools(model_config["built_in_tools"])
 
         self.config.update(model_config)
 
@@ -270,7 +278,7 @@ class GeminiModel(Model):
         Return:
             Gemini tool list, or None when no tools are configured (Vertex AI rejects empty arrays).
         """
-        if not tool_specs and not self.config.get("gemini_tools"):
+        if not tool_specs and not self.config.get("built_in_tools"):
             return None
         tools = [
             genai.types.Tool(
@@ -284,8 +292,8 @@ class GeminiModel(Model):
                 ],
             ),
         ]
-        if self.config.get("gemini_tools"):
-            tools.extend(self.config["gemini_tools"])
+        if self.config.get("built_in_tools"):
+            tools.extend(self.config["built_in_tools"])
         return tools
 
     def _format_request_config(
@@ -632,25 +640,53 @@ class GeminiModel(Model):
         yield {"output": output_model.model_validate(response.parsed)}
 
     @staticmethod
-    def _validate_gemini_tools(gemini_tools: list[genai.types.Tool]) -> None:
-        """Validate that gemini_tools does not contain FunctionDeclarations.
+    def _normalize_built_in_tools(model_config: GeminiConfig) -> GeminiConfig:
+        """Normalize the deprecated gemini_tools alias to built_in_tools.
+
+        Args:
+            model_config: Gemini model configuration to normalize.
+
+        Returns:
+            Gemini model configuration using the canonical built_in_tools field.
+
+        Raises:
+            ValueError: If built_in_tools and gemini_tools are both configured.
+        """
+        if "built_in_tools" in model_config and "gemini_tools" in model_config:
+            raise ValueError(
+                "built_in_tools and gemini_tools cannot be configured in tandem; gemini_tools is deprecated."
+            )
+
+        if "gemini_tools" in model_config:
+            warnings.warn(
+                "gemini_tools is deprecated; use built_in_tools instead.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            model_config["built_in_tools"] = model_config.pop("gemini_tools")
+
+        return model_config
+
+    @staticmethod
+    def _validate_built_in_tools(built_in_tools: list[genai.types.Tool]) -> None:
+        """Validate that built_in_tools does not contain FunctionDeclarations.
 
         Gemini-specific tools should only include tools that cannot be represented
         as FunctionDeclarations (e.g., GoogleSearch, CodeExecution, ComputerUse).
         Standard function calling tools should use the tools interface instead.
 
         Args:
-            gemini_tools: List of Gemini tools to validate
+            built_in_tools: List of Gemini tools to validate.
 
         Raises:
-            ValueError: If any tool contains function_declarations
+            ValueError: If any tool contains function_declarations.
         """
-        for tool in gemini_tools:
+        for tool in built_in_tools:
             # Check if the tool has function_declarations attribute and it's not empty
             if hasattr(tool, "function_declarations") and tool.function_declarations:
                 raise ValueError(
-                    "gemini_tools should not contain FunctionDeclarations. "
+                    "built_in_tools should not contain FunctionDeclarations. "
                     "Use the standard tools interface for function calling tools. "
-                    "gemini_tools is reserved for Gemini-specific tools like "
+                    "built_in_tools is reserved for Gemini-specific tools like "
                     "GoogleSearch, CodeExecution, ComputerUse, UrlContext, and FileSearch."
                 )

--- a/strands-py/tests/strands/models/test_gemini.py
+++ b/strands-py/tests/strands/models/test_gemini.py
@@ -1,5 +1,6 @@
 import logging
 import unittest.mock
+import warnings
 
 import pydantic
 import pytest
@@ -976,7 +977,7 @@ async def test_structured_output(gemini_client, model, messages, model_id, weath
     gemini_client.aio.models.generate_content.assert_called_with(**exp_request)
 
 
-def test_gemini_tools_validation_rejects_function_declarations(model_id):
+def test_built_in_tools_validation_rejects_function_declarations(model_id):
     tool_with_function_declarations = genai.types.Tool(
         function_declarations=[
             genai.types.FunctionDeclaration(
@@ -986,18 +987,99 @@ def test_gemini_tools_validation_rejects_function_declarations(model_id):
         ]
     )
 
-    with pytest.raises(ValueError, match="gemini_tools should not contain FunctionDeclarations"):
-        GeminiModel(model_id=model_id, gemini_tools=[tool_with_function_declarations])
+    with pytest.raises(ValueError, match="built_in_tools should not contain FunctionDeclarations"):
+        GeminiModel(model_id=model_id, built_in_tools=[tool_with_function_declarations])
 
 
-def test_gemini_tools_validation_allows_non_function_tools(model_id):
+def test__init__built_in_tools(model_id):
     tool_with_google_search = genai.types.Tool(google_search=genai.types.GoogleSearch())
 
-    model = GeminiModel(model_id=model_id, gemini_tools=[tool_with_google_search])
-    assert "gemini_tools" in model.config
+    with warnings.catch_warnings(record=True) as captured_warnings:
+        warnings.simplefilter("always")
+        model = GeminiModel(model_id=model_id, built_in_tools=[tool_with_google_search])
+
+    assert captured_warnings == []
+    assert model.config["built_in_tools"] == [tool_with_google_search]
+    assert "gemini_tools" not in model.config
 
 
-def test_gemini_tools_validation_on_update_config(model):
+def test__init__gemini_tools_normalizes_to_built_in_tools(model_id):
+    tool_with_google_search = genai.types.Tool(google_search=genai.types.GoogleSearch())
+
+    with pytest.warns(
+        DeprecationWarning,
+        match="gemini_tools is deprecated; use built_in_tools instead.",
+    ) as captured_warnings:
+        model = GeminiModel(model_id=model_id, gemini_tools=[tool_with_google_search])
+
+    assert captured_warnings[0].filename == __file__
+    assert model.config["built_in_tools"] == [tool_with_google_search]
+    assert "gemini_tools" not in model.config
+
+
+def test__init__built_in_tools_and_gemini_tools_raises(model_id):
+    built_in_tool = genai.types.Tool(google_search=genai.types.GoogleSearch())
+    deprecated_tool = genai.types.Tool(code_execution=genai.types.ToolCodeExecution())
+
+    with pytest.raises(ValueError) as error:
+        GeminiModel(
+            model_id=model_id,
+            built_in_tools=[built_in_tool],
+            gemini_tools=[deprecated_tool],
+        )
+
+    assert (
+        str(error.value)
+        == "built_in_tools and gemini_tools cannot be configured in tandem; gemini_tools is deprecated."
+    )
+
+
+def test_update_config_built_in_tools(model):
+    tool_with_google_search = genai.types.Tool(google_search=genai.types.GoogleSearch())
+
+    model.update_config(built_in_tools=[tool_with_google_search])
+
+    tru_tools = model._format_request_config(None, None, None).to_json_dict()["tools"]
+    exp_tools = [
+        {"function_declarations": []},
+        {"google_search": {}},
+    ]
+    assert tru_tools == exp_tools
+    assert model.config["built_in_tools"] == [tool_with_google_search]
+    assert "gemini_tools" not in model.config
+
+
+def test_update_config_gemini_tools_normalizes_to_built_in_tools(model):
+    tool_with_google_search = genai.types.Tool(google_search=genai.types.GoogleSearch())
+
+    with pytest.warns(
+        DeprecationWarning,
+        match="gemini_tools is deprecated; use built_in_tools instead.",
+    ) as captured_warnings:
+        model.update_config(gemini_tools=[tool_with_google_search])
+
+    assert captured_warnings[0].filename == __file__
+    assert model.config["built_in_tools"] == [tool_with_google_search]
+    assert "gemini_tools" not in model.config
+
+
+def test_update_config_built_in_tools_and_gemini_tools_raises(model):
+    built_in_tool = genai.types.Tool(google_search=genai.types.GoogleSearch())
+    deprecated_tool = genai.types.Tool(code_execution=genai.types.ToolCodeExecution())
+
+    with pytest.raises(ValueError) as error:
+        model.update_config(
+            built_in_tools=[built_in_tool],
+            gemini_tools=[deprecated_tool],
+        )
+
+    assert (
+        str(error.value)
+        == "built_in_tools and gemini_tools cannot be configured in tandem; gemini_tools is deprecated."
+    )
+
+
+def test_update_config_built_in_tools_validation_rejects_function_declarations(model):
     tool_with_function_declarations = genai.types.Tool(
         function_declarations=[
             genai.types.FunctionDeclaration(
@@ -1007,14 +1089,14 @@ def test_gemini_tools_validation_on_update_config(model):
         ]
     )
 
-    with pytest.raises(ValueError, match="gemini_tools should not contain FunctionDeclarations"):
-        model.update_config(gemini_tools=[tool_with_function_declarations])
+    with pytest.raises(ValueError, match="built_in_tools should not contain FunctionDeclarations"):
+        model.update_config(built_in_tools=[tool_with_function_declarations])
 
 
 @pytest.mark.asyncio
-async def test_stream_request_with_gemini_tools(gemini_client, messages, model_id):
+async def test_stream_request_with_built_in_tools(gemini_client, messages, model_id):
     google_search_tool = genai.types.Tool(google_search=genai.types.GoogleSearch())
-    model = GeminiModel(model_id=model_id, gemini_tools=[google_search_tool])
+    model = GeminiModel(model_id=model_id, built_in_tools=[google_search_tool])
 
     await anext(model.stream(messages))
 
@@ -1032,9 +1114,9 @@ async def test_stream_request_with_gemini_tools(gemini_client, messages, model_i
 
 
 @pytest.mark.asyncio
-async def test_stream_request_with_gemini_tools_and_function_tools(gemini_client, messages, tool_spec, model_id):
+async def test_stream_request_with_built_in_tools_and_function_tools(gemini_client, messages, tool_spec, model_id):
     code_execution_tool = genai.types.Tool(code_execution=genai.types.ToolCodeExecution())
-    model = GeminiModel(model_id=model_id, gemini_tools=[code_execution_tool])
+    model = GeminiModel(model_id=model_id, built_in_tools=[code_execution_tool])
 
     await anext(model.stream(messages, tool_specs=[tool_spec]))
 

--- a/strands-py/tests/strands/models/test_gemini.py
+++ b/strands-py/tests/strands/models/test_gemini.py
@@ -991,6 +991,24 @@ def test_built_in_tools_validation_rejects_function_declarations(model_id):
         GeminiModel(model_id=model_id, built_in_tools=[tool_with_function_declarations])
 
 
+def test__init__gemini_tools_validation_rejects_function_declarations(model_id):
+    tool_with_function_declarations = genai.types.Tool(
+        function_declarations=[
+            genai.types.FunctionDeclaration(
+                name="test_function",
+                description="A test function",
+            )
+        ]
+    )
+
+    with pytest.warns(
+        DeprecationWarning,
+        match="gemini_tools is deprecated and will be removed in v2.0.0. Use built_in_tools instead.",
+    ):
+        with pytest.raises(ValueError, match="built_in_tools should not contain FunctionDeclarations"):
+            GeminiModel(model_id=model_id, gemini_tools=[tool_with_function_declarations])
+
+
 def test__init__built_in_tools(model_id):
     tool_with_google_search = genai.types.Tool(google_search=genai.types.GoogleSearch())
 
@@ -1008,7 +1026,7 @@ def test__init__gemini_tools_normalizes_to_built_in_tools(model_id):
 
     with pytest.warns(
         DeprecationWarning,
-        match="gemini_tools is deprecated; use built_in_tools instead.",
+        match="gemini_tools is deprecated and will be removed in v2.0.0. Use built_in_tools instead.",
     ) as captured_warnings:
         model = GeminiModel(model_id=model_id, gemini_tools=[tool_with_google_search])
 
@@ -1054,7 +1072,7 @@ def test_update_config_gemini_tools_normalizes_to_built_in_tools(model):
 
     with pytest.warns(
         DeprecationWarning,
-        match="gemini_tools is deprecated; use built_in_tools instead.",
+        match="gemini_tools is deprecated and will be removed in v2.0.0. Use built_in_tools instead.",
     ) as captured_warnings:
         model.update_config(gemini_tools=[tool_with_google_search])
 
@@ -1091,6 +1109,24 @@ def test_update_config_built_in_tools_validation_rejects_function_declarations(m
 
     with pytest.raises(ValueError, match="built_in_tools should not contain FunctionDeclarations"):
         model.update_config(built_in_tools=[tool_with_function_declarations])
+
+
+def test_update_config_gemini_tools_validation_rejects_function_declarations(model):
+    tool_with_function_declarations = genai.types.Tool(
+        function_declarations=[
+            genai.types.FunctionDeclaration(
+                name="test_function",
+                description="A test function",
+            )
+        ]
+    )
+
+    with pytest.warns(
+        DeprecationWarning,
+        match="gemini_tools is deprecated and will be removed in v2.0.0. Use built_in_tools instead.",
+    ):
+        with pytest.raises(ValueError, match="built_in_tools should not contain FunctionDeclarations"):
+            model.update_config(gemini_tools=[tool_with_function_declarations])
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests_integ/models/test_model_gemini.py
+++ b/strands-py/tests_integ/models/test_model_gemini.py
@@ -28,7 +28,7 @@ def gemini_tool_model():
         client_args={"api_key": os.getenv("GOOGLE_API_KEY")},
         model_id="gemini-2.5-flash",
         params={"temperature": 0.15},  # Lower temperature for consistent test behavior
-        gemini_tools=[genai.types.Tool(code_execution=genai.types.ToolCodeExecution())],
+        built_in_tools=[genai.types.Tool(code_execution=genai.types.ToolCodeExecution())],
     )
 
 


### PR DESCRIPTION
## Description

Python users currently configure Gemini provider-native tools with `gemini_tools`, while the TypeScript SDK uses the canonical `builtInTools` name for the same capability. This aligns the Python public API with `built_in_tools` while preserving `gemini_tools` as a deprecated compatibility alias.

### Public API Changes

```python
# Before
model = GeminiModel(
    model_id="gemini-2.5-flash",
    gemini_tools=[genai.types.Tool(google_search=genai.types.GoogleSearch())],
)

# After
model = GeminiModel(
    model_id="gemini-2.5-flash",
    built_in_tools=[genai.types.Tool(google_search=genai.types.GoogleSearch())],
)
```

Existing `gemini_tools` configurations continue to work with a `DeprecationWarning` and are normalized internally to `built_in_tools`. The alias is normalized at write time, so `get_config()` returns only the canonical `built_in_tools` key even when the model was configured through `gemini_tools`.

Supplying both keys in the same configuration raises a `ValueError` instead of silently choosing one. The current check is presence-based, including when one key is explicitly set to `None` or an empty list; maintainer confirmation of that edge-case behavior is requested in the review thread.

## Related Issues

Resolves #3361

## Documentation PR

The Gemini model provider guide is updated in this PR to use `built_in_tools` and document the deprecated `gemini_tools` alias.

## Type of Change

New feature

## Testing

- [ ] I ran `hatch run prepare`
- [x] Gemini model unit tests (`63 passed`)
- [x] Full Python unit suite (`4650 passed`)
- [x] Ruff format and lint checks
- [x] mypy (`231 source files`)
- [x] Documentation build (`857 pages`, no broken links)
- [x] Gemini integration test collection (`13 skipped` without API credentials)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
