### PR TITLE
fix: preserve summary role attribution

### DIFF
--- a/strands-py/src/strands/agent/conversation_manager/summarizing_conversation_manager.py
+++ b/strands-py/src/strands/agent/conversation_manager/summarizing_conversation_manager.py
@@ -79,6 +79,7 @@ class SummarizingConversationManager(ConversationManager):
         self.summarization_system_prompt = summarization_system_prompt
         self.pin_first = max(0, pin_first) if pin_first is not None else None
         self._pin_first_applied = False
+        self._summary_preamble: Message | None = None
         self._summary_message: Message | None = None
 
     @override
@@ -93,11 +94,27 @@ class SummarizingConversationManager(ConversationManager):
         """
         super().restore_from_session(state)
         self._summary_message = state.get("summary_message")
-        return [self._summary_message] if self._summary_message else None
+        if not self._summary_message:
+            self._summary_preamble = None
+            return None
+
+        self._summary_preamble = state.get("summary_preamble") or self._create_summary_preamble()
+        return [self._summary_preamble, self._summary_message]
 
     def get_state(self) -> dict[str, Any]:
         """Returns a dictionary representation of the state for the Summarizing Conversation Manager."""
-        return {"summary_message": self._summary_message, **super().get_state()}
+        return {
+            "summary_preamble": self._summary_preamble,
+            "summary_message": self._summary_message,
+            **super().get_state(),
+        }
+
+    @staticmethod
+    def _create_summary_preamble() -> Message:
+        """Create the user message that introduces an assistant-authored summary."""
+        preamble: Message = {"role": "user", "content": [{"text": "Previous conversation summary:"}]}
+        _ensure_tracking_id(preamble)
+        return preamble
 
     def apply_management(self, agent: "Agent", **kwargs: Any) -> None:
         """Apply management strategy to conversation history.
@@ -182,21 +199,36 @@ class SummarizingConversationManager(ConversationManager):
         if not to_summarize:
             raise ContextWindowOverflowException("Cannot summarize: all messages in summarize range are pinned")
 
-        remaining_messages = agent.messages[messages_to_summarize_count:]
+        previous_summary_messages = tuple(
+            message for message in (self._summary_preamble, self._summary_message) if message is not None
+        )
+        protected_to_preserve = [
+            message
+            for message in protected_to_preserve
+            if all(message is not previous for previous in previous_summary_messages)
+        ]
+        remaining_messages = [
+            message
+            for message in agent.messages[messages_to_summarize_count:]
+            if all(message is not previous for previous in previous_summary_messages)
+        ]
 
-        # Keep track of the number of messages that have been summarized thus far.
-        self.removed_message_count += len(to_summarize)
-        # If there is a summary message, don't count it in the removed_message_count.
-        if self._summary_message:
-            self.removed_message_count -= 1
+        # Only persisted conversation messages contribute to the repository restore offset.
+        self.removed_message_count += sum(
+            all(message is not previous for previous in previous_summary_messages) for message in to_summarize
+        )
 
-        # Generate summary
-        self._summary_message = self._generate_summary(to_summarize, agent)
+        summary_input = [message for message in to_summarize if message is not self._summary_preamble]
+        if self._summary_message and all(message is not self._summary_message for message in summary_input):
+            summary_input.insert(0, self._summary_message)
+
+        self._summary_preamble = self._create_summary_preamble()
+        self._summary_message = self._generate_summary(summary_input, agent)
         # Assign tracking id to the summary message since it bypasses the append method.
         _ensure_tracking_id(self._summary_message)
 
-        # Replace summarized range with protected messages + summary + remaining
-        agent.messages[:] = protected_to_preserve + [self._summary_message] + remaining_messages
+        # Replace summarized range with protected messages + attributed summary + remaining
+        agent.messages[:] = protected_to_preserve + [self._summary_preamble, self._summary_message] + remaining_messages
 
     def _generate_summary(self, messages: list[Message], agent: "Agent") -> Message:
         """Generate a summary of the provided messages.
@@ -247,7 +279,7 @@ class SummarizingConversationManager(ConversationManager):
 
         try:
             # Disable structured output for summarization. Summaries are plain text and
-            # structured output adds toolUse blocks that are invalid in user messages.
+            # structured output can add toolUse blocks without matching toolResult blocks.
             if hasattr(summarization_agent, "_default_structured_output_model"):
                 summarization_agent._default_structured_output_model = None
 
@@ -260,7 +292,7 @@ class SummarizingConversationManager(ConversationManager):
             summarization_agent.messages = messages
 
             result = summarization_agent("Please summarize this conversation.")
-            return cast(Message, {**result.message, "role": "user"})
+            return cast(Message, {**result.message, "role": "assistant"})
 
         finally:
             summarization_agent.system_prompt = original_system_prompt
@@ -288,7 +320,8 @@ class SummarizingConversationManager(ConversationManager):
         Returns:
             A message containing the conversation summary.
         """
-        return run_async(lambda: generate_summary(messages, agent.model, self.summarization_system_prompt))
+        summary = run_async(lambda: generate_summary(messages, agent.model, self.summarization_system_prompt))
+        return cast(Message, {**summary, "role": "assistant"})
 
     def _adjust_split_point_for_tool_pairs(self, messages: list[Message], split_point: int) -> int:
         """Adjust the split point to avoid breaking ToolUse/ToolResult pairs.

--- a/strands-py/src/strands/agent/conversation_manager/summarizing_conversation_manager.py
+++ b/strands-py/src/strands/agent/conversation_manager/summarizing_conversation_manager.py
@@ -98,6 +98,7 @@ class SummarizingConversationManager(ConversationManager):
             self._summary_preamble = None
             return None
 
+        self._summary_message = cast(Message, {**self._summary_message, "role": "assistant"})
         self._summary_preamble = state.get("summary_preamble") or self._create_summary_preamble()
         return [self._summary_preamble, self._summary_message]
 
@@ -193,15 +194,30 @@ class SummarizingConversationManager(ConversationManager):
             apply_pin_first(agent.messages, self.pin_first)
             self._pin_first_applied = True
 
-        # Partition [0, messages_to_summarize_count) into pinned (preserve) and non-pinned (summarize)
-        protected_to_preserve, to_summarize = partition_pinned(agent.messages, 0, messages_to_summarize_count)
-
-        if not to_summarize:
-            raise ContextWindowOverflowException("Cannot summarize: all messages in summarize range are pinned")
-
         previous_summary_messages = tuple(
             message for message in (self._summary_preamble, self._summary_message) if message is not None
         )
+        max_messages_to_summarize = len(agent.messages) - self.preserve_recent_messages
+        while True:
+            # Partition the range into pinned messages and messages eligible for summarization.
+            protected_to_preserve, to_summarize = partition_pinned(agent.messages, 0, messages_to_summarize_count)
+            persisted_to_summarize = [
+                message
+                for message in to_summarize
+                if all(message is not previous for previous in previous_summary_messages)
+            ]
+            if persisted_to_summarize:
+                break
+
+            messages_to_summarize_count += 1
+            if messages_to_summarize_count > max_messages_to_summarize:
+                raise ContextWindowOverflowException("Cannot summarize: insufficient messages for summarization")
+            messages_to_summarize_count = self._adjust_split_point_for_tool_pairs(
+                agent.messages, messages_to_summarize_count
+            )
+            if messages_to_summarize_count > max_messages_to_summarize:
+                raise ContextWindowOverflowException("Cannot summarize: insufficient messages for summarization")
+
         protected_to_preserve = [
             message
             for message in protected_to_preserve
@@ -214,9 +230,7 @@ class SummarizingConversationManager(ConversationManager):
         ]
 
         # Only persisted conversation messages contribute to the repository restore offset.
-        self.removed_message_count += sum(
-            all(message is not previous for previous in previous_summary_messages) for message in to_summarize
-        )
+        self.removed_message_count += len(persisted_to_summarize)
 
         summary_input = [message for message in to_summarize if message is not self._summary_preamble]
         if self._summary_message and all(message is not self._summary_message for message in summary_input):

--- a/strands-py/tests/strands/agent/test_summarizing_conversation_manager.py
+++ b/strands-py/tests/strands/agent/test_summarizing_conversation_manager.py
@@ -752,6 +752,37 @@ def test_summarizing_conversation_manager_properly_records_removed_message_count
     assert manager.removed_message_count == 5
 
 
+def test_reduce_context_with_pinned_prefix_makes_progress():
+    mock_model = MockedModelProvider(
+        [
+            {"role": "assistant", "content": [{"text": "Summary"}]},
+            {"role": "assistant", "content": [{"text": "Summary"}]},
+        ]
+    )
+    messages: Messages = [
+        {"role": "user", "content": [{"text": "Message 1"}]},
+        {"role": "assistant", "content": [{"text": "Response 1"}]},
+        {"role": "user", "content": [{"text": "Message 2"}]},
+        {"role": "assistant", "content": [{"text": "Response 2"}]},
+        {"role": "user", "content": [{"text": "Message 3"}]},
+        {"role": "assistant", "content": [{"text": "Response 3"}]},
+        {"role": "user", "content": [{"text": "Message 4"}]},
+        {"role": "assistant", "content": [{"text": "Response 4"}]},
+    ]
+    agent = Agent(model=mock_model, messages=messages)
+    manager = SummarizingConversationManager(summary_ratio=0.5, preserve_recent_messages=1, pin_first=1)
+
+    manager.reduce_context(agent)
+    tru_first_state = (len(agent.messages), manager.removed_message_count)
+    exp_first_state = (7, 3)
+    assert tru_first_state == exp_first_state
+
+    manager.reduce_context(agent)
+    tru_second_state = (len(agent.messages), manager.removed_message_count)
+    exp_second_state = (6, 4)
+    assert tru_second_state == exp_second_state
+
+
 @patch("strands.agent.conversation_manager.summarizing_conversation_manager.ToolRegistry")
 def test_summarizing_conversation_manager_generate_summary_with_noop_tool_agent_path(
     mock_registry_cls,
@@ -800,12 +831,7 @@ def test_summarizing_conversation_manager_generate_summary_with_tools_agent_path
 
 
 def test_generate_summary_disables_structured_output_on_summarization_agent():
-    """Test that structured output is disabled during summarization to avoid toolUse in user messages.
-
-    When a summarization agent has structured_output_model configured, the response contains toolUse blocks.
-    Since the summary is converted to a user message, toolUse blocks would violate the model API constraint
-    that user messages cannot contain tool uses. The fix disables structured output during summarization.
-    """
+    """Test that assistant summaries cannot contain unmatched toolUse blocks."""
     summary_agent = create_mock_agent()
     structured_output_model = Mock()
     summary_agent._default_structured_output_model = structured_output_model

--- a/strands-py/tests/strands/agent/test_summarizing_conversation_manager.py
+++ b/strands-py/tests/strands/agent/test_summarizing_conversation_manager.py
@@ -130,13 +130,14 @@ def test_reduce_context_with_summarization(summarizing_manager, mock_agent):
 
     summarizing_manager.reduce_context(mock_agent)
 
-    # Should have: 1 summary message + 2 preserved recent messages + remaining from summarization
-    assert len(mock_agent.messages) == 4
-
-    # First message should be the summary
-    assert mock_agent.messages[0]["role"] == "user"
-    first_content = mock_agent.messages[0]["content"][0]
-    assert "text" in first_content and "This is a summary of the conversation." in first_content["text"]
+    # The user preamble keeps the assistant-authored summary valid as conversation history.
+    assert len(mock_agent.messages) == 5
+    preamble_message, summary_message = mock_agent.messages[:2]
+    assert preamble_message["role"] == "user"
+    assert preamble_message["content"] == [{"text": "Previous conversation summary:"}]
+    assert summary_message["role"] == "assistant"
+    summary_content = summary_message["content"][0]
+    assert "text" in summary_content and "This is a summary of the conversation." in summary_content["text"]
 
     # Recent messages should be preserved
     assert "Message 3" in str(mock_agent.messages[-2]["content"])
@@ -156,9 +157,12 @@ def test_reduce_context_summary_message_has_durable_id(summarizing_manager, mock
 
     summarizing_manager.reduce_context(mock_agent)
 
-    summary_message = mock_agent.messages[0]
+    preamble_message, summary_message = mock_agent.messages[:2]
+    assert isinstance(preamble_message.get("tracking_id"), str)
+    assert preamble_message["tracking_id"]
     assert isinstance(summary_message.get("tracking_id"), str)
     assert summary_message["tracking_id"]
+    assert preamble_message["tracking_id"] != summary_message["tracking_id"]
 
 
 def test_reduce_context_too_few_messages_raises_exception(summarizing_manager, mock_agent):
@@ -236,6 +240,7 @@ def test_generate_summary(summarizing_manager, mock_agent):
 
     summary = summarizing_manager._generate_summary(test_messages, mock_agent)
 
+    assert summary["role"] == "assistant"
     summary_content = summary["content"][0]
     assert "text" in summary_content and summary_content["text"] == "This is a summary of the conversation."
 
@@ -368,6 +373,7 @@ def test_uses_summarization_agent_when_provided():
     summary = manager._generate_summary(messages, parent_agent)
 
     # Should use the dedicated summarization agent, not the parent agent
+    assert summary["role"] == "assistant"
     summary_content = summary["content"][0]
     assert "text" in summary_content and summary_content["text"] == "Custom summary from dedicated agent"
 
@@ -572,17 +578,17 @@ def test_reduce_context_tool_pair_adjustment_works_with_forward_search():
     # messages_to_summarize_count = (3 - 1) * 0.5 = 1
     # But split point adjustment will move forward from the toolUse, potentially increasing count
     manager.reduce_context(mock_agent)
-    # Should have summary + remaining messages
-    assert len(mock_agent.messages) == 2
+    assert len(mock_agent.messages) == 3
 
-    # First message should be the summary
     assert mock_agent.messages[0]["role"] == "user"
-    summary_content = mock_agent.messages[0]["content"][0]
+    assert mock_agent.messages[0]["content"] == [{"text": "Previous conversation summary:"}]
+    assert mock_agent.messages[1]["role"] == "assistant"
+    summary_content = mock_agent.messages[1]["content"][0]
     assert "text" in summary_content and "This is a summary of the conversation." in summary_content["text"]
 
     # Last message should be the preserved recent message
-    assert mock_agent.messages[1]["role"] == "user"
-    assert mock_agent.messages[1]["content"][0]["text"] == "Latest message"
+    assert mock_agent.messages[2]["role"] == "user"
+    assert mock_agent.messages[2]["content"][0]["text"] == "Latest message"
 
 
 def test_adjust_split_point_exceeds_message_length(summarizing_manager):
@@ -729,23 +735,20 @@ def test_summarizing_conversation_manager_properly_records_removed_message_count
     assert manager.removed_message_count == 0
 
     manager.reduce_context(agent)
-    # Assert the oldest message is the sumamry message
     assert manager._summary_message["content"][0]["text"] == "Summary"
-    # There are 8 messages in the agent messages array, since half will be summarized,
-    # 4 will remain plus 1 summary message = 5
-    assert (len(agent.messages)) == 5
-    # Half of the messages were summarized and removed: 8/2 = 4
+    assert manager._summary_message["role"] == "assistant"
+    assert len(agent.messages) == 6
+    assert agent.messages[0]["content"] == [{"text": "Previous conversation summary:"}]
+    assert agent.messages[1] is manager._summary_message
     assert manager.removed_message_count == 4
 
     manager.reduce_context(agent)
     assert manager._summary_message["content"][0]["text"] == "Summary"
-    # After the first summary, 5 messages remain. Summarizing again will lead to:
-    # 5 - (int(5/2)) (messages to be sumamrized) + 1 (new summary message) = 5 - 2 + 1 = 4
-    assert (len(agent.messages)) == 4
-    # Half of the messages were summarized and removed: int(5/2) = 2
-    # However, one of the messages that was summarized was the previous summary message,
-    # so we dont count this toward the total:
-    # 4 (Previously removed messages) + 2 (removed messages) - 1 (Previous summary message) = 5
+    assert manager._summary_message["role"] == "assistant"
+    assert len(agent.messages) == 5
+    assert agent.messages[0]["content"] == [{"text": "Previous conversation summary:"}]
+    assert agent.messages[1] is manager._summary_message
+    # The generated preamble and prior summary do not advance the persisted-message offset.
     assert manager.removed_message_count == 5
 
 
@@ -861,9 +864,10 @@ def test_proactive_compression_summarizes_when_exceeded():
     event = BeforeModelCallEvent(agent=agent, invocation_state={}, projected_input_tokens=800)
     registry.invoke_callbacks(event)
 
-    # 20 * 0.5 = 10 summarized → 1 summary + 10 remaining = 11
-    assert len(agent.messages) == 11
+    # 20 * 0.5 = 10 summarized → preamble + summary + 10 remaining = 12
+    assert len(agent.messages) == 12
     assert agent.messages[0]["role"] == "user"
+    assert agent.messages[1]["role"] == "assistant"
 
 
 def test_proactive_compression_no_summarize_when_below():

--- a/strands-py/tests/strands/session/test_repository_session_manager.py
+++ b/strands-py/tests/strands/session/test_repository_session_manager.py
@@ -179,10 +179,14 @@ def test_initialize_restores_existing_agent_with_summarizing_conversation_manage
 
     # Verify agent state restored
     assert agent.state.get("key") == "value"
-    # The session message plus the summary message
-    assert len(agent.messages) == 2
-    assert agent.messages[1]["role"] == "user"
-    assert agent.messages[1]["content"][0]["text"] == "Hello"
+    # The attributed summary is prepended to the remaining persisted session message.
+    assert len(agent.messages) == 3
+    assert agent.messages[0]["role"] == "user"
+    assert agent.messages[0]["content"] == [{"text": "Previous conversation summary:"}]
+    assert agent.messages[1]["role"] == "assistant"
+    assert agent.messages[1]["content"][0]["text"] == "summary"
+    assert agent.messages[2]["role"] == "user"
+    assert agent.messages[2]["content"][0]["text"] == "Hello"
     assert agent.conversation_manager.removed_message_count == 1
 
 

--- a/strands-py/tests/strands/session/test_repository_session_manager.py
+++ b/strands-py/tests/strands/session/test_repository_session_manager.py
@@ -150,7 +150,7 @@ def test_initialize_restores_existing_agent_with_summarizing_conversation_manage
     """Test that initializing an existing agent restores its state."""
     conversation_manager = SummarizingConversationManager()
     conversation_manager.removed_message_count = 1
-    conversation_manager._summary_message = {"role": "assistant", "content": [{"text": "summary"}]}
+    conversation_manager._summary_message = {"role": "user", "content": [{"text": "summary"}]}
 
     # Create agent in repository first
     session_agent = SessionAgent(

--- a/strands-py/tests_integ/test_summarizing_conversation_manager_integration.py
+++ b/strands-py/tests_integ/test_summarizing_conversation_manager_integration.py
@@ -152,16 +152,17 @@ def test_summarization_with_context_overflow(model):
 
     # Verify summarization occurred
     assert len(agent.messages) < initial_message_count
-    # Should have: 1 summary + remaining messages
+    # Should have: preamble + summary + remaining messages
     # With 6 messages, summary_ratio=0.5, preserve_recent_messages=2:
     # messages_to_summarize = min(6 * 0.5, 6 - 2) = min(3, 4) = 3
-    # So we summarize 3 messages, leaving 3 remaining + 1 summary = 4 total
-    expected_total_messages = 4
+    # So we summarize 3 messages, leaving 3 remaining + 2 attributed summary messages = 5 total
+    expected_total_messages = 5
     assert len(agent.messages) == expected_total_messages
 
-    # First message should be the summary (assistant message)
-    summary_message = agent.messages[0]
-    assert summary_message["role"] == "user"
+    assert agent.messages[0]["role"] == "user"
+    assert agent.messages[0]["content"] == [{"text": "Previous conversation summary:"}]
+    summary_message = agent.messages[1]
+    assert summary_message["role"] == "assistant"
     assert len(summary_message["content"]) > 0
 
     # Verify the summary contains actual text content
@@ -361,9 +362,10 @@ def test_dedicated_summarization_agent(model, summarization_model):
     # Verify summarization occurred
     assert len(agent.messages) < original_length
 
-    # Get the summary message
-    summary_message = agent.messages[0]
-    assert summary_message["role"] == "user"
+    assert agent.messages[0]["role"] == "user"
+    assert agent.messages[0]["content"] == [{"text": "Previous conversation summary:"}]
+    summary_message = agent.messages[1]
+    assert summary_message["role"] == "assistant"
 
     # Extract summary text
     summary_text = None
@@ -405,9 +407,9 @@ def test_summarization_with_tool_messages_and_no_tools():
     conversation_manager.reduce_context(agent)
 
     assert len(agent.tool_names) == 0
-    assert len(agent.messages) == 3
+    assert len(agent.messages) == 4
 
-    summary = str(agent.messages[0]).lower()
+    summary = str(agent.messages[1]).lower()
     assert "12:00" in summary
 
 
@@ -415,9 +417,8 @@ def test_dedicated_summarization_agent_with_structured_output(model, summarizati
     """Test that summarization works when the summarization agent has structured_output_model configured.
 
     When structured_output_model is set on the summarization agent, the response would contain toolUse
-    blocks. Since the summary is converted to a user message, those blocks would cause a
-    ValidationException. This test verifies that structured output is properly disabled during
-    summarization.
+    blocks without matching toolResult blocks. This test verifies that structured output is properly
+    disabled during summarization.
     """
 
     class SummaryOutput(BaseModel):
@@ -461,12 +462,14 @@ def test_dedicated_summarization_agent_with_structured_output(model, summarizati
 
     assert len(agent.messages) < original_length
 
-    summary_message = agent.messages[0]
-    assert summary_message["role"] == "user"
+    assert agent.messages[0]["role"] == "user"
+    assert agent.messages[0]["content"] == [{"text": "Previous conversation summary:"}]
+    summary_message = agent.messages[1]
+    assert summary_message["role"] == "assistant"
 
-    # Summary should contain only valid user message content (no toolUse blocks)
+    # Summary should contain only valid assistant message content (no toolUse blocks)
     for content_block in summary_message["content"]:
-        assert "toolUse" not in content_block, "Summary user message should not contain toolUse blocks"
+        assert "toolUse" not in content_block, "Summary assistant message should not contain toolUse blocks"
 
     # Should have text content
     assert any("text" in cb for cb in summary_message["content"])


### PR DESCRIPTION
## Description

`SummarizingConversationManager` stores model-generated summaries as user-authored history, losing their provenance across compression and session restore. Keep a fixed user preamble for provider compatibility while retaining the generated summary as an assistant message. No public API changes.

## Related Issues

No public issue (privately reported).

## Documentation PR

No documentation changes; the public API is unchanged.

## Type of Change

Bug fix

## Testing

Focused tests, lint, package build, and commit hooks pass. `hatch run prepare` reached the all-version suite but was blocked by existing Python 3.14 OpenTelemetry exporter import errors in `tests/strands/telemetry/test_config.py`.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.