### PR TITLE
docs(site): add agent-as-tool delegation docs

### DIFF
--- a/site/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.mdx
@@ -337,29 +337,37 @@ This example demonstrates how Strands Agents SDK enables specialized experts to 
 
 ## Delegation
 
-When you mark a tool agent as a delegate, the orchestrator returns its
-response directly to the caller, skipping the extra orchestrator model round-trip.
-Use delegation when the sub-agent's response is already complete and the
-orchestrator adds no value by processing it further:
-
+Sometimes, you do not want a sub-agent's response to be re-processed by the
+orchestrator agent, since it would incur unnecessary token usage and potentially
+corrupt the sub-agent's response. For example:
 - A coding agent returning generated source code that shouldn't be rephrased
 - A customer service agent whose compliance-reviewed language must reach
   the user unchanged
 - A retrieval agent returning structured data the caller consumes directly
 
-To mark a tool agent as a delegate, pass `delegate: true` to
-<Syntax py=".as_tool()" ts=".asTool()" />:
+In that case, you can mark a tool agent as a delegate by passing `delegate: true` to
+<Syntax py=".as_tool()" ts=".asTool()" />. When you do so, the orchestrator agent
+returns the delegate's response directly to the user, skipping the extra orchestrator
+model round-trip.
 
 <Tabs>
 <Tab label="Python">
 
 ```python
+from pydantic import BaseModel
 from strands import Agent
+
+
+class BillingResponse(BaseModel):
+    summary: str
+    refund_amount: float
+
 
 billing_agent = Agent(
     name="billing_expert",
     description="Answers billing questions: charges, refunds, and invoices.",
     system_prompt="You handle billing questions with precision.",
+    structured_output_model=BillingResponse,
 )
 
 orchestrator = Agent(
@@ -369,7 +377,7 @@ Answer general questions yourself.""",
 )
 
 result = orchestrator("Why was I charged twice?")
-# result contains the billing agent's response directly
+# result contains the billing agent's structured JSON response, unchanged
 ```
 </Tab>
 <Tab label="TypeScript">
@@ -387,12 +395,12 @@ model processing. Streaming events from the delegate surface natively in
 the parent's stream, so callers see the specialist's tokens as they arrive.
 
 Limitations to be aware of:
-- **Single delegated tool per turn**: Delegated and non-delegated tools
-  can exist on the same agent. However, a delegated tool must be
-  the only tool call in its turn. The SDK cancels the batch if
-  other tools are requested alongside it.
+- **Single delegated tool per turn**: An agent can have both delegated and
+  non-delegated tools. However, if the agent calls a delegated tool during
+  a turn, that tool must be called alone. The SDK cancels the tool
+  batch if other tools are requested alongside the delegated tool.
 - **Incompatible with stateful models**: Delegation exits the
-  loop early, which would leave an unclosed function call on
+  agent loop early, which would leave an unclosed function call on
   the server for models that manage conversation state
   server-side. Combining delegated tools with stateful models
   is not supported.

--- a/site/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.mdx
@@ -341,7 +341,7 @@ response directly to the caller, skipping the extra orchestrator model round-tri
 Use delegation when the sub-agent's response is already complete and the
 orchestrator adds no value by processing it further:
 
-- A coding agent returning generated source that shouldn't be rephrased
+- A coding agent returning generated source code that shouldn't be rephrased
 - A customer service agent whose compliance-reviewed language must reach
   the user unchanged
 - A retrieval agent returning structured data the caller consumes directly
@@ -380,39 +380,21 @@ result = orchestrator("Why was I charged twice?")
 </Tabs>
 
 On success, the agent loop stops with
-<Syntax py="stop_reason == 'end_turn'" ts="stopReason === 'endTurn'" />
-and the `AgentResult` contains the delegate's content without additional
-model processing. Structured JSON output is serialized to text.
-Streaming events from the delegate surface natively in the parent's
-stream, so callers see the specialist's tokens as they arrive.
+<Syntax py="stop_reason == 'end_turn'" ts="stopReason === 'endTurn'" /> and
+the `AgentResult` contains the delegate's content without additional
+model processing. Streaming events from the delegate surface natively in
+the parent's stream, so callers see the specialist's tokens as they arrive.
 
-If the delegate throws, the error surfaces as a failed tool result and
-the orchestrator can attempt recovery on the next turn.
-
-Delegated and non-delegated tools can coexist on the same
-orchestrator. But when the model calls a delegated tool agent, it must
-be the only tool call in that turn. The SDK communicates this to
-the model by appending an instruction to the tool agent's
-description and enforces it at runtime by cancelling every tool in
-the batch if other tools are requested alongside it.
-
-Additional limitations to be aware of:
-
-- **Incompatible with stateful models**: Delegation exits the loop early,
-  which would leave an unclosed function call on the server for models that
-  manage conversation state server-side. The SDK throws at agent
-  initialization if you register a delegation tool on a stateful model.
-  Delegation tools added later silently behave as ordinary tools (in TypeScript)
-  or fail with an error tool result (in Python).
-- **Delegation does not bubble up**: If a delegate is itself an orchestrator
-  that delegates, that only ends its own loop. The agent one level up
-  that invoked it as a non-delegated tool still receives a tool
-  result and continues its loop normally.
-- **Session persistence timing** *(TypeScript)*: The delegation content message
-  is written to `agent.messages` after the loop exits. Session managers
-  configured with `saveLatestOn: 'message'` may persist the `endTurn`
-  placeholder rather than the final delegation content. The default
-  `saveLatestOn: 'invocation'` is unaffected.
+Limitations to be aware of:
+- **Single delegated tool per turn**: Delegated and non-delegated tools
+  can exist on the same agent. However, a delegated tool must be
+  the only tool call in its turn. The SDK cancels the batch if
+  other tools are requested alongside it.
+- **Incompatible with stateful models**: Delegation exits the
+  loop early, which would leave an unclosed function call on
+  the server for models that manage conversation state
+  server-side. Combining delegated tools with stateful models
+  is not supported.
 
 ## Remote Agents with A2A
 

--- a/site/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.mdx
@@ -7,6 +7,7 @@ tags: [multi-agent, tool-authoring, tool-execution]
 sourceLinks:
   - path: strands-py/src/strands/agent/_agent_as_tool.py
   - path: strands-ts/src/agent/agent-as-tool.ts
+  - path: strands-ts/src/agent/agent-delegation.ts
 ---
 
 ## The Concept: Agents as Tools
@@ -332,6 +333,86 @@ response = orchestrator(customer_query)
 </Tabs>
 
 This example demonstrates how Strands Agents SDK enables specialized experts to collaborate on complex queries requiring multiple domains of knowledge. The orchestrator intelligently routes different aspects of the query to the appropriate specialized agents, then synthesizes their responses into a comprehensive answer.
+
+## Delegation
+
+When you mark a tool agent as a delegate, the orchestrator returns its
+response directly to the caller, skipping the extra orchestrator model round-trip.
+Use delegation when the sub-agent's response is already complete and the
+orchestrator adds no value by processing it further:
+
+- A coding agent returning generated source that shouldn't be rephrased
+- A customer service agent whose compliance-reviewed language must reach
+  the user unchanged
+- A retrieval agent returning structured data the caller consumes directly
+
+To mark a tool agent as a delegate, pass `delegate: true` to
+<Syntax py=".as_tool()" ts=".asTool()" />:
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands import Agent
+
+billing_agent = Agent(
+    name="billing_expert",
+    description="Answers billing questions: charges, refunds, and invoices.",
+    system_prompt="You handle billing questions with precision.",
+)
+
+orchestrator = Agent(
+    system_prompt="""Route billing questions to billing_expert.
+Answer general questions yourself.""",
+    tools=[billing_agent.as_tool(delegate=True)],
+)
+
+result = orchestrator("Why was I charged twice?")
+# result contains the billing agent's response directly
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/multi-agent/agents-as-tools.ts:delegation_basic"
+```
+</Tab>
+</Tabs>
+
+On success, the agent loop stops with
+<Syntax py="stop_reason == 'end_turn'" ts="stopReason === 'endTurn'" />
+and the `AgentResult` contains the delegate's content without additional
+model processing. Structured JSON output is serialized to text.
+Streaming events from the delegate surface natively in the parent's
+stream, so callers see the specialist's tokens as they arrive.
+
+If the delegate throws, the error surfaces as a failed tool result and
+the orchestrator can attempt recovery on the next turn.
+
+Delegated and non-delegated tools can coexist on the same
+orchestrator. But when the model calls a delegated tool agent, it must
+be the only tool call in that turn. The SDK communicates this to
+the model by appending an instruction to the tool agent's
+description and enforces it at runtime by cancelling every tool in
+the batch if other tools are requested alongside it.
+
+Additional limitations to be aware of:
+
+- **Incompatible with stateful models**: Delegation exits the loop early,
+  which would leave an unclosed function call on the server for models that
+  manage conversation state server-side. The SDK throws at agent
+  initialization if you register a delegation tool on a stateful model.
+  Delegation tools added later silently behave as ordinary tools (in TypeScript)
+  or fail with an error tool result (in Python).
+- **Delegation does not bubble up**: If a delegate is itself an orchestrator
+  that delegates, that only ends its own loop. The agent one level up
+  that invoked it as a non-delegated tool still receives a tool
+  result and continues its loop normally.
+- **Session persistence timing** *(TypeScript)*: The delegation content message
+  is written to `agent.messages` after the loop exits. Session managers
+  configured with `saveLatestOn: 'message'` may persist the `endTurn`
+  placeholder rather than the final delegation content. The default
+  `saveLatestOn: 'invocation'` is unaffected.
 
 ## Remote Agents with A2A
 

--- a/site/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.mdx
@@ -6,6 +6,7 @@ sidebar:
 tags: [multi-agent, tool-authoring, tool-execution]
 sourceLinks:
   - path: strands-py/src/strands/agent/_agent_as_tool.py
+  - path: strands-py/src/strands/agent/_agent_delegation.py
   - path: strands-ts/src/agent/agent-as-tool.ts
   - path: strands-ts/src/agent/agent-delegation.ts
 ---

--- a/site/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.ts
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.ts
@@ -161,10 +161,16 @@ void orchestratorExample
 
 async function delegationBasicExample() {
   // --8<-- [start:delegation_basic]
+  const BillingResponseSchema = z.object({
+    summary: z.string(),
+    refundAmount: z.number(),
+  })
+
   const billingAgent = new Agent({
     name: 'billing_expert',
     description: 'Answers billing questions: charges, refunds, and invoices.',
     systemPrompt: 'You handle billing questions with precision.',
+    structuredOutputSchema: BillingResponseSchema,
     printer: false,
   })
 
@@ -175,7 +181,7 @@ Answer general questions yourself.`,
   })
 
   const result = await orchestrator.invoke('Why was I charged twice?')
-  // result contains the billing agent's response directly
+  // result contains the billing agent's structured JSON response, unchanged
   // --8<-- [end:delegation_basic]
   void result
 }

--- a/site/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.ts
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.ts
@@ -158,3 +158,25 @@ Always select the most appropriate tool based on the user's query.`,
 }
 
 void orchestratorExample
+
+async function delegationBasicExample() {
+  // --8<-- [start:delegation_basic]
+  const billingAgent = new Agent({
+    name: 'billing_expert',
+    description: 'Answers billing questions: charges, refunds, and invoices.',
+    systemPrompt: 'You handle billing questions with precision.',
+    printer: false,
+  })
+
+  const orchestrator = new Agent({
+    systemPrompt: `Route billing questions to billing_expert.
+Answer general questions yourself.`,
+    tools: [billingAgent.asTool({ delegate: true })],
+  })
+
+  const result = await orchestrator.invoke('Why was I charged twice?')
+  // result contains the billing agent's response directly
+  // --8<-- [end:delegation_basic]
+  void result
+}
+void delegationBasicExample


### PR DESCRIPTION
## Description

Add documentation covering the agent-as-tool delegation option introduced in #3265 (TypeScript) and #3346 (Python).

## Related Issues

https://github.com/strands-agents/harness-sdk/issues/3257
https://github.com/strands-agents/harness-sdk/issues/3479

## Documentation PR

This PR is the documentation itself.

## Type of Change

Documentation update

## Testing

- [x] `npm run typecheck:snippets` passes (no new type errors from the TS snippet)
- [x] `npx prettier --check` passes on the snippet file
- [x] No lines exceed 90 characters in new content

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
