### PR TITLE
fix(ts): complete the message when a provider omits the message start event

### DIFF
--- a/strands-ts/src/models/__tests__/model.test.ts
+++ b/strands-ts/src/models/__tests__/model.test.ts
@@ -406,6 +406,67 @@ describe('Model', () => {
       })
     })
 
+    describe('when the provider omits the message start event', () => {
+      it('completes the message by assuming the assistant role', async () => {
+        // ai-sdk-ollama streams content without a Vercel `stream-start` part, so VercelModel
+        // never emits modelMessageStartEvent. See #3190.
+        const provider = new TestModelProvider(async function* () {
+          yield { type: 'modelContentBlockStartEvent' }
+          yield {
+            type: 'modelContentBlockDeltaEvent',
+            delta: { type: 'textDelta', text: 'Hello' },
+          }
+          yield { type: 'modelContentBlockStopEvent' }
+          yield { type: 'modelMessageStopEvent', stopReason: 'endTurn' }
+        })
+
+        const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
+
+        const { result } = await collectGenerator(provider.streamAggregated(messages))
+
+        expect(result.message.role).toBe('assistant')
+        expect(result.message.content).toEqual([{ type: 'textBlock', text: 'Hello' }])
+        expect(result.stopReason).toBe('endTurn')
+      })
+
+      it('preserves tool use blocks so the agent loop still executes tools', async () => {
+        const provider = new TestModelProvider(async function* () {
+          yield {
+            type: 'modelContentBlockStartEvent',
+            start: { type: 'toolUseStart', toolUseId: 't1', name: 'get_weather' },
+          }
+          yield {
+            type: 'modelContentBlockDeltaEvent',
+            delta: { type: 'toolUseInputDelta', input: '{"city":"Berlin"}' },
+          }
+          yield { type: 'modelContentBlockStopEvent' }
+          yield { type: 'modelMessageStopEvent', stopReason: 'toolUse' }
+        })
+
+        const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
+
+        const { result } = await collectGenerator(provider.streamAggregated(messages))
+
+        expect(result.message.role).toBe('assistant')
+        expect(result.message.content).toEqual([
+          { type: 'toolUseBlock', name: 'get_weather', toolUseId: 't1', input: { city: 'Berlin' } },
+        ])
+        expect(result.stopReason).toBe('toolUse')
+      })
+
+      it('still throws when the stream produced no content at all', async () => {
+        const provider = new TestModelProvider(async function* () {
+          yield { type: 'modelMessageStopEvent', stopReason: 'endTurn' }
+        })
+
+        const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
+
+        await expect(async () => await collectGenerator(provider.streamAggregated(messages))).rejects.toThrow(
+          'Stream ended without completing a message'
+        )
+      })
+    })
+
     describe('when streaming reasoning content', () => {
       it('yields complete reasoning block', async () => {
         const provider = new TestModelProvider(async function* () {

--- a/strands-ts/src/models/model.ts
+++ b/strands-ts/src/models/model.ts
@@ -433,19 +433,33 @@ export abstract class Model<T extends BaseModelConfig = BaseModelConfig> {
             break
           }
 
-          case 'modelMessageStopEvent':
-            // Store message and stop reason
-            if (messageRole) {
+          case 'modelMessageStopEvent': {
+            // Store message and stop reason.
+            // Some providers (e.g. ai-sdk-ollama) stream content but never emit a message start
+            // event. Without a role we would discard a perfectly good response and throw
+            // "Stream ended without completing a message" below. Model output is always the
+            // assistant turn, so synthesize the role rather than lose the message. A stream that
+            // produced no content at all is still a genuinely broken stream and keeps throwing.
+            // See #3190.
+            let role = messageRole
+            if (!role && contentBlocks.length > 0) {
+              logger.warn(
+                'model stream completed without a message start event; assuming role "assistant"'
+              )
+              role = 'assistant'
+            }
+            if (role) {
               const filtered = contentBlocks.filter(
                 (block) => !(block instanceof TextBlock && block.text.trim() === '')
               )
               stoppedMessage = new Message({
-                role: messageRole,
+                role,
                 content: filtered,
               })
               finalStopReason = event.stopReason!
             }
             break
+          }
 
           case 'modelMetadataEvent':
             // Store metadata, keeping the last one if multiple events occur


### PR DESCRIPTION
## Description

Addresses the remaining Strands-side half of #3190.

That issue reported two failures with `ai-sdk-ollama`. The `finish_reason` half was fixed in #3185 - `vercel.ts` now promotes a terminating `endTurn` to `toolUse` when a client tool call completed, with a comment naming this provider. The other half is still present on `main`:

- `strands-ts/src/models/model.ts:438` - `streamAggregated` only finalizes a message inside `if (messageRole)`
- `messageRole` is assigned in exactly one place, `case 'modelMessageStartEvent'` (`:361`)
- a provider that streams content without emitting that event (`ai-sdk-ollama` omits the Vercel `stream-start` part) therefore leaves `messageRole` null, `stoppedMessage` null, and falls through to `:476-482` throwing `ModelError('Stream ended without completing a message')`

The text streamed fine and `contentBlocks` was fully populated - the response is discarded purely because the provider never announced the message.

## Change

In `case 'modelMessageStopEvent'`, when there is no role but content was accumulated, assume `assistant` (model output is always the assistant turn) and `logger.warn` so the misbehaving provider stays visible rather than being silently papered over.

A stream that produced **no** content at all is still a genuinely broken stream and keeps throwing exactly as before - the existing `ModelError` path and its `SyntaxError` cause are untouched.

## Testing

Three tests added to `strands-ts/src/models/__tests__/model.test.ts` under a new `when the provider omits the message start event` describe, using the existing `TestModelProvider` (no live Ollama required):

- text stream with no start event completes as an assistant message
- tool use with no start event preserves the `ToolUseBlock` and `toolUse` stop reason, so the agent loop still executes the tool
- a stream with no content at all still throws `Stream ended without completing a message`

I was not able to build and run the `strands-ts` suite locally, so these three are **unverified by me** - I would appreciate CI confirming them.

## A note on process

CONTRIBUTING asks contributors to comment and wait for maintainer confirmation before significant work, and I am aware @notowen333 previously steered @jstar0 toward an upstream evidence artifact on #3190 rather than a Strands-side patch - which worked, `ai-sdk-ollama@3.8.8` fixed the finish reason.

I opened this as working code rather than a proposal because the change is ~15 lines and #3185 already established that Strands hardens against exactly this provider's stream deviations. The argument here is symmetry: we already refuse to let a wrong `finish_reason` break the loop, and a missing `stream-start` is the same class of defect with the more severe outcome (the entire response is thrown away).

If you would rather keep this provider-side, say so and I will close it - no attachment to the approach.

## Related Issues

Related to #3190. Mirrors #3185.

## Type of Change

Bug fix

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective
- [x] My changes generate no new warnings
- [ ] I have run the test suite locally (see Testing above)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.