### PR TITLE
fix(plugins): preserve initialization failures

### DIFF
--- a/strands-ts/src/agent/__tests__/agent.hook.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.hook.test.ts
@@ -1780,4 +1780,20 @@ describe('Agent Hooks Integration', () => {
       expect(queue).toHaveLength(0)
     })
   })
+
+  describe('plugin initialization failure', () => {
+    it('keeps a plugin initialization failure fail-closed across retries', async () => {
+      const initializationError = new Error('plugin initialization failed')
+      const plugin: Plugin = {
+        name: 'failing-plugin',
+        initAgent: () => {
+          throw initializationError
+        },
+      }
+      const agent = new Agent({ model: new MockMessageModel(), plugins: [plugin] })
+
+      await expect(agent.initialize()).rejects.toBe(initializationError)
+      await expect(agent.initialize()).rejects.toBe(initializationError)
+    })
+  })
 })

--- a/strands-ts/src/multiagent/__tests__/plugins.test.ts
+++ b/strands-ts/src/multiagent/__tests__/plugins.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from 'vitest'
+import { MultiAgentPluginRegistry } from '../plugins.js'
+import type { MultiAgent } from '../multiagent.js'
+
+describe('MultiAgentPluginRegistry', () => {
+  describe('initialize', () => {
+    it('preserves initMultiAgent failures across initialization attempts', async () => {
+      const initializationError = new Error('plugin initialization failed')
+      const initMultiAgent = vi.fn(() => {
+        throw initializationError
+      })
+      const registry = new MultiAgentPluginRegistry([{ name: 'failing-plugin', initMultiAgent }])
+      const orchestrator = {} as MultiAgent
+
+      // Keeps multi-agent plugin initialization fail-closed across retries (#3477).
+      await expect(registry.initialize(orchestrator)).rejects.toBe(initializationError)
+      await expect(registry.initialize(orchestrator)).rejects.toBe(initializationError)
+
+      expect(initMultiAgent).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/strands-ts/src/multiagent/__tests__/plugins.test.ts
+++ b/strands-ts/src/multiagent/__tests__/plugins.test.ts
@@ -12,7 +12,7 @@ describe('MultiAgentPluginRegistry', () => {
       const registry = new MultiAgentPluginRegistry([{ name: 'failing-plugin', initMultiAgent }])
       const orchestrator = {} as MultiAgent
 
-      // Keeps multi-agent plugin initialization fail-closed across retries (#3477).
+      // Keeps multi-agent plugin initialization fail-closed across retries.
       await expect(registry.initialize(orchestrator)).rejects.toBe(initializationError)
       await expect(registry.initialize(orchestrator)).rejects.toBe(initializationError)
 

--- a/strands-ts/src/multiagent/__tests__/swarm.test.ts
+++ b/strands-ts/src/multiagent/__tests__/swarm.test.ts
@@ -11,6 +11,7 @@ import { AgentNode } from '../nodes.js'
 import { Swarm } from '../swarm.js'
 import { SessionManager } from '../../session/session-manager.js'
 import { MockSnapshotStorage } from '../../__fixtures__/mock-storage-provider.js'
+import type { MultiAgentPlugin } from '../plugins.js'
 
 /**
  * Creates an agent that produces a structured output handoff via the strands_structured_output tool.
@@ -611,6 +612,27 @@ describe('Swarm', () => {
       // B no longer exists, so _findResumeNode falls back to start node A
       expect(result.status).toBe(Status.COMPLETED)
       expect(result.results.map((r) => r.nodeId)).toStrictEqual(['a', 'a'])
+    })
+  })
+
+  describe('plugin initialization failure', () => {
+    it('keeps a plugin initialization failure fail-closed across retries', async () => {
+      const initializationError = new Error('plugin initialization failed')
+      const plugin: MultiAgentPlugin = {
+        name: 'failing-plugin',
+        initMultiAgent: () => {
+          throw initializationError
+        },
+      }
+      const agent = new Agent({
+        model: new MockMessageModel().addTurn({ type: 'textBlock', text: 'hi' }),
+        printer: false,
+        id: 'a',
+      })
+      const swarm = new Swarm({ nodes: [agent], start: 'a', plugins: [plugin] })
+
+      await expect(swarm.initialize()).rejects.toBe(initializationError)
+      await expect(swarm.initialize()).rejects.toBe(initializationError)
     })
   })
 })

--- a/strands-ts/src/multiagent/plugins.ts
+++ b/strands-ts/src/multiagent/plugins.ts
@@ -70,7 +70,7 @@ export class MultiAgentPluginRegistry {
 
   /**
    * Initialize all pending plugins with the orchestrator.
-   * Safe to call multiple times — only runs once.
+   * Safe to call multiple times — subsequent calls share the first initialization result, including failures.
    *
    * @param orchestrator - The orchestrator instance to initialize plugins with
    */

--- a/strands-ts/src/multiagent/plugins.ts
+++ b/strands-ts/src/multiagent/plugins.ts
@@ -61,6 +61,7 @@ export interface MultiAgentPlugin {
 export class MultiAgentPluginRegistry {
   private readonly _plugins: Map<string, MultiAgentPlugin>
   private readonly _pending: MultiAgentPlugin[]
+  private _initializationPromise?: Promise<void>
 
   constructor(plugins: MultiAgentPlugin[] = []) {
     this._plugins = new Map()
@@ -74,6 +75,11 @@ export class MultiAgentPluginRegistry {
    * @param orchestrator - The orchestrator instance to initialize plugins with
    */
   async initialize(orchestrator: MultiAgent): Promise<void> {
+    this._initializationPromise ??= this._initialize(orchestrator)
+    return this._initializationPromise
+  }
+
+  private async _initialize(orchestrator: MultiAgent): Promise<void> {
     while (this._pending.length > 0) {
       const plugin = this._pending.shift()!
       await this._addAndInit(plugin, orchestrator)

--- a/strands-ts/src/plugins/__tests__/registry.test.ts
+++ b/strands-ts/src/plugins/__tests__/registry.test.ts
@@ -169,7 +169,7 @@ describe('PluginRegistry', () => {
       })
       registry = new PluginRegistry([{ name: 'failing-plugin', initAgent }])
 
-      // Keeps plugin initialization fail-closed across retries (#3477).
+      // Keeps plugin initialization fail-closed across retries.
       await expect(registry.initialize(mockAgent)).rejects.toBe(initializationError)
       await expect(registry.initialize(mockAgent)).rejects.toBe(initializationError)
 

--- a/strands-ts/src/plugins/__tests__/registry.test.ts
+++ b/strands-ts/src/plugins/__tests__/registry.test.ts
@@ -162,6 +162,20 @@ describe('PluginRegistry', () => {
       expect(plugin.initialized).toBe(true)
     })
 
+    it('preserves initAgent failures across initialization attempts', async () => {
+      const initializationError = new Error('plugin initialization failed')
+      const initAgent = vi.fn(() => {
+        throw initializationError
+      })
+      registry = new PluginRegistry([{ name: 'failing-plugin', initAgent }])
+
+      // Keeps plugin initialization fail-closed across retries (#3477).
+      await expect(registry.initialize(mockAgent)).rejects.toBe(initializationError)
+      await expect(registry.initialize(mockAgent)).rejects.toBe(initializationError)
+
+      expect(initAgent).toHaveBeenCalledTimes(1)
+    })
+
     it('is idempotent — calling initialize twice only runs plugins once', async () => {
       const plugin = new InitializableTestPlugin()
       registry = new PluginRegistry([plugin])

--- a/strands-ts/src/plugins/registry.ts
+++ b/strands-ts/src/plugins/registry.ts
@@ -23,7 +23,7 @@ export class PluginRegistry {
 
   /**
    * Initialize all pending plugins with the agent.
-   * Safe to call multiple times — only runs once per pending batch.
+   * Safe to call multiple times — subsequent calls share the first initialization result, including failures.
    *
    * @param agent - The agent instance to initialize plugins with
    */

--- a/strands-ts/src/plugins/registry.ts
+++ b/strands-ts/src/plugins/registry.ts
@@ -14,6 +14,7 @@ import type { LocalAgent } from '../types/agent.js'
 export class PluginRegistry {
   private readonly _plugins: Map<string, Plugin>
   private readonly _pending: Plugin[]
+  private _initializationPromise?: Promise<void>
 
   constructor(plugins: Plugin[] = []) {
     this._plugins = new Map()
@@ -27,6 +28,11 @@ export class PluginRegistry {
    * @param agent - The agent instance to initialize plugins with
    */
   async initialize(agent: LocalAgent): Promise<void> {
+    this._initializationPromise ??= this._initialize(agent)
+    return this._initializationPromise
+  }
+
+  private async _initialize(agent: LocalAgent): Promise<void> {
     while (this._pending.length > 0) {
       const plugin = this._pending.shift()!
       await this._addAndInit(plugin, agent)


### PR DESCRIPTION
## Description

When a plugin's `initAgent()` throws, a later initialization attempt can find an empty pending queue and mark the agent initialized without the configured plugin. The registry now preserves the original initialization promise, so every subsequent `initialize()` or `invoke()` attempt rejects with the same error instead of running with partially installed plugin behavior.

### Compatibility / Risk

No public types or method signatures change. A registry that fails plugin initialization remains failed for its lifetime; callers must construct a new agent after correcting the plugin or configuration. This avoids re-running a plugin that may already have installed hooks, middleware, or tools before throwing.

## Related Issues

Fixes #3477

## Documentation PR

No documentation changes are needed; this restores fail-closed initialization behavior without changing the public API.

## Type of Change

Bug fix

## Testing

- `npx vitest run --project unit-node src/plugins/__tests__/registry.test.ts` — 9 passed
- `npm run test:all:coverage` — 7,071 passed, 5 skipped across Node.js and Chromium
- `npm run test:package` — ESM, CommonJS, exports, and package contents passed
- Built-SDK Agent reproduction — both initialization attempts rejected with the original error and `initAgent()` ran once

- [ ] I ran `hatch run prepare` (this is a TypeScript-only change; the equivalent build, lint, format, type, browser, test, and package checks were run directly)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
