### PR TITLE
feat(model-routing): add per-call selection, strategies, and ordered fallback

### DIFF
--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -62,6 +62,7 @@ from ..interventions.registry import InterventionRegistry
 from ..memory import MemoryManager, MemoryManagerConfig
 from ..models.bedrock import BedrockModel
 from ..models.model import Model, _ModelPlugin
+from ..models.routing import ModelRouter
 from ..plugins import Plugin
 from ..plugins.registry import _PluginRegistry
 from ..sandbox import Sandbox
@@ -160,7 +161,7 @@ class Agent(AgentBase):
 
     def __init__(
         self,
-        model: Model | str | None = None,
+        model: Model | str | ModelRouter | None = None,
         messages: Messages | None = None,
         tools: list[Union[str, dict[str, str], "ToolProvider", Any]] | None = None,
         system_prompt: str | list[SystemContentBlock] | None = None,
@@ -192,7 +193,8 @@ class Agent(AgentBase):
 
         Args:
             model: Provider for running inference or a string representing the model-id for Bedrock to use.
-                Defaults to strands.models.BedrockModel if None.
+                May also be a ``ModelRouter``, whose first candidate is resolved to a concrete model and
+                exposed as ``agent.model``. Defaults to strands.models.BedrockModel if None.
             messages: List of initial messages to pre-load into the conversation.
                 Defaults to an empty list if None.
             tools: List of tools to make available to the agent.
@@ -291,7 +293,16 @@ class Agent(AgentBase):
         Raises:
             ValueError: If agent id contains path separators.
         """
-        self.model = BedrockModel() if not model else BedrockModel(model_id=model) if isinstance(model, str) else model
+        self._model_router: ModelRouter | None = None
+        if isinstance(model, ModelRouter):
+            self._model_router = model
+            self.model = model.default_model
+        elif not model:
+            self.model = BedrockModel()
+        elif isinstance(model, str):
+            self.model = BedrockModel(model_id=model)
+        else:
+            self.model = model
         self.messages = messages if messages is not None else []
         if sandbox is not None and not isinstance(sandbox, Sandbox):
             raise TypeError(f"sandbox must be a Sandbox instance or None, got {type(sandbox).__name__}")
@@ -477,6 +488,9 @@ class Agent(AgentBase):
 
         # Register built-in plugins
         self._plugin_registry.add_and_init(_ModelPlugin())
+
+        if self._model_router is not None:
+            self._plugin_registry.add_and_init(self._model_router)
 
         plugins_to_register = resolved_plugins if resolved_plugins is not None else plugins
         if plugins_to_register:

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -417,6 +417,17 @@ class Agent(AgentBase):
 
         self._middleware_registry = MiddlewareRegistry()
 
+        # Routing selects the per-call model and must run before capability middleware that reads
+        # context.model. Input handlers run in registration order, so it is registered here in
+        # __init__ (before the agentic middleware below) rather than from ModelRouter.init_agent,
+        # which runs during later plugin registration and would order routing after it.
+        if self._model_router is not None:
+            from .._middleware.stages import InvokeModelStage
+
+            self._middleware_registry.add_middleware(
+                InvokeModelStage.Input, self._model_router._selection_middleware()
+            )
+
         # In agentic mode, surface live token usage to the model so it can decide when to compress.
         if context_manager == "agentic":
             from .._context_manager.modes.agentic.agentic_context import create_token_usage_middleware

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -416,17 +416,11 @@ class Agent(AgentBase):
         self.hooks = HookRegistry()
 
         self._middleware_registry = MiddlewareRegistry()
+        self._plugin_registry = _PluginRegistry(self)
 
-        # Routing selects the per-call model and must run before capability middleware that reads
-        # context.model. Input handlers run in registration order, so it is registered here in
-        # __init__ (before the agentic middleware below) rather than from ModelRouter.init_agent,
-        # which runs during later plugin registration and would order routing after it.
+        # Input handlers preserve registration order, so initialize routing before capability middleware.
         if self._model_router is not None:
-            from .._middleware.stages import InvokeModelStage
-
-            self._middleware_registry.add_middleware(
-                InvokeModelStage.Input, self._model_router._selection_middleware()
-            )
+            self._plugin_registry.add_and_init(self._model_router)
 
         # In agentic mode, surface live token usage to the model so it can decide when to compress.
         if context_manager == "agentic":
@@ -434,8 +428,6 @@ class Agent(AgentBase):
             from .._middleware.stages import InvokeModelStage
 
             self._middleware_registry.add_middleware(InvokeModelStage.Input, create_token_usage_middleware())
-
-        self._plugin_registry = _PluginRegistry(self)
 
         self._interrupt_state = _InterruptState()
 
@@ -499,9 +491,6 @@ class Agent(AgentBase):
 
         # Register built-in plugins
         self._plugin_registry.add_and_init(_ModelPlugin())
-
-        if self._model_router is not None:
-            self._plugin_registry.add_and_init(self._model_router)
 
         plugins_to_register = resolved_plugins if resolved_plugins is not None else plugins
         if plugins_to_register:

--- a/strands-py/src/strands/event_loop/_retry.py
+++ b/strands-py/src/strands/event_loop/_retry.py
@@ -91,7 +91,7 @@ class ModelRetryStrategy(HookProvider):
         delay: int = self._initial_delay * (2**attempt)
         return min(delay, self._max_delay)
 
-    def _reset_retry_state(self) -> None:
+    def reset_retry_state(self) -> None:
         """Reset retry state to initial values."""
         self._current_attempt = 0
 
@@ -101,7 +101,7 @@ class ModelRetryStrategy(HookProvider):
         Args:
             event: The AfterInvocationEvent signaling invocation completion.
         """
-        self._reset_retry_state()
+        self.reset_retry_state()
 
     async def _handle_after_model_call(self, event: AfterModelCallEvent) -> None:
         """Handle model call completion and determine if retry is needed.
@@ -129,12 +129,12 @@ class ModelRetryStrategy(HookProvider):
                 "stop_reason=<%s> | model call succeeded, resetting retry state",
                 event.stop_response.stop_reason,
             )
-            self._reset_retry_state()
+            self.reset_retry_state()
             return
 
         # Check if we have an exception and reset state if no exception
         if event.exception is None:
-            self._reset_retry_state()
+            self.reset_retry_state()
             return
 
         if not self.is_retryable(event.exception):

--- a/strands-py/src/strands/models/routing/__init__.py
+++ b/strands-py/src/strands/models/routing/__init__.py
@@ -1,12 +1,21 @@
 """Model routing primitives.
 
-``ModelRouter`` holds an ordered set of candidate models and resolves a concrete default. The
-API is provisional and may change before it is finalized.
+``ModelRouter`` holds an ordered set of candidate models and, per model call, selects one via a
+``RoutingStrategy`` (default: ``FallbackStrategy``). When the selected model's retries are
+exhausted, the router advances to the next candidate in declaration order. ``ContextFitStrategy``
+selects by context-window capacity. The API is provisional and may change before it is finalized.
 """
 
-from .router import CandidateInput, ModelRouter
+from .router import CandidateInput, FallbackStrategy, ModelRouter, RoutingCandidate
+from .strategies import ContextFitStrategy
+from .strategy import RoutingContext, RoutingStrategy
 
 __all__ = [
     "CandidateInput",
+    "ContextFitStrategy",
+    "FallbackStrategy",
     "ModelRouter",
+    "RoutingCandidate",
+    "RoutingContext",
+    "RoutingStrategy",
 ]

--- a/strands-py/src/strands/models/routing/__init__.py
+++ b/strands-py/src/strands/models/routing/__init__.py
@@ -1,0 +1,12 @@
+"""Model routing primitives.
+
+``ModelRouter`` holds an ordered set of candidate models and resolves a concrete default. The
+API is provisional and may change before it is finalized.
+"""
+
+from .router import CandidateInput, ModelRouter
+
+__all__ = [
+    "CandidateInput",
+    "ModelRouter",
+]

--- a/strands-py/src/strands/models/routing/router.py
+++ b/strands-py/src/strands/models/routing/router.py
@@ -5,8 +5,9 @@ through ``model=``. Its ``RoutingStrategy`` selects a candidate once per agent i
 choice is cached and reused for every model call in that invocation, including tool-loop turns.
 When the selected model fails and no hook has claimed the retry, the router advances to the next
 untried candidate in declaration order (ordered fallback), re-arming the chain after any successful
-call. A nested ``ModelRouter`` candidate is a single atomic fallback slot: its own strategy chooses
-its model, but the outer router does not fall back among the nested candidates.
+call. Each candidate receives a fresh model retry budget. A nested ``ModelRouter`` candidate is one
+atomic fallback slot: its own strategy chooses its model, but the outer router does not fall back
+among the nested candidates.
 """
 
 from __future__ import annotations
@@ -81,7 +82,7 @@ class ModelRouter(Plugin):
         if not candidates:
             raise ValueError("ModelRouter requires at least one candidate model")
         _reject_stateful(candidates)
-        _reject_duplicate_names(candidates)
+        _reject_duplicates(candidates)
         self._candidates = candidates
         self._strategy: RoutingStrategy = strategy or FallbackStrategy()
 
@@ -104,7 +105,7 @@ class ModelRouter(Plugin):
         return model
 
     def init_agent(self, agent: Agent) -> None:
-        """Register the fallback and state-cleanup hooks; reject attachment through ``plugins=[...]``.
+        """Register routing middleware and hooks; reject attachment through ``plugins=[...]``.
 
         Args:
             agent: The agent the router is attached to.
@@ -114,7 +115,11 @@ class ModelRouter(Plugin):
         """
         if agent._model_router is not self:
             raise ValueError("ModelRouter must be passed through Agent(model=...), not plugins=[...]")
-        # SDK_LAST so fallback runs after ModelRetryStrategy has decided whether to retry.
+
+        from ..._middleware.stages import InvokeModelStage
+
+        agent._middleware_registry.add_middleware(InvokeModelStage.Input, self._selection_middleware())
+        # SDK_LAST makes fallback run after ModelRetryStrategy decides whether to retry.
         agent.hooks.add_callback(AfterModelCallEvent, self._on_model_result, order=HookOrder.SDK_LAST)
         agent.hooks.add_callback(AfterInvocationEvent, self._clear_state, order=HookOrder.SDK_LAST)
 
@@ -140,8 +145,8 @@ class ModelRouter(Plugin):
         """Build an ``InvokeModelStage.Input`` handler that selects the per-invocation model."""
 
         async def middleware(context: InvokeModelContext) -> InvokeModelContext:
-            state = context.invocation_state.get(_ROUTING_KEY)
-            if state is None or state.get("router") is not self:
+            state = _owned_state(context.invocation_state.get(_ROUTING_KEY), self, context.agent)
+            if state is None:
                 routing_context = self._routing_context(
                     context.messages, context.system_prompt, context.tool_specs, context.invocation_state
                 )
@@ -149,6 +154,7 @@ class ModelRouter(Plugin):
                 index = self._index_of(candidate)
                 state = {
                     "router": self,
+                    "agent": context.agent,
                     "index": index,
                     "model": await self._resolve(candidate, routing_context),
                     "tried": {index},
@@ -161,8 +167,8 @@ class ModelRouter(Plugin):
 
     async def _on_model_result(self, event: AfterModelCallEvent) -> None:
         """Re-arm the fallback chain on success; on an unretried failure, advance to the next candidate."""
-        state = event.invocation_state.get(_ROUTING_KEY)
-        if state is None or state.get("router") is not self:
+        state = _owned_state(event.invocation_state.get(_ROUTING_KEY), self, event.agent)
+        if state is None:
             return
         if event.stop_response is not None:
             state["tried"] = {state["index"]}  # a successful call re-arms the rest of the chain
@@ -202,8 +208,8 @@ class ModelRouter(Plugin):
 
     async def _clear_state(self, event: AfterInvocationEvent) -> None:
         """Drop this router's routing state at the end of the invocation so it does not leak."""
-        state = event.invocation_state.get(_ROUTING_KEY)
-        if state is not None and state.get("router") is self:
+        state = _owned_state(event.invocation_state.get(_ROUTING_KEY), self, event.agent)
+        if state is not None:
             del event.invocation_state[_ROUTING_KEY]
 
     def _index_of(self, candidate: RoutingCandidate) -> int:
@@ -221,6 +227,18 @@ class ModelRouter(Plugin):
             candidates=self._candidates,
             invocation_state=invocation_state,
         )
+
+
+def _owned_state(value: Any, router: ModelRouter, agent: Agent) -> dict[str, Any] | None:
+    """Return valid routing state owned by the given router and agent."""
+    if not isinstance(value, dict) or value.get("router") is not router or value.get("agent") is not agent:
+        return None
+    if not isinstance(value.get("index"), int) or not isinstance(value.get("model"), Model):
+        return None
+    tried = value.get("tried")
+    if not isinstance(tried, set) or not all(isinstance(index, int) for index in tried):
+        return None
+    return value
 
 
 def _normalize(models: object) -> tuple[RoutingCandidate, ...]:
@@ -253,12 +271,18 @@ def _reject_stateful(candidates: tuple[RoutingCandidate, ...]) -> None:
             raise ValueError(f"candidate=<{label}> is stateful; routing among stateful models is not supported")
 
 
-def _reject_duplicate_names(candidates: tuple[RoutingCandidate, ...]) -> None:
-    """Reject colliding candidate names; unnamed candidates and repeated models are allowed."""
-    seen: set[str] = set()
+def _reject_duplicates(candidates: tuple[RoutingCandidate, ...]) -> None:
+    """Reject repeated candidate instances or colliding names; repeated models are allowed."""
+    seen_candidates: set[int] = set()
+    seen_names: set[str] = set()
     for candidate in candidates:
+        identity = id(candidate)
+        if identity in seen_candidates:
+            raise ValueError("duplicate RoutingCandidate instance")
+        seen_candidates.add(identity)
+
         if candidate.name is None:
             continue
-        if candidate.name in seen:
+        if candidate.name in seen_names:
             raise ValueError(f"duplicate candidate name=<{candidate.name}>")
-        seen.add(candidate.name)
+        seen_names.add(candidate.name)

--- a/strands-py/src/strands/models/routing/router.py
+++ b/strands-py/src/strands/models/routing/router.py
@@ -1,0 +1,90 @@
+"""ModelRouter: a reusable, immutable set of candidate models with a concrete default.
+
+A router holds an ordered sequence of candidate models and is a ``Plugin`` so an agent can
+accept it through ``model=``. It exposes the first candidate, resolved to a concrete model, as
+its default and rejects stateful candidates.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Union
+
+from ...plugins.plugin import Plugin
+from ..model import Model
+
+if TYPE_CHECKING:
+    from ...agent.agent import Agent
+
+
+CandidateInput = Union[Model, "ModelRouter"]
+
+_ROUTER_PLUGIN_NAME = "strands:model-router"
+
+
+class ModelRouter(Plugin):
+    """A reusable, ordered set of candidate models with a concrete default."""
+
+    def __init__(self, models: Sequence[CandidateInput]) -> None:
+        """Initialize the router.
+
+        Args:
+            models: Candidates as a sequence of ``Model`` objects and nested ``ModelRouter``
+                instances. The first candidate is the router's default.
+
+        Raises:
+            TypeError: If ``models`` is not a sequence, or a candidate is not a ``Model`` or
+                ``ModelRouter``.
+            ValueError: If ``models`` is empty or any candidate is a stateful model.
+        """
+        super().__init__()
+        candidates = _normalize(models)
+        if not candidates:
+            raise ValueError("ModelRouter requires at least one candidate model")
+        _reject_stateful(candidates)
+        self._candidates = candidates
+
+    @property
+    def name(self) -> str:
+        """Stable plugin identifier."""
+        return _ROUTER_PLUGIN_NAME
+
+    @property
+    def default_model(self) -> Model:
+        """The first candidate resolved to a concrete model, recursing nested routers."""
+        candidate = self._candidates[0]
+        if isinstance(candidate, ModelRouter):
+            return candidate.default_model
+        return candidate
+
+    def init_agent(self, agent: Agent) -> None:
+        """Reject a router attached through ``plugins=[...]`` instead of ``model=``.
+
+        Raises:
+            ValueError: If the router was not attached through ``Agent(model=...)``.
+        """
+        if agent._model_router is not self:
+            raise ValueError("ModelRouter must be passed through Agent(model=...), not plugins=[...]")
+
+
+def _normalize(models: object) -> tuple[CandidateInput, ...]:
+    """Validate the input is a sequence of candidates and return them as a tuple."""
+    if isinstance(models, (str, bytes, Mapping)) or not isinstance(models, Sequence):
+        raise TypeError("models must be a sequence of candidates")
+    return tuple(_validate_candidate(item) for item in models)
+
+
+def _validate_candidate(candidate: object) -> CandidateInput:
+    """Return the candidate if it is a ``Model`` or ``ModelRouter``; reject other types."""
+    if isinstance(candidate, (Model, ModelRouter)):
+        return candidate
+    raise TypeError(f"candidate must be a Model or ModelRouter; got {type(candidate).__name__}")
+
+
+def _reject_stateful(candidates: tuple[CandidateInput, ...]) -> None:
+    """Reject any stateful candidate model."""
+    for candidate in candidates:
+        if isinstance(candidate, Model) and candidate.stateful:
+            raise ValueError(
+                f"candidate=<{type(candidate).__name__}> is stateful; routing among stateful models is not supported"
+            )

--- a/strands-py/src/strands/models/routing/router.py
+++ b/strands-py/src/strands/models/routing/router.py
@@ -1,48 +1,89 @@
-"""ModelRouter: a reusable, immutable set of candidate models with a concrete default.
+"""ModelRouter: a reusable, immutable set of candidate models with a routing strategy.
 
-A router holds an ordered sequence of candidate models and is a ``Plugin`` so an agent can
-accept it through ``model=``. It exposes the first candidate, resolved to a concrete model, as
-its default and rejects stateful candidates.
+A router holds an ordered sequence of candidates and is a ``Plugin`` so an agent can accept it
+through ``model=``. Its ``RoutingStrategy`` selects a candidate once per agent invocation; the
+choice is cached and reused for every model call in that invocation, including tool-loop turns.
+When the selected model fails and no hook has claimed the retry, the router advances to the next
+untried candidate in declaration order (ordered fallback), re-arming the chain after any successful
+call. A nested ``ModelRouter`` candidate is a single atomic fallback slot: its own strategy chooses
+its model, but the outer router does not fall back among the nested candidates.
 """
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING, Union
+import logging
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING, Any, Union
 
+from ...hooks.events import AfterInvocationEvent, AfterModelCallEvent
+from ...hooks.registry import HookOrder
 from ...plugins.plugin import Plugin
 from ..model import Model
+from .strategy import RoutingContext, RoutingStrategy
 
 if TYPE_CHECKING:
+    from ..._middleware.stages import InvokeModelContext
     from ...agent.agent import Agent
 
+logger = logging.getLogger(__name__)
 
-CandidateInput = Union[Model, "ModelRouter"]
+
+@dataclass(frozen=True)
+class RoutingCandidate:
+    """A routing candidate: a model with an optional name and description.
+
+    ``model`` may be a nested ``ModelRouter``; in a fallback chain it is one atomic slot (its own
+    strategy picks its model, and the outer router does not fall back among the nested candidates).
+    """
+
+    model: Model | ModelRouter
+    name: str | None = None
+    description: str | None = None
+
+
+CandidateInput = Union[Model, "ModelRouter", RoutingCandidate]
 
 _ROUTER_PLUGIN_NAME = "strands:model-router"
+_ROUTING_KEY = "__strands_model_routing__"
+
+
+class FallbackStrategy:
+    """Selects the first candidate; the router advances through the rest on failure."""
+
+    async def select(self, context: RoutingContext, **kwargs: Any) -> RoutingCandidate:
+        """Return the first candidate."""
+        return context.candidates[0]
 
 
 class ModelRouter(Plugin):
-    """A reusable, ordered set of candidate models with a concrete default."""
+    """A reusable, ordered set of candidate models with a routing strategy and ordered fallback."""
 
-    def __init__(self, models: Sequence[CandidateInput]) -> None:
+    def __init__(self, models: Sequence[CandidateInput], *, strategy: RoutingStrategy | None = None) -> None:
         """Initialize the router.
 
         Args:
-            models: Candidates as a sequence of ``Model`` objects and nested ``ModelRouter``
-                instances. The first candidate is the router's default.
+            models: Candidates as a sequence. Each is a ``Model``, a nested ``ModelRouter``, or a
+                ``RoutingCandidate`` carrying an optional name/description. The first candidate is
+                the router's default.
+            strategy: Selects a candidate per invocation. Defaults to selecting the first candidate.
 
         Raises:
-            TypeError: If ``models`` is not a sequence, or a candidate is not a ``Model`` or
-                ``ModelRouter``.
-            ValueError: If ``models`` is empty or any candidate is a stateful model.
+            TypeError: If ``models`` is not a sequence, a candidate is not a ``Model`` or
+                ``ModelRouter``, or ``strategy`` does not implement ``RoutingStrategy``.
+            ValueError: If ``models`` is empty, candidate names collide, or any candidate is a
+                stateful model.
         """
         super().__init__()
+        if strategy is not None and not isinstance(strategy, RoutingStrategy):
+            raise TypeError("strategy must implement RoutingStrategy (a select(context) method)")
         candidates = _normalize(models)
         if not candidates:
             raise ValueError("ModelRouter requires at least one candidate model")
         _reject_stateful(candidates)
+        _reject_duplicate_names(candidates)
         self._candidates = candidates
+        self._strategy: RoutingStrategy = strategy or FallbackStrategy()
 
     @property
     def name(self) -> str:
@@ -50,41 +91,174 @@ class ModelRouter(Plugin):
         return _ROUTER_PLUGIN_NAME
 
     @property
+    def candidates(self) -> tuple[RoutingCandidate, ...]:
+        """The normalized candidates, in declaration order."""
+        return self._candidates
+
+    @property
     def default_model(self) -> Model:
         """The first candidate resolved to a concrete model, recursing nested routers."""
-        candidate = self._candidates[0]
-        if isinstance(candidate, ModelRouter):
-            return candidate.default_model
-        return candidate
+        model = self._candidates[0].model
+        if isinstance(model, ModelRouter):
+            return model.default_model
+        return model
 
     def init_agent(self, agent: Agent) -> None:
-        """Reject a router attached through ``plugins=[...]`` instead of ``model=``.
+        """Register the fallback and state-cleanup hooks; reject attachment through ``plugins=[...]``.
+
+        Args:
+            agent: The agent the router is attached to.
 
         Raises:
             ValueError: If the router was not attached through ``Agent(model=...)``.
         """
         if agent._model_router is not self:
             raise ValueError("ModelRouter must be passed through Agent(model=...), not plugins=[...]")
+        # SDK_LAST so fallback runs after ModelRetryStrategy has decided whether to retry.
+        agent.hooks.add_callback(AfterModelCallEvent, self._on_model_result, order=HookOrder.SDK_LAST)
+        agent.hooks.add_callback(AfterInvocationEvent, self._clear_state, order=HookOrder.SDK_LAST)
+
+    async def _pick(self, context: RoutingContext) -> RoutingCandidate:
+        """Select a candidate via the strategy, requiring the result to be one of the candidates."""
+        candidate = await self._strategy.select(context)
+        if not any(candidate is existing for existing in context.candidates):
+            raise ValueError("strategy.select must return one of the candidates")
+        return candidate
+
+    async def _resolve(self, candidate: RoutingCandidate, context: RoutingContext) -> Model:
+        """Resolve a candidate to a concrete model, recursing into a nested router's strategy."""
+        model = candidate.model
+        if isinstance(model, ModelRouter):
+            return await model._select_model(replace(context, candidates=model.candidates))
+        return model
+
+    async def _select_model(self, context: RoutingContext) -> Model:
+        """Select and resolve a candidate to a concrete model."""
+        return await self._resolve(await self._pick(context), context)
+
+    def _selection_middleware(self) -> Callable[[InvokeModelContext], Awaitable[InvokeModelContext]]:
+        """Build an ``InvokeModelStage.Input`` handler that selects the per-invocation model."""
+
+        async def middleware(context: InvokeModelContext) -> InvokeModelContext:
+            state = context.invocation_state.get(_ROUTING_KEY)
+            if state is None or state.get("router") is not self:
+                routing_context = self._routing_context(
+                    context.messages, context.system_prompt, context.tool_specs, context.invocation_state
+                )
+                candidate = await self._pick(routing_context)
+                index = self._index_of(candidate)
+                state = {
+                    "router": self,
+                    "index": index,
+                    "model": await self._resolve(candidate, routing_context),
+                    "tried": {index},
+                }
+                context.invocation_state[_ROUTING_KEY] = state
+            context.model = state["model"]
+            return context
+
+        return middleware
+
+    async def _on_model_result(self, event: AfterModelCallEvent) -> None:
+        """Re-arm the fallback chain on success; on an unretried failure, advance to the next candidate."""
+        state = event.invocation_state.get(_ROUTING_KEY)
+        if state is None or state.get("router") is not self:
+            return
+        if event.stop_response is not None:
+            state["tried"] = {state["index"]}  # a successful call re-arms the rest of the chain
+            return
+        if event.retry or event.exception is None:
+            return
+
+        tried: set[int] = state["tried"]
+        next_index = next((index for index in range(len(self._candidates)) if index not in tried), None)
+        if next_index is None:
+            return
+
+        routing_context = self._routing_context(
+            event.agent.messages,
+            event.agent.system_prompt,
+            event.agent.tool_registry.get_all_tool_specs(),
+            event.invocation_state,
+        )
+        try:
+            model = await self._resolve(self._candidates[next_index], routing_context)
+        except Exception as error:
+            # A failed advance must not replace the original model error or suppress ForceStopEvent.
+            logger.warning("candidate_index=<%d>, error=<%s> | fallback resolution failed", next_index, error)
+            return
+
+        logger.info(
+            "from_index=<%d>, to_index=<%d>, error=<%s> | model call failed, advancing to next candidate",
+            state["index"],
+            next_index,
+            type(event.exception).__name__,
+        )
+        state["model"] = model
+        state["index"] = next_index
+        tried.add(next_index)
+        event.agent._retry_strategy.reset_retry_state()
+        event.retry = True
+
+    async def _clear_state(self, event: AfterInvocationEvent) -> None:
+        """Drop this router's routing state at the end of the invocation so it does not leak."""
+        state = event.invocation_state.get(_ROUTING_KEY)
+        if state is not None and state.get("router") is self:
+            del event.invocation_state[_ROUTING_KEY]
+
+    def _index_of(self, candidate: RoutingCandidate) -> int:
+        """Return the declaration-order index of a candidate by identity."""
+        return next(index for index, existing in enumerate(self._candidates) if existing is candidate)
+
+    def _routing_context(
+        self, messages: Any, system_prompt: Any, tool_specs: Any, invocation_state: Mapping[str, Any]
+    ) -> RoutingContext:
+        """Build a ``RoutingContext`` over this router's candidates."""
+        return RoutingContext(
+            messages=messages,
+            system_prompt=system_prompt,
+            tool_specs=tool_specs,
+            candidates=self._candidates,
+            invocation_state=invocation_state,
+        )
 
 
-def _normalize(models: object) -> tuple[CandidateInput, ...]:
-    """Validate the input is a sequence of candidates and return them as a tuple."""
+def _normalize(models: object) -> tuple[RoutingCandidate, ...]:
+    """Coerce the input sequence into ``RoutingCandidate`` objects, validating candidate types."""
     if isinstance(models, (str, bytes, Mapping)) or not isinstance(models, Sequence):
         raise TypeError("models must be a sequence of candidates")
-    return tuple(_validate_candidate(item) for item in models)
+    return tuple(_as_candidate(item) for item in models)
 
 
-def _validate_candidate(candidate: object) -> CandidateInput:
-    """Return the candidate if it is a ``Model`` or ``ModelRouter``; reject other types."""
-    if isinstance(candidate, (Model, ModelRouter)):
-        return candidate
-    raise TypeError(f"candidate must be a Model or ModelRouter; got {type(candidate).__name__}")
+def _as_candidate(item: CandidateInput) -> RoutingCandidate:
+    """Wrap a candidate input in a ``RoutingCandidate``, validating its model type."""
+    if isinstance(item, RoutingCandidate):
+        _validate_candidate_model(item.model)
+        return item
+    return RoutingCandidate(model=_validate_candidate_model(item))
 
 
-def _reject_stateful(candidates: tuple[CandidateInput, ...]) -> None:
+def _validate_candidate_model(model: object) -> Model | ModelRouter:
+    """Return the model if it is a ``Model`` or ``ModelRouter``; reject other types."""
+    if isinstance(model, (Model, ModelRouter)):
+        return model
+    raise TypeError(f"candidate must be a Model or ModelRouter; got {type(model).__name__}")
+
+
+def _reject_stateful(candidates: tuple[RoutingCandidate, ...]) -> None:
     """Reject any stateful candidate model."""
     for candidate in candidates:
-        if isinstance(candidate, Model) and candidate.stateful:
-            raise ValueError(
-                f"candidate=<{type(candidate).__name__}> is stateful; routing among stateful models is not supported"
-            )
+        if isinstance(candidate.model, Model) and candidate.model.stateful:
+            label = candidate.name or type(candidate.model).__name__
+            raise ValueError(f"candidate=<{label}> is stateful; routing among stateful models is not supported")
+
+
+def _reject_duplicate_names(candidates: tuple[RoutingCandidate, ...]) -> None:
+    """Reject colliding candidate names; unnamed candidates and repeated models are allowed."""
+    seen: set[str] = set()
+    for candidate in candidates:
+        if candidate.name is None:
+            continue
+        if candidate.name in seen:
+            raise ValueError(f"duplicate candidate name=<{candidate.name}>")
+        seen.add(candidate.name)

--- a/strands-py/src/strands/models/routing/strategies.py
+++ b/strands-py/src/strands/models/routing/strategies.py
@@ -1,0 +1,101 @@
+"""Bundled routing strategies.
+
+``ContextFitStrategy`` is a local (no extra model call) strategy that routes by context capacity,
+reusing the conversation manager's window default and threshold so routing and proactive compression
+share one notion of "how full is too full". ``FallbackStrategy`` lives in ``router.py`` alongside the
+router-owned ordered-fallback mechanism it pairs with.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any
+
+from ...agent.conversation_manager.conversation_manager import (
+    DEFAULT_COMPRESSION_THRESHOLD,
+    DEFAULT_CONTEXT_WINDOW_LIMIT,
+)
+from ..model import Model
+from .router import ModelRouter, RoutingCandidate
+from .strategy import RoutingContext
+
+logger = logging.getLogger(__name__)
+
+
+class ContextFitStrategy:
+    """Routes by context capacity: the smallest window that holds the request within ``threshold``.
+
+    For each candidate it estimates the request's token count with that candidate's own
+    ``count_tokens`` (tokenization differs by provider), then treats the candidate as fitting when
+    the estimate stays within ``threshold`` of its context window. ``threshold`` defaults to the
+    conversation manager's ``DEFAULT_COMPRESSION_THRESHOLD``, so a fitting candidate is one whose
+    context would not immediately trip proactive compression. It returns the smallest fitting window
+    and the largest window when none fit. A model with no declared (or unreadable) window is treated
+    as ``DEFAULT_CONTEXT_WINDOW_LIMIT``. Token counting is best-effort: a candidate whose count fails
+    is treated as not fitting.
+    """
+
+    def __init__(self, *, threshold: float = DEFAULT_COMPRESSION_THRESHOLD) -> None:
+        """Initialize the strategy.
+
+        Args:
+            threshold: Fraction of a candidate's context window the request may occupy and still be
+                considered a fit. Defaults to the conversation manager's compression threshold.
+
+        Raises:
+            ValueError: If ``threshold`` is not in ``(0.0, 1.0]``.
+        """
+        if not 0.0 < threshold <= 1.0:
+            raise ValueError("threshold must be in (0.0, 1.0]")
+        self._threshold = threshold
+
+    async def select(self, context: RoutingContext, **kwargs: Any) -> RoutingCandidate:
+        """Return the smallest-window candidate whose window holds the request within ``threshold``."""
+        windows = [_candidate_window(candidate) for candidate in context.candidates]
+        counts = [await _count(candidate, context) for candidate in context.candidates]
+        fitting = [index for index, window in enumerate(windows) if counts[index] <= window * self._threshold]
+        if not fitting:
+            logger.warning("no candidate window fits the request; falling back to the largest window")
+        chosen = (
+            min(fitting, key=lambda index: windows[index])
+            if fitting
+            else max(range(len(windows)), key=lambda index: windows[index])
+        )
+        return context.candidates[chosen]
+
+
+async def _count(candidate: RoutingCandidate, context: RoutingContext) -> float:
+    """Estimate the request's token count with the candidate's tokenizer; non-finite or errors are unfit."""
+    model = _concrete_model(candidate)
+    system_prompt = context.system_prompt if isinstance(context.system_prompt, str) else None
+    system_prompt_content = context.system_prompt if isinstance(context.system_prompt, list) else None
+    try:
+        value = float(
+            await model.count_tokens(
+                list(context.messages),
+                list(context.tool_specs),
+                system_prompt=system_prompt,
+                system_prompt_content=system_prompt_content,
+            )
+        )
+    except Exception as error:
+        logger.debug("model=<%s>, error=<%s> | token count failed, treating candidate as not fitting", model, error)
+        return math.inf
+    return value if math.isfinite(value) and value >= 0 else math.inf
+
+
+def _concrete_model(candidate: RoutingCandidate) -> Model:
+    """Resolve a candidate to a concrete model, using a nested router's default."""
+    model = candidate.model
+    return model.default_model if isinstance(model, ModelRouter) else model
+
+
+def _candidate_window(candidate: RoutingCandidate) -> int:
+    """Return a candidate's context window, using the shared default when it is undeclared or unreadable."""
+    try:
+        limit = _concrete_model(candidate).context_window_limit
+    except Exception as error:
+        logger.debug("candidate=<%s>, error=<%s> | window read failed, using default", candidate.name, error)
+        return DEFAULT_CONTEXT_WINDOW_LIMIT
+    return limit if limit is not None else DEFAULT_CONTEXT_WINDOW_LIMIT

--- a/strands-py/src/strands/models/routing/strategy.py
+++ b/strands-py/src/strands/models/routing/strategy.py
@@ -1,0 +1,40 @@
+"""Routing strategy protocol and the context passed to it.
+
+A ``RoutingStrategy`` picks one candidate per invocation from the router's candidates, given the
+call's messages, system prompt, tool specs, and invocation state.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from ...types.content import Messages, SystemPrompt
+    from ...types.tools import ToolSpec
+    from .router import RoutingCandidate
+
+
+@dataclass(frozen=True)
+class RoutingContext:
+    """Read-only inputs a strategy sees when selecting a candidate.
+
+    The collections are shared by reference and must not be mutated; a strategy reads them to make
+    its decision and returns one of ``candidates``.
+    """
+
+    messages: Messages
+    system_prompt: SystemPrompt | None
+    tool_specs: Sequence[ToolSpec]
+    candidates: Sequence[RoutingCandidate]
+    invocation_state: Mapping[str, Any]
+
+
+@runtime_checkable
+class RoutingStrategy(Protocol):
+    """Selects one candidate for an invocation."""
+
+    async def select(self, context: RoutingContext, **kwargs: Any) -> RoutingCandidate:
+        """Return the candidate to use, which must be one of ``context.candidates``."""
+        ...

--- a/strands-py/tests/strands/models/routing/test_router.py
+++ b/strands-py/tests/strands/models/routing/test_router.py
@@ -1,0 +1,127 @@
+"""Tests for ModelRouter core: candidate validation, default resolution, guards."""
+
+import pytest
+
+from strands import Agent, Plugin
+from strands.models import BedrockModel
+from strands.models.routing import ModelRouter
+from tests.fixtures.mocked_model_provider import MockedModelProvider
+
+
+class StatefulModel(MockedModelProvider):
+    @property
+    def stateful(self):
+        return True
+
+
+def _model(text="hi"):
+    return MockedModelProvider([{"role": "assistant", "content": [{"text": text}]}])
+
+
+# --- plugin identity ---
+
+
+def test_router_is_a_plugin_with_stable_name():
+    router = ModelRouter(models=[_model()])
+
+    assert isinstance(router, Plugin)
+    assert router.name == "strands:model-router"
+
+
+# --- default resolution (first candidate) ---
+
+
+def test_default_model_is_first_candidate():
+    m0, m1 = _model("0"), _model("1")
+    router = ModelRouter(models=[m0, m1])
+
+    assert router.default_model is m0
+
+
+def test_nested_router_default_resolves_recursively():
+    inner_model = _model()
+    inner = ModelRouter(models=[inner_model])
+    outer = ModelRouter(models=[inner, _model("x")])
+
+    assert outer.default_model is inner_model
+
+
+def test_repeated_model_object_is_allowed():
+    m = _model()
+    router = ModelRouter(models=[m, m])
+
+    assert router.default_model is m
+
+
+# --- guards ---
+
+
+def test_empty_models_raises():
+    with pytest.raises(ValueError, match="at least one"):
+        ModelRouter(models=[])
+
+
+def test_stateful_candidate_raises():
+    with pytest.raises(ValueError, match=r"StatefulModel.*stateful"):
+        ModelRouter(models=[StatefulModel([])])
+
+
+def test_mapping_models_raises():
+    with pytest.raises(TypeError, match="sequence of candidates"):
+        ModelRouter(models={"cheap": _model()})
+
+
+def test_bare_string_models_raises():
+    with pytest.raises(TypeError, match="sequence of candidates"):
+        ModelRouter(models="my-model-id")
+
+
+def test_string_candidate_is_rejected():
+    with pytest.raises(TypeError, match="candidate must be"):
+        ModelRouter(models=["my-model-id"])
+
+
+def test_invalid_candidate_raises():
+    with pytest.raises(TypeError, match="candidate must be"):
+        ModelRouter(models=[object()])
+
+
+# --- agent integration ---
+
+
+def test_agent_accepts_model_router_and_exposes_default():
+    m = _model("routed")
+    router = ModelRouter(models=[m])
+    agent = Agent(model=router, callback_handler=None)
+
+    assert agent.model is m
+    assert agent._model_router is router
+
+
+def test_agent_registers_router_as_plugin():
+    router = ModelRouter(models=[_model()])
+    agent = Agent(model=router, callback_handler=None)
+
+    assert router.name in agent._plugin_registry._plugins
+
+
+def test_router_via_plugins_is_rejected():
+    router = ModelRouter(models=[_model()])
+    with pytest.raises(ValueError, match=r"model=.*not plugins"):
+        Agent(plugins=[router], callback_handler=None)
+
+
+def test_agent_runs_with_router_using_first_candidate():
+    router = ModelRouter(models=[_model("routed")])
+    agent = Agent(model=router, callback_handler=None)
+
+    result = agent("hello")
+
+    assert result.message["content"][0]["text"] == "routed"
+
+
+def test_bedrock_model_object_is_a_valid_candidate():
+    haiku = BedrockModel(model_id="haiku")
+    router = ModelRouter(models=[haiku, BedrockModel(model_id="opus")])
+
+    assert router.default_model is haiku

--- a/strands-py/tests/strands/models/routing/test_router.py
+++ b/strands-py/tests/strands/models/routing/test_router.py
@@ -45,9 +45,17 @@ def _routing_context(candidates, invocation_state=None):
     )
 
 
+_TEST_AGENT = object()
+
+
 def _invoke_context(invocation_state, model):
     return types.SimpleNamespace(
-        messages=[], system_prompt=None, tool_specs=[], invocation_state=invocation_state, model=model
+        agent=_TEST_AGENT,
+        messages=[],
+        system_prompt=None,
+        tool_specs=[],
+        invocation_state=invocation_state,
+        model=model,
     )
 
 
@@ -449,24 +457,26 @@ async def test_selection_middleware_reselects_when_state_belongs_to_another_rout
 async def test_clear_state_removes_only_own_routing_state():
     router = ModelRouter(models=[_model()])
     other = ModelRouter(models=[_model()])
+    agent = object()
 
-    own = {"router": router, "index": 0, "model": _model(), "tried": {0}}
+    own = {"router": router, "agent": agent, "index": 0, "model": _model(), "tried": {0}}
     invocation_state = {_ROUTING_KEY: own}
-    await router._clear_state(types.SimpleNamespace(invocation_state=invocation_state))
+    await router._clear_state(types.SimpleNamespace(invocation_state=invocation_state, agent=agent))
     assert _ROUTING_KEY not in invocation_state
 
-    foreign = {"router": other, "index": 0, "model": _model(), "tried": {0}}
+    foreign = {"router": other, "agent": agent, "index": 0, "model": _model(), "tried": {0}}
     invocation_state = {_ROUTING_KEY: foreign}
-    await router._clear_state(types.SimpleNamespace(invocation_state=invocation_state))
+    await router._clear_state(types.SimpleNamespace(invocation_state=invocation_state, agent=agent))
     assert _ROUTING_KEY in invocation_state  # another router's state is left untouched
 
 
 @pytest.mark.asyncio
 async def test_successful_call_rearms_the_fallback_chain():
     router = ModelRouter(models=[_model(), _model(), _model()])
-    state = {"router": router, "index": 1, "model": _model(), "tried": {0, 1}}
+    agent = object()
+    state = {"router": router, "agent": agent, "index": 1, "model": _model(), "tried": {0, 1}}
     event = types.SimpleNamespace(
-        retry=False, stop_response=object(), exception=None, invocation_state={_ROUTING_KEY: state}, agent=None
+        retry=False, stop_response=object(), exception=None, invocation_state={_ROUTING_KEY: state}, agent=agent
     )
 
     await router._on_model_result(event)
@@ -476,16 +486,15 @@ async def test_successful_call_rearms_the_fallback_chain():
 
 @pytest.mark.asyncio
 async def test_fallback_resolution_error_is_contained():
-    router = ModelRouter(
-        models=[_model(), RoutingCandidate(ModelRouter([_model()], strategy=_RaisingStrategy()))]
-    )
-    state = {"router": router, "index": 0, "model": _model(), "tried": {0}}
+    router = ModelRouter(models=[_model(), RoutingCandidate(ModelRouter([_model()], strategy=_RaisingStrategy()))])
+    agent = _agent_stub()
+    state = {"router": router, "agent": agent, "index": 0, "model": _model(), "tried": {0}}
     event = types.SimpleNamespace(
         retry=False,
         stop_response=None,
         exception=ValueError("original model error"),
         invocation_state={_ROUTING_KEY: state},
-        agent=_agent_stub(),
+        agent=agent,
     )
 
     await router._on_model_result(event)

--- a/strands-py/tests/strands/models/routing/test_router.py
+++ b/strands-py/tests/strands/models/routing/test_router.py
@@ -1,10 +1,15 @@
-"""Tests for ModelRouter core: candidate validation, default resolution, guards."""
+"""Tests for ModelRouter core: candidate validation, strategy selection, guards."""
+
+import types
 
 import pytest
 
 from strands import Agent, Plugin
+from strands.event_loop._retry import ModelRetryStrategy
 from strands.models import BedrockModel
-from strands.models.routing import ModelRouter
+from strands.models.routing import ModelRouter, RoutingCandidate, RoutingContext, RoutingStrategy
+from strands.models.routing.router import _ROUTING_KEY
+from strands.types.exceptions import ModelThrottledException
 from tests.fixtures.mocked_model_provider import MockedModelProvider
 
 
@@ -18,6 +23,34 @@ def _model(text="hi"):
     return MockedModelProvider([{"role": "assistant", "content": [{"text": text}]}])
 
 
+class _PickByName:
+    """Strategy that selects the candidate with a given name and counts its calls."""
+
+    def __init__(self, name):
+        self.name = name
+        self.calls = 0
+
+    async def select(self, context):
+        self.calls += 1
+        return next(candidate for candidate in context.candidates if candidate.name == self.name)
+
+
+def _routing_context(candidates, invocation_state=None):
+    return RoutingContext(
+        messages=[],
+        system_prompt=None,
+        tool_specs=[],
+        candidates=candidates,
+        invocation_state=invocation_state if invocation_state is not None else {},
+    )
+
+
+def _invoke_context(invocation_state, model):
+    return types.SimpleNamespace(
+        messages=[], system_prompt=None, tool_specs=[], invocation_state=invocation_state, model=model
+    )
+
+
 # --- plugin identity ---
 
 
@@ -26,6 +59,31 @@ def test_router_is_a_plugin_with_stable_name():
 
     assert isinstance(router, Plugin)
     assert router.name == "strands:model-router"
+
+
+# --- candidates + metadata ---
+
+
+def test_routing_candidate_metadata_is_preserved():
+    m = _model()
+    router = ModelRouter(models=[RoutingCandidate(model=m, name="routine", description="simple tasks")])
+
+    candidate = router.candidates[0]
+    assert (candidate.model, candidate.name, candidate.description) == (m, "routine", "simple tasks")
+
+
+def test_repeated_model_object_is_allowed():
+    m = _model()
+    router = ModelRouter(models=[m, m])
+
+    assert router.default_model is m
+
+
+def test_bedrock_model_object_is_a_valid_candidate():
+    haiku = BedrockModel(model_id="haiku")
+    router = ModelRouter(models=[haiku, BedrockModel(model_id="opus")])
+
+    assert router.default_model is haiku
 
 
 # --- default resolution (first candidate) ---
@@ -46,11 +104,99 @@ def test_nested_router_default_resolves_recursively():
     assert outer.default_model is inner_model
 
 
-def test_repeated_model_object_is_allowed():
-    m = _model()
-    router = ModelRouter(models=[m, m])
+# --- strategy selection ---
 
-    assert router.default_model is m
+
+@pytest.mark.asyncio
+async def test_select_model_defaults_to_first_candidate():
+    m0, m1 = _model(), _model()
+    router = ModelRouter(models=[m0, m1])
+
+    assert await router._select_model(_routing_context(router.candidates)) is m0
+
+
+@pytest.mark.asyncio
+async def test_custom_strategy_selects_named_candidate():
+    fast, smart = _model(), _model()
+    router = ModelRouter(
+        models=[RoutingCandidate(fast, name="fast"), RoutingCandidate(smart, name="smart")],
+        strategy=_PickByName("smart"),
+    )
+
+    assert await router._select_model(_routing_context(router.candidates)) is smart
+
+
+@pytest.mark.asyncio
+async def test_selection_recurses_into_nested_router_strategy():
+    inner_fast, inner_smart = _model(), _model()
+    inner = ModelRouter(
+        models=[RoutingCandidate(inner_fast, name="if"), RoutingCandidate(inner_smart, name="is")],
+        strategy=_PickByName("is"),
+    )
+    outer = ModelRouter(
+        models=[_model(), RoutingCandidate(inner, name="inner")],
+        strategy=_PickByName("inner"),
+    )
+
+    assert await outer._select_model(_routing_context(outer.candidates)) is inner_smart
+
+
+def test_non_strategy_raises():
+    with pytest.raises(TypeError, match="RoutingStrategy"):
+        ModelRouter(models=[_model()], strategy=object())
+
+
+def test_routing_strategy_protocol_is_runtime_checkable():
+    assert isinstance(_PickByName("x"), RoutingStrategy)
+    assert not isinstance(object(), RoutingStrategy)
+
+
+@pytest.mark.asyncio
+async def test_select_result_must_be_a_candidate():
+    class _Rogue:
+        async def select(self, context):
+            return RoutingCandidate(_model())  # a fresh candidate, not one of context.candidates
+
+    router = ModelRouter(models=[_model()], strategy=_Rogue())
+    with pytest.raises(ValueError, match="one of the candidates"):
+        await router._select_model(_routing_context(router.candidates))
+
+
+# --- selection middleware ---
+
+
+@pytest.mark.asyncio
+async def test_selection_middleware_sets_model_and_caches_per_invocation():
+    fast, smart = _model(), _model()
+    strategy = _PickByName("smart")
+    router = ModelRouter(
+        models=[RoutingCandidate(fast, name="fast"), RoutingCandidate(smart, name="smart")], strategy=strategy
+    )
+    middleware = router._selection_middleware()
+    state: dict = {}
+
+    first = await middleware(_invoke_context(state, model=fast))
+    assert first.model is smart
+    assert strategy.calls == 1
+
+    second = await middleware(_invoke_context(state, model=fast))
+    assert second.model is smart
+    assert strategy.calls == 1  # reused from invocation_state, not re-selected
+
+
+@pytest.mark.asyncio
+async def test_selection_middleware_reselects_for_new_invocation_state():
+    fast, smart = _model(), _model()
+    strategy = _PickByName("smart")
+    router = ModelRouter(
+        models=[RoutingCandidate(fast, name="fast"), RoutingCandidate(smart, name="smart")], strategy=strategy
+    )
+    middleware = router._selection_middleware()
+
+    await middleware(_invoke_context({}, model=fast))
+    await middleware(_invoke_context({}, model=fast))
+
+    assert strategy.calls == 2
 
 
 # --- guards ---
@@ -64,6 +210,16 @@ def test_empty_models_raises():
 def test_stateful_candidate_raises():
     with pytest.raises(ValueError, match=r"StatefulModel.*stateful"):
         ModelRouter(models=[StatefulModel([])])
+
+
+def test_stateful_candidate_error_uses_name_when_present():
+    with pytest.raises(ValueError, match=r"vip.*stateful"):
+        ModelRouter(models=[RoutingCandidate(StatefulModel([]), name="vip")])
+
+
+def test_duplicate_candidate_names_raise():
+    with pytest.raises(ValueError, match="duplicate"):
+        ModelRouter(models=[RoutingCandidate(_model(), name="a"), RoutingCandidate(_model(), name="a")])
 
 
 def test_mapping_models_raises():
@@ -111,7 +267,7 @@ def test_router_via_plugins_is_rejected():
         Agent(plugins=[router], callback_handler=None)
 
 
-def test_agent_runs_with_router_using_first_candidate():
+def test_agent_runs_with_default_first_candidate():
     router = ModelRouter(models=[_model("routed")])
     agent = Agent(model=router, callback_handler=None)
 
@@ -120,8 +276,230 @@ def test_agent_runs_with_router_using_first_candidate():
     assert result.message["content"][0]["text"] == "routed"
 
 
-def test_bedrock_model_object_is_a_valid_candidate():
-    haiku = BedrockModel(model_id="haiku")
-    router = ModelRouter(models=[haiku, BedrockModel(model_id="opus")])
+def test_agent_routes_to_strategy_selected_candidate():
+    fast = _model("fast-says")
+    smart = _model("smart-says")
+    router = ModelRouter(
+        models=[RoutingCandidate(fast, name="fast"), RoutingCandidate(smart, name="smart")],
+        strategy=_PickByName("smart"),
+    )
+    agent = Agent(model=router, callback_handler=None)
 
-    assert router.default_model is haiku
+    assert agent.model is fast  # default is still the first candidate
+
+    result = agent("hello")
+
+    assert result.message["content"][0]["text"] == "smart-says"  # strategy overrode the per-call model
+
+
+class _ModelProbe(Plugin):
+    """Plugin that records the ``context.model`` seen by a downstream Input middleware."""
+
+    name = "test:model-probe"
+
+    def __init__(self):
+        super().__init__()
+        self.seen = None
+
+    def init_agent(self, agent):
+        from strands._middleware.stages import InvokeModelStage
+
+        def record(context):
+            self.seen = context.model
+            return context
+
+        agent._middleware_registry.add_middleware(InvokeModelStage.Input, record)
+
+
+def test_routing_runs_before_other_input_middleware():
+    fast = _model("f")
+    smart = _model("s")
+    router = ModelRouter(
+        models=[RoutingCandidate(fast, name="fast"), RoutingCandidate(smart, name="smart")],
+        strategy=_PickByName("smart"),
+    )
+    probe = _ModelProbe()
+    agent = Agent(model=router, plugins=[probe], callback_handler=None)
+
+    agent("hello")
+
+    assert probe.seen is smart  # routing set the per-call model before the probe middleware ran
+
+
+# --- ordered fallback ---
+
+
+class _FailingModel(MockedModelProvider):
+    """A model whose stream always raises the given exception."""
+
+    def __init__(self, exception):
+        super().__init__([{"role": "assistant", "content": [{"text": "unused"}]}])
+        self._exception = exception
+
+    async def stream(self, *args, **kwargs):
+        raise self._exception
+        yield  # pragma: no cover - marks this an async generator
+
+
+class _FlakyModel(MockedModelProvider):
+    """A model that raises a throttling exception a set number of times, then streams normally."""
+
+    def __init__(self, failures, text):
+        super().__init__([{"role": "assistant", "content": [{"text": text}]}])
+        self._remaining_failures = failures
+
+    async def stream(self, *args, **kwargs):
+        if self._remaining_failures > 0:
+            self._remaining_failures -= 1
+            raise ModelThrottledException("flaky")
+        async for event in super().stream(*args, **kwargs):
+            yield event
+
+
+class _RaisingStrategy:
+    """A strategy whose select always raises, to exercise fallback-resolution error containment."""
+
+    async def select(self, context, **kwargs):
+        raise RuntimeError("strategy boom")
+
+
+def _agent_stub():
+    """A minimal stand-in for the fields the fallback hook reads off the agent."""
+    return types.SimpleNamespace(
+        messages=[], system_prompt=None, tool_registry=types.SimpleNamespace(get_all_tool_specs=lambda: [])
+    )
+
+
+def test_fallback_advances_to_next_candidate_on_throttling():
+    failing = _FailingModel(ModelThrottledException("throttled"))
+    good = _model("recovered")
+    router = ModelRouter(models=[failing, good])
+    agent = Agent(model=router, retry_strategy=None, callback_handler=None)
+
+    result = agent("hello")
+
+    assert result.message["content"][0]["text"] == "recovered"
+
+
+def test_fallback_advances_on_non_retryable_error():
+    failing = _FailingModel(ValueError("boom"))
+    good = _model("recovered")
+    router = ModelRouter(models=[failing, good])
+    agent = Agent(model=router, retry_strategy=None, callback_handler=None)
+
+    result = agent("hello")
+
+    assert result.message["content"][0]["text"] == "recovered"
+
+
+def test_fallback_exhausts_all_candidates_then_raises():
+    router = ModelRouter(
+        models=[_FailingModel(ModelThrottledException("a")), _FailingModel(ModelThrottledException("b"))]
+    )
+    agent = Agent(model=router, retry_strategy=None, callback_handler=None)
+
+    with pytest.raises(ModelThrottledException):
+        agent("hello")
+
+
+@pytest.mark.asyncio
+async def test_advance_is_noop_without_routing_state():
+    router = ModelRouter(models=[_model(), _model()])
+    event = types.SimpleNamespace(
+        retry=False, stop_response=None, exception=ValueError("x"), invocation_state={}, agent=None
+    )
+
+    await router._on_model_result(event)
+
+    assert event.retry is False  # no selection was cached, so there is nothing to advance
+
+
+def test_fallback_resets_retry_budget_so_next_candidate_gets_fresh_retries():
+    # First candidate always fails; second needs two retries before it succeeds. This only passes if
+    # advancing resets the retry budget so the second candidate gets its own attempts.
+    first = _FailingModel(ModelThrottledException("down"))
+    second = _FlakyModel(failures=2, text="recovered")
+    router = ModelRouter(models=[first, second])
+    retry_strategy = ModelRetryStrategy(max_attempts=3, initial_delay=0, max_delay=0)
+    agent = Agent(model=router, retry_strategy=retry_strategy, callback_handler=None)
+
+    result = agent("hello")
+
+    assert result.message["content"][0]["text"] == "recovered"
+
+
+# --- state scoping / lifecycle ---
+
+
+@pytest.mark.asyncio
+async def test_selection_middleware_reselects_when_state_belongs_to_another_router():
+    m_a, m_b = _model(), _model()
+    router_a = ModelRouter(models=[m_a])
+    router_b = ModelRouter(models=[m_b])
+    shared: dict = {}
+
+    await router_a._selection_middleware()(_invoke_context(shared, model=None))
+    context_b = _invoke_context(shared, model=None)
+    await router_b._selection_middleware()(context_b)
+
+    assert context_b.model is m_b  # router_b does not reuse router_a's cached selection
+
+
+@pytest.mark.asyncio
+async def test_clear_state_removes_only_own_routing_state():
+    router = ModelRouter(models=[_model()])
+    other = ModelRouter(models=[_model()])
+
+    own = {"router": router, "index": 0, "model": _model(), "tried": {0}}
+    invocation_state = {_ROUTING_KEY: own}
+    await router._clear_state(types.SimpleNamespace(invocation_state=invocation_state))
+    assert _ROUTING_KEY not in invocation_state
+
+    foreign = {"router": other, "index": 0, "model": _model(), "tried": {0}}
+    invocation_state = {_ROUTING_KEY: foreign}
+    await router._clear_state(types.SimpleNamespace(invocation_state=invocation_state))
+    assert _ROUTING_KEY in invocation_state  # another router's state is left untouched
+
+
+@pytest.mark.asyncio
+async def test_successful_call_rearms_the_fallback_chain():
+    router = ModelRouter(models=[_model(), _model(), _model()])
+    state = {"router": router, "index": 1, "model": _model(), "tried": {0, 1}}
+    event = types.SimpleNamespace(
+        retry=False, stop_response=object(), exception=None, invocation_state={_ROUTING_KEY: state}, agent=None
+    )
+
+    await router._on_model_result(event)
+
+    assert state["tried"] == {1}  # re-armed to the current selection so a later failure can fall over
+
+
+@pytest.mark.asyncio
+async def test_fallback_resolution_error_is_contained():
+    router = ModelRouter(
+        models=[_model(), RoutingCandidate(ModelRouter([_model()], strategy=_RaisingStrategy()))]
+    )
+    state = {"router": router, "index": 0, "model": _model(), "tried": {0}}
+    event = types.SimpleNamespace(
+        retry=False,
+        stop_response=None,
+        exception=ValueError("original model error"),
+        invocation_state={_ROUTING_KEY: state},
+        agent=_agent_stub(),
+    )
+
+    await router._on_model_result(event)
+
+    assert event.retry is False  # a failed advance degrades to "no fallback" instead of crashing
+
+
+def test_nested_router_is_one_atomic_fallback_slot():
+    inner = ModelRouter(models=[_FailingModel(ValueError("inner down")), _model("inner-second")])
+    router = ModelRouter(models=[inner, _model("outer-other")])
+    agent = Agent(model=router, retry_strategy=None, callback_handler=None)
+
+    result = agent("hello")
+
+    # The nested router's first pick fails; the outer router falls over to its own next candidate
+    # rather than trying the nested router's second model.
+    assert result.message["content"][0]["text"] == "outer-other"

--- a/strands-py/tests/strands/models/routing/test_strategies.py
+++ b/strands-py/tests/strands/models/routing/test_strategies.py
@@ -1,0 +1,170 @@
+"""Tests for bundled routing strategies: FallbackStrategy (select-first) and ContextFitStrategy."""
+
+import pytest
+
+from strands.models.routing import ContextFitStrategy, FallbackStrategy, ModelRouter, RoutingCandidate, RoutingContext
+from tests.fixtures.mocked_model_provider import MockedModelProvider
+
+
+def _model():
+    return MockedModelProvider([{"role": "assistant", "content": [{"text": "hi"}]}])
+
+
+class _WindowModel(MockedModelProvider):
+    """A model with a fixed context window and a fixed token-count estimate."""
+
+    def __init__(self, window, tokens):
+        super().__init__([{"role": "assistant", "content": [{"text": "hi"}]}])
+        self._window = window
+        self._tokens = tokens
+
+    @property
+    def context_window_limit(self):
+        return self._window
+
+    async def count_tokens(self, *args, **kwargs):
+        return self._tokens
+
+
+def _context(candidates):
+    return RoutingContext(
+        messages=[], system_prompt=None, tool_specs=[], candidates=candidates, invocation_state={}
+    )
+
+
+# --- FallbackStrategy ---
+
+
+@pytest.mark.asyncio
+async def test_fallback_strategy_selects_first_candidate():
+    first = RoutingCandidate(_model(), name="first")
+    second = RoutingCandidate(_model(), name="second")
+
+    assert await FallbackStrategy().select(_context([first, second])) is first
+
+
+# --- ContextFitStrategy ---
+
+
+@pytest.mark.asyncio
+async def test_context_fit_picks_smallest_window_that_fits():
+    small = RoutingCandidate(_WindowModel(1_000, 5_000))
+    medium = RoutingCandidate(_WindowModel(10_000, 5_000))
+    large = RoutingCandidate(_WindowModel(100_000, 5_000))
+
+    chosen = await ContextFitStrategy().select(_context([small, medium, large]))
+
+    assert chosen is medium  # 5000 exceeds small's usable window; medium is the smallest that fits
+
+
+@pytest.mark.asyncio
+async def test_context_fit_falls_back_to_largest_when_none_fit():
+    small = RoutingCandidate(_WindowModel(1_000, 5_000))
+    medium = RoutingCandidate(_WindowModel(2_000, 5_000))
+
+    chosen = await ContextFitStrategy().select(_context([small, medium]))
+
+    assert chosen is medium  # none fit, so the largest window wins
+
+
+@pytest.mark.asyncio
+async def test_context_fit_treats_undeclared_window_as_shared_default():
+    from strands.models.routing.strategies import DEFAULT_CONTEXT_WINDOW_LIMIT
+
+    bounded = RoutingCandidate(_WindowModel(1_000, 5_000))
+    undeclared = RoutingCandidate(_WindowModel(None, 5_000))  # -> DEFAULT_CONTEXT_WINDOW_LIMIT
+
+    chosen = await ContextFitStrategy().select(_context([bounded, undeclared]))
+
+    assert chosen is undeclared  # 5000 fits the 200k default window but not the 1000 one
+    assert DEFAULT_CONTEXT_WINDOW_LIMIT == 200_000
+
+
+@pytest.mark.asyncio
+async def test_context_fit_threshold_reserves_room():
+    tight = RoutingCandidate(_WindowModel(10_000, 8_500))
+    big = RoutingCandidate(_WindowModel(100_000, 8_500))
+
+    # At 0.7, tight allows 7000 tokens < 8500, so it does not fit.
+    assert await ContextFitStrategy(threshold=0.7).select(_context([tight, big])) is big
+    # At 0.9, tight allows 9000 >= 8500, so the smaller window wins.
+    assert await ContextFitStrategy(threshold=0.9).select(_context([tight, big])) is tight
+
+
+@pytest.mark.asyncio
+async def test_context_fit_counts_tokens_per_candidate():
+    lean = RoutingCandidate(_WindowModel(10_000, 5_000))
+    verbose = RoutingCandidate(_WindowModel(10_000, 9_000))  # same window, tokenizes larger
+
+    chosen = await ContextFitStrategy().select(_context([lean, verbose]))
+
+    assert chosen is lean  # only the candidate whose own tokenizer fits is selected
+
+
+@pytest.mark.asyncio
+async def test_context_fit_treats_failed_count_as_not_fitting():
+    class _RaisingModel(_WindowModel):
+        async def count_tokens(self, *args, **kwargs):
+            raise RuntimeError("count exploded")
+
+    raising = RoutingCandidate(_RaisingModel(1_000_000, 0))  # big window, but counting fails
+    healthy = RoutingCandidate(_WindowModel(10_000, 100))
+
+    chosen = await ContextFitStrategy().select(_context([raising, healthy]))
+
+    assert chosen is healthy  # the candidate whose count failed is not treated as a fit
+
+
+@pytest.mark.asyncio
+async def test_context_fit_uses_nested_router_default_window():
+    small = RoutingCandidate(_WindowModel(1_000, 900))
+    inner = ModelRouter(models=[_WindowModel(2_000, 900)])
+    nested = RoutingCandidate(inner)
+
+    chosen = await ContextFitStrategy().select(_context([small, nested]))
+
+    assert chosen is nested  # small allows 700 < 900; the nested router's default window (2000) fits
+
+
+@pytest.mark.parametrize("threshold", [0.0, -0.1, 1.5])
+def test_context_fit_rejects_invalid_threshold(threshold):
+    with pytest.raises(ValueError, match="threshold"):
+        ContextFitStrategy(threshold=threshold)
+
+
+# --- ContextFitStrategy robustness (best-effort counting) ---
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_count", [None, "not-a-number", float("nan")])
+async def test_context_fit_treats_bad_count_as_not_fitting(bad_count):
+    class _BadCountModel(_WindowModel):
+        async def count_tokens(self, *args, **kwargs):
+            return bad_count
+
+    bad = RoutingCandidate(_BadCountModel(1_000, 0))
+    good = RoutingCandidate(_WindowModel(1_000, 100))
+
+    assert await ContextFitStrategy().select(_context([bad, good])) is good
+
+
+@pytest.mark.asyncio
+async def test_context_fit_survives_a_window_read_error():
+    class _BadWindowModel(_WindowModel):
+        @property
+        def context_window_limit(self):
+            raise RuntimeError("config not initialised")
+
+    only = RoutingCandidate(_BadWindowModel(None, 100))
+
+    # Must not crash: the unreadable window falls back to the shared default.
+    assert await ContextFitStrategy().select(_context([only])) is only
+
+
+@pytest.mark.asyncio
+async def test_context_fit_respects_an_explicit_zero_window():
+    zero = RoutingCandidate(_WindowModel(0, 100))
+    big = RoutingCandidate(_WindowModel(1_000, 100))
+
+    # An explicit 0 window must not be silently replaced by the default; nothing fits 0, so big wins.
+    assert await ContextFitStrategy(threshold=1.0).select(_context([zero, big])) is big

--- a/strands-py/tests_integ/models/test_model_routing.py
+++ b/strands-py/tests_integ/models/test_model_routing.py
@@ -1,0 +1,38 @@
+"""Integration tests for model routing over real Bedrock models.
+
+Ordered fallback is the routing behavior that only a real model surfaces: a real model failure
+triggers a real recovery, observable purely through the answer. Proactive selection (context-fit,
+first-candidate) is deterministic and covered by unit tests, so it is not re-tested here.
+"""
+
+import pytest
+
+from strands import Agent
+from strands.models import BedrockModel
+from strands.models.routing import ModelRouter
+from tests_integ.models import providers
+
+# Routing runs over Bedrock candidates; skip when Bedrock is unavailable.
+pytestmark = providers.bedrock.mark
+
+_HAIKU_MODEL_ID = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+
+
+@pytest.fixture
+def haiku():
+    return BedrockModel(model_id=_HAIKU_MODEL_ID)
+
+
+@pytest.fixture
+def broken_model():
+    """A model whose id does not exist, so the first call raises before any tokens stream."""
+    return BedrockModel(model_id="bogus.nonexistent-model-v1:0")
+
+
+def test_fallback_recovers_a_real_answer_from_a_failing_primary(broken_model, haiku):
+    """The broken primary fails, ordered fallback advances to the healthy model, and the task completes."""
+    agent = Agent(model=ModelRouter(models=[broken_model, haiku]), load_tools_from_directory=False)
+
+    result = agent("What is the capital of France? Reply with just the city name.")
+
+    assert "paris" in result.message["content"][0]["text"].lower()


### PR DESCRIPTION
> **Stacked on #3474 (Phase B).** Phase B is not yet merged to `main`, so this PR's diff currently
> includes the Phase B commit as well. Review Phase B in #3474; the Phase-C-only changes here are
> `models/routing/{strategy,strategies}.py`, the strategy/fallback additions in
> `models/routing/router.py`, the widened public surface in `models/routing/__init__.py`, the
> selection-middleware registration in `agent/agent.py`, and the one-line
> `ModelRetryStrategy.reset_retry_state()` visibility change. Once #3474 merges I will rebase and
> this diff becomes Phase-C-only.

## Description

Phase C of model routing (design `team/designs/0016-model-routing.md`). Where Phase B resolves a single model at construction, this adds **per-call selection** and **ordered fallback**, matching the P0 "router core and fallback" + local-strategy items in the design.

A `RoutingStrategy` chooses a candidate per model call; a selection middleware runs it once per invocation (cached in `invocation_state`), sets the per-call model, and is registered before the agentic capability middleware so the selected model is what capability middleware sees. Independently, the router installs an ordered-fallback hook: when the selected model's retries are exhausted, it advances to the next untried candidate in declaration order and requests another attempt. This composes with the existing `ModelRetryStrategy` rather than replacing it.

## Related Issues

Refs #364

## Type of Change

New feature

## Public API (provisional; package is internal pending API review)

```python
from strands.models.routing import ModelRouter, RoutingCandidate, FallbackStrategy, ContextFitStrategy

# Ordered fallback (default strategy): try sonnet, fall over to opus on failure.
agent = Agent(model=ModelRouter(models=[sonnet, opus]))

# Capacity-based local selection.
agent = Agent(model=ModelRouter(models=[haiku, sonnet, opus], strategy=ContextFitStrategy()))
```

- `RoutingStrategy` (Protocol): `async select(context) -> RoutingCandidate`; the result must be one of the candidates.
- `RoutingContext`: `messages`, `system_prompt`, `tool_specs`, `candidates`, `invocation_state`.
- `ModelRouter(models, *, strategy=None)` — `strategy` defaults to `FallbackStrategy` (selects the first candidate). Selection recurses into nested routers.
- **Ordered fallback is always active**, under any strategy: on an unretried model failure the router advances through untried candidates in declaration order, resetting the retry budget each hop, until one succeeds or all are exhausted.
- Bundled strategies: `FallbackStrategy` (select-first) and `ContextFitStrategy` — routes by capacity, estimating tokens with each candidate's own `count_tokens` and treating a candidate as fitting when usage stays within `threshold` of its window (default: the conversation manager's `DEFAULT_COMPRESSION_THRESHOLD`). Picks the smallest fitting window, the largest when none fit; reuses `DEFAULT_CONTEXT_WINDOW_LIMIT` for models with no declared window, and is best-effort if a count fails.

## Follow-ups (not in this PR)

- **Model-driven routing (Phase D):** a judge model classifies the request and names a candidate.
- P1: cost-aware, cache-affinity (sticky), classifier/semantic.

## Testing

- [x] I ran `hatch run prepare`

Unit tests cover strategy selection (fallback, context-fit with per-candidate counting and threshold), first-candidate/nested resolution, the select-result-must-be-a-candidate guard, per-invocation caching, and the ordered-fallback engine (advance on throttling and non-retryable failures, exhaustion, retry-budget reset, ordering after `ModelRetryStrategy`). The routing package is fully covered. An end-to-end integration test (real Bedrock) confirms ordered fallback recovers a real answer past a broken primary. ruff + mypy clean.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my feature works
- [x] My changes generate no new warnings

> Draft: per-call selection + ordered fallback, pending API review and the model-driven follow-up.

