### PR TITLE
docs(production): add agent execution boundaries

### DIFF
--- a/site/src/content/docs/user-guide/deploy/operating-agents-in-production.mdx
+++ b/site/src/content/docs/user-guide/deploy/operating-agents-in-production.mdx
@@ -71,8 +71,8 @@ that match the request's service-level objective and cost budget, then monitor
 how often each limit is reached. A useful baseline covers four independent
 dimensions:
 
-1. **Agent loop iterations**: Set per-invocation turn limits with the `limits`
-   argument in Python or the `limits` option in TypeScript. A turn limit bounds
+1. **Agent loop iterations**: Set per-invocation turn limits by passing
+   `limits`, which is named the same in both SDKs. A turn limit bounds
    repeated model and tool cycles and prevents an agent from running
    indefinitely.
 2. **Tool invocations**: Put quotas around tools that are costly, rate-limited,
@@ -81,12 +81,14 @@ dimensions:
    invocation.
 3. **Token consumption**: Use the invocation's total-token and output-token
    limits for an end-to-end budget. Also configure the model's
-   `max_tokens`/`maxTokens` setting to cap a single response. Invocation token
+   <Syntax py="max_tokens" ts="maxTokens" /> setting to cap a single response.
+   Invocation token
    limits are checked between turns, so one model call can exceed the configured
    total before the loop stops.
 4. **Wall-clock time**: Enforce a deadline outside the invocation and cancel the
    agent when it expires. Python can call `agent.cancel()` from a watchdog;
-   TypeScript can pass an `AbortSignal` or call `agent.cancel()`. Cancellation is
+   TypeScript can pass a `cancelSignal` to `invoke()`/`stream()` (for example,
+   `AbortSignal.timeout(30_000)`) or call `agent.cancel()`. Cancellation is
    cooperative for work already running inside a tool, so propagate the same
    deadline to downstream network calls and blocking operations.
 

--- a/site/src/content/docs/user-guide/deploy/operating-agents-in-production.mdx
+++ b/site/src/content/docs/user-guide/deploy/operating-agents-in-production.mdx
@@ -64,6 +64,52 @@ For production environments:
 
 ## Performance Optimization
 
+### Execution Limits
+
+Every production agent should have explicit execution boundaries. Choose limits
+that match the request's service-level objective and cost budget, then monitor
+how often each limit is reached. A useful baseline covers four independent
+dimensions:
+
+1. **Agent loop iterations**: Set per-invocation turn limits with the `limits`
+   argument in Python or the `limits` option in TypeScript. A turn limit bounds
+   repeated model and tool cycles and prevents an agent from running
+   indefinitely.
+2. **Tool invocations**: Put quotas around tools that are costly, rate-limited,
+   or have side effects. The [Limit Tool Counts hook](../concepts/agents/hooks.md#limit-tool-counts)
+   shows the same pattern for Python and TypeScript and resets counts for each
+   invocation.
+3. **Token consumption**: Use the invocation's total-token and output-token
+   limits for an end-to-end budget. Also configure the model's
+   `max_tokens`/`maxTokens` setting to cap a single response. Invocation token
+   limits are checked between turns, so one model call can exceed the configured
+   total before the loop stops.
+4. **Wall-clock time**: Enforce a deadline outside the invocation and cancel the
+   agent when it expires. Python can call `agent.cancel()` from a watchdog;
+   TypeScript can pass an `AbortSignal` or call `agent.cancel()`. Cancellation is
+   cooperative for work already running inside a tool, so propagate the same
+   deadline to downstream network calls and blocking operations.
+
+See [Invocation Limits](../concepts/agents/agent-loop.md#invocation-limits) for
+turn and token budgets, [Cancellation](../concepts/agents/agent-loop.md#cancellation)
+for timeout patterns, and [Stop Reasons](../concepts/agents/agent-loop.md#stop-reasons)
+for handling exhausted limits as expected outcomes rather than generic errors.
+
+#### Multi-agent safety boundaries
+
+Apply limits at both the orchestrator and node levels:
+
+- **Swarm**: Bound handoffs/iterations and total/per-node execution time in
+  Python; use `maxSteps`, `timeout`, and `nodeTimeout` in TypeScript. See
+  [Swarm Safety Mechanisms](../concepts/multi-agent/swarm.md#safety-mechanisms).
+- **Graph**: Bound total node executions and total/per-node execution time. The
+  exact configuration names differ by SDK; see
+  [Graph Components](../concepts/multi-agent/graph.md#graph-components).
+
+Do not rely on only one boundary. For example, a turn limit does not constrain a
+single slow tool, while a timeout alone does not provide a predictable token
+budget.
+
 ### Conversation Management
 
 Optimize memory usage and context window management in production:


### PR DESCRIPTION
## Motivation

Production agents need explicit execution boundaries for predictable cost,
latency, and resource usage. The production operations guide covered general
performance practices but did not explain how to prevent runaway model/tool
loops or unbounded multi-agent execution.

Fixes #2593

## Changes

- add an Execution Limits section under Performance Optimization
- cover per-invocation turn, output-token, and total-token budgets in Python and
  TypeScript
- distinguish invocation token budgets from per-response model limits
- point to the cross-language tool-count hook pattern
- explain deadline cancellation and cooperative cancellation inside tools
- document orchestrator- and node-level boundaries for Swarm and Graph
- link directly to the existing limits, cancellation, stop-reason, hook, and
  multi-agent references

## Documentation PR

This is a documentation-only change. It uses the current first-class invocation
limits and current Python/TypeScript multi-agent configuration rather than
introducing new examples or APIs.

## Type of Change

Documentation

## Testing

- Documentation TypeScript checks passed
- Documentation snippet type-checks passed
- Site build: 857 pages, 856 HTML files, no broken links
- Verified the rendered page contains the new sections and cross-links

- [ ] I ran `hatch run prepare`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
