### PR TITLE
test(mcp): wait for the retained task, not the log line

### DIFF
--- a/strands-py/tests/strands/tools/mcp/test_mcp_client.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client.py
@@ -555,8 +555,12 @@ async def test_call_tool_async_caller_cancellation_timeout_preserves_cancelled_e
                 with pytest.raises(asyncio.CancelledError):
                     await caller
                 assert await asyncio.to_thread(call_cancelled.wait, 1)
+                # The client logs the expired window, then sends the cancellation notification, and
+                # only then retains the unfinished invocation. Waiting on the log alone would
+                # observe the client mid-sequence, so wait for the retained task itself. The
+                # client runs on its own thread, so nothing else orders these two observations.
                 for _ in range(150):
-                    if "did not finish within bounded cancellation cleanup" in caplog.text:
+                    if client._background_cleanup_tasks:
                         break
                     await asyncio.sleep(0.01)
 


### PR DESCRIPTION
## Description

`test_call_tool_async_caller_cancellation_timeout_preserves_cancelled_error` fails intermittently in the full suite and never in isolation. It polls for a debug log as a proxy for "the unfinished invocation has been retained", but the client logs that before it retains the task:

```python
if pending:
    self._log_debug_with_thread("MCP invocation did not finish within bounded cancellation cleanup")  # 1340
if cancellation_state is not None:
    await self._cancel_tool_call(cancellation_state)                                                  # 1342
if pending:
    self._track_background_cleanup_task(invoke_event)                                                 # 1346
```

`_cancel_tool_call` creates a cancellation task and waits on it for up to another second. The test exits its poll the moment the log appears and asserts immediately, so it can observe the client mid-sequence. The client runs its own event loop on a separate thread, so nothing else orders the two observations — under parallel load the client thread simply isn't scheduled in time and `_background_cleanup_tasks` is still empty.

The fix waits for the condition being asserted instead of a log line that precedes it. The log assertion stays; it just stops being the loop's exit condition.

Test-only change — no source behavior is modified.

## Related Issues

Closes #3536. The test was introduced in #3402.

## Type of Change

Bug fix

## Testing

The flake can be made deterministic by simulating the scheduling delay, adding one line between 1340 and 1342 in `mcp_client.py`:

```python
await asyncio.sleep(0.5)
```

| Scenario | Result |
| --- | --- |
| Before, full suite | 1 failure in 3 runs (small sample) |
| Before, isolation | 0 failures |
| Before + injected delay | **3 / 3 failed** |
| After + same injected delay | 5 / 5 passed |
| After, no delay, full suite | **30 / 30 passed** |

At the observed baseline, 30 consecutive clean runs is ~1 in 90,000 by chance, so the fix is doing real work rather than getting lucky.

**Confidence ~9.5/10, with one caveat I could not close.** `_cancel_tool_call` catches `except Exception`, which does not catch `asyncio.CancelledError`. If one escaped on this cancellation-heavy path, line 1346 would be skipped and the set would stay empty *permanently* — the same symptom, but not fixable by polling in the test. Thirty clean runs suggest that does not happen at a rate that matters, but I could not prove it unreachable; whoever knows this design will likely settle it at a glance. If the flake recurs after this lands, that `except Exception` is where I would look.

For context, the bounded-cleanup machinery is Python-only. `strands-ts/src/mcp/` has no equivalent, since the TypeScript side cancels via `AbortSignal` on a single thread, so there is no TypeScript counterpart to fix.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
