### PR TITLE
feat(ts): support appending to notebooks

### DIFF
--- a/strands-ts/src/vended-tools/notebook/README.md
+++ b/strands-ts/src/vended-tools/notebook/README.md
@@ -79,7 +79,7 @@ The agent can perform these operations through natural language:
 - **Write**:
   - Append: "Append 'new line' to the notes notebook"
   - Replace: "Replace 'old text' with 'new text' in notes"
-  - Insert: "Add 'new line' to the notes notebook"
+  - Insert: "Insert 'new line' after 'old line' in notes"
 - **Clear**: "Clear the notes notebook"
 
 ## Example: Building a Task Manager

--- a/strands-ts/src/vended-tools/notebook/README.md
+++ b/strands-ts/src/vended-tools/notebook/README.md
@@ -77,6 +77,7 @@ The agent can perform these operations through natural language:
 - **List**: "List all notebooks"
 - **Read**: "Read the notes notebook" or "Read lines 5-10 from notes"
 - **Write**:
+  - Append: "Append 'new line' to the notes notebook"
   - Replace: "Replace 'old text' with 'new text' in notes"
   - Insert: "Add 'new line' to the notes notebook"
 - **Clear**: "Clear the notes notebook"
@@ -162,7 +163,7 @@ const content = await notebook.invoke(
 type NotebookInput = {
   mode: 'create' | 'list' | 'read' | 'write' | 'clear'
   name?: string // Notebook name (defaults to 'default')
-  newStr?: string // Content for create/write operations
+  newStr?: string // Content for create or append; replacement/insertion text for write
   oldStr?: string // Text to replace (write mode)
   insertLine?: string | number // Line to insert after (write mode)
   readRange?: [number, number] // Line range for read (1-indexed)

--- a/strands-ts/src/vended-tools/notebook/__tests__/notebook.test.ts
+++ b/strands-ts/src/vended-tools/notebook/__tests__/notebook.test.ts
@@ -246,6 +246,44 @@ describe('notebook tool', () => {
     })
   })
 
+  describe('write operation - append', () => {
+    it('appends newStr to a populated notebook', async () => {
+      const { state, context } = createFreshContext()
+      state.set('notebooks', { notes: 'First entry' })
+
+      const result = await notebook.invoke({ mode: 'write', name: 'notes', newStr: 'Second entry' }, context)
+
+      expect(result).toBe("Appended text to notebook 'notes'")
+      expect(state.get<NotebookState>('notebooks')!.notes).toBe('First entry\nSecond entry')
+    })
+
+    it('writes newStr directly to an empty notebook', async () => {
+      const { state, context } = createFreshContext()
+      state.set('notebooks', { notes: '' })
+
+      await notebook.invoke({ mode: 'write', name: 'notes', newStr: 'First entry' }, context)
+
+      expect(state.get<NotebookState>('notebooks')!.notes).toBe('First entry')
+    })
+
+    it('does not add an extra newline when the notebook already ends with one', async () => {
+      const { state, context } = createFreshContext()
+      state.set('notebooks', { notes: 'First entry\n' })
+
+      await notebook.invoke({ mode: 'write', name: 'notes', newStr: 'Second entry\nThird entry' }, context)
+
+      expect(state.get<NotebookState>('notebooks')!.notes).toBe('First entry\nSecond entry\nThird entry')
+    })
+
+    it('throws for a notebook that does not exist', async () => {
+      const { context } = createFreshContext()
+
+      await expect(notebook.invoke({ mode: 'write', name: 'missing', newStr: 'Entry' }, context)).rejects.toThrow(
+        "Notebook 'missing' not found"
+      )
+    })
+  })
+
   describe('write operation - line insertion', () => {
     it('inserts after line number', async () => {
       const { state, context } = createFreshContext()
@@ -434,8 +472,8 @@ describe('notebook tool', () => {
       let notebooks = state.get<NotebookState>('notebooks')
       expect(notebooks!.notes).toBe('Initial')
 
-      // Write to notebook - use oldStr/newStr instead of insertLine for appending
-      await notebook.invoke({ mode: 'write', name: 'notes', oldStr: 'Initial', newStr: 'Initial\nAdded' }, context)
+      // Append to notebook
+      await notebook.invoke({ mode: 'write', name: 'notes', newStr: 'Added' }, context)
       notebooks = state.get<NotebookState>('notebooks')
       expect(notebooks!.notes).toBe('Initial\nAdded')
 

--- a/strands-ts/src/vended-tools/notebook/__tests__/notebook.test.ts
+++ b/strands-ts/src/vended-tools/notebook/__tests__/notebook.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { notebook } from '../notebook.js'
-import type { NotebookState } from '../types.js'
+import type { NotebookInput, NotebookState } from '../types.js'
 import type { ToolContext } from '../../../index.js'
 import { StateStore } from '../../../state-store.js'
 import { createMockAgent } from '../../../__fixtures__/agent-helpers.js'
@@ -250,8 +250,9 @@ describe('notebook tool', () => {
     it('appends newStr to a populated notebook', async () => {
       const { state, context } = createFreshContext()
       state.set('notebooks', { notes: 'First entry' })
+      const input: NotebookInput = { mode: 'write', name: 'notes', newStr: 'Second entry' }
 
-      const result = await notebook.invoke({ mode: 'write', name: 'notes', newStr: 'Second entry' }, context)
+      const result = await notebook.invoke(input, context)
 
       expect(result).toBe("Appended text to notebook 'notes'")
       expect(state.get<NotebookState>('notebooks')!.notes).toBe('First entry\nSecond entry')
@@ -261,8 +262,9 @@ describe('notebook tool', () => {
       const { state, context } = createFreshContext()
       state.set('notebooks', { notes: '' })
 
-      await notebook.invoke({ mode: 'write', name: 'notes', newStr: 'First entry' }, context)
+      const result = await notebook.invoke({ mode: 'write', name: 'notes', newStr: 'First entry' }, context)
 
+      expect(result).toBe("Appended text to notebook 'notes'")
       expect(state.get<NotebookState>('notebooks')!.notes).toBe('First entry')
     })
 
@@ -270,9 +272,23 @@ describe('notebook tool', () => {
       const { state, context } = createFreshContext()
       state.set('notebooks', { notes: 'First entry\n' })
 
-      await notebook.invoke({ mode: 'write', name: 'notes', newStr: 'Second entry\nThird entry' }, context)
+      const result = await notebook.invoke(
+        { mode: 'write', name: 'notes', newStr: 'Second entry\nThird entry' },
+        context
+      )
 
+      expect(result).toBe("Appended text to notebook 'notes'")
       expect(state.get<NotebookState>('notebooks')!.notes).toBe('First entry\nSecond entry\nThird entry')
+    })
+
+    it('leaves the notebook unchanged when newStr is empty', async () => {
+      const { state, context } = createFreshContext()
+      state.set('notebooks', { notes: 'First entry' })
+
+      const result = await notebook.invoke({ mode: 'write', name: 'notes', newStr: '' }, context)
+
+      expect(result).toBe("No changes made to notebook 'notes'")
+      expect(state.get<NotebookState>('notebooks')!.notes).toBe('First entry')
     })
 
     it('throws for a notebook that does not exist', async () => {

--- a/strands-ts/src/vended-tools/notebook/notebook.ts
+++ b/strands-ts/src/vended-tools/notebook/notebook.ts
@@ -66,7 +66,7 @@ const notebookInputSchema = z
 export const notebook = tool({
   name: 'notebook',
   description:
-    'Manages text notebooks for note-taking and documentation. Supports create, list, read, write (append, replace, or insert), and clear operations. In write mode: newStr alone appends to the end; newStr with oldStr replaces matching text; newStr with insertLine inserts at a position. The notebook must already exist—use create first if you are not sure it does. Notebooks persist within the agent invocation.',
+    'Manages text notebooks for note-taking and documentation. Supports create, list, read, write (append, replace, or insert), and clear operations. In write mode: newStr alone appends to the end; newStr with oldStr replaces matching text; newStr with insertLine inserts at a position. A write only succeeds on a notebook that already exists: use list to check, or create to start a new one (create replaces any existing content). Notebooks persist within the agent invocation.',
   inputSchema: notebookInputSchema,
   callback: (input, context) => {
     if (!context) {

--- a/strands-ts/src/vended-tools/notebook/notebook.ts
+++ b/strands-ts/src/vended-tools/notebook/notebook.ts
@@ -11,7 +11,10 @@ const notebookInputSchema = z
       .enum(['create', 'list', 'read', 'write', 'clear'])
       .describe('The operation to perform: `create`, `list`, `read`, `write`, `clear`.'),
     name: z.string().optional().describe('Name of the notebook to operate on. Defaults to "default".'),
-    newStr: z.string().optional().describe('New string for replacement or insertion operations.'),
+    newStr: z
+      .string()
+      .optional()
+      .describe('Text to append, or the new string for replacement and insertion operations.'),
     readRange: z
       .array(z.number())
       .optional()
@@ -30,13 +33,13 @@ const notebookInputSchema = z
       if (data.mode === 'write') {
         const hasReplacement = data.oldStr !== undefined && data.newStr !== undefined
         const hasInsertion = data.insertLine !== undefined && data.newStr !== undefined
-        return hasReplacement || hasInsertion
+        const hasAppend = data.oldStr === undefined && data.insertLine === undefined && data.newStr !== undefined
+        return hasReplacement || hasInsertion || hasAppend
       }
       return true
     },
     {
-      message:
-        'Write operation requires either (oldStr + newStr) for replacement or (insertLine + newStr) for insertion',
+      message: 'Write operation requires newStr, optionally with oldStr for replacement or insertLine for insertion',
     }
   )
 
@@ -44,7 +47,7 @@ const notebookInputSchema = z
  * Notebook tool for managing persistent text notebooks.
  *
  * Notebooks are stored in agent state under the 'notebooks' key and persist within an agent session.
- * Supports create, list, read, write (replace/insert), and clear operations.
+ * Supports create, list, read, write (append/replace/insert), and clear operations.
  *
  * @example
  * ```typescript
@@ -63,7 +66,7 @@ const notebookInputSchema = z
 export const notebook = tool({
   name: 'notebook',
   description:
-    'Manages text notebooks for note-taking and documentation. Supports create, list, read, write (replace or insert), and clear operations. Notebooks persist within the agent invocation.',
+    'Manages text notebooks for note-taking and documentation. Supports create, list, read, write (append, replace, or insert), and clear operations. In write mode, newStr by itself appends text. Notebooks persist within the agent invocation.',
   inputSchema: notebookInputSchema,
   callback: (input, context) => {
     if (!context) {
@@ -183,7 +186,7 @@ function handleRead(notebooks: Record<string, string>, name: string, readRange?:
 }
 
 /**
- * Handles write operation (both string replacement and line insertion).
+ * Handles write operation (append, string replacement, or line insertion).
  */
 function handleWrite(
   notebooks: Record<string, string>,
@@ -194,6 +197,14 @@ function handleWrite(
 ): string {
   if (!(name in notebooks)) {
     throw new Error(`Notebook '${name}' not found`)
+  }
+
+  // Append mode
+  if (oldStr === undefined && insertLine === undefined && newStr !== undefined) {
+    const content = notebooks[name]!
+    const separator = content.length > 0 && !content.endsWith('\n') ? '\n' : ''
+    notebooks[name] = `${content}${separator}${newStr}`
+    return `Appended text to notebook '${name}'`
   }
 
   // String replacement mode

--- a/strands-ts/src/vended-tools/notebook/notebook.ts
+++ b/strands-ts/src/vended-tools/notebook/notebook.ts
@@ -66,7 +66,7 @@ const notebookInputSchema = z
 export const notebook = tool({
   name: 'notebook',
   description:
-    'Manages text notebooks for note-taking and documentation. Supports create, list, read, write (append, replace, or insert), and clear operations. In write mode, newStr by itself appends text. Notebooks persist within the agent invocation.',
+    'Manages text notebooks for note-taking and documentation. Supports create, list, read, write (append, replace, or insert), and clear operations. In write mode: newStr alone appends to the end; newStr with oldStr replaces matching text; newStr with insertLine inserts at a position. The notebook must already exist—use create first if you are not sure it does. Notebooks persist within the agent invocation.',
   inputSchema: notebookInputSchema,
   callback: (input, context) => {
     if (!context) {
@@ -201,6 +201,9 @@ function handleWrite(
 
   // Append mode
   if (oldStr === undefined && insertLine === undefined && newStr !== undefined) {
+    if (newStr.length === 0) {
+      return `No changes made to notebook '${name}'`
+    }
     const content = notebooks[name]!
     const separator = content.length > 0 && !content.endsWith('\n') ? '\n' : ''
     notebooks[name] = `${content}${separator}${newStr}`

--- a/strands-ts/src/vended-tools/notebook/types.ts
+++ b/strands-ts/src/vended-tools/notebook/types.ts
@@ -45,12 +45,15 @@ export interface ReadInput {
  * Input parameters for write operation (append to the end).
  * - mode: Operation mode, must be 'write'
  * - name: Name of the notebook to append to
- * - newStr: Text to append to the end of the notebook
+ * - newStr: Text to append. A newline separator is added only when the notebook is non-empty and
+ *   does not already end in one; an empty string is a no-op.
  */
 export interface WriteAppendInput {
   mode: 'write'
   name?: string
   newStr: string
+  oldStr?: never
+  insertLine?: never
 }
 
 /**

--- a/strands-ts/src/vended-tools/notebook/types.ts
+++ b/strands-ts/src/vended-tools/notebook/types.ts
@@ -42,6 +42,18 @@ export interface ReadInput {
 }
 
 /**
+ * Input parameters for write operation (append to the end).
+ * - mode: Operation mode, must be 'write'
+ * - name: Name of the notebook to append to
+ * - newStr: Text to append to the end of the notebook
+ */
+export interface WriteAppendInput {
+  mode: 'write'
+  name?: string
+  newStr: string
+}
+
+/**
  * Input parameters for write operation (string replacement).
  * - mode: Operation mode, must be 'write'
  * - name: Name of the notebook to write to
@@ -82,4 +94,5 @@ export interface ClearInput {
 /**
  * Union type of all valid notebook inputs.
  */
-export type NotebookInput = CreateInput | ListInput | ReadInput | WriteReplaceInput | WriteInsertInput | ClearInput
+export type NotebookInput =
+  CreateInput | ListInput | ReadInput | WriteAppendInput | WriteReplaceInput | WriteInsertInput | ClearInput


### PR DESCRIPTION
## Summary

- allow notebook `write` calls with only `newStr` to append content
- preserve clean line boundaries for empty notebooks and content that already ends in a newline
- clarify the tool schema and description, with regressions for append and existing persistence behavior

## Testing

- `npm test` (3,871 tests)
- `npm run type-check`
- `npm run lint`
- `npm run format:check`
- `npm run check:browser-bundle`

Closes #2530