### PR TITLE
feat(a2a): support the interrupt round trip in TypeScript

### DIFF
--- a/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
@@ -381,15 +381,11 @@ In single-agent mode the server reuses one agent across every context, swapping 
 
 ### Answering Interrupts
 
-:::note[Python only]
-This feature is currently available in the Python SDK only.
-:::
+When a tool or hook on the served agent raises an [interrupt](../interrupts.md), the task moves to the A2A `input-required` state and waits. The client answers it, and the task resumes the paused tool exactly where it stopped.
 
-When a tool or hook on the served agent raises an [interrupt](../interrupts.md), the task moves to the A2A `input_required` state and waits. The client answers it, and the task resumes the paused tool exactly where it stopped.
+Answering an interrupt is the one flow on this page that needs the raw A2A client rather than `A2AAgent`. `A2AAgent` speaks in text, so it rejects interrupt responses on the way out and drops the data part carrying the interrupt ids on the way back. The examples below build A2A messages directly.
 
-Answering an interrupt is the one flow on this page that needs the raw [`a2a-sdk`](https://github.com/a2aproject/a2a-python) client rather than `A2AAgent`. `A2AAgent` speaks in text, so it raises `ValueError` if you pass it interrupt responses, and it drops the `DataPart` carrying the interrupt ids when it reads the reply. The examples below build A2A messages directly.
-
-Each interrupt has a server-generated id, and an answer is bound to the id of the interrupt that raised it. The server advertises the pending interrupts on the `input_required` status message as a `DataPart`, alongside the human-readable `TextPart`:
+Each interrupt has a server-generated id, and an answer is bound to the id of the interrupt that raised it. The server advertises the pending interrupts on the `input-required` status message as a data part, alongside the human-readable text part:
 
 ```json
 {
@@ -420,14 +416,17 @@ To answer, send a new message on the same `taskId` containing a `DataPart` that 
 }
 ```
 
-The `response` becomes the return value of the `interrupt()` call that paused the tool. It is any JSON value except `null`, which the server refuses — a null answer would leave the interrupt unsatisfied and re-raise it. `false` and `0` are fine. Answer several interrupts in one message by sending one `DataPart` for each.
+The `response` becomes the return value of the `interrupt()` call that paused the tool. It is any JSON value except `null`, which the server refuses — a null answer would leave the interrupt unsatisfied and re-raise it. `false` and `0` are fine. Answer several interrupts in one message by sending one data part for each.
 
 Reading the ids off the status message and answering them:
+
+<Tabs>
+<Tab label="Python">
 
 ```python
 from a2a.types import DataPart, Part
 
-# The task parked in input_required; read the interrupts it is waiting on.
+# The task parked in input-required; read the interrupts it is waiting on.
 pending = next(
     part.root.data["interrupts"]
     for part in task.status.message.parts
@@ -442,6 +441,25 @@ answers = [
     for item in pending
 ]
 ```
+
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+// The task parked in input-required; read the interrupts it is waiting on.
+const pending = (task.status.message?.parts ?? []).flatMap((part) =>
+  part.kind === 'data' && 'interrupts' in part.data ? (part.data.interrupts as { interruptId: string }[]) : []
+)
+
+// Answer each one on the same taskId.
+const answers = pending.map((item) => ({
+  kind: 'data' as const,
+  data: { interruptResponse: { interruptId: item.interruptId, response: { approved: true } } },
+}))
+```
+
+</Tab>
+</Tabs>
 
 The server rejects an answer it cannot bind, before the agent runs, so a refused answer leaves the interrupt pending and the task still answerable. An answer is rejected when:
 

--- a/strands-ts/src/a2a/__tests__/executor.test.ts
+++ b/strands-ts/src/a2a/__tests__/executor.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { A2AExecutor } from '../executor.js'
 import type { AgentExecutionEvent, ExecutionEventBus, RequestContext } from '@a2a-js/sdk/server'
 import type { TaskArtifactUpdateEvent, TaskStatusUpdateEvent } from '@a2a-js/sdk'
@@ -6,10 +6,12 @@ import { Agent } from '../../agent/agent.js'
 import type { InvokableAgent } from '../../types/agent.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
 import { createMockAgent } from '../../__fixtures__/agent-helpers.js'
+import { createMockTool } from '../../__fixtures__/tool-helpers.js'
 import { TextBlock } from '../../types/messages.js'
 import { ImageBlock, encodeBase64 } from '../../types/media.js'
 import { ContentBlockEvent, ModelStreamUpdateEvent } from '../../hooks/events.js'
 import { AgentResult } from '../../types/agent.js'
+import { Interrupt } from '../../interrupt.js'
 import { Message } from '../../types/messages.js'
 import type { ModelStreamEvent } from '../../models/streaming.js'
 
@@ -413,6 +415,248 @@ describe('A2AExecutor context isolation', () => {
       const agent = makeEchoAgent()
       ;(agent as unknown as { sessionManager: unknown }).sessionManager = {}
       expect(() => new A2AExecutor({ agent })).toThrow('sessionManager is not supported')
+    })
+  })
+
+  describe('interrupts', () => {
+    function interruptingAgent(interrupts: Interrupt[]): InvokableAgent {
+      return {
+        id: 'test-agent',
+        name: 'Test Agent',
+        invoke: vi.fn(),
+        // An agent that stops on an interrupt emits no stream events, only the result.
+        // eslint-disable-next-line require-yield
+        async *stream() {
+          return new AgentResult({
+            stopReason: 'interrupt',
+            lastMessage: new Message({ role: 'assistant', content: [new TextBlock('')] }),
+            invocationState: {},
+            interrupts,
+          })
+        },
+      }
+    }
+
+    async function runInterrupting(interrupts: Interrupt[]) {
+      const executor = new A2AExecutor({ agentFactory: () => interruptingAgent(interrupts) })
+      const eventBus = createMockEventBus()
+      await executor.execute(createRequestContext('create the spring campaign'), eventBus)
+      return eventBus.events.filter((e): e is TaskStatusUpdateEvent => e.kind === 'status-update')
+    }
+
+    it('parks the task instead of reporting it completed', async () => {
+      const statuses = await runInterrupting([new Interrupt({ id: 'int-1', name: 'approve', source: 'tool' })])
+
+      expect(statuses.map((e) => e.status.state)).toEqual(['input-required'])
+    })
+
+    it('advertises each interrupt id so a client can answer it', async () => {
+      const statuses = await runInterrupting([
+        new Interrupt({ id: 'int-1', name: 'approve', reason: { campaign: 'spring' }, source: 'tool' }),
+        new Interrupt({ id: 'int-2', name: 'confirm', source: 'tool' }),
+      ])
+
+      const dataParts = (statuses[0]!.status.message?.parts ?? []).filter((p) => p.kind === 'data')
+      expect(dataParts).toHaveLength(1)
+      expect(dataParts[0]).toEqual({
+        kind: 'data',
+        data: {
+          interrupts: [
+            { interruptId: 'int-1', name: 'approve', reason: { campaign: 'spring' } },
+            { interruptId: 'int-2', name: 'confirm' },
+          ],
+        },
+      })
+    })
+
+    it('keeps the human-readable text part first', async () => {
+      const statuses = await runInterrupting([
+        new Interrupt({ id: 'int-1', name: 'approve', reason: 'needs sign-off', source: 'tool' }),
+      ])
+
+      const parts = statuses[0]!.status.message?.parts ?? []
+      expect(parts[0]!.kind).toBe('text')
+      expect(parts[0]).toMatchObject({ text: expect.stringContaining('approve') })
+      expect(parts[0]).toMatchObject({ text: expect.stringContaining('needs sign-off') })
+    })
+
+    it('still parks the task when no interrupt details are given', async () => {
+      const statuses = await runInterrupting([])
+
+      expect(statuses.map((e) => e.status.state)).toEqual(['input-required'])
+      const parts = statuses[0]!.status.message?.parts ?? []
+      expect(parts.filter((p) => p.kind === 'data')).toHaveLength(0)
+      expect(parts[0]!.kind).toBe('text')
+    })
+
+    it('reports a normal completion as completed', async () => {
+      const executor = new A2AExecutor({ agentFactory: () => makeEchoAgent() })
+      const eventBus = createMockEventBus()
+
+      await executor.execute(createRequestContext('hello'), eventBus)
+
+      const statuses = eventBus.events.filter((e): e is TaskStatusUpdateEvent => e.kind === 'status-update')
+      expect(statuses.map((e) => e.status.state)).toEqual(['completed'])
+    })
+
+    it('advertises the id a real agent is actually waiting on', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'createCampaign', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Campaign is live.' })
+      const tool = createMockTool('createCampaign', (context) => {
+        context.interrupt({ name: 'approveCampaign', reason: { campaign: 'spring-launch' } })
+      })
+      const agent = new Agent({ model, tools: [tool], printer: false })
+
+      const executor = new A2AExecutor({ agentFactory: () => agent })
+      const eventBus = createMockEventBus()
+      await executor.execute(createRequestContext('create the spring-launch campaign'), eventBus)
+
+      const statuses = eventBus.events.filter((e): e is TaskStatusUpdateEvent => e.kind === 'status-update')
+      expect(statuses.map((e) => e.status.state)).toEqual(['input-required'])
+
+      // Read the advertised interrupts the way a client would, with no access to server internals.
+      const dataParts = (statuses[0]!.status.message?.parts ?? []).filter((p) => p.kind === 'data')
+      const advertised = (dataParts[0] as unknown as { data: { interrupts: { interruptId: string }[] } }).data
+        .interrupts
+
+      // The advertised id must be the one the agent parked, or the client cannot answer it.
+      const parked = (agent as unknown as { _interruptState: { interrupts: Record<string, unknown> } })._interruptState
+      expect(Object.keys(parked.interrupts)).toEqual([advertised[0]!.interruptId])
+    })
+
+    beforeEach(() => {
+      resumedWith.length = 0
+    })
+
+    function resumeContext(interruptId: string, response: unknown): RequestContext {
+      return {
+        taskId: 'task-1',
+        contextId: 'ctx-1',
+        userMessage: {
+          kind: 'message',
+          messageId: 'msg-2',
+          role: 'user',
+          parts: [{ kind: 'data', data: { interruptResponse: { interruptId, response } } }],
+        },
+      }
+    }
+
+    /** Records what the paused tool receives when it resumes, so the payload can be asserted. */
+    const resumedWith: unknown[] = []
+
+    function campaignAgent(): Agent {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'createCampaign', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Campaign is live.' })
+      const tool = createMockTool('createCampaign', (context) => {
+        const approval = context.interrupt({ name: 'approveCampaign', reason: { campaign: 'spring-launch' } })
+        resumedWith.push(approval)
+      })
+      return new Agent({ model, tools: [tool], printer: false })
+    }
+
+    /** Runs the first turn and returns the interrupt id a client would read off the wire. */
+    async function parkAndReadId(executor: A2AExecutor): Promise<string> {
+      const eventBus = createMockEventBus()
+      await executor.execute(createRequestContext('create the spring-launch campaign'), eventBus)
+      const statuses = eventBus.events.filter((e): e is TaskStatusUpdateEvent => e.kind === 'status-update')
+      const dataParts = (statuses[0]!.status.message?.parts ?? []).filter((p) => p.kind === 'data')
+      return (dataParts[0] as unknown as { data: { interrupts: { interruptId: string }[] } }).data.interrupts[0]!
+        .interruptId
+    }
+
+    it('completes the round trip when the advertised id is answered', async () => {
+      const executor = new A2AExecutor({ agentFactory: () => campaignAgent() })
+      const interruptId = await parkAndReadId(executor)
+
+      const eventBus = createMockEventBus()
+      await executor.execute(resumeContext(interruptId, { approved: true }), eventBus)
+
+      const statuses = eventBus.events.filter((e): e is TaskStatusUpdateEvent => e.kind === 'status-update')
+      expect(statuses.map((e) => e.status.state)).toEqual(['completed'])
+
+      // The paused tool resumed with the client's answer, not merely with the task marked done.
+      expect(resumedWith).toEqual([{ approved: true }])
+    })
+
+    it('refuses an id the task is not waiting on and leaves it answerable', async () => {
+      const executor = new A2AExecutor({ agentFactory: () => campaignAgent() })
+      const interruptId = await parkAndReadId(executor)
+
+      await expect(
+        executor.execute(resumeContext('guessed-id', { approved: true }), createMockEventBus())
+      ).rejects.toThrow(/No pending interrupt matches/)
+
+      // The refused answer must not have consumed the interrupt.
+      const eventBus = createMockEventBus()
+      await executor.execute(resumeContext(interruptId, { approved: true }), eventBus)
+      const statuses = eventBus.events.filter((e): e is TaskStatusUpdateEvent => e.kind === 'status-update')
+      expect(statuses.map((e) => e.status.state)).toEqual(['completed'])
+    })
+
+    it('publishes nothing when an answer is refused, so the task stays parked for the client', async () => {
+      const executor = new A2AExecutor({ agentFactory: () => campaignAgent() })
+      await parkAndReadId(executor)
+
+      const eventBus = createMockEventBus()
+      await expect(executor.execute(resumeContext('guessed-id', { approved: true }), eventBus)).rejects.toThrow()
+
+      // Registering the task would move it out of input-required, hiding from the client that it is
+      // still waiting on them.
+      expect(eventBus.events).toEqual([])
+    })
+
+    it('refuses a null response rather than silently re-firing the interrupt', async () => {
+      const executor = new A2AExecutor({ agentFactory: () => campaignAgent() })
+      const interruptId = await parkAndReadId(executor)
+
+      await expect(executor.execute(resumeContext(interruptId, null), createMockEventBus())).rejects.toThrow(
+        /non-null 'response'/
+      )
+    })
+
+    it('refuses a fresh conversational turn while the task is parked', async () => {
+      const executor = new A2AExecutor({ agentFactory: () => campaignAgent() })
+      await parkAndReadId(executor)
+
+      await expect(executor.execute(createRequestContext('never mind'), createMockEventBus())).rejects.toThrow(
+        /awaiting an interrupt response/
+      )
+    })
+
+    it('refuses interrupt responses when nothing is pending', async () => {
+      const executor = new A2AExecutor({ agentFactory: () => campaignAgent() })
+
+      await expect(executor.execute(resumeContext('int-1', { approved: true }), createMockEventBus())).rejects.toThrow(
+        /no interrupt is pending/
+      )
+    })
+
+    it('leaves an ordinary data part on the generic content path', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'ok' })
+      const agent = new Agent({ model, printer: false })
+      vi.spyOn(agent, 'stream')
+      const executor = new A2AExecutor({ agent })
+
+      await executor.execute(
+        {
+          taskId: 'task-1',
+          contextId: 'ctx-1',
+          userMessage: {
+            kind: 'message',
+            messageId: 'msg-1',
+            role: 'user',
+            parts: [{ kind: 'data', data: { campaign: 'spring', budget: 100 } }],
+          },
+        },
+        createMockEventBus()
+      )
+
+      expect(agent.stream).toHaveBeenCalledWith(
+        [new TextBlock('[Structured Data]\n' + JSON.stringify({ campaign: 'spring', budget: 100 }, null, 2))],
+        expect.anything()
+      )
     })
   })
 })

--- a/strands-ts/src/a2a/adapters.ts
+++ b/strands-ts/src/a2a/adapters.ts
@@ -5,12 +5,96 @@
  */
 
 import type { Part, FileWithBytes, FileWithUri } from '@a2a-js/sdk'
+import { A2AError } from '@a2a-js/sdk/server'
 import type { ContentBlock } from '../types/messages.js'
 import { TextBlock } from '../types/messages.js'
 import type { ImageFormat, DocumentFormat, VideoFormat } from '../mime.js'
 import { toMimeType, toMediaFormat } from '../mime.js'
 import { ImageBlock, VideoBlock, DocumentBlock, decodeBase64, encodeBase64 } from '../types/media.js'
+import { InterruptResponseContent } from '../types/interrupt.js'
+import type { JSONValue } from '../types/json.js'
 import { logger } from '../logging/logger.js'
+
+/**
+ * Key identifying a data part that carries a Strands interrupt response. The A2A payload mirrors
+ * the `InterruptResponseContent` type verbatim, so the wire contract and the SDK type cannot drift.
+ */
+export const INTERRUPT_RESPONSE_KEY = 'interruptResponse'
+
+/**
+ * Key under which an `input-required` status message advertises the interrupts awaiting an answer.
+ * Each entry carries the `interruptId` that the matching interrupt response must echo back.
+ */
+export const INTERRUPTS_KEY = 'interrupts'
+
+/**
+ * Extracts Strands interrupt responses from inbound A2A message parts.
+ *
+ * A client resumes a task parked in `input-required` by sending a data part shaped like the
+ * `InterruptResponseContent` type:
+ *
+ * ```json
+ * { "kind": "data", "data": { "interruptResponse": { "interruptId": "<id>", "response": <any> } } }
+ * ```
+ *
+ * Recognition is deliberately narrow: only the explicit shape above is treated as a resume, so an
+ * ordinary data part still reaches the generic content-block path unchanged.
+ *
+ * @param parts - Array of A2A protocol parts from the inbound message
+ * @returns The interrupt responses carried by `parts`, or undefined when none are present and the
+ *   caller should fall back to generic content-block conversion
+ * @throws A2AError when an interrupt response is malformed, carries a null response, repeats an
+ *   interrupt id, or is accompanied by unrelated content in the same message
+ */
+export function extractInterruptResponses(parts: Part[]): InterruptResponseContent[] | undefined {
+  const responses: InterruptResponseContent[] = []
+  const seenIds = new Set<string>()
+  let unrelatedParts = 0
+
+  for (const part of parts) {
+    if (part.kind !== 'data' || !(INTERRUPT_RESPONSE_KEY in part.data)) {
+      unrelatedParts += 1
+      continue
+    }
+
+    const payload = part.data[INTERRUPT_RESPONSE_KEY]
+    if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) {
+      throw A2AError.invalidParams(`'${INTERRUPT_RESPONSE_KEY}' must be an object with 'interruptId' and 'response'`)
+    }
+
+    const { interruptId, response } = payload as { interruptId?: unknown; response?: unknown }
+    if (typeof interruptId !== 'string' || interruptId.length === 0) {
+      throw A2AError.invalidParams("Interrupt response is missing a non-empty 'interruptId'")
+    }
+
+    // An interrupt whose response is null reads as "not yet answered", so a null answer would leave
+    // the interrupt unsatisfied and re-raise it: the client would see an identical input-required
+    // and no error. Falsy answers such as false are fine.
+    if (response === undefined || response === null) {
+      throw A2AError.invalidParams(`Interrupt response for '${interruptId}' must provide a non-null 'response'`)
+    }
+
+    // Two answers for one interrupt are ambiguous; reject rather than silently choosing one.
+    if (seenIds.has(interruptId)) {
+      throw A2AError.invalidParams(`Duplicate interrupt response for '${interruptId}'`)
+    }
+
+    seenIds.add(interruptId)
+    responses.push(new InterruptResponseContent({ interruptId, response: response as JSONValue }))
+  }
+
+  if (responses.length === 0) {
+    return undefined
+  }
+
+  // The agent resumes from interrupt responses alone, so delivering both would mean dropping the
+  // conversational content — exactly the silent behaviour the resume path must avoid.
+  if (unrelatedParts > 0) {
+    throw A2AError.invalidParams('A message carrying interrupt responses must not contain other content parts')
+  }
+
+  return responses
+}
 
 /**
  * Converts A2A protocol parts to Strands SDK content blocks.

--- a/strands-ts/src/a2a/executor.ts
+++ b/strands-ts/src/a2a/executor.ts
@@ -8,11 +8,15 @@
 import type { ExecutionEventBus, RequestContext } from '@a2a-js/sdk/server'
 import type { AgentExecutor } from '@a2a-js/sdk/server'
 import { A2AError } from '@a2a-js/sdk/server'
+import type { Part } from '@a2a-js/sdk'
 import type { InvokableAgent, LocalAgent } from '../types/agent.js'
 import type { Snapshot } from '../types/snapshot.js'
 import type { ContentBlock } from '../types/messages.js'
+import type { Interrupt, InterruptState } from '../interrupt.js'
+import type { InterruptResponseContent } from '../types/interrupt.js'
+import { isInterruptResponseContent } from '../types/interrupt.js'
 import { ModelStreamUpdateEvent, ContentBlockEvent } from '../hooks/events.js'
-import { contentBlocksToParts, partsToContentBlocks } from './adapters.js'
+import { INTERRUPTS_KEY, contentBlocksToParts, extractInterruptResponses, partsToContentBlocks } from './adapters.js'
 import { normalizeError } from '../errors.js'
 import { logger } from '../logging/logger.js'
 import { AsyncLock } from './async-lock.js'
@@ -41,6 +45,23 @@ export interface A2AExecutorOptions {
   agentFactory?: AgentFactory
   /** Maximum contexts to retain; the least-recently-used is evicted beyond it. Must be at least 1. */
   maxContexts?: number
+}
+
+/**
+ * What this executor invokes the agent with: fresh conversational content, or interrupt responses
+ * resuming a task parked in `input-required`. Each arm stays homogeneous because the agent rejects
+ * a prompt whose contents are not all interrupt responses.
+ */
+type AgentPrompt = ContentBlock[] | InterruptResponseContent[]
+
+/** Whether a prompt carries interrupt responses rather than conversational content. */
+function isInterruptResume(prompt: AgentPrompt): prompt is InterruptResponseContent[] {
+  return prompt.length > 0 && isInterruptResponseContent(prompt[0])
+}
+
+/** Reads the agent's interrupt state, a field not declared on {@link InvokableAgent}. */
+function interruptStateOf(agent: InvokableAgent): InterruptState | undefined {
+  return (agent as { _interruptState?: InterruptState })._interruptState
 }
 
 /** A full Strands `Agent` that can be both invoked and snapshotted. */
@@ -192,44 +213,44 @@ export class A2AExecutor implements AgentExecutor {
    * @param eventBus - The event bus for publishing A2A artifact and status events
    */
   async execute(context: RequestContext, eventBus: ExecutionEventBus): Promise<void> {
-    const { taskId, contextId, userMessage } = context
-    const contentBlocks = partsToContentBlocks(userMessage.parts)
-    if (contentBlocks.length === 0) {
+    const { userMessage } = context
+
+    // Interrupt responses resume a parked task, so they are recognised before the generic
+    // conversion below would flatten them into text.
+    const prompt: AgentPrompt = extractInterruptResponses(userMessage.parts) ?? partsToContentBlocks(userMessage.parts)
+    if (prompt.length === 0) {
       throw A2AError.invalidRequest('No content blocks available')
     }
 
-    // Register the task with the ResultManager; without this, later events are ignored as "unknown task".
-    eventBus.publish({ kind: 'task', id: taskId, contextId, status: { state: 'working' } })
-
     if (this._agentFactory !== undefined) {
-      await this._runWithContextAgent(context, contentBlocks, eventBus)
+      await this._runWithContextAgent(context, prompt, eventBus)
     } else {
-      await this._runWithSharedAgent(context, contentBlocks, eventBus)
+      await this._runWithSharedAgent(context, prompt, eventBus)
     }
   }
 
   /** Factory mode: run against this context's dedicated agent, serialized only per context. */
   private async _runWithContextAgent(
     context: RequestContext,
-    contentBlocks: ContentBlock[],
+    prompt: AgentPrompt,
     eventBus: ExecutionEventBus
   ): Promise<void> {
     const { agent, lock } = this._acquireContextAgent(context.contextId)
     using _release = await lock.acquire()
-    await this._streamAgent(agent, context, contentBlocks, eventBus)
+    await this._streamAgent(agent, context, prompt, eventBus)
   }
 
   /** Single-agent mode: swap this context's snapshot on/off the shared agent under a lock. */
   private async _runWithSharedAgent(
     context: RequestContext,
-    contentBlocks: ContentBlock[],
+    prompt: AgentPrompt,
     eventBus: ExecutionEventBus
   ): Promise<void> {
     const agent = this._agent!
     using _release = await this._sharedAgentLock.acquire()
     this._restoreState(agent, this._snapshots.get(context.contextId) ?? this._templateSnapshot!)
     try {
-      await this._streamAgent(agent, context, contentBlocks, eventBus)
+      await this._streamAgent(agent, context, prompt, eventBus)
     } finally {
       // Persist updated history (even on error), evict, then reset the agent for the next caller.
       this._snapshots.delete(context.contextId)
@@ -243,15 +264,27 @@ export class A2AExecutor implements AgentExecutor {
   private async _streamAgent(
     agent: InvokableAgent,
     context: RequestContext,
-    contentBlocks: ContentBlock[],
+    prompt: AgentPrompt,
     eventBus: ExecutionEventBus
   ): Promise<void> {
     const { taskId, contextId } = context
     const artifactId = globalThis.crypto.randomUUID()
     let isFirstChunk = true
 
+    // Checked before the agent runs, so a refused answer leaves the interrupt parked and retryable.
+    if (isInterruptResume(prompt)) {
+      this._validateInterruptResume(agent, prompt)
+    } else if (interruptStateOf(agent)?.activated === true) {
+      throw A2AError.invalidParams('Task is awaiting an interrupt response and cannot accept a new message')
+    }
+
+    // Registered only once the request is known to be servable. Registering earlier would move a
+    // task parked in `input-required` to `working` before a refused answer threw, leaving the client
+    // unable to see that the task is still waiting on them.
+    eventBus.publish({ kind: 'task', id: taskId, contextId, status: { state: 'working' } })
+
     try {
-      const stream = agent.stream(contentBlocks, {
+      const stream = agent.stream(prompt, {
         invocationState: { a2aRequestContext: context },
       })
       let next = await stream.next()
@@ -310,11 +343,104 @@ export class A2AExecutor implements AgentExecutor {
         lastChunk: true,
       })
 
+      // An agent that stopped on an interrupt has not finished its work, so the task waits for the
+      // client to answer rather than reporting success.
+      const result = next.value
+      if (result?.stopReason === 'interrupt') {
+        this._publishInputRequired(result.interrupts ?? [], taskId, contextId, eventBus)
+        return
+      }
+
       eventBus.publish({ kind: 'status-update', taskId, contextId, status: { state: 'completed' }, final: true })
     } catch (error) {
       logger.error(`task_id=<${taskId}> | error in streaming execution`, normalizeError(error))
       throw error
     }
+  }
+
+  /**
+   * Verifies interrupt responses bind to interrupts actually parked on this context's agent.
+   *
+   * @param agent - The agent serving this context, with its interrupt state already restored
+   * @param responses - Interrupt responses extracted from the inbound message
+   * @throws A2AError when the agent holds no parked interrupts, or a response names an interrupt
+   *   the agent is not waiting on
+   */
+  private _validateInterruptResume(agent: InvokableAgent, responses: InterruptResponseContent[]): void {
+    const state = interruptStateOf(agent)
+    if (state?.activated !== true) {
+      throw A2AError.invalidParams('Received interrupt responses but no interrupt is pending')
+    }
+
+    const unknownIds = responses
+      .map((content) => content.interruptResponse.interruptId)
+      .filter((id) => !(id in state.interrupts))
+      .sort()
+    if (unknownIds.length > 0) {
+      throw A2AError.invalidParams(`No pending interrupt matches id(s): ${unknownIds.join(', ')}`)
+    }
+  }
+
+  /**
+   * Moves the task to `input-required` and tells the client which interrupts are waiting.
+   *
+   * The interrupts are published twice: a text part describing what is needed, and a data part
+   * carrying each `interruptId`. Only the id lets a client address its answer back to the interrupt
+   * that raised it, and ids are generated server-side so they cannot be inferred from the prose.
+   *
+   * @param interrupts - The unanswered interrupts that stopped the agent
+   * @param taskId - The A2A task being paused
+   * @param contextId - The A2A context the task belongs to
+   * @param eventBus - The event bus for publishing status events
+   */
+  private _publishInputRequired(
+    interrupts: Interrupt[],
+    taskId: string,
+    contextId: string,
+    eventBus: ExecutionEventBus
+  ): void {
+    const descriptions = interrupts.map((interrupt) =>
+      interrupt.reason === undefined
+        ? `- ${interrupt.name}`
+        : `- ${interrupt.name}: ${JSON.stringify(interrupt.reason)}`
+    )
+    const text =
+      descriptions.length > 0
+        ? `Agent requires input:\n${descriptions.join('\n')}`
+        : 'Agent requires additional input to continue'
+
+    // The text part stays first so clients that only read prose are unaffected.
+    const parts: Part[] = [{ kind: 'text', text }]
+    if (interrupts.length > 0) {
+      parts.push({
+        kind: 'data',
+        data: {
+          [INTERRUPTS_KEY]: interrupts.map((interrupt) => ({
+            interruptId: interrupt.id,
+            name: interrupt.name,
+            ...(interrupt.reason === undefined ? {} : { reason: interrupt.reason }),
+          })),
+        },
+      })
+    }
+
+    eventBus.publish({
+      kind: 'status-update',
+      taskId,
+      contextId,
+      status: {
+        state: 'input-required',
+        message: {
+          kind: 'message',
+          role: 'agent',
+          messageId: globalThis.crypto.randomUUID(),
+          taskId,
+          contextId,
+          parts,
+        },
+      },
+      final: true,
+    })
   }
 
   /**


### PR DESCRIPTION
## Description

Human-in-the-loop did not work over A2A in the TypeScript SDK, and failed silently in both directions.

- **Outbound**: `_streamAgent` published `state: 'completed'` once the stream ended, without checking `stopReason`. A task whose tool had paused for approval reported **success** while the tool never ran.
- **Inbound**: `partsToContentBlocks` flattened every data part to `[Structured Data]` text, so an interrupt response arrived as a plain conversational turn and the agent never resumed.

This ports the contract merged for Python in #3486. The agent side was already in place — `InterruptState` carries `interrupts`/`activated`/`resumeResponses`, and `AgentInput` accepts `InterruptResponseContent[]`; only the A2A adapter was missing.

Resume is treated as a continuation of the parked state rather than a new conversational turn: once a task is in `input-required`, the next message for it must carry an interrupt response, and every rejection happens before the agent runs, so a refused answer leaves the interrupt pending and retryable.

A refused turn also publishes no events at all. Task registration moved from `execute()` to just before the stream starts, because registering first would move a task parked in `input-required` to `working` and then throw, leaving the client unable to see that the task is still waiting on them.

## Public API Changes

Two data-part contracts on the A2A wire, identical to the Python ones. No TypeScript signature changes.

**Outbound** — the `input-required` status message carries the pending interrupts. The existing text part stays first, so clients that only read prose are unaffected:

```json
{
  "kind": "data",
  "data": { "interrupts": [{ "interruptId": "tool:tool-1:approveCampaign", "name": "approveCampaign", "reason": { "campaign": "spring-launch" } }] }
}
```

**Inbound** — a client resumes by echoing the id back:

```json
{
  "kind": "data",
  "data": { "interruptResponse": { "interruptId": "tool:tool-1:approveCampaign", "response": { "approved": true } } }
}
```

This needed no format decisions: it is already the JSON form of the TS type. `InterruptResponseContent.toJSON()` emits exactly this shape, `fromJSON()` reads it back, and `isInterruptResponseContent` guards on it — so both SDKs speak it without a mapping layer.

### Rejected inputs

All raise `A2AError.invalidParams` before the agent is invoked:

| Input | Why |
| --- | --- |
| Interrupt id not parked on this context's agent | An answer must bind to the interrupt that requested it |
| Interrupt response with no interrupt pending | Nothing to resume |
| Two responses for the same interrupt id | Ambiguous; picking one silently would discard a decision |
| A `null` response | `Interrupt.response` of null reads as "not yet answered", so it would silently re-fire the same interrupt. `false` and `0` are fine |
| Missing/blank `interruptId`, non-object payload | Malformed |
| Interrupt response mixed with other content parts | The agent resumes from responses alone, so the rest would be silently dropped |
| A fresh conversational turn while a task is parked | A parked task is answered or cancelled, not talked past |

A data part without an `interruptResponse` key is untouched and still takes the generic path.

## Related Issues

Closes #3584. Ports #3486, which fixed the same gap in Python (#2948).

## Type of Change

New feature

## Testing

Verified by running the same script against unmodified `main` and this branch. It drives a real `Agent` with a real interrupting tool through `executor.execute()` and reads only the published events — the surface a client actually has.

| Observation | `main` | this branch |
| --- | --- | --- |
| Task state when the tool pauses | `completed` | `input-required` |
| Interrupt ids sent to the client | none | advertised in a data part |
| Answering with the parked id | rejected by the agent | `completed` |
| Tool actually resumed | `false` | `true` |
| Payload the tool received | — | `{"approved":true}` |

The `main` column is the bug in full: the first turn reports `completed` while the tool log reads only `["entered"]`, so the client is told the work succeeded when the approval never happened. Answering then fails with *"Agent is in an interrupted state. Resume by invoking with interruptResponse content blocks"* — the agent rejecting a text turn, because the data part had been flattened before it arrived.

Unit coverage adds 13 cases to `src/a2a/__tests__/executor.test.ts`, including a round trip against a real agent that asserts the advertised id matches the one the agent parked, and that the resumed tool receives the client's payload rather than merely that the task completed. Another asserts a refused answer publishes no events, so the task stays visibly parked in `input-required` for the client rather than being stranded in `working`.

Shared-agent mode was checked separately: a parked interrupt survives the snapshot swap, since `interrupts` is part of the `session` snapshot preset.

Docs: the **Answering Interrupts** section on `agent-to-agent.mdx` loses its `:::note[Python only]` and gains a TypeScript tab.

Run against this branch: `npm run lint` reports no problems, `npm run format` leaves the tree unchanged, `npm test` is green at 3901 tests across 141 files, `tsc --noEmit --project src/tsconfig.json` reports no errors, and `npm run build` in `site/` finds no broken links.

- [ ] I ran `hatch run prepare` — not applicable; this is a TypeScript-only change, so the equivalent TypeScript checks are listed above

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
