### PR TITLE
feat(mcp): surface tool annotations

### DIFF
--- a/site/src/content/docs/user-guide/concepts/tools/mcp-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/mcp-tools.mdx
@@ -388,6 +388,31 @@ and `toolFilters` too, where filter strings are regexes.
 </Tab>
 </Tabs>
 
+## Tool Annotations
+
+MCP tool annotations are available on each discovered tool's `tool_spec` (Python) or `toolSpec` (TypeScript). You can inspect hints such as `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint` in hooks, interventions, or approval workflows.
+
+<Tabs>
+<Tab label="Python">
+
+```python
+tools = mcp_client.list_tools_sync()
+read_only_tools = [
+    tool for tool in tools
+    if tool.tool_spec.get("annotations", {}).get("readOnlyHint") is True
+]
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/tools/mcp-tools.ts:tool_annotations"
+```
+</Tab>
+</Tabs>
+
+Annotations are opaque, untrusted hints supplied by the MCP server. Do not use them as the sole basis for security decisions unless you trust the server.
+
 ## Direct Tool Invocation
 
 While tools are typically invoked by the agent based on user requests, MCP tools can also be called directly:

--- a/site/src/content/docs/user-guide/concepts/tools/mcp-tools.ts
+++ b/site/src/content/docs/user-guide/concepts/tools/mcp-tools.ts
@@ -43,6 +43,13 @@ const tools = await mcpClient.listTools()
 const agentExplicit = new Agent({ tools })
 // --8<-- [end:explicit_tools]
 
+// --8<-- [start:tool_annotations]
+const discoveredTools = await mcpClient.listTools()
+const readOnlyTools = discoveredTools.filter(
+  (tool) => tool.toolSpec.annotations?.readOnlyHint === true
+)
+// --8<-- [end:tool_annotations]
+
 // --8<-- [start:stdio_transport]
 const stdioClient = new McpClient({
   transport: new StdioClientTransport({

--- a/strands-py/src/strands/tools/mcp/mcp_agent_tool.py
+++ b/strands-py/src/strands/tools/mcp/mcp_agent_tool.py
@@ -66,7 +66,7 @@ class MCPAgentTool(AgentTool):
         """Get the specification of the tool.
 
         This method converts the MCP tool specification to the agent framework's
-        ToolSpec format, including the input schema, description, and optional output schema.
+        ToolSpec format, including the input schema, description, annotations, and optional output schema.
 
         Returns:
             ToolSpec: The tool specification in the agent framework format
@@ -81,6 +81,9 @@ class MCPAgentTool(AgentTool):
 
         if self.mcp_tool.outputSchema:
             spec["outputSchema"] = {"json": self.mcp_tool.outputSchema}
+
+        if self.mcp_tool.annotations:
+            spec["annotations"] = self.mcp_tool.annotations.model_dump(by_alias=True, exclude_none=True)
 
         return spec
 

--- a/strands-py/src/strands/types/tools.py
+++ b/strands-py/src/strands/types/tools.py
@@ -30,12 +30,16 @@ class ToolSpec(TypedDict):
         outputSchema: Optional JSON Schema defining the expected output format.
             Note: Not all model providers support this field. Providers that don't
             support it should filter it out before sending to their API.
+        annotations: Optional opaque metadata describing the tool. Annotation values
+            are untrusted hints and must not be used for security decisions without
+            verifying that the source is trusted.
     """
 
     description: str
     inputSchema: JSONSchema
     name: str
     outputSchema: NotRequired[JSONSchema]
+    annotations: NotRequired[dict[str, Any]]
 
 
 class Tool(TypedDict):

--- a/strands-py/tests/strands/tools/mcp/test_mcp_agent_tool.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_agent_tool.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from mcp.types import Tool as MCPTool
+from mcp.types import ToolAnnotations
 
 from strands.tools.mcp import MCPAgentTool, MCPClient
 from strands.types._events import ToolResultEvent
@@ -16,6 +17,7 @@ def mock_mcp_tool():
     mock_tool.description = "A test tool"
     mock_tool.inputSchema = {"type": "object", "properties": {}}
     mock_tool.outputSchema = None  # MCP tools can have optional outputSchema
+    mock_tool.annotations = None
     return mock_tool
 
 
@@ -79,6 +81,30 @@ def test_tool_spec_without_output_schema(mock_mcp_tool, mock_mcp_client):
     tool_spec = agent_tool.tool_spec
 
     assert "outputSchema" not in tool_spec
+
+
+def test_tool_spec_with_annotations(mock_mcp_tool, mock_mcp_client):
+    mock_mcp_tool.annotations = ToolAnnotations(
+        title="Safe search",
+        readOnlyHint=True,
+        futureHint="preserved",
+    )
+
+    agent_tool = MCPAgentTool(mock_mcp_tool, mock_mcp_client)
+    tru_annotations = agent_tool.tool_spec["annotations"]
+    exp_annotations = {
+        "title": "Safe search",
+        "readOnlyHint": True,
+        "futureHint": "preserved",
+    }
+
+    assert tru_annotations == exp_annotations
+
+
+def test_tool_spec_without_annotations(mock_mcp_tool, mock_mcp_client):
+    agent_tool = MCPAgentTool(mock_mcp_tool, mock_mcp_client)
+
+    assert "annotations" not in agent_tool.tool_spec
 
 
 @pytest.mark.asyncio

--- a/strands-ts/src/mcp/__tests__/client.test.ts
+++ b/strands-ts/src/mcp/__tests__/client.test.ts
@@ -279,7 +279,19 @@ describe('MCP Integration', () => {
         required: ['forecast'],
       }
       sdkClientMock.listTools.mockResolvedValue({
-        tools: [{ name: 'weather', description: 'Get weather', inputSchema: {}, outputSchema }],
+        tools: [
+          {
+            name: 'weather',
+            description: 'Get weather',
+            inputSchema: {},
+            outputSchema,
+            annotations: {
+              title: 'Weather lookup',
+              readOnlyHint: true,
+              futureHint: 'preserved',
+            },
+          },
+        ],
       })
 
       const tools = await client.listTools()
@@ -292,6 +304,11 @@ describe('MCP Integration', () => {
         description: 'Get weather',
         inputSchema: {},
         outputSchema,
+        annotations: {
+          title: 'Weather lookup',
+          readOnlyHint: true,
+          futureHint: 'preserved',
+        },
       })
     })
 

--- a/strands-ts/src/mcp/client.ts
+++ b/strands-ts/src/mcp/client.ts
@@ -380,6 +380,9 @@ export class McpClient {
           description: toolSpec.description || `Tool which performs ${toolSpec.name}`,
           inputSchema: toolSpec.inputSchema as JSONSchema,
           ...(toolSpec.outputSchema !== undefined && { outputSchema: toolSpec.outputSchema as JSONSchema }),
+          ...(toolSpec.annotations !== undefined && {
+            annotations: toolSpec.annotations as Record<string, unknown>,
+          }),
           client: this,
         })
         this._serverToolNames.set(tool, toolSpec.name)

--- a/strands-ts/src/tools/mcp-tool.ts
+++ b/strands-ts/src/tools/mcp-tool.ts
@@ -14,6 +14,7 @@ export interface McpToolConfig {
   description: string
   inputSchema: JSONSchema
   outputSchema?: JSONSchema
+  annotations?: Record<string, unknown>
   client: McpClient
 }
 
@@ -39,6 +40,7 @@ export class McpTool extends Tool {
       description: config.description,
       inputSchema: config.inputSchema,
       ...(config.outputSchema !== undefined && { outputSchema: config.outputSchema }),
+      ...(config.annotations !== undefined && { annotations: config.annotations }),
     }
     this.mcpClient = config.client
   }

--- a/strands-ts/src/tools/types.ts
+++ b/strands-ts/src/tools/types.ts
@@ -32,6 +32,14 @@ export interface ToolSpec {
    * JSON Schema defining the expected output structure for the tool.
    */
   outputSchema?: JSONSchema
+
+  /**
+   * Opaque metadata describing the tool.
+   *
+   * Annotation values are untrusted hints. Do not use them for security decisions
+   * unless the source of the tool specification is trusted.
+   */
+  annotations?: Record<string, unknown>
 }
 
 /**


### PR DESCRIPTION
## Motivation

Both SDKs currently discard annotations attached to tools returned by MCP
servers. Hooks, interventions, and approval workflows therefore cannot inspect
standard hints such as `readOnlyHint` or `destructiveHint`.

This preserves the complete annotations object when converting an MCP tool into
a Strands tool. The metadata remains opaque so future MCP annotation fields do
not require a Strands allowlist update.

Fixes #3271

## Public API Changes

Python and TypeScript `ToolSpec` now include an optional `annotations` mapping:

```typescript
const tools = await mcpClient.listTools()
const hints = tools[0]?.toolSpec.annotations
```

MCP mappers populate this field without interpreting its keys. The API
documentation explicitly notes that server-supplied annotations are untrusted
hints and must not be the sole basis for security decisions.

## Documentation PR

The MCP tools guide now shows how to inspect annotations in both SDKs and
documents their trust boundary.

## Type of Change

New feature

## Testing

- Python MCP agent tool tests: 12 passed
- Full Python suite: 4,645 passed
- Full TypeScript suite: 3,867 passed
- Python ruff and mypy checks passed for changed files
- TypeScript type-check, lint, formatting, and package build passed
- Documentation and snippet type-checks passed
- Site build: 857 pages, 856 HTML files, no broken links

- [ ] I ran `hatch run prepare`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
