### PR TITLE
docs(team): require both decorator and log when deprecating a tool

### DIFF
--- a/team/FEATURE_LIFECYCLE.md
+++ b/team/FEATURE_LIFECYCLE.md
@@ -142,7 +142,7 @@ Releases within minor versions are additive and maintain backward compatibility.
 
 * **Major Version X:** Old way of doing something and new way of doing something introduced
     * **Minor Version X.Y-1**: Old way of doing something
-    * **Minor Version X.Y**: New way of doing something is added, deprecation warning is applied to old way to with `@warnings.**deprecated**(*msg*, ***, *category=DeprecationWarning*, *stacklevel=1*) `
+    * **Minor Version X.Y**: New way of doing something is added, deprecation warning is applied to the old way with `@deprecated(msg)` (see [Implementation Standards](#implementation-standards))
     * **Minor Version X.Y+1**: (optional) Enhance warning with migration examples or appropriate link to our docs pointing to the workaround
 * **Major Version X+1**: Remove older, deprecated feature entirely
 
@@ -153,17 +153,19 @@ Releases within minor versions are additive and maintain backward compatibility.
 
 Python
 
-```python
-import warnings
+Import `deprecated` from `typing_extensions`, not `warnings`. The `warnings` version
+requires Python 3.13, and the SDK supports 3.10 and later; `typing_extensions` is already
+a dependency and backports it.
 
-@warnings.deprecated( 
-        "deprecated_function() is deprecated and will be removed in v2.0.0. "
-        "Use new_function() instead. See migration guide: https://strands-agents.com/migration/deprecated_function", 
-        *, 
-        category=DeprecationWarning, 
-        stacklevel=2
-    ) 
-    
+```python
+from typing_extensions import deprecated
+
+
+@deprecated(
+    "deprecated_function() is deprecated and will be removed in v2.0.0. "
+    "Use new_function() instead. See migration guide: https://strands-agents.com/migration/deprecated_function"
+)
+def deprecated_function() -> None: ...
 ```
 
 Typescript
@@ -174,6 +176,58 @@ Typescript
  */
  export const deprecated_function = () => {}
 ```
+
+#### Deprecating a tool
+
+Apply the decorator **and** log the same message from inside the tool. Both are required,
+because they reach different audiences and neither covers the other:
+
+| | Reaches a user running an agent | Reaches type checkers, IDEs, `-W error` |
+|---|---|---|
+| `@deprecated` | no | yes |
+| `logger.warning` | yes | no |
+
+`@deprecated` raises a `DeprecationWarning`, and Python's default filter only displays that
+warning when it originates in `__main__` — every other module is ignored. A tool is invoked
+by the framework, so the warning is attributed to SDK internals and suppressed. The user
+sees nothing.
+
+The log line is what they actually see. Keep the decorator anyway: it is what marks the
+call site for type checkers and IDEs, and what surfaces under `-W error` or in pytest.
+
+```python
+import logging
+
+from strands import tool
+from typing_extensions import deprecated
+
+logger = logging.getLogger(__name__)
+
+_DEPRECATION_MESSAGE = (
+    "old_tool is deprecated and will be removed in v2.0.0. Use new_tool instead. "
+    "See migration guide: https://strands-agents.com/migration/old_tool"
+)
+
+
+@tool
+@deprecated(_DEPRECATION_MESSAGE)
+def old_tool(query: str) -> str:
+    """Does the old thing.
+
+    Args:
+        query: What to look up.
+    """
+    logger.warning("DEPRECATION WARNING: %s", _DEPRECATION_MESSAGE)
+    ...
+```
+
+Order matters: `@tool` goes outermost so the tool spec is built from the real signature.
+Share the message through a constant so the two copies cannot drift. Log before any early
+return, so the warning fires on error paths too.
+
+Note that a deprecated tool *instance* — as opposed to a factory function — cannot carry the
+decorator at all. Resolve those through a module-level `__getattr__` that warns and returns
+the replacement.
 
 
 

--- a/team/FEATURE_LIFECYCLE.md
+++ b/team/FEATURE_LIFECYCLE.md
@@ -217,13 +217,14 @@ def old_tool(query: str) -> str:
     Args:
         query: What to look up.
     """
-    logger.warning("DEPRECATION WARNING: %s", _DEPRECATION_MESSAGE)
+    logger.warning("tool_name=<old_tool> | %s", _DEPRECATION_MESSAGE)
     ...
 ```
 
 Order matters: `@tool` goes outermost so the tool spec is built from the real signature.
 Share the message through a constant so the two copies cannot drift. Log before any early
-return, so the warning fires on error paths too.
+return, so the warning fires on error paths too. The log call follows the
+[structured logging format](../AGENTS.md) used across both SDKs.
 
 Note that a deprecated tool *instance* — as opposed to a factory function — cannot carry the
 decorator at all. Resolve those through a module-level `__getattr__` that warns and returns


### PR DESCRIPTION
## Description

`FEATURE_LIFECYCLE.md` prescribes `@deprecated` as the deprecation mechanism. That works for ordinary functions, but **it cannot carry a tool deprecation on its own** — and following the doc literally produces a deprecation the user never sees.

`@deprecated` raises a `DeprecationWarning`. Python's default filter displays that warning only when it originates in `__main__`:

```
('default', None, <class 'DeprecationWarning'>, '__main__', 0)
('ignore',  None, <class 'DeprecationWarning'>, None, 0)
```

A tool is invoked by the framework, not by user code, so the warning is attributed to SDK internals and falls into the `ignore` rule. Verified with a decorator-only tool:

```
>>> agent.tool.old_tool(query="hi")
RESULT: success        # ...and nothing on stderr
```

So this adds a **Deprecating a tool** subsection stating that tools need both the decorator and a log line, with a table of what each one reaches, plus the mechanics that are easy to get wrong: `@tool` must be outermost so the spec is built from the real signature, the message should be shared through a constant so the two copies cannot drift, and the log must come before any early return so it fires on error paths.

It also notes that a deprecated tool *instance* (as opposed to a factory) cannot carry the decorator at all and needs a module-level `__getattr__`.

### Second, unrelated fix in the same section

The Python snippet prescribed `@warnings.deprecated`, which **requires Python 3.13** while `strands-py` sets `requires-python = ">=3.10"`. Anyone following it on a supported version gets `AttributeError: module 'warnings' has no attribute 'deprecated'`. It also carried stray signature syntax (`*,`, `category=`, `stacklevel=`) copied from the API reference, and decorated nothing, so it could not run as written.

Corrected to `from typing_extensions import deprecated` — already a dependency (`typing-extensions>=4.13.2`) and a backport of the same decorator. The Timeline bullet referencing the old form is updated to match and now links to the section.

## Related Issues

Came out of review discussion on strands-agents/tools#550 and #3595, where this gap surfaced in practice. Filing separately since it changes team process guidance rather than code.

## Documentation PR

This is the documentation change.

## Type of Change

Documentation update

## Testing

Every snippet in the edited section was executed against `strands-py` before committing — the previous ones could not run, so I did not want to replace them with more of the same. Confirmed:

- `@tool` over `@deprecated` builds the correct spec: `tool_name: old_tool`, `props: ['query']`
- the decorator's `__deprecated__` marker is present for static analysis
- the plain-function example raises `DeprecationWarning`
- the `warnings` vs `typing_extensions` claim, by checking `hasattr(warnings, 'deprecated')` on 3.12 (False) against the 3.10 floor in `strands-py/pyproject.toml`

No code changes, so no test suite applies. The `#implementation-standards` anchor resolves to the existing heading at line 151.

- [ ] I ran `hatch run prepare`

Not applicable — this PR touches only `team/FEATURE_LIFECYCLE.md`.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.