### PR TITLE
feat(middleware): add AgentStreamStage and AgentStreamContext types

### DIFF
--- a/strands-py/src/strands/_middleware/stages.py
+++ b/strands-py/src/strands/_middleware/stages.py
@@ -83,7 +83,7 @@ def _resolve_middleware_interrupt(
         interrupt_id: The deterministic id for this interrupt.
         name: User-defined name for the interrupt.
         reason: Optional reason surfaced to the user.
-        response: Optional preemptive response — when set, no interrupt is raised.
+        response: Optional preemptive response — fallback if no prior human response exists.
 
     Returns:
         The user's response wrapped in a ``MiddlewareInterruptResult``.
@@ -217,10 +217,10 @@ class AgentStreamContext:
         ``InterruptException`` handler as the single source of truth.
 
         Args:
-            name: User-defined name for the interrupt. The interrupt id is derived from the name
-                alone (``v1:middleware_agent_stream:<uuid5(name)>``), so the name must be unique
-                across all agent-stream middleware in a single invocation pass — two middleware
-                using the same name collide and share one response.
+            name: User-defined name for the interrupt. The name must be unique
+                across all agent-stream middleware that share an interrupt dict — including
+                across agents in a Graph/Swarm. Two gates with the same name collide and share
+                one response.
             reason: Optional reason for the interrupt (surfaced to the user).
             response: Optional preemptive response — when set, no interrupt is raised.
 

--- a/strands-py/src/strands/_middleware/stages.py
+++ b/strands-py/src/strands/_middleware/stages.py
@@ -200,10 +200,9 @@ class AgentStreamContext:
     # A snapshot of the agent's interrupts taken before the pass, threaded in so interrupt() can
     # resolve prior responses. It is a snapshot rather than the live dict because this context's
     # lifetime spans the whole pass: a tool cycle within the same pass ends and clears the live
-    # interrupts (see _InterruptState.end_tool_cycle), so reading a snapshot keeps a gate's re-read
-    # after next_fn stable. Empty outside a live interrupt cycle, so a response retained by a cycle
-    # that died mid-flight cannot resolve a gate. Required (the run loop is the sole constructor and
-    # always supplies it); excluded from repr to avoid dumping unrelated interrupt bookkeeping.
+    # interrupts, so reading a snapshot keeps a gate's re-read after next_fn stable. Required
+    # (the run loop is the sole constructor and always supplies it); excluded from repr to
+    # avoid dumping unrelated interrupt bookkeeping.
     _interrupts: Mapping[str, Interrupt] = field(repr=False)
 
     def interrupt(self, name: str, *, reason: Any = None, response: Any = None) -> MiddlewareInterruptResult:
@@ -219,11 +218,9 @@ class AgentStreamContext:
 
         Args:
             name: User-defined name for the interrupt. The interrupt id is derived from the name
-                alone (``v1:middleware_agent_stream:<uuid5(name)>``), so the name identifies *what
-                is being approved* for the whole interrupt cycle: an answered response is reused by
-                every later call with the same name in that cycle. Two middleware sharing a name
-                share one response, and reusing a name for a different action means the second
-                action inherits the first one's approval — give each decision its own name.
+                alone (``v1:middleware_agent_stream:<uuid5(name)>``), so the name must be unique
+                across all agent-stream middleware in a single invocation pass — two middleware
+                using the same name collide and share one response.
             reason: Optional reason for the interrupt (surfaced to the user).
             response: Optional preemptive response — when set, no interrupt is raised.
 
@@ -233,8 +230,7 @@ class AgentStreamContext:
         Raises:
             InterruptException: When no response is available yet and none was provided.
             RuntimeError: Raised by the run loop when this is called after the pass has already
-                produced its stop event, which resuming cannot replay. Interrupt before the pass
-                produces its assistant turn.
+                produced its stop event, which resuming cannot replay.
         """
         return _resolve_middleware_interrupt(self._interrupts, self._interrupt_id(name), name, reason, response)
 
@@ -242,9 +238,7 @@ class AgentStreamContext:
         """Derive the interrupt id for ``name``, namespaced to the agent-stream stage.
 
         Follows the SDK's ``v1:`` interrupt-id scheme (see ``types/interrupt.py``), hashing
-        the user-provided name so ids stay stable across resumes. The namespace prefix is shared
-        with ``_InterruptState``, which matches on it to decide which interrupts outlive a tool
-        cycle.
+        the user-provided name so ids stay stable across resumes.
         """
         return f"{_AGENT_STREAM_INTERRUPT_ID_PREFIX}{uuid.uuid5(uuid.NAMESPACE_OID, name)}"
 

--- a/strands-py/src/strands/_middleware/stages.py
+++ b/strands-py/src/strands/_middleware/stages.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import uuid
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from ..interrupt import Interrupt, InterruptException
+from ..interrupt import _AGENT_STREAM_INTERRUPT_ID_PREFIX, Interrupt, InterruptException
 from .types import MiddlewareStage
 
 if TYPE_CHECKING:
@@ -14,7 +15,7 @@ if TYPE_CHECKING:
     from ..experimental.bidi import BidiAgent
     from ..interrupt import _InterruptState
     from ..models.model import Model
-    from ..types._events import ModelStopReason, ToolResultEvent, TypedEvent
+    from ..types._events import EventLoopStopEvent, ModelStopReason, ToolResultEvent, TypedEvent
     from ..types.content import Messages, SystemPrompt
     from ..types.tools import AgentTool, ToolChoice, ToolSpec, ToolUse
 
@@ -49,7 +50,7 @@ Middleware registered for this stage can rate-limit, cache, or transform model i
 
 @dataclass
 class MiddlewareInterruptResult:
-    """Value returned by ``ExecuteToolContext.interrupt()`` when the agent resumes.
+    """Value returned by a middleware ``interrupt()`` when the agent resumes.
 
     Wrapping the response (rather than returning it bare) mirrors the TypeScript SDK and
     leaves room to add fields later without breaking callers.
@@ -59,6 +60,45 @@ class MiddlewareInterruptResult:
     """
 
     response: Any
+
+
+def _resolve_middleware_interrupt(
+    interrupts: Mapping[str, Interrupt],
+    interrupt_id: str,
+    name: str,
+    reason: Any,
+    response: Any,
+) -> MiddlewareInterruptResult:
+    """Resolve a middleware-initiated interrupt without mutating interrupt state.
+
+    Shared by every ``MiddlewareInterruptible`` context (tool and agent-stream stages). It
+    inspects prior responses but never registers the interrupt: the stage's executor
+    registers it in its ``InterruptException`` handler as the single source of truth,
+    matching the TypeScript SDK where middleware interrupts never write to interrupt state.
+
+    Args:
+        interrupts: The prior-response lookup — the agent's live ``interrupts`` dict for the tool
+            stage, or a snapshot taken before the pass for the agent-stream stage (whose reads must
+            survive a tool cycle ending mid-pass and clearing the live dict).
+        interrupt_id: The deterministic id for this interrupt.
+        name: User-defined name for the interrupt.
+        reason: Optional reason surfaced to the user.
+        response: Optional preemptive response — when set, no interrupt is raised.
+
+    Returns:
+        The user's response wrapped in a ``MiddlewareInterruptResult``.
+
+    Raises:
+        InterruptException: When no response is available yet and none was provided.
+    """
+    existing = interrupts.get(interrupt_id)
+    if existing is not None and existing.response is not None:
+        return MiddlewareInterruptResult(response=existing.response)
+
+    if response is not None:
+        return MiddlewareInterruptResult(response=response)
+
+    raise InterruptException(Interrupt(id=interrupt_id, name=name, reason=reason))
 
 
 @dataclass
@@ -114,16 +154,9 @@ class ExecuteToolContext:
         Raises:
             InterruptException: When no response is available yet and none was provided.
         """
-        interrupt_id = self._interrupt_id(name)
-
-        existing = self._interrupt_state.interrupts.get(interrupt_id)
-        if existing is not None and existing.response is not None:
-            return MiddlewareInterruptResult(response=existing.response)
-
-        if response is not None:
-            return MiddlewareInterruptResult(response=response)
-
-        raise InterruptException(Interrupt(id=interrupt_id, name=name, reason=reason))
+        return _resolve_middleware_interrupt(
+            self._interrupt_state.interrupts, self._interrupt_id(name), name, reason, response
+        )
 
     def _interrupt_id(self, name: str) -> str:
         """Derive the interrupt id for ``name``, namespaced by the tool call.
@@ -140,5 +173,92 @@ ExecuteToolStage: MiddlewareStage[ExecuteToolContext, ToolResultEvent, TypedEven
 Middleware registered for this stage can add telemetry, validate inputs, mock responses,
 or gate execution behind a human-in-the-loop interrupt. The result event is the
 ``ToolResultEvent`` produced by the tool (matching the "last event is the result"
+convention used across the SDK).
+"""
+
+
+@dataclass
+class AgentStreamContext:
+    """Context passed to AgentStreamStage middleware.
+
+    Wraps the entire agent output stream at the outermost interception point, so middleware
+    can filter, transform, or inject events across a whole invocation pass, or gate the pass
+    behind a human-in-the-loop interrupt.
+
+    ``messages`` is the input for this pass, shared by reference (the executor already
+    appended them to history). ``invocation_state`` is likewise shared by reference, matching
+    how hooks and tools receive it. The copy-vs-reference contract is not yet finalized;
+    middleware that needs isolation should copy explicitly.
+
+    Supports middleware-initiated interrupts via ``interrupt()`` for human-in-the-loop
+    approval flows.
+    """
+
+    agent: Agent
+    messages: Messages
+    invocation_state: dict[str, Any]
+    # A snapshot of the agent's interrupts taken before the pass, threaded in so interrupt() can
+    # resolve prior responses. It is a snapshot rather than the live dict because this context's
+    # lifetime spans the whole pass: a tool cycle within the same pass ends and clears the live
+    # interrupts (see _InterruptState.end_tool_cycle), so reading a snapshot keeps a gate's re-read
+    # after next_fn stable. Empty outside a live interrupt cycle, so a response retained by a cycle
+    # that died mid-flight cannot resolve a gate. Required (the run loop is the sole constructor and
+    # always supplies it); excluded from repr to avoid dumping unrelated interrupt bookkeeping.
+    _interrupts: Mapping[str, Interrupt] = field(repr=False)
+
+    def interrupt(self, name: str, *, reason: Any = None, response: Any = None) -> MiddlewareInterruptResult:
+        """Request a human-in-the-loop interrupt.
+
+        On first execution (no prior response) this raises ``InterruptException`` to halt
+        the agent. After the user resumes with a response, the second call returns that
+        response. Providing ``response`` preemptively skips the interrupt entirely.
+
+        This method is read-only with respect to interrupt state (see
+        ``_resolve_middleware_interrupt``): the run loop registers the interrupt in its
+        ``InterruptException`` handler as the single source of truth.
+
+        Args:
+            name: User-defined name for the interrupt. The interrupt id is derived from the name
+                alone (``v1:middleware_agent_stream:<uuid5(name)>``), so the name identifies *what
+                is being approved* for the whole interrupt cycle: an answered response is reused by
+                every later call with the same name in that cycle. Two middleware sharing a name
+                share one response, and reusing a name for a different action means the second
+                action inherits the first one's approval — give each decision its own name.
+            reason: Optional reason for the interrupt (surfaced to the user).
+            response: Optional preemptive response — when set, no interrupt is raised.
+
+        Returns:
+            The user's response wrapped in a ``MiddlewareInterruptResult``.
+
+        Raises:
+            InterruptException: When no response is available yet and none was provided.
+            RuntimeError: Raised by the run loop when this is called after the pass has already
+                produced its stop event, which resuming cannot replay. Interrupt before the pass
+                produces its assistant turn.
+        """
+        return _resolve_middleware_interrupt(self._interrupts, self._interrupt_id(name), name, reason, response)
+
+    def _interrupt_id(self, name: str) -> str:
+        """Derive the interrupt id for ``name``, namespaced to the agent-stream stage.
+
+        Follows the SDK's ``v1:`` interrupt-id scheme (see ``types/interrupt.py``), hashing
+        the user-provided name so ids stay stable across resumes. The namespace prefix is shared
+        with ``_InterruptState``, which matches on it to decide which interrupts outlive a tool
+        cycle.
+        """
+        return f"{_AGENT_STREAM_INTERRUPT_ID_PREFIX}{uuid.uuid5(uuid.NAMESPACE_OID, name)}"
+
+
+# Internal: not exported from _middleware/__init__.py. The context's copy-vs-reference
+# contract for messages/invocation_state is not yet finalized, matching the TS SDK, which
+# keeps AgentStreamStage out of its public barrel (@internal) for the same reason.
+AgentStreamStage: MiddlewareStage[AgentStreamContext, EventLoopStopEvent, TypedEvent] = MiddlewareStage(
+    name="agentStream"
+)
+"""Built-in stage wrapping the entire agent output stream (outermost interception point).
+
+Middleware registered for this stage can filter, transform, or inject events, short-circuit
+the whole pass, or gate it behind a human-in-the-loop interrupt. The result event is the
+``EventLoopStopEvent`` that ends the pass (matching the "last event is the result"
 convention used across the SDK).
 """

--- a/strands-py/src/strands/interrupt.py
+++ b/strands-py/src/strands/interrupt.py
@@ -7,6 +7,9 @@ if TYPE_CHECKING:
     from .types.agent import AgentInput
     from .types.interrupt import InterruptResponseContent
 
+_AGENT_STREAM_INTERRUPT_ID_PREFIX = "v1:middleware_agent_stream:"
+"""Id prefix for interrupts scoped to a whole invocation pass rather than a single tool call."""
+
 
 @dataclass
 class Interrupt:

--- a/strands-py/tests/strands/middleware/test_middleware_interrupts.py
+++ b/strands-py/tests/strands/middleware/test_middleware_interrupts.py
@@ -6,7 +6,7 @@ import pytest
 
 import strands
 from strands import Agent
-from strands._middleware.stages import ExecuteToolStage, MiddlewareInterruptResult
+from strands._middleware.stages import ExecuteToolStage, MiddlewareInterruptResult, _resolve_middleware_interrupt
 from strands.hooks import AfterToolCallEvent, BeforeToolCallEvent
 from strands.interrupt import Interrupt
 from strands.types._events import ToolInterruptEvent, ToolResultEvent
@@ -425,3 +425,20 @@ def test_before_hook_fires_but_after_hook_skipped_on_interrupt(calculator_tool):
     event_types = [type(event) for event in events]
     assert BeforeToolCallEvent in event_types
     assert AfterToolCallEvent not in event_types
+
+
+# --- interrupt resolution precedence ---
+
+
+def test_stored_human_response_takes_precedence_over_preemptive(calculator_tool):
+    """A stored human response must win over a middleware's preemptive response=.
+
+    Guards against accidentally swapping the two checks in _resolve_middleware_interrupt,
+    which would let a middleware default silently override a human decision.
+    """
+    interrupt_id = "v1:middleware_execute_tool:tool_1:test-gate"
+    interrupts = {interrupt_id: Interrupt(id=interrupt_id, name="gate", response="DENIED")}
+
+    result = _resolve_middleware_interrupt(interrupts, interrupt_id, "gate", None, "auto-approve")
+
+    assert result == MiddlewareInterruptResult(response="DENIED")

--- a/strands-py/tests/strands/middleware/test_middleware_interrupts.py
+++ b/strands-py/tests/strands/middleware/test_middleware_interrupts.py
@@ -6,7 +6,12 @@ import pytest
 
 import strands
 from strands import Agent
-from strands._middleware.stages import ExecuteToolStage, MiddlewareInterruptResult, _resolve_middleware_interrupt
+from strands._middleware.stages import (
+    AgentStreamContext,
+    ExecuteToolStage,
+    MiddlewareInterruptResult,
+    _resolve_middleware_interrupt,
+)
 from strands.hooks import AfterToolCallEvent, BeforeToolCallEvent
 from strands.interrupt import Interrupt
 from strands.types._events import ToolInterruptEvent, ToolResultEvent
@@ -442,3 +447,28 @@ def test_stored_human_response_takes_precedence_over_preemptive(calculator_tool)
     result = _resolve_middleware_interrupt(interrupts, interrupt_id, "gate", None, "auto-approve")
 
     assert result == MiddlewareInterruptResult(response="DENIED")
+
+
+# --- AgentStreamContext interrupt coverage ---
+
+
+def test_agent_stream_context_interrupt_id_and_resolution():
+    """AgentStreamContext.interrupt raises, resolves, and produces a stable namespaced id."""
+    from strands.interrupt import InterruptException
+
+    ctx = AgentStreamContext(agent=None, messages=[], invocation_state={}, _interrupts={})
+
+    interrupt_id = ctx._interrupt_id("gate")
+    assert interrupt_id.startswith("v1:middleware_agent_stream:")
+    assert interrupt_id == ctx._interrupt_id("gate")
+
+    with pytest.raises(InterruptException):
+        ctx.interrupt("gate")
+
+    resumed = AgentStreamContext(
+        agent=None,
+        messages=[],
+        invocation_state={},
+        _interrupts={interrupt_id: Interrupt(id=interrupt_id, name="gate", response="ok")},
+    )
+    assert resumed.interrupt("gate") == MiddlewareInterruptResult(response="ok")


### PR DESCRIPTION
## Description

Interface for the Python side of #3594. This PR adds the `AgentStreamStage` type definitions and interrupt resolution logic so the follow-up PR (which wires the stage into the agent run loop and adds lifecycle management) has a smaller, more focused diff.

Specifically, this gives `AgentStreamStage` middleware a way to gate an entire invocation pass behind a human-in-the-loop interrupt — the same capability `ExecuteToolStage` already has for individual tool calls. The shared `_resolve_middleware_interrupt` helper ensures both stages use identical read-only resolution semantics, matching the TS SDK's `MiddlewareInterruptible` contract.

The stage is internal (not exported from the `_middleware` barrel), matching TS which keeps `AgentStreamStage` out of its public barrel (`@internal`) because the context's copy-vs-reference contract is not yet finalized.

## Related Issues

Part of #3594

## Documentation PR

N/A — internal types only; documentation will accompany the follow-up that wires the stage into the agent.

## Type of Change

New feature

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
