### PR TITLE
docs: remove redundant language support banners

### DIFF
--- a/site/src/content/docs/user-guide/concepts/agents/interventions/human-in-the-loop.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/human-in-the-loop.mdx
@@ -2,7 +2,6 @@
 title: Human in the Loop
 tags: [interventions, tool-execution]
 description: "Gate agent tool execution behind human approval. Configurable modes for CLI, web, and custom UIs with optional session trust."
-languages: [python, typescript]
 sourceLinks:
   - path: strands-py/src/strands/vended_interventions/hitl/hitl.py
   - path: strands-ts/src/vended-interventions/hitl/hitl.ts

--- a/site/src/content/docs/user-guide/concepts/agents/interventions/index.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/index.mdx
@@ -2,7 +2,6 @@
 title: Interventions
 description: "A composable control layer for authorization, guardrails, and steering with typed actions, ordered evaluation, and short-circuiting."
 tags: [interventions, hooks, event-loop, tool-execution]
-languages: [python, typescript]
 sourceLinks:
   - path: strands-py/src/strands/interventions/handler.py
   - path: strands-py/src/strands/interventions/actions.py

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -3,7 +3,6 @@ title: Vended Tools
 description: "Pre-built tools included in the SDK for common agent tasks like file operations, shell commands, HTTP requests, and persistent notes."
 sidebar:
   label: "Vended Tools"
-languages: [python, typescript]
 tags: [tool-authoring]
 sourceLinks:
   - path: strands-ts/src/vended-tools/file-editor/file-editor.ts


### PR DESCRIPTION

## Description
Pages listing both python and typescript in `languages` frontmatter show a banner that adds no information since the SDK only has those two languages. Omitting the field already means "both supported" per the site convention.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Documentation update


## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [X] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
