### PR TITLE
fix(bedrock/py): retry incompatible tool-result turns

### DIFF
--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -56,6 +56,9 @@ BEDROCK_CONTEXT_WINDOW_OVERFLOW_MESSAGES = [
     "prompt is too long",
 ]
 
+# Bedrock reports this exact substring for the Converse incompatibility tracked in #1223.
+_TOOL_RESULT_TURN_VALIDATION_MESSAGE = "Conversation blocks and tool result blocks cannot be provided in the same turn."
+
 # Models that should include tool result status (include_tool_result_status = True)
 _MODELS_INCLUDE_STATUS = [
     "anthropic.claude",
@@ -194,6 +197,7 @@ class BedrockModel(Model):
             model_id=BedrockModel._get_default_model_with_warning(resolved_region, model_config),
             include_tool_result_status="auto",
         )
+        self._tool_result_turn_separation_model_id: str | None = None
         self.update_config(**model_config)
 
         logger.debug("config=<%s> | initializing", self.config)
@@ -288,9 +292,13 @@ class BedrockModel(Model):
             )
             system_blocks.append({"cachePoint": {"type": cache_prompt}})
 
+        formatted_messages = self._format_bedrock_messages(messages)
+        if self._tool_result_turn_separation_model_id == self.config["model_id"]:
+            formatted_messages = self._separate_tool_result_turns(formatted_messages)
+
         return {
             "modelId": self.config["model_id"],
-            "messages": self._format_bedrock_messages(messages),
+            "messages": formatted_messages,
             "system": system_blocks,
             **({"serviceTier": {"type": self.config["service_tier"]}} if self.config.get("service_tier") else {}),
             **(
@@ -686,6 +694,33 @@ class BedrockModel(Model):
                 self._inject_cache_point(cleaned_messages)
 
         return cleaned_messages
+
+    @staticmethod
+    def _separate_tool_result_turns(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Separate adjacent user turns rejected by some Bedrock models.
+
+        A neutral assistant turn separates a tool-result-only user turn from the
+        next conversation turn described in #1223. The transformation is
+        request-local and idempotent, so persisted conversation history is not
+        mutated and repeated application does not add more separators.
+        """
+        separated_messages: list[dict[str, Any]] = []
+
+        for message in messages:
+            if separated_messages and separated_messages[-1].get("role") == "user" and message.get("role") == "user":
+                previous_content = separated_messages[-1].get("content", [])
+                current_content = message.get("content", [])
+                if (
+                    previous_content
+                    and all("toolResult" in block for block in previous_content)
+                    and current_content
+                    and all("toolResult" not in block for block in current_content)
+                ):
+                    separated_messages.append({"role": "assistant", "content": [{"text": "Tool result received."}]})
+
+            separated_messages.append(message)
+
+        return separated_messages
 
     def _should_include_tool_result_status(self) -> bool:
         """Determine whether to include tool result status based on current config."""
@@ -1127,14 +1162,35 @@ class BedrockModel(Model):
         try:
             logger.debug("formatting request")
             request = self.format_request(messages, tool_specs, system_prompt_content, tool_choice)
+            model_id = request["modelId"]
             logger.debug("request=<%s>", request)
 
             logger.debug("invoking model")
             streaming = self.config.get("streaming", True)
+            converse_method = self.client.converse_stream if streaming else self.client.converse
+
+            try:
+                response = converse_method(**request)
+            except ClientError as error:
+                error_details = error.response.get("Error", {})
+                if error_details.get(
+                    "Code"
+                ) != "ValidationException" or _TOOL_RESULT_TURN_VALIDATION_MESSAGE not in error_details.get(
+                    "Message", ""
+                ):
+                    raise
+
+                separated_messages = self._separate_tool_result_turns(request["messages"])
+                if separated_messages == request["messages"]:
+                    raise
+
+                logger.debug("model_id=<%s> | separating tool result and conversation turns", model_id)
+                request = {**request, "messages": separated_messages}
+                response = converse_method(**request)
+                self._tool_result_turn_separation_model_id = model_id
 
             logger.debug("got response from model")
             if streaming:
-                response = self.client.converse_stream(**request)
                 for chunk in response["stream"]:
                     if (
                         "metadata" in chunk
@@ -1149,7 +1205,6 @@ class BedrockModel(Model):
                     callback(chunk)
 
             else:
-                response = self.client.converse(**request)
                 for event in self.convert_non_streaming_to_streaming(response):
                     callback(event)
 

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -72,6 +72,31 @@ def messages():
 
 
 @pytest.fixture
+def tool_result_turn_messages():
+    return [
+        {"role": "user", "content": [{"text": "Create structured output"}]},
+        {
+            "role": "assistant",
+            "content": [{"toolUse": {"toolUseId": "tool-1", "name": "Result", "input": {"value": 1}}}],
+        },
+        {
+            "role": "user",
+            "content": [{"toolResult": {"toolUseId": "tool-1", "content": [{"text": "Validated"}]}}],
+        },
+        {"role": "user", "content": [{"text": "Create another result"}]},
+    ]
+
+
+@pytest.fixture
+def separated_tool_result_turn_messages(tool_result_turn_messages):
+    return [
+        *tool_result_turn_messages[:3],
+        {"role": "assistant", "content": [{"text": "Tool result received."}]},
+        tool_result_turn_messages[3],
+    ]
+
+
+@pytest.fixture
 def system_prompt():
     return "s1"
 
@@ -892,6 +917,212 @@ async def test_stream_throttling_exception_lowercase_non_streaming(bedrock_clien
     assert error_message in str(excinfo.value)
     bedrock_client.converse.assert_called_once()
     bedrock_client.converse_stream.assert_not_called()
+
+
+@pytest.mark.parametrize("streaming", [True, False])
+@pytest.mark.asyncio
+async def test_stream_retries_with_separated_tool_result_turns(
+    bedrock_client,
+    alist,
+    streaming,
+    tool_result_turn_messages,
+    separated_tool_result_turn_messages,
+):
+    """Tool-result turns are separated when Bedrock reports the incompatibility from issue #1223."""
+    validation_error = ClientError(
+        {
+            "Error": {
+                "Code": "ValidationException",
+                "Message": (
+                    "messages.3.content: "
+                    "Conversation blocks and tool result blocks cannot be provided in the same turn."
+                ),
+            }
+        },
+        "ConverseStream" if streaming else "Converse",
+    )
+    response = (
+        {"stream": []}
+        if streaming
+        else {
+            "output": {"message": {"role": "assistant", "content": [{"text": "Done"}]}},
+            "stopReason": "end_turn",
+        }
+    )
+    converse_method = bedrock_client.converse_stream if streaming else bedrock_client.converse
+    converse_method.side_effect = [validation_error, response]
+    model = BedrockModel(
+        model_id="us.meta.llama4-maverick-17b-instruct-v1:0",
+        streaming=streaming,
+        use_native_token_count=True,
+    )
+
+    await alist(model.stream(tool_result_turn_messages))
+
+    tru_first_messages = converse_method.call_args_list[0].kwargs["messages"]
+    assert tru_first_messages == tool_result_turn_messages
+
+    tru_retry_messages = converse_method.call_args_list[1].kwargs["messages"]
+    assert tru_retry_messages == separated_tool_result_turn_messages
+    assert model._tool_result_turn_separation_model_id == "us.meta.llama4-maverick-17b-instruct-v1:0"
+
+
+def test_format_request_separates_tool_result_turns_for_remembered_model(
+    bedrock_client,
+    tool_result_turn_messages,
+    separated_tool_result_turn_messages,
+):
+    """Remembered model formatting separates incompatible user turns."""
+    _ = bedrock_client
+    model = BedrockModel(model_id="us.meta.llama4-maverick-17b-instruct-v1:0")
+    model._tool_result_turn_separation_model_id = "us.meta.llama4-maverick-17b-instruct-v1:0"
+
+    tru_messages = model.format_request(tool_result_turn_messages)["messages"]
+
+    assert tru_messages == separated_tool_result_turn_messages
+
+
+@pytest.mark.asyncio
+async def test_count_tokens_separates_tool_result_turns_for_remembered_model(
+    bedrock_client,
+    tool_result_turn_messages,
+    separated_tool_result_turn_messages,
+):
+    """Native token counting uses the same separated request as invocation."""
+    bedrock_client.count_tokens.return_value = {"inputTokens": 42}
+    model = BedrockModel(
+        model_id="us.meta.llama4-maverick-17b-instruct-v1:0",
+        use_native_token_count=True,
+    )
+    model._tool_result_turn_separation_model_id = "us.meta.llama4-maverick-17b-instruct-v1:0"
+
+    await model.count_tokens(tool_result_turn_messages)
+
+    tru_messages = bedrock_client.count_tokens.call_args.kwargs["input"]["converse"]["messages"]
+    assert tru_messages == separated_tool_result_turn_messages
+
+
+@pytest.mark.parametrize("streaming", [True, False])
+@pytest.mark.asyncio
+async def test_stream_uses_separated_tool_result_turns_for_remembered_model(
+    bedrock_client,
+    alist,
+    streaming,
+    tool_result_turn_messages,
+    separated_tool_result_turn_messages,
+):
+    """Remembered models skip the failing canonical request."""
+    response = (
+        {"stream": []}
+        if streaming
+        else {
+            "output": {"message": {"role": "assistant", "content": [{"text": "Done"}]}},
+            "stopReason": "end_turn",
+        }
+    )
+    converse_method = bedrock_client.converse_stream if streaming else bedrock_client.converse
+    converse_method.return_value = response
+    model = BedrockModel(
+        model_id="us.meta.llama4-maverick-17b-instruct-v1:0",
+        streaming=streaming,
+    )
+    model._tool_result_turn_separation_model_id = "us.meta.llama4-maverick-17b-instruct-v1:0"
+
+    await alist(model.stream(tool_result_turn_messages))
+
+    converse_method.assert_called_once()
+    tru_messages = converse_method.call_args.kwargs["messages"]
+    assert tru_messages == separated_tool_result_turn_messages
+
+
+@pytest.mark.parametrize("streaming", [True, False])
+@pytest.mark.asyncio
+async def test_stream_does_not_retry_when_tool_result_turns_cannot_be_separated(
+    bedrock_client,
+    alist,
+    streaming,
+    messages,
+):
+    """The targeted validation error is re-raised when no transform applies."""
+    validation_error = ClientError(
+        {
+            "Error": {
+                "Code": "ValidationException",
+                "Message": (
+                    "messages.3.content: "
+                    "Conversation blocks and tool result blocks cannot be provided in the same turn."
+                ),
+            }
+        },
+        "ConverseStream" if streaming else "Converse",
+    )
+    converse_method = bedrock_client.converse_stream if streaming else bedrock_client.converse
+    converse_method.side_effect = validation_error
+    model = BedrockModel(model_id="us.meta.llama4-maverick-17b-instruct-v1:0", streaming=streaming)
+
+    with pytest.raises(ClientError):
+        await alist(model.stream(messages))
+
+    converse_method.assert_called_once()
+
+
+@pytest.mark.parametrize("streaming", [True, False])
+@pytest.mark.asyncio
+async def test_stream_does_not_remember_separation_when_retry_fails(
+    bedrock_client,
+    alist,
+    streaming,
+    tool_result_turn_messages,
+):
+    """Tool-result separation is remembered only after Bedrock accepts the retry."""
+    validation_error = ClientError(
+        {
+            "Error": {
+                "Code": "ValidationException",
+                "Message": (
+                    "messages.3.content: "
+                    "Conversation blocks and tool result blocks cannot be provided in the same turn."
+                ),
+            }
+        },
+        "ConverseStream" if streaming else "Converse",
+    )
+    converse_method = bedrock_client.converse_stream if streaming else bedrock_client.converse
+    converse_method.side_effect = [validation_error, validation_error]
+    model = BedrockModel(
+        model_id="us.meta.llama4-maverick-17b-instruct-v1:0",
+        streaming=streaming,
+    )
+
+    with pytest.raises(ClientError):
+        await alist(model.stream(tool_result_turn_messages))
+
+    assert model._tool_result_turn_separation_model_id is None
+
+    converse_method.reset_mock(side_effect=True)
+    converse_method.return_value = (
+        {"stream": []}
+        if streaming
+        else {
+            "output": {"message": {"role": "assistant", "content": [{"text": "Done"}]}},
+            "stopReason": "end_turn",
+        }
+    )
+
+    await alist(model.stream(tool_result_turn_messages))
+
+    converse_method.assert_called_once()
+    assert converse_method.call_args.kwargs["messages"] == tool_result_turn_messages
+
+
+def test_separate_tool_result_turns_ignores_conversation_only_user_turns():
+    """Adjacent conversation-only user turns do not gain a separator."""
+    messages = [
+        {"role": "user", "content": [{"text": "First"}]},
+        {"role": "user", "content": [{"text": "Second"}]},
+    ]
+
+    assert BedrockModel._separate_tool_result_turns(messages) == messages
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Some Bedrock models reject structured-output conversation history when a tool-result-only user turn is immediately followed by another user turn, causing Converse to fail with a `ValidationException`.

This change sends the canonical request first and retries once with a request-local separator only when Bedrock returns that exact validation error. The model instance remembers the affected model for subsequent requests, avoiding a hard-coded global model list without changing persisted conversation history or public API.

## Related Issues

Provides the narrow Bedrock compatibility fix discussed in #780

Supersedes (and closes) #1240

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

- [x] I ran `hatch test`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.