### PR TITLE
feat(middleware): add AgentStreamStage with middleware-initiated interrupts

### DIFF
--- a/strands-py/src/strands/_middleware/README.md
+++ b/strands-py/src/strands/_middleware/README.md
@@ -258,12 +258,12 @@ answered agent-stream response does not survive a tool cycle. Tracked as a follo
 
 ### Interrupt before the pass produces its result
 
-An agent-stream interrupt must fire *before* the pass produces its `EventLoopStopEvent`. Once the
-stop event has been yielded, the assistant turn is already appended to history. If nothing was
-stored for a resume to replay, the resumed pass calls the model a second time — duplicate assistant
-turn, non-alternating history, re-fired tool side effects. The run loop refuses that case: it
-clears interrupt state and raises `RuntimeError` naming the interrupt rather than corrupting the
-conversation.
+An agent-stream interrupt must fire before the pass produces its model turn. Once the assistant
+turn is in history, if nothing was stored for a resume to replay, the resumed pass calls the model
+a second time — duplicate assistant turn, non-alternating history, re-fired tool side effects. The
+run loop refuses the part of this it can detect precisely — an interrupt raised after the pass
+produced its EventLoopStopEvent — by clearing interrupt state and raising RuntimeError naming the
+interrupt. Interrupts in the window between the model turn and the stop event are not caught.
 
 A *tool* interrupt is exempt: its stored `tool_use_message` is replayed on resume, so no second
 model call happens, and gating on top of a tool interrupt keeps working.
@@ -277,7 +277,7 @@ The refusal only catches the case it can detect precisely. Interrupting mid-drai
 turn has landed (e.g. from a `ModelMessageEvent`) is past the point where the assistant message
 entered history, so resuming re-calls the model exactly as above — the run loop cannot distinguish
 that from a legitimate mid-drain interrupt. Treat "before the model turn is produced" as the safe
-interrupt position, not merely "before the stop event".
+interrupt position, not merely before the stop event.
 
 ## Hook-initiated retries re-run the middleware chain
 

--- a/strands-py/src/strands/_middleware/README.md
+++ b/strands-py/src/strands/_middleware/README.md
@@ -207,16 +207,53 @@ fires only when the state is activated, the pass did not stop on an interrupt, *
 context is present (`"tool_use_message" not in context`). That last condition is essential: a
 pending *tool* interrupt also leaves the state activated, and some non-interrupt endings keep it
 that way on purpose — e.g. cancelling a resumed tool interrupt ends the pass `"cancelled"` while
-the event loop deliberately preserves the interrupt for a later resume. Without the tool-context
-check the run loop would wipe that pending tool interrupt. Scoped this way, the run-loop
-deactivation only ever clears agent-stream interrupts (which never store tool context); the event
-loop remains the sole owner of tool-interrupt state.
+the interrupt is still owed a resume. Without the tool-context check the run loop would wipe that
+pending tool interrupt. Scoped this way, the run-loop deactivation only ever clears agent-stream
+interrupts (which never store tool context); the event loop remains the sole owner of
+tool-interrupt state.
+
+A cancelled pass keeps that tool interrupt because the event loop only completes the tool resume
+when the tools actually ran: cancellation (`agent.cancel()` or a `BeforeToolsEvent` cancel) produces
+cancel tool results without executing anything, so the stored `tool_use_message` and the human's
+answer are left in place for a later resume. Clearing them would strand the caller holding
+interrupt responses for state that no longer exists.
 
 (TypeScript mirrors this: its AgentStreamStage wrapper deactivates on a non-interrupt completion
 when no pending tool execution is stored, so an agent-stream interrupt that resumes to a plain
 `end_turn` clears the `activated` flag and the next fresh invocation is not rejected. Both SDKs
-likewise preserve a pending *tool* interrupt across a cancelled resume — Python via the
-`"tool_use_message"` guard, TS by not clearing its pending marker until the tools actually run.)
+likewise preserve a pending *tool* interrupt across a cancelled resume by not clearing it until the
+tools actually run.)
+
+### Interrupt response lifetime
+
+An answered agent-stream response is scoped to the **interrupt cycle** that produced it — every pass
+from the interrupt that asked the human to the pass that finally completes, spanning however many
+resumes that takes. Two mechanisms keep that window exact:
+
+- A tool cycle that finishes with no pending interrupts completes the *tool* resume and clears its
+  own bookkeeping, but keeps answered agent-stream responses
+  (`_InterruptState.complete_tool_resume`). Without this, a gate that is answered in one pass and
+  re-read in a later pass of the same cycle would be asked again — once per interrupt round trip,
+  because each round trip's reset dropped the answer the pass-start snapshot is copied from.
+- When a pass ends and no interrupt is owed a resume, the cycle is over and answered agent-stream
+  responses are dropped (`_InterruptState.clear_agent_stream_interrupts`). Without this an answer
+  would become a standing approval: the ids are deterministic, so the *next* invocation's gate would
+  resolve against the old response and never ask.
+
+Net effect: a gate asks the human exactly once per interrupt cycle, and never inherits an approval
+from a previous one.
+
+### Interrupt before the pass completes, not after
+
+`interrupt()` must be called before, or while draining, `next()` — not after the stream has
+finished. A pass that has already yielded its `EventLoopStopEvent` has appended its assistant turn
+to history, and there is no tool-use message to replay on resume, so the resumed pass would call the
+model a second time: a duplicate assistant turn, a non-alternating history, and re-fired tool side
+effects. The run loop refuses instead, raising `RuntimeError` naming the interrupt.
+
+This makes the Output phase unsuitable for gating, since its adapter drains the whole inner chain
+before the handler runs. A post-hoc approval gate ("inspect the finished stream, then ask a human")
+has to be expressed as a wrap handler that interrupts *before* `next()` on the following pass.
 
 ## Hook-initiated retries re-run the middleware chain
 

--- a/strands-py/src/strands/_middleware/README.md
+++ b/strands-py/src/strands/_middleware/README.md
@@ -226,34 +226,54 @@ tools actually run.)
 
 ### Interrupt response lifetime
 
-An answered agent-stream response is scoped to the **interrupt cycle** that produced it — every pass
-from the interrupt that asked the human to the pass that finally completes, spanning however many
-resumes that takes. Two mechanisms keep that window exact:
+An answered agent-stream response is scoped to the **interrupt cycle** that produced it: every pass
+from the interrupt that asked the human through to the pass that completes with nothing owed a
+resume. A cycle spans as many `agent(...)` calls as the resumes take. Three rules keep that window
+exact:
 
-- A tool cycle that finishes with no pending interrupts completes the *tool* resume and clears its
-  own bookkeeping, but keeps answered agent-stream responses
-  (`_InterruptState.complete_tool_resume`). Without this, a gate that is answered in one pass and
-  re-read in a later pass of the same cycle would be asked again — once per interrupt round trip,
-  because each round trip's reset dropped the answer the pass-start snapshot is copied from.
-- When a pass ends and no interrupt is owed a resume, the cycle is over and answered agent-stream
-  responses are dropped (`_InterruptState.clear_agent_stream_interrupts`). Without this an answer
-  would become a standing approval: the ids are deterministic, so the *next* invocation's gate would
-  resolve against the old response and never ask.
+- A tool cycle that finishes with nothing pending clears its own interrupts and context but keeps
+  answered agent-stream responses (`_InterruptState.end_tool_cycle`). Without this, a gate answered
+  in one pass and re-read in a later pass of the same cycle is asked again — once per interrupt
+  round trip, because each round trip's reset dropped the answer the pass-start snapshot copies.
+- When a pass ends with nothing owed a resume, the cycle is over and those responses are released
+  (`_InterruptState.end_interrupt_cycle`). Without this an answer becomes a standing approval: ids
+  are deterministic, so the next cycle's gate resolves against the old response and never asks. The
+  release runs before the `AfterInvocationEvent` hook that syncs sessions, so the released state is
+  what gets persisted, and before `apply_management`, so a failure there cannot strand a response.
+- The pass-start snapshot is only populated while interrupt state is activated. A resume always
+  arrives activated, so a live cycle reads normally; outside one — a cycle abandoned mid-flight
+  because the caller stopped consuming the stream, say — there is nothing to read and a leftover
+  response cannot resolve a gate that should be asking.
 
-Net effect: a gate asks the human exactly once per interrupt cycle, and never inherits an approval
-from a previous one.
+Net effect: a gate asks the human once per interrupt cycle and never inherits an approval from a
+previous one.
 
-### Interrupt before the pass completes, not after
+Because the id is derived from the name alone, **the name identifies what is being approved for the
+whole cycle**. Reusing one name for two different decisions in a cycle means the second inherits the
+first's approval, so give each decision its own stable name.
 
-`interrupt()` must be called before, or while draining, `next()` — not after the stream has
-finished. A pass that has already yielded its `EventLoopStopEvent` has appended its assistant turn
-to history, and there is no tool-use message to replay on resume, so the resumed pass would call the
-model a second time: a duplicate assistant turn, a non-alternating history, and re-fired tool side
-effects. The run loop refuses instead, raising `RuntimeError` naming the interrupt.
+(TypeScript does not implement this lifetime yet: its `deactivate()` clears everything, so an
+answered agent-stream response does not survive a tool cycle. Tracked as a follow-up.)
+
+### Interrupt before the pass produces its result
+
+A pass that has already produced its `EventLoopStopEvent` has appended its assistant turn to
+history. If nothing was stored for a resume to replay, the resumed pass calls the model a second
+time: a duplicate assistant turn, a non-alternating history, and re-fired tool side effects. The run
+loop refuses that case — it clears interrupt state and raises `RuntimeError` naming the interrupt,
+rather than corrupting the conversation. A pass that stopped for a *tool* interrupt is exempt: its
+stored tool-use message is replayed on resume, so no second model call happens, and gating on top of
+a tool interrupt keeps working.
 
 This makes the Output phase unsuitable for gating, since its adapter drains the whole inner chain
 before the handler runs. A post-hoc approval gate ("inspect the finished stream, then ask a human")
-has to be expressed as a wrap handler that interrupts *before* `next()` on the following pass.
+has to be a wrap handler that interrupts *before* `next()` on the following pass.
+
+The refusal only catches the case it can detect precisely. Interrupting mid-drain *after* the model
+turn has landed (e.g. from a `ModelMessageEvent`) is already past the point where the assistant
+message entered history, so resuming re-calls the model exactly as above — the run loop cannot tell
+that from a legitimate mid-drain interrupt and does not try. Treat "before the model turn is
+produced" as the safe position, not merely "before the stop event".
 
 ## Hook-initiated retries re-run the middleware chain
 

--- a/strands-py/src/strands/_middleware/README.md
+++ b/strands-py/src/strands/_middleware/README.md
@@ -4,7 +4,8 @@ This implementation follows the behavioral spec defined in `strands-ts/src/middl
 
 ## Scope
 
-`InvokeModelStage` and `ExecuteToolStage` are implemented. `AgentStreamStage` will be added as needed.
+All three stages are implemented: `InvokeModelStage`, `ExecuteToolStage`, and `AgentStreamStage`.
+`AgentStreamStage` is internal (see below), matching the TS SDK.
 
 ## Result encoding
 
@@ -60,6 +61,11 @@ directly, so there is no equivalent wrapper class:
 - `InvokeModelStage` → `ModelStopReason` (the last event from `stream_messages()`).
 - `ExecuteToolStage` → `ToolResultEvent` (the last event from tool execution). It already
   carries both `tool_result` and `exception`, so a separate `ExecuteToolResult` is redundant.
+- `AgentStreamStage` → `EventLoopStopEvent` (the last event from an invocation pass). It carries
+  the full stop tuple (`stop_reason`, `message`, `metrics`, ...) the `AgentResult` is built from,
+  so a separate `AgentStreamResult` is redundant. Since middleware may yield trailing events
+  *after* the stop event, `stream_async` selects the last `EventLoopStopEvent` — not the last
+  event overall — and raises `RuntimeError` if the chain drops it entirely.
 
 Short-circuiting a tool call yields a `ToolResultEvent` directly:
 ```python
@@ -67,17 +73,22 @@ async def cached(context, next_fn):
     yield ToolResultEvent({"toolUseId": context.tool_use["toolUseId"], "status": "success", ...})
 ```
 
-## Middleware-initiated interrupts (ExecuteToolStage)
+## Middleware-initiated interrupts (ExecuteToolStage + AgentStreamStage)
 
-`ExecuteToolContext.interrupt(name, reason=..., response=...)` lets tool middleware gate
-execution behind a human-in-the-loop approval, mirroring the TS `MiddlewareInterruptible`
-contract. It returns a `MiddlewareInterruptResult` (a wrapper around `response`, kept for
-forward-compatibility with TS) on resume, and raises `InterruptException` on first call.
+`ExecuteToolContext.interrupt(name, reason=..., response=...)` and
+`AgentStreamContext.interrupt(...)` let middleware gate execution behind a human-in-the-loop
+approval, mirroring the TS `MiddlewareInterruptible` contract. Both return a
+`MiddlewareInterruptResult` (a wrapper around `response`, kept for forward-compatibility with
+TS) on resume, and raise `InterruptException` on first call. `InvokeModelStage` does **not**
+support interrupts, matching TS (only `ExecuteToolContext` and `AgentStreamContext` are
+`MiddlewareInterruptible`).
 
 `interrupt()` is **read-only** with respect to interrupt state — it inspects prior responses
-but never registers the interrupt itself. The tool executor's `InterruptException` handler is
-the single registration site. This matches TS, where middleware interrupts deliberately never
-write to interrupt state (unlike hook/tool interrupts, which self-register).
+but never registers the interrupt itself. The executor's `InterruptException` handler (the tool
+executor for `ExecuteToolStage`, the agent run loop for `AgentStreamStage`) is the single
+registration site. This matches TS, where middleware interrupts deliberately never write to
+interrupt state (unlike hook/tool interrupts, which self-register). The read-only resolution
+logic is shared by both contexts (`_resolve_middleware_interrupt`).
 
 A halted (or partially executed) tool call has no result, so interrupts must not be treated as
 the stage result:
@@ -92,9 +103,12 @@ the stage result:
   its interrupts and short-circuits. The protocol keeps the stage-agnostic registry from
   importing tool-specific event types.
 
-Either way `_stream` surfaces a single `ToolInterruptEvent` to the event loop. Only
-`ExecuteToolStage` supports interrupts — `InvokeModelStage` does not, matching TS (only
-`ExecuteToolContext` and `AgentStreamContext` are `MiddlewareInterruptible`).
+Either way `_stream` surfaces a single `ToolInterruptEvent` to the event loop.
+
+For **`AgentStreamStage`**, `Agent._run_loop` catches the `InterruptException`, registers and
+activates the interrupt, and yields a terminal `EventLoopStopEvent("interrupt", ...)` — so the
+`AgentResult` looks identical to a tool interrupt. (TS yields a distinct `InterruptEvent`; Python
+has no per-interrupt event, so this reuses how tool interrupts already surface.)
 
 **Hazard: `except Exception` swallows interrupts.** `InterruptException` subclasses `Exception`
 (not `BaseException`). A middleware that wraps `next_fn` or `interrupt()` in a broad
@@ -104,11 +118,23 @@ This is inherent to the SDK-wide interrupt design (the same is true for hooks/to
 that must catch tool errors should re-raise `InterruptException` (and `CancelledError`, a
 `BaseException` that a bare `except Exception` already lets through).
 
-Interrupt IDs are `v1:middleware_execute_tool:<toolUseId>:<uuid5(name)>` — deterministic across
+Interrupt IDs are `v1:middleware_execute_tool:<toolUseId>:<uuid5(name)>` for tool middleware and
+`v1:middleware_agent_stream:<uuid5(name)>` for agent-stream middleware — deterministic across
 resumes so a resumed response resolves the same interrupt. This follows Python's `v1:`
-interrupt-id scheme (`v1:tool_call:...`, `v1:before_tool_call:...`) and its convention of
-hashing the name with `uuid5`. (TS uses a different, unversioned literal — id *strings* are
-opaque per-SDK handles and are not compared across SDKs, so only the within-SDK scheme matters.)
+interrupt-id scheme (`v1:tool_call:...`, `v1:before_tool_call:...`) and its convention of hashing
+the name with `uuid5`. (TS uses a different, unversioned literal — id *strings* are opaque per-SDK
+handles and are not compared across SDKs, so only the within-SDK scheme matters.)
+
+The tool id embeds the `toolUseId`, so it is unique per tool call. The agent-stream id has **no**
+scoping component — it is a pure hash of `name`, identical in every pass and in every agent. What
+keeps it collision-safe within one agent is the lifecycle, not the id: only one agent-stream
+interrupt is live at a time and the state is deactivated (clearing `interrupts`) before the next
+pass could reuse the name. **Across agents it is not safe**: two agents (e.g. `Graph`/`Swarm`
+nodes) running the same reusable gate middleware produce the same id, and an orchestrator that
+aggregates interrupts into a flat id-keyed dict can cross-wire one human approval to both. This is
+an identity-layer gap the middleware can't resolve on its own (a plain `Agent`'s `agent_id`
+defaults to `"default"`), tracked as a follow-up rather than fixed here. Until then, a reusable
+agent-stream gate should not be shared across multiple agents that interrupt on the same `name`.
 
 ### No interrupt `source`
 
@@ -118,7 +144,46 @@ hooks, tools, or middleware — so there is nothing for the middleware path to s
 pre-existing, SDK-wide gap in the Python interrupt system rather than a middleware-specific
 choice; adding it means changing the core `Interrupt` type and every hook/tool call site, which
 is out of scope here. Consumers currently disambiguate by the interrupt id prefix
-(`v1:middleware_execute_tool:...`) instead.
+(`v1:middleware_execute_tool:...` / `v1:middleware_agent_stream:...`) instead.
+
+## AgentStreamStage context fields
+
+Unlike `InvokeModelContext`/`ExecuteToolContext`, which mirror their TS counterparts field-for-field
+(modulo `camelCase`↔`snake_case`), `AgentStreamContext` genuinely renames: TS exposes `args` +
+`options`, Python exposes `messages` (the input for this pass, already appended to history) +
+`invocation_state` (the per-invocation state dict). The rename reflects what Python's `_run_loop`
+actually threads through the pass. Note this drops the extra fields TS's `options` (`InvokeOptions`)
+carries — `cancel_signal`, structured-output config, `limits` — from the agent-stream context;
+those remain reachable on `agent` but are not surfaced as first-class context fields here. Since
+the stage is internal, that surface is not yet finalized.
+
+## AgentStreamStage interrupt resume
+
+Python interrupts were tool-only: the event loop keyed resume behavior on interrupt state being
+`activated` alone — priming a resume by replaying the stored `tool_use_message`, and merging the
+stored `tool_results`. An `AgentStreamStage` interrupt activates interrupt state **without** a
+pending tool execution (empty context), so both reads are gated on the presence of their tool
+context key (`"tool_use_message" in context` / `"tool_results" in context`). An agent-stream
+resume therefore falls through to a normal model call — and if that call then invokes a tool, the
+tool path no longer trips over the empty context — while the middleware resolves its own interrupt
+(returning the response) before calling `next()`.
+
+Because an agent-stream interrupt has no tool cycle to deactivate the state afterward, the run
+loop deactivates interrupt state when the pass completes without one. The guard is narrow — it
+fires only when the state is activated, the pass did not stop on an interrupt, **and** no tool
+context is present (`"tool_use_message" not in context`). That last condition is essential: a
+pending *tool* interrupt also leaves the state activated, and some non-interrupt endings keep it
+that way on purpose — e.g. cancelling a resumed tool interrupt ends the pass `"cancelled"` while
+the event loop deliberately preserves the interrupt for a later resume. Without the tool-context
+check the run loop would wipe that pending tool interrupt. Scoped this way, the run-loop
+deactivation only ever clears agent-stream interrupts (which never store tool context); the event
+loop remains the sole owner of tool-interrupt state.
+
+(TypeScript mirrors this: its AgentStreamStage wrapper deactivates on a non-interrupt completion
+when no pending tool execution is stored, so an agent-stream interrupt that resumes to a plain
+`end_turn` clears the `activated` flag and the next fresh invocation is not rejected. Both SDKs
+likewise preserve a pending *tool* interrupt across a cancelled resume — Python via the
+`"tool_use_message"` guard, TS by not clearing its pending marker until the tools actually run.)
 
 ## Hook-initiated retries re-run the middleware chain
 

--- a/strands-py/src/strands/_middleware/README.md
+++ b/strands-py/src/strands/_middleware/README.md
@@ -157,6 +157,39 @@ carries — `cancel_signal`, structured-output config, `limits` — from the age
 those remain reachable on `agent` but are not surfaced as first-class context fields here. Since
 the stage is internal, that surface is not yet finalized.
 
+### Transforming `messages` vs `invocation_state`
+
+The two agent-stream context fields have **different** transform semantics, and only one is fully
+transformable via `dataclasses.replace()`:
+
+- **`invocation_state`** — fully transformable. The terminal reads `ctx.invocation_state`, so a
+  handler returning `replace(context, invocation_state=...)` reaches the event loop and the model.
+- **`messages`** — shared by reference for **in-place** edits only. Mutating a message in place
+  (`context.messages[0]["content"] = ...`) is visible to the model because those same dict objects
+  are already in `agent.messages`. But `replace(context, messages=[...])` is **silently dropped**:
+  the pass's input messages are appended to `agent.messages` *before* the middleware chain runs,
+  and the terminal streams against `agent.messages`, not `ctx.messages`.
+
+This asymmetry is deliberate, and it is a consequence of *when* history is appended, which is a
+lifecycle event — not just a middleware concern. Appending the input fires `MessageAddedEvent`
+**before** the AgentStreamStage chain, and it fires **even when a middleware short-circuits** (the
+user turn always lands in history and hooks always observe it). Moving the append into the terminal
+to make `replace(messages=...)` work would change that hook timing for *every* agent (middleware or
+not) and would stop `MessageAddedEvent` firing on short-circuit — an observable behavior change we
+chose not to make. Middleware that must rewrite the input for the model should mutate `messages` in
+place, or use an `InvokeModelStage` Input handler (whose `messages` *are* transformable via
+`replace()`, since that stage's terminal reads them from the context).
+
+**Divergence from TS.** TypeScript makes the opposite trade-off: it appends the input *inside*
+the chain terminal (`_streamCore` → `_stream` normalizes and appends `ctx.args`), so there a
+`{...ctx, args}` swap *does* reach the model — but as a direct consequence, TS's short-circuit
+does **not** append the user message and does **not** fire its `MessageAddedEvent` (the terminal
+never runs), and that hook fires *inside* the chain rather than before it. Python keeps the append
+before the chain so the user turn and its `MessageAddedEvent` are unconditional (including on
+short-circuit), at the cost of `replace(messages=...)` not being honored. Both SDKs keep
+`AgentStreamStage` internal partly because this input contract is not yet finalized. (In both,
+`BeforeInvocationEvent`/`AfterInvocationEvent` bracket the chain from outside and fire regardless.)
+
 ## AgentStreamStage interrupt resume
 
 Python interrupts were tool-only: the event loop keyed resume behavior on interrupt state being

--- a/strands-py/src/strands/_middleware/README.md
+++ b/strands-py/src/strands/_middleware/README.md
@@ -226,54 +226,58 @@ tools actually run.)
 
 ### Interrupt response lifetime
 
-An answered agent-stream response is scoped to the **interrupt cycle** that produced it: every pass
-from the interrupt that asked the human through to the pass that completes with nothing owed a
-resume. A cycle spans as many `agent(...)` calls as the resumes take. Three rules keep that window
-exact:
+An answered agent-stream response lives for exactly one **interrupt cycle**: the span from the
+interrupt that asked the human through to the pass that completes with nothing owed a resume. A
+cycle can span multiple `agent(...)` calls (one per resume round trip). Three coordinated rules
+keep that window exact.
 
-- A tool cycle that finishes with nothing pending clears its own interrupts and context but keeps
-  answered agent-stream responses (`_InterruptState.end_tool_cycle`). Without this, a gate answered
-  in one pass and re-read in a later pass of the same cycle is asked again — once per interrupt
-  round trip, because each round trip's reset dropped the answer the pass-start snapshot copies.
-- When a pass ends with nothing owed a resume, the cycle is over and those responses are released
-  (`_InterruptState.end_interrupt_cycle`). Without this an answer becomes a standing approval: ids
-  are deterministic, so the next cycle's gate resolves against the old response and never asks. The
-  release runs before the `AfterInvocationEvent` hook that syncs sessions, so the released state is
-  what gets persisted, and before `apply_management`, so a failure there cannot strand a response.
-- The pass-start snapshot is only populated while interrupt state is activated. A resume always
-  arrives activated, so a live cycle reads normally; outside one — a cycle abandoned mid-flight
-  because the caller stopped consuming the stream, say — there is nothing to read and a leftover
-  response cannot resolve a gate that should be asking.
+`_InterruptState.end_tool_cycle` clears per-tool-cycle interrupts and context but retains answered
+agent-stream responses (matched by the `_AGENT_STREAM_INTERRUPT_ID_PREFIX`). The agent-stream
+context reads a snapshot taken at pass start, so a gate answered in one pass and re-read in a later
+pass of the same cycle still resolves — even though the tool cycle that separated them cleared the
+live dict.
+
+`_InterruptState.end_interrupt_cycle` releases those retained responses when the cycle is over (a
+pass ends with nothing pending). Without this, an answer becomes a standing approval: ids are
+deterministic, so a later cycle's gate resolves against the stale response and never asks. The
+release runs before `AfterInvocationEvent` (session sync) and before `apply_management`, so the
+released state is what gets persisted and a failure in either cannot strand a response.
+
+The pass-start snapshot is only populated while interrupt state is activated. A resume always
+arrives activated, so a live cycle reads normally. Outside one — a cycle abandoned mid-flight
+because the caller stopped consuming the stream — there is nothing to read and a leftover response
+cannot resolve a gate that should be asking.
 
 Net effect: a gate asks the human once per interrupt cycle and never inherits an approval from a
-previous one.
-
-Because the id is derived from the name alone, **the name identifies what is being approved for the
-whole cycle**. Reusing one name for two different decisions in a cycle means the second inherits the
-first's approval, so give each decision its own stable name.
+previous one. Because the id is derived from the name alone, the **name identifies what is being
+approved for the whole cycle**. Reusing one name for two different decisions in a cycle means the
+second inherits the first's approval, so give each decision its own stable name.
 
 (TypeScript does not implement this lifetime yet: its `deactivate()` clears everything, so an
 answered agent-stream response does not survive a tool cycle. Tracked as a follow-up.)
 
 ### Interrupt before the pass produces its result
 
-A pass that has already produced its `EventLoopStopEvent` has appended its assistant turn to
-history. If nothing was stored for a resume to replay, the resumed pass calls the model a second
-time: a duplicate assistant turn, a non-alternating history, and re-fired tool side effects. The run
-loop refuses that case — it clears interrupt state and raises `RuntimeError` naming the interrupt,
-rather than corrupting the conversation. A pass that stopped for a *tool* interrupt is exempt: its
-stored tool-use message is replayed on resume, so no second model call happens, and gating on top of
-a tool interrupt keeps working.
+An agent-stream interrupt must fire *before* the pass produces its `EventLoopStopEvent`. Once the
+stop event has been yielded, the assistant turn is already appended to history. If nothing was
+stored for a resume to replay, the resumed pass calls the model a second time — duplicate assistant
+turn, non-alternating history, re-fired tool side effects. The run loop refuses that case: it
+clears interrupt state and raises `RuntimeError` naming the interrupt rather than corrupting the
+conversation.
 
-This makes the Output phase unsuitable for gating, since its adapter drains the whole inner chain
-before the handler runs. A post-hoc approval gate ("inspect the finished stream, then ask a human")
-has to be a wrap handler that interrupts *before* `next()` on the following pass.
+A *tool* interrupt is exempt: its stored `tool_use_message` is replayed on resume, so no second
+model call happens, and gating on top of a tool interrupt keeps working.
+
+This makes the Output phase unsuitable for gating. The Output adapter drains the whole inner chain
+before the handler runs, so the stop event has already been produced. A post-hoc approval gate
+("inspect the finished stream, then ask a human") must be a Wrap handler that interrupts *before*
+`next()` on the following pass.
 
 The refusal only catches the case it can detect precisely. Interrupting mid-drain *after* the model
-turn has landed (e.g. from a `ModelMessageEvent`) is already past the point where the assistant
-message entered history, so resuming re-calls the model exactly as above — the run loop cannot tell
-that from a legitimate mid-drain interrupt and does not try. Treat "before the model turn is
-produced" as the safe position, not merely "before the stop event".
+turn has landed (e.g. from a `ModelMessageEvent`) is past the point where the assistant message
+entered history, so resuming re-calls the model exactly as above — the run loop cannot distinguish
+that from a legitimate mid-drain interrupt. Treat "before the model turn is produced" as the safe
+interrupt position, not merely "before the stop event".
 
 ## Hook-initiated retries re-run the middleware chain
 

--- a/strands-py/src/strands/_middleware/stages.py
+++ b/strands-py/src/strands/_middleware/stages.py
@@ -238,7 +238,9 @@ class AgentStreamContext:
         """Derive the interrupt id for ``name``, namespaced to the agent-stream stage.
 
         Follows the SDK's ``v1:`` interrupt-id scheme (see ``types/interrupt.py``), hashing
-        the user-provided name so ids stay stable across resumes.
+        the user-provided name so ids stay stable across resumes. The namespace prefix is shared
+        with ``_InterruptState``, which matches on it to decide which interrupts outlive a tool
+        cycle.
         """
         return f"{_AGENT_STREAM_INTERRUPT_ID_PREFIX}{uuid.uuid5(uuid.NAMESPACE_OID, name)}"
 

--- a/strands-py/src/strands/_middleware/stages.py
+++ b/strands-py/src/strands/_middleware/stages.py
@@ -238,9 +238,7 @@ class AgentStreamContext:
         """Derive the interrupt id for ``name``, namespaced to the agent-stream stage.
 
         Follows the SDK's ``v1:`` interrupt-id scheme (see ``types/interrupt.py``), hashing
-        the user-provided name so ids stay stable across resumes. The namespace prefix is shared
-        with ``_InterruptState``, which matches on it to decide which interrupts outlive a tool
-        cycle.
+        the user-provided name so ids stay stable across resumes.
         """
         return f"{_AGENT_STREAM_INTERRUPT_ID_PREFIX}{uuid.uuid5(uuid.NAMESPACE_OID, name)}"
 

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -1365,8 +1365,8 @@ class Agent(AgentBase):
                         and "tool_use_message" not in self._interrupt_state.context
                     ):
                         # The event loop already produced this pass's result and stored no tool use
-                        # to replay,
-                        # so resuming would re-enter the event loop and call the model again: a
+                        # to replay, so resuming would re-enter the event loop and call the model
+                        # again: a
                         # duplicate assistant turn, a non-alternating history, and re-fired tool
                         # side effects. Refuse rather than corrupt the conversation, and clear the
                         # state so the caller is not left holding an interrupt it cannot answer.

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -14,6 +14,7 @@ import logging
 import threading
 import warnings
 from collections.abc import AsyncGenerator, AsyncIterator, Callable, Mapping
+from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -146,6 +147,18 @@ _CONTEXT_MANAGER_SUMMARY_RATIO = 0.3
 
 _CONTEXT_MANAGER_COMPRESSION_THRESHOLD = 0.85
 """Benchmark-validated context window ratio that triggers proactive compression."""
+
+
+@dataclass
+class _PassProgress:
+    """What the event loop itself did during one ``AgentStreamStage`` pass.
+
+    Middleware can produce a pass's result without the event loop running at all (a short-circuit),
+    which resuming replays harmlessly. Only a result the event loop produced means a resume would
+    call the model again.
+    """
+
+    event_loop_produced_result: bool = False
 
 
 class Agent(AgentBase):
@@ -1309,6 +1322,7 @@ class Agent(AgentBase):
                 # Run this invocation pass through the AgentStreamStage middleware chain, whose
                 # terminal drives the event loop cycle. With no middleware registered the registry
                 # returns the terminal directly.
+                pass_progress = _PassProgress()
                 middleware_context = AgentStreamContext(
                     agent=self,
                     messages=current_messages,
@@ -1325,7 +1339,7 @@ class Agent(AgentBase):
                     async for event in self._middleware_registry.invoke(
                         AgentStreamStage,
                         middleware_context,
-                        self._make_agent_stream_terminal(structured_output_context, limits),
+                        self._make_agent_stream_terminal(structured_output_context, limits, pass_progress),
                     ):
                         # Middleware may yield more events after the stop event, so capture the
                         # last EventLoopStopEvent as the result rather than the final event.
@@ -1346,8 +1360,12 @@ class Agent(AgentBase):
                     ):
                         self._interrupt_state.deactivate()
                 except InterruptException as interrupt_exception:
-                    if agent_result is not None and "tool_use_message" not in self._interrupt_state.context:
-                        # The pass already yielded its stop event and stored no tool use to replay,
+                    if (
+                        pass_progress.event_loop_produced_result
+                        and "tool_use_message" not in self._interrupt_state.context
+                    ):
+                        # The event loop already produced this pass's result and stored no tool use
+                        # to replay,
                         # so resuming would re-enter the event loop and call the model again: a
                         # duplicate assistant turn, a non-alternating history, and re-fired tool
                         # side effects. Refuse rather than corrupt the conversation, and clear the
@@ -1365,9 +1383,15 @@ class Agent(AgentBase):
                     # interrupt() is read-only, so this handler is the single place the interrupt
                     # is registered and the state activated before surfacing a terminal
                     # EventLoopStopEvent("interrupt"), matching how tool interrupts stop the loop.
-                    self._interrupt_state.interrupts.setdefault(
-                        interrupt_exception.interrupt.id, interrupt_exception.interrupt
-                    )
+                    # interrupt() only raises when this pass saw no answer for that id, so a
+                    # registered entry that already carries a response is stale and would leave the
+                    # caller an interrupt stop with nothing to answer. Keep an existing unanswered
+                    # registration; replace anything else.
+                    registered = self._interrupt_state.interrupts.get(interrupt_exception.interrupt.id)
+                    if registered is None or registered.response is not None:
+                        self._interrupt_state.interrupts[interrupt_exception.interrupt.id] = (
+                            interrupt_exception.interrupt
+                        )
                     self._interrupt_state.activate()
                     interrupt_message: Message = (
                         self.messages[-1]
@@ -1424,6 +1448,7 @@ class Agent(AgentBase):
         self,
         structured_output_context: StructuredOutputContext,
         limits: Limits | None,
+        pass_progress: _PassProgress,
     ) -> Callable[["AgentStreamContext"], AsyncGenerator[TypedEvent, None]]:
         """Build the terminal for the AgentStreamStage middleware chain.
 
@@ -1437,6 +1462,8 @@ class Agent(AgentBase):
         Args:
             structured_output_context: Structured output context for this pass.
             limits: Optional per-invocation budget caps.
+            pass_progress: Records whether the event loop produced this pass's result, which
+                determines whether resuming the pass would call the model again.
 
         Returns:
             An async generator function yielding the pass's events, ending with an
@@ -1447,6 +1474,9 @@ class Agent(AgentBase):
             # Execute the event loop cycle with retry logic for context limits
             events = self._execute_event_loop_cycle(ctx.invocation_state, structured_output_context, limits)
             async for event in events:
+                if isinstance(event, EventLoopStopEvent):
+                    pass_progress.event_loop_produced_result = True
+
                 # Signal from the model provider that the message sent by the user should be redacted,
                 # likely due to a guardrail.
                 if (

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -1343,6 +1343,18 @@ class Agent(AgentBase):
                     ):
                         self._interrupt_state.deactivate()
                 except InterruptException as interrupt_exception:
+                    if agent_result is not None:
+                        # The pass already yielded its stop event, so its assistant turn is in
+                        # history. Resuming re-enters the event loop with no tool-use message to
+                        # replay, which calls the model again: a duplicate assistant turn, a
+                        # non-alternating history, and re-fired tool side effects. Refuse instead
+                        # of corrupting the conversation.
+                        raise RuntimeError(
+                            f"interrupt_name=<{interrupt_exception.interrupt.name}> | agent-stream middleware "
+                            "raised an interrupt after the pass completed. Raise it before or while draining "
+                            "next_fn, not after the stream finishes."
+                        ) from interrupt_exception
+
                     # Middleware-initiated interrupt (context.interrupt() with no response yet).
                     # interrupt() is read-only, so this handler is the single place the interrupt
                     # is registered and the state activated before surfacing a terminal
@@ -1380,6 +1392,13 @@ class Agent(AgentBase):
                 after_invocation_event, _interrupts = await self.hooks.invoke_callbacks_async(
                     AfterInvocationEvent(agent=self, invocation_state=invocation_state, result=agent_result)
                 )
+
+                if not self._interrupt_state.activated:
+                    # No interrupt is owed a resume, so this pass ends the interrupt cycle. Answered
+                    # agent-stream responses are kept across the cycle's passes (see
+                    # _InterruptState.complete_tool_resume) so a gate asks the human once; drop them
+                    # here so the next cycle asks again instead of reusing a stale approval.
+                    self._interrupt_state.clear_agent_stream_interrupts()
 
             # Convert resume input to messages for next iteration, or None to stop
             if after_invocation_event.resume is not None:

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -1327,12 +1327,9 @@ class Agent(AgentBase):
                     agent=self,
                     messages=current_messages,
                     invocation_state=invocation_state,
-                    # Snapshot interrupts before the pass: a tool cycle within this pass clears the
-                    # live dict, but a gate that re-reads its approval after next_fn must still see
-                    # the resumed response. Only a live interrupt cycle is readable — a resume
-                    # always arrives activated, so outside one there is nothing legitimate to read
-                    # and a response retained by a cycle that died mid-flight must not resolve a
-                    # gate that should be asking the human.
+                    # Snapshot interrupts before the pass so a gate's re-read after next_fn
+                    # survives the tool cycle clearing the live dict. Empty when not activated,
+                    # so a dead cycle's retained response cannot resolve a fresh gate.
                     _interrupts=dict(self._interrupt_state.interrupts) if self._interrupt_state.activated else {},
                 )
                 try:
@@ -1364,14 +1361,10 @@ class Agent(AgentBase):
                         pass_progress.event_loop_produced_result
                         and "tool_use_message" not in self._interrupt_state.context
                     ):
-                        # The event loop already produced this pass's result and stored no tool use
-                        # to replay, so resuming would re-enter the event loop and call the model
-                        # again: a
-                        # duplicate assistant turn, a non-alternating history, and re-fired tool
-                        # side effects. Refuse rather than corrupt the conversation, and clear the
-                        # state so the caller is not left holding an interrupt it cannot answer.
-                        # A pass that stopped for a tool interrupt is exempt: its stored tool use
-                        # is replayed on resume, so no second model call happens.
+                        # The event loop already produced this pass's result with nothing stored
+                        # to replay, so resuming would call the model again. Refuse rather than
+                        # corrupt the conversation. Tool interrupts are exempt (stored tool use
+                        # is replayed on resume).
                         self._interrupt_state.deactivate()
                         raise RuntimeError(
                             f"interrupt_name=<{interrupt_exception.interrupt.name}> | agent-stream middleware "
@@ -1380,13 +1373,9 @@ class Agent(AgentBase):
                         ) from interrupt_exception
 
                     # Middleware-initiated interrupt (context.interrupt() with no response yet).
-                    # interrupt() is read-only, so this handler is the single place the interrupt
-                    # is registered and the state activated before surfacing a terminal
-                    # EventLoopStopEvent("interrupt"), matching how tool interrupts stop the loop.
-                    # interrupt() only raises when this pass saw no answer for that id, so a
-                    # registered entry that already carries a response is stale and would leave the
-                    # caller an interrupt stop with nothing to answer. Keep an existing unanswered
-                    # registration; replace anything else.
+                    # interrupt() is read-only, so this handler is the single registration site
+                    # before surfacing EventLoopStopEvent("interrupt"). Keep an existing unanswered
+                    # registration; replace a stale one that already carries a response.
                     registered = self._interrupt_state.interrupts.get(interrupt_exception.interrupt.id)
                     if registered is None or registered.response is not None:
                         self._interrupt_state.interrupts[interrupt_exception.interrupt.id] = (
@@ -1419,13 +1408,10 @@ class Agent(AgentBase):
 
             finally:
                 if not self._interrupt_state.activated:
-                    # Nothing is owed a resume, so this pass ends the interrupt cycle. Invocation-
-                    # scoped responses are held across the cycle's passes (see
-                    # _InterruptState.end_tool_cycle) so a gate asks the human once; release them
-                    # here so the next cycle asks again instead of resolving against a stale
-                    # approval. This runs before the session-syncing AfterInvocationEvent hook so
-                    # the released state is what gets persisted, and before apply_management so a
-                    # failure there cannot strand a retained response.
+                    # Nothing is owed a resume, so the interrupt cycle is over. Release
+                    # invocation-scoped responses so the next cycle asks again rather than
+                    # resolving against a stale approval. Runs before AfterInvocationEvent
+                    # and apply_management so the released state is what gets persisted.
                     self._interrupt_state.end_interrupt_cycle()
 
                 self.conversation_manager.apply_management(self)

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -1319,9 +1319,6 @@ class Agent(AgentBase):
                     structured_output_prompt=structured_output_prompt or self._structured_output_prompt,
                 )
 
-                # Run this invocation pass through the AgentStreamStage middleware chain, whose
-                # terminal drives the event loop cycle. With no middleware registered the registry
-                # returns the terminal directly.
                 pass_progress = _PassProgress()
                 middleware_context = AgentStreamContext(
                     agent=self,
@@ -1338,18 +1335,12 @@ class Agent(AgentBase):
                         middleware_context,
                         self._make_agent_stream_terminal(structured_output_context, limits, pass_progress),
                     ):
-                        # Middleware may yield more events after the stop event, so capture the
-                        # last EventLoopStopEvent as the result rather than the final event.
                         if isinstance(event, EventLoopStopEvent):
                             agent_result = AgentResult(*event["stop"])
                         yield event
 
                     # A resumed AgentStreamStage interrupt that finished without tool execution
-                    # (e.g. a plain end_turn) never hits the tool path's deactivate(), so clear
-                    # the interrupt state here. Guard on the absence of tool context so this only
-                    # fires for agent-stream interrupts (which never store one) and never wipes a
-                    # pending tool interrupt — the event loop owns tool-interrupt state, and some
-                    # paths (e.g. cancel mid-resume) intentionally leave it activated.
+                    # never hits the tool path's deactivate(), so clear the interrupt state here.
                     if (
                         self._interrupt_state.activated
                         and (agent_result is None or agent_result.stop_reason != "interrupt")
@@ -1357,14 +1348,12 @@ class Agent(AgentBase):
                     ):
                         self._interrupt_state.deactivate()
                 except InterruptException as interrupt_exception:
+                    # Refuse a late interrupt — resuming would re-call the model
+                    # and corrupt history.
                     if (
                         pass_progress.event_loop_produced_result
                         and "tool_use_message" not in self._interrupt_state.context
                     ):
-                        # The event loop already produced this pass's result with nothing stored
-                        # to replay, so resuming would call the model again. Refuse rather than
-                        # corrupt the conversation. Tool interrupts are exempt (stored tool use
-                        # is replayed on resume).
                         self._interrupt_state.deactivate()
                         raise RuntimeError(
                             f"interrupt_name=<{interrupt_exception.interrupt.name}> | agent-stream middleware "
@@ -1372,10 +1361,6 @@ class Agent(AgentBase):
                             "produces its assistant turn"
                         ) from interrupt_exception
 
-                    # Middleware-initiated interrupt (context.interrupt() with no response yet).
-                    # interrupt() is read-only, so this handler is the single registration site
-                    # before surfacing EventLoopStopEvent("interrupt"). Keep an existing unanswered
-                    # registration; replace a stale one that already carries a response.
                     registered = self._interrupt_state.interrupts.get(interrupt_exception.interrupt.id)
                     if registered is None or registered.response is not None:
                         self._interrupt_state.interrupts[interrupt_exception.interrupt.id] = (
@@ -1387,10 +1372,7 @@ class Agent(AgentBase):
                         if self.messages
                         else {"role": "assistant", "content": [{"text": "Interrupted"}]}
                     )
-                    # Report every still-unanswered interrupt, not just the one raised here: a
-                    # prior interrupt (e.g. a tool interrupt only partially answered on this
-                    # resume) may still be outstanding, and the caller needs the full set to
-                    # resume cleanly (matching the TS getUnansweredInterrupts() contract).
+                    # Surface all unanswered interrupts so the caller can build a complete resume payload.
                     unanswered = [
                         interrupt
                         for interrupt in self._interrupt_state.interrupts.values()
@@ -1408,10 +1390,6 @@ class Agent(AgentBase):
 
             finally:
                 if not self._interrupt_state.activated:
-                    # Nothing is owed a resume, so the interrupt cycle is over. Release
-                    # invocation-scoped responses so the next cycle asks again rather than
-                    # resolving against a stale approval. Runs before AfterInvocationEvent
-                    # and apply_management so the released state is what gets persisted.
                     self._interrupt_state.end_interrupt_cycle()
 
                 self.conversation_manager.apply_management(self)

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -1313,10 +1313,13 @@ class Agent(AgentBase):
                     agent=self,
                     messages=current_messages,
                     invocation_state=invocation_state,
-                    # Snapshot interrupts before the pass: a tool cycle within this pass can call
-                    # the event loop's deactivate() and clear the live dict, but a gate that
-                    # re-reads its approval after next_fn must still see the resumed response.
-                    _interrupts=dict(self._interrupt_state.interrupts),
+                    # Snapshot interrupts before the pass: a tool cycle within this pass clears the
+                    # live dict, but a gate that re-reads its approval after next_fn must still see
+                    # the resumed response. Only a live interrupt cycle is readable — a resume
+                    # always arrives activated, so outside one there is nothing legitimate to read
+                    # and a response retained by a cycle that died mid-flight must not resolve a
+                    # gate that should be asking the human.
+                    _interrupts=dict(self._interrupt_state.interrupts) if self._interrupt_state.activated else {},
                 )
                 try:
                     async for event in self._middleware_registry.invoke(
@@ -1343,16 +1346,19 @@ class Agent(AgentBase):
                     ):
                         self._interrupt_state.deactivate()
                 except InterruptException as interrupt_exception:
-                    if agent_result is not None:
-                        # The pass already yielded its stop event, so its assistant turn is in
-                        # history. Resuming re-enters the event loop with no tool-use message to
-                        # replay, which calls the model again: a duplicate assistant turn, a
-                        # non-alternating history, and re-fired tool side effects. Refuse instead
-                        # of corrupting the conversation.
+                    if agent_result is not None and "tool_use_message" not in self._interrupt_state.context:
+                        # The pass already yielded its stop event and stored no tool use to replay,
+                        # so resuming would re-enter the event loop and call the model again: a
+                        # duplicate assistant turn, a non-alternating history, and re-fired tool
+                        # side effects. Refuse rather than corrupt the conversation, and clear the
+                        # state so the caller is not left holding an interrupt it cannot answer.
+                        # A pass that stopped for a tool interrupt is exempt: its stored tool use
+                        # is replayed on resume, so no second model call happens.
+                        self._interrupt_state.deactivate()
                         raise RuntimeError(
                             f"interrupt_name=<{interrupt_exception.interrupt.name}> | agent-stream middleware "
-                            "raised an interrupt after the pass completed. Raise it before or while draining "
-                            "next_fn, not after the stream finishes."
+                            "interrupted after the pass produced its result | interrupt before the pass "
+                            "produces its assistant turn"
                         ) from interrupt_exception
 
                     # Middleware-initiated interrupt (context.interrupt() with no response yet).
@@ -1388,17 +1394,20 @@ class Agent(AgentBase):
                     yield stop_event
 
             finally:
+                if not self._interrupt_state.activated:
+                    # Nothing is owed a resume, so this pass ends the interrupt cycle. Invocation-
+                    # scoped responses are held across the cycle's passes (see
+                    # _InterruptState.end_tool_cycle) so a gate asks the human once; release them
+                    # here so the next cycle asks again instead of resolving against a stale
+                    # approval. This runs before the session-syncing AfterInvocationEvent hook so
+                    # the released state is what gets persisted, and before apply_management so a
+                    # failure there cannot strand a retained response.
+                    self._interrupt_state.end_interrupt_cycle()
+
                 self.conversation_manager.apply_management(self)
                 after_invocation_event, _interrupts = await self.hooks.invoke_callbacks_async(
                     AfterInvocationEvent(agent=self, invocation_state=invocation_state, result=agent_result)
                 )
-
-                if not self._interrupt_state.activated:
-                    # No interrupt is owed a resume, so this pass ends the interrupt cycle. Answered
-                    # agent-stream responses are kept across the cycle's passes (see
-                    # _InterruptState.complete_tool_resume) so a gate asks the human once; drop them
-                    # here so the next cycle asks again instead of reusing a stale approval.
-                    self._interrupt_state.clear_agent_stream_interrupts()
 
             # Convert resume input to messages for next iteration, or None to stop
             if after_invocation_event.resume is not None:

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -44,6 +44,7 @@ from ..types._snapshot import (
 if TYPE_CHECKING:
     from ..tools import ToolProvider
 from .._middleware import MiddlewareRegistry
+from .._middleware.stages import AgentStreamContext, AgentStreamStage
 from ..handlers.callback_handler import PrintingCallbackHandler, null_callback_handler
 from ..hooks import (
     AfterInvocationEvent,
@@ -56,7 +57,7 @@ from ..hooks import (
     MessageAddedEvent,
 )
 from ..hooks.registry import TEvent
-from ..interrupt import _InterruptState
+from ..interrupt import InterruptException, _InterruptState
 from ..interventions.handler import InterventionHandler
 from ..interventions.registry import InterventionRegistry
 from ..memory import MemoryManager, MemoryManagerConfig
@@ -1202,15 +1203,27 @@ class Agent(AgentBase):
                         messages, merged_state, structured_output_model, structured_output_prompt, limits
                     )
 
+                    # The result is the last EventLoopStopEvent, not the last event overall:
+                    # AgentStreamStage middleware may yield trailing events after the stop event.
+                    stop_event: EventLoopStopEvent | None = None
                     async for event in events:
                         event.prepare(invocation_state=merged_state)
+
+                        if isinstance(event, EventLoopStopEvent):
+                            stop_event = event
 
                         if event.is_callback_event:
                             as_dict = event.as_dict()
                             callback_handler(**as_dict)
                             yield as_dict
 
-                    result = AgentResult(*event["stop"])
+                    if stop_event is None:
+                        raise RuntimeError(
+                            "Agent stream produced no result event. AgentStreamStage middleware must "
+                            "forward events from next() and must not drop the terminal stop event."
+                        )
+
+                    result = AgentResult(*stop_event["stop"])
                     callback_handler(result=result)
                     yield AgentResultEvent(result=result).as_dict()
 
@@ -1293,28 +1306,74 @@ class Agent(AgentBase):
                     structured_output_prompt=structured_output_prompt or self._structured_output_prompt,
                 )
 
-                # Execute the event loop cycle with retry logic for context limits
-                events = self._execute_event_loop_cycle(invocation_state, structured_output_context, limits)
-                async for event in events:
-                    # Signal from the model provider that the message sent by the user should be redacted,
-                    # likely due to a guardrail.
-                    if (
-                        isinstance(event, ModelStreamChunkEvent)
-                        and event.chunk
-                        and event.chunk.get("redactContent")
-                        and event.chunk["redactContent"].get("redactUserContentMessage")
+                # Run this invocation pass through the AgentStreamStage middleware chain, whose
+                # terminal drives the event loop cycle. With no middleware registered the registry
+                # returns the terminal directly.
+                middleware_context = AgentStreamContext(
+                    agent=self,
+                    messages=current_messages,
+                    invocation_state=invocation_state,
+                    # Snapshot interrupts before the pass: a tool cycle within this pass can call
+                    # the event loop's deactivate() and clear the live dict, but a gate that
+                    # re-reads its approval after next_fn must still see the resumed response.
+                    _interrupts=dict(self._interrupt_state.interrupts),
+                )
+                try:
+                    async for event in self._middleware_registry.invoke(
+                        AgentStreamStage,
+                        middleware_context,
+                        self._make_agent_stream_terminal(structured_output_context, limits),
                     ):
-                        self.messages[-1]["content"] = self._redact_user_content(
-                            self.messages[-1]["content"],
-                            str(event.chunk["redactContent"]["redactUserContentMessage"]),
-                        )
-                        if self._session_manager:
-                            self._session_manager.redact_latest_message(self.messages[-1], self)
-                    yield event
+                        # Middleware may yield more events after the stop event, so capture the
+                        # last EventLoopStopEvent as the result rather than the final event.
+                        if isinstance(event, EventLoopStopEvent):
+                            agent_result = AgentResult(*event["stop"])
+                        yield event
 
-                # Capture the result from the final event if available
-                if isinstance(event, EventLoopStopEvent):
-                    agent_result = AgentResult(*event["stop"])
+                    # A resumed AgentStreamStage interrupt that finished without tool execution
+                    # (e.g. a plain end_turn) never hits the tool path's deactivate(), so clear
+                    # the interrupt state here. Guard on the absence of tool context so this only
+                    # fires for agent-stream interrupts (which never store one) and never wipes a
+                    # pending tool interrupt — the event loop owns tool-interrupt state, and some
+                    # paths (e.g. cancel mid-resume) intentionally leave it activated.
+                    if (
+                        self._interrupt_state.activated
+                        and (agent_result is None or agent_result.stop_reason != "interrupt")
+                        and "tool_use_message" not in self._interrupt_state.context
+                    ):
+                        self._interrupt_state.deactivate()
+                except InterruptException as interrupt_exception:
+                    # Middleware-initiated interrupt (context.interrupt() with no response yet).
+                    # interrupt() is read-only, so this handler is the single place the interrupt
+                    # is registered and the state activated before surfacing a terminal
+                    # EventLoopStopEvent("interrupt"), matching how tool interrupts stop the loop.
+                    self._interrupt_state.interrupts.setdefault(
+                        interrupt_exception.interrupt.id, interrupt_exception.interrupt
+                    )
+                    self._interrupt_state.activate()
+                    interrupt_message: Message = (
+                        self.messages[-1]
+                        if self.messages
+                        else {"role": "assistant", "content": [{"text": "Interrupted"}]}
+                    )
+                    # Report every still-unanswered interrupt, not just the one raised here: a
+                    # prior interrupt (e.g. a tool interrupt only partially answered on this
+                    # resume) may still be outstanding, and the caller needs the full set to
+                    # resume cleanly (matching the TS getUnansweredInterrupts() contract).
+                    unanswered = [
+                        interrupt
+                        for interrupt in self._interrupt_state.interrupts.values()
+                        if interrupt.response is None
+                    ]
+                    stop_event = EventLoopStopEvent(
+                        "interrupt",
+                        interrupt_message,
+                        self.event_loop_metrics,
+                        invocation_state.get("request_state", {}),
+                        unanswered,
+                    )
+                    agent_result = AgentResult(*stop_event["stop"])
+                    yield stop_event
 
             finally:
                 self.conversation_manager.apply_management(self)
@@ -1332,6 +1391,51 @@ class Agent(AgentBase):
                 current_messages = await self._convert_prompt_to_messages(after_invocation_event.resume)
             else:
                 current_messages = None
+
+    def _make_agent_stream_terminal(
+        self,
+        structured_output_context: StructuredOutputContext,
+        limits: Limits | None,
+    ) -> Callable[["AgentStreamContext"], AsyncGenerator[TypedEvent, None]]:
+        """Build the terminal for the AgentStreamStage middleware chain.
+
+        The terminal drives the event loop cycle for one invocation pass — the core work the
+        AgentStreamStage middleware wraps. It reads ``invocation_state`` from the context it
+        receives (not a captured value), so an Input/wrap handler that transforms the context
+        via ``dataclasses.replace()`` actually reaches the event loop. It also handles
+        guardrail-driven user-content redaction inline so that behavior runs whether or not
+        middleware is registered.
+
+        Args:
+            structured_output_context: Structured output context for this pass.
+            limits: Optional per-invocation budget caps.
+
+        Returns:
+            An async generator function yielding the pass's events, ending with an
+            ``EventLoopStopEvent``.
+        """
+
+        async def terminal(ctx: "AgentStreamContext") -> AsyncGenerator[TypedEvent, None]:
+            # Execute the event loop cycle with retry logic for context limits
+            events = self._execute_event_loop_cycle(ctx.invocation_state, structured_output_context, limits)
+            async for event in events:
+                # Signal from the model provider that the message sent by the user should be redacted,
+                # likely due to a guardrail.
+                if (
+                    isinstance(event, ModelStreamChunkEvent)
+                    and event.chunk
+                    and event.chunk.get("redactContent")
+                    and event.chunk["redactContent"].get("redactUserContentMessage")
+                ):
+                    self.messages[-1]["content"] = self._redact_user_content(
+                        self.messages[-1]["content"],
+                        str(event.chunk["redactContent"]["redactUserContentMessage"]),
+                    )
+                    if self._session_manager:
+                        self._session_manager.redact_latest_message(self.messages[-1], self)
+                yield event
+
+        return terminal
 
     async def _execute_event_loop_cycle(
         self,

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -1344,7 +1344,7 @@ class Agent(AgentBase):
                     if (
                         self._interrupt_state.activated
                         and (agent_result is None or agent_result.stop_reason != "interrupt")
-                        and "tool_use_message" not in self._interrupt_state.context
+                        and not self._interrupt_state.has_pending_tool_execution
                     ):
                         self._interrupt_state.deactivate()
                 except InterruptException as interrupt_exception:
@@ -1352,7 +1352,7 @@ class Agent(AgentBase):
                     # and corrupt history.
                     if (
                         pass_progress.event_loop_produced_result
-                        and "tool_use_message" not in self._interrupt_state.context
+                        and not self._interrupt_state.has_pending_tool_execution
                     ):
                         self._interrupt_state.deactivate()
                         raise RuntimeError(

--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -283,9 +283,7 @@ async def event_loop_cycle(
 
     with trace_api.use_span(cycle_span, end_on_exit=False):
         try:
-            # Resuming a tool interrupt: replay the stored tool-use message instead of calling
-            # the model. AgentStreamStage interrupts activate the state without tool context, so
-            # gate on the stored message (they fall through to a normal model call).
+            # Resume a tool interrupt by replaying its stored message instead of calling the model.
             if agent._interrupt_state.activated and "tool_use_message" in agent._interrupt_state.context:
                 stop_reason: StopReason = "tool_use"
                 message = agent._interrupt_state.context["tool_use_message"]
@@ -775,9 +773,7 @@ async def _handle_tool_execution(
     tool_uses: list[ToolUse] = [content["toolUse"] for content in message["content"] if "toolUse" in content]
     tool_results: list[ToolResult] = []
 
-    # Only a tool-interrupt resume stores prior tool_results to merge. AgentStreamStage
-    # interrupts activate the state without tool context, so gate on the stored results
-    # (a resumed agent-stream interrupt may reach here on its way into a fresh tool call).
+    # Merge tool results from a resumed tool interrupt.
     if agent._interrupt_state.activated and "tool_results" in agent._interrupt_state.context:
         tool_results.extend(agent._interrupt_state.context["tool_results"])
 
@@ -887,10 +883,8 @@ async def _handle_tool_execution(
             yield interrupt_event
         return
 
+    # Reset interrupt state if tools ran so the next cycle starts clean.
     if not agent._cancel_signal.is_set():
-        # A cancelled pass (agent.cancel()) keeps its interrupt state so a pending tool
-        # interrupt stays resumable. A BeforeToolsEvent cancel only cancels this batch
-        # and the loop continues, so its state is cleared normally.
         agent._interrupt_state.end_tool_cycle()
 
     await agent._append_messages(tool_result_message)

--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -890,6 +890,9 @@ async def _handle_tool_execution(
     # Reset interrupt state if tools ran so the next cycle starts clean.
     if not agent._cancel_signal.is_set():
         agent._interrupt_state.end_tool_cycle()
+    # Update stored results so replay filter skips already-executed tools on next resume.
+    elif cancel_message is None and agent._interrupt_state.has_pending_tool_execution:
+        agent._interrupt_state.context["tool_results"] = tool_results
 
     await agent._append_messages(tool_result_message)
 

--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -283,8 +283,10 @@ async def event_loop_cycle(
 
     with trace_api.use_span(cycle_span, end_on_exit=False):
         try:
-            # Skipping model invocation if in interrupt state as interrupts are currently only supported for tool calls.
-            if agent._interrupt_state.activated:
+            # Resuming a tool interrupt: replay the stored tool-use message instead of calling
+            # the model. AgentStreamStage interrupts activate the state without tool context, so
+            # gate on the stored message (they fall through to a normal model call).
+            if agent._interrupt_state.activated and "tool_use_message" in agent._interrupt_state.context:
                 stop_reason: StopReason = "tool_use"
                 message = agent._interrupt_state.context["tool_use_message"]
             # Skip model invocation if the latest message contains ToolUse
@@ -773,7 +775,10 @@ async def _handle_tool_execution(
     tool_uses: list[ToolUse] = [content["toolUse"] for content in message["content"] if "toolUse" in content]
     tool_results: list[ToolResult] = []
 
-    if agent._interrupt_state.activated:
+    # Only a tool-interrupt resume stores prior tool_results to merge. AgentStreamStage
+    # interrupts activate the state without tool context, so gate on the stored results
+    # (a resumed agent-stream interrupt may reach here on its way into a fresh tool call).
+    if agent._interrupt_state.activated and "tool_results" in agent._interrupt_state.context:
         tool_results.extend(agent._interrupt_state.context["tool_results"])
 
         # Filter to only the interrupted tools when resuming from interrupt (tool uses without results)

--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -318,8 +318,12 @@ async def event_loop_cycle(
                 )
 
             if stop_reason == "tool_use":
-                # Emit after_model checkpoint, unless we just resumed from one or an interrupt.
-                if agent._checkpointing and not agent._cancel_signal.is_set() and not agent._interrupt_state.activated:
+                # Emit after_model checkpoint, unless we just resumed from one or a tool interrupt.
+                if (
+                    agent._checkpointing
+                    and not agent._cancel_signal.is_set()
+                    and not agent._interrupt_state.has_pending_tool_execution
+                ):
                     resume_position = agent._checkpoint_resume_position
                     agent._checkpoint_resume_position = None
                     if resume_position != "after_model":
@@ -720,6 +724,7 @@ async def _stop_for_interrupts(
     """
     # Session state stored on AfterInvocationEvent.
     agent._interrupt_state.context = {"tool_use_message": message, "tool_results": tool_results}
+    agent._interrupt_state.has_pending_tool_execution = True
     agent._interrupt_state.activate()
 
     agent.event_loop_metrics.end_cycle(cycle_start_time, cycle_trace)
@@ -862,6 +867,7 @@ async def _handle_tool_execution(
             # Persist pending interrupts before re-raising so they aren't lost.
             if interrupts:
                 agent._interrupt_state.context = {"tool_use_message": message, "tool_results": tool_results}
+                agent._interrupt_state.has_pending_tool_execution = True
                 agent._interrupt_state.activate()
             raise
 
@@ -886,6 +892,8 @@ async def _handle_tool_execution(
     # Reset interrupt state if tools ran so the next cycle starts clean.
     if not agent._cancel_signal.is_set():
         agent._interrupt_state.end_tool_cycle()
+    else:
+        agent._interrupt_state.has_pending_tool_execution = False
 
     await agent._append_messages(tool_result_message)
 

--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -888,12 +888,9 @@ async def _handle_tool_execution(
         return
 
     if not agent._cancel_signal.is_set():
-        # An aborting pass keeps its interrupt state: the tool never ran, so a pending tool
-        # interrupt (its stored tool_use_message and the human's answer) is still owed a resume,
-        # and clearing it would leave the caller holding responses for state that no longer
-        # exists. Only cancellation aborts the pass. A BeforeToolsEvent cancel just cancels this
-        # batch and the loop continues below, so its state must be cleared like any other cycle —
-        # a retained tool_use_message would be replayed and run the cancelled tool after all.
+        # A cancelled pass (agent.cancel()) keeps its interrupt state so a pending tool
+        # interrupt stays resumable. A BeforeToolsEvent cancel only cancels this batch
+        # and the loop continues, so its state is cleared normally.
         agent._interrupt_state.end_tool_cycle()
 
     await agent._append_messages(tool_result_message)

--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -724,7 +724,6 @@ async def _stop_for_interrupts(
     """
     # Session state stored on AfterInvocationEvent.
     agent._interrupt_state.context = {"tool_use_message": message, "tool_results": tool_results}
-    agent._interrupt_state.has_pending_tool_execution = True
     agent._interrupt_state.activate()
 
     agent.event_loop_metrics.end_cycle(cycle_start_time, cycle_trace)
@@ -867,7 +866,6 @@ async def _handle_tool_execution(
             # Persist pending interrupts before re-raising so they aren't lost.
             if interrupts:
                 agent._interrupt_state.context = {"tool_use_message": message, "tool_results": tool_results}
-                agent._interrupt_state.has_pending_tool_execution = True
                 agent._interrupt_state.activate()
             raise
 
@@ -892,8 +890,6 @@ async def _handle_tool_execution(
     # Reset interrupt state if tools ran so the next cycle starts clean.
     if not agent._cancel_signal.is_set():
         agent._interrupt_state.end_tool_cycle()
-    else:
-        agent._interrupt_state.has_pending_tool_execution = False
 
     await agent._append_messages(tool_result_message)
 

--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -887,7 +887,12 @@ async def _handle_tool_execution(
             yield interrupt_event
         return
 
-    agent._interrupt_state.deactivate()
+    if not cancel_message:
+        # A cancelled pass keeps its interrupt state: the tool never ran, so a pending tool
+        # interrupt (its stored tool_use_message and the human's answer) is still owed a resume.
+        # Clearing it here would leave the caller holding interrupt responses for state that no
+        # longer exists.
+        agent._interrupt_state.complete_tool_resume()
 
     await agent._append_messages(tool_result_message)
 

--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -887,11 +887,13 @@ async def _handle_tool_execution(
             yield interrupt_event
         return
 
-    if not cancel_message:
-        # A cancelled pass keeps its interrupt state: the tool never ran, so a pending tool
-        # interrupt (its stored tool_use_message and the human's answer) is still owed a resume.
-        # Clearing it here would leave the caller holding interrupt responses for state that no
-        # longer exists.
+    if not agent._cancel_signal.is_set():
+        # An aborting pass keeps its interrupt state: the tool never ran, so a pending tool
+        # interrupt (its stored tool_use_message and the human's answer) is still owed a resume,
+        # and clearing it would leave the caller holding responses for state that no longer
+        # exists. Only cancellation aborts the pass. A BeforeToolsEvent cancel just cancels this
+        # batch and the loop continues below, so its state must be cleared like any other cycle —
+        # a retained tool_use_message would be replayed and run the cancelled tool after all.
         agent._interrupt_state.end_tool_cycle()
 
     await agent._append_messages(tool_result_message)

--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -892,7 +892,7 @@ async def _handle_tool_execution(
         # interrupt (its stored tool_use_message and the human's answer) is still owed a resume.
         # Clearing it here would leave the caller holding interrupt responses for state that no
         # longer exists.
-        agent._interrupt_state.complete_tool_resume()
+        agent._interrupt_state.end_tool_cycle()
 
     await agent._append_messages(tool_result_message)
 

--- a/strands-py/src/strands/interrupt.py
+++ b/strands-py/src/strands/interrupt.py
@@ -103,6 +103,9 @@ class _InterruptState:
         from the interrupt that asked the human through to the pass that completes with nothing
         owed a resume (see ``end_tool_cycle``) — so the human is asked once. Releasing it here
         stops it becoming a standing approval that a later cycle would silently resolve against.
+
+        Runs on every pass that ends a cycle, so it bumps the version only when it actually
+        released something and a no-op does not mark the state dirty for session writes.
         """
         remaining = {
             interrupt_id: interrupt

--- a/strands-py/src/strands/interrupt.py
+++ b/strands-py/src/strands/interrupt.py
@@ -79,14 +79,9 @@ class _InterruptState:
     def end_tool_cycle(self) -> None:
         """Clear the state a completed tool cycle owns, keeping answered invocation-scoped ones.
 
-        Called when a tool cycle finishes and nothing is pending for it, so its interrupts and
-        context are done with. An answered invocation-scoped interrupt is kept: it belongs to the
-        interrupt cycle rather than to this tool cycle, and the pass that reads its response can
-        be a later one than the pass the human answered. An unanswered one is not kept — it is
-        either about to be raised (and registered) again or no longer wanted.
-
-        Use ``deactivate`` to reset the state completely, or ``end_interrupt_cycle`` to release
-        the responses this method retains.
+        An answered invocation-scoped interrupt belongs to the interrupt cycle, not this tool
+        cycle, and later passes may still read its response. An unanswered one is not kept — it
+        is either about to be re-raised or no longer wanted.
         """
         self.interrupts = {
             interrupt_id: interrupt
@@ -100,13 +95,8 @@ class _InterruptState:
     def end_interrupt_cycle(self) -> None:
         """Release invocation-scoped interrupts once their interrupt cycle is over.
 
-        An answered invocation-scoped response is held for the whole interrupt cycle — every pass
-        from the interrupt that asked the human through to the pass that completes with nothing
-        owed a resume (see ``end_tool_cycle``) — so the human is asked once. Releasing it here
-        stops it becoming a standing approval that a later cycle would silently resolve against.
-
-        Runs on every pass that ends a cycle, so it bumps the version only when it actually
-        released something and a no-op does not mark the state dirty for session writes.
+        Stops a stale approval from silently resolving a later cycle's gate. Only bumps the
+        version when something was actually released, so a no-op does not dirty session state.
         """
         remaining = {
             interrupt_id: interrupt

--- a/strands-py/src/strands/interrupt.py
+++ b/strands-py/src/strands/interrupt.py
@@ -57,8 +57,12 @@ class _InterruptState:
     interrupts: dict[str, Interrupt] = field(default_factory=dict)
     context: dict[str, Any] = field(default_factory=dict)
     activated: bool = False
-    has_pending_tool_execution: bool = False
     _version: int = field(default=0, compare=False, repr=False)
+
+    @property
+    def has_pending_tool_execution(self) -> bool:
+        """Whether a tool execution is pending resume."""
+        return "tool_use_message" in self.context
 
     def activate(self) -> None:
         """Activate the interrupt state."""
@@ -73,7 +77,6 @@ class _InterruptState:
         self.interrupts = {}
         self.context = {}
         self.activated = False
-        self.has_pending_tool_execution = False
         self._version += 1
 
     def end_tool_cycle(self) -> None:
@@ -85,7 +88,6 @@ class _InterruptState:
         }
         self.context = {}
         self.activated = False
-        self.has_pending_tool_execution = False
         self._version += 1
 
     def end_interrupt_cycle(self) -> None:

--- a/strands-py/src/strands/interrupt.py
+++ b/strands-py/src/strands/interrupt.py
@@ -57,6 +57,7 @@ class _InterruptState:
     interrupts: dict[str, Interrupt] = field(default_factory=dict)
     context: dict[str, Any] = field(default_factory=dict)
     activated: bool = False
+    has_pending_tool_execution: bool = False
     _version: int = field(default=0, compare=False, repr=False)
 
     def activate(self) -> None:
@@ -72,6 +73,7 @@ class _InterruptState:
         self.interrupts = {}
         self.context = {}
         self.activated = False
+        self.has_pending_tool_execution = False
         self._version += 1
 
     def end_tool_cycle(self) -> None:
@@ -83,6 +85,7 @@ class _InterruptState:
         }
         self.context = {}
         self.activated = False
+        self.has_pending_tool_execution = False
         self._version += 1
 
     def end_interrupt_cycle(self) -> None:

--- a/strands-py/src/strands/interrupt.py
+++ b/strands-py/src/strands/interrupt.py
@@ -168,9 +168,22 @@ class _InterruptState:
         return self._version
 
     def to_dict(self) -> dict[str, Any]:
-        """Serialize to dict for session management."""
+        """Serialize to dict for session management.
+
+        A response retained by ``end_tool_cycle`` while deactivated is readable only for the
+        remainder of the pass that retained it, so it is never serialized: sessions sync mid-pass
+        (on message-added), and persisting it would hand a restored agent a standing approval.
+        """
+        interrupts = self.interrupts
+        if not self.activated:
+            interrupts = {
+                interrupt_id: interrupt
+                for interrupt_id, interrupt in interrupts.items()
+                if not interrupt_id.startswith(_AGENT_STREAM_INTERRUPT_ID_PREFIX)
+            }
+
         return {
-            "interrupts": {k: v.to_dict() for k, v in self.interrupts.items()},
+            "interrupts": {k: v.to_dict() for k, v in interrupts.items()},
             "context": self.context,
             "activated": self.activated,
         }
@@ -181,10 +194,15 @@ class _InterruptState:
 
         Interrupt state can be serialized with the `to_dict` method.
         """
+        activated = data["activated"]
         return cls(
             interrupts={
-                interrupt_id: Interrupt(**interrupt_data) for interrupt_id, interrupt_data in data["interrupts"].items()
+                interrupt_id: Interrupt(**interrupt_data)
+                for interrupt_id, interrupt_data in data["interrupts"].items()
+                # Deactivated state carries no invocation-scoped response (see to_dict); drop any
+                # a previously written session still holds rather than reviving it as an approval.
+                if activated or not interrupt_id.startswith(_AGENT_STREAM_INTERRUPT_ID_PREFIX)
             },
             context=data["context"],
-            activated=data["activated"],
+            activated=activated,
         )

--- a/strands-py/src/strands/interrupt.py
+++ b/strands-py/src/strands/interrupt.py
@@ -47,7 +47,10 @@ class _InterruptState:
     Note, interrupt state is cleared after resuming.
 
     Attributes:
-        interrupts: Interrupts raised by the user.
+        interrupts: Interrupts raised by the user. An answered invocation-scoped interrupt can
+            outlive ``activated`` being cleared: it is held until the interrupt cycle it belongs
+            to ends (see ``end_tool_cycle`` and ``end_interrupt_cycle``), so ``activated`` alone
+            does not imply this mapping is empty.
         context: Additional context associated with an interrupt event.
         activated: True if agent is in an interrupt state, False otherwise.
     """
@@ -72,40 +75,39 @@ class _InterruptState:
         self.activated = False
         self._version += 1
 
-    def complete_tool_resume(self) -> None:
-        """Clear tool-resume bookkeeping, keeping answered agent-stream responses.
+    def end_tool_cycle(self) -> None:
+        """Clear the state a completed tool cycle owns, keeping answered invocation-scoped ones.
 
-        Called when a tool cycle completes with no pending interrupts: the tool-interrupt resume
-        is finished, so its interrupts and context are done with. Answered agent-stream interrupts
-        are kept because they belong to the enclosing invocation, not to the tool cycle —
-        middleware may re-read its approval in a later pass of the same invocation, and the pass
-        that reads it can be a different pass from the one the human answered. Unanswered
-        agent-stream interrupts are not kept: an unanswered one is either about to be raised again
-        (and re-registered) or no longer wanted.
+        Called when a tool cycle finishes and nothing is pending for it, so its interrupts and
+        context are done with. An answered invocation-scoped interrupt is kept: it belongs to the
+        interrupt cycle rather than to this tool cycle, and the pass that reads its response can
+        be a later one than the pass the human answered. An unanswered one is not kept — it is
+        either about to be raised (and registered) again or no longer wanted.
 
-        Use ``deactivate`` instead to reset the state completely.
+        Use ``deactivate`` to reset the state completely, or ``end_interrupt_cycle`` to release
+        the responses this method retains.
         """
         self.interrupts = {
             interrupt_id: interrupt
             for interrupt_id, interrupt in self.interrupts.items()
-            if interrupt_id.startswith(AGENT_STREAM_INTERRUPT_ID_PREFIX) and interrupt.response is not None
+            if interrupt_id.startswith(_AGENT_STREAM_INTERRUPT_ID_PREFIX) and interrupt.response is not None
         }
         self.context = {}
         self.activated = False
         self._version += 1
 
-    def clear_agent_stream_interrupts(self) -> None:
-        """Drop agent-stream interrupts once the invocation that owns them is over.
+    def end_interrupt_cycle(self) -> None:
+        """Release invocation-scoped interrupts once their interrupt cycle is over.
 
-        An answered agent-stream response is scoped to one invocation: it is kept across the
-        passes of that invocation (see ``complete_tool_resume``) so a gate is asked once, and
-        dropped here so a later invocation asks the human again instead of reusing a stale
-        approval.
+        An answered invocation-scoped response is held for the whole interrupt cycle — every pass
+        from the interrupt that asked the human through to the pass that completes with nothing
+        owed a resume (see ``end_tool_cycle``) — so the human is asked once. Releasing it here
+        stops it becoming a standing approval that a later cycle would silently resolve against.
         """
         remaining = {
             interrupt_id: interrupt
             for interrupt_id, interrupt in self.interrupts.items()
-            if not interrupt_id.startswith(AGENT_STREAM_INTERRUPT_ID_PREFIX)
+            if not interrupt_id.startswith(_AGENT_STREAM_INTERRUPT_ID_PREFIX)
         }
         if remaining == self.interrupts:
             return
@@ -152,7 +154,8 @@ class _InterruptState:
     def _get_version(self) -> int:
         """Get the current version number of the interrupt state.
 
-        The version is incremented each time activate(), deactivate(), or resume() is called.
+        The version is incremented each time the state is mutated — activate(), deactivate(),
+        resume(), end_tool_cycle(), or end_interrupt_cycle().
         Consumers can compare versions to detect changes without requiring
         explicit dirty flag clearing.
 

--- a/strands-py/src/strands/interrupt.py
+++ b/strands-py/src/strands/interrupt.py
@@ -44,7 +44,8 @@ class InterruptException(Exception):
 class _InterruptState:
     """Track the state of interrupt events raised by the user.
 
-    Note, interrupt state is cleared after resuming.
+    Note, unanswered interrupts are cleared after resuming; an answered invocation-scoped response
+    is retained for the rest of its interrupt cycle (see ``interrupts`` below).
 
     Attributes:
         interrupts: Interrupts raised by the user. An answered invocation-scoped interrupt can

--- a/strands-py/src/strands/interrupt.py
+++ b/strands-py/src/strands/interrupt.py
@@ -45,13 +45,11 @@ class _InterruptState:
     """Track the state of interrupt events raised by the user.
 
     Note, unanswered interrupts are cleared after resuming; an answered invocation-scoped response
-    is retained for the rest of its interrupt cycle (see ``interrupts`` below).
+    is retained for the rest of its interrupt cycle.
 
     Attributes:
-        interrupts: Interrupts raised by the user. An answered invocation-scoped interrupt can
-            outlive ``activated`` being cleared: it is held until the interrupt cycle it belongs
-            to ends (see ``end_tool_cycle`` and ``end_interrupt_cycle``), so ``activated`` alone
-            does not imply this mapping is empty.
+        interrupts: Interrupts raised by the user. May be non-empty even when ``activated`` is
+            False because retained responses persist until their cycle ends.
         context: Additional context associated with an interrupt event.
         activated: True if agent is in an interrupt state, False otherwise.
     """
@@ -77,12 +75,7 @@ class _InterruptState:
         self._version += 1
 
     def end_tool_cycle(self) -> None:
-        """Clear the state a completed tool cycle owns, keeping answered invocation-scoped ones.
-
-        An answered invocation-scoped interrupt belongs to the interrupt cycle, not this tool
-        cycle, and later passes may still read its response. An unanswered one is not kept — it
-        is either about to be re-raised or no longer wanted.
-        """
+        """Clear a completed tool cycle's state, keeping answered invocation-scoped responses."""
         self.interrupts = {
             interrupt_id: interrupt
             for interrupt_id, interrupt in self.interrupts.items()
@@ -93,11 +86,7 @@ class _InterruptState:
         self._version += 1
 
     def end_interrupt_cycle(self) -> None:
-        """Release invocation-scoped interrupts once their interrupt cycle is over.
-
-        Stops a stale approval from silently resolving a later cycle's gate. Only bumps the
-        version when something was actually released, so a no-op does not dirty session state.
-        """
+        """Release invocation-scoped interrupts once their interrupt cycle is over."""
         remaining = {
             interrupt_id: interrupt
             for interrupt_id, interrupt in self.interrupts.items()
@@ -161,9 +150,8 @@ class _InterruptState:
     def to_dict(self) -> dict[str, Any]:
         """Serialize to dict for session management.
 
-        A response retained by ``end_tool_cycle`` while deactivated is readable only for the
-        remainder of the pass that retained it, so it is never serialized: sessions sync mid-pass
-        (on message-added), and persisting it would hand a restored agent a standing approval.
+        Exclude deactivated invocation-scoped responses — persisting them would
+        give a restored agent a standing approval.
         """
         interrupts = self.interrupts
         if not self.activated:
@@ -190,8 +178,7 @@ class _InterruptState:
             interrupts={
                 interrupt_id: Interrupt(**interrupt_data)
                 for interrupt_id, interrupt_data in data["interrupts"].items()
-                # Deactivated state carries no invocation-scoped response (see to_dict); drop any
-                # a previously written session still holds rather than reviving it as an approval.
+                # Mirror to_dict's filter — don't revive a stale response as a standing approval.
                 if activated or not interrupt_id.startswith(_AGENT_STREAM_INTERRUPT_ID_PREFIX)
             },
             context=data["context"],

--- a/strands-py/src/strands/interrupt.py
+++ b/strands-py/src/strands/interrupt.py
@@ -72,6 +72,47 @@ class _InterruptState:
         self.activated = False
         self._version += 1
 
+    def complete_tool_resume(self) -> None:
+        """Clear tool-resume bookkeeping, keeping answered agent-stream responses.
+
+        Called when a tool cycle completes with no pending interrupts: the tool-interrupt resume
+        is finished, so its interrupts and context are done with. Answered agent-stream interrupts
+        are kept because they belong to the enclosing invocation, not to the tool cycle —
+        middleware may re-read its approval in a later pass of the same invocation, and the pass
+        that reads it can be a different pass from the one the human answered. Unanswered
+        agent-stream interrupts are not kept: an unanswered one is either about to be raised again
+        (and re-registered) or no longer wanted.
+
+        Use ``deactivate`` instead to reset the state completely.
+        """
+        self.interrupts = {
+            interrupt_id: interrupt
+            for interrupt_id, interrupt in self.interrupts.items()
+            if interrupt_id.startswith(AGENT_STREAM_INTERRUPT_ID_PREFIX) and interrupt.response is not None
+        }
+        self.context = {}
+        self.activated = False
+        self._version += 1
+
+    def clear_agent_stream_interrupts(self) -> None:
+        """Drop agent-stream interrupts once the invocation that owns them is over.
+
+        An answered agent-stream response is scoped to one invocation: it is kept across the
+        passes of that invocation (see ``complete_tool_resume``) so a gate is asked once, and
+        dropped here so a later invocation asks the human again instead of reusing a stale
+        approval.
+        """
+        remaining = {
+            interrupt_id: interrupt
+            for interrupt_id, interrupt in self.interrupts.items()
+            if not interrupt_id.startswith(AGENT_STREAM_INTERRUPT_ID_PREFIX)
+        }
+        if remaining == self.interrupts:
+            return
+
+        self.interrupts = remaining
+        self._version += 1
+
     def resume(self, prompt: "AgentInput") -> None:
         """Configure the interrupt state if resuming from an interrupt event.
 

--- a/strands-py/tests/strands/agent/test_agent_cancellation.py
+++ b/strands-py/tests/strands/agent/test_agent_cancellation.py
@@ -297,13 +297,7 @@ async def test_agent_cancel_continue_after():
 
 @pytest.mark.asyncio
 async def test_cancel_during_tool_interrupt_resume_preserves_interrupt_state():
-    """Cancelling a resumed tool interrupt must not wipe the pending interrupt state.
-
-    A tool interrupt stores its resume context (tool_use_message / tool_results) and keeps the
-    interrupt state activated. If the resume is cancelled before the tool executes, the event
-    loop deliberately leaves that state intact so the interrupt can still be resumed later. The
-    interrupt state must survive the cancelled pass rather than being deactivated.
-    """
+    """Cancelling a resumed tool interrupt preserves the pending interrupt state for a later resume."""
 
     @tool(context=True)
     def approver(tool_context) -> str:
@@ -369,12 +363,7 @@ def _approve_all(result):
 
 @pytest.mark.asyncio
 async def test_hook_cancelled_tool_batch_does_not_replay_the_stored_tool_use():
-    """A hook that cancels the tool batch on a resumed pass does not let the tool run anyway.
-
-    Cancelling a batch does not abort the pass — the event loop continues with cancel results — so
-    the tool-resume bookkeeping is cleared like any other cycle. Keeping it would replay the stored
-    tool use and execute the tool the hook just denied.
-    """
+    """A hook that cancels the tool batch prevents the tool from running on a resumed pass."""
     ran: list[str] = []
     deny = [False]
     agent = _charge_agent([_CHARGE_TOOL_USE, _CHARGE_DONE], ran, deny)

--- a/strands-py/tests/strands/agent/test_agent_cancellation.py
+++ b/strands-py/tests/strands/agent/test_agent_cancellation.py
@@ -330,45 +330,6 @@ async def test_cancel_during_tool_interrupt_resume_preserves_interrupt_state():
     assert "tool_use_message" in agent._interrupt_state.context
 
 
-@pytest.mark.asyncio
-async def test_cancel_after_tool_completion_clears_pending_execution():
-    """Cancelling after tools complete clears has_pending_tool_execution so the next invocation doesn't replay."""
-
-    call_count = []
-
-    @tool
-    def slow_tool() -> str:
-        """A tool that completes despite a cancel signal."""
-        call_count.append(1)
-        return "done"
-
-    tool_use_response = {
-        "role": "assistant",
-        "content": [{"toolUse": {"toolUseId": "tool_1", "name": "slow_tool", "input": {}}}],
-    }
-    agent = Agent(
-        model=MockedModelProvider([tool_use_response, DEFAULT_RESPONSE, DEFAULT_RESPONSE]),
-        tools=[slow_tool],
-        callback_handler=None,
-    )
-
-    agent.hooks.add_callback(BeforeToolCallEvent, lambda event: event.interrupt("gate", reason="approve?"))
-
-    first = await agent.invoke_async("go")
-    assert first.stop_reason == "interrupt"
-    assert agent._interrupt_state.has_pending_tool_execution
-
-    def cancel_after_model(event):
-        agent.cancel()
-
-    agent.hooks.add_callback(AfterModelCallEvent, cancel_after_model)
-
-    await agent.invoke_async([{"interruptResponse": {"interruptId": first.interrupts[0].id, "response": "yes"}}])
-
-    assert len(call_count) == 1
-    assert not agent._interrupt_state.has_pending_tool_execution
-
-
 _CHARGE_TOOL_USE = {
     "role": "assistant",
     "content": [{"toolUse": {"toolUseId": "t1", "name": "charge_card", "input": {"amount": "$100"}}}],

--- a/strands-py/tests/strands/agent/test_agent_cancellation.py
+++ b/strands-py/tests/strands/agent/test_agent_cancellation.py
@@ -7,7 +7,7 @@ from unittest.mock import ANY
 import pytest
 
 from strands import Agent, tool
-from strands.hooks import AfterModelCallEvent
+from strands.hooks import AfterModelCallEvent, BeforeToolCallEvent, BeforeToolsEvent
 from tests.fixtures.mocked_model_provider import MockedModelProvider
 
 # Default agent response for simple tests
@@ -334,3 +334,75 @@ async def test_cancel_during_tool_interrupt_resume_preserves_interrupt_state():
     # The pending tool interrupt state survives the cancelled pass.
     assert agent._interrupt_state.activated
     assert "tool_use_message" in agent._interrupt_state.context
+
+_CHARGE_TOOL_USE = {
+    "role": "assistant",
+    "content": [{"toolUse": {"toolUseId": "t1", "name": "charge_card", "input": {"amount": "$100"}}}],
+}
+_CHARGE_DONE = {"role": "assistant", "content": [{"text": "done"}]}
+
+
+def _charge_agent(model_messages, ran, deny):
+    """An agent whose tool interrupts for approval, with a hook that can cancel the batch."""
+
+    @tool(name="charge_card")
+    def charge_card(amount: str) -> str:
+        """Charge the customer's card."""
+        ran.append(amount)
+        return f"charged {amount}"
+
+    agent = Agent(model=MockedModelProvider(model_messages), tools=[charge_card], callback_handler=None)
+    agent.hooks.add_callback(BeforeToolCallEvent, lambda event: event.interrupt("approve_tool", reason="run it?"))
+
+    def maybe_cancel(event):
+        if deny[0]:
+            event.cancel = "policy denied"
+
+    agent.hooks.add_callback(BeforeToolsEvent, maybe_cancel)
+    return agent
+
+
+def _approve_all(result):
+    return [
+        {"interruptResponse": {"interruptId": interrupt.id, "response": "yes"}} for interrupt in result.interrupts
+    ]
+
+
+@pytest.mark.asyncio
+async def test_hook_cancelled_tool_batch_does_not_replay_the_stored_tool_use():
+    """A hook that cancels the tool batch on a resumed pass does not let the tool run anyway.
+
+    Cancelling a batch does not abort the pass — the event loop continues with cancel results — so
+    the tool-resume bookkeeping is cleared like any other cycle. Keeping it would replay the stored
+    tool use and execute the tool the hook just denied.
+    """
+    ran: list[str] = []
+    deny = [False]
+    agent = _charge_agent([_CHARGE_TOOL_USE, _CHARGE_DONE], ran, deny)
+
+    first = await agent.invoke_async("charge $100")
+    assert first.stop_reason == "interrupt"
+
+    deny[0] = True
+    resumed = await agent.invoke_async(_approve_all(first))
+
+    assert resumed.stop_reason == "end_turn"
+    assert ran == []
+    assert [message["role"] for message in agent.messages] == ["user", "assistant", "user", "assistant"]
+
+
+@pytest.mark.asyncio
+async def test_hook_cancelled_tool_batch_leaves_no_interrupt_state():
+    """An invocation that completes after a cancelled batch leaves no interrupt state behind."""
+    ran: list[str] = []
+    deny = [False]
+    agent = _charge_agent([_CHARGE_TOOL_USE, _CHARGE_DONE, _CHARGE_DONE], ran, deny)
+
+    first = await agent.invoke_async("charge $100")
+    deny[0] = True
+    resumed = await agent.invoke_async(_approve_all(first))
+
+    assert resumed.stop_reason == "end_turn"
+    assert not agent._interrupt_state.activated
+    assert not agent._interrupt_state.context
+    assert not agent._interrupt_state.interrupts

--- a/strands-py/tests/strands/agent/test_agent_cancellation.py
+++ b/strands-py/tests/strands/agent/test_agent_cancellation.py
@@ -388,20 +388,7 @@ async def test_hook_cancelled_tool_batch_does_not_replay_the_stored_tool_use():
     assert resumed.stop_reason == "end_turn"
     assert ran == []
     assert [message["role"] for message in agent.messages] == ["user", "assistant", "user", "assistant"]
-
-
-@pytest.mark.asyncio
-async def test_hook_cancelled_tool_batch_leaves_no_interrupt_state():
-    """An invocation that completes after a cancelled batch leaves no interrupt state behind."""
-    ran: list[str] = []
-    deny = [False]
-    agent = _charge_agent([_CHARGE_TOOL_USE, _CHARGE_DONE], ran, deny)
-
-    first = await agent.invoke_async("charge $100")
-    deny[0] = True
-    resumed = await agent.invoke_async(_approve_all(first))
-
-    assert resumed.stop_reason == "end_turn"
+    # The completed invocation leaves no interrupt state behind.
     assert not agent._interrupt_state.activated
     assert not agent._interrupt_state.context
     assert not agent._interrupt_state.interrupts

--- a/strands-py/tests/strands/agent/test_agent_cancellation.py
+++ b/strands-py/tests/strands/agent/test_agent_cancellation.py
@@ -293,3 +293,44 @@ async def test_agent_cancel_continue_after():
     # Second invocation should work normally
     result2 = await agent.invoke_async("Hello again")
     assert result2.stop_reason == "end_turn"
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_tool_interrupt_resume_preserves_interrupt_state():
+    """Cancelling a resumed tool interrupt must not wipe the pending interrupt state.
+
+    A tool interrupt stores its resume context (tool_use_message / tool_results) and keeps the
+    interrupt state activated. If the resume is cancelled before the tool executes, the event
+    loop deliberately leaves that state intact so the interrupt can still be resumed later. The
+    interrupt state must survive the cancelled pass rather than being deactivated.
+    """
+
+    @tool(context=True)
+    def approver(tool_context) -> str:
+        """Require approval before returning."""
+        return tool_context.interrupt("approve", reason="proceed?")
+
+    tool_use_response = {
+        "role": "assistant",
+        "content": [{"toolUse": {"toolUseId": "tool_1", "name": "approver", "input": {}}}],
+    }
+    agent = Agent(
+        model=MockedModelProvider([tool_use_response, DEFAULT_RESPONSE]),
+        tools=[approver],
+    )
+
+    interrupt_result = await agent.invoke_async("go")
+    assert interrupt_result.stop_reason == "interrupt"
+    assert agent._interrupt_state.activated
+    assert "tool_use_message" in agent._interrupt_state.context
+
+    # Cancel the resume before the tool runs.
+    agent.cancel()
+    cancelled_result = await agent.invoke_async(
+        [{"interruptResponse": {"interruptId": interrupt_result.interrupts[0].id, "response": "go"}}]
+    )
+
+    assert cancelled_result.stop_reason == "cancelled"
+    # The pending tool interrupt state survives the cancelled pass.
+    assert agent._interrupt_state.activated
+    assert "tool_use_message" in agent._interrupt_state.context

--- a/strands-py/tests/strands/agent/test_agent_cancellation.py
+++ b/strands-py/tests/strands/agent/test_agent_cancellation.py
@@ -335,6 +335,7 @@ async def test_cancel_during_tool_interrupt_resume_preserves_interrupt_state():
     assert agent._interrupt_state.activated
     assert "tool_use_message" in agent._interrupt_state.context
 
+
 _CHARGE_TOOL_USE = {
     "role": "assistant",
     "content": [{"toolUse": {"toolUseId": "t1", "name": "charge_card", "input": {"amount": "$100"}}}],
@@ -363,9 +364,7 @@ def _charge_agent(model_messages, ran, deny):
 
 
 def _approve_all(result):
-    return [
-        {"interruptResponse": {"interruptId": interrupt.id, "response": "yes"}} for interrupt in result.interrupts
-    ]
+    return [{"interruptResponse": {"interruptId": interrupt.id, "response": "yes"}} for interrupt in result.interrupts]
 
 
 @pytest.mark.asyncio
@@ -396,7 +395,7 @@ async def test_hook_cancelled_tool_batch_leaves_no_interrupt_state():
     """An invocation that completes after a cancelled batch leaves no interrupt state behind."""
     ran: list[str] = []
     deny = [False]
-    agent = _charge_agent([_CHARGE_TOOL_USE, _CHARGE_DONE, _CHARGE_DONE], ran, deny)
+    agent = _charge_agent([_CHARGE_TOOL_USE, _CHARGE_DONE], ran, deny)
 
     first = await agent.invoke_async("charge $100")
     deny[0] = True

--- a/strands-py/tests/strands/agent/test_agent_cancellation.py
+++ b/strands-py/tests/strands/agent/test_agent_cancellation.py
@@ -330,6 +330,45 @@ async def test_cancel_during_tool_interrupt_resume_preserves_interrupt_state():
     assert "tool_use_message" in agent._interrupt_state.context
 
 
+@pytest.mark.asyncio
+async def test_cancel_after_tool_completion_clears_pending_execution():
+    """Cancelling after tools complete clears has_pending_tool_execution so the next invocation doesn't replay."""
+
+    call_count = []
+
+    @tool
+    def slow_tool() -> str:
+        """A tool that completes despite a cancel signal."""
+        call_count.append(1)
+        return "done"
+
+    tool_use_response = {
+        "role": "assistant",
+        "content": [{"toolUse": {"toolUseId": "tool_1", "name": "slow_tool", "input": {}}}],
+    }
+    agent = Agent(
+        model=MockedModelProvider([tool_use_response, DEFAULT_RESPONSE, DEFAULT_RESPONSE]),
+        tools=[slow_tool],
+        callback_handler=None,
+    )
+
+    agent.hooks.add_callback(BeforeToolCallEvent, lambda event: event.interrupt("gate", reason="approve?"))
+
+    first = await agent.invoke_async("go")
+    assert first.stop_reason == "interrupt"
+    assert agent._interrupt_state.has_pending_tool_execution
+
+    def cancel_after_model(event):
+        agent.cancel()
+
+    agent.hooks.add_callback(AfterModelCallEvent, cancel_after_model)
+
+    await agent.invoke_async([{"interruptResponse": {"interruptId": first.interrupts[0].id, "response": "yes"}}])
+
+    assert len(call_count) == 1
+    assert not agent._interrupt_state.has_pending_tool_execution
+
+
 _CHARGE_TOOL_USE = {
     "role": "assistant",
     "content": [{"toolUse": {"toolUseId": "t1", "name": "charge_card", "input": {"amount": "$100"}}}],

--- a/strands-py/tests/strands/agent/test_agent_cancellation.py
+++ b/strands-py/tests/strands/agent/test_agent_cancellation.py
@@ -381,3 +381,62 @@ async def test_hook_cancelled_tool_batch_does_not_replay_the_stored_tool_use():
     assert not agent._interrupt_state.activated
     assert not agent._interrupt_state.context
     assert not agent._interrupt_state.interrupts
+
+
+def _approver_agent(ran, cancel_on_first_run=False):
+    @tool(context=True)
+    def approver(tool_context) -> str:
+        """Require approval before doing the work."""
+        tool_context.interrupt("approve", reason="proceed?")
+        ran.append("executed")
+        if cancel_on_first_run and len(ran) == 1:
+            tool_context.agent.cancel()
+        return "done"
+
+    tool_use_response = {
+        "role": "assistant",
+        "content": [{"toolUse": {"toolUseId": "tool_1", "name": "approver", "input": {}}}],
+    }
+
+    return Agent(
+        model=MockedModelProvider([tool_use_response, DEFAULT_RESPONSE] * 3),
+        tools=[approver],
+        callback_handler=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancel_before_tool_runs_still_executes_the_approved_tool():
+    """A cancel that lands before the tool runs must not consume the approval."""
+    ran: list[str] = []
+    agent = _approver_agent(ran)
+
+    interrupted = await agent.invoke_async("go")
+    response = [{"interruptResponse": {"interruptId": interrupted.interrupts[0].id, "response": "go"}}]
+
+    agent.cancel()
+    cancelled = await agent.invoke_async(response)
+    assert cancelled.stop_reason == "cancelled"
+    assert ran == []
+
+    agent._cancel_signal.clear()
+    await agent.invoke_async(response)
+    assert ran == ["executed"]
+
+
+@pytest.mark.asyncio
+async def test_cancel_while_tool_runs_does_not_re_execute_the_tool():
+    """A cancel that lands while the tool runs must not replay the completed tool."""
+    ran: list[str] = []
+    agent = _approver_agent(ran, cancel_on_first_run=True)
+
+    interrupted = await agent.invoke_async("go")
+    response = [{"interruptResponse": {"interruptId": interrupted.interrupts[0].id, "response": "go"}}]
+
+    cancelled = await agent.invoke_async(response)
+    assert cancelled.stop_reason == "cancelled"
+    assert ran == ["executed"]
+
+    agent._cancel_signal.clear()
+    await agent.invoke_async(response)
+    assert ran == ["executed"]

--- a/strands-py/tests/strands/middleware/test_agent_stream_middleware.py
+++ b/strands-py/tests/strands/middleware/test_agent_stream_middleware.py
@@ -1,0 +1,903 @@
+"""Integration tests for AgentStreamStage middleware (the outermost interception point)."""
+
+from dataclasses import replace
+
+import pytest
+
+import strands
+from strands import Agent
+from strands._middleware.stages import AgentStreamContext, AgentStreamStage, MiddlewareInterruptResult
+from strands.telemetry.metrics import EventLoopMetrics
+from strands.types._events import EventLoopStopEvent, InitEventLoopEvent, ModelMessageEvent, TextStreamEvent
+from tests.fixtures.mocked_model_provider import MockedModelProvider
+
+
+@pytest.fixture
+def model():
+    return MockedModelProvider([{"role": "assistant", "content": [{"text": "Hello!"}]}])
+
+
+@pytest.fixture
+def agent(model):
+    return Agent(model=model, callback_handler=None)
+
+
+# --- wrap phase: wrapping the whole stream ---
+
+
+def test_wrap_executes_around_full_stream(agent):
+    """Middleware runs before and after the entire agent stream."""
+    call_order: list[str] = []
+
+    async def middleware(context, next_fn):
+        call_order.append("before")
+        async for event in next_fn(context):
+            yield event
+        call_order.append("after")
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, middleware)
+    result = agent("Test prompt")
+
+    assert call_order == ["before", "after"]
+    assert result.stop_reason == "end_turn"
+    assert result.message["content"][0]["text"] == "Hello!"
+
+
+def test_wrap_receives_agent_stream_context(agent):
+    """Middleware receives an AgentStreamContext with agent, messages, and invocation_state."""
+    received: list[AgentStreamContext] = []
+
+    async def capture(context, next_fn):
+        received.append(context)
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, capture)
+    agent("Test prompt")
+
+    assert len(received) == 1
+    ctx = received[0]
+    assert ctx.agent is agent
+    assert isinstance(ctx.messages, list)
+    assert isinstance(ctx.invocation_state, dict)
+
+
+def test_context_invocation_state_shared_by_reference(agent):
+    """invocation_state is shared by reference: the context holds the caller's dict and mutations stick.
+
+    Mirrors the TS copy-on-input suite, which pins that AgentStreamContext shares args/options by
+    reference. Python's analog is invocation_state (see the README "shared by reference" callout).
+    """
+    caller_state = {"key": "value"}
+    is_same_object = False
+
+    async def capture(context, next_fn):
+        nonlocal is_same_object
+        is_same_object = context.invocation_state is caller_state
+        context.invocation_state["added_by_middleware"] = True
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, capture)
+    agent("Test prompt", invocation_state=caller_state)
+
+    assert is_same_object
+    # The middleware's mutation is visible on the caller's own dict (no defensive copy).
+    assert caller_state["added_by_middleware"] is True
+
+
+def test_wrap_short_circuits_entire_stream(agent):
+    """Middleware can short-circuit the whole pass by yielding a stop event without calling next."""
+    agent.model.stream = _fail_if_called
+
+    async def short_circuit(context, next_fn):
+        message = {"role": "assistant", "content": [{"text": "Short-circuited"}]}
+        yield EventLoopStopEvent("end_turn", message, EventLoopMetrics(), {})
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, short_circuit)
+    result = agent("Test prompt")
+
+    assert result.stop_reason == "end_turn"
+    assert result.message["content"][0]["text"] == "Short-circuited"
+
+
+def test_wrap_multiple_middleware_execute_in_registration_order(agent):
+    """Multiple AgentStreamStage middleware compose in registration order (outer wraps inner)."""
+    call_order: list[str] = []
+
+    async def outer(context, next_fn):
+        call_order.append("outer-before")
+        async for event in next_fn(context):
+            yield event
+        call_order.append("outer-after")
+
+    async def inner(context, next_fn):
+        call_order.append("inner-before")
+        async for event in next_fn(context):
+            yield event
+        call_order.append("inner-after")
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, outer)
+    agent._middleware_registry.add_middleware(AgentStreamStage, inner)
+    agent("Test prompt")
+
+    assert call_order == ["outer-before", "inner-before", "inner-after", "outer-after"]
+
+
+def test_wrap_can_filter_events(agent):
+    """Middleware can drop events from the stream without affecting the final result."""
+
+    async def drop_init_events(context, next_fn):
+        async for event in next_fn(context):
+            if not isinstance(event, InitEventLoopEvent):
+                yield event
+
+    saw_init = False
+
+    async def observer(context, next_fn):
+        nonlocal saw_init
+        async for event in next_fn(context):
+            if isinstance(event, InitEventLoopEvent):
+                saw_init = True
+            yield event
+
+    # observer (outer) sees events after drop_init_events (inner) removed them.
+    agent._middleware_registry.add_middleware(AgentStreamStage, observer)
+    agent._middleware_registry.add_middleware(AgentStreamStage, drop_init_events)
+    result = agent("Test prompt")
+
+    assert not saw_init
+    assert result.stop_reason == "end_turn"
+
+
+def test_wrap_buffers_content_across_a_multi_turn_pass():
+    """Middleware wraps a whole multi-cycle pass and can suppress intermediate-turn content.
+
+    A single AgentStreamStage pass spans every event-loop cycle of the invocation (tool-use turn
+    then follow-up turn), so middleware can buffer text deltas per turn and emit only the final
+    turn's — the TS "stream final turn only" use case. This exercises the stage across more than
+    one turn, which the single-turn wrap tests do not.
+    """
+    tool_use_msg = {
+        "role": "assistant",
+        "content": [{"text": "Let me calculate.", "toolUse": {"toolUseId": "t1", "name": "calc", "input": {}}}],
+    }
+    final_msg = {"role": "assistant", "content": [{"text": "The answer is 42."}]}
+    model = MockedModelProvider([tool_use_msg, final_msg])
+
+    @strands.tool(name="calc")
+    def calc() -> str:
+        """Return a constant."""
+        return "42"
+
+    agent = Agent(model=model, tools=[calc], callback_handler=None)
+
+    emitted_text: list[str] = []
+
+    async def stream_final_turn_only(context, next_fn):
+        buffered: list[TextStreamEvent] = []
+        last_turn_text: list[TextStreamEvent] = []
+        async for event in next_fn(context):
+            if isinstance(event, TextStreamEvent):
+                # Buffer this turn's text; drop it from the stream for now.
+                buffered.append(event)
+                continue
+            if isinstance(event, ModelMessageEvent):
+                # A turn completed: keep only its buffered text as the latest turn, discarding
+                # any earlier intermediate turn. The last one standing is the final turn.
+                last_turn_text = buffered
+                buffered = []
+            yield event
+        # Flush the final turn's buffered text after the stream completes.
+        for text_event in last_turn_text:
+            emitted_text.append(text_event["data"])
+            yield text_event
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, stream_final_turn_only)
+    result = agent("go")
+
+    assert result.stop_reason == "end_turn"
+    # Only the final turn's text is emitted; the intermediate tool-use turn's text is suppressed.
+    assert emitted_text == ["The answer is 42."]
+
+
+def test_wrap_can_inject_trailing_event_after_stop(agent):
+    """Middleware may yield events after the terminal stop event; the result stays authoritative.
+
+    The result derives from the last EventLoopStopEvent, not the last event overall, so a
+    trailing non-stop event injected after the stream does not displace the result.
+    """
+
+    async def inject_trailing(context, next_fn):
+        async for event in next_fn(context):
+            yield event
+        yield InitEventLoopEvent()  # trailing non-stop event after the result
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, inject_trailing)
+    result = agent("Test prompt")
+
+    assert result.stop_reason == "end_turn"
+    assert result.message["content"][0]["text"] == "Hello!"
+
+
+def test_wrap_can_suppress_all_events_except_result(agent):
+    """Middleware can drop every streamed event and still produce the result from the stop event."""
+
+    async def suppress_non_results(context, next_fn):
+        async for event in next_fn(context):
+            if isinstance(event, EventLoopStopEvent):
+                yield event
+
+    events = []
+
+    async def observer(context, next_fn):
+        async for event in next_fn(context):
+            events.append(event)
+            yield event
+
+    # observer (outer) sees only what suppress_non_results (inner) let through.
+    agent._middleware_registry.add_middleware(AgentStreamStage, observer)
+    agent._middleware_registry.add_middleware(AgentStreamStage, suppress_non_results)
+    result = agent("Test prompt")
+
+    assert all(isinstance(event, EventLoopStopEvent) for event in events)
+    assert result.stop_reason == "end_turn"
+
+
+def test_wrap_dropping_stop_event_raises_actionable_error(agent):
+    """Dropping the terminal stop event produces an actionable RuntimeError, not an opaque KeyError."""
+
+    async def drop_stop(context, next_fn):
+        async for event in next_fn(context):
+            if not isinstance(event, EventLoopStopEvent):
+                yield event
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, drop_stop)
+
+    with pytest.raises(RuntimeError, match="no result event"):
+        agent("Test prompt")
+
+
+# --- input / output phases ---
+
+
+def test_input_transforms_context_reaches_event_loop(agent):
+    """A replace()-based context transform reaches the event loop, not just the next middleware.
+
+    The terminal must run against the (possibly transformed) context it receives — a handler
+    returning ``replace(context, invocation_state=...)`` must have that replacement drive the
+    event loop cycle, or the transform is silently dropped.
+    """
+    from strands.hooks import BeforeModelCallEvent
+
+    marker_seen_by_model = False
+
+    def inject_marker(context):
+        return replace(context, invocation_state={**context.invocation_state, "marker": "from_input"})
+
+    def check_invocation_state(event: BeforeModelCallEvent):
+        nonlocal marker_seen_by_model
+        marker_seen_by_model = event.invocation_state.get("marker") == "from_input"
+
+    agent.hooks.add_callback(BeforeModelCallEvent, check_invocation_state)
+    agent._middleware_registry.add_middleware(AgentStreamStage.Input, inject_marker)
+    agent("Test prompt")
+
+    assert marker_seen_by_model
+
+
+def test_phase_ordering_at_agent_level(agent):
+    """Input/Wrap/Output run in canonical order regardless of registration order."""
+    order: list[str] = []
+
+    def output_handler(result):
+        order.append("output")
+        return result
+
+    async def wrap_handler(context, next_fn):
+        order.append("wrap")
+        async for event in next_fn(context):
+            yield event
+
+    def input_handler(context):
+        order.append("input")
+        return context
+
+    agent._middleware_registry.add_middleware(AgentStreamStage.Output, output_handler)
+    agent._middleware_registry.add_middleware(AgentStreamStage, wrap_handler)
+    agent._middleware_registry.add_middleware(AgentStreamStage.Input, input_handler)
+    agent("Test prompt")
+
+    assert order == ["input", "wrap", "output"]
+
+
+# --- no-middleware baseline ---
+
+
+def test_no_agent_stream_middleware_works(agent):
+    """With no AgentStreamStage middleware, the agent behaves normally (zero-overhead fast path)."""
+    result = agent("hello")
+    assert result.stop_reason == "end_turn"
+    assert result.message["content"][0]["text"] == "Hello!"
+
+
+def test_other_stage_middleware_does_not_affect_agent_stream():
+    """Middleware on InvokeModelStage does not run as AgentStreamStage middleware."""
+    from strands._middleware.stages import InvokeModelStage
+
+    model = MockedModelProvider([{"role": "assistant", "content": [{"text": "ok"}]}])
+    agent = Agent(model=model, callback_handler=None)
+
+    agent_stream_ran = False
+
+    async def invoke_model_mw(context, next_fn):
+        async for event in next_fn(context):
+            yield event
+
+    async def agent_stream_mw(context, next_fn):
+        nonlocal agent_stream_ran
+        agent_stream_ran = True
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(InvokeModelStage, invoke_model_mw)
+    agent("test")
+
+    assert not agent_stream_ran
+
+
+# --- interrupts ---
+
+
+def test_middleware_interrupt_halts_agent(agent):
+    """Calling context.interrupt() with no prior response halts the agent with stop_reason interrupt."""
+
+    async def gate(context, next_fn):
+        context.interrupt("confirm_stream", reason="Are you sure?")
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, gate)
+    result = agent("Test")
+
+    assert result.stop_reason == "interrupt"
+    assert len(result.interrupts) == 1
+    assert result.interrupts[0].name == "confirm_stream"
+    assert result.interrupts[0].reason == "Are you sure?"
+
+
+def test_middleware_interrupt_does_not_call_model(agent):
+    """An AgentStreamStage interrupt stops before the model is invoked."""
+    agent.model.stream = _fail_if_called
+
+    async def gate(context, next_fn):
+        context.interrupt("gate")
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, gate)
+    result = agent("Test")
+
+    assert result.stop_reason == "interrupt"
+
+
+def test_middleware_interrupt_id_uses_agent_stream_namespace(agent):
+    """The interrupt id is namespaced to the agent-stream stage and stable across resumes."""
+
+    async def gate(context, next_fn):
+        context.interrupt("my_gate")
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, gate)
+    result = agent("Test")
+
+    assert result.interrupts[0].id.startswith("v1:middleware_agent_stream:")
+
+
+def test_middleware_interrupt_registered_in_state(agent):
+    """When AgentStreamStage middleware interrupts, the interrupt is registered in agent state."""
+
+    async def gate(context, next_fn):
+        context.interrupt("gate", reason="confirm")
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, gate)
+    result = agent("Test")
+
+    assert result.stop_reason == "interrupt"
+    assert len(agent._interrupt_state.interrupts) == 1
+
+
+def test_middleware_gets_response_on_resume_and_continues():
+    """After resuming, interrupt() returns the response (wrapped) and the stream continues to end_turn."""
+    model = MockedModelProvider(
+        [
+            {"role": "assistant", "content": [{"text": "Hello!"}]},
+            {"role": "assistant", "content": [{"text": "Hello!"}]},
+        ]
+    )
+    agent = Agent(model=model, callback_handler=None)
+
+    interrupt_result = None
+
+    async def gate(context, next_fn):
+        nonlocal interrupt_result
+        interrupt_result = context.interrupt("gate", reason="Proceed?")
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, gate)
+
+    result = agent("Test")
+    assert result.stop_reason == "interrupt"
+
+    result = agent([{"interruptResponse": {"interruptId": result.interrupts[0].id, "response": "go"}}])
+    # interrupt() returns the response wrapped in a MiddlewareInterruptResult on resume.
+    assert isinstance(interrupt_result, MiddlewareInterruptResult)
+    assert interrupt_result.response == "go"
+    assert result.stop_reason == "end_turn"
+    assert result.message["content"][0]["text"] == "Hello!"
+
+
+def test_middleware_interrupt_with_preemptive_response_skips_interrupt(agent):
+    """Providing a preemptive response skips the interrupt entirely and the stream runs."""
+    skipped = False
+
+    async def gate(context, next_fn):
+        nonlocal skipped
+        interrupt_result = context.interrupt("gate", response="pre-approved")
+        skipped = interrupt_result.response == "pre-approved"
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, gate)
+    result = agent("Test")
+
+    assert result.stop_reason == "end_turn"
+    assert skipped
+
+
+def test_resumed_interrupt_deactivates_state_after_completion():
+    """After a resumed AgentStreamStage interrupt completes with end_turn, interrupt state clears.
+
+    An agent-stream interrupt activates the interrupt state without a pending tool execution,
+    so unless the run loop deactivates on non-interrupt completion, the state would leak and
+    break the next fresh invocation. This guards that lifecycle.
+    """
+    model = MockedModelProvider(
+        [
+            {"role": "assistant", "content": [{"text": "First"}]},
+            {"role": "assistant", "content": [{"text": "Second"}]},
+        ]
+    )
+    agent = Agent(model=model, callback_handler=None)
+
+    interrupted_once = False
+
+    async def gate(context, next_fn):
+        nonlocal interrupted_once
+        if not interrupted_once:
+            interrupted_once = True
+            context.interrupt("gate")
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, gate)
+
+    result = agent("Test")
+    assert result.stop_reason == "interrupt"
+
+    result = agent([{"interruptResponse": {"interruptId": result.interrupts[0].id, "response": "go"}}])
+    assert result.stop_reason == "end_turn"
+    # State is clean so a subsequent fresh invocation is not rejected.
+    assert not agent._interrupt_state.activated
+    assert agent._interrupt_state.interrupts == {}
+
+
+def test_resumed_interrupt_can_proceed_into_a_tool_call():
+    """A resumed AgentStreamStage interrupt whose pass then calls a tool completes cleanly.
+
+    An agent-stream interrupt activates interrupt state with an empty context (no tool context).
+    On resume the pass falls through to a normal model call that may return a tool_use, so the
+    tool-execution path's context reads are gated on the presence of tool context rather than on
+    `activated` alone — a resumed agent-stream interrupt that proceeds into a tool call runs and
+    finishes without tripping over the empty context.
+    """
+    tool_use_msg = {
+        "role": "assistant",
+        "content": [{"toolUse": {"toolUseId": "t1", "name": "calc", "input": {}}}],
+    }
+    final_msg = {"role": "assistant", "content": [{"text": "done"}]}
+    model = MockedModelProvider([tool_use_msg, final_msg])
+
+    @strands.tool(name="calc")
+    def calc() -> str:
+        """Return a constant."""
+        return "42"
+
+    agent = Agent(model=model, tools=[calc], callback_handler=None)
+
+    interrupted_once = False
+
+    async def gate(context, next_fn):
+        nonlocal interrupted_once
+        if not interrupted_once:
+            interrupted_once = True
+            context.interrupt("gate")
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, gate)
+
+    result = agent("go")
+    assert result.stop_reason == "interrupt"
+
+    result = agent([{"interruptResponse": {"interruptId": result.interrupts[0].id, "response": "go"}}])
+    assert result.stop_reason == "end_turn"
+    assert result.message["content"][0]["text"] == "done"
+
+
+def test_resumed_interrupt_reads_response_after_a_tool_cycle_runs():
+    """A gate that re-reads its approval after next_fn drains still sees it when a tool ran.
+
+    The middleware resolves its interrupt before next_fn and re-reads it after the chain drains.
+    The inner pass runs a tool, whose successful cycle deactivates interrupt state in the event
+    loop. The re-read must still return the resumed response (from a snapshot taken before the
+    pass) rather than re-raising — otherwise the resume never converges.
+    """
+    tool_use_msg = {
+        "role": "assistant",
+        "content": [{"toolUse": {"toolUseId": "t1", "name": "calc", "input": {}}}],
+    }
+    final_msg = {"role": "assistant", "content": [{"text": "done"}]}
+    model = MockedModelProvider([tool_use_msg, final_msg])
+
+    @strands.tool(name="calc")
+    def calc() -> str:
+        """Return a constant."""
+        return "42"
+
+    agent = Agent(model=model, tools=[calc], callback_handler=None)
+
+    reads: list[tuple[str, object]] = []
+
+    async def gate(context, next_fn):
+        pre = context.interrupt("gate")
+        reads.append(("pre", pre.response))
+        async for event in next_fn(context):
+            yield event
+        post = context.interrupt("gate")
+        reads.append(("post", post.response))
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, gate)
+
+    result = agent("go")
+    assert result.stop_reason == "interrupt"
+
+    result = agent([{"interruptResponse": {"interruptId": result.interrupts[0].id, "response": "go"}}])
+    assert result.stop_reason == "end_turn"
+    assert result.message["content"][0]["text"] == "done"
+    # Both the pre- and post-next_fn reads saw the resumed response (no re-raise mid-pass).
+    assert reads == [("pre", "go"), ("post", "go")]
+
+
+def test_resumed_agent_stream_interrupt_then_tool_interrupt():
+    """A resumed agent-stream interrupt whose pass then raises a tool interrupt stops cleanly.
+
+    Exercises the interaction between the two interrupt mechanisms: the agent-stream interrupt is
+    resolved on resume (it carries a response, so it will not re-raise) while a fresh tool
+    interrupt is raised in the same pass. The pass must stop with the tool interrupt, and resuming
+    that one must drive the invocation to completion.
+    """
+    tool_use_msg = {
+        "role": "assistant",
+        "content": [{"toolUse": {"toolUseId": "t1", "name": "confirm_tool", "input": {}}}],
+    }
+    final_msg = {"role": "assistant", "content": [{"text": "done"}]}
+    model = MockedModelProvider([tool_use_msg, final_msg])
+
+    @strands.tool(name="confirm_tool", context=True)
+    def confirm_tool(tool_context) -> str:
+        """Interrupt for approval, then return once resumed."""
+        return tool_context.interrupt("tool_gate", reason="approve tool?")
+
+    agent = Agent(model=model, tools=[confirm_tool], callback_handler=None)
+
+    stream_interrupted_once = False
+
+    async def gate(context, next_fn):
+        nonlocal stream_interrupted_once
+        if not stream_interrupted_once:
+            stream_interrupted_once = True
+            context.interrupt("stream_gate")
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, gate)
+
+    # Pass 1: the agent-stream middleware interrupt halts the invocation.
+    result = agent("go")
+    assert result.stop_reason == "interrupt"
+    assert result.interrupts[0].name == "stream_gate"
+
+    # Pass 2: resume the agent-stream interrupt; the pass runs the model, calls the tool, and
+    # the tool raises its own interrupt.
+    result = agent([{"interruptResponse": {"interruptId": result.interrupts[0].id, "response": "go"}}])
+    assert result.stop_reason == "interrupt"
+    assert result.interrupts[0].name == "tool_gate"
+
+    # Pass 3: resume the tool interrupt; the invocation completes.
+    result = agent([{"interruptResponse": {"interruptId": result.interrupts[0].id, "response": "yes"}}])
+    assert result.stop_reason == "end_turn"
+    assert result.message["content"][0]["text"] == "done"
+    # No interrupt state leaks past a clean completion.
+    assert not agent._interrupt_state.activated
+    assert agent._interrupt_state.interrupts == {}
+
+
+def test_cancel_during_agent_stream_interrupt_resume_clears_state():
+    """Cancelling a resumed AgentStreamStage interrupt clears the interrupt state.
+
+    An agent-stream interrupt never stores tool context, so a cancelled resume ends the pass
+    with stop_reason "cancelled" and the run loop deactivates the interrupt state — the agent is
+    left clean and reusable. (This is the agent-stream counterpart to a tool interrupt, whose
+    state the event loop deliberately preserves across a cancelled resume.)
+    """
+    model = MockedModelProvider(
+        [
+            {"role": "assistant", "content": [{"text": "First"}]},
+            {"role": "assistant", "content": [{"text": "Second"}]},
+        ]
+    )
+    agent = Agent(model=model, callback_handler=None)
+
+    interrupted_once = False
+
+    async def gate(context, next_fn):
+        nonlocal interrupted_once
+        if not interrupted_once:
+            interrupted_once = True
+            context.interrupt("gate")
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, gate)
+
+    result = agent("Test")
+    assert result.stop_reason == "interrupt"
+
+    # Cancel the resume; the pass ends cancelled and the agent-stream interrupt state is cleared.
+    agent.cancel()
+    result = agent([{"interruptResponse": {"interruptId": result.interrupts[0].id, "response": "go"}}])
+
+    assert result.stop_reason == "cancelled"
+    assert not agent._interrupt_state.activated
+    assert agent._interrupt_state.interrupts == {}
+
+
+def test_sequential_agent_stream_interrupts_across_passes():
+    """Two agent-stream interrupts in a row each halt and resume, cycling activate/deactivate.
+
+    The chain is rebuilt per pass, so the interrupt state must fully reset between them: a first
+    interrupt halts and resumes, a second (distinct) interrupt halts and resumes, and the final
+    pass completes with clean state. This guards the activate -> deactivate -> activate ->
+    deactivate lifecycle the run loop drives across passes.
+    """
+    model = MockedModelProvider(
+        [
+            {"role": "assistant", "content": [{"text": "a"}]},
+            {"role": "assistant", "content": [{"text": "b"}]},
+            {"role": "assistant", "content": [{"text": "c"}]},
+        ]
+    )
+    agent = Agent(model=model, callback_handler=None)
+
+    pass_count = 0
+
+    async def gate(context, next_fn):
+        nonlocal pass_count
+        pass_count += 1
+        if pass_count in (1, 2):
+            context.interrupt(f"gate_{pass_count}")
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, gate)
+
+    result = agent("go")
+    assert result.stop_reason == "interrupt"
+    assert result.interrupts[0].name == "gate_1"
+
+    result = agent([{"interruptResponse": {"interruptId": result.interrupts[0].id, "response": "x"}}])
+    assert result.stop_reason == "interrupt"
+    assert result.interrupts[0].name == "gate_2"
+
+    result = agent([{"interruptResponse": {"interruptId": result.interrupts[0].id, "response": "y"}}])
+    assert result.stop_reason == "end_turn"
+    assert not agent._interrupt_state.activated
+    assert agent._interrupt_state.interrupts == {}
+
+
+def test_interrupt_message_uses_last_message_when_messages_exist(agent):
+    """The interrupt result message is the last message in history.
+
+    Python appends the prompt to history before the AgentStreamStage chain runs, so at interrupt
+    time ``self.messages[-1]`` is the current pass's user prompt (unlike TS, which appends inside
+    ``next()`` and so hits the "Interrupted" fallback for a fresh agent). This pins the Python
+    behavior — the result message is the last existing message.
+    """
+
+    async def gate(context, next_fn):
+        context.interrupt("gate")
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, gate)
+    result = agent("Test")
+
+    assert result.stop_reason == "interrupt"
+    assert result.message == agent.messages[-1]
+
+
+# --- hooks fire outside the middleware chain ---
+
+
+def test_invocation_hooks_fire_outside_agent_stream_middleware(agent):
+    """Before/AfterInvocationEvent fire outside the AgentStreamStage chain (before/after it)."""
+    from strands.hooks import AfterInvocationEvent, BeforeInvocationEvent
+
+    order: list[str] = []
+
+    class RecordingHooks:
+        def register_hooks(self, registry, **kwargs):
+            registry.add_callback(BeforeInvocationEvent, lambda event: order.append("before_invocation"))
+            registry.add_callback(AfterInvocationEvent, lambda event: order.append("after_invocation"))
+
+    agent.hooks.add_hook(RecordingHooks())
+
+    async def middleware(context, next_fn):
+        order.append("middleware-before")
+        async for event in next_fn(context):
+            yield event
+        order.append("middleware-after")
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, middleware)
+    agent("Test prompt")
+
+    assert order == ["before_invocation", "middleware-before", "middleware-after", "after_invocation"]
+
+
+def test_after_invocation_hook_fires_when_middleware_short_circuits(agent):
+    """AfterInvocationEvent still fires (in the finally) when middleware short-circuits the pass."""
+    from strands.hooks import AfterInvocationEvent
+
+    after_fired = False
+
+    class RecordingHooks:
+        def register_hooks(self, registry, **kwargs):
+            def _record(event):
+                nonlocal after_fired
+                after_fired = True
+
+            registry.add_callback(AfterInvocationEvent, _record)
+
+    agent.hooks.add_hook(RecordingHooks())
+
+    async def short_circuit(context, next_fn):
+        message = {"role": "assistant", "content": [{"text": "Short-circuited"}]}
+        yield EventLoopStopEvent("end_turn", message, EventLoopMetrics(), {})
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, short_circuit)
+    agent("Test prompt")
+
+    assert after_fired
+
+
+def test_context_replace_preserves_interrupt(agent):
+    """dataclasses.replace() on AgentStreamContext preserves interrupt functionality."""
+
+    async def replace_then_interrupt(context, next_fn):
+        modified = replace(context, invocation_state={**context.invocation_state, "tagged": True})
+        modified.interrupt("gate")
+        async for event in next_fn(modified):
+            yield event
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, replace_then_interrupt)
+    result = agent("Test")
+
+    assert result.stop_reason == "interrupt"
+    assert result.interrupts[0].id.startswith("v1:middleware_agent_stream:")
+
+
+# --- tool interrupts still surface through the agent-stream chain ---
+
+
+def test_tool_interrupt_surfaces_through_agent_stream_chain():
+    """A tool-originated interrupt flows through AgentStreamStage middleware as a normal event."""
+
+    @strands.tool(name="interrupting_tool", context=True)
+    def interrupting_tool(tool_context) -> str:
+        """Interrupts on first call."""
+        return tool_context.interrupt("confirm", reason="approve?")
+
+    tool_use_msg = {
+        "role": "assistant",
+        "content": [{"toolUse": {"toolUseId": "t1", "name": "interrupting_tool", "input": {}}}],
+    }
+    final_msg = {"role": "assistant", "content": [{"text": "done"}]}
+    model = MockedModelProvider([tool_use_msg, final_msg])
+    agent = Agent(model=model, tools=[interrupting_tool], callback_handler=None)
+
+    async def passthrough(context, next_fn):
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, passthrough)
+    result = agent("go")
+
+    assert result.stop_reason == "interrupt"
+    assert result.interrupts[0].name == "confirm"
+
+
+def test_agent_stream_interrupt_reports_all_unanswered_interrupts():
+    """An agent-stream interrupt reports every still-unanswered interrupt, not just the one it raised.
+
+    Mixing interrupt sources within one invocation: a tool raises two interrupts, the caller
+    resumes only one, and on the resumed pass an agent-stream middleware raises a fresh one. The
+    resulting stop must report both the still-unanswered tool interrupt and the new agent-stream
+    one, so a caller treating ``result.interrupts`` as "everything I owe an answer to" is correct.
+    """
+    from strands.interrupt import Interrupt
+    from strands.types._events import ToolInterruptEvent
+
+    @strands.tool(name="multi_tool")
+    def multi_tool() -> str:
+        """Placeholder; real behavior is in the custom stream below."""
+        return "unused"
+
+    tool_interrupts = [
+        Interrupt(id="v1:tool:a", name="gate_a", reason="a?"),
+        Interrupt(id="v1:tool:b", name="gate_b", reason="b?"),
+    ]
+
+    async def multi_stream(tool_use, _invocation_state, **_kwargs):
+        yield ToolInterruptEvent(tool_use, tool_interrupts)
+
+    multi_tool.stream = multi_stream
+
+    tool_use_msg = {
+        "role": "assistant",
+        "content": [{"toolUse": {"toolUseId": "t1", "name": "multi_tool", "input": {}}}],
+    }
+    model = MockedModelProvider([tool_use_msg, {"role": "assistant", "content": [{"text": "done"}]}])
+    agent = Agent(model=model, tools=[multi_tool], callback_handler=None)
+
+    raise_stream_gate = False
+
+    async def gate(context, next_fn):
+        if raise_stream_gate:
+            context.interrupt("stream_gate", reason="confirm stream?")
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, gate)
+
+    # Pass 1: tool raises two interrupts.
+    result = agent("go")
+    assert result.stop_reason == "interrupt"
+    assert {interrupt.name for interrupt in result.interrupts} == {"gate_a", "gate_b"}
+
+    # Pass 2: answer only gate_a; the agent-stream middleware raises stream_gate on the resumed pass.
+    raise_stream_gate = True
+    result = agent([{"interruptResponse": {"interruptId": "v1:tool:a", "response": "yes"}}])
+
+    assert result.stop_reason == "interrupt"
+    # Both the still-unanswered tool interrupt and the fresh agent-stream one are reported.
+    assert {interrupt.name for interrupt in result.interrupts} == {"gate_b", "stream_gate"}
+
+
+async def _fail_if_called(*args, **kwargs):
+    raise AssertionError("model.stream must not be called")
+    yield  # noqa: B901  # make this an async generator

--- a/strands-py/tests/strands/middleware/test_agent_stream_middleware.py
+++ b/strands-py/tests/strands/middleware/test_agent_stream_middleware.py
@@ -1273,8 +1273,14 @@ def test_answered_interrupt_is_released_when_a_pass_ends_with_an_error():
     with pytest.raises(RuntimeError, match="session write failed"):
         agent(_approve(first))
 
+    assert agent._interrupt_state.interrupts == {}
+
+    # The next cycle raises its own unanswered interrupt rather than inheriting the answered one,
+    # which would leave the caller told to respond with nothing to respond to.
     charges.clear()
-    assert agent("charge $9999").stop_reason == "interrupt"
+    third = agent("charge $9999")
+    assert third.stop_reason == "interrupt"
+    assert [(interrupt.name, interrupt.response) for interrupt in third.interrupts] == [("approve_charge", None)]
     assert charges == []
 
 

--- a/strands-py/tests/strands/middleware/test_agent_stream_middleware.py
+++ b/strands-py/tests/strands/middleware/test_agent_stream_middleware.py
@@ -64,11 +64,7 @@ def test_wrap_receives_agent_stream_context(agent):
 
 
 def test_context_invocation_state_shared_by_reference(agent):
-    """invocation_state is shared by reference: the context holds the caller's dict and mutations stick.
-
-    Mirrors the TS copy-on-input suite, which pins that AgentStreamContext shares args/options by
-    reference. Python's analog is invocation_state (see the README "shared by reference" callout).
-    """
+    """invocation_state is shared by reference: mutations in middleware are visible to the caller."""
     caller_state = {"key": "value"}
     is_same_object = False
 
@@ -152,13 +148,7 @@ def test_wrap_can_filter_events(agent):
 
 
 def test_wrap_buffers_content_across_a_multi_turn_pass():
-    """Middleware wraps a whole multi-cycle pass and can suppress intermediate-turn content.
-
-    A single AgentStreamStage pass spans every event-loop cycle of the invocation (tool-use turn
-    then follow-up turn), so middleware can buffer text deltas per turn and emit only the final
-    turn's — the TS "stream final turn only" use case. This exercises the stage across more than
-    one turn, which the single-turn wrap tests do not.
-    """
+    """Middleware wraps a whole multi-cycle pass and can suppress intermediate-turn content."""
     tool_use_msg = {
         "role": "assistant",
         "content": [{"text": "Let me calculate.", "toolUse": {"toolUseId": "t1", "name": "calc", "input": {}}}],
@@ -263,12 +253,7 @@ def test_wrap_dropping_stop_event_raises_actionable_error(agent):
 
 
 def test_input_transforms_context_reaches_event_loop(agent):
-    """A replace()-based context transform reaches the event loop, not just the next middleware.
-
-    The terminal must run against the (possibly transformed) context it receives — a handler
-    returning ``replace(context, invocation_state=...)`` must have that replacement drive the
-    event loop cycle, or the transform is silently dropped.
-    """
+    """A replace()-based context transform reaches the event loop."""
     from strands.hooks import BeforeModelCallEvent
 
     marker_seen_by_model = False
@@ -288,13 +273,7 @@ def test_input_transforms_context_reaches_event_loop(agent):
 
 
 def test_messages_in_place_edit_reaches_history_but_replace_is_dropped(agent):
-    """`messages` is shared by reference for in-place edits; ``replace(messages=...)`` is dropped.
-
-    Input messages are appended to ``agent.messages`` before the chain runs, so mutating a message
-    in place reaches the model, but swapping the list on the context does not (the terminal streams
-    against ``agent.messages``, not ``ctx.messages``). This documents the deliberate asymmetry with
-    ``invocation_state`` (which the terminal does read from the context).
-    """
+    """`messages` is shared by reference for in-place edits; `replace(messages=...)` is silently dropped."""
 
     async def edit_in_place(context, next_fn):
         context.messages[0]["content"] = [{"text": "mutated-in-place"}]
@@ -497,12 +476,7 @@ def test_middleware_interrupt_with_preemptive_response_skips_interrupt(agent):
 
 
 def test_resumed_interrupt_deactivates_state_after_completion():
-    """After a resumed AgentStreamStage interrupt completes with end_turn, interrupt state clears.
-
-    An agent-stream interrupt activates the interrupt state without a pending tool execution,
-    so unless the run loop deactivates on non-interrupt completion, the state would leak and
-    break the next fresh invocation. This guards that lifecycle.
-    """
+    """After a resumed interrupt completes with end_turn, interrupt state is deactivated."""
     model = MockedModelProvider(
         [
             {"role": "assistant", "content": [{"text": "First"}]},
@@ -534,14 +508,7 @@ def test_resumed_interrupt_deactivates_state_after_completion():
 
 
 def test_resumed_interrupt_can_proceed_into_a_tool_call():
-    """A resumed AgentStreamStage interrupt whose pass then calls a tool completes cleanly.
-
-    An agent-stream interrupt activates interrupt state with an empty context (no tool context).
-    On resume the pass falls through to a normal model call that may return a tool_use, so the
-    tool-execution path's context reads are gated on the presence of tool context rather than on
-    `activated` alone — a resumed agent-stream interrupt that proceeds into a tool call runs and
-    finishes without tripping over the empty context.
-    """
+    """A resumed agent-stream interrupt whose pass calls a tool completes without error."""
     tool_use_msg = {
         "role": "assistant",
         "content": [{"toolUse": {"toolUseId": "t1", "name": "calc", "input": {}}}],
@@ -577,13 +544,7 @@ def test_resumed_interrupt_can_proceed_into_a_tool_call():
 
 
 def test_resumed_interrupt_reads_response_after_a_tool_cycle_runs():
-    """A gate that re-reads its approval after next_fn drains still sees it when a tool ran.
-
-    The middleware resolves its interrupt before next_fn and re-reads it after the chain drains.
-    The inner pass runs a tool, whose successful cycle deactivates interrupt state in the event
-    loop. The re-read must still return the resumed response (from a snapshot taken before the
-    pass) rather than re-raising — otherwise the resume never converges.
-    """
+    """A gate that re-reads its approval after next_fn drains still resolves when a tool cycle ran."""
     tool_use_msg = {
         "role": "assistant",
         "content": [{"toolUse": {"toolUseId": "t1", "name": "calc", "input": {}}}],
@@ -621,13 +582,7 @@ def test_resumed_interrupt_reads_response_after_a_tool_cycle_runs():
 
 
 def test_resumed_agent_stream_interrupt_then_tool_interrupt():
-    """A resumed agent-stream interrupt whose pass then raises a tool interrupt stops cleanly.
-
-    Exercises the interaction between the two interrupt mechanisms: the agent-stream interrupt is
-    resolved on resume (it carries a response, so it will not re-raise) while a fresh tool
-    interrupt is raised in the same pass. The pass must stop with the tool interrupt, and resuming
-    that one must drive the invocation to completion.
-    """
+    """A resumed agent-stream interrupt followed by a tool interrupt stops and resumes cleanly."""
     tool_use_msg = {
         "role": "assistant",
         "content": [{"toolUse": {"toolUseId": "t1", "name": "confirm_tool", "input": {}}}],
@@ -675,13 +630,7 @@ def test_resumed_agent_stream_interrupt_then_tool_interrupt():
 
 
 def test_cancel_during_agent_stream_interrupt_resume_clears_state():
-    """Cancelling a resumed AgentStreamStage interrupt clears the interrupt state.
-
-    An agent-stream interrupt never stores tool context, so a cancelled resume ends the pass
-    with stop_reason "cancelled" and the run loop deactivates the interrupt state — the agent is
-    left clean and reusable. (This is the agent-stream counterpart to a tool interrupt, whose
-    state the event loop deliberately preserves across a cancelled resume.)
-    """
+    """Cancelling a resumed agent-stream interrupt clears the interrupt state."""
     model = MockedModelProvider(
         [
             {"role": "assistant", "content": [{"text": "First"}]},
@@ -715,13 +664,7 @@ def test_cancel_during_agent_stream_interrupt_resume_clears_state():
 
 
 def test_sequential_agent_stream_interrupts_across_passes():
-    """Two agent-stream interrupts in a row each halt and resume, cycling activate/deactivate.
-
-    The chain is rebuilt per pass, so the interrupt state must fully reset between them: a first
-    interrupt halts and resumes, a second (distinct) interrupt halts and resumes, and the final
-    pass completes with clean state. This guards the activate -> deactivate -> activate ->
-    deactivate lifecycle the run loop drives across passes.
-    """
+    """Two sequential agent-stream interrupts each halt and resume independently."""
     model = MockedModelProvider(
         [
             {"role": "assistant", "content": [{"text": "a"}]},
@@ -758,13 +701,7 @@ def test_sequential_agent_stream_interrupts_across_passes():
 
 
 def test_interrupt_message_uses_last_message_when_messages_exist(agent):
-    """The interrupt result message is the last message in history.
-
-    Python appends the prompt to history before the AgentStreamStage chain runs, so at interrupt
-    time ``self.messages[-1]`` is the current pass's user prompt (unlike TS, which appends inside
-    ``next()`` and so hits the "Interrupted" fallback for a fresh agent). This pins the Python
-    behavior — the result message is the last existing message.
-    """
+    """The interrupt result message is the last message in history (the user prompt)."""
 
     async def gate(context, next_fn):
         context.interrupt("gate")
@@ -833,19 +770,12 @@ def test_after_invocation_hook_fires_when_middleware_short_circuits(agent):
 
 
 def test_user_message_added_hook_fires_before_the_chain(agent):
-    """The input MessageAddedEvent fires before the AgentStreamStage chain, not inside it.
-
-    Input messages are appended to history before the chain runs, so a wrap middleware sees the
-    user turn already in ``agent.messages`` when it starts. This pins that ordering (a divergence
-    from TS, which appends inside the terminal) so it can't regress silently.
-    """
+    """The input MessageAddedEvent fires before the AgentStreamStage chain starts."""
     from strands.hooks import MessageAddedEvent
 
     order: list[str] = []
 
-    agent.hooks.add_callback(
-        MessageAddedEvent, lambda event: order.append(f"msg_added:{event.message['role']}")
-    )
+    agent.hooks.add_callback(MessageAddedEvent, lambda event: order.append(f"msg_added:{event.message['role']}"))
 
     async def middleware(context, next_fn):
         order.append("middleware-before")
@@ -861,12 +791,7 @@ def test_user_message_added_hook_fires_before_the_chain(agent):
 
 
 def test_user_message_added_hook_fires_even_when_middleware_short_circuits(agent):
-    """The input MessageAddedEvent fires even when a middleware short-circuits the pass.
-
-    Because the input is appended before the chain, a short-circuit (which never runs the
-    terminal) still records the user turn in history and still fires MessageAddedEvent — unlike
-    TS, where the append lives in the terminal and is skipped on short-circuit.
-    """
+    """The input MessageAddedEvent fires even when middleware short-circuits the pass."""
     from strands.hooks import MessageAddedEvent
 
     added_roles: list[str] = []
@@ -932,13 +857,7 @@ def test_tool_interrupt_surfaces_through_agent_stream_chain():
 
 
 def test_agent_stream_interrupt_reports_all_unanswered_interrupts():
-    """An agent-stream interrupt reports every still-unanswered interrupt, not just the one it raised.
-
-    Mixing interrupt sources within one invocation: a tool raises two interrupts, the caller
-    resumes only one, and on the resumed pass an agent-stream middleware raises a fresh one. The
-    resulting stop must report both the still-unanswered tool interrupt and the new agent-stream
-    one, so a caller treating ``result.interrupts`` as "everything I owe an answer to" is correct.
-    """
+    """An agent-stream interrupt reports all unanswered interrupts, not just the one it raised."""
     from strands.interrupt import Interrupt
     from strands.types._events import ToolInterruptEvent
 
@@ -989,13 +908,7 @@ def test_agent_stream_interrupt_reports_all_unanswered_interrupts():
 
 
 def test_resumed_interrupt_is_not_re_asked_after_a_later_tool_interrupt():
-    """An answered gate is asked once, even when a later pass of the same cycle interrupts again.
-
-    The gate reads its approval before next_fn only. The resumed pass runs a successful tool cycle
-    (which completes the tool resume) and then a second tool raises its own interrupt, so a further
-    pass follows. The gate's answer must survive those passes: asking again would make the human
-    re-approve the same action once per interrupt round trip.
-    """
+    """An answered gate is not re-asked on later passes within the same interrupt cycle."""
     model = MockedModelProvider(
         [
             {"role": "assistant", "content": [{"toolUse": {"toolUseId": "t1", "name": "calc", "input": {}}}]},
@@ -1038,14 +951,7 @@ def test_resumed_interrupt_is_not_re_asked_after_a_later_tool_interrupt():
 
 
 def test_answered_interrupt_is_not_reused_by_a_later_invocation():
-    """A gate's answer dies with its interrupt cycle, so the next invocation asks again.
-
-    The answered response is kept across the passes of one cycle (so the human is asked once),
-    which must not turn into a standing approval. The resumed pass here runs a tool, so the tool
-    cycle completes the tool resume and leaves the state deactivated with the answer still held —
-    the cycle therefore ends without the run loop's interrupt-completion path firing, and the
-    answer has to be dropped anyway.
-    """
+    """A gate's answer does not carry over to the next invocation — the human is asked again."""
     model = MockedModelProvider(
         [
             {"role": "assistant", "content": [{"toolUse": {"toolUseId": "t1", "name": "calc", "input": {}}}]},
@@ -1082,12 +988,7 @@ def test_answered_interrupt_is_not_reused_by_a_later_invocation():
 
 
 def test_interrupt_after_the_pass_completes_raises():
-    """Interrupting after the stream finished is refused instead of replaying the pass.
-
-    Resuming such an interrupt has no tool-use message to replay, so the event loop would call the
-    model a second time and append a duplicate assistant turn. The agent raises an actionable error
-    instead. Interrupting before or while draining next_fn is unaffected.
-    """
+    """Interrupting after the stream finished raises RuntimeError instead of corrupting history."""
     model = MockedModelProvider([{"role": "assistant", "content": [{"text": "Hello!"}]}])
     agent = Agent(model=model, callback_handler=None)
 
@@ -1130,11 +1031,7 @@ def test_after_invocation_result_is_the_stop_event_when_a_trailing_event_follows
 
 
 def test_middleware_yielded_interrupt_stop_preserves_interrupt_state():
-    """A pass that stops on an interrupt keeps its interrupt state, even with no tool context.
-
-    Middleware can surface an interrupt stop itself (short-circuiting the pass). The run loop must
-    not clear interrupt state after such a pass: the caller still owes a response.
-    """
+    """A pass that stops on an interrupt keeps its interrupt state active."""
     model = MockedModelProvider(
         [
             {"role": "assistant", "content": [{"text": "first"}]},
@@ -1209,13 +1106,7 @@ def _charge_gate(gate_calls):
 
 
 def test_answered_interrupt_is_not_persisted_as_a_standing_approval(tmp_path):
-    """A completed cycle leaves no answered interrupt in the session.
-
-    The cycle is released before ``AfterInvocationEvent``, which is where the session manager
-    syncs, so the persisted state carries no response. A fresh agent restored from that session —
-    the ordinary one-agent-per-request server shape — must gate again rather than resolve against
-    what the previous cycle answered.
-    """
+    """A completed cycle leaves no answered interrupt in the persisted session."""
     gate_calls: list[str] = []
     charges: list[str] = []
 
@@ -1242,12 +1133,7 @@ def test_answered_interrupt_is_not_persisted_as_a_standing_approval(tmp_path):
 
 
 def test_answered_interrupt_is_released_when_a_pass_ends_with_an_error():
-    """A raise from an AfterInvocationEvent hook does not strand an answered interrupt.
-
-    The hook runs inside the run loop's ``finally`` and is a public extension point, so a failure
-    there (a session write error, a summarizing conversation manager whose model call fails) must
-    not leave a response behind for the next cycle to resolve against.
-    """
+    """A raise from AfterInvocationEvent does not strand an answered interrupt."""
     from strands.hooks import AfterInvocationEvent
 
     gate_calls: list[str] = []
@@ -1281,11 +1167,7 @@ def test_answered_interrupt_is_released_when_a_pass_ends_with_an_error():
 
 @pytest.mark.asyncio
 async def test_answered_interrupt_is_not_reused_after_the_caller_abandons_the_stream():
-    """A caller that stops consuming the stream leaves no usable approval behind.
-
-    The run loop's cleanup only runs if the generator is driven to completion, so a disconnected
-    client must not leave a response that the next cycle's gate resolves against.
-    """
+    """A caller that stops consuming the stream leaves no usable approval behind."""
     gate_calls: list[str] = []
     charges: list[str] = []
     agent = _charging_agent(_charge_gate(gate_calls), charges)
@@ -1310,12 +1192,7 @@ async def test_answered_interrupt_is_not_reused_after_the_caller_abandons_the_st
 
 
 def test_interrupt_after_a_tool_interrupt_stop_is_allowed():
-    """Gating on top of a tool interrupt works: the stored tool use is replayed on resume.
-
-    Refusing a post-result interrupt is only correct when resuming would re-call the model. A pass
-    that stopped for a tool interrupt has a tool-use message to replay, so the pass-level gate can
-    still interrupt after the stream drains and the caller answers both in one round trip.
-    """
+    """Gating on top of a tool interrupt works: the stored tool use is replayed on resume."""
     tool_use = {
         "role": "assistant",
         "content": [{"toolUse": {"toolUseId": "t1", "name": "confirm_tool", "input": {}}}],
@@ -1350,11 +1227,7 @@ def test_interrupt_after_a_tool_interrupt_stop_is_allowed():
 
 
 def test_interrupt_after_the_pass_completes_on_a_resumed_pass_leaves_no_state():
-    """The refusal clears interrupt state, so the agent stays usable afterwards.
-
-    A refusal on a resumed pass would otherwise leave the state activated with an interrupt the
-    caller can no longer answer, wedging every later call.
-    """
+    """The refusal clears interrupt state, so the agent stays usable afterwards."""
     model = MockedModelProvider(
         [
             {"role": "assistant", "content": [{"text": "first"}]},
@@ -1404,12 +1277,7 @@ async def _drain_until_tool_result(agent, prompt):
 
 @pytest.mark.asyncio
 async def test_answered_interrupt_is_not_persisted_when_a_stream_is_abandoned(tmp_path):
-    """An abandoned stream leaves no answered interrupt in the session.
-
-    Sessions sync on every message added, including the one right after a tool cycle retains an
-    answered response, so keeping the retained response out of the session cannot rely on the
-    end-of-cycle release running.
-    """
+    """An abandoned stream leaves no answered interrupt in the persisted session."""
     gate_calls: list[str] = []
     charges: list[str] = []
 
@@ -1431,11 +1299,7 @@ async def test_answered_interrupt_is_not_persisted_when_a_stream_is_abandoned(tm
 
 @pytest.mark.asyncio
 async def test_restored_agent_reports_an_answerable_interrupt(tmp_path):
-    """A restored agent never reports an interrupt stop the caller cannot answer.
-
-    A stale answered entry would both satisfy the gate silently and be filtered out of the reported
-    interrupts, leaving the caller told to respond with nothing to respond to.
-    """
+    """A restored agent gates again rather than resolving against a stale approval."""
     gate_calls: list[str] = []
     charges: list[str] = []
 
@@ -1458,11 +1322,7 @@ async def test_restored_agent_reports_an_answerable_interrupt(tmp_path):
 
 
 def test_interrupt_after_a_middleware_yielded_result_is_allowed():
-    """Gating after a short-circuited pass works: nothing was produced for a resume to replay.
-
-    A middleware that yields the result itself never calls the model, so the resumed pass replays
-    nothing and re-yields the same result — there is no duplicate assistant turn to prevent.
-    """
+    """Gating after a short-circuited pass works since nothing was produced for a resume to replay."""
     agent = Agent(
         model=MockedModelProvider([{"role": "assistant", "content": [{"text": "unused"}]}]),
         callback_handler=None,
@@ -1486,11 +1346,7 @@ def test_interrupt_after_a_middleware_yielded_result_is_allowed():
 
 
 def test_answered_interrupt_is_released_when_conversation_management_raises():
-    """A failure in conversation management does not strand an answered interrupt.
-
-    apply_management runs inside the run loop's finally, so the release has to happen before it for
-    a raise there to leave nothing behind.
-    """
+    """A failure in conversation management does not strand an answered interrupt."""
     gate_calls: list[str] = []
     charges: list[str] = []
     agent = _charging_agent(_charge_gate(gate_calls), charges)

--- a/strands-py/tests/strands/middleware/test_agent_stream_middleware.py
+++ b/strands-py/tests/strands/middleware/test_agent_stream_middleware.py
@@ -1150,7 +1150,8 @@ def test_middleware_yielded_interrupt_stop_preserves_interrupt_state():
     async def gate(context, next_fn):
         if short_circuit:
             message = {"role": "assistant", "content": [{"text": "Awaiting approval"}]}
-            yield EventLoopStopEvent("interrupt", message, EventLoopMetrics(), {}, list(agent._interrupt_state.interrupts.values()))
+            pending = list(agent._interrupt_state.interrupts.values())
+            yield EventLoopStopEvent("interrupt", message, EventLoopMetrics(), {}, pending)
             return
         context.interrupt("stream_gate", reason="approve the pass?")
         async for event in next_fn(context):

--- a/strands-py/tests/strands/middleware/test_agent_stream_middleware.py
+++ b/strands-py/tests/strands/middleware/test_agent_stream_middleware.py
@@ -286,6 +286,42 @@ def test_input_transforms_context_reaches_event_loop(agent):
     assert marker_seen_by_model
 
 
+def test_messages_in_place_edit_reaches_history_but_replace_is_dropped(agent):
+    """`messages` is shared by reference for in-place edits; ``replace(messages=...)`` is dropped.
+
+    Input messages are appended to ``agent.messages`` before the chain runs, so mutating a message
+    in place reaches the model, but swapping the list on the context does not (the terminal streams
+    against ``agent.messages``, not ``ctx.messages``). This documents the deliberate asymmetry with
+    ``invocation_state`` (which the terminal does read from the context).
+    """
+
+    async def edit_in_place(context, next_fn):
+        context.messages[0]["content"] = [{"text": "mutated-in-place"}]
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, edit_in_place)
+    agent("original")
+
+    user_texts = [m["content"][0].get("text") for m in agent.messages if m["role"] == "user"]
+    assert user_texts == ["mutated-in-place"]
+
+    # A replace()-swapped list, by contrast, is not honored: history keeps the original input.
+    other_model = MockedModelProvider([{"role": "assistant", "content": [{"text": "ok"}]}])
+    other = Agent(model=other_model, callback_handler=None)
+
+    async def swap_list(context, next_fn):
+        modified = replace(context, messages=[{"role": "user", "content": [{"text": "replaced-list"}]}])
+        async for event in next_fn(modified):
+            yield event
+
+    other._middleware_registry.add_middleware(AgentStreamStage, swap_list)
+    other("original")
+
+    other_user_texts = [m["content"][0].get("text") for m in other.messages if m["role"] == "user"]
+    assert other_user_texts == ["original"]
+
+
 def test_phase_ordering_at_agent_level(agent):
     """Input/Wrap/Output run in canonical order regardless of registration order."""
     order: list[str] = []
@@ -793,6 +829,59 @@ def test_after_invocation_hook_fires_when_middleware_short_circuits(agent):
     agent("Test prompt")
 
     assert after_fired
+
+
+def test_user_message_added_hook_fires_before_the_chain(agent):
+    """The input MessageAddedEvent fires before the AgentStreamStage chain, not inside it.
+
+    Input messages are appended to history before the chain runs, so a wrap middleware sees the
+    user turn already in ``agent.messages`` when it starts. This pins that ordering (a divergence
+    from TS, which appends inside the terminal) so it can't regress silently.
+    """
+    from strands.hooks import MessageAddedEvent
+
+    order: list[str] = []
+
+    agent.hooks.add_callback(
+        MessageAddedEvent, lambda event: order.append(f"msg_added:{event.message['role']}")
+    )
+
+    async def middleware(context, next_fn):
+        order.append("middleware-before")
+        async for event in next_fn(context):
+            yield event
+        order.append("middleware-after")
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, middleware)
+    agent("Test prompt")
+
+    # The user message is added before the chain starts; the assistant message during it.
+    assert order == ["msg_added:user", "middleware-before", "msg_added:assistant", "middleware-after"]
+
+
+def test_user_message_added_hook_fires_even_when_middleware_short_circuits(agent):
+    """The input MessageAddedEvent fires even when a middleware short-circuits the pass.
+
+    Because the input is appended before the chain, a short-circuit (which never runs the
+    terminal) still records the user turn in history and still fires MessageAddedEvent — unlike
+    TS, where the append lives in the terminal and is skipped on short-circuit.
+    """
+    from strands.hooks import MessageAddedEvent
+
+    added_roles: list[str] = []
+
+    agent.hooks.add_callback(MessageAddedEvent, lambda event: added_roles.append(event.message["role"]))
+
+    async def short_circuit(context, next_fn):
+        message = {"role": "assistant", "content": [{"text": "Short-circuited"}]}
+        yield EventLoopStopEvent("end_turn", message, EventLoopMetrics(), {})
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, short_circuit)
+    agent("Test prompt")
+
+    assert added_roles == ["user"]
+    assert agent.messages[-1]["role"] == "user"
+    assert agent.messages[-1]["content"] == [{"text": "Test prompt"}]
 
 
 def test_context_replace_preserves_interrupt(agent):

--- a/strands-py/tests/strands/middleware/test_agent_stream_middleware.py
+++ b/strands-py/tests/strands/middleware/test_agent_stream_middleware.py
@@ -1394,6 +1394,127 @@ def test_interrupt_after_the_pass_completes_on_a_resumed_pass_leaves_no_state():
     assert agent("plain prompt").stop_reason == "end_turn"
 
 
+async def _drain_until_tool_result(agent, prompt):
+    """Consume a stream up to the tool result, then abandon it like a disconnected client."""
+    stream = agent.stream_async(prompt)
+    async for event in stream:
+        message = event.get("message")
+        if message and message["role"] == "user" and "toolResult" in message["content"][0]:
+            break
+    await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_answered_interrupt_is_not_persisted_when_a_stream_is_abandoned(tmp_path):
+    """An abandoned stream leaves no answered interrupt in the session.
+
+    Sessions sync on every message added, including the one right after a tool cycle retains an
+    answered response, so keeping the retained response out of the session cannot rely on the
+    end-of-cycle release running.
+    """
+    gate_calls: list[str] = []
+    charges: list[str] = []
+
+    def build():
+        return _charging_agent(
+            _charge_gate(gate_calls),
+            charges,
+            session_manager=FileSessionManager(session_id="s1", storage_dir=str(tmp_path)),
+        )
+
+    first = await build().invoke_async("charge $100")
+    assert first.stop_reason == "interrupt"
+
+    await _drain_until_tool_result(build(), _approve(first))
+
+    persisted = FileSessionManager(session_id="s1", storage_dir=str(tmp_path)).read_agent("s1", "default")
+    assert persisted._internal_state["interrupt_state"]["interrupts"] == {}
+
+
+@pytest.mark.asyncio
+async def test_restored_agent_reports_an_answerable_interrupt(tmp_path):
+    """A restored agent never reports an interrupt stop the caller cannot answer.
+
+    A stale answered entry would both satisfy the gate silently and be filtered out of the reported
+    interrupts, leaving the caller told to respond with nothing to respond to.
+    """
+    gate_calls: list[str] = []
+    charges: list[str] = []
+
+    def build():
+        return _charging_agent(
+            _charge_gate(gate_calls),
+            charges,
+            session_manager=FileSessionManager(session_id="s1", storage_dir=str(tmp_path)),
+        )
+
+    first = await build().invoke_async("charge $100")
+    await _drain_until_tool_result(build(), _approve(first))
+
+    charges.clear()
+    restored = await build().invoke_async("charge $9999 for something else")
+
+    assert restored.stop_reason == "interrupt"
+    assert [interrupt.name for interrupt in restored.interrupts] == ["approve_charge"]
+    assert charges == []
+
+
+def test_interrupt_after_a_middleware_yielded_result_is_allowed():
+    """Gating after a short-circuited pass works: nothing was produced for a resume to replay.
+
+    A middleware that yields the result itself never calls the model, so the resumed pass replays
+    nothing and re-yields the same result — there is no duplicate assistant turn to prevent.
+    """
+    agent = Agent(
+        model=MockedModelProvider([{"role": "assistant", "content": [{"text": "unused"}]}]),
+        callback_handler=None,
+    )
+    agent.model.stream = _fail_if_called
+
+    async def cached_then_confirm(context, next_fn):
+        message = {"role": "assistant", "content": [{"text": "cached answer"}]}
+        yield EventLoopStopEvent("end_turn", message, EventLoopMetrics(), {})
+        context.interrupt("confirm_cached", reason="serve the cached answer?")
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, cached_then_confirm)
+
+    first = agent("what is 2+2?")
+    assert first.stop_reason == "interrupt"
+    assert [interrupt.name for interrupt in first.interrupts] == ["confirm_cached"]
+
+    resumed = agent(_approve(first))
+    assert resumed.stop_reason == "end_turn"
+    assert resumed.message["content"][0]["text"] == "cached answer"
+
+
+def test_answered_interrupt_is_released_when_conversation_management_raises():
+    """A failure in conversation management does not strand an answered interrupt.
+
+    apply_management runs inside the run loop's finally, so the release has to happen before it for
+    a raise there to leave nothing behind.
+    """
+    gate_calls: list[str] = []
+    charges: list[str] = []
+    agent = _charging_agent(_charge_gate(gate_calls), charges)
+
+    calls: list[int] = []
+    original_apply = agent.conversation_manager.apply_management
+
+    def failing_apply(*args, **kwargs):
+        calls.append(1)
+        if len(calls) == 2:  # the resumed pass
+            raise RuntimeError("summarization unavailable")
+        return original_apply(*args, **kwargs)
+
+    agent.conversation_manager.apply_management = failing_apply
+
+    first = agent("charge $100")
+    assert first.stop_reason == "interrupt"
+    with pytest.raises(RuntimeError, match="summarization unavailable"):
+        agent(_approve(first))
+
+    assert agent._interrupt_state.interrupts == {}
+
 async def _fail_if_called(*args, **kwargs):
     raise AssertionError("model.stream must not be called")
     yield  # noqa: B901  # make this an async generator

--- a/strands-py/tests/strands/middleware/test_agent_stream_middleware.py
+++ b/strands-py/tests/strands/middleware/test_agent_stream_middleware.py
@@ -1042,17 +1042,26 @@ def test_resumed_interrupt_is_not_re_asked_after_a_later_tool_interrupt():
 def test_answered_interrupt_is_not_reused_by_a_later_invocation():
     """A gate's answer dies with its interrupt cycle, so the next invocation asks again.
 
-    The response is kept across the passes of one cycle (so the human is asked once), which must
-    not turn into a standing approval: a later invocation has to gate on a fresh answer rather
-    than silently reusing the previous one.
+    The answered response is kept across the passes of one cycle (so the human is asked once),
+    which must not turn into a standing approval. The resumed pass here runs a tool, so the tool
+    cycle completes the tool resume and leaves the state deactivated with the answer still held —
+    the cycle therefore ends without the run loop's interrupt-completion path firing, and the
+    answer has to be dropped anyway.
     """
     model = MockedModelProvider(
         [
-            {"role": "assistant", "content": [{"text": "first"}]},
-            {"role": "assistant", "content": [{"text": "second"}]},
+            {"role": "assistant", "content": [{"toolUse": {"toolUseId": "t1", "name": "calc", "input": {}}}]},
+            {"role": "assistant", "content": [{"text": "done"}]},
+            {"role": "assistant", "content": [{"text": "unused"}]},
         ]
     )
-    agent = Agent(model=model, callback_handler=None)
+
+    @strands.tool(name="calc")
+    def calc() -> str:
+        """Return a constant."""
+        return "42"
+
+    agent = Agent(model=model, tools=[calc], callback_handler=None)
 
     async def gate(context, next_fn):
         context.interrupt("stream_gate", reason="approve the pass?")
@@ -1065,6 +1074,7 @@ def test_answered_interrupt_is_not_reused_by_a_later_invocation():
     assert first.stop_reason == "interrupt"
     first = agent([{"interruptResponse": {"interruptId": first.interrupts[0].id, "response": "yes"}}])
     assert first.stop_reason == "end_turn"
+    assert first.message["content"][0]["text"] == "done"
     assert not agent._interrupt_state.interrupts
 
     # A second, independent invocation must gate again rather than reuse the earlier approval.

--- a/strands-py/tests/strands/middleware/test_agent_stream_middleware.py
+++ b/strands-py/tests/strands/middleware/test_agent_stream_middleware.py
@@ -1308,6 +1308,9 @@ async def test_answered_interrupt_is_not_reused_after_the_caller_abandons_the_st
     charges.clear()
     second = await agent.invoke_async("charge $9999")
     assert second.stop_reason == "interrupt"
+    # The reported interrupt must be answerable: a retained answered entry would both satisfy the
+    # gate and be filtered out of the report, leaving the caller nothing to respond to.
+    assert [(interrupt.name, interrupt.response) for interrupt in second.interrupts] == [("approve_charge", None)]
     assert charges == []
 
 

--- a/strands-py/tests/strands/middleware/test_agent_stream_middleware.py
+++ b/strands-py/tests/strands/middleware/test_agent_stream_middleware.py
@@ -7,6 +7,7 @@ import pytest
 import strands
 from strands import Agent
 from strands._middleware.stages import AgentStreamContext, AgentStreamStage, MiddlewareInterruptResult
+from strands.session import FileSessionManager
 from strands.telemetry.metrics import EventLoopMetrics
 from strands.types._events import EventLoopStopEvent, InitEventLoopEvent, ModelMessageEvent, TextStreamEvent
 from tests.fixtures.mocked_model_provider import MockedModelProvider
@@ -1100,7 +1101,7 @@ def test_interrupt_after_the_pass_completes_raises():
 
     agent._middleware_registry.add_middleware(AgentStreamStage, post_hoc_gate)
 
-    exp_message = r"interrupt_name=<approve_output> \| agent-stream middleware raised an interrupt after the pass"
+    exp_message = r"interrupt_name=<approve_output> \| agent-stream middleware interrupted after the pass"
     with pytest.raises(RuntimeError, match=exp_message):
         agent("Test prompt")
 
@@ -1170,6 +1171,221 @@ def test_middleware_yielded_interrupt_stop_preserves_interrupt_state():
     assert result.stop_reason == "interrupt"
     assert agent._interrupt_state.activated
     assert interrupt_id in agent._interrupt_state.interrupts
+
+
+def _charging_agent(gate, charges, **kwargs):
+    """An agent whose model calls a charging tool, gated by ``gate``."""
+    tool_use = {
+        "role": "assistant",
+        "content": [{"toolUse": {"toolUseId": "t1", "name": "charge_card", "input": {"amount": "$100"}}}],
+    }
+    done = {"role": "assistant", "content": [{"text": "done"}]}
+
+    @strands.tool(name="charge_card")
+    def charge_card(amount: str) -> str:
+        """Charge the customer's card."""
+        charges.append(amount)
+        return f"charged {amount}"
+
+    agent = Agent(
+        model=MockedModelProvider([tool_use, done, tool_use, done]),
+        tools=[charge_card],
+        callback_handler=None,
+        **kwargs,
+    )
+    agent._middleware_registry.add_middleware(AgentStreamStage, gate)
+    return agent
+
+
+def _approve(result):
+    return [
+        {"interruptResponse": {"interruptId": interrupt.id, "response": "yes"}} for interrupt in result.interrupts
+    ]
+
+
+def _charge_gate(gate_calls):
+    async def gate(context, next_fn):
+        gate_calls.append("call")
+        context.interrupt("approve_charge", reason="approve this request?")
+        async for event in next_fn(context):
+            yield event
+
+    return gate
+
+
+def test_answered_interrupt_is_not_persisted_as_a_standing_approval(tmp_path):
+    """A completed cycle leaves no answered interrupt in the session.
+
+    The cycle is released before ``AfterInvocationEvent``, which is where the session manager
+    syncs, so the persisted state carries no response. A fresh agent restored from that session —
+    the ordinary one-agent-per-request server shape — must gate again rather than resolve against
+    what the previous cycle answered.
+    """
+    gate_calls: list[str] = []
+    charges: list[str] = []
+
+    def build():
+        return _charging_agent(
+            _charge_gate(gate_calls),
+            charges,
+            session_manager=FileSessionManager(session_id="s1", storage_dir=str(tmp_path)),
+        )
+
+    first = build()("charge $100")
+    assert first.stop_reason == "interrupt"
+
+    resumed = build()(_approve(first))
+    assert resumed.stop_reason == "end_turn"
+
+    persisted = FileSessionManager(session_id="s1", storage_dir=str(tmp_path)).read_agent("s1", "default")
+    assert persisted._internal_state["interrupt_state"]["interrupts"] == {}
+
+    charges.clear()
+    third = build()("charge $9999")
+    assert third.stop_reason == "interrupt"
+    assert charges == []
+
+
+def test_answered_interrupt_is_released_when_a_pass_ends_with_an_error():
+    """A raise from an AfterInvocationEvent hook does not strand an answered interrupt.
+
+    The hook runs inside the run loop's ``finally`` and is a public extension point, so a failure
+    there (a session write error, a summarizing conversation manager whose model call fails) must
+    not leave a response behind for the next cycle to resolve against.
+    """
+    from strands.hooks import AfterInvocationEvent
+
+    gate_calls: list[str] = []
+    charges: list[str] = []
+    agent = _charging_agent(_charge_gate(gate_calls), charges)
+
+    hook_calls: list[object] = []
+
+    def failing_hook(event):
+        hook_calls.append(event)
+        if len(hook_calls) == 2:  # the resumed pass
+            raise RuntimeError("session write failed")
+
+    agent.hooks.add_callback(AfterInvocationEvent, failing_hook)
+
+    first = agent("charge $100")
+    assert first.stop_reason == "interrupt"
+    with pytest.raises(RuntimeError, match="session write failed"):
+        agent(_approve(first))
+
+    charges.clear()
+    assert agent("charge $9999").stop_reason == "interrupt"
+    assert charges == []
+
+
+@pytest.mark.asyncio
+async def test_answered_interrupt_is_not_reused_after_the_caller_abandons_the_stream():
+    """A caller that stops consuming the stream leaves no usable approval behind.
+
+    The run loop's cleanup only runs if the generator is driven to completion, so a disconnected
+    client must not leave a response that the next cycle's gate resolves against.
+    """
+    gate_calls: list[str] = []
+    charges: list[str] = []
+    agent = _charging_agent(_charge_gate(gate_calls), charges)
+
+    first = await agent.invoke_async("charge $100")
+    assert first.stop_reason == "interrupt"
+
+    stream = agent.stream_async(_approve(first))
+    async for event in stream:
+        message = event.get("message")
+        if message and message["role"] == "user" and "toolResult" in message["content"][0]:
+            break
+    await stream.aclose()
+
+    charges.clear()
+    second = await agent.invoke_async("charge $9999")
+    assert second.stop_reason == "interrupt"
+    assert charges == []
+
+
+def test_interrupt_after_a_tool_interrupt_stop_is_allowed():
+    """Gating on top of a tool interrupt works: the stored tool use is replayed on resume.
+
+    Refusing a post-result interrupt is only correct when resuming would re-call the model. A pass
+    that stopped for a tool interrupt has a tool-use message to replay, so the pass-level gate can
+    still interrupt after the stream drains and the caller answers both in one round trip.
+    """
+    tool_use = {
+        "role": "assistant",
+        "content": [{"toolUse": {"toolUseId": "t1", "name": "confirm_tool", "input": {}}}],
+    }
+    done = {"role": "assistant", "content": [{"text": "done"}]}
+
+    @strands.tool(name="confirm_tool", context=True)
+    def confirm_tool(tool_context) -> str:
+        """Interrupt for approval, then return once resumed."""
+        return f"ran: {tool_context.interrupt('tool_gate', reason='approve tool?')}"
+
+    agent = Agent(model=MockedModelProvider([tool_use, done]), tools=[confirm_tool], callback_handler=None)
+
+    async def batch_gate(context, next_fn):
+        stopped_for_interrupt = False
+        async for event in next_fn(context):
+            if isinstance(event, EventLoopStopEvent) and event["stop"][0] == "interrupt":
+                stopped_for_interrupt = True
+            yield event
+        if stopped_for_interrupt:
+            context.interrupt("batch_approve", reason="approve the batch too?")
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, batch_gate)
+
+    first = agent("go")
+    assert first.stop_reason == "interrupt"
+    assert {interrupt.name for interrupt in first.interrupts} == {"tool_gate", "batch_approve"}
+
+    resumed = agent(_approve(first))
+    assert resumed.stop_reason == "end_turn"
+    assert [message["role"] for message in agent.messages] == ["user", "assistant", "user", "assistant"]
+
+
+def test_interrupt_after_the_pass_completes_on_a_resumed_pass_leaves_no_state():
+    """The refusal clears interrupt state, so the agent stays usable afterwards.
+
+    A refusal on a resumed pass would otherwise leave the state activated with an interrupt the
+    caller can no longer answer, wedging every later call.
+    """
+    model = MockedModelProvider(
+        [
+            {"role": "assistant", "content": [{"text": "first"}]},
+            {"role": "assistant", "content": [{"text": "second"}]},
+        ]
+    )
+    agent = Agent(model=model, callback_handler=None)
+
+    # "before": gate ahead of next_fn; "after": gate once the stream drained; "off": pass through.
+    mode = "before"
+
+    async def gate(context, next_fn):
+        if mode == "before":
+            context.interrupt("stream_gate", reason="approve the pass?")
+        async for event in next_fn(context):
+            yield event
+        if mode == "after":
+            context.interrupt("post_gate", reason="approve the output?")
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, gate)
+
+    first = agent("go")
+    assert first.stop_reason == "interrupt"
+
+    mode = "after"
+    with pytest.raises(RuntimeError, match="interrupted after the pass produced its result"):
+        agent(_approve(first))
+
+    assert not agent._interrupt_state.activated
+    assert not agent._interrupt_state.interrupts
+    assert not agent._interrupt_state.context
+
+    # The agent takes an ordinary prompt again rather than demanding interrupt responses.
+    mode = "off"
+    assert agent("plain prompt").stop_reason == "end_turn"
 
 
 async def _fail_if_called(*args, **kwargs):

--- a/strands-py/tests/strands/middleware/test_agent_stream_middleware.py
+++ b/strands-py/tests/strands/middleware/test_agent_stream_middleware.py
@@ -1030,10 +1030,7 @@ def test_resumed_interrupt_is_not_re_asked_after_a_later_tool_interrupt():
             break
         asked.extend(interrupt.name for interrupt in result.interrupts)
         result = agent(
-            [
-                {"interruptResponse": {"interruptId": interrupt.id, "response": "yes"}}
-                for interrupt in result.interrupts
-            ]
+            [{"interruptResponse": {"interruptId": interrupt.id, "response": "yes"}} for interrupt in result.interrupts]
         )
 
     assert result.stop_reason == "end_turn"
@@ -1198,9 +1195,7 @@ def _charging_agent(gate, charges, **kwargs):
 
 
 def _approve(result):
-    return [
-        {"interruptResponse": {"interruptId": interrupt.id, "response": "yes"}} for interrupt in result.interrupts
-    ]
+    return [{"interruptResponse": {"interruptId": interrupt.id, "response": "yes"}} for interrupt in result.interrupts]
 
 
 def _charge_gate(gate_calls):
@@ -1517,6 +1512,7 @@ def test_answered_interrupt_is_released_when_conversation_management_raises():
         agent(_approve(first))
 
     assert agent._interrupt_state.interrupts == {}
+
 
 async def _fail_if_called(*args, **kwargs):
     raise AssertionError("model.stream must not be called")

--- a/strands-py/tests/strands/middleware/test_agent_stream_middleware.py
+++ b/strands-py/tests/strands/middleware/test_agent_stream_middleware.py
@@ -987,6 +987,180 @@ def test_agent_stream_interrupt_reports_all_unanswered_interrupts():
     assert {interrupt.name for interrupt in result.interrupts} == {"gate_b", "stream_gate"}
 
 
+def test_resumed_interrupt_is_not_re_asked_after_a_later_tool_interrupt():
+    """An answered gate is asked once, even when a later pass of the same cycle interrupts again.
+
+    The gate reads its approval before next_fn only. The resumed pass runs a successful tool cycle
+    (which completes the tool resume) and then a second tool raises its own interrupt, so a further
+    pass follows. The gate's answer must survive those passes: asking again would make the human
+    re-approve the same action once per interrupt round trip.
+    """
+    model = MockedModelProvider(
+        [
+            {"role": "assistant", "content": [{"toolUse": {"toolUseId": "t1", "name": "calc", "input": {}}}]},
+            {"role": "assistant", "content": [{"toolUse": {"toolUseId": "t2", "name": "confirm_tool", "input": {}}}]},
+            {"role": "assistant", "content": [{"text": "done"}]},
+        ]
+    )
+
+    @strands.tool(name="calc")
+    def calc() -> str:
+        """Return a constant."""
+        return "42"
+
+    @strands.tool(name="confirm_tool", context=True)
+    def confirm_tool(tool_context) -> str:
+        """Interrupt for approval, then return once resumed."""
+        return tool_context.interrupt("tool_gate", reason="approve tool?")
+
+    agent = Agent(model=model, tools=[calc, confirm_tool], callback_handler=None)
+
+    async def gate(context, next_fn):
+        context.interrupt("stream_gate", reason="approve the pass?")
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, gate)
+
+    asked: list[str] = []
+    result = agent("go")
+    for _ in range(8):
+        if result.stop_reason != "interrupt":
+            break
+        asked.extend(interrupt.name for interrupt in result.interrupts)
+        result = agent(
+            [
+                {"interruptResponse": {"interruptId": interrupt.id, "response": "yes"}}
+                for interrupt in result.interrupts
+            ]
+        )
+
+    assert result.stop_reason == "end_turn"
+    assert asked == ["stream_gate", "tool_gate"]
+
+
+def test_answered_interrupt_is_not_reused_by_a_later_invocation():
+    """A gate's answer dies with its interrupt cycle, so the next invocation asks again.
+
+    The response is kept across the passes of one cycle (so the human is asked once), which must
+    not turn into a standing approval: a later invocation has to gate on a fresh answer rather
+    than silently reusing the previous one.
+    """
+    model = MockedModelProvider(
+        [
+            {"role": "assistant", "content": [{"text": "first"}]},
+            {"role": "assistant", "content": [{"text": "second"}]},
+        ]
+    )
+    agent = Agent(model=model, callback_handler=None)
+
+    async def gate(context, next_fn):
+        context.interrupt("stream_gate", reason="approve the pass?")
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, gate)
+
+    first = agent("go")
+    assert first.stop_reason == "interrupt"
+    first = agent([{"interruptResponse": {"interruptId": first.interrupts[0].id, "response": "yes"}}])
+    assert first.stop_reason == "end_turn"
+    assert not agent._interrupt_state.interrupts
+
+    # A second, independent invocation must gate again rather than reuse the earlier approval.
+    second = agent("go again")
+    assert second.stop_reason == "interrupt"
+    assert second.interrupts[0].name == "stream_gate"
+
+
+def test_interrupt_after_the_pass_completes_raises():
+    """Interrupting after the stream finished is refused instead of replaying the pass.
+
+    Resuming such an interrupt has no tool-use message to replay, so the event loop would call the
+    model a second time and append a duplicate assistant turn. The agent raises an actionable error
+    instead. Interrupting before or while draining next_fn is unaffected.
+    """
+    model = MockedModelProvider([{"role": "assistant", "content": [{"text": "Hello!"}]}])
+    agent = Agent(model=model, callback_handler=None)
+
+    async def post_hoc_gate(context, next_fn):
+        async for event in next_fn(context):
+            yield event
+        context.interrupt("approve_output", reason="approve the reply?")
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, post_hoc_gate)
+
+    exp_message = r"interrupt_name=<approve_output> \| agent-stream middleware raised an interrupt after the pass"
+    with pytest.raises(RuntimeError, match=exp_message):
+        agent("Test prompt")
+
+    # The refused interrupt is not left registered, so the next invocation starts clean.
+    assert not agent._interrupt_state.activated
+    assert not agent._interrupt_state.interrupts
+
+
+def test_after_invocation_result_is_the_stop_event_when_a_trailing_event_follows(agent):
+    """AfterInvocationEvent.result comes from the stop event, not from a later trailing event."""
+    from strands.hooks import AfterInvocationEvent
+
+    results = []
+
+    async def inject_trailing(context, next_fn):
+        async for event in next_fn(context):
+            yield event
+        yield InitEventLoopEvent()
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, inject_trailing)
+    agent.hooks.add_callback(AfterInvocationEvent, lambda event: results.append(event.result))
+
+    agent("Test prompt")
+
+    assert len(results) == 1
+    assert results[0] is not None
+    assert results[0].stop_reason == "end_turn"
+    assert results[0].message["content"][0]["text"] == "Hello!"
+
+
+def test_middleware_yielded_interrupt_stop_preserves_interrupt_state():
+    """A pass that stops on an interrupt keeps its interrupt state, even with no tool context.
+
+    Middleware can surface an interrupt stop itself (short-circuiting the pass). The run loop must
+    not clear interrupt state after such a pass: the caller still owes a response.
+    """
+    model = MockedModelProvider(
+        [
+            {"role": "assistant", "content": [{"text": "first"}]},
+            {"role": "assistant", "content": [{"text": "second"}]},
+        ]
+    )
+    agent = Agent(model=model, callback_handler=None)
+
+    short_circuit = False
+
+    async def gate(context, next_fn):
+        if short_circuit:
+            message = {"role": "assistant", "content": [{"text": "Awaiting approval"}]}
+            yield EventLoopStopEvent("interrupt", message, EventLoopMetrics(), {}, list(agent._interrupt_state.interrupts.values()))
+            return
+        context.interrupt("stream_gate", reason="approve the pass?")
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(AgentStreamStage, gate)
+
+    result = agent("go")
+    assert result.stop_reason == "interrupt"
+    interrupt_id = result.interrupts[0].id
+
+    # The resumed pass stops on a middleware-yielded interrupt stop event.
+    short_circuit = True
+    result = agent([{"interruptResponse": {"interruptId": interrupt_id, "response": "yes"}}])
+
+    assert result.stop_reason == "interrupt"
+    assert agent._interrupt_state.activated
+    assert interrupt_id in agent._interrupt_state.interrupts
+
+
 async def _fail_if_called(*args, **kwargs):
     raise AssertionError("model.stream must not be called")
     yield  # noqa: B901  # make this an async generator

--- a/strands-py/tests/strands/test_interrupt.py
+++ b/strands-py/tests/strands/test_interrupt.py
@@ -236,6 +236,18 @@ def test_interrupt_state_end_interrupt_cycle():
     assert interrupt_state.activated
 
 
+def test_interrupt_state_end_interrupt_cycle_nothing_to_release():
+    """With nothing to drop the state is left alone, version included."""
+    tool_interrupt = Interrupt(id="v1:tool_call:t1:abc", name="tool_gate")
+    interrupt_state = _InterruptState(interrupts={tool_interrupt.id: tool_interrupt})
+    version = interrupt_state._get_version()
+
+    interrupt_state.end_interrupt_cycle()
+
+    assert interrupt_state.interrupts == {tool_interrupt.id: tool_interrupt}
+    assert interrupt_state._get_version() == version
+
+
 def test_interrupt_state_to_dict_omits_retained_invocation_scoped_responses():
     """A response retained while deactivated is readable only in-pass, so it is never serialized."""
     retained = Interrupt(id=f"{_AGENT_STREAM_INTERRUPT_ID_PREFIX}retained", name="gate", response="approved")

--- a/strands-py/tests/strands/test_interrupt.py
+++ b/strands-py/tests/strands/test_interrupt.py
@@ -1,6 +1,6 @@
 import pytest
 
-from strands.interrupt import AGENT_STREAM_INTERRUPT_ID_PREFIX, Interrupt, _InterruptState
+from strands.interrupt import _AGENT_STREAM_INTERRUPT_ID_PREFIX, Interrupt, _InterruptState
 
 
 @pytest.fixture
@@ -193,10 +193,10 @@ def test_interrupt_state_version_not_in_to_dict():
     assert "version" not in data
 
 
-def test_interrupt_state_complete_tool_resume():
+def test_interrupt_state_end_tool_cycle():
     """Answered agent-stream interrupts outlive a tool cycle; everything else is cleared."""
-    answered_gate = Interrupt(id=f"{AGENT_STREAM_INTERRUPT_ID_PREFIX}answered", name="gate", response="approved")
-    unanswered_gate = Interrupt(id=f"{AGENT_STREAM_INTERRUPT_ID_PREFIX}unanswered", name="gate2")
+    answered_gate = Interrupt(id=f"{_AGENT_STREAM_INTERRUPT_ID_PREFIX}answered", name="gate", response="approved")
+    unanswered_gate = Interrupt(id=f"{_AGENT_STREAM_INTERRUPT_ID_PREFIX}unanswered", name="gate2")
     tool_interrupt = Interrupt(id="v1:tool_call:t1:abc", name="tool_gate", response="approved")
     interrupt_state = _InterruptState(
         interrupts={
@@ -208,7 +208,7 @@ def test_interrupt_state_complete_tool_resume():
         activated=True,
     )
 
-    interrupt_state.complete_tool_resume()
+    interrupt_state.end_tool_cycle()
 
     tru_interrupts = interrupt_state.interrupts
     exp_interrupts = {answered_gate.id: answered_gate}
@@ -217,9 +217,9 @@ def test_interrupt_state_complete_tool_resume():
     assert not interrupt_state.activated
 
 
-def test_interrupt_state_clear_agent_stream_interrupts():
+def test_interrupt_state_end_interrupt_cycle():
     """Agent-stream interrupts are dropped; tool interrupts and context are untouched."""
-    answered_gate = Interrupt(id=f"{AGENT_STREAM_INTERRUPT_ID_PREFIX}answered", name="gate", response="approved")
+    answered_gate = Interrupt(id=f"{_AGENT_STREAM_INTERRUPT_ID_PREFIX}answered", name="gate", response="approved")
     tool_interrupt = Interrupt(id="v1:tool_call:t1:abc", name="tool_gate")
     interrupt_state = _InterruptState(
         interrupts={answered_gate.id: answered_gate, tool_interrupt.id: tool_interrupt},
@@ -227,7 +227,7 @@ def test_interrupt_state_clear_agent_stream_interrupts():
         activated=True,
     )
 
-    interrupt_state.clear_agent_stream_interrupts()
+    interrupt_state.end_interrupt_cycle()
 
     tru_interrupts = interrupt_state.interrupts
     exp_interrupts = {tool_interrupt.id: tool_interrupt}
@@ -236,22 +236,22 @@ def test_interrupt_state_clear_agent_stream_interrupts():
     assert interrupt_state.activated
 
 
-def test_interrupt_state_clear_agent_stream_interrupts_no_agent_stream_interrupts():
+def test_interrupt_state_end_interrupt_cycle_nothing_to_release():
     """With nothing to drop the state is left alone, version included."""
     tool_interrupt = Interrupt(id="v1:tool_call:t1:abc", name="tool_gate")
     interrupt_state = _InterruptState(interrupts={tool_interrupt.id: tool_interrupt})
     version = interrupt_state._get_version()
 
-    interrupt_state.clear_agent_stream_interrupts()
+    interrupt_state.end_interrupt_cycle()
 
     assert interrupt_state.interrupts == {tool_interrupt.id: tool_interrupt}
     assert interrupt_state._get_version() == version
 
 
-def test_interrupt_state_version_increments_after_complete_tool_resume():
+def test_interrupt_state_version_increments_after_end_tool_cycle():
     interrupt_state = _InterruptState(activated=True)
     version = interrupt_state._get_version()
 
-    interrupt_state.complete_tool_resume()
+    interrupt_state.end_tool_cycle()
 
     assert interrupt_state._get_version() > version

--- a/strands-py/tests/strands/test_interrupt.py
+++ b/strands-py/tests/strands/test_interrupt.py
@@ -255,3 +255,32 @@ def test_interrupt_state_version_increments_after_end_tool_cycle():
     interrupt_state.end_tool_cycle()
 
     assert interrupt_state._get_version() > version
+
+
+def test_interrupt_state_to_dict_omits_retained_invocation_scoped_responses():
+    """A response retained while deactivated is readable only in-pass, so it is never serialized."""
+    retained = Interrupt(id=f"{_AGENT_STREAM_INTERRUPT_ID_PREFIX}retained", name="gate", response="approved")
+    tool_interrupt = Interrupt(id="v1:tool_call:t1:abc", name="tool_gate", response="approved")
+    interrupt_state = _InterruptState(
+        interrupts={retained.id: retained, tool_interrupt.id: tool_interrupt},
+        activated=False,
+    )
+
+    tru_interrupts = interrupt_state.to_dict()["interrupts"]
+    exp_interrupts = {tool_interrupt.id: tool_interrupt.to_dict()}
+    assert tru_interrupts == exp_interrupts
+
+    # While activated the caller is owed a resume, so everything is serialized.
+    interrupt_state.activate()
+    assert set(interrupt_state.to_dict()["interrupts"]) == {retained.id, tool_interrupt.id}
+
+
+def test_interrupt_state_from_dict_drops_retained_invocation_scoped_responses():
+    """A session written before responses stopped being serialized does not revive an approval."""
+    retained = Interrupt(id=f"{_AGENT_STREAM_INTERRUPT_ID_PREFIX}retained", name="gate", response="approved")
+    data = {"interrupts": {retained.id: retained.to_dict()}, "context": {}, "activated": False}
+
+    assert _InterruptState.from_dict(data).interrupts == {}
+
+    data["activated"] = True
+    assert set(_InterruptState.from_dict(data).interrupts) == {retained.id}

--- a/strands-py/tests/strands/test_interrupt.py
+++ b/strands-py/tests/strands/test_interrupt.py
@@ -236,27 +236,6 @@ def test_interrupt_state_end_interrupt_cycle():
     assert interrupt_state.activated
 
 
-def test_interrupt_state_end_interrupt_cycle_nothing_to_release():
-    """With nothing to drop the state is left alone, version included."""
-    tool_interrupt = Interrupt(id="v1:tool_call:t1:abc", name="tool_gate")
-    interrupt_state = _InterruptState(interrupts={tool_interrupt.id: tool_interrupt})
-    version = interrupt_state._get_version()
-
-    interrupt_state.end_interrupt_cycle()
-
-    assert interrupt_state.interrupts == {tool_interrupt.id: tool_interrupt}
-    assert interrupt_state._get_version() == version
-
-
-def test_interrupt_state_version_increments_after_end_tool_cycle():
-    interrupt_state = _InterruptState(activated=True)
-    version = interrupt_state._get_version()
-
-    interrupt_state.end_tool_cycle()
-
-    assert interrupt_state._get_version() > version
-
-
 def test_interrupt_state_to_dict_omits_retained_invocation_scoped_responses():
     """A response retained while deactivated is readable only in-pass, so it is never serialized."""
     retained = Interrupt(id=f"{_AGENT_STREAM_INTERRUPT_ID_PREFIX}retained", name="gate", response="approved")

--- a/strands-py/tests/strands/test_interrupt.py
+++ b/strands-py/tests/strands/test_interrupt.py
@@ -1,6 +1,6 @@
 import pytest
 
-from strands.interrupt import Interrupt, _InterruptState
+from strands.interrupt import AGENT_STREAM_INTERRUPT_ID_PREFIX, Interrupt, _InterruptState
 
 
 @pytest.fixture
@@ -191,3 +191,67 @@ def test_interrupt_state_version_not_in_to_dict():
     data = interrupt_state.to_dict()
     assert "_version" not in data
     assert "version" not in data
+
+
+def test_interrupt_state_complete_tool_resume():
+    """Answered agent-stream interrupts outlive a tool cycle; everything else is cleared."""
+    answered_gate = Interrupt(id=f"{AGENT_STREAM_INTERRUPT_ID_PREFIX}answered", name="gate", response="approved")
+    unanswered_gate = Interrupt(id=f"{AGENT_STREAM_INTERRUPT_ID_PREFIX}unanswered", name="gate2")
+    tool_interrupt = Interrupt(id="v1:tool_call:t1:abc", name="tool_gate", response="approved")
+    interrupt_state = _InterruptState(
+        interrupts={
+            answered_gate.id: answered_gate,
+            unanswered_gate.id: unanswered_gate,
+            tool_interrupt.id: tool_interrupt,
+        },
+        context={"tool_use_message": {"role": "assistant"}, "tool_results": []},
+        activated=True,
+    )
+
+    interrupt_state.complete_tool_resume()
+
+    tru_interrupts = interrupt_state.interrupts
+    exp_interrupts = {answered_gate.id: answered_gate}
+    assert tru_interrupts == exp_interrupts
+    assert interrupt_state.context == {}
+    assert not interrupt_state.activated
+
+
+def test_interrupt_state_clear_agent_stream_interrupts():
+    """Agent-stream interrupts are dropped; tool interrupts and context are untouched."""
+    answered_gate = Interrupt(id=f"{AGENT_STREAM_INTERRUPT_ID_PREFIX}answered", name="gate", response="approved")
+    tool_interrupt = Interrupt(id="v1:tool_call:t1:abc", name="tool_gate")
+    interrupt_state = _InterruptState(
+        interrupts={answered_gate.id: answered_gate, tool_interrupt.id: tool_interrupt},
+        context={"tool_use_message": {"role": "assistant"}},
+        activated=True,
+    )
+
+    interrupt_state.clear_agent_stream_interrupts()
+
+    tru_interrupts = interrupt_state.interrupts
+    exp_interrupts = {tool_interrupt.id: tool_interrupt}
+    assert tru_interrupts == exp_interrupts
+    assert interrupt_state.context == {"tool_use_message": {"role": "assistant"}}
+    assert interrupt_state.activated
+
+
+def test_interrupt_state_clear_agent_stream_interrupts_no_agent_stream_interrupts():
+    """With nothing to drop the state is left alone, version included."""
+    tool_interrupt = Interrupt(id="v1:tool_call:t1:abc", name="tool_gate")
+    interrupt_state = _InterruptState(interrupts={tool_interrupt.id: tool_interrupt})
+    version = interrupt_state._get_version()
+
+    interrupt_state.clear_agent_stream_interrupts()
+
+    assert interrupt_state.interrupts == {tool_interrupt.id: tool_interrupt}
+    assert interrupt_state._get_version() == version
+
+
+def test_interrupt_state_version_increments_after_complete_tool_resume():
+    interrupt_state = _InterruptState(activated=True)
+    version = interrupt_state._get_version()
+
+    interrupt_state.complete_tool_resume()
+
+    assert interrupt_state._get_version() > version


### PR DESCRIPTION
## Description

@mkmeral asked me to fork #3466 and fix the issues my review of it found, so this branch **contains #3466's work plus four fixes on top** — it is not a patch to be applied alongside it. **Merge this or #3466, not both.** `strands-ts/` is carried over from #3466 untouched; every change of mine is under `strands-py/`.

`AgentStreamStage` lets middleware gate a whole invocation pass behind a human-in-the-loop interrupt. The bugs were all about *how long an answered approval lives*, and they failed in the direction that matters: a human being asked to approve the same action repeatedly, or — worse — an action being approved silently because a stale answer was still lying around.

Four fixes, each with a reproduction that failed before it:

1. **A cancelled resume destroyed a pending tool interrupt.** The tool phase cleared interrupt state unconditionally, so cancelling a resumed tool interrupt threw away the stored `tool_use_message` and the human's answer, leaving the invocation unresumable. Only an aborting pass (`agent.cancel()`) now keeps its state. This one is **a live bug on `main`, not just in #3466** — it arrived with #3508's tool-batch hooks, and #3466's own `test_cancel_during_tool_interrupt_resume_preserves_interrupt_state` fails on `main` today because of it. The TypeScript side already had the equivalent guard.
2. **An answered gate was re-asked once per later interrupt round trip.** The same unconditional clear also destroyed an *answered* agent-stream response mid-invocation. #3466's pass-start snapshot stabilises reads within a pass, but it is copied from live state, so it cannot recover what an earlier pass already cleared. A gate reading its approval before `next_fn` was asked 4 times in one flow; with a session manager and a fresh `Agent` per pass it never converged, re-firing tool side effects each round.
3. **An interrupt raised after the pass produced its result silently replayed the pass** — a second model call, two consecutive assistant turns, and re-fired side effects (one repro charged a card twice for a single request). Now refused with an actionable error, with interrupt state cleared so the caller isn't wedged.
4. **Two run-loop branches nothing exercised** — the per-pass result capture that feeds `AfterInvocationEvent` (and therefore session persistence), and the `stop_reason != "interrupt"` guard. Both survived mutation at two different heads; both are now pinned.

The model this settles on: an answered agent-stream response is scoped to its **interrupt cycle** — every pass from the interrupt that asked the human through to the pass that completes with nothing owed a resume, across however many resume calls that takes. It survives a tool cycle inside the cycle (`_InterruptState.end_tool_cycle`) and is released when the cycle ends (`end_interrupt_cycle`), so a gate asks once and never inherits an approval from a previous cycle.

Note: `InterruptException` reaching the run loop is now caught and converted to `stop_reason="interrupt"` with an `AgentResult` (previously it propagated unhandled). No middleware registration required to observe this.

<details>
<summary><b>Independent review loop — 3 rounds, 8 findings, all fixed (worth reading: 5 of the 8 were mine)</b></summary>

I don't get to approve my own work, so each round was an independent fresh-context pass that hadn't written the code. Every round found something real, including two regressions **I introduced while fixing the first ones**:

**Round 1** — correctness (approve + 1), adversarial (3 regressions), API/DevX (2 blockers):
- 🔴 The cycle release ran *after* the `AfterInvocationEvent` hook, which is where sessions sync — so the answered response was persisted anyway and a restored agent never asked. Release now runs first in the `finally`.
- 🔴 A raise from `apply_management` or a hook, or a caller abandoning the stream, skipped the release entirely. The pass-start snapshot is now only populated while interrupt state is activated (fail-closed), so a response retained by a cycle that died mid-flight can't resolve a gate.
- 🟡 The refusal also fired for a pass that stopped for a *tool* interrupt, where the stored tool use **is** replayed and no second model call happens — a false positive that wedged the agent.
- 🔴 (API) `AGENT_STREAM_INTERRUPT_ID_PREFIX` was an un-underscored name in the public `strands.interrupt` module — i.e. accidental public API, which would have pulled in the `api/needs-review` workflow. Now `_`-prefixed.
- 🔴 (API) The refusal left the agent unrecoverable on a resume pass. Now clears state first.
- 🟡 (API) Methods renamed to `end_tool_cycle` / `end_interrupt_cycle` (transition-named, not subsystem-named), plus lifetime wording, error-message format, and `Raises:` docs.

**Round 2** — correctness (approve + 2 cleanups), adversarial (2 more blockers):
- 🔴 My cancel guard was too broad. A `BeforeToolsEvent` cancel does *not* abort the pass — the loop continues — so retaining state replayed the stored tool use and **ran the tool the hook had just denied**, de-alternated history, replayed to `RecursionError` (326 messages), and left a completed invocation activated. Narrowed to `_cancel_signal`.
- 🔴 The retained response was still *persisted*, because sessions sync mid-pass on message-added. A restored agent held a standing approval **and** reported an interrupt stop with zero interrupts — told to respond, with nothing to respond to. Fixed in `to_dict`/`from_dict`, plus registration now replaces a stale answered entry instead of keeping it.
- 🟡 The refusal false-positived on a middleware-yielded result (short-circuit then confirm: zero model calls, safe on base). Now gated on whether the *event loop* produced the result.

**Round 3** — correctness: **approve, "ready for a maintainer as-is"** (1 docstring contradiction + nits, all fixed).

**One pass did not complete:** round 3's adversarial pass failed three times on transient infrastructure errors (`internalServerException`, an empty result, a read timeout). Rather than claim coverage I don't have, I re-ran round 2's entire attack suite — all 11 repro scripts plus its 6 recommended regression tests — against the final head myself: zero defect markers, 6/6 passing. So the *specific* attacks that broke this branch before are verified fixed, but a fresh adversarial sweep at the final head is genuinely missing from the ledger.
</details>

<details>
<summary><b>Verification evidence</b></summary>

| | |
|---|---|
| Tests | `hatch test tests/strands/` (excl. a2a) → **4536 passed**, 0 failed |
| Lint / types | `hatch run hatch-static-analysis:lint-check` → ruff clean, mypy clean (232 source files) |
| Mutation testing | **14/14 caught.** Every behavior here is pinned by a named test — I broke each one and confirmed a specific test fails |
| Formatting | `ruff format --check` deviation count is identical to base (12 files); the one remaining deviation in a file I touched is pre-existing from #3466 and deliberately left alone |
| Attack replay | 11 round-2 repro scripts + its 6 recommended regression tests, re-run at the final head: clean |

**Worth knowing about the tests:** three of my own new tests were vacuous or too weak when first written — they passed *without* the fix — and mutation testing is what caught that. Each was rewritten until it failed for the right reason. I'd rather flag that than have you assume the green tick means more than it does.

I did **not** run `hatch run prepare` (the sandbox has only Python 3.12, so the multi-version matrix is CI's job) — I ran the suite and the static-analysis gate directly, as above.
</details>

<details>
<summary><b>Deliberately out of scope, and open questions for a maintainer</b></summary>

- **Cross-agent interrupt-id collision** (from my #3466 review): two `Graph`/`Swarm` nodes running one reusable gate share an id, so one approval satisfies both. Not fixed here — it needs an identity decision (`agent_id` defaults to `"default"`), and #3466 already documents it as deferred.
- **Ownership is expressed by id-prefix matching.** The reviewer's preferred long-term shape is an explicit `scope`/`source` field on `Interrupt` — but that's a public, session-serialized field on a type both SDKs share, so it's API-bar-raising territory rather than something to slip into a bug-fix branch. Related: issue #2737 is framed as "add a `source` field", and TS's single `'middleware'` value can't express this distinction either, so that issue probably wants reframing as *scope/lifetime*.
- **TypeScript is unchanged.** It has the same structural gaps; fixing Python alone adds no *new* divergence, and the README now says TS doesn't implement this lifetime yet. Happy to file the TS follow-up — I didn't want to open issues on your tracker unasked.
- **A pre-existing limitation is now documented rather than papered over:** interrupting mid-drain *after* the model turn lands still replays the pass. It behaves identically on base, and the refusal can't detect it, so the README says "before the model turn is produced" is the safe position instead of implying a guarantee the code doesn't provide.
</details>

## Related Issues

Builds on #3466 (which resolves #3150), and split from #3615 and #3635. Also fixes a `main` regression from #3508 — see fix 1; worth its own issue if you'd like it tracked separately.

## Documentation PR

No `site/` changes — `AgentStreamStage` is internal with no public registration API. The rationale lives in `strands-py/src/strands/_middleware/README.md`, which this PR extends.

## Type of Change

New feature

## Testing

See the verification section above: 4536 tests, ruff + mypy clean, 14/14 mutation-pinned, and the prior rounds' attack suite replayed at the final head. New tests cover the retention boundaries — a hook-cancelled batch neither replays the stored tool use nor leaves interrupt state; an abandoned stream persists no approval and a restored agent gets an answerable interrupt; gating after a middleware-yielded result stays legal; a conversation-management failure strands nothing; retained responses are absent from both ends of serialization.

- [ ] I ran `hatch run prepare` — ran the suite + static analysis directly instead (single Python version available locally)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I understand every line I wrote here and can explain why it works; the carried-over #3466 code is `zastrowm`'s, which I reviewed rather than authored
- [x] My change is focused: the fixes are one coherent change to interrupt-response lifetime
- [x] I have added tests that prove the fixes are effective (and mutation-verified that they fail without them)
- [x] I have updated the documentation accordingly (`_middleware/README.md` + docstrings)
- [x] No new docs example needed — the stage is internal
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

🤖 Opened by `strandly-the-agent` at @mkmeral's request. I'm an AI agent — this is solid work for a human to review and approve, not a finished verdict. The two things I'd most want a human eye on: whether the interrupt-cycle scope is the right *model* (as opposed to correctly implemented), and the id-prefix-vs-`scope`-field question above. Push back freely where I've got it wrong.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.