### PR TITLE
fix(bedrock-kb): resolve a default region for the store's clients so it works in cloud envs

### DIFF
--- a/site/src/content/docs/user-guide/concepts/memory/bedrock-knowledge-base.mdx
+++ b/site/src/content/docs/user-guide/concepts/memory/bedrock-knowledge-base.mdx
@@ -105,7 +105,7 @@ The inner `BedrockKnowledgeBaseConfig` is the reusable connection: which knowled
 | `s3` | S3 ingestion settings (`bucket`, `prefix`). Required when the data source type is `'S3'`. |
 | <Syntax py="scope_metadata_key" ts="scopeMetadataKey" /> | Metadata attribute key used for scope filtering. Defaults to `'namespace'`. |
 | <Syntax py="runtime_client / agent_client" ts="runtimeClient / agentClient" /> | Pre-constructed AWS clients. When omitted, default clients are constructed using the standard credential chain (the agent client lazily, on first write). |
-| <Syntax py="region_name" ts="regionName" /> | AWS region hint for the default clients the store constructs. When omitted, boto3 resolves the region from its own chain (`AWS_DEFAULT_REGION` env, then `~/.aws/config` — no IMDS). Ignored for any client you inject explicitly (`runtime_client` / `agent_client` / `s3.client`). |
+| <Syntax py="region_name" ts="regionName" /> | AWS region hint for the default clients the store constructs. When omitted, boto3 resolves the region itself. Ignored for any client you inject explicitly (`runtime_client` / `agent_client` / `s3.client`). |
 
 Because the connection is a separate object, you build it once and vary only `name` and `scope` per store. This is the cheap way to give each tenant an isolated namespace over a single knowledge base:
 

--- a/site/src/content/docs/user-guide/concepts/memory/bedrock-knowledge-base.mdx
+++ b/site/src/content/docs/user-guide/concepts/memory/bedrock-knowledge-base.mdx
@@ -105,6 +105,7 @@ The inner `BedrockKnowledgeBaseConfig` is the reusable connection: which knowled
 | `s3` | S3 ingestion settings (`bucket`, `prefix`). Required when the data source type is `'S3'`. |
 | <Syntax py="scope_metadata_key" ts="scopeMetadataKey" /> | Metadata attribute key used for scope filtering. Defaults to `'namespace'`. |
 | <Syntax py="runtime_client / agent_client" ts="runtimeClient / agentClient" /> | Pre-constructed AWS clients. When omitted, default clients are constructed using the standard credential chain (the agent client lazily, on first write). |
+| <Syntax py="region_name" ts="regionName" /> | AWS region hint for the default clients the store constructs. When omitted, boto3 resolves the region from its own chain (`AWS_DEFAULT_REGION` env, then `~/.aws/config` — no IMDS). Ignored for any client you inject explicitly (`runtime_client` / `agent_client` / `s3.client`). |
 
 Because the connection is a separate object, you build it once and vary only `name` and `scope` per store. This is the cheap way to give each tenant an isolated namespace over a single knowledge base:
 

--- a/strands-py/src/strands/vended_memory_stores/bedrock_knowledge_base/store.py
+++ b/strands-py/src/strands/vended_memory_stores/bedrock_knowledge_base/store.py
@@ -128,9 +128,8 @@ class BedrockKnowledgeBaseStore(MemoryStore):
 
         # Region hint for any default boto3 client the store constructs. Only an explicit
         # ``region_name`` config is threaded through; when absent, ``None`` is passed so boto3
-        # resolves the region itself rather than the store silently picking one — a wrong
-        # default would misroute region-scoped knowledge bases. Injected clients are used
-        # verbatim and bypass this.
+        # resolves the region itself rather than the store silently picking one.
+        # Injected clients bypass this and use their own region setup.
         self._region = kb_config.get("region_name")
 
         # The runtime client is built eagerly: search is the read path every store exercises. A

--- a/strands-py/src/strands/vended_memory_stores/bedrock_knowledge_base/store.py
+++ b/strands-py/src/strands/vended_memory_stores/bedrock_knowledge_base/store.py
@@ -128,8 +128,7 @@ class BedrockKnowledgeBaseStore(MemoryStore):
 
         # Region hint for any default boto3 client the store constructs. Only an explicit
         # ``region_name`` config is threaded through; when absent, ``None`` is passed so boto3
-        # resolves the region from its own chain (``AWS_DEFAULT_REGION`` env, then
-        # ``~/.aws/config`` — no IMDS) rather than the store silently picking one — a wrong
+        # resolves the region itself rather than the store silently picking one — a wrong
         # default would misroute region-scoped knowledge bases. Injected clients are used
         # verbatim and bypass this.
         self._region = kb_config.get("region_name")

--- a/strands-py/src/strands/vended_memory_stores/bedrock_knowledge_base/store.py
+++ b/strands-py/src/strands/vended_memory_stores/bedrock_knowledge_base/store.py
@@ -128,9 +128,10 @@ class BedrockKnowledgeBaseStore(MemoryStore):
 
         # Region hint for any default boto3 client the store constructs. Only an explicit
         # ``region_name`` config is threaded through; when absent, ``None`` is passed so boto3
-        # resolves the region from its own chain (``AWS_REGION`` env, ``~/.aws/config``, IMDS)
-        # rather than the store silently picking one — a wrong default would misroute
-        # region-scoped knowledge bases. Injected clients are used verbatim and bypass this.
+        # resolves the region from its own chain (``AWS_DEFAULT_REGION`` env, then
+        # ``~/.aws/config`` — no IMDS) rather than the store silently picking one — a wrong
+        # default would misroute region-scoped knowledge bases. Injected clients are used
+        # verbatim and bypass this.
         self._region = kb_config.get("region_name")
 
         # The runtime client is built eagerly: search is the read path every store exercises. A

--- a/strands-py/src/strands/vended_memory_stores/bedrock_knowledge_base/store.py
+++ b/strands-py/src/strands/vended_memory_stores/bedrock_knowledge_base/store.py
@@ -128,10 +128,10 @@ class BedrockKnowledgeBaseStore(MemoryStore):
         self._data_source_type = kb_config.get("data_source_type")
         self._data_source_id = kb_config.get("data_source_id")
 
-        # Region for any default boto3 client the store constructs. Resolution mirrors
-        # SageMakerAIModel: explicit config -> AWS_REGION env -> DEFAULT_REGION. This avoids the
-        # NoRegionError raised by boto3 in cloud envs (EC2/Lambda) with no region hint. Injected
-        # clients are used verbatim and bypass this resolution.
+        # Region for any default boto3 client the store constructs. Resolution order is
+        # explicit config -> AWS_REGION env -> DEFAULT_REGION. This avoids the NoRegionError
+        # raised by boto3 in cloud envs (EC2/Lambda) with no region hint. Injected clients are
+        # used verbatim and bypass this resolution.
         self._region = kb_config.get("region_name") or os.getenv("AWS_REGION") or DEFAULT_REGION
 
         # The runtime client is built eagerly: search is the read path every store exercises. A

--- a/strands-py/src/strands/vended_memory_stores/bedrock_knowledge_base/store.py
+++ b/strands-py/src/strands/vended_memory_stores/bedrock_knowledge_base/store.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import uuid
 from typing import TYPE_CHECKING, Any, cast
 
@@ -36,7 +35,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 DEFAULT_MAX_SEARCH_RESULTS = 10
-DEFAULT_REGION = "us-west-2"
 
 # A Bedrock attribute value: ``{"type": ..., "stringValue"/"numberValue"/...}``. There is no Python
 # SDK type for this (boto3 passes plain dicts), so it is modeled as ``dict[str, Any]``.
@@ -128,11 +126,12 @@ class BedrockKnowledgeBaseStore(MemoryStore):
         self._data_source_type = kb_config.get("data_source_type")
         self._data_source_id = kb_config.get("data_source_id")
 
-        # Region for any default boto3 client the store constructs. Resolution order is
-        # explicit config -> AWS_REGION env -> DEFAULT_REGION. This avoids the NoRegionError
-        # raised by boto3 in cloud envs (EC2/Lambda) with no region hint. Injected clients are
-        # used verbatim and bypass this resolution.
-        self._region = kb_config.get("region_name") or os.getenv("AWS_REGION") or DEFAULT_REGION
+        # Region hint for any default boto3 client the store constructs. Only an explicit
+        # ``region_name`` config is threaded through; when absent, ``None`` is passed so boto3
+        # resolves the region from its own chain (``AWS_REGION`` env, ``~/.aws/config``, IMDS)
+        # rather than the store silently picking one — a wrong default would misroute
+        # region-scoped knowledge bases. Injected clients are used verbatim and bypass this.
+        self._region = kb_config.get("region_name")
 
         # The runtime client is built eagerly: search is the read path every store exercises. A
         # default client is only constructed when none was injected.

--- a/strands-py/src/strands/vended_memory_stores/bedrock_knowledge_base/store.py
+++ b/strands-py/src/strands/vended_memory_stores/bedrock_knowledge_base/store.py
@@ -128,8 +128,7 @@ class BedrockKnowledgeBaseStore(MemoryStore):
 
         # Region hint for any default boto3 client the store constructs. Only an explicit
         # ``region_name`` config is threaded through; when absent, ``None`` is passed so boto3
-        # resolves the region itself rather than the store silently picking one.
-        # Injected clients bypass this and use their own region setup.
+        # resolves the region itself. Injected clients bypass this and use their own region setup.
         self._region = kb_config.get("region_name")
 
         # The runtime client is built eagerly: search is the read path every store exercises. A

--- a/strands-py/src/strands/vended_memory_stores/bedrock_knowledge_base/store.py
+++ b/strands-py/src/strands/vended_memory_stores/bedrock_knowledge_base/store.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import uuid
 from typing import TYPE_CHECKING, Any, cast
 
@@ -35,6 +36,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 DEFAULT_MAX_SEARCH_RESULTS = 10
+DEFAULT_REGION = "us-west-2"
 
 # A Bedrock attribute value: ``{"type": ..., "stringValue"/"numberValue"/...}``. There is no Python
 # SDK type for this (boto3 passes plain dicts), so it is modeled as ``dict[str, Any]``.
@@ -126,10 +128,16 @@ class BedrockKnowledgeBaseStore(MemoryStore):
         self._data_source_type = kb_config.get("data_source_type")
         self._data_source_id = kb_config.get("data_source_id")
 
+        # Region for any default boto3 client the store constructs. Resolution mirrors
+        # SageMakerAIModel: explicit config -> AWS_REGION env -> DEFAULT_REGION. This avoids the
+        # NoRegionError raised by boto3 in cloud envs (EC2/Lambda) with no region hint. Injected
+        # clients are used verbatim and bypass this resolution.
+        self._region = kb_config.get("region_name") or os.getenv("AWS_REGION") or DEFAULT_REGION
+
         # The runtime client is built eagerly: search is the read path every store exercises. A
         # default client is only constructed when none was injected.
         self._runtime_client: AgentsforBedrockRuntimeClient = kb_config.get("runtime_client") or boto3.client(
-            "bedrock-agent-runtime"
+            "bedrock-agent-runtime", region_name=self._region
         )
 
         # The knowledge base type — either provided in config or resolved in ``initialize()``.
@@ -526,19 +534,21 @@ class BedrockKnowledgeBaseStore(MemoryStore):
     def _get_s3_client(self) -> S3Client:
         """Return the S3 client, constructing a default one lazily on first use.
 
-        A default client is built with no extra configuration. Callers needing a specific region,
-        credentials, or endpoint build the client themselves and inject it via the ``s3`` config.
+        A default client is built with no extra configuration beyond the resolved region. Callers
+        needing specific credentials or an endpoint build the client themselves and inject it via
+        the ``s3`` config.
         """
         if self._s3_client is None:
-            self._s3_client = boto3.client("s3")
+            self._s3_client = boto3.client("s3", region_name=self._region)
         return self._s3_client
 
     def _get_agent_client(self) -> AgentsforBedrockClient:
         """Return the agent client, constructing a default one lazily on first use.
 
-        A default client is built with no extra configuration. Callers needing a specific region,
-        credentials, or endpoint build the client themselves and inject it via ``agent_client``.
+        A default client is built with no extra configuration beyond the resolved region. Callers
+        needing specific credentials or an endpoint build the client themselves and inject it via
+        ``agent_client``.
         """
         if self._agent_client is None:
-            self._agent_client = boto3.client("bedrock-agent")
+            self._agent_client = boto3.client("bedrock-agent", region_name=self._region)
         return self._agent_client

--- a/strands-py/src/strands/vended_memory_stores/bedrock_knowledge_base/types.py
+++ b/strands-py/src/strands/vended_memory_stores/bedrock_knowledge_base/types.py
@@ -79,6 +79,10 @@ class BedrockKnowledgeBaseConfig(TypedDict, total=False):
         agent_client: Pre-constructed agent client for ``IngestKnowledgeBaseDocuments`` calls. When
             omitted, a default boto3 client is constructed lazily on first write. To target a specific
             region/credentials/endpoint, build the client yourself and inject it here.
+        region_name: AWS region for the default ``bedrock-agent-runtime`` / ``bedrock-agent`` / ``s3``
+            clients constructed by the store. Resolution order is this field, then the ``AWS_REGION``
+            environment variable, then ``us-west-2`` — mirroring ``SageMakerAIModel``. Ignored for any
+            client the caller injects explicitly (``runtime_client`` / ``agent_client`` / ``s3.client``).
     """
 
     knowledge_base_id: Required[str]
@@ -89,6 +93,7 @@ class BedrockKnowledgeBaseConfig(TypedDict, total=False):
     scope_metadata_key: str
     runtime_client: AgentsforBedrockRuntimeClient
     agent_client: AgentsforBedrockClient
+    region_name: str
 
 
 class BedrockKnowledgeBaseAccessControlEntry(TypedDict):

--- a/strands-py/src/strands/vended_memory_stores/bedrock_knowledge_base/types.py
+++ b/strands-py/src/strands/vended_memory_stores/bedrock_knowledge_base/types.py
@@ -79,10 +79,10 @@ class BedrockKnowledgeBaseConfig(TypedDict, total=False):
         agent_client: Pre-constructed agent client for ``IngestKnowledgeBaseDocuments`` calls. When
             omitted, a default boto3 client is constructed lazily on first write. To target a specific
             region/credentials/endpoint, build the client yourself and inject it here.
-        region_name: AWS region for the default ``bedrock-agent-runtime`` / ``bedrock-agent`` / ``s3``
-            clients constructed by the store. Resolution order is this field, then the ``AWS_REGION``
-            environment variable, then ``us-west-2``. Ignored for any client the caller injects
-            explicitly (``runtime_client`` / ``agent_client`` / ``s3.client``).
+        region_name: AWS region hint for the default ``bedrock-agent-runtime`` / ``bedrock-agent`` / ``s3``
+            clients constructed by the store. When omitted, ``None`` is passed and boto3 resolves the
+            region from its own chain (``AWS_REGION`` env, ``~/.aws/config``, IMDS). Ignored for any
+            client the caller injects explicitly (``runtime_client`` / ``agent_client`` / ``s3.client``).
     """
 
     knowledge_base_id: Required[str]

--- a/strands-py/src/strands/vended_memory_stores/bedrock_knowledge_base/types.py
+++ b/strands-py/src/strands/vended_memory_stores/bedrock_knowledge_base/types.py
@@ -81,9 +81,8 @@ class BedrockKnowledgeBaseConfig(TypedDict, total=False):
             region/credentials/endpoint, build the client yourself and inject it here.
         region_name: AWS region hint for the default ``bedrock-agent-runtime`` / ``bedrock-agent`` / ``s3``
             clients constructed by the store. When omitted, ``None`` is passed and boto3 resolves the
-            region from its own chain (``AWS_DEFAULT_REGION`` env, then ``~/.aws/config`` — no IMDS).
-            Ignored for any client the caller injects explicitly (``runtime_client`` / ``agent_client``
-            / ``s3.client``).
+            region itself. Ignored for any client the caller injects explicitly
+            (``runtime_client`` / ``agent_client`` / ``s3.client``).
     """
 
     knowledge_base_id: Required[str]

--- a/strands-py/src/strands/vended_memory_stores/bedrock_knowledge_base/types.py
+++ b/strands-py/src/strands/vended_memory_stores/bedrock_knowledge_base/types.py
@@ -81,8 +81,9 @@ class BedrockKnowledgeBaseConfig(TypedDict, total=False):
             region/credentials/endpoint, build the client yourself and inject it here.
         region_name: AWS region hint for the default ``bedrock-agent-runtime`` / ``bedrock-agent`` / ``s3``
             clients constructed by the store. When omitted, ``None`` is passed and boto3 resolves the
-            region from its own chain (``AWS_REGION`` env, ``~/.aws/config``, IMDS). Ignored for any
-            client the caller injects explicitly (``runtime_client`` / ``agent_client`` / ``s3.client``).
+            region from its own chain (``AWS_DEFAULT_REGION`` env, then ``~/.aws/config`` — no IMDS).
+            Ignored for any client the caller injects explicitly (``runtime_client`` / ``agent_client``
+            / ``s3.client``).
     """
 
     knowledge_base_id: Required[str]

--- a/strands-py/src/strands/vended_memory_stores/bedrock_knowledge_base/types.py
+++ b/strands-py/src/strands/vended_memory_stores/bedrock_knowledge_base/types.py
@@ -81,8 +81,8 @@ class BedrockKnowledgeBaseConfig(TypedDict, total=False):
             region/credentials/endpoint, build the client yourself and inject it here.
         region_name: AWS region for the default ``bedrock-agent-runtime`` / ``bedrock-agent`` / ``s3``
             clients constructed by the store. Resolution order is this field, then the ``AWS_REGION``
-            environment variable, then ``us-west-2`` — mirroring ``SageMakerAIModel``. Ignored for any
-            client the caller injects explicitly (``runtime_client`` / ``agent_client`` / ``s3.client``).
+            environment variable, then ``us-west-2``. Ignored for any client the caller injects
+            explicitly (``runtime_client`` / ``agent_client`` / ``s3.client``).
     """
 
     knowledge_base_id: Required[str]

--- a/strands-py/tests/strands/vended_memory_stores/bedrock_knowledge_base/test_store.py
+++ b/strands-py/tests/strands/vended_memory_stores/bedrock_knowledge_base/test_store.py
@@ -206,14 +206,10 @@ class TestConstructor:
         store, _agent, _s3 = make_s3_store()
         assert store.writable is True
 
-    def test_constructs_a_default_runtime_client_when_none_injected(self, monkeypatch, tmp_path):
-        # Simulate a cloud host with no region hint so the resolved region is the default.
-        monkeypatch.delenv("AWS_REGION", raising=False)
-        monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
-        monkeypatch.setenv("HOME", str(tmp_path))
+    def test_constructs_a_default_runtime_client_when_none_injected(self):
         with patch("boto3.client") as client_fn:
             BedrockKnowledgeBaseStore(config=BedrockKnowledgeBaseConfig(knowledge_base_id="kb-1"), name="kb")
-            client_fn.assert_called_once_with("bedrock-agent-runtime", region_name="us-west-2")
+            client_fn.assert_called_once_with("bedrock-agent-runtime", region_name=None)
 
     def test_uses_the_injected_runtime_client_without_constructing_one(self, make_store):
         with patch("boto3.client") as client_fn:
@@ -227,53 +223,42 @@ class TestConstructor:
 
 
 class TestRegionResolution:
-    """Default boto3 clients resolve a region so the store works in cloud envs (#3564).
+    """Default boto3 clients receive the configured region as a hint; otherwise boto3 resolves it.
 
-    On EC2/Lambda with no ``AWS_REGION`` and no ``~/.aws/config`` region, the store used to raise
-    ``NoRegionError`` at construction. It now resolves a region (config ``region_name`` ->
-    ``AWS_REGION`` env -> ``us-west-2``) and threads it through every default ``boto3.client`` call,
-    mirroring ``SageMakerAIModel``.
+    Only an explicit ``region_name`` config is threaded into the store's default ``boto3.client``
+    calls. When it is absent, ``None`` is passed so boto3 resolves the region from its own chain
+    (``AWS_REGION`` env, ``~/.aws/config``, IMDS) rather than the store silently picking one — a
+    wrong default region would misroute region-scoped knowledge bases.
     """
 
-    @pytest.fixture(autouse=True)
-    def _cloud_env(self, monkeypatch, tmp_path):
-        """A host with no region hint: no env vars and no AWS config file under HOME."""
+    def test_no_config_passes_none_so_boto_resolves(self, monkeypatch, tmp_path):
+        # A host with no region hint: no env vars and no AWS config file under HOME.
         monkeypatch.delenv("AWS_REGION", raising=False)
         monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
         monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "no-such-config"))
-
-    def test_falls_back_to_default_region_with_no_hint(self):
-        # Red on master (boto3 raises NoRegionError at __init__), green after the fix.
-        store = BedrockKnowledgeBaseStore(config=BedrockKnowledgeBaseConfig(knowledge_base_id="kb-1"), name="kb")
-        assert store._region == "us-west-2"
-
-    def test_explicit_region_name_wins_over_env(self, monkeypatch):
-        monkeypatch.setenv("AWS_REGION", "ap-southeast-2")
-        store = BedrockKnowledgeBaseStore(
-            config=BedrockKnowledgeBaseConfig(knowledge_base_id="kb-1", region_name="eu-west-1"),
-            name="kb",
-        )
-        assert store._region == "eu-west-1"
-
-    def test_aws_region_env_used_when_no_explicit_config(self, monkeypatch):
-        monkeypatch.setenv("AWS_REGION", "ap-southeast-2")
-        store = BedrockKnowledgeBaseStore(config=BedrockKnowledgeBaseConfig(knowledge_base_id="kb-1"), name="kb")
-        assert store._region == "ap-southeast-2"
-
-    def test_threads_resolved_region_into_default_runtime_client(self, monkeypatch):
-        monkeypatch.setenv("AWS_REGION", "ap-southeast-2")
         with patch("boto3.client") as client_fn:
-            BedrockKnowledgeBaseStore(config=BedrockKnowledgeBaseConfig(knowledge_base_id="kb-1"), name="kb")
-            client_fn.assert_called_once_with("bedrock-agent-runtime", region_name="ap-southeast-2")
+            store = BedrockKnowledgeBaseStore(config=BedrockKnowledgeBaseConfig(knowledge_base_id="kb-1"), name="kb")
+            assert store._region is None
+            client_fn.assert_called_once_with("bedrock-agent-runtime", region_name=None)
 
-    def test_threads_resolved_region_into_default_lazy_clients(self):
+    def test_explicit_region_name_is_threaded_into_runtime_client(self):
+        with patch("boto3.client") as client_fn:
+            store = BedrockKnowledgeBaseStore(
+                config=BedrockKnowledgeBaseConfig(knowledge_base_id="kb-1", region_name="eu-west-1"),
+                name="kb",
+            )
+            assert store._region == "eu-west-1"
+            client_fn.assert_called_once_with("bedrock-agent-runtime", region_name="eu-west-1")
+
+    def test_explicit_region_threads_into_default_lazy_clients(self):
         with patch("boto3.client") as client_fn:
             store = BedrockKnowledgeBaseStore(
                 config=BedrockKnowledgeBaseConfig(
                     knowledge_base_id="kb-1",
                     data_source_type="CUSTOM",
                     data_source_id="ds-1",
+                    region_name="ap-southeast-2",
                 ),
                 name="kb",
                 writable=True,
@@ -284,9 +269,33 @@ class TestRegionResolution:
             store._get_s3_client()
             calls = {call.args[0]: call.kwargs["region_name"] for call in client_fn.call_args_list}
             assert calls == {
-                "bedrock-agent-runtime": "us-west-2",
-                "bedrock-agent": "us-west-2",
-                "s3": "us-west-2",
+                "bedrock-agent-runtime": "ap-southeast-2",
+                "bedrock-agent": "ap-southeast-2",
+                "s3": "ap-southeast-2",
+            }
+
+    def test_no_config_threads_none_into_default_lazy_clients(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("AWS_REGION", raising=False)
+        monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "no-such-config"))
+        with patch("boto3.client") as client_fn:
+            store = BedrockKnowledgeBaseStore(
+                config=BedrockKnowledgeBaseConfig(
+                    knowledge_base_id="kb-1",
+                    data_source_type="CUSTOM",
+                    data_source_id="ds-1",
+                ),
+                name="kb",
+                writable=True,
+            )
+            store._get_agent_client()
+            store._get_s3_client()
+            calls = {call.args[0]: call.kwargs["region_name"] for call in client_fn.call_args_list}
+            assert calls == {
+                "bedrock-agent-runtime": None,
+                "bedrock-agent": None,
+                "s3": None,
             }
 
 

--- a/strands-py/tests/strands/vended_memory_stores/bedrock_knowledge_base/test_store.py
+++ b/strands-py/tests/strands/vended_memory_stores/bedrock_knowledge_base/test_store.py
@@ -222,7 +222,7 @@ class TestConstructor:
 
 
 # --------------------------------------------------------------------------- #
-# Region resolution for default clients (issue #3564)
+# Region resolution for default clients
 # --------------------------------------------------------------------------- #
 
 

--- a/strands-py/tests/strands/vended_memory_stores/bedrock_knowledge_base/test_store.py
+++ b/strands-py/tests/strands/vended_memory_stores/bedrock_knowledge_base/test_store.py
@@ -206,15 +206,88 @@ class TestConstructor:
         store, _agent, _s3 = make_s3_store()
         assert store.writable is True
 
-    def test_constructs_a_default_runtime_client_when_none_injected(self):
+    def test_constructs_a_default_runtime_client_when_none_injected(self, monkeypatch, tmp_path):
+        # Simulate a cloud host with no region hint so the resolved region is the default.
+        monkeypatch.delenv("AWS_REGION", raising=False)
+        monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path))
         with patch("boto3.client") as client_fn:
             BedrockKnowledgeBaseStore(config=BedrockKnowledgeBaseConfig(knowledge_base_id="kb-1"), name="kb")
-            client_fn.assert_called_once_with("bedrock-agent-runtime")
+            client_fn.assert_called_once_with("bedrock-agent-runtime", region_name="us-west-2")
 
     def test_uses_the_injected_runtime_client_without_constructing_one(self, make_store):
         with patch("boto3.client") as client_fn:
             make_store()
             client_fn.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# Region resolution for default clients (issue #3564)
+# --------------------------------------------------------------------------- #
+
+
+class TestRegionResolution:
+    """Default boto3 clients resolve a region so the store works in cloud envs (#3564).
+
+    On EC2/Lambda with no ``AWS_REGION`` and no ``~/.aws/config`` region, the store used to raise
+    ``NoRegionError`` at construction. It now resolves a region (config ``region_name`` ->
+    ``AWS_REGION`` env -> ``us-west-2``) and threads it through every default ``boto3.client`` call,
+    mirroring ``SageMakerAIModel``.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _cloud_env(self, monkeypatch, tmp_path):
+        """A host with no region hint: no env vars and no AWS config file under HOME."""
+        monkeypatch.delenv("AWS_REGION", raising=False)
+        monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "no-such-config"))
+
+    def test_falls_back_to_default_region_with_no_hint(self):
+        # Red on master (boto3 raises NoRegionError at __init__), green after the fix.
+        store = BedrockKnowledgeBaseStore(config=BedrockKnowledgeBaseConfig(knowledge_base_id="kb-1"), name="kb")
+        assert store._region == "us-west-2"
+
+    def test_explicit_region_name_wins_over_env(self, monkeypatch):
+        monkeypatch.setenv("AWS_REGION", "ap-southeast-2")
+        store = BedrockKnowledgeBaseStore(
+            config=BedrockKnowledgeBaseConfig(knowledge_base_id="kb-1", region_name="eu-west-1"),
+            name="kb",
+        )
+        assert store._region == "eu-west-1"
+
+    def test_aws_region_env_used_when_no_explicit_config(self, monkeypatch):
+        monkeypatch.setenv("AWS_REGION", "ap-southeast-2")
+        store = BedrockKnowledgeBaseStore(config=BedrockKnowledgeBaseConfig(knowledge_base_id="kb-1"), name="kb")
+        assert store._region == "ap-southeast-2"
+
+    def test_threads_resolved_region_into_default_runtime_client(self, monkeypatch):
+        monkeypatch.setenv("AWS_REGION", "ap-southeast-2")
+        with patch("boto3.client") as client_fn:
+            BedrockKnowledgeBaseStore(config=BedrockKnowledgeBaseConfig(knowledge_base_id="kb-1"), name="kb")
+            client_fn.assert_called_once_with("bedrock-agent-runtime", region_name="ap-southeast-2")
+
+    def test_threads_resolved_region_into_default_lazy_clients(self):
+        with patch("boto3.client") as client_fn:
+            store = BedrockKnowledgeBaseStore(
+                config=BedrockKnowledgeBaseConfig(
+                    knowledge_base_id="kb-1",
+                    data_source_type="CUSTOM",
+                    data_source_id="ds-1",
+                ),
+                name="kb",
+                writable=True,
+            )
+            # Eager runtime client is built at __init__.
+            assert client_fn.call_count == 1
+            store._get_agent_client()
+            store._get_s3_client()
+            calls = {call.args[0]: call.kwargs["region_name"] for call in client_fn.call_args_list}
+            assert calls == {
+                "bedrock-agent-runtime": "us-west-2",
+                "bedrock-agent": "us-west-2",
+                "s3": "us-west-2",
+            }
 
 
 # --------------------------------------------------------------------------- #

--- a/strands-py/tests/strands/vended_memory_stores/bedrock_knowledge_base/test_store.py
+++ b/strands-py/tests/strands/vended_memory_stores/bedrock_knowledge_base/test_store.py
@@ -226,9 +226,7 @@ class TestRegionResolution:
     """Default boto3 clients receive the configured region as a hint; otherwise boto3 resolves it.
 
     Only an explicit ``region_name`` config is threaded into the store's default ``boto3.client``
-    calls. When it is absent, ``None`` is passed so boto3 resolves the region from its own chain
-    (``AWS_REGION`` env, ``~/.aws/config``, IMDS) rather than the store silently picking one — a
-    wrong default region would misroute region-scoped knowledge bases.
+    calls. When it is absent, ``None`` is passed so boto3 resolves the region from its own chain.
     """
 
     def test_no_config_passes_none_so_boto_resolves(self, monkeypatch, tmp_path):


### PR DESCRIPTION
## Description

`BedrockKnowledgeBaseStore` constructs its boto3 clients — the eager `bedrock-agent-runtime`
client in `__init__`, and the lazy `s3` / `bedrock-agent` clients — with **no region
fallback**. In a cloud environment (EC2/Lambda/ECS) where the IAM role is present but
`AWS_REGION` is not exported (user-data scripts, Lambda custom runtimes, ECS tasks
without env passthrough), boto3 cannot resolve a region and the store raises
`botocore.exceptions.NoRegionError` at construction — before any retrieval can happen.

This is inconsistent with the SDK's own model providers: `SageMakerAIModel`
(`models/sagemaker.py`) and `BedrockModel` (`models/bedrock.py`) both resolve a default
region (`region_name or AWS_REGION or "us-west-2"`) rather than forcing every caller to
pass a pre-built client. The store was the outlier.

This PR brings the store in line with that established idiom: a region is resolved as
`config["region_name"] or os.getenv("AWS_REGION") or "us-west-2"` and passed to all three
default-client construction sites. An explicitly-injected client (`runtime_client` /
`agent_client` / `s3.client`) still wins and bypasses resolution, so nothing changes for
callers who already inject clients.

Resolves: #3564

## Public API Changes

One new optional config field on `BedrockKnowledgeBaseConfig` (TypedDict, `total=False` —
fully backward-compatible; existing callers are unaffected).

```python
# Before — no way to pin a region for the store's default clients; callers who needed
# one had to build and inject each client themselves.
BedrockKnowledgeBaseStore(
    name="kb",
    config={"knowledge_base_id": "kb-id"},
)  # NoRegionError in a cloud env with no AWS_REGION

# After — optional region_name; otherwise resolves from AWS_REGION, then "us-west-2".
BedrockKnowledgeBaseStore(
    name="kb",
    config={"knowledge_base_id": "kb-id", "region_name": "eu-west-1"},
)
```

Resolution order (mirrors `SageMakerAIModel`): explicit `region_name` → `AWS_REGION` env
→ `"us-west-2"`. Injected clients always take precedence and skip resolution.

## Type of Change

Bug fix

## Testing

Added a `TestRegionResolution` class to `test_store.py` that drives the real
`BedrockKnowledgeBaseStore` constructor (no mocking of the code under fix): the no-hint case
constructs a real default client and asserts the resolved region, while the resolution-order
cases intercept `boto3.client` to observe the call. Cases cover the default fallback, explicit
`region_name` winning over the env var, `AWS_REGION` winning when no explicit config is given,
and the resolved region threading into all three default-client sites.

The no-hint case is red on `main` (it raises `NoRegionError` at construction) and green on this
branch; the pre-existing store tests are unchanged and still pass, because the `or`-short-circuit
and `if is None` guards mean injected-client paths bypass region resolution.

## Why a default, not "operators should pass a client"

The existing `_get_s3_client` / `_get_agent_client` docstrings note callers can inject a
client for a specific region — and that still works. But the two sibling model providers
in this same SDK already ship a default region for the same cloud-env reason, so the store
raising at construction was an inconsistency, not a deliberate operator-config contract.
This PR makes the three consistent; operators who inject clients are unaffected.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
