### PR TITLE
feat(model): add estimateUtilization method to Model base class

### DIFF
--- a/strands-py/src/strands/_context_manager/modes/agentic/agentic_context.py
+++ b/strands-py/src/strands/_context_manager/modes/agentic/agentic_context.py
@@ -23,7 +23,7 @@ from ....agent.conversation_manager.compression.context_compression import (
     matches_message_type,
 )
 from ....agent.conversation_manager.compression.pin_message import is_pinned, pin_message, unpin_message
-from ....agent.conversation_manager.conversation_manager import DEFAULT_CONTEXT_WINDOW_LIMIT
+from ....models._defaults import DEFAULT_CONTEXT_WINDOW_LIMIT
 from ....tools.decorator import tool
 from ....types.content import Message, _ensure_tracking_id
 from ....types.exceptions import ContextWindowOverflowException

--- a/strands-py/src/strands/agent/conversation_manager/conversation_manager.py
+++ b/strands-py/src/strands/agent/conversation_manager/conversation_manager.py
@@ -14,7 +14,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 DEFAULT_COMPRESSION_THRESHOLD = 0.7
-DEFAULT_CONTEXT_WINDOW_LIMIT = 200_000
 
 
 class ProactiveCompressionConfig(TypedDict, total=False):
@@ -93,7 +92,6 @@ class ConversationManager(ABC, HookProvider):
 
         self.removed_message_count = 0
         self._compression_threshold = threshold
-        self._context_window_limit_warned = False
 
     def register_hooks(self, registry: HookRegistry, **kwargs: Any) -> None:
         """Register hooks for agent lifecycle events.
@@ -125,28 +123,17 @@ class ConversationManager(ABC, HookProvider):
         if self._compression_threshold is None:
             return
 
-        context_window_limit = event.agent.model.context_window_limit
-        if context_window_limit is None:
-            context_window_limit = DEFAULT_CONTEXT_WINDOW_LIMIT
-            if not self._context_window_limit_warned:
-                self._context_window_limit_warned = True
-                logger.warning(
-                    "context_window_limit=<%s> | context_window_limit not set on model, using default."
-                    " Set context_window_limit in your model config for accurate proactive compression",
-                    DEFAULT_CONTEXT_WINDOW_LIMIT,
-                )
-
         if event.projected_input_tokens is None:
             logger.debug("projected_input_tokens=<None> | skipping proactive compression")
             return
 
-        ratio = event.projected_input_tokens / context_window_limit
+        ratio = event.agent.model.estimate_utilization(event.projected_input_tokens)
         if ratio >= self._compression_threshold:
             logger.debug(
-                "projected_tokens=<%s>, limit=<%s>, ratio=<%.2f>, compression_threshold=<%s>"
+                "projected_tokens=<%s>, context_window_limit=<%s>, ratio=<%.2f>, compression_threshold=<%s>"
                 " | compression threshold exceeded, reducing context",
                 event.projected_input_tokens,
-                context_window_limit,
+                event.agent.model.context_window_limit,
                 ratio,
                 self._compression_threshold,
             )

--- a/strands-py/src/strands/models/_defaults.py
+++ b/strands-py/src/strands/models/_defaults.py
@@ -19,6 +19,9 @@ logger = logging.getLogger(__name__)
 
 _C = TypeVar("_C", bound=Mapping[str, object])
 
+# Default context window limit (in tokens) when the model does not report one.
+DEFAULT_CONTEXT_WINDOW_LIMIT = 200_000
+
 # Context window limits (in tokens) for known model IDs.
 #
 # Best-effort lookup table — unknown models return None and callers

--- a/strands-py/src/strands/models/model.py
+++ b/strands-py/src/strands/models/model.py
@@ -15,6 +15,7 @@ from ..plugins.plugin import Plugin
 from ..types.content import ContentBlock, Messages, SystemContentBlock
 from ..types.streaming import StreamEvent
 from ..types.tools import ToolChoice, ToolSpec
+from ._defaults import DEFAULT_CONTEXT_WINDOW_LIMIT
 
 if TYPE_CHECKING:
     from ..agent.agent import Agent
@@ -290,6 +291,31 @@ class Model(abc.ABC):
             Estimated total input tokens.
         """
         return _estimate_tokens_with_heuristic(messages, tool_specs, system_prompt, system_prompt_content)
+
+    def estimate_utilization(self, input_tokens: int) -> float:
+        """Estimate the fraction of the model's context window consumed by the given input token count.
+
+        Resolves the model's context window limit (falling back to :data:`DEFAULT_CONTEXT_WINDOW_LIMIT`
+        with a warning when not configured) and returns ``input_tokens / context_window_limit``.
+
+        Args:
+            input_tokens: Total input token count (e.g. from a model event's projected input tokens).
+
+        Returns:
+            Token usage ratio (0–1+; above 1.0 means overflow).
+        """
+        context_window_limit = self.context_window_limit
+        if not context_window_limit:
+            context_window_limit = DEFAULT_CONTEXT_WINDOW_LIMIT
+            if not getattr(self, "_utilization_limit_warned", False):
+                self._utilization_limit_warned = True
+                logger.warning(
+                    "context_window_limit=<%s> | context_window_limit not set on model, using default"
+                    " for utilization estimate | set context_window_limit in your model config for accurate results",
+                    DEFAULT_CONTEXT_WINDOW_LIMIT,
+                )
+
+        return input_tokens / context_window_limit
 
 
 class _ModelPlugin(Plugin):

--- a/strands-py/tests/strands/agent/test_conversation_manager.py
+++ b/strands-py/tests/strands/agent/test_conversation_manager.py
@@ -9,6 +9,7 @@ from strands.agent.conversation_manager.null_conversation_manager import NullCon
 from strands.agent.conversation_manager.sliding_window_conversation_manager import SlidingWindowConversationManager
 from strands.hooks.events import BeforeModelCallEvent
 from strands.hooks.registry import HookProvider, HookRegistry
+from strands.models.model import Model
 from strands.types.exceptions import ContextWindowOverflowException
 from tests.fixtures.mocked_model_provider import MockedModelProvider
 
@@ -825,6 +826,8 @@ def _make_mock_agent(messages=None, context_window_limit=1000):
     agent.messages = messages if messages is not None else []
     agent.model = MagicMock()
     agent.model.context_window_limit = context_window_limit
+    agent.model._utilization_limit_warned = False
+    agent.model.estimate_utilization = lambda input_tokens: Model.estimate_utilization(agent.model, input_tokens)
     return agent
 
 
@@ -939,7 +942,7 @@ def test_proactive_compression_uses_default_when_context_window_limit_not_set():
 
     # projected_input_tokens=150_000 is 75% of the 200k default, exceeding 0.7 threshold
     event = _make_threshold_event(agent, projected_input_tokens=150_000)
-    with patch("strands.agent.conversation_manager.conversation_manager.logger") as mock_logger:
+    with patch("strands.models.model.logger") as mock_logger:
         registry.invoke_callbacks(event)
         mock_logger.warning.assert_called_once()
         assert "using default" in mock_logger.warning.call_args[0][0]
@@ -955,7 +958,7 @@ def test_proactive_compression_warns_only_once_per_instance():
     manager.register_hooks(registry)
 
     event = _make_threshold_event(agent, projected_input_tokens=150_000)
-    with patch("strands.agent.conversation_manager.conversation_manager.logger") as mock_logger:
+    with patch("strands.models.model.logger") as mock_logger:
         registry.invoke_callbacks(event)
         registry.invoke_callbacks(event)
         assert mock_logger.warning.call_count == 1

--- a/strands-py/tests/strands/agent/test_summarizing_conversation_manager.py
+++ b/strands-py/tests/strands/agent/test_summarizing_conversation_manager.py
@@ -10,6 +10,7 @@ from strands.agent.conversation_manager.summarizing_conversation_manager import 
 )
 from strands.hooks.events import BeforeModelCallEvent
 from strands.hooks.registry import HookRegistry
+from strands.models.model import Model
 from strands.types.content import Messages
 from strands.types.exceptions import ContextWindowOverflowException
 from tests.fixtures.mocked_model_provider import MockedModelProvider
@@ -838,6 +839,8 @@ def _make_summarizing_threshold_agent(messages, summary_response="Summary of con
     agent.messages = messages
     agent.model = MagicMock()
     agent.model.context_window_limit = context_window_limit
+    agent.model._utilization_limit_warned = False
+    agent.model.estimate_utilization = lambda input_tokens: Model.estimate_utilization(agent.model, input_tokens)
     agent.model.stream = Mock(side_effect=lambda *a, **kw: _mock_model_stream(summary_response))
     return agent
 
@@ -900,6 +903,8 @@ def test_proactive_compression_swallows_errors():
     agent.messages = messages
     agent.model = MagicMock()
     agent.model.context_window_limit = 1000
+    agent.model._utilization_limit_warned = False
+    agent.model.estimate_utilization = lambda input_tokens: Model.estimate_utilization(agent.model, input_tokens)
     agent.model.stream = Mock(side_effect=lambda *a, **kw: _mock_model_stream_error(RuntimeError("model failed")))
 
     registry = HookRegistry()

--- a/strands-py/tests/strands/models/test_model.py
+++ b/strands-py/tests/strands/models/test_model.py
@@ -613,3 +613,62 @@ class TestHeuristicEstimation:
         """Model.count_tokens uses heuristic estimation."""
         result = await model.count_tokens(messages=[{"role": "user", "content": [{"text": "hello world!"}]}])
         assert result == 3  # ceil(12 / 4)
+
+
+class TestEstimateUtilization:
+    """Tests for Model.estimate_utilization."""
+
+    class ConfigurableModel(SAModel):
+        def __init__(self, context_window_limit=None):
+            self._config = {"context_window_limit": context_window_limit}
+
+        def update_config(self, **model_config):
+            self._config.update(model_config)
+
+        def get_config(self):
+            return self._config
+
+        async def structured_output(self, output_model, prompt=None, system_prompt=None, **kwargs):
+            yield {}
+
+        async def stream(self, messages, tool_specs=None, system_prompt=None):
+            yield {}
+
+    def test_returns_ratio_of_tokens_to_limit(self):
+        """Returns input_tokens / context_window_limit when limit is configured."""
+        model = self.ConfigurableModel(context_window_limit=100_000)
+
+        assert model.estimate_utilization(50_000) == 0.5
+
+    def test_uses_default_when_limit_not_set(self):
+        """Falls back to DEFAULT_CONTEXT_WINDOW_LIMIT (200_000) when not configured."""
+        model = self.ConfigurableModel(context_window_limit=None)
+
+        assert model.estimate_utilization(100_000) == 100_000 / 200_000
+
+    def test_returns_above_one_on_overflow(self):
+        """Returns > 1.0 when tokens exceed the limit."""
+        model = self.ConfigurableModel(context_window_limit=1000)
+
+        assert model.estimate_utilization(1500) > 1.0
+
+    def test_returns_zero_for_zero_tokens(self):
+        """Returns 0 for zero input tokens."""
+        model = self.ConfigurableModel(context_window_limit=100_000)
+
+        assert model.estimate_utilization(0) == 0
+
+    def test_handles_zero_context_window_limit(self):
+        """Falls back to default when context_window_limit is 0."""
+        model = self.ConfigurableModel(context_window_limit=0)
+
+        assert model.estimate_utilization(100_000) == 100_000 / 200_000
+
+    def test_warns_only_once(self):
+        """Logs the fallback warning only on the first call."""
+        model = self.ConfigurableModel(context_window_limit=None)
+
+        model.estimate_utilization(1000)
+        model.estimate_utilization(2000)
+
+        assert model._utilization_limit_warned is True

--- a/strands-ts/src/context-manager/modes/agentic/agentic-context.ts
+++ b/strands-ts/src/context-manager/modes/agentic/agentic-context.ts
@@ -18,7 +18,7 @@ import {
 import type { InvokeModelContext } from '../../../middleware/stages.js'
 import type { MiddlewareInputHandler } from '../../../middleware/types.js'
 import type { Model } from '../../../models/model.js'
-import { DEFAULT_CONTEXT_WINDOW_LIMIT } from '../../../conversation-manager/conversation-manager.js'
+import { DEFAULT_CONTEXT_WINDOW_LIMIT } from '../../../models/defaults.js'
 
 /** Default number of recent messages to preserve verbatim during summarization or truncation. */
 const DEFAULT_KEEP_RECENT_MESSAGES = 10

--- a/strands-ts/src/conversation-manager/__tests__/conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/conversation-manager.test.ts
@@ -12,6 +12,7 @@ import { ContextWindowOverflowError } from '../../errors.js'
 import { createMockAgent, invokeTrackedHook } from '../../__fixtures__/agent-helpers.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
 import type { BaseModelConfig } from '../../models/model.js'
+import { Model } from '../../models/model.js'
 import { warnOnce } from '../../logging/warn-once.js'
 
 vi.mock('../../logging/warn-once.js', () => ({
@@ -159,7 +160,10 @@ describe('ConversationManager', () => {
   })
 
   describe('proactiveCompression', () => {
-    const mockModel = { getConfig: () => ({ contextWindowLimit: 1000 }) as BaseModelConfig } as any
+    const mockModel = {
+      getConfig: () => ({ contextWindowLimit: 1000 }) as BaseModelConfig,
+      estimateUtilization: Model.prototype.estimateUtilization,
+    } as any
 
     it('always registers a BeforeModelCallEvent hook regardless of proactiveCompression setting', () => {
       const manager = new TestConversationManager()
@@ -291,7 +295,10 @@ describe('ConversationManager', () => {
       const mockAgent = createMockAgent({ messages })
       manager.initAgent(mockAgent)
 
-      const modelWithoutLimit = { getConfig: () => ({}) as BaseModelConfig } as any
+      const modelWithoutLimit = {
+        getConfig: () => ({}) as BaseModelConfig,
+        estimateUtilization: Model.prototype.estimateUtilization,
+      } as any
       // 150000/200000 = 0.75 >= 0.7 — should trigger with the 200k default
       const event = new BeforeModelCallEvent({
         agent: mockAgent,
@@ -313,7 +320,10 @@ describe('ConversationManager', () => {
       const mockAgent = createMockAgent()
       manager.initAgent(mockAgent)
 
-      const modelWithoutLimit = { getConfig: () => ({}) as BaseModelConfig } as any
+      const modelWithoutLimit = {
+        getConfig: () => ({}) as BaseModelConfig,
+        estimateUtilization: Model.prototype.estimateUtilization,
+      } as any
       // 100000/200000 = 0.5 < 0.7 — should NOT trigger
       const event = new BeforeModelCallEvent({
         agent: mockAgent,

--- a/strands-ts/src/conversation-manager/__tests__/sliding-window-conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/sliding-window-conversation-manager.test.ts
@@ -10,11 +10,11 @@ import {
   ToolUseBlock,
   ToolResultBlock,
   VideoBlock,
-  type Model,
 } from '../../index.js'
 import { AfterInvocationEvent, AfterModelCallEvent, BeforeModelCallEvent } from '../../hooks/events.js'
 import { createMockAgent, invokeTrackedHook } from '../../__fixtures__/agent-helpers.js'
 import type { Agent } from '../../agent/agent.js'
+import { Model } from '../../models/model.js'
 import type { BaseModelConfig } from '../../models/model.js'
 
 async function triggerSlidingWindow(manager: SlidingWindowConversationManager, agent: Agent): Promise<void> {
@@ -1192,7 +1192,10 @@ describe('SlidingWindowConversationManager', () => {
         new Message({ role: 'user', content: [new TextBlock('Message 3')] }),
         new Message({ role: 'assistant', content: [new TextBlock('Response 3')] }),
       ]
-      const mockModel = { getConfig: () => ({ contextWindowLimit: 1000 }) as BaseModelConfig } as any
+      const mockModel = {
+        getConfig: () => ({ contextWindowLimit: 1000 }) as BaseModelConfig,
+        estimateUtilization: Model.prototype.estimateUtilization,
+      } as any
       const mockAgent = createMockAgent({ messages })
       manager.initAgent(mockAgent)
 
@@ -1216,7 +1219,10 @@ describe('SlidingWindowConversationManager', () => {
         new Message({ role: 'user', content: [new TextBlock('Message 1')] }),
         new Message({ role: 'assistant', content: [new TextBlock('Response 1')] }),
       ]
-      const mockModel = { getConfig: () => ({ contextWindowLimit: 1000 }) as BaseModelConfig } as any
+      const mockModel = {
+        getConfig: () => ({ contextWindowLimit: 1000 }) as BaseModelConfig,
+        estimateUtilization: Model.prototype.estimateUtilization,
+      } as any
       const mockAgent = createMockAgent({ messages })
       manager.initAgent(mockAgent)
 

--- a/strands-ts/src/conversation-manager/__tests__/summarizing-conversation-manager.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/summarizing-conversation-manager.test.ts
@@ -4,6 +4,7 @@ import { ContextWindowOverflowError, Message, TextBlock, ToolUseBlock, ToolResul
 import { AfterModelCallEvent, BeforeModelCallEvent } from '../../hooks/events.js'
 import { createMockAgent, invokeTrackedHook } from '../../__fixtures__/agent-helpers.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
+import { Model as ModelBase } from '../../models/model.js'
 import type { Model, BaseModelConfig } from '../../models/model.js'
 
 function textMsg(role: 'user' | 'assistant', text: string): Message {
@@ -349,7 +350,10 @@ describe('SummarizingConversationManager', () => {
       })
       const messages = makeMessages(20)
       const mockAgent = createMockAgent({ messages })
-      const mockModel = { getConfig: () => ({ contextWindowLimit: 1000 }) as BaseModelConfig } as any
+      const mockModel = {
+        getConfig: () => ({ contextWindowLimit: 1000 }) as BaseModelConfig,
+        estimateUtilization: ModelBase.prototype.estimateUtilization,
+      } as any
 
       manager.initAgent(mockAgent)
 
@@ -380,7 +384,10 @@ describe('SummarizingConversationManager', () => {
       })
       const messages = makeMessages(20)
       const mockAgent = createMockAgent({ messages })
-      const mockModel = { getConfig: () => ({ contextWindowLimit: 1000 }) as BaseModelConfig } as any
+      const mockModel = {
+        getConfig: () => ({ contextWindowLimit: 1000 }) as BaseModelConfig,
+        estimateUtilization: ModelBase.prototype.estimateUtilization,
+      } as any
 
       manager.initAgent(mockAgent)
 
@@ -407,7 +414,10 @@ describe('SummarizingConversationManager', () => {
       })
       const messages = makeMessages(20)
       const mockAgent = createMockAgent({ messages })
-      const mockModel = { getConfig: () => ({ contextWindowLimit: 1000 }) as BaseModelConfig } as any
+      const mockModel = {
+        getConfig: () => ({ contextWindowLimit: 1000 }) as BaseModelConfig,
+        estimateUtilization: ModelBase.prototype.estimateUtilization,
+      } as any
 
       manager.initAgent(mockAgent)
 

--- a/strands-ts/src/conversation-manager/conversation-manager.ts
+++ b/strands-ts/src/conversation-manager/conversation-manager.ts
@@ -11,13 +11,9 @@ import { AfterModelCallEvent, BeforeModelCallEvent } from '../hooks/events.js'
 import { ContextWindowOverflowError } from '../errors.js'
 import type { Model } from '../models/model.js'
 import { logger } from '../logging/logger.js'
-import { warnOnce } from '../logging/warn-once.js'
 
 /** Default compression threshold ratio. */
 const DEFAULT_COMPRESSION_THRESHOLD = 0.7
-
-/** @internal Default context window limit fallback when the model doesn't report one. */
-export const DEFAULT_CONTEXT_WINDOW_LIMIT = 200_000
 
 /**
  * Options passed to {@link ConversationManager.reduce}.
@@ -183,23 +179,14 @@ export abstract class ConversationManager implements Plugin {
         return
       }
 
-      let contextWindowLimit = event.model.getConfig().contextWindowLimit
-      if (contextWindowLimit === undefined) {
-        contextWindowLimit = DEFAULT_CONTEXT_WINDOW_LIMIT
-        warnOnce(
-          logger,
-          `conversation_manager=<${this.name}> | contextWindowLimit is not set on the model, using default of ${DEFAULT_CONTEXT_WINDOW_LIMIT} | set contextWindowLimit in your model config for accurate proactive compression`
-        )
-      }
-
       if (event.projectedInputTokens === undefined) {
         return
       }
 
-      const ratio = event.projectedInputTokens / contextWindowLimit
+      const ratio = event.model.estimateUtilization(event.projectedInputTokens)
       if (ratio >= this._compressionThreshold) {
         logger.debug(
-          `projected_tokens=<${event.projectedInputTokens}>, limit=<${contextWindowLimit}>, ratio=<${ratio.toFixed(2)}>, compression_threshold=<${this._compressionThreshold}> | compression threshold exceeded, reducing context`
+          `projected_tokens=<${event.projectedInputTokens}>, ratio=<${ratio.toFixed(2)}>, compression_threshold=<${this._compressionThreshold}> | compression threshold exceeded, reducing context`
         )
         // Proactive compression is best-effort: swallow errors so the model call can still proceed.
         try {

--- a/strands-ts/src/models/__tests__/model.test.ts
+++ b/strands-ts/src/models/__tests__/model.test.ts
@@ -1111,3 +1111,32 @@ describe('countTokens', () => {
     expect(result).toBe(expected)
   })
 })
+
+describe('estimateUtilization', () => {
+  it('returns ratio of inputTokens to contextWindowLimit', () => {
+    const provider = new TestModelProvider()
+    provider.updateConfig({ contextWindowLimit: 100_000 })
+
+    expect(provider.estimateUtilization(50_000)).toBe(0.5)
+  })
+
+  it('uses DEFAULT_CONTEXT_WINDOW_LIMIT when contextWindowLimit is not set', () => {
+    const provider = new TestModelProvider()
+
+    expect(provider.estimateUtilization(100_000)).toBe(100_000 / 200_000)
+  })
+
+  it('returns value above 1.0 when tokens exceed limit', () => {
+    const provider = new TestModelProvider()
+    provider.updateConfig({ contextWindowLimit: 1000 })
+
+    expect(provider.estimateUtilization(1500)).toBeGreaterThan(1.0)
+  })
+
+  it('returns 0 for zero tokens', () => {
+    const provider = new TestModelProvider()
+    provider.updateConfig({ contextWindowLimit: 100_000 })
+
+    expect(provider.estimateUtilization(0)).toBe(0)
+  })
+})

--- a/strands-ts/src/models/defaults.ts
+++ b/strands-ts/src/models/defaults.ts
@@ -42,6 +42,9 @@ export function defaultMaxTokensWarningMessage(defaultMaxTokens: number): string
   return `max_tokens=<${defaultMaxTokens}> | using default maxTokens, which is subject to change | set maxTokens explicitly to pin the value`
 }
 
+/** Default context window limit (in tokens) when the model does not report one. */
+export const DEFAULT_CONTEXT_WINDOW_LIMIT = 200_000
+
 /**
  * Context window limits (in tokens) for known model IDs.
  *

--- a/strands-ts/src/models/model.ts
+++ b/strands-ts/src/models/model.ts
@@ -26,7 +26,8 @@ import {
 import { MaxTokensError, ModelError, normalizeError } from '../errors.js'
 import type { Redaction } from '../hooks/events.js'
 import { logger } from '../logging/logger.js'
-import { getContextWindowLimit } from './defaults.js'
+import { DEFAULT_CONTEXT_WINDOW_LIMIT, getContextWindowLimit } from './defaults.js'
+import { warnOnce } from '../logging/warn-once.js'
 
 /**
  * Resolves model metadata fields on a config object from built-in lookup tables
@@ -270,6 +271,28 @@ export abstract class Model<T extends BaseModelConfig = BaseModelConfig> {
    */
   async countTokens(messages: Message[], options?: CountTokensOptions): Promise<number> {
     return estimateTokensHeuristic(messages, options)
+  }
+
+  /**
+   * Estimate the fraction of the model's context window consumed by the given input token count.
+   *
+   * Resolves the model's context window limit (falling back to {@link DEFAULT_CONTEXT_WINDOW_LIMIT}
+   * with a warning when not configured) and returns `inputTokens / contextWindowLimit`.
+   *
+   * @param inputTokens - Total input token count (e.g. from a model event's projectedInputTokens)
+   * @returns Token usage ratio (0–1+; above 1.0 means overflow)
+   */
+  estimateUtilization(inputTokens: number): number {
+    let contextWindowLimit = this.getConfig().contextWindowLimit
+    if (!contextWindowLimit) {
+      contextWindowLimit = DEFAULT_CONTEXT_WINDOW_LIMIT
+      warnOnce(
+        logger,
+        `contextWindowLimit is not set on the model, using default of ${DEFAULT_CONTEXT_WINDOW_LIMIT} for utilization estimate | set contextWindowLimit in your model config for accurate results`
+      )
+    }
+
+    return inputTokens / contextWindowLimit
   }
 
   /**


### PR DESCRIPTION

## Description
Centralizes context-window utilization calculation (tokens / limit) into a single public method on Model, eliminating duplicated fallback logic in `ConversationManager` and `ContextManager`. Deduplicates `DEFAULT_CONTEXT_WINDOW_LIMIT` by defining it once in `models/defaults.ts`.

**estimateUtilization** is exported on model similarly to `model.countTokens()`

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change


New feature


## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [X] I ran `hatch run prepare`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [X] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
