### PR TITLE
feat(mcp): surface tool annotations in ToolSpec

### DIFF
--- a/strands-py/src/strands/tools/mcp/mcp_agent_tool.py
+++ b/strands-py/src/strands/tools/mcp/mcp_agent_tool.py
@@ -66,7 +66,8 @@ class MCPAgentTool(AgentTool):
         """Get the specification of the tool.
 
         This method converts the MCP tool specification to the agent framework's
-        ToolSpec format, including the input schema, description, and optional output schema.
+        ToolSpec format, including the input schema, description, optional output
+        schema, and optional tool annotations.
 
         Returns:
             ToolSpec: The tool specification in the agent framework format
@@ -81,6 +82,11 @@ class MCPAgentTool(AgentTool):
 
         if self.mcp_tool.outputSchema:
             spec["outputSchema"] = {"json": self.mcp_tool.outputSchema}
+
+        # Pass annotations through opaquely: per MCP spec they are untrusted hints,
+        # and the annotation vocabulary is still evolving (SEP-1984, SEP-1913).
+        if self.mcp_tool.annotations:
+            spec["annotations"] = self.mcp_tool.annotations.model_dump(exclude_none=True)
 
         return spec
 

--- a/strands-py/src/strands/tools/mcp/mcp_agent_tool.py
+++ b/strands-py/src/strands/tools/mcp/mcp_agent_tool.py
@@ -85,8 +85,11 @@ class MCPAgentTool(AgentTool):
 
         # Pass annotations through opaquely: per MCP spec they are untrusted hints,
         # and the annotation vocabulary is still evolving (SEP-1984, SEP-1913).
+        # An annotations object with no set fields is treated the same as no annotations.
         if self.mcp_tool.annotations:
-            spec["annotations"] = self.mcp_tool.annotations.model_dump(exclude_none=True)
+            annotations = self.mcp_tool.annotations.model_dump(exclude_none=True)
+            if annotations:
+                spec["annotations"] = annotations
 
         return spec
 

--- a/strands-py/src/strands/types/tools.py
+++ b/strands-py/src/strands/types/tools.py
@@ -30,12 +30,18 @@ class ToolSpec(TypedDict):
         outputSchema: Optional JSON Schema defining the expected output format.
             Note: Not all model providers support this field. Providers that don't
             support it should filter it out before sending to their API.
+        annotations: Optional metadata describing tool behavior (e.g. MCP tool
+            annotations such as `readOnlyHint` or `destructiveHint`). Annotations
+            are untrusted hints from the tool provider, not guarantees; consumers
+            such as permission layers must not treat them as a security boundary.
+            This field is not sent to model provider APIs.
     """
 
     description: str
     inputSchema: JSONSchema
     name: str
     outputSchema: NotRequired[JSONSchema]
+    annotations: NotRequired[dict[str, Any]]
 
 
 class Tool(TypedDict):

--- a/strands-py/src/strands/types/tools.py
+++ b/strands-py/src/strands/types/tools.py
@@ -31,17 +31,22 @@ class ToolSpec(TypedDict):
             Note: Not all model providers support this field. Providers that don't
             support it should filter it out before sending to their API.
         annotations: Optional metadata describing tool behavior (e.g. MCP tool
-            annotations such as `readOnlyHint` or `destructiveHint`). Annotations
-            are untrusted hints from the tool provider, not guarantees; consumers
-            such as permission layers must not treat them as a security boundary.
-            This field is not sent to model provider APIs.
+            annotations such as `readOnlyHint` or `destructiveHint`). Distinct
+            from content-level annotations on tool results.
+            Annotations are untrusted hints from the tool provider, not
+            guarantees; consumers such as permission layers must not treat them
+            as a security boundary. A missing key means unknown, not False:
+            per MCP spec `destructiveHint` and `openWorldHint` default to True
+            when absent (`readOnlyHint` and `idempotentHint` default to False),
+            and this field is absent entirely for non-MCP tools. This field is
+            not sent to model provider APIs.
     """
 
     description: str
     inputSchema: JSONSchema
     name: str
     outputSchema: NotRequired[JSONSchema]
-    annotations: NotRequired[dict[str, Any]]
+    annotations: NotRequired[dict[str, object]]
 
 
 class Tool(TypedDict):

--- a/strands-py/tests/strands/tools/mcp/test_mcp_agent_tool.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_agent_tool.py
@@ -110,6 +110,24 @@ def test_tool_spec_with_empty_annotations(mock_mcp_tool, mock_mcp_client):
     assert "annotations" not in tool_spec
 
 
+def test_tool_spec_preserves_explicit_false_hints(mock_mcp_tool, mock_mcp_client):
+    mock_mcp_tool.annotations = ToolAnnotations(readOnlyHint=False, destructiveHint=False)
+
+    agent_tool = MCPAgentTool(mock_mcp_tool, mock_mcp_client)
+    tool_spec = agent_tool.tool_spec
+
+    assert tool_spec["annotations"] == {"readOnlyHint": False, "destructiveHint": False}
+
+
+def test_tool_spec_preserves_unknown_annotation_keys(mock_mcp_tool, mock_mcp_client):
+    mock_mcp_tool.annotations = ToolAnnotations(readOnlyHint=True, futureHint="x")
+
+    agent_tool = MCPAgentTool(mock_mcp_tool, mock_mcp_client)
+    tool_spec = agent_tool.tool_spec
+
+    assert tool_spec["annotations"] == {"readOnlyHint": True, "futureHint": "x"}
+
+
 @pytest.mark.asyncio
 async def test_stream(mcp_agent_tool, mock_mcp_client, alist):
     tool_use = {"toolUseId": "test-123", "name": "test_tool", "input": {"param": "value"}}

--- a/strands-py/tests/strands/tools/mcp/test_mcp_agent_tool.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_agent_tool.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from mcp.types import Tool as MCPTool
+from mcp.types import ToolAnnotations
 
 from strands.tools.mcp import MCPAgentTool, MCPClient
 from strands.types._events import ToolResultEvent
@@ -16,6 +17,7 @@ def mock_mcp_tool():
     mock_tool.description = "A test tool"
     mock_tool.inputSchema = {"type": "object", "properties": {}}
     mock_tool.outputSchema = None  # MCP tools can have optional outputSchema
+    mock_tool.annotations = None  # MCP tools can have optional annotations
     return mock_tool
 
 
@@ -79,6 +81,24 @@ def test_tool_spec_without_output_schema(mock_mcp_tool, mock_mcp_client):
     tool_spec = agent_tool.tool_spec
 
     assert "outputSchema" not in tool_spec
+
+
+def test_tool_spec_with_annotations(mock_mcp_tool, mock_mcp_client):
+    mock_mcp_tool.annotations = ToolAnnotations(title="Test Tool", readOnlyHint=True)
+
+    agent_tool = MCPAgentTool(mock_mcp_tool, mock_mcp_client)
+    tool_spec = agent_tool.tool_spec
+
+    assert tool_spec["annotations"] == {"title": "Test Tool", "readOnlyHint": True}
+
+
+def test_tool_spec_without_annotations(mock_mcp_tool, mock_mcp_client):
+    mock_mcp_tool.annotations = None
+
+    agent_tool = MCPAgentTool(mock_mcp_tool, mock_mcp_client)
+    tool_spec = agent_tool.tool_spec
+
+    assert "annotations" not in tool_spec
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests/strands/tools/mcp/test_mcp_agent_tool.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_agent_tool.py
@@ -101,6 +101,15 @@ def test_tool_spec_without_annotations(mock_mcp_tool, mock_mcp_client):
     assert "annotations" not in tool_spec
 
 
+def test_tool_spec_with_empty_annotations(mock_mcp_tool, mock_mcp_client):
+    mock_mcp_tool.annotations = ToolAnnotations()
+
+    agent_tool = MCPAgentTool(mock_mcp_tool, mock_mcp_client)
+    tool_spec = agent_tool.tool_spec
+
+    assert "annotations" not in tool_spec
+
+
 @pytest.mark.asyncio
 async def test_stream(mcp_agent_tool, mock_mcp_client, alist):
     tool_use = {"toolUseId": "test-123", "name": "test_tool", "input": {"param": "value"}}

--- a/strands-ts/src/mcp/__tests__/client-annotations.test.ts
+++ b/strands-ts/src/mcp/__tests__/client-annotations.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { z } from 'zod'
+import { McpClient } from '../client.js'
+
+/**
+ * Exercises annotation pass-through over a real (in-memory) MCP transport, unlike
+ * client.test.ts, which mocks the MCP SDK Client and therefore bypasses the SDK's
+ * Zod validation of listTools responses.
+ */
+describe('McpClient annotations over a real transport', () => {
+  async function listToolsFromServer(annotations: Record<string, unknown> | undefined): Promise<McpClient> {
+    const server = new McpServer({ name: 'annotations-test-server', version: '1.0.0' })
+    server.registerTool(
+      'echo',
+      {
+        description: 'Echoes input',
+        inputSchema: { value: z.string() },
+        ...(annotations !== undefined && { annotations }),
+      },
+      async ({ value }) => ({ content: [{ type: 'text', text: value }] })
+    )
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+    await server.connect(serverTransport)
+    return new McpClient({ transport: clientTransport })
+  }
+
+  it('surfaces known annotation keys from the server', async () => {
+    const client = await listToolsFromServer({ title: 'Echo', readOnlyHint: true, openWorldHint: false })
+
+    const tools = await client.listTools()
+
+    expect(tools[0]!.toolSpec.annotations).toEqual({ title: 'Echo', readOnlyHint: true, openWorldHint: false })
+  })
+
+  it('preserves explicitly-false hints', async () => {
+    const client = await listToolsFromServer({ readOnlyHint: false, destructiveHint: false })
+
+    const tools = await client.listTools()
+
+    expect(tools[0]!.toolSpec.annotations).toEqual({ readOnlyHint: false, destructiveHint: false })
+  })
+
+  it('strips unknown annotation keys at the MCP SDK boundary', async () => {
+    // The MCP SDK's ToolAnnotationsSchema is a non-passthrough Zod object: keys outside the
+    // spec'd vocabulary are dropped during listTools validation, before McpClient sees them.
+    // If this test starts failing with futureSepKey present, the SDK now passes unknown keys
+    // through and the pass-through comment in client.ts should be updated to match Python.
+    const client = await listToolsFromServer({ readOnlyHint: true, futureSepKey: 'x' })
+
+    const tools = await client.listTools()
+
+    expect(tools[0]!.toolSpec.annotations).toEqual({ readOnlyHint: true })
+  })
+
+  it('omits annotations when the server declares none', async () => {
+    const client = await listToolsFromServer(undefined)
+
+    const tools = await client.listTools()
+
+    expect(tools[0]!.toolSpec).not.toHaveProperty('annotations')
+  })
+})

--- a/strands-ts/src/mcp/__tests__/client.test.ts
+++ b/strands-ts/src/mcp/__tests__/client.test.ts
@@ -456,6 +456,32 @@ describe('MCP Integration', () => {
       )
     })
 
+    it('surfaces tool annotations in the tool spec', async () => {
+      const annotations = { title: 'Get Weather', readOnlyHint: true }
+      sdkClientMock.listTools.mockResolvedValue({
+        tools: [{ name: 'weather', description: 'Get weather', inputSchema: {}, annotations }],
+      })
+
+      const tools = await client.listTools()
+
+      expect(tools[0]!.toolSpec).toEqual({
+        name: 'weather',
+        description: 'Get weather',
+        inputSchema: {},
+        annotations,
+      })
+    })
+
+    it('omits annotations from the tool spec when the server provides none', async () => {
+      sdkClientMock.listTools.mockResolvedValue({
+        tools: [{ name: 'weather', description: 'Get weather', inputSchema: {} }],
+      })
+
+      const tools = await client.listTools()
+
+      expect(tools[0]!.toolSpec).not.toHaveProperty('annotations')
+    })
+
     it('generates description fallback when description is missing', async () => {
       sdkClientMock.listTools.mockResolvedValue({
         tools: [{ name: 'my_tool', inputSchema: {} }],

--- a/strands-ts/src/mcp/__tests__/client.test.ts
+++ b/strands-ts/src/mcp/__tests__/client.test.ts
@@ -482,6 +482,16 @@ describe('MCP Integration', () => {
       expect(tools[0]!.toolSpec).not.toHaveProperty('annotations')
     })
 
+    it('omits annotations from the tool spec when the server provides an empty annotations object', async () => {
+      sdkClientMock.listTools.mockResolvedValue({
+        tools: [{ name: 'weather', description: 'Get weather', inputSchema: {}, annotations: {} }],
+      })
+
+      const tools = await client.listTools()
+
+      expect(tools[0]!.toolSpec).not.toHaveProperty('annotations')
+    })
+
     it('generates description fallback when description is missing', async () => {
       sdkClientMock.listTools.mockResolvedValue({
         tools: [{ name: 'my_tool', inputSchema: {} }],

--- a/strands-ts/src/mcp/client.ts
+++ b/strands-ts/src/mcp/client.ts
@@ -380,6 +380,11 @@ export class McpClient {
           description: toolSpec.description || `Tool which performs ${toolSpec.name}`,
           inputSchema: toolSpec.inputSchema as JSONSchema,
           ...(toolSpec.outputSchema !== undefined && { outputSchema: toolSpec.outputSchema as JSONSchema }),
+          // Annotations pass through opaquely: the MCP spec treats them as untrusted hints,
+          // and the annotation vocabulary is still evolving (SEP-1984, SEP-1913).
+          ...(toolSpec.annotations !== undefined && {
+            annotations: toolSpec.annotations as Record<string, JSONValue>,
+          }),
           client: this,
         })
         this._serverToolNames.set(tool, toolSpec.name)

--- a/strands-ts/src/mcp/client.ts
+++ b/strands-ts/src/mcp/client.ts
@@ -382,9 +382,11 @@ export class McpClient {
           ...(toolSpec.outputSchema !== undefined && { outputSchema: toolSpec.outputSchema as JSONSchema }),
           // Annotations pass through opaquely: the MCP spec treats them as untrusted hints,
           // and the annotation vocabulary is still evolving (SEP-1984, SEP-1913).
-          ...(toolSpec.annotations !== undefined && {
-            annotations: toolSpec.annotations as Record<string, JSONValue>,
-          }),
+          // An empty annotations object is treated the same as no annotations.
+          ...(toolSpec.annotations !== undefined &&
+            Object.keys(toolSpec.annotations).length > 0 && {
+              annotations: toolSpec.annotations as Record<string, JSONValue>,
+            }),
           client: this,
         })
         this._serverToolNames.set(tool, toolSpec.name)

--- a/strands-ts/src/mcp/client.ts
+++ b/strands-ts/src/mcp/client.ts
@@ -380,12 +380,14 @@ export class McpClient {
           description: toolSpec.description || `Tool which performs ${toolSpec.name}`,
           inputSchema: toolSpec.inputSchema as JSONSchema,
           ...(toolSpec.outputSchema !== undefined && { outputSchema: toolSpec.outputSchema as JSONSchema }),
-          // Annotations pass through opaquely: the MCP spec treats them as untrusted hints,
-          // and the annotation vocabulary is still evolving (SEP-1984, SEP-1913).
+          // Pass through only the annotation keys the MCP SDK's Zod schema recognizes
+          // (title, readOnlyHint, destructiveHint, idempotentHint, openWorldHint). The SDK strips
+          // unknown keys before this code runs, so new annotation vocabulary won't surface here
+          // until the SDK dependency updates. The MCP spec treats these as untrusted hints.
           // An empty annotations object is treated the same as no annotations.
           ...(toolSpec.annotations !== undefined &&
             Object.keys(toolSpec.annotations).length > 0 && {
-              annotations: toolSpec.annotations as Record<string, JSONValue>,
+              annotations: toolSpec.annotations,
             }),
           client: this,
         })

--- a/strands-ts/src/tools/mcp-tool.ts
+++ b/strands-ts/src/tools/mcp-tool.ts
@@ -14,6 +14,7 @@ export interface McpToolConfig {
   description: string
   inputSchema: JSONSchema
   outputSchema?: JSONSchema
+  annotations?: Record<string, JSONValue>
   client: McpClient
 }
 
@@ -39,6 +40,7 @@ export class McpTool extends Tool {
       description: config.description,
       inputSchema: config.inputSchema,
       ...(config.outputSchema !== undefined && { outputSchema: config.outputSchema }),
+      ...(config.annotations !== undefined && { annotations: config.annotations }),
     }
     this.mcpClient = config.client
   }

--- a/strands-ts/src/tools/mcp-tool.ts
+++ b/strands-ts/src/tools/mcp-tool.ts
@@ -14,7 +14,7 @@ export interface McpToolConfig {
   description: string
   inputSchema: JSONSchema
   outputSchema?: JSONSchema
-  annotations?: Record<string, JSONValue>
+  annotations?: Record<string, JSONValue | undefined>
   client: McpClient
 }
 

--- a/strands-ts/src/tools/types.ts
+++ b/strands-ts/src/tools/types.ts
@@ -34,12 +34,13 @@ export interface ToolSpec {
   outputSchema?: JSONSchema
 
   /**
-   * Metadata describing tool behavior (e.g. MCP tool annotations such as `readOnlyHint`
-   * or `destructiveHint`). Annotations are untrusted hints from the tool provider, not
-   * guarantees; consumers such as permission layers must not treat them as a security
-   * boundary. This field is not sent to model provider APIs.
+   * Untrusted tool-behavior hints (e.g. MCP `readOnlyHint`, `destructiveHint`); never a security boundary.
+   *
+   * Not sent to model provider APIs. A missing key means unknown, not `false` — per MCP spec
+   * `destructiveHint` and `openWorldHint` default to `true` when absent — and the field is absent
+   * entirely for non-MCP tools.
    */
-  annotations?: Record<string, JSONValue>
+  annotations?: Record<string, JSONValue | undefined>
 }
 
 /**

--- a/strands-ts/src/tools/types.ts
+++ b/strands-ts/src/tools/types.ts
@@ -32,6 +32,14 @@ export interface ToolSpec {
    * JSON Schema defining the expected output structure for the tool.
    */
   outputSchema?: JSONSchema
+
+  /**
+   * Metadata describing tool behavior (e.g. MCP tool annotations such as `readOnlyHint`
+   * or `destructiveHint`). Annotations are untrusted hints from the tool provider, not
+   * guarantees; consumers such as permission layers must not treat them as a security
+   * boundary. This field is not sent to model provider APIs.
+   */
+  annotations?: Record<string, JSONValue>
 }
 
 /**


### PR DESCRIPTION
## Description

Both SDKs drop MCP tool annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`, `title`) when mapping server tools: Python never reads `mcp_tool.annotations` and TypeScript never reads the listing's `annotations`. Hooks and permission layers have no way to see them, so a policy like "auto-approve read-only tools, confirm destructive ones" can't be built on top of the SDK.

This PR passes annotations through into `ToolSpec` in both SDKs.

Two deliberate choices:

- **Opaque pass-through.** The annotation vocabulary is still moving (SEP-1984, SEP-1913 in flight), so the field is an untyped dict/record instead of a typed allowlist. Consumers read the keys they know, and new server-side annotations arrive without an SDK change. Per the MCP spec these are untrusted hints, and the field docs say so.
- **Not sent to model providers.** Every provider in both SDKs builds its request from explicit `ToolSpec` fields, so the new key never reaches a vendor API.

## Public API Changes

New optional `annotations` field on `ToolSpec`, populated for MCP tools that declare annotations and absent otherwise:

```python
# Python
tool.tool_spec.get("annotations")
# {'title': 'Echo Tool', 'readOnlyHint': True, 'openWorldHint': False}
```

```typescript
// TypeScript
tool.toolSpec.annotations
// { title: 'Echo Tool', readOnlyHint: true, openWorldHint: false }
```

## Related Issues

Closes #3271 (parent: #1659)

## Documentation PR

No docs change; the field is documented in the `ToolSpec` type itself.

## Type of Change

New feature

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

Also verified end to end against a real stdio MCP server (FastMCP with `ToolAnnotations`) through both SDK clients: annotated tools surface the dict, unannotated tools omit the field.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
