### PR TITLE
fix(telemetry): record gen_ai.tool.call.arguments/result on execute_tool spans

### DIFF
--- a/strands-py/src/strands/telemetry/tracer.py
+++ b/strands-py/src/strands/telemetry/tracer.py
@@ -94,7 +94,9 @@ class Tracer:
     span events, for backends that cannot read span events. This applies to the aggregated content events
     (latest-convention "gen_ai.*" messages and the "memory.query"/"memory.content" events); the legacy
     per-message events are always emitted as events. The default (token absent, non-Langfuse) emits span
-    events for backward compatibility.
+    events for backward compatibility. Independent of this token, tool spans under the latest
+    conventions additionally record `gen_ai.tool.call.arguments` and `gen_ai.tool.call.result` as
+    span attributes per the execute_tool span convention.
 
     Span attribute redaction is opt-in via the `gen_ai_unredacted_attributes=<list>` token in the same
     environment variable. The list uses `;` as a separator and supports trailing-`*` glob patterns.
@@ -105,7 +107,9 @@ class Tracer:
 
     Sensitive attributes subject to the redaction policy are: `gen_ai.input.messages` (user messages
     and tool inputs/results being fed into the model), `gen_ai.output.messages` (agent/model responses
-    and tool call responses), and `gen_ai.system_instructions` (system prompts).
+    and tool call responses), `gen_ai.system_instructions` (system prompts), and, on execute_tool
+    spans under the latest conventions, `gen_ai.tool.call.arguments` and `gen_ai.tool.call.result`
+    (tool inputs/outputs).
     """
 
     def __init__(self) -> None:
@@ -175,11 +179,11 @@ class Tracer:
 
         Args:
             attribute_name: The canonical semantic attribute name used for policy lookup
-                (one of `gen_ai.input.messages`, `gen_ai.output.messages`, or
-                `gen_ai.system_instructions`). This may differ from the physical event
-                field key emitted under legacy conventions (which uses `content`/`message`),
-                but the canonical name is always used so that allowlist entries are
-                independent of the convention in use.
+                (`gen_ai.input.messages`, `gen_ai.output.messages`, `gen_ai.system_instructions`,
+                `gen_ai.tool.call.arguments`, or `gen_ai.tool.call.result`). This may differ
+                from the physical event field key emitted under legacy conventions (which uses
+                `content`/`message`), but the canonical name is always used so that allowlist
+                entries are independent of the convention in use.
             value: The serialized attribute value to potentially redact.
 
         Returns:
@@ -508,6 +512,13 @@ class Tracer:
         span = self._start_span(span_name, parent_span, attributes=attributes, span_kind=trace_api.SpanKind.INTERNAL)
 
         if self.use_latest_genai_conventions:
+            # The execute_tool span convention records tool inputs in the dedicated
+            # gen_ai.tool.call.arguments span attribute (Opt-In), which spec-compliant
+            # consumers read on tool spans.
+            span.set_attribute(
+                "gen_ai.tool.call.arguments",
+                self._redact("gen_ai.tool.call.arguments", serialize(tool["input"])),
+            )
             input_messages = serialize(
                 [
                     {
@@ -560,6 +571,12 @@ class Tracer:
             attributes["gen_ai.tool.status"] = str(status) if status is not None else ""
 
             if self.use_latest_genai_conventions:
+                # The execute_tool span convention records tool outputs in the dedicated
+                # gen_ai.tool.call.result span attribute (Opt-In), which spec-compliant
+                # consumers read on tool spans. The spec scopes the attribute to successful
+                # executions; failures are captured in the span status instead.
+                if status != "error":
+                    attributes["gen_ai.tool.call.result"] = self._redact("gen_ai.tool.call.result", serialize(content))
                 output_messages = serialize(
                     [
                         {

--- a/strands-py/tests/strands/telemetry/test_tracer.py
+++ b/strands-py/tests/strands/telemetry/test_tracer.py
@@ -453,6 +453,7 @@ def test_start_tool_call_span_latest_conventions(mock_tracer, monkeypatch):
                 "gen_ai.tool.call.id": "123",
             }
         )
+        mock_span.set_attribute.assert_any_call("gen_ai.tool.call.arguments", serialize(tool["input"]))
         mock_span.add_event.assert_called_with(
             "gen_ai.client.inference.operation.details",
             attributes={
@@ -685,7 +686,12 @@ def test_end_tool_call_span_latest_conventions(mock_span, monkeypatch):
 
     tracer.end_tool_call_span(mock_span, tool_result)
 
-    mock_span.set_attributes.assert_called_once_with({"gen_ai.tool.status": "success"})
+    mock_span.set_attributes.assert_called_once_with(
+        {
+            "gen_ai.tool.status": "success",
+            "gen_ai.tool.call.result": serialize(tool_result.get("content")),
+        }
+    )
     mock_span.add_event.assert_called_with(
         "gen_ai.client.inference.operation.details",
         attributes={

--- a/strands-py/tests/strands/telemetry/test_tracer.py
+++ b/strands-py/tests/strands/telemetry/test_tracer.py
@@ -715,6 +715,19 @@ def test_end_tool_call_span_latest_conventions(mock_span, monkeypatch):
     mock_span.end.assert_called_once()
 
 
+def test_end_tool_call_span_latest_conventions_error_omits_result(mock_span, monkeypatch):
+    """The gen_ai.tool.call.result attribute is scoped to successful executions and omitted on error status."""
+    monkeypatch.setenv("OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental")
+    tracer = Tracer()
+    tool_result = {"toolUseId": "abc", "status": "error", "content": [{"text": "tool exploded"}]}
+
+    tracer.end_tool_call_span(mock_span, tool_result)
+
+    mock_span.set_attributes.assert_called_once_with({"gen_ai.tool.status": "error"})
+    mock_span.set_status.assert_called_once_with(StatusCode.ERROR, "tool exploded")
+    mock_span.end.assert_called_once()
+
+
 def test_end_tool_call_span_with_error(mock_span):
     """Test ending a tool call span with an explicit error sets StatusCode.ERROR."""
     tracer = Tracer()

--- a/strands-ts/src/telemetry/__tests__/tracer.test.node.ts
+++ b/strands-ts/src/telemetry/__tests__/tracer.test.node.ts
@@ -497,6 +497,17 @@ describe('Tracer', () => {
         },
       ])
     })
+
+    it('sets latest convention tool call arguments attribute', () => {
+      vi.stubEnv('OTEL_SEMCONV_STABILITY_OPT_IN', 'gen_ai_latest_experimental')
+      const tracer = new Tracer()
+
+      tracer.startToolCallSpan({
+        tool: { name: 'search', toolUseId: 'call-2', input: { query: 'test' } },
+      })
+
+      expect(mockSpan.getAttributeValue('gen_ai.tool.call.arguments')).toBe('{"query":"test"}')
+    })
   })
 
   describe('endToolCallSpan', () => {
@@ -543,6 +554,47 @@ describe('Tracer', () => {
       expect(parsed[0].role).toBe('tool')
       expect(parsed[0].parts[0].type).toBe('tool_call_response')
       expect(parsed[0].parts[0].id).toBe('call-1')
+    })
+
+    it('sets latest convention tool call result attribute on success', () => {
+      vi.stubEnv('OTEL_SEMCONV_STABILITY_OPT_IN', 'gen_ai_latest_experimental')
+      const tracer = new Tracer()
+      const span = tracer.startToolCallSpan({
+        tool: { name: 'calc', toolUseId: 'call-1', input: {} },
+      })
+
+      const toolResult = new ToolResultBlock({
+        toolUseId: 'call-1',
+        status: 'success',
+        content: [new TextBlock('42')],
+      })
+
+      tracer.endToolCallSpan(span, { toolResult })
+
+      const resultAttr = mockSpan.getAttributeValue('gen_ai.tool.call.result')
+      expect(resultAttr).toBeDefined()
+      const parsed = JSON.parse(resultAttr as string)
+      expect(parsed).toHaveLength(1)
+      expect(parsed[0]).toMatchObject({ text: '42' })
+    })
+
+    it('omits latest convention tool call result attribute on error status', () => {
+      vi.stubEnv('OTEL_SEMCONV_STABILITY_OPT_IN', 'gen_ai_latest_experimental')
+      const tracer = new Tracer()
+      const span = tracer.startToolCallSpan({
+        tool: { name: 'calc', toolUseId: 'call-1', input: {} },
+      })
+
+      const toolResult = new ToolResultBlock({
+        toolUseId: 'call-1',
+        status: 'error',
+        content: [new TextBlock('tool exploded')],
+      })
+
+      tracer.endToolCallSpan(span, { toolResult })
+
+      expect(mockSpan.getAttributeValue('gen_ai.tool.call.result')).toBeUndefined()
+      expect(mockSpan.getAttributeValue('gen_ai.tool.status')).toBe('error')
     })
 
     it('records error on tool failure', () => {

--- a/strands-ts/src/telemetry/tracer.ts
+++ b/strands-ts/src/telemetry/tracer.ts
@@ -450,6 +450,10 @@ export class Tracer {
       })
 
       if (this._useLatestConventions) {
+        // The execute_tool span convention records tool inputs in the dedicated
+        // gen_ai.tool.call.arguments span attribute (Opt-In), which spec-compliant
+        // consumers read on tool spans.
+        span.setAttribute('gen_ai.tool.call.arguments', JSON.stringify(tool.input, jsonReplacer))
         this._addEvent(
           span,
           'gen_ai.client.inference.operation.details',
@@ -506,6 +510,13 @@ export class Tracer {
         attributes['gen_ai.tool.status'] = statusStr
 
         if (this._useLatestConventions) {
+          // The execute_tool span convention records tool outputs in the dedicated
+          // gen_ai.tool.call.result span attribute (Opt-In), which spec-compliant
+          // consumers read on tool spans. The spec scopes the attribute to successful
+          // executions; failures are captured in the span status instead.
+          if (statusStr !== 'error') {
+            attributes['gen_ai.tool.call.result'] = JSON.stringify(toolResult.content, jsonReplacer)
+          }
           this._addEvent(
             span,
             'gen_ai.client.inference.operation.details',


### PR DESCRIPTION
## Description

Under `gen_ai_latest_experimental`, tool payloads on `execute_tool` spans are recorded only inside the `gen_ai.input.messages` / `gen_ai.output.messages` envelopes — attributes the OTel GenAI semantic conventions define for inference spans, not tool spans. Consumers implementing the execute_tool span convention read `gen_ai.tool.call.arguments` and `gen_ai.tool.call.result` (added to the spec in v1.38) and find nothing, so every spec-compliant backend renders an empty tool span.

This PR additionally records `gen_ai.tool.call.arguments` at tool-span start and `gen_ai.tool.call.result` at tool-span end, in both the Python and TypeScript tracers. The existing message-envelope events are unchanged, so current consumers see no difference. Per the spec, the result attribute is scoped to successful executions and is omitted when the tool status is `error` (failures remain visible via `gen_ai.tool.status` and the span's error status). Both attributes are recorded directly as span attributes regardless of the `gen_ai_span_attributes_only` token, since span attributes are their native home in the convention.

In the Python tracer, both attributes participate in the `gen_ai_unredacted_attributes` redaction policy under their own canonical names — an existing allowlist entry for `gen_ai.input.messages`/`gen_ai.output.messages` does not cover them, so users who want tool payloads unredacted need to add the new names (or a `gen_ai.tool.call.*` glob). The TypeScript tracer has no redaction mechanism, so the values are recorded directly, consistent with all other content attributes there.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

No documentation changes needed; the attributes follow the OTel GenAI execute_tool span convention and are documented in the tracer docstring.

## Type of Change

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

Python: full tracer unit suite passes, including latest-conventions tool-span tests asserting both the new attributes and the unchanged event emission. TypeScript: tracer unit suite plus the agent/swarm/graph tracer suites pass; lint, type-check, and format checks are clean.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
