### PR TITLE
chore: skipped mcp otel instrumentation for mcp v2

### DIFF
--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -61,7 +61,7 @@ from ...types.media import ImageFormat
 from ...types.tools import AgentTool, ToolResultContent, ToolResultStatus
 from ..tool_provider import ToolProvider
 from .mcp_agent_tool import MCPAgentTool
-from .mcp_instrumentation import mcp_instrumentation
+from .mcp_instrumentation import inject_trace_context, mcp_instrumentation
 from .mcp_tasks import DEFAULT_TASK_CONFIG, DEFAULT_TASK_POLL_TIMEOUT, DEFAULT_TASK_TTL, TasksConfig
 from .mcp_types import MCPToolResult, MCPTransport
 
@@ -775,6 +775,19 @@ class MCPClient(ToolProvider):
         """
         use_task = self._should_use_task(name)
         effective_callback = progress_callback if progress_callback is not None else self._progress_callback
+
+        # Inject once, before branching, so both the task-augmented and direct
+        # call paths below carry the same enriched meta. This is safe on the
+        # caller's thread: asyncio.run_coroutine_threadsafe, used to hand the
+        # resulting coroutine to the background loop, copies the caller's
+        # contextvars, so the caller's active span is still current when the
+        # coroutine runs on the background thread.
+        #
+        # Under mcp 2.x this injection becomes redundant rather than wrong: the
+        # dispatcher injects its own traceparent, overwriting this one with its
+        # own CLIENT span. That span is parented to the caller's span, so the
+        # trace stays connected.
+        meta = inject_trace_context(meta)
 
         if use_task:
             self._log_debug_with_thread("tool=<%s> | using task-augmented execution", name)

--- a/strands-py/src/strands/tools/mcp/mcp_instrumentation.py
+++ b/strands-py/src/strands/tools/mcp/mcp_instrumentation.py
@@ -1,17 +1,27 @@
 """OpenTelemetry instrumentation for Model Context Protocol (MCP) tracing.
 
-Enables distributed tracing across MCP client-server boundaries by injecting
-OpenTelemetry context into MCP request metadata (_meta field) and extracting
-it on the server side, creating unified traces that span from agent calls
-through MCP tool executions.
+Enables distributed tracing across MCP client-server boundaries. The client
+side is handled with `inject_trace_context`, which `MCPClient` uses to merge
+the current OpenTelemetry context into the `_meta` field of outgoing tool
+calls through the public `meta` parameter of the official `mcp` package.
+
+The server side covers MCP servers hosted in the same process. It extracts
+client-injected context from incoming messages so server-side spans join the
+client's trace. This requires patching private internals of the `mcp` package
+and those internals are only stable within the 1.x line, so the patches are
+gated to `mcp` 1.x. The `mcp` 2.x line propagates trace context natively.
 
 Based on: https://github.com/traceloop/openllmetry/tree/main/packages/opentelemetry-instrumentation-mcp
 Related issue: https://github.com/modelcontextprotocol/modelcontextprotocol/issues/246
 """
 
+import logging
+import threading
 from collections.abc import AsyncGenerator, Callable
 from contextlib import _AsyncGeneratorContextManager, asynccontextmanager
 from dataclasses import dataclass
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _package_version
 from typing import Any
 
 from mcp.shared.message import SessionMessage
@@ -19,8 +29,53 @@ from mcp.types import JSONRPCMessage, JSONRPCRequest
 from opentelemetry import context, propagate
 from wrapt import ObjectProxy, register_post_import_hook, wrap_function_wrapper
 
-# Module-level flag to ensure instrumentation is applied only once
+logger = logging.getLogger(__name__)
+
+# Module-level flag to ensure instrumentation is applied only once. The lock
+# makes the check-and-set atomic: `_is_mcp_v1` performs GIL-releasing I/O, so
+# without it concurrent MCPClient construction could stack duplicate wrappers.
 _instrumentation_applied = False
+_instrumentation_lock = threading.Lock()
+
+
+def inject_trace_context(meta: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Merge the current OpenTelemetry context into MCP request metadata.
+
+    Injects the active trace context (for example `traceparent` and
+    `tracestate`) into a copy of `meta` so it can be sent as the `_meta`
+    field of an MCP request. This enables server-side context extraction and
+    trace continuation across the client-server boundary.
+
+    Telemetry must never fail the tool call itself, so propagator errors are
+    logged and swallowed; the caller's metadata is still returned.
+
+    Args:
+        meta: Existing request metadata, or None. The input is not mutated.
+
+    Returns:
+        A new dict containing the caller's entries plus the injected trace
+        context, or None when there is no metadata to send.
+    """
+    carrier: dict[str, Any] = dict(meta) if meta else {}
+    try:
+        propagate.get_global_textmap().inject(carrier)
+    except Exception:
+        logger.warning("failed to inject trace context into mcp request meta", exc_info=True)
+    return carrier or None
+
+
+def _is_mcp_v1() -> bool:
+    """Report whether the installed `mcp` package is on the 1.x line.
+
+    The server-side patches wrap private `mcp` internals that are only stable
+    within 1.x. When the version cannot be determined, the patches are skipped
+    rather than applied to an unknown internal surface.
+    """
+    try:
+        major_version = int(_package_version("mcp").split(".")[0])
+    except (PackageNotFoundError, ValueError):
+        return False
+    return major_version == 1
 
 
 @dataclass(slots=True, frozen=True)
@@ -41,79 +96,36 @@ class ItemWithContext:
 
 
 def mcp_instrumentation() -> None:
-    """Apply OpenTelemetry instrumentation patches to MCP components.
+    """Apply OpenTelemetry instrumentation patches for in-process MCP servers.
 
-    This function instruments three key areas of MCP communication:
-    1. Client-side: Injects tracing context into tool call requests
-    2. Transport-level: Extracts context from incoming messages
-    3. Session-level: Manages bidirectional context flow
+    Instruments two areas of server-side MCP communication:
+    1. Transport-level: Extracts context from incoming messages
+    2. Session-level: Preserves context across async message processing
+       boundaries
 
-    The patches enable distributed tracing by:
-    - Adding OpenTelemetry context to the _meta field of MCP requests
-    - Extracting and activating context on the server side
-    - Preserving context across async message processing boundaries
+    Together the patches let an MCP server hosted in the same process join
+    the trace of the client that injected context into the request's `_meta`
+    field. Client-side injection does not require patching; `MCPClient`
+    injects context via `inject_trace_context`.
+
+    The patches wrap private internals of the `mcp` package that are only
+    stable within the 1.x line, so they are applied only when `mcp` 1.x is
+    installed. The `mcp` 2.x line propagates trace context natively.
 
     This function is idempotent - multiple calls will not accumulate wrappers.
     """
     global _instrumentation_applied
 
-    # Return early if instrumentation has already been applied
-    if _instrumentation_applied:
-        return
+    with _instrumentation_lock:
+        # Return early if instrumentation has already been applied
+        if _instrumentation_applied:
+            return
+        # Set before the version probe: it leaves the GIL, and a concurrent
+        # caller checking under the lock must see the flag.
+        _instrumentation_applied = True
 
-    def patch_mcp_client(wrapped: Callable[..., Any], instance: Any, args: Any, kwargs: Any) -> Any:
-        """Patch MCP client to inject OpenTelemetry context into tool calls.
-
-        Intercepts outgoing MCP requests and injects the current OpenTelemetry
-        context into the request's _meta field for tools/call methods. This
-        enables server-side context extraction and trace continuation.
-
-        Args:
-            wrapped: The original function being wrapped
-            instance: The instance the method is being called on
-            args: Positional arguments to the wrapped function
-            kwargs: Keyword arguments to the wrapped function
-
-        Returns:
-            Result of the wrapped function call
-        """
-        if len(args) < 1:
-            return wrapped(*args, **kwargs)
-
-        request = args[0]
-        method = getattr(request.root, "method", None)
-
-        if method != "tools/call":
-            return wrapped(*args, **kwargs)
-
-        try:
-            if hasattr(request.root, "params") and request.root.params:
-                # Handle Pydantic models
-                if hasattr(request.root.params, "model_dump") and hasattr(request.root.params, "model_validate"):
-                    params_dict = request.root.params.model_dump(by_alias=True)
-                    # Add _meta with tracing context
-                    meta = params_dict.get("_meta") if params_dict.get("_meta") is not None else {}
-                    params_dict["_meta"] = meta
-                    propagate.get_global_textmap().inject(meta)
-
-                    # Recreate the Pydantic model with the updated data
-                    # This preserves the original model type and avoids serialization warnings
-                    params_class = type(request.root.params)
-                    try:
-                        request.root.params = params_class.model_validate(params_dict)
-                    except Exception:
-                        # Fallback to dict if model recreation fails
-                        request.root.params = params_dict
-
-                elif isinstance(request.root.params, dict):
-                    # Handle dict params directly
-                    meta = request.root.params.setdefault("_meta", {})
-                    propagate.get_global_textmap().inject(meta)
-
-            return wrapped(*args, **kwargs)
-
-        except Exception:
-            return wrapped(*args, **kwargs)
+        if not _is_mcp_v1():
+            return
 
     def transport_wrapper() -> Callable[
         [Callable[..., Any], Any, Any, Any], _AsyncGeneratorContextManager[tuple[Any, Any]]
@@ -165,8 +177,6 @@ def mcp_instrumentation() -> None:
         return traced_method
 
     # Apply patches
-    wrap_function_wrapper("mcp.shared.session", "BaseSession.send_request", patch_mcp_client)
-
     register_post_import_hook(
         lambda _: wrap_function_wrapper(
             "mcp.server.streamable_http", "StreamableHTTPServerTransport.connect", transport_wrapper()

--- a/strands-py/tests/strands/tools/mcp/test_mcp_instrumentation.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_instrumentation.py
@@ -1,3 +1,6 @@
+import threading
+import time
+from importlib.metadata import PackageNotFoundError
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -5,12 +8,14 @@ from mcp.shared.message import SessionMessage
 from mcp.types import JSONRPCMessage, JSONRPCRequest
 from opentelemetry import context, propagate
 
+import strands.tools.mcp.mcp_instrumentation as mcp_instrumentation_module
 from strands.tools.mcp.mcp_client import MCPClient
 from strands.tools.mcp.mcp_instrumentation import (
     ItemWithContext,
     SessionContextAttachingReader,
     SessionContextSavingWriter,
     TransportContextExtractingReader,
+    inject_trace_context,
     mcp_instrumentation,
 )
 
@@ -24,6 +29,92 @@ def reset_mcp_instrumentation():
     yield
     # Reset after test too
     mcp_inst._instrumentation_applied = False
+
+
+class TestIsMcpV1:
+    @pytest.mark.parametrize(
+        ("installed_version", "expected"),
+        [
+            ("1.23.0", True),
+            ("1.30.0", True),
+            ("2.0.0", False),
+            ("2.0.0b1", False),
+        ],
+    )
+    def test_version_detection(self, installed_version, expected):
+        """Test that the major version of the installed mcp package is detected correctly."""
+        with patch("strands.tools.mcp.mcp_instrumentation._package_version", return_value=installed_version):
+            assert mcp_instrumentation_module._is_mcp_v1() is expected
+
+    def test_unparseable_version_skips(self):
+        """Test that an unparseable version reports non-1.x so no patches are applied."""
+        with patch("strands.tools.mcp.mcp_instrumentation._package_version", return_value="unknown"):
+            assert mcp_instrumentation_module._is_mcp_v1() is False
+
+    def test_missing_package_skips(self):
+        """Test that a missing mcp distribution reports non-1.x so no patches are applied."""
+        with patch(
+            "strands.tools.mcp.mcp_instrumentation._package_version",
+            side_effect=PackageNotFoundError("mcp"),
+        ):
+            assert mcp_instrumentation_module._is_mcp_v1() is False
+
+
+class TestInjectTraceContext:
+    def test_injects_context_into_empty_meta(self):
+        """Test that trace context is injected when no metadata is supplied."""
+        with patch.object(propagate, "get_global_textmap") as mock_textmap:
+            mock_textmap.return_value.inject = lambda carrier: carrier.update({"traceparent": "00-abc-def-01"})
+
+            result = inject_trace_context(None)
+
+            assert result == {"traceparent": "00-abc-def-01"}
+
+    def test_preserves_existing_meta_entries(self):
+        """Test that caller-supplied metadata survives injection."""
+        with patch.object(propagate, "get_global_textmap") as mock_textmap:
+            mock_textmap.return_value.inject = lambda carrier: carrier.update({"traceparent": "00-abc-def-01"})
+
+            result = inject_trace_context({"com.example/request_id": "abc-123"})
+
+            assert result == {"com.example/request_id": "abc-123", "traceparent": "00-abc-def-01"}
+
+    def test_does_not_mutate_input(self):
+        """Test that the caller's metadata dict is copied, not mutated."""
+        original = {"com.example/request_id": "abc-123"}
+
+        with patch.object(propagate, "get_global_textmap") as mock_textmap:
+            mock_textmap.return_value.inject = lambda carrier: carrier.update({"traceparent": "00-abc-def-01"})
+
+            inject_trace_context(original)
+
+        assert original == {"com.example/request_id": "abc-123"}
+
+    def test_returns_none_when_nothing_to_send(self):
+        """Test that None is returned when there is no metadata and no active context."""
+        with patch.object(propagate, "get_global_textmap") as mock_textmap:
+            mock_textmap.return_value.inject = lambda carrier: None
+
+            result = inject_trace_context(None)
+
+            assert result is None
+
+    def test_propagator_error_does_not_raise(self):
+        """Test that a failing propagator never escapes to fail the tool call.
+
+        Guards https://github.com/strands-agents/harness-sdk/pull/3611#discussion_r3706469408: custom
+        propagators (configurable via OTEL_PROPAGATORS) may raise, and telemetry must not break calls.
+        """
+
+        def broken_inject(carrier):
+            raise RuntimeError("propagator boom")
+
+        with patch.object(propagate, "get_global_textmap") as mock_textmap:
+            mock_textmap.return_value.inject = broken_inject
+
+            result = inject_trace_context({"com.example/request_id": "abc-123"})
+
+            assert result == {"com.example/request_id": "abc-123"}
 
 
 class TestItemWithContext:
@@ -321,24 +412,6 @@ class TestSessionContextAttachingReader:
         assert items[0] == regular_item
 
 
-# Mock Pydantic-like class for testing
-class MockPydanticParams:
-    """Mock class that behaves like a Pydantic model."""
-
-    def __init__(self, **data):
-        self._data = data
-
-    def model_dump(self, by_alias=False):
-        return self._data.copy()
-
-    @classmethod
-    def model_validate(cls, data):
-        return cls(**data)
-
-    def __getattr__(self, name):
-        return self._data.get(name)
-
-
 class TestMCPInstrumentation:
     def test_mcp_instrumentation_called_on_client_init(self):
         """Test that mcp_instrumentation is called when MCPClient is initialized."""
@@ -358,8 +431,8 @@ class TestMCPInstrumentation:
     def test_mcp_instrumentation_idempotent_with_multiple_clients(self):
         """Test that mcp_instrumentation is only called once even with multiple MCPClient instances."""
 
-        # Mock the wrap_function_wrapper to count calls
-        with patch("strands.tools.mcp.mcp_instrumentation.wrap_function_wrapper") as mock_wrap:
+        # Mock register_post_import_hook to count calls
+        with patch("strands.tools.mcp.mcp_instrumentation.register_post_import_hook") as mock_register:
             # Mock transport
             def mock_transport():
                 read_stream = AsyncMock()
@@ -368,28 +441,18 @@ class TestMCPInstrumentation:
 
             # Create first MCPClient instance - should apply instrumentation
             MCPClient(mock_transport)
-            first_call_count = mock_wrap.call_count
+            first_call_count = mock_register.call_count
 
             # Create second MCPClient instance - should NOT apply instrumentation again
             MCPClient(mock_transport)
 
-            # wrap_function_wrapper should not be called again for the second client
-            assert mock_wrap.call_count == first_call_count
+            # register_post_import_hook should not be called again for the second client
+            assert mock_register.call_count == first_call_count
 
-    def test_mcp_instrumentation_calls_wrap_function_wrapper(self):
-        """Test that mcp_instrumentation calls the expected wrapper functions."""
-        with (
-            patch("strands.tools.mcp.mcp_instrumentation.wrap_function_wrapper") as mock_wrap,
-            patch("strands.tools.mcp.mcp_instrumentation.register_post_import_hook") as mock_register,
-        ):
+    def test_mcp_instrumentation_registers_server_side_hooks(self):
+        """Test that mcp_instrumentation registers the transport and session wrappers."""
+        with patch("strands.tools.mcp.mcp_instrumentation.register_post_import_hook") as mock_register:
             mcp_instrumentation()
-
-            # Verify wrap_function_wrapper was called for client patching
-            mock_wrap.assert_called_once_with(
-                "mcp.shared.session",
-                "BaseSession.send_request",
-                mock_wrap.call_args_list[0][0][2],  # The patch function
-            )
 
             # Verify register_post_import_hook was called for transport and session wrappers
             assert mock_register.call_count == 2
@@ -399,167 +462,47 @@ class TestMCPInstrumentation:
             assert "mcp.server.streamable_http" in registered_modules
             assert "mcp.server.session" in registered_modules
 
-    def test_patch_mcp_client_injects_context_pydantic_model(self):
-        """Test that the client patch injects OpenTelemetry context into Pydantic models."""
-        # Create a mock request with tools/call method and Pydantic params
-        mock_request = MagicMock()
-        mock_request.root.method = "tools/call"
-
-        # Use our mock Pydantic-like class
-        mock_params = MockPydanticParams(existing="param")
-        mock_request.root.params = mock_params
-
-        # Create the patch function
-        with patch("strands.tools.mcp.mcp_instrumentation.wrap_function_wrapper") as mock_wrap:
+    def test_mcp_instrumentation_skips_patches_on_mcp_v2(self):
+        """Test that the server-side patches are not applied when mcp 2.x is installed."""
+        with (
+            patch("strands.tools.mcp.mcp_instrumentation._is_mcp_v1", return_value=False),
+            patch("strands.tools.mcp.mcp_instrumentation.register_post_import_hook") as mock_register,
+        ):
             mcp_instrumentation()
-            patch_function = mock_wrap.call_args_list[0][0][2]
 
-        # Mock the wrapped function
-        mock_wrapped = MagicMock()
+            mock_register.assert_not_called()
 
-        with patch.object(propagate, "get_global_textmap") as mock_textmap:
-            mock_textmap_instance = MagicMock()
-            mock_textmap.return_value = mock_textmap_instance
+    def test_mcp_instrumentation_applies_once_under_concurrency(self):
+        """Test that concurrent callers cannot apply the patches more than once.
 
-            # Call the patch function
-            patch_function(mock_wrapped, None, [mock_request], {})
+        Guards https://github.com/strands-agents/harness-sdk/pull/3611#discussion_r3706469411: the
+        version probe does GIL-releasing I/O, so an unlocked check-and-set let concurrent MCPClient
+        construction stack duplicate wrappers.
+        """
 
-            # Verify context was injected
-            mock_textmap_instance.inject.assert_called_once()
-            mock_wrapped.assert_called_once_with(mock_request)
+        def slow_is_mcp_v1():
+            time.sleep(0.01)
+            return True
 
-            # Verify the params object is still a MockPydanticParams (or dict if fallback occurred)
-            assert hasattr(mock_request.root.params, "model_dump") or isinstance(mock_request.root.params, dict)
+        with (
+            patch("strands.tools.mcp.mcp_instrumentation._is_mcp_v1", side_effect=slow_is_mcp_v1),
+            patch("strands.tools.mcp.mcp_instrumentation.register_post_import_hook") as mock_register,
+        ):
+            threads = [threading.Thread(target=mcp_instrumentation) for _ in range(8)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join(timeout=5)
 
-    def test_patch_mcp_client_preserves_existing_meta_pydantic(self):
-        """Test that instrumentation preserves existing _meta values in Pydantic models."""
-        mock_request = MagicMock()
-        mock_request.root.method = "tools/call"
+            # Two hooks registered exactly once, regardless of caller count
+            assert mock_register.call_count == 2
 
-        # Pydantic model with existing _meta (returned via by_alias=True)
-        mock_params = MockPydanticParams(_meta={"com.example/request_id": "abc-123"}, name="echo")
-        mock_request.root.params = mock_params
-
-        with patch("strands.tools.mcp.mcp_instrumentation.wrap_function_wrapper") as mock_wrap:
+    def test_mcp_instrumentation_skip_is_sticky(self):
+        """Test that a skipped application still marks instrumentation as applied."""
+        with patch("strands.tools.mcp.mcp_instrumentation._is_mcp_v1", return_value=False):
             mcp_instrumentation()
-            patch_function = mock_wrap.call_args_list[0][0][2]
 
-        mock_wrapped = MagicMock()
-
-        with patch.object(propagate, "get_global_textmap") as mock_textmap:
-            mock_textmap_instance = MagicMock()
-            mock_textmap.return_value = mock_textmap_instance
-
-            patch_function(mock_wrapped, None, [mock_request], {})
-
-            # Verify the reconstructed params use the key "_meta" (alias) not "meta" (Python name)
-            validated_params = mock_request.root.params.model_dump(by_alias=True)
-            assert "_meta" in validated_params
-            assert validated_params["_meta"]["com.example/request_id"] == "abc-123"
-
-    def test_patch_mcp_client_injects_context_dict_params(self):
-        """Test that the client patch injects OpenTelemetry context into dict params."""
-        # Create a mock request with tools/call method and dict params
-        mock_request = MagicMock()
-        mock_request.root.method = "tools/call"
-        mock_request.root.params = {"existing": "param"}
-
-        # Create the patch function
-        with patch("strands.tools.mcp.mcp_instrumentation.wrap_function_wrapper") as mock_wrap:
+        with patch("strands.tools.mcp.mcp_instrumentation.register_post_import_hook") as mock_register:
             mcp_instrumentation()
-            patch_function = mock_wrap.call_args_list[0][0][2]
 
-        # Mock the wrapped function
-        mock_wrapped = MagicMock()
-
-        with patch.object(propagate, "get_global_textmap") as mock_textmap:
-            mock_textmap_instance = MagicMock()
-            mock_textmap.return_value = mock_textmap_instance
-
-            # Call the patch function
-            patch_function(mock_wrapped, None, [mock_request], {})
-
-            # Verify context was injected
-            mock_textmap_instance.inject.assert_called_once()
-            mock_wrapped.assert_called_once_with(mock_request)
-
-            # Verify _meta was added to the params dict
-            assert "_meta" in mock_request.root.params
-
-    def test_patch_mcp_client_skips_non_tools_call(self):
-        """Test that the client patch skips non-tools/call methods."""
-        mock_request = MagicMock()
-        mock_request.root.method = "other/method"
-
-        with patch("strands.tools.mcp.mcp_instrumentation.wrap_function_wrapper") as mock_wrap:
-            mcp_instrumentation()
-            patch_function = mock_wrap.call_args_list[0][0][2]
-
-        mock_wrapped = MagicMock()
-
-        with patch.object(propagate, "get_global_textmap") as mock_textmap:
-            mock_textmap_instance = MagicMock()
-            mock_textmap.return_value = mock_textmap_instance
-
-            patch_function(mock_wrapped, None, [mock_request], {})
-
-            # Verify context injection was skipped
-            mock_textmap_instance.inject.assert_not_called()
-            mock_wrapped.assert_called_once_with(mock_request)
-
-    def test_patch_mcp_client_handles_exception_gracefully(self):
-        """Test that the client patch handles exceptions gracefully."""
-        # Create a mock request that will cause an exception
-        mock_request = MagicMock()
-        mock_request.root.method = "tools/call"
-        mock_request.root.params = MagicMock()
-        mock_request.root.params.model_dump.side_effect = Exception("Test exception")
-
-        with patch("strands.tools.mcp.mcp_instrumentation.wrap_function_wrapper") as mock_wrap:
-            mcp_instrumentation()
-            patch_function = mock_wrap.call_args_list[0][0][2]
-
-        mock_wrapped = MagicMock()
-
-        # Should not raise an exception, should call wrapped function normally
-        patch_function(mock_wrapped, None, [mock_request], {})
-        mock_wrapped.assert_called_once_with(mock_request)
-
-    def test_patch_mcp_client_pydantic_fallback_to_dict(self):
-        """Test that Pydantic model recreation falls back to dict on failure."""
-
-        # Create a Pydantic-like class that fails on model_validate
-        class FailingMockPydanticParams:
-            def __init__(self, **data):
-                self._data = data
-
-            def model_dump(self, by_alias=False):
-                return self._data.copy()
-
-            def model_validate(self, data):
-                raise Exception("Reconstruction failed")
-
-        # Create a mock request with failing Pydantic params
-        mock_request = MagicMock()
-        mock_request.root.method = "tools/call"
-
-        failing_params = FailingMockPydanticParams(existing="param")
-        mock_request.root.params = failing_params
-
-        with patch("strands.tools.mcp.mcp_instrumentation.wrap_function_wrapper") as mock_wrap:
-            mcp_instrumentation()
-            patch_function = mock_wrap.call_args_list[0][0][2]
-
-        mock_wrapped = MagicMock()
-
-        with patch.object(propagate, "get_global_textmap") as mock_textmap:
-            mock_textmap_instance = MagicMock()
-            mock_textmap.return_value = mock_textmap_instance
-
-            # Call the patch function
-            patch_function(mock_wrapped, None, [mock_request], {})
-
-            # Verify it fell back to dict
-            assert isinstance(mock_request.root.params, dict)
-            assert "_meta" in mock_request.root.params
-            mock_wrapped.assert_called_once_with(mock_request)
+            mock_register.assert_not_called()


### PR DESCRIPTION
## Description

The MCP client injected OpenTelemetry trace context into tool calls by monkey-patching `mcp.shared.session.BaseSession.send_request` with `wrapt`. That module is private and gone in `mcp` 2.0, so the patch is the first breakage when we adopt the new major version for MCP spec 2026-07-28 support (#1659). The official SDK exposes a public `meta` parameter on `call_tool` that does the same job.

Client-side injection is now a plain function feeding that `meta` parameter. Propagator errors are logged and swallowed so telemetry can never fail on a tool call. The two server-side patches (trace extraction for in-process MCP servers) still monkey-patch `mcp` internals, so they only apply on 1.x where those internals exist. Applying them now takes a lock: the version probe does I/O, and the old unlocked check let concurrent clients stack duplicate wrappers.

## Related Issues

#1659

## Documentation PR

N/A

## Type of Change

Other (please describe): internal refactor, no public API change

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

Verified against a real stdio MCP server with a real `TracerProvider`, no mocks: the server receives a `traceparent` matching the client span, caller-supplied `meta` survives, a raising propagator logs a warning while the call still succeeds, and 16 threads racing `mcp_instrumentation()` apply the patches exactly once.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
