### PR TITLE
fix(python): preserve structured output schemas

### DIFF
--- a/strands-py/src/strands/models/_strict_schema.py
+++ b/strands-py/src/strands/models/_strict_schema.py
@@ -34,9 +34,12 @@ def ensure_strict_json_schema(
 
     Returns:
         A new schema dict with strict-mode constraints applied.
+
+    Raises:
+        ValueError: If a circular ``$ref`` with sibling keys would require unbounded inlining.
     """
     schema_copy = copy.deepcopy(schema)
-    _apply_strict(schema_copy, root=schema_copy, require_all_properties=require_all_properties)
+    _apply_strict(schema_copy, root=schema_copy, require_all_properties=require_all_properties, ref_stack=())
     return schema_copy
 
 
@@ -45,6 +48,7 @@ def _apply_strict(
     *,
     root: dict[str, Any],
     require_all_properties: bool,
+    ref_stack: tuple[str, ...],
 ) -> None:
     """Recursively apply strict-mode constraints to a JSON schema in place.
 
@@ -52,6 +56,7 @@ def _apply_strict(
         schema: The schema node to process (modified in place).
         root: The root schema, used for resolving ``$ref`` pointers.
         require_all_properties: If True, add all properties to ``required``.
+        ref_stack: References inlined along the current traversal branch.
     """
     # Process $defs / definitions blocks
     for defs_key in ("$defs", "definitions"):
@@ -59,7 +64,12 @@ def _apply_strict(
         if isinstance(defs, dict):
             for def_schema in defs.values():
                 if isinstance(def_schema, dict):
-                    _apply_strict(def_schema, root=root, require_all_properties=require_all_properties)
+                    _apply_strict(
+                        def_schema,
+                        root=root,
+                        require_all_properties=require_all_properties,
+                        ref_stack=ref_stack,
+                    )
 
     # Add additionalProperties: false to object types that lack it
     if schema.get("type") == "object" and "additionalProperties" not in schema:
@@ -73,37 +83,47 @@ def _apply_strict(
 
         for prop_schema in properties.values():
             if isinstance(prop_schema, dict):
-                _apply_strict(prop_schema, root=root, require_all_properties=require_all_properties)
+                _apply_strict(
+                    prop_schema,
+                    root=root,
+                    require_all_properties=require_all_properties,
+                    ref_stack=ref_stack,
+                )
 
     # Process array items
     items = schema.get("items")
     if isinstance(items, dict):
-        _apply_strict(items, root=root, require_all_properties=require_all_properties)
+        _apply_strict(items, root=root, require_all_properties=require_all_properties, ref_stack=ref_stack)
 
     # Process anyOf variants
     any_of = schema.get("anyOf")
     if isinstance(any_of, list):
         for variant in any_of:
             if isinstance(variant, dict):
-                _apply_strict(variant, root=root, require_all_properties=require_all_properties)
+                _apply_strict(variant, root=root, require_all_properties=require_all_properties, ref_stack=ref_stack)
 
     # Process allOf variants
     all_of = schema.get("allOf")
     if isinstance(all_of, list):
         for entry in all_of:
             if isinstance(entry, dict):
-                _apply_strict(entry, root=root, require_all_properties=require_all_properties)
+                _apply_strict(entry, root=root, require_all_properties=require_all_properties, ref_stack=ref_stack)
 
     # Process oneOf variants
     one_of = schema.get("oneOf")
     if isinstance(one_of, list):
         for variant in one_of:
             if isinstance(variant, dict):
-                _apply_strict(variant, root=root, require_all_properties=require_all_properties)
+                _apply_strict(variant, root=root, require_all_properties=require_all_properties, ref_stack=ref_stack)
 
     # Resolve $ref combined with other keys by inlining the referenced schema
     ref = schema.get("$ref")
     if isinstance(ref, str) and len(schema) > 1:
+        if ref in ref_stack:
+            cycle_start = ref_stack.index(ref)
+            cycle = " -> ".join((*ref_stack[cycle_start:], ref))
+            raise ValueError(f"Circular JSON Schema reference with sibling keys cannot be inlined: {cycle}")
+
         resolved = _resolve_ref(root, ref)
         if isinstance(resolved, dict):
             # Inline the resolved schema, giving priority to existing keys
@@ -112,7 +132,12 @@ def _apply_strict(
             schema.clear()
             schema.update(merged)
             # Re-apply strict to the inlined schema
-            _apply_strict(schema, root=root, require_all_properties=require_all_properties)
+            _apply_strict(
+                schema,
+                root=root,
+                require_all_properties=require_all_properties,
+                ref_stack=(*ref_stack, ref),
+            )
 
 
 def _resolve_ref(root: dict[str, Any], ref: str) -> dict[str, Any] | None:

--- a/strands-py/src/strands/tools/structured_output/structured_output_utils.py
+++ b/strands-py/src/strands/tools/structured_output/structured_output_utils.py
@@ -1,404 +1,65 @@
-"""Tools for converting Pydantic models to Bedrock tools."""
+"""Tools for converting Pydantic models to structured-output tool specifications."""
 
-from typing import Any, Union
+from copy import deepcopy
+from typing import Any
 
 from pydantic import BaseModel
 
 from ...types.tools import ToolSpec
 
 
-def _flatten_schema(schema: dict[str, Any]) -> dict[str, Any]:
-    """Flattens a JSON schema by removing $defs and resolving $ref references.
-
-    Handles required vs optional fields properly.
-
-    Args:
-        schema: The JSON schema to flatten
-
-    Returns:
-        Flattened JSON schema
-    """
-    # Extract required fields list
-    required_fields = schema.get("required", [])
-
-    # Initialize the flattened schema with basic properties
-    flattened = {
-        "type": schema.get("type", "object"),
-        "properties": {},
-    }
-
-    if "title" in schema:
-        flattened["title"] = schema["title"]
-
-    if "description" in schema and schema["description"]:
-        flattened["description"] = schema["description"]
-
-    # Process properties
-    required_props: list[str] = []
-    if "properties" not in schema and "$ref" in schema:
-        raise ValueError("Circular reference detected and not supported.")
-    if "properties" in schema:
-        required_props = []
-        for prop_name, prop_value in schema["properties"].items():
-            # Process the property and add to flattened properties
-            is_required = prop_name in required_fields
-
-            # If the property already has nested properties (expanded), preserve them
-            if "properties" in prop_value:
-                # This is an expanded nested schema, preserve its structure
-                processed_prop = {
-                    "type": prop_value.get("type", "object"),
-                    "description": prop_value.get("description", ""),
-                    "properties": {},
-                }
-
-                # Process each nested property
-                for nested_prop_name, nested_prop_value in prop_value["properties"].items():
-                    is_required = "required" in prop_value and nested_prop_name in prop_value["required"]
-                    sub_property = _process_property(nested_prop_value, schema.get("$defs", {}), is_required)
-                    processed_prop["properties"][nested_prop_name] = sub_property
-
-                # Copy required fields if present
-                if "required" in prop_value:
-                    processed_prop["required"] = prop_value["required"]
-            else:
-                # Process as normal
-                processed_prop = _process_property(prop_value, schema.get("$defs", {}), is_required)
-
-            flattened["properties"][prop_name] = processed_prop
-
-            # Track which properties are actually required after processing
-            if is_required and "null" not in str(processed_prop.get("type", "")):
-                required_props.append(prop_name)
-
-    # Add required fields if any (only those that are truly required after processing)
-    # Check if required props are empty, if so, raise an error because it means there is a circular reference
-
-    if len(required_props) > 0:
-        flattened["required"] = required_props
-    return flattened
-
-
-def _process_property(
-    prop: dict[str, Any],
-    defs: dict[str, Any],
-    is_required: bool = False,
-    fully_expand: bool = True,
-) -> dict[str, Any]:
-    """Process a property in a schema, resolving any references.
-
-    Args:
-        prop: The property to process
-        defs: The definitions dictionary for resolving references
-        is_required: Whether this property is required
-        fully_expand: Whether to fully expand nested properties
-
-    Returns:
-        Processed property
-    """
-    result = {}
-    is_nullable = False
-
-    # Handle anyOf for optional fields (like Optional[Type])
-    if "anyOf" in prop:
-        # Check if this is an Optional[...] case (one null, one type)
-        null_type = False
-        non_null_type = None
-
-        for option in prop["anyOf"]:
-            if option.get("type") == "null":
-                null_type = True
-                is_nullable = True
-            elif "$ref" in option:
-                ref_path = option["$ref"].split("/")[-1]
-                if ref_path in defs:
-                    non_null_type = _process_schema_object(defs[ref_path], defs, fully_expand)
-                else:
-                    # Handle missing reference path gracefully
-                    raise ValueError(f"Missing reference: {ref_path}")
-            else:
-                non_null_type = option
-
-        if null_type and non_null_type:
-            # For Optional fields, we mark as nullable but copy all properties from the non-null option
-            result = non_null_type.copy() if isinstance(non_null_type, dict) else {}
-
-            # For type, ensure it includes "null"
-            if "type" in result and isinstance(result["type"], str):
-                result["type"] = [result["type"], "null"]
-            elif "type" in result and isinstance(result["type"], list) and "null" not in result["type"]:
-                result["type"].append("null")
-            elif "type" not in result:
-                # Default to object type if not specified
-                result["type"] = ["object", "null"]
-
-            # Copy description if available in the property
-            if "description" in prop:
-                result["description"] = prop["description"]
-
-            # Need to process item refs as well (#337)
-            if "items" in result:
-                result["items"] = _process_property(result["items"], defs)
-
-            return result
-
-    # Handle direct references
-    elif "$ref" in prop:
-        # Resolve reference
-        ref_path = prop["$ref"].split("/")[-1]
-        if ref_path in defs:
-            ref_dict = defs[ref_path]
-            # Process the referenced object to get a complete schema
-            result = _process_schema_object(ref_dict, defs, fully_expand)
-        else:
-            # Handle missing reference path gracefully
-            raise ValueError(f"Missing reference: {ref_path}")
-
-    # For regular fields, copy all properties
-    for key, value in prop.items():
-        if key not in ["$ref", "anyOf"]:
-            if isinstance(value, dict):
-                result[key] = _process_nested_dict(value, defs)
-            elif key == "type" and not is_required and not is_nullable:
-                # For non-required fields, ensure type is a list with "null"
-                if isinstance(value, str):
-                    result[key] = [value, "null"]
-                elif isinstance(value, list) and "null" not in value:
-                    result[key] = value + ["null"]
-                else:
-                    result[key] = value
-            else:
-                result[key] = value
-
-    return result
-
-
-def _process_schema_object(
-    schema_obj: dict[str, Any], defs: dict[str, Any], fully_expand: bool = True
-) -> dict[str, Any]:
-    """Process a schema object, typically from $defs, to resolve all nested properties.
-
-    Args:
-        schema_obj: The schema object to process
-        defs: The definitions dictionary for resolving references
-        fully_expand: Whether to fully expand nested properties
-
-    Returns:
-        Processed schema object with all properties resolved
-    """
-    result = {}
-
-    # Copy basic attributes
-    for key, value in schema_obj.items():
-        if key != "properties" and key != "required" and key != "$defs":
-            result[key] = value
-
-    # Process properties if present
-    if "properties" in schema_obj:
-        result["properties"] = {}
-        required_props = []
-
-        # Get required fields list
-        required_fields = schema_obj.get("required", [])
-
-        for prop_name, prop_value in schema_obj["properties"].items():
-            # Process each property
-            is_required = prop_name in required_fields
-            processed = _process_property(prop_value, defs, is_required, fully_expand)
-            result["properties"][prop_name] = processed
-
-            # Track which properties are actually required after processing
-            if is_required and "null" not in str(processed.get("type", "")):
-                required_props.append(prop_name)
-
-        # Add required fields if any
-        if required_props:
-            result["required"] = required_props
-
-    return result
-
-
-def _process_nested_dict(d: dict[str, Any], defs: dict[str, Any]) -> dict[str, Any]:
-    """Recursively processes nested dictionaries and resolves $ref references.
-
-    Args:
-        d: The dictionary to process
-        defs: The definitions dictionary for resolving references
-
-    Returns:
-        Processed dictionary
-    """
-    result: dict[str, Any] = {}
-
-    # Handle direct reference
-    if "$ref" in d:
-        ref_path = d["$ref"].split("/")[-1]
-        if ref_path in defs:
-            ref_dict = defs[ref_path]
-            # Recursively process the referenced object
-            return _process_schema_object(ref_dict, defs)
-        else:
-            # Handle missing reference path gracefully
-            raise ValueError(f"Missing reference: {ref_path}")
-
-    # Process each key-value pair
-    for key, value in d.items():
-        if key == "$ref":
-            # Already handled above
-            continue
-        elif isinstance(value, dict):
-            result[key] = _process_nested_dict(value, defs)
-        elif isinstance(value, list):
-            # Process lists (like for enum values)
-            result[key] = [_process_nested_dict(item, defs) if isinstance(item, dict) else item for item in value]
-        else:
-            result[key] = value
-
-    return result
-
-
 def convert_pydantic_to_tool_spec(
     model: type[BaseModel],
     description: str | None = None,
 ) -> ToolSpec:
-    """Converts a Pydantic model to a tool description for the Amazon Bedrock Converse API.
+    """Convert a Pydantic model to a structured-output tool specification.
 
-    Handles optional vs. required fields, resolves $refs, and uses docstrings.
+    Preserves Pydantic's JSON Schema and uses model docstrings for the tool description.
 
     Args:
-        model: The Pydantic model class to convert
-        description: Optional description of the tool's purpose
+        model: The Pydantic model class to convert.
+        description: Optional description of the tool's purpose.
 
     Returns:
-        ToolSpec: Dict containing the Bedrock tool specification
+        The structured-output tool specification.
+
+    Raises:
+        ValueError: If a top-level schema reference cannot be resolved.
     """
     name = model.__name__
+    input_schema = _inline_root_reference(model.model_json_schema())
+    model_description = description or (model.__doc__.strip() if model.__doc__ else None)
 
-    # Get the JSON schema
-    input_schema = model.model_json_schema()
-
-    # Get model docstring for description if not provided
-    model_description = description
-    if not model_description and model.__doc__:
-        model_description = model.__doc__.strip()
-
-    # Process all referenced models to ensure proper docstrings
-    # This step is important for gathering descriptions from referenced models
-    _process_referenced_models(input_schema, model)
-
-    # Now, let's fully expand the nested models with all their properties
-    _expand_nested_properties(input_schema, model)
-
-    # Flatten the schema
-    flattened_schema = _flatten_schema(input_schema)
-
-    final_schema = flattened_schema
-
-    # Construct the tool specification
     return ToolSpec(
         name=name,
         description=model_description or f"{name} structured output tool",
-        inputSchema={"json": final_schema},
+        inputSchema={"json": input_schema},
     )
 
 
-def _expand_nested_properties(schema: dict[str, Any], model: type[BaseModel]) -> None:
-    """Expand the properties of nested models in the schema to include their full structure.
-
-    This updates the schema in place.
+def _inline_root_reference(schema: dict[str, Any]) -> dict[str, Any]:
+    """Inline a top-level Pydantic definition while preserving its reference scope.
 
     Args:
-        schema: The JSON schema to process
-        model: The Pydantic model class
+        schema: The JSON Schema returned by the Pydantic model.
+
+    Returns:
+        A top-level object schema with internal definitions preserved.
     """
-    # First, process the properties at this level
-    if "properties" not in schema:
-        return
+    root_reference = schema.get("$ref")
+    if not isinstance(root_reference, str):
+        return schema
 
-    # Create a modified copy of the properties to avoid modifying while iterating
-    for prop_name, prop_info in list(schema["properties"].items()):
-        field = model.model_fields.get(prop_name)
-        if not field:
-            continue
+    prefix = "#/$defs/"
+    definitions = schema.get("$defs")
+    if not root_reference.startswith(prefix) or not isinstance(definitions, dict):
+        raise ValueError(f"Unsupported top-level JSON Schema reference: {root_reference}")
 
-        field_type = field.annotation
-        is_optional = not field.is_required()
+    definition_name = root_reference.removeprefix(prefix).replace("~1", "/").replace("~0", "~")
+    root_definition = definitions.get(definition_name)
+    if not isinstance(root_definition, dict):
+        raise ValueError(f"Missing top-level JSON Schema definition: {definition_name}")
 
-        # If this is a BaseModel field, expand its properties with full details
-        if isinstance(field_type, type) and issubclass(field_type, BaseModel):
-            # Get the nested model's schema with all its properties
-            nested_model_schema = field_type.model_json_schema()
-
-            # Create a properly expanded nested object
-            expanded_object = {
-                "type": ["object", "null"] if is_optional else "object",
-                "description": prop_info.get("description", field.description or f"The {prop_name}"),
-                "properties": {},
-            }
-
-            # Copy all properties from the nested schema
-            if "properties" in nested_model_schema:
-                expanded_object["properties"] = nested_model_schema["properties"]
-
-            # Copy required fields
-            if "required" in nested_model_schema:
-                expanded_object["required"] = nested_model_schema["required"]
-
-            # Replace the original property with this expanded version
-            schema["properties"][prop_name] = expanded_object
-
-
-def _process_referenced_models(schema: dict[str, Any], model: type[BaseModel]) -> None:
-    """Process referenced models to ensure their docstrings are included.
-
-    This updates the schema in place.
-
-    Args:
-        schema: The JSON schema to process
-        model: The Pydantic model class
-    """
-    # Process $defs to add docstrings from the referenced models
-    if "$defs" in schema:
-        # Look through model fields to find referenced models
-        for _, field in model.model_fields.items():
-            field_type = field.annotation
-
-            # Handle Optional types - with null checks
-            if field_type is not None and hasattr(field_type, "__origin__"):
-                origin = field_type.__origin__
-                if origin is Union and hasattr(field_type, "__args__"):
-                    # Find the non-None type in the Union (for Optional fields)
-                    for arg in field_type.__args__:
-                        if arg is not type(None):
-                            field_type = arg
-                            break
-
-            # Check if this is a BaseModel subclass
-            if isinstance(field_type, type) and issubclass(field_type, BaseModel):
-                # Update $defs with this model's information
-                ref_name = field_type.__name__
-                if ref_name in schema.get("$defs", {}):
-                    ref_def = schema["$defs"][ref_name]
-
-                    # Add docstring as description if available
-                    if field_type.__doc__ and not ref_def.get("description"):
-                        ref_def["description"] = field_type.__doc__.strip()
-
-                    # Recursively process properties in the referenced model
-                    _process_properties(ref_def, field_type)
-
-
-def _process_properties(schema_def: dict[str, Any], model: type[BaseModel]) -> None:
-    """Process properties in a schema definition to add descriptions from field metadata.
-
-    Args:
-        schema_def: The schema definition to update
-        model: The model class that defines the schema
-    """
-    if "properties" in schema_def:
-        for prop_name, prop_info in schema_def["properties"].items():
-            field = model.model_fields.get(prop_name)
-
-            # Add field description if available and not already set
-            if field and field.description and not prop_info.get("description"):
-                prop_info["description"] = field.description
+    inlined_schema = deepcopy(root_definition)
+    inlined_schema["$defs"] = deepcopy(definitions)
+    return inlined_schema

--- a/strands-py/tests/strands/models/test_strict_schema.py
+++ b/strands-py/tests/strands/models/test_strict_schema.py
@@ -1,3 +1,5 @@
+import pytest
+
 from strands.models._strict_schema import ensure_strict_json_schema
 
 
@@ -129,6 +131,72 @@ def test_ref_inline_uses_deep_copy():
     assert result["properties"]["a"]["description"] == "first"
     assert result["properties"]["b"]["description"] == "second"
     assert result["properties"]["a"] is not result["properties"]["b"]
+
+
+def test_recursive_array_ref_is_preserved():
+    schema = {
+        "$defs": {
+            "Node": {
+                "type": "object",
+                "properties": {
+                    "children": {
+                        "type": "array",
+                        "items": {"$ref": "#/$defs/Node"},
+                    }
+                },
+            }
+        },
+        "type": "object",
+        "properties": {"root": {"$ref": "#/$defs/Node"}},
+    }
+
+    tru_schema = ensure_strict_json_schema(schema)
+    exp_schema = {
+        "$defs": {
+            "Node": {
+                "type": "object",
+                "properties": {
+                    "children": {
+                        "type": "array",
+                        "items": {"$ref": "#/$defs/Node"},
+                    }
+                },
+                "additionalProperties": False,
+            }
+        },
+        "type": "object",
+        "properties": {"root": {"$ref": "#/$defs/Node"}},
+        "additionalProperties": False,
+    }
+
+    assert tru_schema == exp_schema
+
+
+def test_circular_ref_with_sibling_keys_is_rejected():
+    schema = {
+        "$defs": {
+            "Node": {
+                "type": "object",
+                "properties": {
+                    "child": {
+                        "$ref": "#/$defs/Node",
+                        "description": "The child node",
+                    }
+                },
+                "required": ["child"],
+            }
+        },
+        "$ref": "#/$defs/Node",
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"Circular JSON Schema reference with sibling keys cannot be inlined: "
+            r"#/\$defs/Node -> #/\$defs/Node"
+        ),
+    ):
+        ensure_strict_json_schema(schema)
 
 
 def test_arrays_anyof_allof():

--- a/strands-py/tests/strands/tools/test_structured_output.py
+++ b/strands-py/tests/strands/tools/test_structured_output.py
@@ -1,13 +1,15 @@
-from typing import Literal, Optional
+from typing import Any, Literal
 
 import pytest
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
 from pydantic import BaseModel, Field
+from pydantic.json_schema import GenerateJsonSchema, JsonSchemaMode
 
 from strands.tools.structured_output import convert_pydantic_to_tool_spec
 from strands.types.tools import ToolSpec
 
 
-# Basic test model
 class User(BaseModel):
     """User model with name and age."""
 
@@ -15,37 +17,34 @@ class User(BaseModel):
     age: int = Field(description="The age of the user", ge=18, le=100)
 
 
-# Test model with inheritance and literals
-class UserWithPlanet(User):
-    """User with planet."""
+class Address(BaseModel):
+    """A postal address."""
 
-    planet: Literal["Earth", "Mars"] = Field(description="The planet")
-
-
-# Test model with multiple same type fields and optional field
-class TwoUsersWithPlanet(BaseModel):
-    """Two users model with planet."""
-
-    user1: UserWithPlanet = Field(description="The first user")
-    user2: UserWithPlanet | None = Field(description="The second user", default=None)
+    city: str
+    postal_code: str | None = None
 
 
-# Test model with list of same type fields
-class ListOfUsersWithPlanet(BaseModel):
-    """List of users model with planet."""
+class Person(BaseModel):
+    """Complete person information."""
 
-    users: list[UserWithPlanet] = Field(description="The users", min_length=2, max_length=3)
+    name: str
+    addresses: tuple[Address, ...]
+
+
+class Node(BaseModel):
+    """A node in a recursive tree."""
+
+    name: str
+    children: list["Node"] = Field(default_factory=list)
 
 
 def test_convert_pydantic_to_tool_spec_basic():
-    tool_spec = convert_pydantic_to_tool_spec(User)
-
-    expected_spec = {
+    tru_spec = convert_pydantic_to_tool_spec(User)
+    exp_spec = {
         "name": "User",
         "description": "User model with name and age.",
         "inputSchema": {
             "json": {
-                "type": "object",
                 "properties": {
                     "name": {"description": "The name of the user", "title": "Name", "type": "string"},
                     "age": {
@@ -56,370 +55,150 @@ def test_convert_pydantic_to_tool_spec_basic():
                         "type": "integer",
                     },
                 },
+                "required": ["name", "age"],
                 "title": "User",
                 "description": "User model with name and age.",
-                "required": ["name", "age"],
-            }
-        },
-    }
-
-    # Verify we can construct a valid ToolSpec
-    tool_spec_obj = ToolSpec(**tool_spec)
-    assert tool_spec_obj is not None
-    assert tool_spec == expected_spec
-
-
-def test_convert_pydantic_to_tool_spec_complex():
-    tool_spec = convert_pydantic_to_tool_spec(ListOfUsersWithPlanet)
-
-    expected_spec = {
-        "name": "ListOfUsersWithPlanet",
-        "description": "List of users model with planet.",
-        "inputSchema": {
-            "json": {
                 "type": "object",
-                "properties": {
-                    "users": {
-                        "description": "The users",
-                        "items": {
-                            "description": "User with planet.",
-                            "title": "UserWithPlanet",
-                            "type": "object",
-                            "properties": {
-                                "name": {"description": "The name of the user", "title": "Name", "type": "string"},
-                                "age": {
-                                    "description": "The age of the user",
-                                    "maximum": 100,
-                                    "minimum": 18,
-                                    "title": "Age",
-                                    "type": "integer",
-                                },
-                                "planet": {
-                                    "description": "The planet",
-                                    "enum": ["Earth", "Mars"],
-                                    "title": "Planet",
-                                    "type": "string",
-                                },
-                            },
-                            "required": ["name", "age", "planet"],
-                        },
-                        "maxItems": 3,
-                        "minItems": 2,
-                        "title": "Users",
-                        "type": "array",
-                    }
-                },
-                "title": "ListOfUsersWithPlanet",
-                "description": "List of users model with planet.",
-                "required": ["users"],
             }
         },
     }
 
-    assert tool_spec == expected_spec
-
-    # Verify we can construct a valid ToolSpec
-    tool_spec_obj = ToolSpec(**tool_spec)
-    assert tool_spec_obj is not None
+    assert tru_spec == exp_spec
+    assert ToolSpec(**tru_spec) == exp_spec
 
 
-def test_convert_pydantic_to_tool_spec_multiple_same_type():
-    tool_spec = convert_pydantic_to_tool_spec(TwoUsersWithPlanet)
-
-    expected_spec = {
-        "name": "TwoUsersWithPlanet",
-        "description": "Two users model with planet.",
-        "inputSchema": {
-            "json": {
-                "type": "object",
-                "properties": {
-                    "user1": {
-                        "type": "object",
-                        "description": "The first user",
-                        "properties": {
-                            "name": {"description": "The name of the user", "title": "Name", "type": "string"},
-                            "age": {
-                                "description": "The age of the user",
-                                "maximum": 100,
-                                "minimum": 18,
-                                "title": "Age",
-                                "type": "integer",
-                            },
-                            "planet": {
-                                "description": "The planet",
-                                "enum": ["Earth", "Mars"],
-                                "title": "Planet",
-                                "type": "string",
-                            },
-                        },
-                        "required": ["name", "age", "planet"],
-                    },
-                    "user2": {
-                        "type": ["object", "null"],
-                        "description": "The second user",
-                        "title": "UserWithPlanet",
-                        "properties": {
-                            "name": {"description": "The name of the user", "title": "Name", "type": "string"},
-                            "age": {
-                                "description": "The age of the user",
-                                "maximum": 100,
-                                "minimum": 18,
-                                "title": "Age",
-                                "type": "integer",
-                            },
-                            "planet": {
-                                "description": "The planet",
-                                "enum": ["Earth", "Mars"],
-                                "title": "Planet",
-                                "type": "string",
-                            },
-                        },
-                        "required": ["name", "age", "planet"],
-                    },
-                },
-                "title": "TwoUsersWithPlanet",
-                "description": "Two users model with planet.",
-                "required": ["user1"],
-            }
-        },
+def test_convert_pydantic_to_tool_spec_preserves_nested_definitions():
+    tru_spec = convert_pydantic_to_tool_spec(Person)
+    exp_spec = {
+        "name": "Person",
+        "description": "Complete person information.",
+        "inputSchema": {"json": Person.model_json_schema()},
     }
 
-    assert tool_spec == expected_spec
-
-    # Verify we can construct a valid ToolSpec
-    tool_spec_obj = ToolSpec(**tool_spec)
-    assert tool_spec_obj is not None
+    assert tru_spec == exp_spec
+    Draft202012Validator.check_schema(tru_spec["inputSchema"]["json"])
 
 
-def test_convert_pydantic_with_missing_refs():
-    """Test that the tool handles missing $refs gracefully."""
-    # This test checks that our error handling for missing $refs works correctly
-    # by testing with a model that has circular references
+# Preserves nullable enum semantics through structured output conversion (#3590).
+def test_convert_pydantic_to_tool_spec_preserves_nullable_enum():
+    class FeedbackFilter(BaseModel):
+        sentiment: Literal["positive", "negative"] | None
 
-    class NodeWithCircularRef(BaseModel):
-        """A node with a circular reference to itself."""
+    tru_spec = convert_pydantic_to_tool_spec(FeedbackFilter)
+    exp_spec = {
+        "name": "FeedbackFilter",
+        "description": "FeedbackFilter structured output tool",
+        "inputSchema": {"json": FeedbackFilter.model_json_schema()},
+    }
 
-        name: str = Field(description="The name of the node")
-        parent: Optional["NodeWithCircularRef"] = Field(None, description="Parent node")
-        children: list["NodeWithCircularRef"] = Field(default_factory=list, description="Child nodes")
-
-    # This forward reference normally causes issues with schema generation
-    # but our error handling should prevent errors
-    with pytest.raises(ValueError, match="Circular reference detected and not supported"):
-        convert_pydantic_to_tool_spec(NodeWithCircularRef)
-
-
-def test_convert_pydantic_with_circular_required_dependency():
-    """Test that the tool handles circular dependencies gracefully."""
-
-    class NodeWithCircularRef(BaseModel):
-        """A node with a circular reference to itself."""
-
-        name: str = Field(description="The name of the node")
-        parent: "NodeWithCircularRef"
-
-    with pytest.raises(ValueError, match="Circular reference detected and not supported"):
-        convert_pydantic_to_tool_spec(NodeWithCircularRef)
+    assert tru_spec == exp_spec
+    validator = Draft202012Validator(tru_spec["inputSchema"]["json"])
+    validator.validate({"sentiment": "negative"})
+    validator.validate({"sentiment": None})
 
 
-def test_convert_pydantic_with_circular_optional_dependency():
-    """Test that the tool handles circular dependencies gracefully."""
+# Treats a custom Pydantic schema as authoritative instead of reconstructing nested fields (#3590).
+def test_convert_pydantic_to_tool_spec_preserves_custom_model_schema():
+    custom_schema = {
+        "type": "object",
+        "properties": {
+            "addresses": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            }
+        },
+        "required": ["addresses"],
+    }
 
-    class NodeWithCircularRef(BaseModel):
-        """A node with a circular reference to itself."""
+    class CustomPerson(Person):
+        @classmethod
+        def model_json_schema(
+            cls,
+            by_alias: bool = True,
+            ref_template: str = "#/$defs/{model}",
+            schema_generator: type[GenerateJsonSchema] = GenerateJsonSchema,
+            mode: JsonSchemaMode = "validation",
+            *,
+            union_format: Literal["any_of", "primitive_type_array"] = "any_of",
+        ) -> dict[str, Any]:
+            del cls, by_alias, ref_template, schema_generator, mode, union_format
+            return custom_schema
 
-        name: str = Field(description="The name of the node")
-        parent: Optional["NodeWithCircularRef"] = None
+    tru_schema = convert_pydantic_to_tool_spec(CustomPerson)["inputSchema"]["json"]
 
-    with pytest.raises(ValueError, match="Circular reference detected and not supported"):
-        convert_pydantic_to_tool_spec(NodeWithCircularRef)
-
-
-def test_convert_pydantic_with_circular_optional_dependenc_not_using_optional_typing():
-    """Test that the tool handles circular dependencies gracefully."""
-
-    class NodeWithCircularRef(BaseModel):
-        """A node with a circular reference to itself."""
-
-        name: str = Field(description="The name of the node")
-        parent: "NodeWithCircularRef" = None
-
-    with pytest.raises(ValueError, match="Circular reference detected and not supported"):
-        convert_pydantic_to_tool_spec(NodeWithCircularRef)
+    assert tru_schema == custom_schema
 
 
-def test_conversion_works_with_fields_that_are_not_marked_as_optional_but_have_a_default_value_which_makes_them_optional():  # noqa E501
+def test_convert_pydantic_to_tool_spec_keeps_default_fields_non_nullable():
     class Family(BaseModel):
-        ages: list[str] = Field(default_factory=list)
         names: list[str] = Field(default_factory=list)
 
-    converted_output = convert_pydantic_to_tool_spec(Family)
-    expected_output = {
-        "name": "Family",
-        "description": "Family structured output tool",
-        "inputSchema": {
-            "json": {
-                "type": "object",
-                "properties": {
-                    "ages": {
-                        "items": {"type": "string"},
-                        "title": "Ages",
-                        "type": ["array", "null"],
-                    },
-                    "names": {
-                        "items": {"type": "string"},
-                        "title": "Names",
-                        "type": ["array", "null"],
-                    },
-                },
-                "title": "Family",
-            }
-        },
+    tru_schema = convert_pydantic_to_tool_spec(Family)["inputSchema"]["json"]
+    exp_schema = Family.model_json_schema()
+
+    assert tru_schema == exp_schema
+    validator = Draft202012Validator(tru_schema)
+    validator.validate({})
+    with pytest.raises(ValidationError):
+        validator.validate({"names": None})
+
+
+def test_convert_pydantic_to_tool_spec_inlines_recursive_root_reference():
+    native_schema = Node.model_json_schema()
+    tru_schema = convert_pydantic_to_tool_spec(Node)["inputSchema"]["json"]
+    exp_schema = {
+        **native_schema["$defs"]["Node"],
+        "$defs": native_schema["$defs"],
     }
-    assert converted_output == expected_output
+
+    assert tru_schema == exp_schema
+    Draft202012Validator.check_schema(tru_schema)
+    Draft202012Validator(tru_schema).validate({"name": "root", "children": [{"name": "child", "children": []}]})
 
 
-def test_marks_fields_as_optional_for_model_w_fields_that_are_not_marked_as_optional_but_have_a_default_value_which_makes_them_optional():  # noqa E501
-    class Family(BaseModel):
-        ages: list[str] = Field(default_factory=list)
-        names: list[str] = Field(default_factory=list)
+@pytest.mark.parametrize(
+    ("schema", "message"),
+    [
+        ({"$ref": "https://example.com/schema"}, "Unsupported top-level JSON Schema reference"),
+        ({"$ref": "#/$defs/Missing", "$defs": {}}, "Missing top-level JSON Schema definition"),
+    ],
+)
+def test_convert_pydantic_to_tool_spec_rejects_unresolvable_root_reference(
+    schema: dict[str, Any],
+    message: str,
+):
+    class ReferencedModel(BaseModel):
+        @classmethod
+        def model_json_schema(
+            cls,
+            by_alias: bool = True,
+            ref_template: str = "#/$defs/{model}",
+            schema_generator: type[GenerateJsonSchema] = GenerateJsonSchema,
+            mode: JsonSchemaMode = "validation",
+            *,
+            union_format: Literal["any_of", "primitive_type_array"] = "any_of",
+        ) -> dict[str, Any]:
+            del cls, by_alias, ref_template, schema_generator, mode, union_format
+            return schema
 
-    converted_output = convert_pydantic_to_tool_spec(Family)
-    assert "null" in converted_output["inputSchema"]["json"]["properties"]["ages"]["type"]
+    with pytest.raises(ValueError, match=message):
+        convert_pydantic_to_tool_spec(ReferencedModel)
 
 
-def test_convert_pydantic_with_custom_description():
-    """Test that custom descriptions override model docstrings."""
+def test_convert_pydantic_to_tool_spec_custom_description():
+    tru_description = convert_pydantic_to_tool_spec(User, description="Custom tool description")["description"]
 
-    # Test with custom description
-    custom_description = "Custom tool description for user model"
-    tool_spec = convert_pydantic_to_tool_spec(User, description=custom_description)
-
-    assert tool_spec["description"] == custom_description
+    assert tru_description == "Custom tool description"
 
 
-def test_convert_pydantic_with_empty_docstring():
-    """Test that empty docstrings use default description."""
-
+def test_convert_pydantic_to_tool_spec_empty_docstring():
     class EmptyDocUser(BaseModel):
-        name: str = Field(description="The name of the user")
+        name: str
 
-    tool_spec = convert_pydantic_to_tool_spec(EmptyDocUser)
-    assert tool_spec["description"] == "EmptyDocUser structured output tool"
+    tru_description = convert_pydantic_to_tool_spec(EmptyDocUser)["description"]
 
-
-def test_convert_pydantic_with_items_refs():
-    """Test that no $refs exist after lists of different components."""
-
-    class Address(BaseModel):
-        postal_code: str | None = None
-
-    class Person(BaseModel):
-        """Complete person information."""
-
-        list_of_items: list[Address]
-        list_of_items_nullable: list[Address] | None
-        list_of_item_or_nullable: list[Address | None]
-
-    tool_spec = convert_pydantic_to_tool_spec(Person)
-
-    expected_spec = {
-        "description": "Complete person information.",
-        "inputSchema": {
-            "json": {
-                "description": "Complete person information.",
-                "properties": {
-                    "list_of_item_or_nullable": {
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "properties": {"postal_code": {"type": ["string", "null"]}},
-                                    "title": "Address",
-                                    "type": "object",
-                                },
-                                {"type": "null"},
-                            ]
-                        },
-                        "title": "List Of Item Or Nullable",
-                        "type": "array",
-                    },
-                    "list_of_items": {
-                        "items": {
-                            "properties": {"postal_code": {"type": ["string", "null"]}},
-                            "title": "Address",
-                            "type": "object",
-                        },
-                        "title": "List Of Items",
-                        "type": "array",
-                    },
-                    "list_of_items_nullable": {
-                        "items": {
-                            "properties": {"postal_code": {"type": ["string", "null"]}},
-                            "title": "Address",
-                            "type": "object",
-                        },
-                        "type": ["array", "null"],
-                    },
-                },
-                "required": ["list_of_items", "list_of_item_or_nullable"],
-                "title": "Person",
-                "type": "object",
-            }
-        },
-        "name": "Person",
-    }
-    assert tool_spec == expected_spec
-
-
-def test_convert_pydantic_with_refs():
-    """Test that no $refs exist after processing complex hierarchies."""
-
-    class Address(BaseModel):
-        street: str
-        city: str
-        country: str
-        postal_code: str | None = None
-
-    class Contact(BaseModel):
-        address: Address
-
-    class Person(BaseModel):
-        """Complete person information."""
-
-        contact: Contact = Field(description="Contact methods")
-
-    tool_spec = convert_pydantic_to_tool_spec(Person)
-
-    expected_spec = {
-        "description": "Complete person information.",
-        "inputSchema": {
-            "json": {
-                "description": "Complete person information.",
-                "properties": {
-                    "contact": {
-                        "description": "Contact methods",
-                        "properties": {
-                            "address": {
-                                "properties": {
-                                    "city": {"title": "City", "type": "string"},
-                                    "country": {"title": "Country", "type": "string"},
-                                    "postal_code": {"type": ["string", "null"]},
-                                    "street": {"title": "Street", "type": "string"},
-                                },
-                                "required": ["street", "city", "country"],
-                                "title": "Address",
-                                "type": "object",
-                            }
-                        },
-                        "required": ["address"],
-                        "type": "object",
-                    }
-                },
-                "required": ["contact"],
-                "title": "Person",
-                "type": "object",
-            }
-        },
-        "name": "Person",
-    }
-    assert tool_spec == expected_spec
+    assert tru_description == "EmptyDocUser structured output tool"


### PR DESCRIPTION
## Description

Pydantic already emits valid JSON Schema for nullable enums, nested models, defaults, and recursive types. Reconstructing that schema inside Strands changes field semantics and can introduce unresolved references, causing valid structured-output models to fail before provider invocation. This change treats the model-generated schema as authoritative and only inlines a recursive top-level reference while retaining its definition scope.

The generated schema now retains `$defs` and internal `$ref` values. Providers consuming this shared converter must therefore support the JSON Schema references already emitted by Pydantic.

## Related Issues

Resolves #3590

## Documentation PR

No documentation changes are required; the public API and documented usage are unchanged.

## Type of Change

Bug fix

## Testing

- [ ] I ran `hatch run prepare`
- [x] I ran the full Python unit suite (`4,712` tests)
- [x] I ran Ruff linting and formatting checks for the changed files
- [x] I ran strict MyPy over all Python source files
- [x] I exercised nullable-enum validation with the converted schema

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published