### PR TITLE
feat(bedrock): support API key authentication

### DIFF
--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -12,6 +12,7 @@ from collections.abc import AsyncGenerator, Callable, Iterable, ValuesView
 from typing import Any, Literal, TypeVar, cast
 
 import boto3
+from botocore import UNSIGNED
 from botocore.config import Config as BotocoreConfig
 from botocore.exceptions import ClientError
 from pydantic import BaseModel
@@ -173,6 +174,7 @@ class BedrockModel(Model):
         boto_client_config: BotocoreConfig | None = None,
         region_name: str | None = None,
         endpoint_url: str | None = None,
+        api_key: str | None = None,
         **model_config: Unpack[BedrockConfig],
     ):
         """Initialize provider instance.
@@ -183,6 +185,8 @@ class BedrockModel(Model):
             region_name: AWS region to use for the Bedrock service.
                 Defaults to the AWS_REGION environment variable if set, or "us-west-2" if not set.
             endpoint_url: Custom endpoint URL for VPC endpoints (PrivateLink)
+            api_key: Amazon Bedrock API key for bearer token authentication.
+                When provided, requests use the API key instead of SigV4 signing.
             **model_config: Configuration options for the Bedrock model.
         """
         if region_name and boto_session:
@@ -208,9 +212,18 @@ class BedrockModel(Model):
             else:
                 new_user_agent = "strands-agents"
 
-            client_config = boto_client_config.merge(BotocoreConfig(user_agent_extra=new_user_agent))
+            client_config = boto_client_config.merge(
+                BotocoreConfig(
+                    user_agent_extra=new_user_agent,
+                    **({"signature_version": UNSIGNED} if api_key else {}),
+                )
+            )
         else:
-            client_config = BotocoreConfig(user_agent_extra="strands-agents", read_timeout=DEFAULT_READ_TIMEOUT)
+            client_config = BotocoreConfig(
+                user_agent_extra="strands-agents",
+                read_timeout=DEFAULT_READ_TIMEOUT,
+                **({"signature_version": UNSIGNED} if api_key else {}),
+            )
 
         self.client = session.client(
             service_name="bedrock-runtime",
@@ -218,6 +231,13 @@ class BedrockModel(Model):
             endpoint_url=endpoint_url,
             region_name=resolved_region,
         )
+
+        if api_key:
+
+            def set_bearer_auth(request: Any, **_: Any) -> None:
+                request.headers["Authorization"] = f"Bearer {api_key}"
+
+            self.client.meta.events.register("before-send.bedrock-runtime.*", set_bearer_auth)
 
         logger.debug("region=<%s> | bedrock client created", self.client.meta.region_name)
 

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -11,6 +11,7 @@ from unittest.mock import ANY
 import boto3
 import pydantic
 import pytest
+from botocore import UNSIGNED
 from botocore.config import Config as BotocoreConfig
 from botocore.exceptions import ClientError, EventStreamError
 
@@ -277,6 +278,36 @@ def test__init__with_custom_boto_client_config_with_user_agent(session_cls, bedr
     assert isinstance(kwargs["config"], BotocoreConfig)
     assert kwargs["config"].user_agent_extra == "existing-agent strands-agents"
     assert kwargs["config"].read_timeout == 900
+
+
+def test__init__with_api_key_configures_bearer_auth(session_cls, bedrock_client):
+    """Use unsigned requests and a bearer authorization hook for an API key (#1238)."""
+    model = BedrockModel(
+        api_key="br-test-key", boto_client_config=BotocoreConfig(read_timeout=900, signature_version="v4")
+    )
+
+    client = session_cls.return_value.client
+    _, kwargs = client.call_args
+    assert kwargs["config"].signature_version == UNSIGNED
+    assert kwargs["config"].read_timeout == 900
+    assert model.get_config().get("api_key") is None
+
+    bedrock_client.meta.events.register.assert_called_once_with("before-send.bedrock-runtime.*", ANY)
+    auth_handler = bedrock_client.meta.events.register.call_args.args[1]
+    request = unittest.mock.Mock(headers={"Authorization": "AWS4-HMAC-SHA256 ..."})
+
+    auth_handler(request)
+
+    assert request.headers == {"Authorization": "Bearer br-test-key"}
+
+
+def test__init__without_api_key_does_not_register_bearer_auth(session_cls, bedrock_client):
+    """Keep the default IAM-signing path when no API key is provided."""
+    _ = BedrockModel()
+
+    _, kwargs = session_cls.return_value.client.call_args
+    assert kwargs["config"].signature_version is None
+    bedrock_client.meta.events.register.assert_not_called()
 
 
 def test__init__model_config(bedrock_client):


### PR DESCRIPTION
## Description

Add explicit Amazon Bedrock API-key authentication to the Python `BedrockModel`.

When `api_key` is provided, the model configures the Bedrock Runtime client for unsigned requests and registers a request hook that supplies the AWS bearer authorization header. This keeps authentication instance-scoped and avoids mutating `AWS_BEARER_TOKEN_BEDROCK`. Existing IAM/SigV4 behavior is unchanged when the option is omitted.

The API is intentionally aligned with the TypeScript SDK's existing `apiKey` option. The credential is constructor-only and is not exposed by `get_config()`.

## Related Issues

Resolves #1238

## Documentation PR

No separate documentation change is needed for this focused provider API addition; the public constructor docstring documents the new option.

## Type of Change

New feature

## Testing

- Added unit coverage for unsigned client configuration, preservation of caller config, request-hook registration, bearer-header replacement, and the unchanged no-key path.
- `hatch test tests/strands/models/test_bedrock.py`: 180 passed.
- Full Python test suite: 4,723 passed.
- Ruff formatting/check and mypy pass.
- `hatch run prepare` passed formatting, lint, mypy, and the Python 3.14 suite (4,723 passed); later interpreter setup was interrupted by a PyPI tunnel failure while downloading `coverage`, not by a test failure.

- [ ] I ran `hatch run prepare` to completion (remaining interpreter environments were blocked by the dependency-download failure described above)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
