### PR TITLE
feat(mcp): add client OAuth authentication for streamable HTTP

### DIFF
--- a/site/src/content/docs/user-guide/concepts/tools/mcp-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/mcp-tools.mdx
@@ -186,6 +186,53 @@ github_mcp_client = MCPClient(
 )
 ```
 
+#### OAuth Authentication
+
+For servers protected by OAuth, pass the server `url` directly with an `auth` credential. `MCPClient` builds the streamable HTTP transport internally and authenticates with the OAuth client_credentials grant, which suits machine-to-machine deployments where no user is present to complete a browser flow.
+
+```python
+import os
+from strands.tools.mcp import MCPClient
+
+oauth_mcp_client = MCPClient(
+    url="https://api.example.com/mcp/",
+    auth={
+        "client_id": os.environ["OAUTH_CLIENT_ID"],
+        "client_secret": os.environ["OAUTH_CLIENT_SECRET"],
+        "scopes": ["mcp:tools"],  # optional
+    },
+)
+```
+
+Scopes are joined with spaces before being sent to the token endpoint. Token acquisition and refresh happen automatically. The `headers` parameter can be combined with `auth` when the server also expects custom headers.
+
+For advanced flows such as the interactive authorization_code grant, pass any `httpx.Auth` implementation as `auth_provider` instead. The `mcp` package's `OAuthClientProvider` is one such implementation:
+
+```python
+from mcp.client.auth import OAuthClientProvider
+
+oauth_mcp_client = MCPClient(
+    url="https://api.example.com/mcp/",
+    auth_provider=OAuthClientProvider(...),
+)
+```
+
+`auth` and `auth_provider` are mutually exclusive, both require `url`, and OAuth is supported for streamable HTTP only. The same `auth` credential can be set on a server entry in a [`load_servers`](#using-multiple-mcp-servers) config, where `${VAR}` interpolation keeps secrets in the environment:
+
+```json
+{
+  "mcpServers": {
+    "protected-server": {
+      "url": "https://api.example.com/mcp/",
+      "auth": {
+        "client_id": "${OAUTH_CLIENT_ID}",
+        "client_secret": "${OAUTH_CLIENT_SECRET}"
+      }
+    }
+  }
+}
+```
+
 #### AWS IAM 
 
 For MCP servers on AWS that use SigV4 authentication with IAM credentials, you can conveniently use the [`mcp-proxy-for-aws`](https://pypi.org/project/mcp-proxy-for-aws/) package to handle AWS credential management and request signing automatically. See the [detailed guide](https://dev.to/aws/no-oauth-required-an-mcp-client-for-aws-iam-k1o) for more information.

--- a/site/src/content/docs/user-guide/concepts/tools/mcp-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/mcp-tools.mdx
@@ -204,7 +204,7 @@ oauth_mcp_client = MCPClient(
 )
 ```
 
-Scopes are joined with spaces before being sent to the token endpoint. Token acquisition and refresh happen automatically. The `headers` parameter can be combined with `auth` when the server also expects custom headers.
+`scopes` is joined with spaces and is advisory only: if the server advertises its own scopes (via the `WWW-Authenticate` header or its protected-resource / authorization-server metadata), the server's scopes are used instead and this value is ignored. Token acquisition and refresh happen automatically. The `headers` parameter can be combined with `auth` when the server also expects custom headers.
 
 For advanced flows such as the interactive authorization_code grant, pass any `httpx.Auth` implementation as `auth_provider` instead. The `mcp` package's `OAuthClientProvider` is one such implementation:
 

--- a/strands-py/src/strands/tools/mcp/__init__.py
+++ b/strands-py/src/strands/tools/mcp/__init__.py
@@ -9,6 +9,14 @@ servers.
 from .mcp_agent_tool import MCPAgentTool
 from .mcp_client import MCPClient, MCPServerConfig, ToolFilters
 from .mcp_tasks import TasksConfig
-from .mcp_types import MCPTransport
+from .mcp_types import MCPClientCredentials, MCPTransport
 
-__all__ = ["MCPAgentTool", "MCPClient", "MCPServerConfig", "MCPTransport", "TasksConfig", "ToolFilters"]
+__all__ = [
+    "MCPAgentTool",
+    "MCPClient",
+    "MCPClientCredentials",
+    "MCPServerConfig",
+    "MCPTransport",
+    "TasksConfig",
+    "ToolFilters",
+]

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from re import Pattern
 from types import TracebackType
 from typing import Any, TypeVar, cast
+from urllib.parse import urlparse
 
 import anyio
 import httpx
@@ -280,8 +281,9 @@ class MCPClient(ToolProvider):
 
         Raises:
             ValueError: If neither or both of `transport_callable` and `url` are provided, if
-                `headers`, `auth`, or `auth_provider` is provided without `url`, or if both `auth`
-                and `auth_provider` are provided.
+                `headers`, `auth`, or `auth_provider` is provided without `url`, if both `auth`
+                and `auth_provider` are provided, if `url` is not an http:// or https:// URL, or
+                if `auth` is missing required keys or a value has the wrong type.
         """
         self._startup_timeout = startup_timeout
         self._tool_filters = tool_filters
@@ -1696,13 +1698,28 @@ class _InMemoryTokenStorage:
 
 
 def _build_client_credentials_auth(url: str, auth: MCPClientCredentials) -> httpx.Auth:
-    """Build an httpx.Auth performing the OAuth client_credentials grant against the server."""
-    scopes = auth.get("scopes")
+    """Build an httpx.Auth performing the OAuth client_credentials grant against the server.
+
+    Error messages name only the offending keys, never their values, so credentials cannot
+    leak into logs.
+
+    Raises:
+        ValueError: If `auth` is missing required keys or a value has the wrong type.
+    """
+    values = cast(dict[str, Any], auth)
+    missing_keys = sorted({"client_id", "client_secret"} - values.keys())
+    if missing_keys:
+        raise ValueError(f"MCPClient: 'auth' is missing required keys: {missing_keys}")
+    if not isinstance(values["client_id"], str) or not isinstance(values["client_secret"], str):
+        raise ValueError("MCPClient: 'auth' requires 'client_id' and 'client_secret' to be strings")
+    scopes = values.get("scopes")
+    if scopes is not None and not (isinstance(scopes, list) and all(isinstance(scope, str) for scope in scopes)):
+        raise ValueError("MCPClient: 'auth' requires 'scopes' to be a list of strings")
     return ClientCredentialsOAuthProvider(
         server_url=url,
         storage=_InMemoryTokenStorage(),
-        client_id=auth["client_id"],
-        client_secret=auth["client_secret"],
+        client_id=values["client_id"],
+        client_secret=values["client_secret"],
         scopes=" ".join(scopes) if scopes else None,
     )
 
@@ -1719,11 +1736,11 @@ def _resolve_transport_callable(
 
     Enforces the constructor invariants: exactly one of `transport_callable` and `url`;
     `headers`, `auth`, and `auth_provider` require `url`; `auth` and `auth_provider` are
-    mutually exclusive.
+    mutually exclusive; `url` must be an http:// or https:// URL.
     """
-    if transport_callable is not None and url is not None:
+    if transport_callable is not None and url:
         raise ValueError("MCPClient: provide either 'transport_callable' or 'url', not both")
-    if transport_callable is None and url is None:
+    if transport_callable is None and not url:
         raise ValueError("MCPClient: either 'transport_callable' or 'url' must be provided")
     if transport_callable is not None:
         if auth is not None or auth_provider is not None or headers is not None:
@@ -1736,6 +1753,11 @@ def _resolve_transport_callable(
         raise ValueError("MCPClient: provide either 'auth' or 'auth_provider', not both")
 
     server_url = cast(str, url)
+    scheme = urlparse(server_url).scheme
+    if scheme not in ("http", "https"):
+        raise ValueError(f"MCPClient: 'url' must be an http:// or https:// URL, got '{server_url}'")
+    if scheme == "http" and (auth is not None or auth_provider is not None):
+        logger.warning("url=<%s> | sending oauth credentials over plaintext http", server_url)
     resolved_auth = _build_client_credentials_auth(server_url, auth) if auth is not None else auth_provider
     return lambda: streamablehttp_client(url=server_url, headers=headers, auth=resolved_auth)
 
@@ -1804,7 +1826,7 @@ def _config_transport_callable(name: str, transport: str, server: dict[str, Any]
     """Return a zero-arg callable that opens the transport for the given server entry."""
     if transport != "streamable-http" and server.get("auth"):
         raise ValueError(
-            f"server '{name}': 'auth' is only supported for streamable-http transport — "
+            f"server '{name}': Strands supports 'auth' for streamable-http transport only — "
             "use streamable-http or provide a pre-configured transport"
         )
 
@@ -1842,7 +1864,7 @@ def _config_transport_callable(name: str, transport: str, server: dict[str, Any]
 
 def _parse_config_auth(name: str, url: str, auth: dict[str, Any] | None) -> httpx.Auth | None:
     """Validate a config 'auth' entry and build the client_credentials httpx.Auth from it."""
-    if not auth:
+    if auth is None:
         return None
     if not isinstance(auth, dict):
         raise ValueError(f"server '{name}': 'auth' must be an object with 'client_id' and 'client_secret'")

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -28,10 +28,13 @@ from types import TracebackType
 from typing import Any, TypeVar, cast
 
 import anyio
+import httpx
 from mcp import ClientSession, ListToolsResult, StdioServerParameters, stdio_client
+from mcp.client.auth.extensions.client_credentials import ClientCredentialsOAuthProvider
 from mcp.client.session import ElicitationFnT
 from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamablehttp_client
+from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 from mcp.shared.exceptions import McpError
 from mcp.shared.session import ProgressFnT
 from mcp.types import (
@@ -63,7 +66,7 @@ from ..tool_provider import ToolProvider
 from .mcp_agent_tool import MCPAgentTool
 from .mcp_instrumentation import inject_trace_context, mcp_instrumentation
 from .mcp_tasks import DEFAULT_TASK_CONFIG, DEFAULT_TASK_POLL_TIMEOUT, DEFAULT_TASK_TTL, TasksConfig
-from .mcp_types import MCPToolResult, MCPTransport
+from .mcp_types import MCPClientCredentials, MCPToolResult, MCPTransport
 
 logger = logging.getLogger(__name__)
 
@@ -107,6 +110,9 @@ class MCPServerConfig(TypedDict, total=False):
     omitted it is auto-detected from the fields present. String values support '${VAR}' /
     '${env:VAR}' interpolation, and '~' in 'command' and 'cwd' is expanded to the home directory.
 
+    'auth' holds client credentials for OAuth machine-to-machine (client_credentials grant)
+    authentication and is only supported for streamable-http transport.
+
     'disabled' skips the server entirely. 'continue_on_error' keeps the rest of the servers usable
     when this one fails: a config-resolution failure (e.g. a missing env var) skips it during
     load_servers instead of raising, and a connection failure yields no tools instead of raising
@@ -120,6 +126,7 @@ class MCPServerConfig(TypedDict, total=False):
     url: str
     headers: dict[str, str]
     transport: str
+    auth: MCPClientCredentials
     disabled: bool
     continue_on_error: bool
     prefix: str
@@ -222,8 +229,12 @@ class MCPClient(ToolProvider):
 
     def __init__(
         self,
-        transport_callable: Callable[[], MCPTransport],
+        transport_callable: Callable[[], MCPTransport] | None = None,
         *,
+        url: str | None = None,
+        headers: dict[str, str] | None = None,
+        auth: MCPClientCredentials | None = None,
+        auth_provider: httpx.Auth | None = None,
         startup_timeout: int = 30,
         tool_filters: ToolFilters | None = None,
         prefix: str | None = None,
@@ -238,6 +249,14 @@ class MCPClient(ToolProvider):
 
         Args:
             transport_callable: A callable that returns an MCPTransport (read_stream, write_stream) tuple.
+                Mutually exclusive with `url`.
+            url: Server URL. When provided, a streamable HTTP transport is constructed automatically.
+                Mutually exclusive with `transport_callable`.
+            headers: HTTP headers to include on every request to the server. Requires `url`.
+            auth: Client credentials for OAuth machine-to-machine (client_credentials grant)
+                authentication. Requires `url`. Mutually exclusive with `auth_provider`.
+            auth_provider: Custom `httpx.Auth` for advanced auth flows, passed through to the
+                streamable HTTP transport. Requires `url`. Mutually exclusive with `auth`.
             startup_timeout: Timeout after which MCP server initialization should be cancelled.
                 Defaults to 30.
             tool_filters: Optional filters to apply to tools.
@@ -247,17 +266,22 @@ class MCPClient(ToolProvider):
                 Defaults to None (uses the MCP SDK default "mcp").
             application_version: Optional version string to report alongside application_name.
                 Defaults to None (uses the Strands SDK version).
-            continue_on_error: When True, a connection failure during ``load_tools`` is logged and
+            continue_on_error: When True, a connection failure during `load_tools` is logged and
                 yields no tools instead of raising, so one unavailable server does not prevent an
-                agent from using the others. Only the connection (``start()``) is swallowed; an error
+                agent from using the others. Only the connection (`start()`) is swallowed; an error
                 while listing tools after a successful connect still propagates. Defaults to False.
             elicitation_callback: Optional callback function to handle elicitation requests from the MCP server.
             progress_callback: Optional callback to receive progress notifications during tool execution.
-                Called with ``(progress, total, message)`` as the server reports progress. The ``total``
-                and ``message`` parameters may be ``None`` if the server does not provide them.
+                Called with `(progress, total, message)` as the server reports progress. The `total`
+                and `message` parameters may be `None` if the server does not provide them.
             tasks_config: Configuration for MCP task-augmented execution for long-running tools.
                 If provided (not None), enables task-augmented execution for tools that support it.
                 See TasksConfig for details. This feature is experimental and subject to change.
+
+        Raises:
+            ValueError: If neither or both of `transport_callable` and `url` are provided, if
+                `headers`, `auth`, or `auth_provider` is provided without `url`, or if both `auth`
+                and `auth_provider` are provided.
         """
         self._startup_timeout = startup_timeout
         self._tool_filters = tool_filters
@@ -279,7 +303,9 @@ class MCPClient(ToolProvider):
         self._close_future: asyncio.futures.Future[None] | None = None
         self._close_exception: None | Exception = None
         # Do not want to block other threads while close event is false
-        self._transport_callable = transport_callable
+        self._transport_callable = _resolve_transport_callable(
+            transport_callable, url=url, headers=headers, auth=auth, auth_provider=auth_provider
+        )
 
         self._background_thread: threading.Thread | None = None
         self._background_thread_session: ClientSession | None = None
@@ -1645,6 +1671,75 @@ class MCPClient(ToolProvider):
         return self._create_task_error_result(f"Unexpected task status: {final_status.status}")
 
 
+class _InMemoryTokenStorage:
+    """Process-lifetime OAuth token storage for machine-to-machine credentials.
+
+    The client_credentials grant re-authenticates with the stored secret whenever the access
+    token expires, so tokens only need to live as long as the client instance.
+    """
+
+    def __init__(self) -> None:
+        self._tokens: OAuthToken | None = None
+        self._client_info: OAuthClientInformationFull | None = None
+
+    async def get_tokens(self) -> OAuthToken | None:
+        return self._tokens
+
+    async def set_tokens(self, tokens: OAuthToken) -> None:
+        self._tokens = tokens
+
+    async def get_client_info(self) -> OAuthClientInformationFull | None:
+        return self._client_info
+
+    async def set_client_info(self, client_info: OAuthClientInformationFull) -> None:
+        self._client_info = client_info
+
+
+def _build_client_credentials_auth(url: str, auth: MCPClientCredentials) -> httpx.Auth:
+    """Build an httpx.Auth performing the OAuth client_credentials grant against the server."""
+    scopes = auth.get("scopes")
+    return ClientCredentialsOAuthProvider(
+        server_url=url,
+        storage=_InMemoryTokenStorage(),
+        client_id=auth["client_id"],
+        client_secret=auth["client_secret"],
+        scopes=" ".join(scopes) if scopes else None,
+    )
+
+
+def _resolve_transport_callable(
+    transport_callable: Callable[[], MCPTransport] | None,
+    *,
+    url: str | None,
+    headers: dict[str, str] | None,
+    auth: MCPClientCredentials | None,
+    auth_provider: httpx.Auth | None,
+) -> Callable[[], MCPTransport]:
+    """Resolve the MCPClient constructor arguments into a single transport callable.
+
+    Enforces the constructor invariants: exactly one of `transport_callable` and `url`;
+    `headers`, `auth`, and `auth_provider` require `url`; `auth` and `auth_provider` are
+    mutually exclusive.
+    """
+    if transport_callable is not None and url is not None:
+        raise ValueError("MCPClient: provide either 'transport_callable' or 'url', not both")
+    if transport_callable is None and url is None:
+        raise ValueError("MCPClient: either 'transport_callable' or 'url' must be provided")
+    if transport_callable is not None:
+        if auth is not None or auth_provider is not None or headers is not None:
+            raise ValueError(
+                "MCPClient: 'auth', 'auth_provider', and 'headers' require 'url' "
+                "(not compatible with 'transport_callable')"
+            )
+        return transport_callable
+    if auth is not None and auth_provider is not None:
+        raise ValueError("MCPClient: provide either 'auth' or 'auth_provider', not both")
+
+    server_url = cast(str, url)
+    resolved_auth = _build_client_credentials_auth(server_url, auth) if auth is not None else auth_provider
+    return lambda: streamablehttp_client(url=server_url, headers=headers, auth=resolved_auth)
+
+
 # Matches ${VAR} and ${env:VAR} where VAR is a valid environment variable identifier.
 _ENV_VAR_PATTERN = re.compile(r"\$\{(?:env:)?([A-Za-z_][A-Za-z0-9_]*)\}")
 
@@ -1707,6 +1802,12 @@ def _build_client_from_config(name: str, server: dict[str, Any]) -> MCPClient:
 
 def _config_transport_callable(name: str, transport: str, server: dict[str, Any]) -> Callable[[], MCPTransport]:
     """Return a zero-arg callable that opens the transport for the given server entry."""
+    if transport != "streamable-http" and server.get("auth"):
+        raise ValueError(
+            f"server '{name}': 'auth' is only supported for streamable-http transport — "
+            "use streamable-http or provide a pre-configured transport"
+        )
+
     match transport:
         case "stdio":
             command = server.get("command")
@@ -1725,7 +1826,8 @@ def _config_transport_callable(name: str, transport: str, server: dict[str, Any]
             if not url:
                 raise ValueError(f"server '{name}': streamable-http transport requires 'url'")
             headers = server.get("headers")
-            return lambda: streamablehttp_client(url=cast(str, url), headers=headers)
+            resolved_auth = _parse_config_auth(name, cast(str, url), server.get("auth"))
+            return lambda: streamablehttp_client(url=cast(str, url), headers=headers, auth=resolved_auth)
 
         case "sse":
             url = server.get("url")
@@ -1736,6 +1838,26 @@ def _config_transport_callable(name: str, transport: str, server: dict[str, Any]
 
         case _:
             raise ValueError(f"server '{name}': unsupported transport type '{transport}'")
+
+
+def _parse_config_auth(name: str, url: str, auth: dict[str, Any] | None) -> httpx.Auth | None:
+    """Validate a config 'auth' entry and build the client_credentials httpx.Auth from it."""
+    if not auth:
+        return None
+    if not isinstance(auth, dict):
+        raise ValueError(f"server '{name}': 'auth' must be an object with 'client_id' and 'client_secret'")
+
+    missing_keys = sorted({"client_id", "client_secret"} - auth.keys())
+    if missing_keys:
+        raise ValueError(f"server '{name}': 'auth' is missing required keys: {missing_keys}")
+    unknown_keys = sorted(auth.keys() - MCPClientCredentials.__annotations__.keys())
+    if unknown_keys:
+        logger.warning("server_name=<%s>, unknown_keys=<%s> | ignoring unrecognized auth keys", name, unknown_keys)
+
+    credentials = MCPClientCredentials(client_id=auth["client_id"], client_secret=auth["client_secret"])
+    if auth.get("scopes") is not None:
+        credentials["scopes"] = auth["scopes"]
+    return _build_client_credentials_auth(url, credentials)
 
 
 def _parse_config_tool_filters(name: str, config: dict[str, Any] | None) -> ToolFilters | None:

--- a/strands-py/src/strands/tools/mcp/mcp_types.py
+++ b/strands-py/src/strands/tools/mcp/mcp_types.py
@@ -7,9 +7,28 @@ from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStre
 from mcp.client.streamable_http import GetSessionIdCallback
 from mcp.shared.memory import MessageStream
 from mcp.shared.message import SessionMessage
-from typing_extensions import NotRequired
+from typing_extensions import NotRequired, TypedDict
 
 from ...types.tools import ToolResult
+
+
+class MCPClientCredentials(TypedDict):
+    """OAuth client credentials for machine-to-machine authentication.
+
+    Used with the `MCPClient` `auth` parameter, or the `auth` key of a server entry in a
+    `load_servers` config, to authenticate against a streamable HTTP MCP server with the
+    OAuth client_credentials grant.
+
+    Attributes:
+        client_id: The OAuth client ID.
+        client_secret: The OAuth client secret.
+        scopes: OAuth scopes to request. Joined with spaces before sending to the token endpoint.
+    """
+
+    client_id: str
+    client_secret: str
+    scopes: NotRequired[list[str]]
+
 
 """
 MCPTransport defines the interface for MCP transport implementations. This abstracts

--- a/strands-py/src/strands/tools/mcp/mcp_types.py
+++ b/strands-py/src/strands/tools/mcp/mcp_types.py
@@ -22,7 +22,10 @@ class MCPClientCredentials(TypedDict):
     Attributes:
         client_id: The OAuth client ID.
         client_secret: The OAuth client secret.
-        scopes: OAuth scopes to request. Joined with spaces before sending to the token endpoint.
+        scopes: OAuth scopes to request, joined with spaces. Advisory only: if the server
+            advertises its own scopes (via the `WWW-Authenticate` header or its
+            protected-resource / authorization-server metadata), the server's list is used
+            instead and this value is ignored.
     """
 
     client_id: str

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client_auth.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client_auth.py
@@ -1,0 +1,157 @@
+"""Unit tests for MCPClient OAuth authentication (url/auth/auth_provider constructor path)."""
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+from mcp.client.auth.extensions.client_credentials import ClientCredentialsOAuthProvider
+
+from strands.tools.mcp import MCPClient, MCPClientCredentials
+from strands.tools.mcp.mcp_client import _InMemoryTokenStorage
+
+
+@pytest.fixture
+def streamablehttp_transport():
+    """Patch streamablehttp_client as imported into mcp_client."""
+    with patch("strands.tools.mcp.mcp_client.streamablehttp_client") as http:
+        yield http
+
+
+# Transport resolution
+
+
+def test_url_builds_streamable_http_transport(streamablehttp_transport):
+    client = MCPClient(url="https://mcp.example.com")
+
+    client._transport_callable()
+
+    streamablehttp_transport.assert_called_once_with(url="https://mcp.example.com", headers=None, auth=None)
+
+
+def test_transport_callable_passthrough(streamablehttp_transport):
+    def transport_callable():
+        return None
+
+    client = MCPClient(transport_callable)
+
+    assert client._transport_callable is transport_callable
+    streamablehttp_transport.assert_not_called()
+
+
+def test_headers_passed_to_transport(streamablehttp_transport):
+    client = MCPClient(url="https://mcp.example.com", headers={"X-Api-Key": "abc"})
+
+    client._transport_callable()
+
+    streamablehttp_transport.assert_called_once_with(
+        url="https://mcp.example.com", headers={"X-Api-Key": "abc"}, auth=None
+    )
+
+
+# Auth construction
+
+
+def test_auth_builds_client_credentials_provider(streamablehttp_transport):
+    client = MCPClient(
+        url="https://mcp.example.com",
+        auth=MCPClientCredentials(client_id="id", client_secret="secret"),
+    )
+
+    client._transport_callable()
+
+    provider = streamablehttp_transport.call_args.kwargs["auth"]
+    assert isinstance(provider, ClientCredentialsOAuthProvider)
+    assert provider.context.server_url == "https://mcp.example.com"
+    assert provider._fixed_client_info.client_id == "id"
+    assert provider._fixed_client_info.client_secret == "secret"
+    assert provider._fixed_client_info.scope is None
+
+
+def test_auth_scopes_joined_with_spaces(streamablehttp_transport):
+    client = MCPClient(
+        url="https://mcp.example.com",
+        auth=MCPClientCredentials(client_id="id", client_secret="secret", scopes=["read", "write"]),
+    )
+
+    client._transport_callable()
+
+    provider = streamablehttp_transport.call_args.kwargs["auth"]
+    assert provider._fixed_client_info.scope == "read write"
+
+
+def test_auth_provider_passed_through(streamablehttp_transport):
+    custom_provider = httpx.BasicAuth("user", "pass")
+    client = MCPClient(url="https://mcp.example.com", auth_provider=custom_provider)
+
+    client._transport_callable()
+
+    assert streamablehttp_transport.call_args.kwargs["auth"] is custom_provider
+
+
+def test_auth_and_headers_passed_together(streamablehttp_transport):
+    client = MCPClient(
+        url="https://mcp.example.com",
+        auth=MCPClientCredentials(client_id="id", client_secret="secret"),
+        headers={"X-Trace": "123"},
+    )
+
+    client._transport_callable()
+
+    kwargs = streamablehttp_transport.call_args.kwargs
+    assert kwargs["headers"] == {"X-Trace": "123"}
+    assert isinstance(kwargs["auth"], ClientCredentialsOAuthProvider)
+
+
+# Constructor invariants
+
+
+def test_both_transport_callable_and_url_raises():
+    with pytest.raises(ValueError, match="not both"):
+        MCPClient(lambda: None, url="https://mcp.example.com")
+
+
+def test_neither_transport_callable_nor_url_raises():
+    with pytest.raises(ValueError, match="must be provided"):
+        MCPClient()
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"auth": MCPClientCredentials(client_id="x", client_secret="y")},
+        {"auth_provider": httpx.BasicAuth("user", "pass")},
+        {"headers": {"X-Foo": "bar"}},
+    ],
+)
+def test_auth_or_headers_with_transport_callable_raises(kwargs):
+    with pytest.raises(ValueError, match="require 'url'"):
+        MCPClient(lambda: None, **kwargs)
+
+
+def test_both_auth_and_auth_provider_raises():
+    with pytest.raises(ValueError, match="either 'auth' or 'auth_provider', not both"):
+        MCPClient(
+            url="https://mcp.example.com",
+            auth=MCPClientCredentials(client_id="x", client_secret="y"),
+            auth_provider=httpx.BasicAuth("user", "pass"),
+        )
+
+
+# In-memory token storage
+
+
+@pytest.mark.asyncio
+async def test_in_memory_token_storage_round_trip():
+    from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+    storage = _InMemoryTokenStorage()
+    assert await storage.get_tokens() is None
+    assert await storage.get_client_info() is None
+
+    tokens = OAuthToken(access_token="token", token_type="Bearer")
+    client_info = OAuthClientInformationFull(client_id="id", redirect_uris=None)
+    await storage.set_tokens(tokens)
+    await storage.set_client_info(client_info)
+
+    assert await storage.get_tokens() is tokens
+    assert await storage.get_client_info() is client_info

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client_auth.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client_auth.py
@@ -1,6 +1,6 @@
 """Unit tests for MCPClient OAuth authentication (url/auth/auth_provider constructor path)."""
 
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import httpx
 import pytest
@@ -52,31 +52,33 @@ def test_headers_passed_to_transport(streamablehttp_transport):
 
 
 def test_auth_builds_client_credentials_provider(streamablehttp_transport):
-    client = MCPClient(
-        url="https://mcp.example.com",
-        auth=MCPClientCredentials(client_id="id", client_secret="secret"),
-    )
+    with patch("strands.tools.mcp.mcp_client.ClientCredentialsOAuthProvider") as provider_cls:
+        client = MCPClient(
+            url="https://mcp.example.com",
+            auth=MCPClientCredentials(client_id="id", client_secret="secret"),
+        )
 
     client._transport_callable()
 
-    provider = streamablehttp_transport.call_args.kwargs["auth"]
-    assert isinstance(provider, ClientCredentialsOAuthProvider)
-    assert provider.context.server_url == "https://mcp.example.com"
-    assert provider._fixed_client_info.client_id == "id"
-    assert provider._fixed_client_info.client_secret == "secret"
-    assert provider._fixed_client_info.scope is None
-
-
-def test_auth_scopes_joined_with_spaces(streamablehttp_transport):
-    client = MCPClient(
-        url="https://mcp.example.com",
-        auth=MCPClientCredentials(client_id="id", client_secret="secret", scopes=["read", "write"]),
+    provider_cls.assert_called_once_with(
+        server_url="https://mcp.example.com",
+        storage=ANY,
+        client_id="id",
+        client_secret="secret",
+        scopes=None,
     )
+    assert isinstance(provider_cls.call_args.kwargs["storage"], _InMemoryTokenStorage)
+    assert streamablehttp_transport.call_args.kwargs["auth"] is provider_cls.return_value
 
-    client._transport_callable()
 
-    provider = streamablehttp_transport.call_args.kwargs["auth"]
-    assert provider._fixed_client_info.scope == "read write"
+def test_auth_scopes_joined_with_spaces():
+    with patch("strands.tools.mcp.mcp_client.ClientCredentialsOAuthProvider") as provider_cls:
+        MCPClient(
+            url="https://mcp.example.com",
+            auth=MCPClientCredentials(client_id="id", client_secret="secret", scopes=["read", "write"]),
+        )
+
+    assert provider_cls.call_args.kwargs["scopes"] == "read write"
 
 
 def test_auth_provider_passed_through(streamablehttp_transport):
@@ -106,13 +108,24 @@ def test_auth_and_headers_passed_together(streamablehttp_transport):
 
 
 def test_both_transport_callable_and_url_raises():
-    with pytest.raises(ValueError, match="not both"):
+    with pytest.raises(ValueError, match="either 'transport_callable' or 'url', not both"):
         MCPClient(lambda: None, url="https://mcp.example.com")
 
 
 def test_neither_transport_callable_nor_url_raises():
     with pytest.raises(ValueError, match="must be provided"):
         MCPClient()
+
+
+def test_empty_url_raises():
+    with pytest.raises(ValueError, match="must be provided"):
+        MCPClient(url="")
+
+
+@pytest.mark.parametrize("url", ["not-a-url", "ftp://mcp.example.com", "mcp.example.com/mcp"])
+def test_non_http_url_raises(url):
+    with pytest.raises(ValueError, match="must be an http:// or https:// URL"):
+        MCPClient(url=url)
 
 
 @pytest.mark.parametrize(
@@ -134,6 +147,25 @@ def test_both_auth_and_auth_provider_raises():
             url="https://mcp.example.com",
             auth=MCPClientCredentials(client_id="x", client_secret="y"),
             auth_provider=httpx.BasicAuth("user", "pass"),
+        )
+
+
+def test_auth_missing_required_keys_raises():
+    with pytest.raises(ValueError, match="missing required keys"):
+        MCPClient(url="https://mcp.example.com", auth={"client_id": "id"})
+
+
+def test_auth_non_string_credentials_raise():
+    with pytest.raises(ValueError, match="'client_id' and 'client_secret' to be strings"):
+        MCPClient(url="https://mcp.example.com", auth={"client_id": "id", "client_secret": 123})
+
+
+@pytest.mark.parametrize("scopes", ["read write", [1, 2], {"read": 1}])
+def test_auth_scopes_not_a_list_of_strings_raises(scopes):
+    with pytest.raises(ValueError, match="'scopes' to be a list of strings"):
+        MCPClient(
+            url="https://mcp.example.com",
+            auth={"client_id": "id", "client_secret": "secret", "scopes": scopes},
         )
 
 

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client_load_servers.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client_load_servers.py
@@ -1,10 +1,9 @@
 """Unit tests for MCPClient.load_servers (mcpServers JSON config loading)."""
 
 import json
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
-from mcp.client.auth.extensions.client_credentials import ClientCredentialsOAuthProvider
 
 from strands.tools.mcp.mcp_client import MCPClient
 
@@ -332,43 +331,47 @@ def test_mixed_config_non_opted_in_failure_aborts_whole_load(mock_client, transp
 # OAuth Client Credentials (auth) Tests
 
 
-def test_auth_builds_client_credentials_provider(mock_client, transports):
-    MCPClient.load_servers(
-        {
-            "srv": {
-                "url": "https://example.com/mcp",
-                "auth": {"client_id": "id", "client_secret": "secret", "scopes": ["read", "write"]},
+def test_config_auth_builds_client_credentials_provider(mock_client, transports):
+    with patch("strands.tools.mcp.mcp_client.ClientCredentialsOAuthProvider") as provider_cls:
+        MCPClient.load_servers(
+            {
+                "srv": {
+                    "url": "https://example.com/mcp",
+                    "auth": {"client_id": "id", "client_secret": "secret", "scopes": ["read", "write"]},
+                }
             }
-        }
-    )
+        )
     _open(mock_client[0][0])
-    provider = transports["http"].call_args.kwargs["auth"]
-    assert isinstance(provider, ClientCredentialsOAuthProvider)
-    assert provider.context.server_url == "https://example.com/mcp"
-    assert provider._fixed_client_info.client_id == "id"
-    assert provider._fixed_client_info.client_secret == "secret"
-    assert provider._fixed_client_info.scope == "read write"
+
+    provider_cls.assert_called_once_with(
+        server_url="https://example.com/mcp",
+        storage=ANY,
+        client_id="id",
+        client_secret="secret",
+        scopes="read write",
+    )
+    assert transports["http"].call_args.kwargs["auth"] is provider_cls.return_value
 
 
 def test_auth_interpolates_env_vars(mock_client, transports, monkeypatch):
     monkeypatch.setenv("OAUTH_ID", "env-id")
     monkeypatch.setenv("OAUTH_SECRET", "env-secret")
-    MCPClient.load_servers(
-        {
-            "srv": {
-                "url": "https://example.com/mcp",
-                "auth": {"client_id": "${OAUTH_ID}", "client_secret": "${OAUTH_SECRET}"},
+    with patch("strands.tools.mcp.mcp_client.ClientCredentialsOAuthProvider") as provider_cls:
+        MCPClient.load_servers(
+            {
+                "srv": {
+                    "url": "https://example.com/mcp",
+                    "auth": {"client_id": "${OAUTH_ID}", "client_secret": "${OAUTH_SECRET}"},
+                }
             }
-        }
-    )
-    _open(mock_client[0][0])
-    provider = transports["http"].call_args.kwargs["auth"]
-    assert provider._fixed_client_info.client_id == "env-id"
-    assert provider._fixed_client_info.client_secret == "env-secret"
+        )
+
+    assert provider_cls.call_args.kwargs["client_id"] == "env-id"
+    assert provider_cls.call_args.kwargs["client_secret"] == "env-secret"
 
 
 def test_auth_with_sse_transport_raises(mock_client, transports):
-    with pytest.raises(ValueError, match="only supported for streamable-http"):
+    with pytest.raises(ValueError, match="'auth' for streamable-http transport only"):
         MCPClient.load_servers(
             {
                 "srv": {
@@ -381,18 +384,20 @@ def test_auth_with_sse_transport_raises(mock_client, transports):
 
 
 def test_auth_with_stdio_transport_raises(mock_client, transports):
-    with pytest.raises(ValueError, match="only supported for streamable-http"):
+    with pytest.raises(ValueError, match="'auth' for streamable-http transport only"):
         MCPClient.load_servers({"srv": {"command": "node", "auth": {"client_id": "id", "client_secret": "secret"}}})
 
 
-def test_auth_missing_required_keys_raises(mock_client, transports):
+@pytest.mark.parametrize("auth", [{}, {"client_id": "id"}])
+def test_auth_missing_required_keys_raises(mock_client, transports, auth):
     with pytest.raises(ValueError, match="missing required keys"):
-        MCPClient.load_servers({"srv": {"url": "https://example.com/mcp", "auth": {"client_id": "id"}}})
+        MCPClient.load_servers({"srv": {"url": "https://example.com/mcp", "auth": auth}})
 
 
-def test_auth_non_dict_raises(mock_client, transports):
+@pytest.mark.parametrize("auth", ["not-a-dict", [], 0, ""])
+def test_auth_non_dict_raises(mock_client, transports, auth):
     with pytest.raises(ValueError, match="'auth' must be an object"):
-        MCPClient.load_servers({"srv": {"url": "https://example.com/mcp", "auth": "not-a-dict"}})
+        MCPClient.load_servers({"srv": {"url": "https://example.com/mcp", "auth": auth}})
 
 
 def test_auth_unknown_keys_warn(mock_client, transports, caplog):

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client_load_servers.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client_load_servers.py
@@ -4,6 +4,7 @@ import json
 from unittest.mock import patch
 
 import pytest
+from mcp.client.auth.extensions.client_credentials import ClientCredentialsOAuthProvider
 
 from strands.tools.mcp.mcp_client import MCPClient
 
@@ -55,7 +56,7 @@ def test_url_detects_streamable_http(mock_client, transports):
     clients = MCPClient.load_servers({"srv": {"url": "https://example.com/mcp"}})
     assert len(clients) == 1
     _open(mock_client[0][0])
-    transports["http"].assert_called_once_with(url="https://example.com/mcp", headers=None)
+    transports["http"].assert_called_once_with(url="https://example.com/mcp", headers=None, auth=None)
     transports["sse"].assert_not_called()
 
 
@@ -95,7 +96,9 @@ def test_interpolates_in_headers(mock_client, transports, monkeypatch):
     monkeypatch.setenv("TOKEN", "abc")
     MCPClient.load_servers({"srv": {"url": "https://example.com/mcp", "headers": {"Authorization": "Bearer ${TOKEN}"}}})
     _open(mock_client[0][0])
-    transports["http"].assert_called_once_with(url="https://example.com/mcp", headers={"Authorization": "Bearer abc"})
+    transports["http"].assert_called_once_with(
+        url="https://example.com/mcp", headers={"Authorization": "Bearer abc"}, auth=None
+    )
 
 
 def test_interpolates_in_command_and_args(mock_client, transports, monkeypatch):
@@ -200,7 +203,7 @@ def test_extracts_mcp_servers_key(mock_client, transports, tmp_path):
     _open(mock_client[0][0])
     _open(mock_client[1][0])
     transports["stdio"].assert_called_once()
-    transports["http"].assert_called_once_with(url="https://x.com", headers=None)
+    transports["http"].assert_called_once_with(url="https://x.com", headers=None, auth=None)
 
 
 def test_flat_object_without_wrapper(mock_client, transports, tmp_path):
@@ -294,7 +297,7 @@ def test_continue_on_error_skips_server_with_failed_config(mock_client, transpor
     assert len(clients) == 1
     # The one surviving client must be "ok" (http), not the broken stdio server that failed to build.
     _open(mock_client[0][0])
-    transports["http"].assert_called_once_with(url="https://example.com/mcp", headers=None)
+    transports["http"].assert_called_once_with(url="https://example.com/mcp", headers=None, auth=None)
     transports["stdio"].assert_not_called()
 
 
@@ -324,3 +327,82 @@ def test_mixed_config_non_opted_in_failure_aborts_whole_load(mock_client, transp
                 "strict": {"command": "node", "env": {"V": "${NONEXISTENT_VAR}"}},
             }
         )
+
+
+# OAuth Client Credentials (auth) Tests
+
+
+def test_auth_builds_client_credentials_provider(mock_client, transports):
+    MCPClient.load_servers(
+        {
+            "srv": {
+                "url": "https://example.com/mcp",
+                "auth": {"client_id": "id", "client_secret": "secret", "scopes": ["read", "write"]},
+            }
+        }
+    )
+    _open(mock_client[0][0])
+    provider = transports["http"].call_args.kwargs["auth"]
+    assert isinstance(provider, ClientCredentialsOAuthProvider)
+    assert provider.context.server_url == "https://example.com/mcp"
+    assert provider._fixed_client_info.client_id == "id"
+    assert provider._fixed_client_info.client_secret == "secret"
+    assert provider._fixed_client_info.scope == "read write"
+
+
+def test_auth_interpolates_env_vars(mock_client, transports, monkeypatch):
+    monkeypatch.setenv("OAUTH_ID", "env-id")
+    monkeypatch.setenv("OAUTH_SECRET", "env-secret")
+    MCPClient.load_servers(
+        {
+            "srv": {
+                "url": "https://example.com/mcp",
+                "auth": {"client_id": "${OAUTH_ID}", "client_secret": "${OAUTH_SECRET}"},
+            }
+        }
+    )
+    _open(mock_client[0][0])
+    provider = transports["http"].call_args.kwargs["auth"]
+    assert provider._fixed_client_info.client_id == "env-id"
+    assert provider._fixed_client_info.client_secret == "env-secret"
+
+
+def test_auth_with_sse_transport_raises(mock_client, transports):
+    with pytest.raises(ValueError, match="only supported for streamable-http"):
+        MCPClient.load_servers(
+            {
+                "srv": {
+                    "url": "https://example.com/sse",
+                    "transport": "sse",
+                    "auth": {"client_id": "id", "client_secret": "secret"},
+                }
+            }
+        )
+
+
+def test_auth_with_stdio_transport_raises(mock_client, transports):
+    with pytest.raises(ValueError, match="only supported for streamable-http"):
+        MCPClient.load_servers({"srv": {"command": "node", "auth": {"client_id": "id", "client_secret": "secret"}}})
+
+
+def test_auth_missing_required_keys_raises(mock_client, transports):
+    with pytest.raises(ValueError, match="missing required keys"):
+        MCPClient.load_servers({"srv": {"url": "https://example.com/mcp", "auth": {"client_id": "id"}}})
+
+
+def test_auth_non_dict_raises(mock_client, transports):
+    with pytest.raises(ValueError, match="'auth' must be an object"):
+        MCPClient.load_servers({"srv": {"url": "https://example.com/mcp", "auth": "not-a-dict"}})
+
+
+def test_auth_unknown_keys_warn(mock_client, transports, caplog):
+    with caplog.at_level("WARNING", logger="strands.tools.mcp.mcp_client"):
+        MCPClient.load_servers(
+            {
+                "srv": {
+                    "url": "https://example.com/mcp",
+                    "auth": {"client_id": "id", "client_secret": "secret", "unexpected": "value"},
+                }
+            }
+        )
+    assert "ignoring unrecognized auth keys" in caplog.text


### PR DESCRIPTION
## Description

The TypeScript client accepts a server `url` with either machine-to-machine credentials or a custom auth provider, while Python only accepts a pre-built `transport_callable`, so users of authed servers had to assemble the transport and the OAuth flow themselves. This ports the TS feature to Python (#3155).

`mcp>=1.23.0` ships `ClientCredentialsOAuthProvider` in `mcp.client.auth.extensions.client_credentials`. The `auth` shortcut wraps that official provider with a process-lifetime in-memory `TokenStorage`.

### Public API Changes

`MCPClient` can now build its streamable HTTP transport internally from a `url`, matching the TS constructor:

```python
from strands.tools.mcp import MCPClient

# machine-to-machine (client_credentials grant)
client = MCPClient(
    url="https://api.example.com/mcp/",
    auth={"client_id": "...", "client_secret": "...", "scopes": ["mcp:tools"]},
)

# advanced flows: any httpx.Auth, e.g. mcp's interactive OAuthClientProvider
client = MCPClient(url="https://api.example.com/mcp/", auth_provider=my_httpx_auth)
```

Complete constructor signature for API review (new parameters marked, all defaults shown):

```python
MCPClient(
    transport_callable: Callable[[], MCPTransport] | None = None,
    *,
    url: str | None = None,                    # new
    headers: dict[str, str] | None = None,     # new
    auth: MCPClientCredentials | None = None,  # new
    auth_provider: httpx.Auth | None = None,   # new
    startup_timeout: int = 30,
    tool_filters: ToolFilters | None = None,
    prefix: str | None = None,
    application_name: str | None = None,
    application_version: str | None = None,
    continue_on_error: bool = False,
    elicitation_callback: ElicitationFnT | None = None,
    progress_callback: ProgressFnT | None = None,
    tasks_config: TasksConfig | None = None,
)
```

```python
class MCPClientCredentials(TypedDict):
    client_id: str
    client_secret: str
    scopes: NotRequired[list[str]]
```

Module exports: `strands.tools.mcp.__all__` gains `MCPClientCredentials`, making the full surface `MCPAgentTool`, `MCPClient`, `MCPClientCredentials`, `MCPServerConfig`, `MCPTransport`, `TasksConfig`, `ToolFilters`.

`transport_callable` is now optional and the constructor invariants are enforced: exactly one of `transport_callable` and `url`; `headers`, `auth`, and `auth_provider` require `url`; `auth` and `auth_provider` are mutually exclusive; `url` must be an http:// or https:// URL. `auth` values are validated (string credentials, `scopes` as a list of strings) with error messages that name keys but never values, so credentials cannot leak into logs.

`load_servers` configs gain a matching `auth` key (streamable-http only, with the existing `${VAR}` interpolation so secrets stay in the environment):

```json
{
  "mcpServers": {
    "protected": {
      "url": "https://api.example.com/mcp/",
      "auth": {"client_id": "${OAUTH_CLIENT_ID}", "client_secret": "${OAUTH_CLIENT_SECRET}"}
    }
  }
}
```

### Callouts

- `scopes` is advisory. The `mcp` provider applies the MCP scope-selection strategy, so scopes advertised by the server (via the `WWW-Authenticate` header or its protected-resource / authorization-server metadata) replace the configured value before the token request is built. The docstring and docs state this. Honoring the configured scope for the M2M grant, as the TS SDK does, remains open in #3155.
- A present-but-empty or non-object config `auth` entry (for example `{}` or `[]`) is rejected instead of silently building an unauthenticated client.
- The config `auth` keys are `client_id`/`client_secret` (snake_case, consistent with the rest of `MCPServerConfig`), while the TS config uses `clientId`/`clientSecret`. This follows the config file's existing casing convention, which already differs from TS (`continue_on_error`, `tool_filters`).
- Existing positional `MCPClient(transport_callable)` usage is unaffected; making the parameter optional is backward compatible.

## Related Issues

Addresses #3155. The `scopes` parity gap with the TS SDK stays open there (see Callouts).

## Documentation PR

Included under `site/`: a new "OAuth Authentication" section on the MCP tools page covering `auth`, `auth_provider`, and the config-file shape.

## Type of Change

New feature

## Testing

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
