### PR TITLE
fix(injection): keep injected context out of the prompt cache prefix

### DIFF
--- a/site/src/content/docs/user-guide/concepts/plugins/context-injector.mdx
+++ b/site/src/content/docs/user-guide/concepts/plugins/context-injector.mdx
@@ -118,6 +118,12 @@ injector = ContextInjector(
 The rendered text is a prompt-injection surface. If it interpolates attacker-influenced data (tool output, user-derived state), escape it yourself before returning. A callback that throws fails open: injection is skipped and the model call proceeds.
 :::
 
+## Prompt Caching
+
+Injected text is appended to the end of the latest user message, so it is the last thing the model reads. It is preceded by a cache point marking where the reusable prefix ends, so providers that support prompt caching keep the volatile text out of the cached prefix and the rest of the conversation still gets cache hits. Providers without cache-point control ignore the marker.
+
+Injecting a large payload still costs input tokens on every model call, since the injected text itself is never cached. Prefer the default `'userTurn'` over `'everyTurn'` to reduce token costs, except for an autonomous agent that needs the context at each step.
+
 ## Related
 
 - [Memory](../memory/overview#context-injection) builds on this engine to inject retrieved knowledge before a model call.

--- a/strands-py/src/strands/_context_manager/modes/agentic/agentic_context.py
+++ b/strands-py/src/strands/_context_manager/modes/agentic/agentic_context.py
@@ -25,7 +25,7 @@ from ....agent.conversation_manager.compression.context_compression import (
 from ....agent.conversation_manager.compression.pin_message import is_pinned, pin_message, unpin_message
 from ....agent.conversation_manager.conversation_manager import DEFAULT_CONTEXT_WINDOW_LIMIT
 from ....tools.decorator import tool
-from ....types.content import Message, _ensure_tracking_id
+from ....types.content import Message, _append_ephemeral_content, _ensure_tracking_id
 from ....types.exceptions import ContextWindowOverflowException
 from ....types.tools import ToolContext
 
@@ -292,7 +292,8 @@ def create_token_usage_middleware() -> MiddlewareInputHandler:
     The block reports projected input-token usage against the context window limit of the
     model that will actually handle the call (``context.model``), so guidance stays correct
     even when middleware has redirected the call to a different model. The original messages
-    are not mutated; the last message is copied and the status text appended to the copy.
+    are not mutated; the last message is copied and the status text appended to the copy as 
+    ephemeral content to keep it out of the prompt cache's reusable prefix.
 
     Returns:
         An async ``MiddlewareInputHandler`` for the ``InvokeModelStage.Input`` phase.
@@ -318,14 +319,7 @@ def create_token_usage_middleware() -> MiddlewareInputHandler:
         if not messages:
             return context
 
-        last_message = messages[-1]
-        new_message: Message = {
-            "role": last_message["role"],
-            "content": [*last_message["content"], {"text": status_text}],
-        }
-        if "metadata" in last_message:
-            new_message["metadata"] = last_message["metadata"]
-        messages[-1] = new_message
+        messages[-1] = _append_ephemeral_content(messages[-1], [{"text": status_text}])
 
         return replace(context, messages=messages)
 

--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -136,11 +136,13 @@ async def _estimate_input_tokens(agent: "Agent") -> int:
     """
     messages = agent.messages
 
-    # Find the last assistant message with usage metadata
+    # Skip calls that used the cache: providers disagree on whether a cached portion is included in
+    # ``inputTokens``, so those fall through to counting the messages below rather than being guessed.
     last_assistant_idx = -1
-    for i, msg in reversed(list(enumerate(messages))):
-        if msg.get("role") == "assistant" and msg.get("metadata", {}).get("usage"):
-            last_assistant_idx = i
+    for index, message in reversed(list(enumerate(messages))):
+        usage = message.get("metadata", {}).get("usage") if message.get("role") == "assistant" else None
+        if usage and not (usage.get("cacheReadInputTokens") or usage.get("cacheWriteInputTokens")):
+            last_assistant_idx = index
             break
 
     if last_assistant_idx >= 0:

--- a/strands-py/src/strands/injection/_message_injection.py
+++ b/strands-py/src/strands/injection/_message_injection.py
@@ -14,11 +14,12 @@ from collections.abc import Awaitable, Callable
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any, Protocol
 
+from ..types.content import _append_ephemeral_content
 from .types import InjectionContext, InjectionTriggerPredicate
 
 if TYPE_CHECKING:
     from .._middleware.stages import InvokeModelContext
-    from ..types.content import ContentBlock, Message, Messages
+    from ..types.content import Messages
 
 logger = logging.getLogger(__name__)
 
@@ -147,14 +148,12 @@ def _fold_into_last_user_message(messages: Messages, text: str) -> Messages:
     """Fold ``text`` into the most recent ``user`` message as a text block, returning a NEW list.
 
     Folding into the existing user message (rather than inserting a standalone message) keeps
-    role alternation valid in both chat and the autonomous tool loop. The block is placed to
-    keep the message valid for the model:
+    role alternation valid in both chat and the autonomous tool loop.
 
-    - A plain user ask: the text is **prepended**, leaving the user's own ask in the recency
-      slot — the last thing the model reads.
-    - A tool-result turn (the message carries a tool result block): the text is **appended**,
-      because providers require the tool result to be the first content block in the turn that
-      answers a tool use.
+    The text is appended behind a cache-point boundary via
+    :func:`~strands.types.content._append_ephemeral_content`. Two reasons: providers require a tool
+    result to stay the first content block in the turn that answers a tool use, and a trailing run
+    is the only placement a provider can exclude from a cached prefix.
 
     The input list and its messages are never mutated. When there is no ``user`` message, the
     input list is returned unchanged.
@@ -174,17 +173,6 @@ def _fold_into_last_user_message(messages: Messages, text: str) -> Messages:
     if target_index < 0:
         return messages
 
-    target = messages[target_index]
-    injected: ContentBlock = {"text": text}
-    # A tool result must stay the first block in the turn that answers a tool use, so append
-    # rather than prepend when the target carries one.
-    has_tool_result = any("toolResult" in block for block in target["content"])
-    content = [*target["content"], injected] if has_tool_result else [injected, *target["content"]]
-
-    folded: Message = {"role": target["role"], "content": content}
-    if "metadata" in target:
-        folded["metadata"] = target["metadata"]
-
     result = list(messages)
-    result[target_index] = folded
+    result[target_index] = _append_ephemeral_content(messages[target_index], [{"text": text}])
     return result

--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -409,6 +409,9 @@ class BedrockModel(Model):
     def _inject_cache_point(self, messages: list[dict[str, Any]]) -> None:
         """Inject a cache point at the end of the last user message.
 
+        A cache point already present in the last user message is left where it is: callers place
+        one to mark the end of the reusable prefix, ahead of injected content that is rebuilt every call.
+
         Args:
             messages: List of messages to inject cache point into (modified in place).
         """
@@ -417,6 +420,14 @@ class BedrockModel(Model):
 
         last_user_idx: int | None = None
         for msg_idx, msg in enumerate(messages):
+            if msg.get("role") == "user":
+                last_user_idx = msg_idx
+
+        # Strip cache points everywhere except the last user message, where auto mode would
+        # otherwise accumulate one per turn and exceed Bedrock's 4-cache-point ceiling.
+        for msg_idx, msg in enumerate(messages):
+            if msg_idx == last_user_idx:
+                continue
             content = msg.get("content", [])
             for block_idx, block in reversed(list(enumerate(content))):
                 if "cachePoint" in block:
@@ -426,22 +437,27 @@ class BedrockModel(Model):
                         msg_idx,
                         block_idx,
                     )
-            if msg.get("role") == "user":
-                last_user_idx = msg_idx
 
         if last_user_idx is not None and messages[last_user_idx].get("content"):
-            cache_point: dict[str, Any] = {"type": "default"}
+            content = messages[last_user_idx]["content"]
             cache_config = self.config.get("cache_config")
+
+            placed = next((block for block in content if "cachePoint" in block), None)
+            if placed is not None:
+                if cache_config and cache_config.ttl and "ttl" not in placed["cachePoint"]:
+                    placed["cachePoint"]["ttl"] = cache_config.ttl
+                logger.debug("msg_idx=<%s> | honored caller-placed cache point", last_user_idx)
+                return
+
+            cache_point: dict[str, Any] = {"type": "default"}
             if cache_config and cache_config.ttl:
                 cache_point["ttl"] = cache_config.ttl
 
-            content = messages[last_user_idx]["content"]
-
             # Insert before non-PDF document blocks to avoid Bedrock ValidationException
             first_non_pdf_doc_idx: int | None = None
-            for i, block in enumerate(content):
+            for block_idx, block in enumerate(content):
                 if "document" in block and block["document"].get("format", "") != "pdf":
-                    first_non_pdf_doc_idx = i
+                    first_non_pdf_doc_idx = block_idx
                     break
 
             # Insert the cache point before the first non-PDF document so it is not directly

--- a/strands-py/src/strands/models/openai.py
+++ b/strands-py/src/strands/models/openai.py
@@ -412,6 +412,10 @@ class OpenAIModel(Model):
                 if _has_location_source(content):
                     logger.warning("Location sources are not supported by OpenAI | skipping content block")
                     continue
+                if "cachePoint" in content:
+                    # OpenAI caches prefixes server-side and offers no cache-point control
+                    logger.warning("cache points are not supported by OpenAI | skipping content block")
+                    continue
                 filtered_contents.append(content)
 
             formatted_contents = [cls.format_request_message_content(content) for content in filtered_contents]

--- a/strands-py/src/strands/types/content.py
+++ b/strands-py/src/strands/types/content.py
@@ -281,3 +281,40 @@ def get_message_metadata(message: Message) -> MessageMetadata:
     Individual fields (usage, metrics, custom) may not be present. Use .get() to safely access them.
     """
     return message.get("metadata", {})
+
+
+def _append_ephemeral_content(message: Message, blocks: list[ContentBlock]) -> Message:
+    """Append single-call content to a message, marking where the reusable prefix ends.
+
+    Content that is rebuilt on every model call (injected context) must sit
+    outside any cached prefix to avoid invalidating the cache. 
+    Appending puts it at the end and the leading ``cachePoint`` declares the
+    boundary, so providers that manage prompt caching keep the durable conversation cacheable.
+
+    A boundary another caller already opened is reused rather than duplicated, so several callers
+    appending in turn produce exactly one boundary ahead of all the ephemeral content. 
+
+    The input message is not mutated.
+
+    Args:
+        message: The message to append to.
+        blocks: The ephemeral content blocks to append.
+
+    Returns:
+        A new message with the boundary and ``blocks`` appended, or ``message`` when ``blocks``
+        is empty.
+    """
+    if not blocks:
+        return message
+
+    content = list(message["content"])
+    if content and not any("cachePoint" in block for block in content):
+        content.append({"cachePoint": {"type": "default"}})
+    content.extend(blocks)
+
+    appended: Message = {"role": message["role"], "content": content}
+    if "tracking_id" in message:
+        appended["tracking_id"] = message["tracking_id"]
+    if "metadata" in message:
+        appended["metadata"] = message["metadata"]
+    return appended

--- a/strands-py/tests/strands/agent/conversation_manager/test_token_usage_middleware.py
+++ b/strands-py/tests/strands/agent/conversation_manager/test_token_usage_middleware.py
@@ -8,6 +8,7 @@ from strands import Agent
 from strands._context_manager.modes.agentic.agentic_context import create_token_usage_middleware
 from strands._middleware.stages import InvokeModelContext
 from strands.types.content import Message
+from strands.vended_plugins.context_injector import ContextInjector
 from tests.fixtures.mocked_model_provider import MockedModelProvider
 
 
@@ -57,8 +58,10 @@ class TestCreateTokenUsageMiddleware:
 
         assert len(result.messages) == 1
         last_msg = result.messages[0]
-        assert len(last_msg["content"]) == 2
-        status_text = last_msg["content"][1]["text"]
+        # The status text carries a live token count that changes every call, so it is appended
+        # behind a cachePoint boundary to keep it out of the prompt cache's reusable prefix.
+        assert [next(iter(block)) for block in last_msg["content"]] == ["text", "cachePoint", "text"]
+        status_text = last_msg["content"][-1]["text"]
         assert "<context-status>" in status_text
         assert "25.0%" in status_text
         assert "<remaining>" in status_text
@@ -71,7 +74,7 @@ class TestCreateTokenUsageMiddleware:
 
         result = await middleware(context)
 
-        status_text = result.messages[0]["content"][1]["text"]
+        status_text = result.messages[0]["content"][-1]["text"]
         assert "8,000 / 10,000 tokens (80.0%)" in status_text
         assert "<remaining>~2,000 tokens</remaining>" in status_text
 
@@ -91,7 +94,7 @@ class TestCreateTokenUsageMiddleware:
 
         result = await middleware(context)
 
-        status_text = result.messages[0]["content"][1]["text"]
+        status_text = result.messages[0]["content"][-1]["text"]
         assert "<context-status>" in status_text
         assert "50.0%" in status_text
         assert "200,000" in status_text
@@ -114,7 +117,7 @@ class TestCreateTokenUsageMiddleware:
 
         result = await middleware(context)
 
-        status_text = result.messages[0]["content"][1]["text"]
+        status_text = result.messages[0]["content"][-1]["text"]
         assert "80.0%" in status_text
         assert "<remaining>~20,000 tokens</remaining>" in status_text
 
@@ -188,3 +191,37 @@ class TestTokenUsageMiddlewareIntegration:
         for messages in seen_messages:
             for block in messages[-1]["content"]:
                 assert "<context-status>" not in block.get("text", "")
+
+
+@pytest.mark.asyncio
+async def test_shares_one_cache_boundary_with_an_injector():
+    """Both volatile blocks must sit behind a single cache-point boundary.
+
+    Agentic mode appends ``<context-status>`` and the injector appends after it. Both change every
+    call, so both belong outside the cached prefix. Two boundaries would waste one of the provider's
+    limited cache points, and a boundary between them would leave ``<context-status>`` inside the
+    cached prefix and invalidate it every turn.
+    """
+    model = MockedModelProvider([{"role": "assistant", "content": [{"text": "ok"}]}])
+    seen_messages = []
+    original_stream = model.stream
+
+    def capturing_stream(messages, *args, **kwargs):
+        seen_messages.append([dict(message) for message in messages])
+        return original_stream(messages, *args, **kwargs)
+
+    model.stream = capturing_stream
+
+    agent = Agent(
+        model=model,
+        context_manager="agentic",
+        plugins=[ContextInjector(lambda context: "INJECTED")],
+        callback_handler=None,
+    )
+    await agent.invoke_async("ask")
+
+    content = seen_messages[0][-1]["content"]
+    assert [next(iter(block)) for block in content] == ["text", "cachePoint", "text", "text"]
+    assert content[0] == {"text": "ask"}
+    assert "<context-status>" in content[2]["text"]
+    assert content[3] == {"text": "INJECTED"}

--- a/strands-py/tests/strands/injection/test_message_injection.py
+++ b/strands-py/tests/strands/injection/test_message_injection.py
@@ -56,14 +56,17 @@ def invoke_ctx(messages: list[dict], agent: Any = None) -> InvokeModelContext:
 
 
 class TestFoldIntoLastUserMessage:
-    def test_prepends_text_ahead_of_user_content(self):
+    def test_appends_text_after_user_content(self):
         messages = [user("original task"), assistant("prior step"), user("next ask")]
         result = _fold_into_last_user_message(messages, "INJECTED")
 
         assert result == [
             {"role": "user", "content": [{"text": "original task"}]},
             {"role": "assistant", "content": [{"text": "prior step"}]},
-            {"role": "user", "content": [{"text": "INJECTED"}, {"text": "next ask"}]},
+            {
+                "role": "user",
+                "content": [{"text": "next ask"}, {"cachePoint": {"type": "default"}}, {"text": "INJECTED"}],
+            },
         ]
 
     def test_returns_new_list_and_does_not_mutate_input(self):
@@ -84,7 +87,7 @@ class TestFoldIntoLastUserMessage:
         assert result == [
             {"role": "user", "content": [{"text": "task"}]},
             {"role": "assistant", "content": [{"text": "thinking"}]},
-            {"role": "user", "content": [tr["content"][0], {"text": "INJECTED"}]},
+            {"role": "user", "content": [tr["content"][0], {"cachePoint": {"type": "default"}}, {"text": "INJECTED"}]},
         ]
 
     def test_targets_most_recent_user_message(self):
@@ -94,7 +97,10 @@ class TestFoldIntoLastUserMessage:
         assert result == [
             {"role": "user", "content": [{"text": "first"}]},
             {"role": "assistant", "content": [{"text": "a"}]},
-            {"role": "user", "content": [{"text": "INJECTED"}, {"text": "second"}]},
+            {
+                "role": "user",
+                "content": [{"text": "second"}, {"cachePoint": {"type": "default"}}, {"text": "INJECTED"}],
+            },
         ]
 
     def test_preserves_message_metadata(self):
@@ -160,7 +166,7 @@ class TestCreateInjectionMiddleware:
 
         assert result.messages == [
             {"role": "assistant", "content": [{"text": "prior"}]},
-            {"role": "user", "content": [{"text": "INJECTED"}, {"text": "ask"}]},
+            {"role": "user", "content": [{"text": "ask"}, {"cachePoint": {"type": "default"}}, {"text": "INJECTED"}]},
         ]
 
     async def test_passes_conversation_to_render_content(self):
@@ -196,7 +202,9 @@ class TestCreateInjectionMiddleware:
         handler = _create_injection_middleware(render)
         result = await handler(invoke_ctx([user("ask")]))
 
-        assert result.messages == [{"role": "user", "content": [{"text": "INJECTED"}, {"text": "ask"}]}]
+        assert result.messages == [
+            {"role": "user", "content": [{"text": "ask"}, {"cachePoint": {"type": "default"}}, {"text": "INJECTED"}]}
+        ]
 
     async def test_returns_context_unchanged_when_trigger_does_not_fire(self):
         render = MagicMock(return_value="x")
@@ -215,7 +223,7 @@ class TestCreateInjectionMiddleware:
         assert result.messages == [
             {"role": "user", "content": [{"text": "task"}]},
             {"role": "assistant", "content": [{"text": "a"}]},
-            {"role": "user", "content": [tr["content"][0], {"text": "INJECTED"}]},
+            {"role": "user", "content": [tr["content"][0], {"cachePoint": {"type": "default"}}, {"text": "INJECTED"}]},
         ]
 
     async def test_returns_context_unchanged_when_render_yields_empty(self):
@@ -243,3 +251,31 @@ class TestCreateInjectionMiddleware:
         await handler(ctx)
 
         assert len(before["content"]) == 1  # original user message untouched
+
+    async def test_marks_injected_text_ephemeral_with_a_cache_point_boundary(self):
+        # The boundary tells cache-managing providers where the reusable prefix ends; without it the
+        # per-call text would sit inside the cached prefix and invalidate it every turn.
+        handler = _create_injection_middleware(lambda context: "INJECTED")
+        result = await handler(invoke_ctx([user("ask")]))
+
+        assert result.messages == [
+            {
+                "role": "user",
+                "content": [{"text": "ask"}, {"cachePoint": {"type": "default"}}, {"text": "INJECTED"}],
+            }
+        ]
+
+    async def test_reuses_one_boundary_across_injectors_on_the_same_call(self):
+        # Providers cap how many cache points a request may carry, so appending must not stack them.
+        ctx = invoke_ctx([user("ask")])
+        first = _create_injection_middleware(lambda context: "ONE")
+        second = _create_injection_middleware(lambda context: "TWO")
+
+        result = await second(await first(ctx))
+
+        assert result.messages == [
+            {
+                "role": "user",
+                "content": [{"text": "ask"}, {"cachePoint": {"type": "default"}}, {"text": "ONE"}, {"text": "TWO"}],
+            }
+        ]

--- a/strands-py/tests/strands/memory/test_memory_manager.py
+++ b/strands-py/tests/strands/memory/test_memory_manager.py
@@ -1259,8 +1259,9 @@ async def test_init_agent_wires_middleware_to_provide_pipeline_folds_a_search_hi
         {
             "role": "user",
             "content": [
-                {"text": '<memory>\n<entry source="s">dark mode preferred</entry>\n</memory>'},
                 {"text": "what is my plan"},
+                {"cachePoint": {"type": "default"}},
+                {"text": '<memory>\n<entry source="s">dark mode preferred</entry>\n</memory>'},
             ],
         },
     ]
@@ -1287,7 +1288,11 @@ async def test_init_agent_forwards_trigger_to_registered_middleware():
         {"role": "assistant", "content": [{"text": "prev"}]},
         {
             "role": "user",
-            "content": [tool_result["content"][0], {"text": '<memory>\n<entry source="s">fact</entry>\n</memory>'}],
+            "content": [
+                tool_result["content"][0],
+                {"cachePoint": {"type": "default"}},
+                {"text": '<memory>\n<entry source="s">fact</entry>\n</memory>'},
+            ],
         },
     ]
     assert store.search.call_args.args[0] == "prev"

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -3230,6 +3230,92 @@ def test_inject_cache_point_strips_existing_cache_points(bedrock_client):
     assert "cachePoint" in cleaned_messages[2]["content"][-1]
 
 
+def test_inject_cache_point_honors_caller_placed_boundary(bedrock_client):
+    """A cache point the caller placed is left alone, not relocated to the end.
+
+    Callers open a boundary ahead of content that is rebuilt every call (injected context, a live
+    token count). Moving it to the end would pull that volatile content into the cached prefix.
+    """
+    model = BedrockModel(
+        model_id="us.anthropic.claude-sonnet-4-20250514-v1:0", cache_config=CacheConfig(strategy="auto")
+    )
+
+    cleaned_messages = [
+        {
+            "role": "user",
+            "content": [{"text": "durable ask"}, {"cachePoint": {"type": "default"}}, {"text": "EPHEMERAL"}],
+        }
+    ]
+
+    model._inject_cache_point(cleaned_messages)
+
+    assert cleaned_messages[0]["content"] == [
+        {"text": "durable ask"},
+        {"cachePoint": {"type": "default"}},
+        {"text": "EPHEMERAL"},
+    ]
+
+
+def test_inject_cache_point_applies_configured_ttl_to_a_honored_boundary(bedrock_client):
+    """A configured TTL still applies when the caller placed the boundary.
+
+    The caller owns placement; TTL remains provider policy. Dropping it here would silently fall
+    back to the default 5m, which means more 1.25x cache writes.
+    """
+    model = BedrockModel(
+        model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
+        cache_config=CacheConfig(strategy="auto", ttl="1h"),
+    )
+
+    cleaned_messages = [
+        {
+            "role": "user",
+            "content": [{"text": "durable ask"}, {"cachePoint": {"type": "default"}}, {"text": "EPHEMERAL"}],
+        }
+    ]
+
+    model._inject_cache_point(cleaned_messages)
+
+    assert cleaned_messages[0]["content"][1] == {"cachePoint": {"type": "default", "ttl": "1h"}}
+
+
+def test_inject_cache_point_keeps_a_hand_placed_ttl(bedrock_client):
+    """An explicit TTL on the placed boundary wins over the configured one."""
+    model = BedrockModel(
+        model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
+        cache_config=CacheConfig(strategy="auto", ttl="1h"),
+    )
+
+    cleaned_messages = [
+        {
+            "role": "user",
+            "content": [{"text": "durable ask"}, {"cachePoint": {"type": "default", "ttl": "5m"}}],
+        }
+    ]
+
+    model._inject_cache_point(cleaned_messages)
+
+    assert cleaned_messages[0]["content"][1] == {"cachePoint": {"type": "default", "ttl": "5m"}}
+
+
+def test_inject_cache_point_strips_boundaries_outside_the_last_user_message(bedrock_client):
+    """Stale boundaries from earlier turns are removed so they cannot exhaust the cache-point cap."""
+    model = BedrockModel(
+        model_id="us.anthropic.claude-sonnet-4-20250514-v1:0", cache_config=CacheConfig(strategy="auto")
+    )
+
+    cleaned_messages = [
+        {"role": "user", "content": [{"text": "old ask"}, {"cachePoint": {"type": "default"}}, {"text": "stale"}]},
+        {"role": "assistant", "content": [{"text": "reply"}]},
+        {"role": "user", "content": [{"text": "new ask"}]},
+    ]
+
+    model._inject_cache_point(cleaned_messages)
+
+    assert cleaned_messages[0]["content"] == [{"text": "old ask"}, {"text": "stale"}]
+    assert cleaned_messages[2]["content"] == [{"text": "new ask"}, {"cachePoint": {"type": "default"}}]
+
+
 def test_inject_cache_point_before_non_pdf_document(bedrock_client):
     """Test that cache point is inserted before non-PDF document blocks."""
     model = BedrockModel(

--- a/strands-py/tests/strands/models/test_openai.py
+++ b/strands-py/tests/strands/models/test_openai.py
@@ -1817,6 +1817,32 @@ def test_format_request_filters_s3_source_image(model, caplog):
     assert "Location sources are not supported by OpenAI" in caplog.text
 
 
+def test_format_request_skips_cache_point_in_message(model, caplog):
+    """Cache points in a message are skipped with a warning rather than raising.
+
+    OpenAI caches prefixes server-side and offers no cache-point control, so the block carries no
+    meaning here. Skipping matches how the system-prompt path and the Gemini/Vercel providers treat
+    cache points, and lets provider-agnostic callers mark ephemeral content without special-casing.
+    """
+    caplog.set_level(logging.WARNING, logger="strands.models.openai")
+
+    messages = [
+        {
+            "role": "user",
+            "content": [{"text": "durable ask"}, {"cachePoint": {"type": "default"}}, {"text": "EPHEMERAL"}],
+        },
+    ]
+
+    request = model.format_request(messages)
+
+    formatted_content = request["messages"][0]["content"]
+    assert formatted_content == [
+        {"text": "durable ask", "type": "text"},
+        {"text": "EPHEMERAL", "type": "text"},
+    ]
+    assert "cache points are not supported by OpenAI" in caplog.text
+
+
 def test_format_request_filters_location_source_document(model, caplog):
     """Test that documents with Location sources are filtered out with warning."""
     caplog.set_level(logging.WARNING, logger="strands.models.openai")

--- a/strands-py/tests/strands/types/test_append_ephemeral_content.py
+++ b/strands-py/tests/strands/types/test_append_ephemeral_content.py
@@ -1,0 +1,66 @@
+"""Tests for _append_ephemeral_content, the shared cache-boundary primitive.
+
+Both the injection engine and the agentic token-usage middleware append per-call content through
+this function, so its contract is pinned here rather than only transitively through those callers.
+"""
+
+from strands.types.content import Message, _append_ephemeral_content
+
+_BOUNDARY = {"cachePoint": {"type": "default"}}
+
+
+def test_appends_behind_a_boundary():
+    message: Message = {"role": "user", "content": [{"text": "durable ask"}]}
+
+    appended = _append_ephemeral_content(message, [{"text": "EPHEMERAL"}])
+
+    assert appended["content"] == [{"text": "durable ask"}, _BOUNDARY, {"text": "EPHEMERAL"}]
+
+
+def test_returns_input_unchanged_when_no_blocks():
+    message: Message = {"role": "user", "content": [{"text": "ask"}]}
+
+    assert _append_ephemeral_content(message, []) is message
+
+
+def test_emits_no_boundary_when_content_is_empty():
+    # Nothing precedes the appended content, so there is no prefix worth caching.
+    message: Message = {"role": "user", "content": []}
+
+    appended = _append_ephemeral_content(message, [{"text": "EPHEMERAL"}])
+
+    assert appended["content"] == [{"text": "EPHEMERAL"}]
+
+
+def test_reuses_a_boundary_another_caller_already_opened():
+    # Providers cap how many cache points a request may carry, so appending must not stack them.
+    message: Message = {"role": "user", "content": [{"text": "ask"}]}
+
+    first = _append_ephemeral_content(message, [{"text": "ONE"}])
+    second = _append_ephemeral_content(first, [{"text": "TWO"}])
+
+    assert second["content"] == [{"text": "ask"}, _BOUNDARY, {"text": "ONE"}, {"text": "TWO"}]
+
+
+def test_does_not_mutate_the_input_message():
+    original_content = [{"text": "ask"}]
+    message: Message = {"role": "user", "content": original_content}
+
+    appended = _append_ephemeral_content(message, [{"text": "EPHEMERAL"}])
+
+    assert message["content"] == [{"text": "ask"}]
+    assert appended["content"] is not original_content
+
+
+def test_preserves_identity_fields():
+    message: Message = {
+        "role": "user",
+        "content": [{"text": "ask"}],
+        "tracking_id": "durable-1",
+        "metadata": {"custom": {"keep": "me"}},
+    }
+
+    appended = _append_ephemeral_content(message, [{"text": "EPHEMERAL"}])
+
+    assert appended["tracking_id"] == "durable-1"
+    assert appended["metadata"] == {"custom": {"keep": "me"}}

--- a/strands-py/tests/strands/vended_plugins/context_injector/test_integration.py
+++ b/strands-py/tests/strands/vended_plugins/context_injector/test_integration.py
@@ -52,3 +52,40 @@ def test_injected_text_reaches_model_but_not_durable_history(model, model_seen):
     # (b) The durable conversation never contains the injected text.
     assert "<ctx>EPHEMERAL</ctx>" not in _texts(agent.messages)
     assert "what is the weather?" in _texts(agent.messages)
+
+
+def test_injected_text_is_marked_ephemeral_for_the_model():
+    """The model receives the injected text behind a cache-point boundary, every call.
+
+    The boundary is what keeps per-call content out of a provider's cached prefix, so it must be
+    present on each call and must not accumulate across calls.
+    """
+    model = MockedModelProvider(
+        [
+            {"role": "assistant", "content": [{"text": "first"}]},
+            {"role": "assistant", "content": [{"text": "second"}]},
+        ]
+    )
+    seen: list[list] = []
+    original_stream = model.stream
+
+    def stream(messages, *args, **kwargs):
+        seen.append([dict(message) for message in messages])
+        return original_stream(messages, *args, **kwargs)
+
+    model.stream = stream
+
+    agent = Agent(
+        model=model,
+        callback_handler=None,
+        plugins=[ContextInjector(lambda context: "<ctx>EPHEMERAL</ctx>")],
+    )
+    agent("first ask")
+    agent("second ask")
+
+    for call in seen:
+        last_content = call[-1]["content"]
+        assert last_content[-2] == {"cachePoint": {"type": "default"}}
+        assert last_content[-1] == {"text": "<ctx>EPHEMERAL</ctx>"}
+        # Exactly one boundary per call, so the provider's cache-point budget is not exhausted.
+        assert sum(1 for msg in call for block in msg["content"] if "cachePoint" in block) == 1

--- a/strands-py/tests/strands/vended_plugins/context_injector/test_plugin.py
+++ b/strands-py/tests/strands/vended_plugins/context_injector/test_plugin.py
@@ -74,7 +74,7 @@ class TestRegisteredHandler:
         )
         assert result.messages == [
             {"role": "assistant", "content": [{"text": "prior"}]},
-            {"role": "user", "content": [{"text": "INJECTED"}, {"text": "ask"}]},
+            {"role": "user", "content": [{"text": "ask"}, {"cachePoint": {"type": "default"}}, {"text": "INJECTED"}]},
         ]
 
     async def test_skips_on_non_user_turn_by_default(self):
@@ -94,7 +94,7 @@ class TestRegisteredHandler:
         )
         # No later user message than index 0, so the fold targets it.
         assert result.messages == [
-            {"role": "user", "content": [{"text": "INJECTED"}, {"text": "ask"}]},
+            {"role": "user", "content": [{"text": "ask"}, {"cachePoint": {"type": "default"}}, {"text": "INJECTED"}]},
             {"role": "assistant", "content": [{"text": "reply"}]},
         ]
 

--- a/strands-py/tests_integ/test_agentic_context_integration.py
+++ b/strands-py/tests_integ/test_agentic_context_integration.py
@@ -11,11 +11,14 @@ These tests validate end-to-end behavior of ``context_manager="agentic"``:
 They make real Bedrock API calls and rely on default AWS credential resolution.
 """
 
+import re
+
 import pytest
 
 import strands
 from strands import Agent
 from strands.models import BedrockModel
+from strands.models.model import CacheConfig
 from strands.types.content import Messages
 
 
@@ -108,6 +111,49 @@ class TestMiddlewareContextInjection:
         assert "<used>" in status_text
         assert "<remaining>" in status_text
         assert "</context-status>" in status_text
+
+    def test_context_status_tracks_real_size_once_the_cache_is_warm(self):
+        """The reported figure must survive prompt caching.
+
+        Once the cache is warm most of the prompt is reported under the cache counters, not
+        ``inputTokens``. An estimator anchored on it collapses and stops prompting compression.
+        """
+        model = BedrockModel(cache_config=CacheConfig(strategy="auto"), max_tokens=512)
+        seen_messages: list[Messages] = []
+        original_stream = model.stream
+
+        def capturing_stream(messages, *args, **kwargs):
+            seen_messages.append([dict(message) for message in messages])
+            return original_stream(messages, *args, **kwargs)
+
+        model.stream = capturing_stream
+
+        agent = Agent(model=model, context_manager="agentic", callback_handler=None)
+        filler = "This is background context that stays stable across turns. " * 200
+        agent(f"{filler}\n\nReply with OK.")
+        agent("Reply with OK again.")
+        agent("And once more.")
+
+        reported = []
+        for messages in seen_messages:
+            for message in messages:
+                for block in message["content"]:
+                    text = block.get("text", "")
+                    if "<context-status>" in text:
+                        used = re.search(r"<used>([\d,]+) /", text)
+                        if used:
+                            reported.append(int(used.group(1).replace(",", "")))
+
+        # Without this the test would pass vacuously on a cold cache.
+        usages = [
+            message["metadata"]["usage"] for message in agent.messages if message.get("metadata", {}).get("usage")
+        ]
+        assert any(usage.get("cacheReadInputTokens", 0) > 0 for usage in usages), (
+            f"expected the prompt cache to engage, got {usages}"
+        )
+
+        assert len(reported) > 1
+        assert all(used > 500 for used in reported), f"context-status collapsed under caching: {reported}"
 
     def test_context_status_not_injected_when_not_agentic(self, model):
         seen_messages: list[Messages] = []

--- a/strands-py/tests_integ/test_context_injector_caching.py
+++ b/strands-py/tests_integ/test_context_injector_caching.py
@@ -1,0 +1,142 @@
+"""Integration tests for ContextInjector and Bedrock prompt caching, against a real model.
+
+Injected context is ephemeral — it is present on one model call and gone (or re-rendered) on the
+next. If it lands inside the cached prefix, the prefix diverges exactly where the injection sat
+and the cache is lost from that point on. These tests assert the real Bedrock cache counters, so
+they fail if the ephemeral boundary stops being honored end to end.
+"""
+
+import uuid
+
+import pytest
+
+from strands import Agent, tool
+from strands.models import BedrockModel
+from strands.models.model import CacheConfig
+from strands.vended_plugins.context_injector import ContextInjector
+
+_MODEL_ID = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+
+
+class _UsageCapturingBedrockModel(BedrockModel):
+    """Records the per-call cache counters Bedrock reports.
+
+    ``AgentResult.metrics.accumulated_usage`` sums across calls, which hides whether an individual
+    call read from the cache; these tests need the per-call values.
+    """
+
+    def __init__(self, **config):
+        super().__init__(**config)
+        self.usage_per_call: list[dict[str, int]] = []
+
+    async def stream(self, messages, tool_specs=None, system_prompt=None, **kwargs):
+        async for event in super().stream(messages, tool_specs, system_prompt, **kwargs):
+            usage = event.get("metadata", {}).get("usage") if "metadata" in event else None
+            if usage:
+                self.usage_per_call.append(
+                    {
+                        "write": usage.get("cacheWriteInputTokens", 0),
+                        "read": usage.get("cacheReadInputTokens", 0),
+                    }
+                )
+            yield event
+
+
+@pytest.fixture
+def cacheable_prefix():
+    """A prefix long enough to cache, unique per run so other runs cannot satisfy the read."""
+    nonce = uuid.uuid4()
+    return f"Reference dossier {nonce}. " + ("The subject prefers concise written answers. " * 400)
+
+
+@pytest.fixture
+def injector():
+    """An injector whose text changes on every call — the cache-hostile case."""
+    calls = {"n": 0}
+
+    def render(context):
+        calls["n"] += 1
+        return f"<runtime-context>call={calls['n']}</runtime-context>"
+
+    return ContextInjector(render)
+
+
+def test_injected_context_does_not_prevent_cache_reads(cacheable_prefix, injector, quiet_strands_logging):
+    """A second turn must read the prefix cached by the first, despite per-call injected text."""
+    model = _UsageCapturingBedrockModel(model_id=_MODEL_ID, streaming=False, cache_config=CacheConfig(strategy="auto"))
+    agent = Agent(
+        model=model,
+        plugins=[injector],
+        load_tools_from_directory=False,
+        callback_handler=None,
+    )
+
+    agent(f"{cacheable_prefix}\n\nQuestion one: reply with the single word ALPHA.")
+    agent("Question two: reply with the single word BETA.")
+
+    first_call, second_call = model.usage_per_call[0], model.usage_per_call[1]
+    assert first_call["write"] > 0, f"expected the first call to write a cache entry, got {first_call}"
+    assert second_call["read"] > 0, (
+        f"expected the second call to read the cached prefix, got {second_call}. The injected block "
+        "is likely inside the cached prefix again."
+    )
+    # The durable prefix is served from cache rather than rewritten wholesale.
+    assert second_call["write"] < first_call["write"]
+
+
+def test_injected_context_does_not_reach_durable_history(cacheable_prefix, injector, quiet_strands_logging):
+    """The ephemerality contract holds against a real model, not just a mock."""
+    agent = Agent(
+        model=BedrockModel(model_id=_MODEL_ID, streaming=False),
+        plugins=[injector],
+        load_tools_from_directory=False,
+        callback_handler=None,
+    )
+
+    agent(f"{cacheable_prefix}\n\nReply with the single word ALPHA.")
+
+    durable_text = " ".join(
+        block["text"] for message in agent.messages for block in message["content"] if "text" in block
+    )
+    assert "<runtime-context>" not in durable_text
+
+
+def test_every_turn_injection_keeps_caching_across_a_tool_loop(cacheable_prefix, quiet_strands_logging):
+    """``everyTurn`` re-renders on tool-result turns too, so every iteration must still cache.
+
+    Also exercises the placement constraint: a tool result has to stay the first block of its
+    message, and Bedrock rejects a cache point placed directly before one, so a bad boundary
+    surfaces here as a ValidationException rather than a silent cache miss.
+    """
+
+    @tool
+    def lookup_price(item: str) -> str:
+        """Look up the price of an item.
+
+        Args:
+            item: The item to price.
+        """
+        return f"The price of {item} is 42 dollars."
+
+    calls = {"n": 0}
+
+    def render(context):
+        calls["n"] += 1
+        return f"<runtime-context>call={calls['n']}</runtime-context>"
+
+    model = _UsageCapturingBedrockModel(model_id=_MODEL_ID, streaming=False, cache_config=CacheConfig(strategy="auto"))
+    agent = Agent(
+        model=model,
+        tools=[lookup_price],
+        plugins=[ContextInjector(render, trigger="everyTurn")],
+        load_tools_from_directory=False,
+        callback_handler=None,
+    )
+
+    agent(f"{cacheable_prefix}\n\nUse the lookup_price tool to find the price of a widget, then state it.")
+
+    # The loop runs several model calls; every call after the first should read the warm prefix.
+    assert len(model.usage_per_call) > 1, "expected the tool loop to make more than one model call"
+    assert sum(call["read"] for call in model.usage_per_call) > 0, (
+        f"expected cache reads across the tool loop, got {model.usage_per_call}"
+    )

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -2337,11 +2337,14 @@ export class Agent implements LocalAgent, InvokableAgent {
    * @returns Estimated input token count
    */
   private async _estimateInputTokens(streamOptions: StreamOptions): Promise<number> {
-    // Find the last assistant message with usage metadata
+    // Skip calls that used the cache: providers disagree on whether a cached portion is included in
+    // `inputTokens`, so those fall through to counting the messages below rather than being guessed.
     let lastAssistantIdx = -1
-    for (let i = this.messages.length - 1; i >= 0; i--) {
-      if (this.messages[i]!.role === 'assistant' && this.messages[i]!.metadata?.usage) {
-        lastAssistantIdx = i
+    for (let index = this.messages.length - 1; index >= 0; index--) {
+      const message = this.messages[index]!
+      const usage = message.role === 'assistant' ? message.metadata?.usage : undefined
+      if (usage && !usage.cacheReadInputTokens && !usage.cacheWriteInputTokens) {
+        lastAssistantIdx = index
         break
       }
     }

--- a/strands-ts/src/context-manager/modes/agentic/agentic-context.ts
+++ b/strands-ts/src/context-manager/modes/agentic/agentic-context.ts
@@ -5,7 +5,7 @@
  */
 
 import { z } from 'zod'
-import { Message, TextBlock } from '../../../types/messages.js'
+import { appendEphemeralContent, Message, TextBlock } from '../../../types/messages.js'
 import { tool } from '../../../tools/tool-factory.js'
 import { pinMessage, unpinMessage, isPinned } from '../../../conversation-manager/compression/pin-message.js'
 import {
@@ -204,11 +204,8 @@ export function createTokenUsageMiddleware(model: Model): MiddlewareInputHandler
       return context
     }
 
-    messages[messages.length - 1] = new Message({
-      role: lastMessage.role,
-      content: [...lastMessage.content, new TextBlock(statusText)],
-      ...(lastMessage.metadata && { metadata: lastMessage.metadata }),
-    })
+    // Append as ephemeral content to avoid cache invalidation
+    messages[messages.length - 1] = appendEphemeralContent(lastMessage, [new TextBlock(statusText)])
 
     return { ...context, messages }
   }

--- a/strands-ts/src/conversation-manager/__tests__/token-usage-middleware.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/token-usage-middleware.test.ts
@@ -5,6 +5,7 @@ import type { InvokeModelContext } from '../../middleware/stages.js'
 import type { Model } from '../../models/model.js'
 import { Agent } from '../../agent/agent.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
+import { ContextInjector } from '../../vended-plugins/context-injector/plugin.js'
 
 function createMockModel(contextWindowLimit?: number): Model {
   return {
@@ -54,8 +55,10 @@ describe('createTokenUsageMiddleware', () => {
 
     expect(result.messages.length).toBe(1)
     const lastMsg = result.messages[0]!
-    expect(lastMsg.content.length).toBe(2)
-    const statusBlock = lastMsg.content[1] as TextBlock
+    // The status text carries a live token count that changes every call, so it is appended behind a
+    // cachePoint boundary to keep it out of the prompt cache's reusable prefix.
+    expect(lastMsg.content.map((block) => block.type)).toStrictEqual(['textBlock', 'cachePointBlock', 'textBlock'])
+    const statusBlock = lastMsg.content[lastMsg.content.length - 1] as TextBlock
     expect(statusBlock.text).toContain('<context-status>')
     expect(statusBlock.text).toContain('25.0%')
     expect(statusBlock.text).toContain('<remaining>')
@@ -84,7 +87,9 @@ describe('createTokenUsageMiddleware', () => {
 
     const result = await middleware(context)
 
-    const statusBlock = (result.messages[0]! as Message).content[1] as TextBlock
+    const statusBlock = (result.messages[0]! as Message).content[
+      (result.messages[0]! as Message).content.length - 1
+    ] as TextBlock
     expect(statusBlock.text).toContain('<context-status>')
     expect(statusBlock.text).toContain('50.0%')
     expect(statusBlock.text).toContain('200,000')
@@ -111,7 +116,9 @@ describe('createTokenUsageMiddleware', () => {
 
     const result = await middleware(context)
 
-    const statusBlock = (result.messages[0]! as Message).content[1] as TextBlock
+    const statusBlock = (result.messages[0]! as Message).content[
+      (result.messages[0]! as Message).content.length - 1
+    ] as TextBlock
     expect(statusBlock.text).toContain('80.0%')
     expect(statusBlock.text).toContain('<remaining>~20,000 tokens</remaining>')
   })
@@ -188,5 +195,32 @@ describe('token usage middleware integration', () => {
     const lastMessage = secondCallMessages[secondCallMessages.length - 1]!
     const lastBlock = lastMessage.content[lastMessage.content.length - 1] as TextBlock
     expect(lastBlock.text).not.toContain('<context-status>')
+  })
+
+  it('shares one cache boundary with an injector so both volatile blocks stay outside the prefix', async () => {
+    const model = new MockMessageModel().addTurn(
+      { type: 'textBlock', text: 'response' },
+      { usage: { inputTokens: 1000, outputTokens: 100, totalTokens: 1100 } }
+    )
+    model.updateConfig({ contextWindowLimit: 100_000 })
+
+    const agent = new Agent({
+      model,
+      contextManager: 'agentic',
+      plugins: [new ContextInjector({ renderContent: async () => 'INJECTED' })],
+      printer: false,
+    })
+    const streamSpy = vi.spyOn(model, 'stream')
+
+    await agent.invoke('ask')
+
+    const sent = streamSpy.mock.calls[0]![0] as Message[]
+    const lastMessage = sent[sent.length - 1]!
+    expect(lastMessage.content.map((block) => block.type)).toStrictEqual([
+      'textBlock', // the durable ask
+      'cachePointBlock', // the single boundary
+      'textBlock', // <context-status>
+      'textBlock', // injected text
+    ])
   })
 })

--- a/strands-ts/src/injection/__tests__/message-injection.test.ts
+++ b/strands-ts/src/injection/__tests__/message-injection.test.ts
@@ -19,18 +19,19 @@ const toolResult = () =>
 // resolveTrigger predicates take an InjectionContext; tests only exercise `messages`, so a minimal bag suffices.
 const injectionCtx = (messages: MessageData[]) => ({ messages }) as unknown as InjectionContext
 describe('foldIntoLastUserMessage', () => {
-  it('prepends the text as a leading TextBlock on the last user message, ahead of its content', () => {
+  it('appends the text as a trailing TextBlock on the last user message, after its content', () => {
     const messages = [user('original task'), assistant('prior step'), user('next ask')]
     const result = foldIntoLastUserMessage(messages, 'INJECTED')
 
-    // The earlier user/assistant turns are untouched; the last user message gains a leading INJECTED
-    // block ahead of its own content, keeping the user's ask in the recency slot.
+    // The earlier user/assistant turns are untouched; the last user message gains a trailing INJECTED
+    // block, so the volatile content forms a run at the end that a provider can exclude from the
+    // cached prefix.
     expect(result.map((m) => m.toJSON())).toStrictEqual([
       { role: 'user', content: [{ text: 'original task' }], trackingId: anyTrackingId },
       { role: 'assistant', content: [{ text: 'prior step' }], trackingId: anyTrackingId },
       {
         role: 'user',
-        content: [{ text: 'INJECTED' }, { text: 'next ask' }],
+        content: [{ text: 'next ask' }, { cachePoint: { cacheType: 'default' } }, { text: 'INJECTED' }],
         trackingId: anyTrackingId,
       },
     ])
@@ -59,14 +60,13 @@ describe('foldIntoLastUserMessage', () => {
     const tr = toolResult()
     const result = foldIntoLastUserMessage([user('task'), assistant('thinking'), tr], 'INJECTED')
 
-    // Providers require the tool result to be the first block in the turn, so the injected text is
-    // appended rather than prepended here.
+    // Providers require the tool result to be the first block in the turn, so appending keeps it valid.
     expect(result.map((m) => m.toJSON())).toStrictEqual([
       { role: 'user', content: [{ text: 'task' }], trackingId: anyTrackingId },
       { role: 'assistant', content: [{ text: 'thinking' }], trackingId: anyTrackingId },
       {
         role: 'user',
-        content: [tr.toJSON().content[0], { text: 'INJECTED' }],
+        content: [tr.toJSON().content[0], { cachePoint: { cacheType: 'default' } }, { text: 'INJECTED' }],
         trackingId: anyTrackingId,
       },
     ])
@@ -81,7 +81,7 @@ describe('foldIntoLastUserMessage', () => {
       { role: 'assistant', content: [{ text: 'a' }], trackingId: anyTrackingId },
       {
         role: 'user',
-        content: [{ text: 'INJECTED' }, { text: 'second' }],
+        content: [{ text: 'second' }, { cachePoint: { cacheType: 'default' } }, { text: 'INJECTED' }],
         trackingId: anyTrackingId,
       },
     ])
@@ -162,7 +162,8 @@ describe('createInjectionMiddleware', () => {
   // The handler is an InvokeModelStage.Input transformer. It reads `context.messages` and derives the
   // InjectionContext (appState/agent) from `context.agent`, then spreads the rest through, so a context
   // carrying `messages` plus a mock agent exercises it faithfully.
-  const ctx = (messages: Message[]) => ({ messages, agent: createMockAgent() }) as unknown as InvokeModelContext
+  const ctx = (messages: Message[]) =>
+    ({ messages, agent: createMockAgent(), invocationState: {} }) as unknown as InvokeModelContext
 
   it('folds renderContent() text into the latest user message, leaving other context fields intact', async () => {
     const handler = createInjectionMiddleware({ renderContent: async () => 'INJECTED' })
@@ -172,7 +173,7 @@ describe('createInjectionMiddleware', () => {
       { role: 'assistant', content: [{ text: 'prior' }], trackingId: anyTrackingId },
       {
         role: 'user',
-        content: [{ text: 'INJECTED' }, { text: 'ask' }],
+        content: [{ text: 'ask' }, { cachePoint: { cacheType: 'default' } }, { text: 'INJECTED' }],
         trackingId: anyTrackingId,
       },
     ])
@@ -194,7 +195,7 @@ describe('createInjectionMiddleware', () => {
   it('exposes appState and the agent on the InjectionContext', async () => {
     const appState = { get: () => 'stashed' }
     const agent = { appState } as unknown as InvokeModelContext['agent']
-    const input = { messages: [user('ask')], agent } as unknown as InvokeModelContext
+    const input = { messages: [user('ask')], agent, invocationState: {} } as unknown as InvokeModelContext
     let received: { appState: unknown; agent: unknown } | undefined
     const handler = createInjectionMiddleware({
       renderContent: async (context) => {
@@ -229,7 +230,7 @@ describe('createInjectionMiddleware', () => {
       { role: 'assistant', content: [{ text: 'a' }], trackingId: anyTrackingId },
       {
         role: 'user',
-        content: [tr.toJSON().content[0], { text: 'INJECTED' }],
+        content: [tr.toJSON().content[0], { cachePoint: { cacheType: 'default' } }, { text: 'INJECTED' }],
         trackingId: anyTrackingId,
       },
     ])
@@ -265,5 +266,28 @@ describe('createInjectionMiddleware', () => {
     await handler(input)
 
     expect(before.content).toHaveLength(1) // the original user message is untouched
+  })
+
+  it('marks the injected text as ephemeral with a cachePoint boundary', async () => {
+    const handler = createInjectionMiddleware({ renderContent: async () => 'INJECTED' })
+    const result = await handler(ctx([user('ask')]))
+
+    expect(result.messages[0]!.toJSON()).toStrictEqual({
+      role: 'user',
+      content: [{ text: 'ask' }, { cachePoint: { cacheType: 'default' } }, { text: 'INJECTED' }],
+      trackingId: anyTrackingId,
+    })
+  })
+
+  it('reuses one boundary when several injectors append on the same call', async () => {
+    const first = createInjectionMiddleware({ renderContent: async () => 'ONE' })
+    const second = createInjectionMiddleware({ renderContent: async () => 'TWO' })
+    const result = await second(await first(ctx([user('ask')])))
+
+    expect(result.messages[0]!.toJSON()).toStrictEqual({
+      role: 'user',
+      content: [{ text: 'ask' }, { cachePoint: { cacheType: 'default' } }, { text: 'ONE' }, { text: 'TWO' }],
+      trackingId: anyTrackingId,
+    })
   })
 })

--- a/strands-ts/src/injection/message-injection.ts
+++ b/strands-ts/src/injection/message-injection.ts
@@ -1,4 +1,4 @@
-import { Message, TextBlock } from '../types/messages.js'
+import { appendEphemeralContent, Message, TextBlock } from '../types/messages.js'
 import type { MessageData } from '../types/messages.js'
 import { logger } from '../logging/logger.js'
 import { normalizeError } from '../errors.js'
@@ -100,13 +100,13 @@ export function isUserTurn(messages: MessageData[]): boolean {
  * messages are returned as-is.
  *
  * Folding into the existing user message (rather than inserting a standalone message) keeps role
- * alternation valid in both chat and the autonomous tool loop. The block is placed to keep the message
- * valid for the model:
- * - A plain user ask: the text is **prepended**, leaving the user's own ask in the recency slot — the
- *   last thing the model reads.
- * - A tool-result turn (the message carries a `ToolResultBlock`): the text is **appended**,
- *   because providers require the tool result to be the first content block in the turn that answers a
- *   tool use.
+ * alternation valid in both chat and the autonomous tool loop.
+ *
+ * The text is appended behind a cache-point boundary via {@link appendEphemeralContent}. Two reasons:
+ * providers require a tool result to stay the first content block in the turn that answers a tool use, and
+ * a trailing run is the only placement a provider can exclude from a cached prefix. Prepending would put
+ * content that changes every call ahead of the stable conversation, invalidating the prompt cache from the
+ * first block onward.
  *
  * {@link Message} fields are readonly, so the target is rebuilt as a new {@link Message}. When there is
  * no `user` message, the input array is returned unchanged.
@@ -128,21 +128,7 @@ export function foldIntoLastUserMessage(messages: Message[], text: string): Mess
     return messages
   }
 
-  const target = messages[targetIndex]!
-  const injected = new TextBlock(text)
-  // A tool result must stay the first block in the turn that answers a tool use, so append rather than
-  // prepend when the target carries one.
-  const hasToolResult = target.content.some((block) => block.type === 'toolResultBlock')
-  const content = hasToolResult ? [...target.content, injected] : [injected, ...target.content]
-  const folded = new Message({
-    role: target.role,
-    content,
-    // Folding injects content into the same logical message, so keep its tracking id.
-    trackingId: target.trackingId,
-    ...(target.metadata !== undefined && { metadata: target.metadata }),
-  })
-
   const result = [...messages]
-  result[targetIndex] = folded
+  result[targetIndex] = appendEphemeralContent(messages[targetIndex]!, [new TextBlock(text)])
   return result
 }

--- a/strands-ts/src/memory/__tests__/memory-manager.test.ts
+++ b/strands-ts/src/memory/__tests__/memory-manager.test.ts
@@ -647,15 +647,16 @@ describe('MemoryManager', () => {
         new Message({ role: 'assistant', content: [new TextBlock('prior')] }),
         new Message({ role: 'user', content: [new TextBlock('what is my plan')] }),
       ]
-      const result = await handler({ messages, agent } as unknown as InvokeModelContext)
+      const result = await handler({ messages, agent, invocationState: {} } as unknown as InvokeModelContext)
 
       expect(result.messages.map((m) => m.toJSON())).toStrictEqual([
         { role: 'assistant', content: [{ text: 'prior' }], trackingId: anyTrackingId },
         {
           role: 'user',
           content: [
-            { text: '<memory>\n<entry source="s">dark mode preferred</entry>\n</memory>' },
             { text: 'what is my plan' },
+            { cachePoint: { cacheType: 'default' } },
+            { text: '<memory>\n<entry source="s">dark mode preferred</entry>\n</memory>' },
           ],
           trackingId: anyTrackingId,
         },

--- a/strands-ts/src/models/__tests__/bedrock.test.ts
+++ b/strands-ts/src/models/__tests__/bedrock.test.ts
@@ -1701,6 +1701,63 @@ describe('BedrockModel', () => {
       expect(assistantLastBlock).not.toStrictEqual({ cachePoint: { type: 'default' } })
     })
 
+    it('honors a caller-placed cache point in the last user message', async () => {
+      const provider = new BedrockModel({ cacheConfig: { strategy: 'auto' } })
+      const messages = [
+        new Message({
+          role: 'user',
+          content: [
+            new TextBlock('durable ask'),
+            new CachePointBlock({ cacheType: 'default' }),
+            new TextBlock('EPHEMERAL'),
+          ],
+        }),
+      ]
+
+      collectIterator(provider.stream(messages, {}))
+
+      const call = mockConverseStreamCommand.mock.lastCall?.[0]
+      expect(call?.messages?.[0]?.content).toStrictEqual([
+        { text: 'durable ask' },
+        { cachePoint: { type: 'default' } },
+        { text: 'EPHEMERAL' },
+      ])
+    })
+
+    it('applies a configured messagesTTL to a honored boundary', async () => {
+      const provider = new BedrockModel({ cacheConfig: { strategy: 'auto', messagesTTL: '1h' } })
+      const messages = [
+        new Message({
+          role: 'user',
+          content: [
+            new TextBlock('durable ask'),
+            new CachePointBlock({ cacheType: 'default' }),
+            new TextBlock('EPHEMERAL'),
+          ],
+        }),
+      ]
+
+      collectIterator(provider.stream(messages, {}))
+
+      const call = mockConverseStreamCommand.mock.lastCall?.[0]
+      expect(call?.messages?.[0]?.content?.[1]).toStrictEqual({ cachePoint: { type: 'default', ttl: '1h' } })
+    })
+
+    it('keeps a hand-placed ttl on a honored boundary', async () => {
+      const provider = new BedrockModel({ cacheConfig: { strategy: 'auto', messagesTTL: '1h' } })
+      const messages = [
+        new Message({
+          role: 'user',
+          content: [new TextBlock('durable ask'), new CachePointBlock({ cacheType: 'default', ttl: '5m' })],
+        }),
+      ]
+
+      collectIterator(provider.stream(messages, {}))
+
+      const call = mockConverseStreamCommand.mock.lastCall?.[0]
+      expect(call?.messages?.[0]?.content?.[1]).toStrictEqual({ cachePoint: { type: 'default', ttl: '5m' } })
+    })
+
     it('propagates cacheConfig ttls independently to tools and last user message', async () => {
       const provider = new BedrockModel({
         cacheConfig: { strategy: 'auto', toolsTTL: '1h', messagesTTL: '5m' },

--- a/strands-ts/src/models/bedrock.ts
+++ b/strands-ts/src/models/bedrock.ts
@@ -834,7 +834,10 @@ export class BedrockModel extends Model<BedrockModelConfig> {
 
   /**
    * Inject a cache point at the end of the last user message.
-   * Strips any existing cache points from all messages first.
+   *
+   * A cache point already present in the last user message is left where it is: callers place one to
+   * mark the end of the reusable prefix, ahead of content that is rebuilt every call (e.g. injected
+   * context).
    *
    * @param messages - List of messages to inject cache point into (modified in place)
    */
@@ -844,14 +847,17 @@ export class BedrockModel extends Model<BedrockModelConfig> {
     }
 
     let lastUserIdx: number | null = null
-
-    // Strip existing cache points and find last user message
     for (let msgIdx = 0; msgIdx < messages.length; msgIdx++) {
-      const msg = messages[msgIdx]
-      if (!msg) continue
+      if (messages[msgIdx]?.role === 'user') {
+        lastUserIdx = msgIdx
+      }
+    }
 
-      const content = msg.content ?? []
-
+    // Strip cache points everywhere except the last user message, where auto mode would otherwise
+    // accumulate one per turn and blow Bedrock's 4-cache-point ceiling.
+    for (let msgIdx = 0; msgIdx < messages.length; msgIdx++) {
+      if (msgIdx === lastUserIdx) continue
+      const content = messages[msgIdx]?.content ?? []
       for (let blockIdx = content.length - 1; blockIdx >= 0; blockIdx--) {
         const block = content[blockIdx]
         if (block && 'cachePoint' in block) {
@@ -861,31 +867,36 @@ export class BedrockModel extends Model<BedrockModelConfig> {
           )
         }
       }
-
-      if (msg.role === 'user') {
-        lastUserIdx = msgIdx
-      }
     }
 
     // Add cache point to last user message
     if (lastUserIdx !== null) {
       const lastMsg = messages[lastUserIdx]
       if (lastMsg && lastMsg.content) {
-        const cachePoint: BedrockCachePointBlock = { type: 'default' }
+        const content = lastMsg.content
         const ttl = this._config.cacheConfig?.messagesTTL
+
+        const placed = content.find((block) => block && 'cachePoint' in block)
+        if (placed?.cachePoint) {
+          if (ttl !== undefined && placed.cachePoint.ttl === undefined) {
+            placed.cachePoint.ttl = ttl as BedrockSdkCacheTTL
+          }
+          logger.debug(`msg_idx=<${lastUserIdx}> | honored caller-placed cache point`)
+          return
+        }
+
+        const cachePoint: BedrockCachePointBlock = { type: 'default' }
         if (ttl !== undefined) {
           // Bedrock validates TTL values server-side, so accept any string here.
           cachePoint.ttl = ttl as BedrockSdkCacheTTL
         }
 
-        const content = lastMsg.content
-
         // Locate the first non-PDF document block
         let firstNonPdfDocIdx: number | null = null
-        for (let i = 0; i < content.length; i++) {
-          const block = content[i]
+        for (let blockIdx = 0; blockIdx < content.length; blockIdx++) {
+          const block = content[blockIdx]
           if (block && 'document' in block && block.document?.format !== 'pdf') {
-            firstNonPdfDocIdx = i
+            firstNonPdfDocIdx = blockIdx
             break
           }
         }

--- a/strands-ts/src/types/__tests__/messages.test.ts
+++ b/strands-ts/src/types/__tests__/messages.test.ts
@@ -9,6 +9,7 @@ import {
   GuardContentBlock,
   JsonBlock,
   generateTrackingId,
+  appendEphemeralContent,
   type MessageData,
   type SystemPromptData,
   systemPromptFromData,
@@ -818,5 +819,71 @@ describe('toJSON format', () => {
       image: { format: 'jpeg', source: { bytes: new Uint8Array([1, 2, 3]) } },
     })
     expect(typeof block.toJSON().guardContent.image?.source.bytes).toBe('string')
+  })
+})
+
+describe('appendEphemeralContent', () => {
+  const boundary = { cachePoint: { cacheType: 'default' } }
+
+  it('appends behind a cachePoint boundary', () => {
+    const message = new Message({ role: 'user', content: [new TextBlock('durable ask')] })
+
+    const appended = appendEphemeralContent(message, [new TextBlock('EPHEMERAL')])
+
+    expect(appended.content.map((block) => block.toJSON())).toStrictEqual([
+      { text: 'durable ask' },
+      boundary,
+      { text: 'EPHEMERAL' },
+    ])
+  })
+
+  it('returns the input unchanged when there are no blocks', () => {
+    const message = new Message({ role: 'user', content: [new TextBlock('ask')] })
+
+    expect(appendEphemeralContent(message, [])).toBe(message)
+  })
+
+  it('emits no boundary when content is empty', () => {
+    const message = new Message({ role: 'user', content: [] })
+
+    const appended = appendEphemeralContent(message, [new TextBlock('EPHEMERAL')])
+
+    expect(appended.content.map((block) => block.toJSON())).toStrictEqual([{ text: 'EPHEMERAL' }])
+  })
+
+  it('reuses a boundary another caller already opened', () => {
+    const message = new Message({ role: 'user', content: [new TextBlock('ask')] })
+
+    const first = appendEphemeralContent(message, [new TextBlock('ONE')])
+    const second = appendEphemeralContent(first, [new TextBlock('TWO')])
+
+    expect(second.content.map((block) => block.toJSON())).toStrictEqual([
+      { text: 'ask' },
+      boundary,
+      { text: 'ONE' },
+      { text: 'TWO' },
+    ])
+  })
+
+  it('does not mutate the input message', () => {
+    const message = new Message({ role: 'user', content: [new TextBlock('ask')] })
+
+    appendEphemeralContent(message, [new TextBlock('EPHEMERAL')])
+
+    expect(message.content).toHaveLength(1)
+  })
+
+  it('preserves identity fields', () => {
+    const message = new Message({
+      role: 'user',
+      content: [new TextBlock('ask')],
+      trackingId: 'durable-1',
+      metadata: { custom: { keep: 'me' } },
+    })
+
+    const appended = appendEphemeralContent(message, [new TextBlock('EPHEMERAL')])
+
+    expect(appended.trackingId).toBe('durable-1')
+    expect(appended.metadata).toStrictEqual({ custom: { keep: 'me' } })
   })
 })

--- a/strands-ts/src/types/messages.ts
+++ b/strands-ts/src/types/messages.ts
@@ -962,6 +962,40 @@ export class GuardContentBlock
 }
 
 /**
+ * Appends single-call content to a message, marking where the reusable prefix ends.
+ *
+ * Content that is rebuilt on every model call (e.g. injected context count) must sit outside
+ * any cached prefix to avoid invalidating the cache from that
+ * point on. Appending puts it at the end and the leading {@link CachePointBlock} declares the
+ * boundary, so providers that manage prompt caching keep the durable conversation cacheable.
+ *
+ * A boundary another caller already opened is reused rather than duplicated, so several callers
+ * appending in turn produce exactly one boundary ahead of all the ephemeral content.
+ *
+ * The input message is not mutated.
+ *
+ * @param message - The message to append to
+ * @param blocks - The ephemeral content blocks to append
+ * @returns A new message with the boundary and `blocks` appended, or `message` when `blocks` is empty
+ * @internal Framework primitive for producers of per-call content. Not part of the public API.
+ */
+export function appendEphemeralContent(message: Message, blocks: ContentBlock[]): Message {
+  if (blocks.length === 0) {
+    return message
+  }
+
+  const needsBoundary = message.content.length > 0 && !message.content.some((block) => block.type === 'cachePointBlock')
+
+  return new Message({
+    role: message.role,
+    content: [...message.content, ...(needsBoundary ? [new CachePointBlock({ cacheType: 'default' })] : []), ...blocks],
+    // The appended content belongs to the same logical message, so keep its tracking id.
+    trackingId: message.trackingId,
+    ...(message.metadata !== undefined && { metadata: message.metadata }),
+  })
+}
+
+/**
  * Converts ContentBlockData to a ContentBlock instance.
  * Handles all content block types including text, tool use/result, reasoning, cache points, guard content, and media blocks.
  *

--- a/strands-ts/src/vended-plugins/context-injector/__tests__/plugin.test.ts
+++ b/strands-ts/src/vended-plugins/context-injector/__tests__/plugin.test.ts
@@ -5,6 +5,8 @@ import { Message, TextBlock } from '../../../types/messages.js'
 import type { InvokeModelContext } from '../../../middleware/index.js'
 import { createMockAgent } from '../../../__fixtures__/agent-helpers.js'
 import { anyTrackingId } from '../../../__fixtures__/message-helpers.js'
+import { MockMessageModel } from '../../../__fixtures__/mock-message-model.js'
+import { Agent } from '../../../agent/agent.js'
 
 const user = (text: string) => new Message({ role: 'user', content: [new TextBlock(text)] })
 const assistant = (text: string) => new Message({ role: 'assistant', content: [new TextBlock(text)] })
@@ -42,7 +44,7 @@ describe('ContextInjector', () => {
       const { agent, addMiddleware } = makeAgent()
       plugin.initAgent(agent)
       const handler = addMiddleware.mock.calls[0]![1] as (ctx: InvokeModelContext) => Promise<InvokeModelContext>
-      return handler({ messages, agent } as unknown as InvokeModelContext)
+      return handler({ messages, agent, invocationState: {} } as unknown as InvokeModelContext)
     }
 
     it('folds renderContent() text into the latest user message', async () => {
@@ -54,7 +56,7 @@ describe('ContextInjector', () => {
         { role: 'assistant', content: [{ text: 'prior' }], trackingId: anyTrackingId },
         {
           role: 'user',
-          content: [{ text: 'INJECTED' }, { text: 'ask' }],
+          content: [{ text: 'ask' }, { cachePoint: { cacheType: 'default' } }, { text: 'INJECTED' }],
           trackingId: anyTrackingId,
         },
       ])
@@ -77,7 +79,7 @@ describe('ContextInjector', () => {
       expect(result.messages.map((m) => m.toJSON())).toStrictEqual([
         {
           role: 'user',
-          content: [{ text: 'INJECTED' }, { text: 'ask' }],
+          content: [{ text: 'ask' }, { cachePoint: { cacheType: 'default' } }, { text: 'INJECTED' }],
           trackingId: anyTrackingId,
         },
         { role: 'assistant', content: [{ text: 'reply' }], trackingId: anyTrackingId },
@@ -96,7 +98,7 @@ describe('ContextInjector', () => {
         },
       }).initAgent(agent)
       const handler = addMiddleware.mock.calls[0]![1] as (ctx: InvokeModelContext) => Promise<InvokeModelContext>
-      await handler({ messages: [user('ask')], agent } as unknown as InvokeModelContext)
+      await handler({ messages: [user('ask')], agent, invocationState: {} } as unknown as InvokeModelContext)
 
       expect(sawAgent).toBe(true)
       expect(sawAppState).toBe(true)
@@ -116,6 +118,25 @@ describe('ContextInjector', () => {
         { role: 'assistant', content: [{ text: 'prior' }], trackingId: anyTrackingId },
         { role: 'user', content: [{ text: 'ask' }], trackingId: anyTrackingId },
       ])
+    })
+  })
+
+  describe('against a real agent', () => {
+    it('marks injected text ephemeral and keeps it out of durable history', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'first' })
+      const agent = new Agent({
+        model,
+        plugins: [new ContextInjector({ renderContent: async () => '<ctx>EPHEMERAL</ctx>' })],
+        printer: false,
+      })
+
+      await agent.invoke('first ask')
+
+      // The injected text is ephemeral, so it must never reach durable history.
+      const durableText = agent.messages.flatMap((message) =>
+        message.content.filter((block) => block.type === 'textBlock').map((block) => block.text)
+      )
+      expect(durableText.some((text) => text.includes('EPHEMERAL'))).toBe(false)
     })
   })
 })

--- a/strands-ts/test/integ/agent.test.ts
+++ b/strands-ts/test/integ/agent.test.ts
@@ -156,6 +156,26 @@ describe.each(allProviders)('Agent with $name', ({ name, skip, createModel, mode
         expect(result.lastMessage.role).toBe('assistant')
         expect(result.lastMessage.content.length).toBeGreaterThan(0)
       })
+
+      it('reports inputTokens as the whole prompt when nothing was served from cache', async () => {
+        // Token estimation anchors on inputTokens only when no cache counters are present. Pins that
+        // precondition: with no caching, inputTokens must cover the whole prompt on every provider.
+        const agent = new Agent({
+          model: createModel(),
+          printer: false,
+        })
+
+        const prompt = `Summarize in one word: ${'the quick brown fox jumps over the lazy dog. '.repeat(120)}`
+        await agent.invoke(prompt)
+
+        const usage = agent.messages.find((message) => message.role === 'assistant' && message.metadata?.usage)
+          ?.metadata?.usage
+        expect(usage).toBeDefined()
+        expect(usage?.cacheReadInputTokens ?? 0).toBe(0)
+        expect(usage?.cacheWriteInputTokens ?? 0).toBe(0)
+        // The prompt alone exceeds 500 tokens, so a small count means inputTokens is not the whole prompt.
+        expect(usage!.inputTokens).toBeGreaterThan(500)
+      })
     })
 
     describe('Multi-turn Conversations', () => {

--- a/strands-ts/test/integ/conversation-manager/agentic-context.test.ts
+++ b/strands-ts/test/integ/conversation-manager/agentic-context.test.ts
@@ -103,6 +103,45 @@ describe.skipIf(bedrock.skip)('Agentic Context Manager Integration', () => {
       expect(statusText).toContain('</context-status>')
     })
 
+    it('context-status keeps tracking real context size once the prompt cache is warm', async () => {
+      // Once the cache is warm most of the prompt is reported under the cache counters, not
+      // inputTokens. An estimator anchored on it collapses and stops prompting compression.
+      const model = bedrock.createModel({ maxTokens: 512, cacheConfig: { strategy: 'auto' } })
+      const streamSpy = vi.spyOn(model, 'stream')
+
+      const agent = new Agent({
+        model,
+        contextManager: 'agentic',
+        printer: false,
+      })
+
+      const filler = 'This is background context that stays stable across turns. '.repeat(200)
+      await agent.invoke(`${filler}\n\nReply with OK.`)
+      await agent.invoke('Reply with OK again.')
+      await agent.invoke('And once more.')
+
+      const reported: number[] = []
+      for (const call of streamSpy.mock.calls) {
+        for (const message of call[0] as Message[]) {
+          for (const block of message.content) {
+            if (block.type === 'textBlock' && (block as TextBlock).text.includes('<context-status>')) {
+              const used = /<used>([\d,]+) \//.exec((block as TextBlock).text)?.[1]
+              if (used) reported.push(Number(used.replace(/,/g, '')))
+            }
+          }
+        }
+      }
+
+      // Without this the test would pass vacuously on a cold cache.
+      const usages = agent.messages.filter((message) => message.metadata?.usage).map((m) => m.metadata!.usage!)
+      expect(usages.some((usage) => (usage.cacheReadInputTokens ?? 0) > 0)).toBe(true)
+
+      expect(reported.length).toBeGreaterThan(1)
+      for (const used of reported) {
+        expect(used).toBeGreaterThan(500)
+      }
+    })
+
     it('context-status is NOT injected when contextManager is not agentic', async () => {
       const model = bedrock.createModel({ maxTokens: 1024 })
       const streamSpy = vi.spyOn(model, 'stream')
@@ -135,16 +174,21 @@ describe.skipIf(bedrock.skip)('Agentic Context Manager Integration', () => {
         printer: false,
       })
 
+      // Total context is what grows; inputTokens alone can shrink as the cache warms.
+      const contextSize = (message: Message | undefined) => {
+        const usage = message?.metadata?.usage
+        if (!usage) return 0
+        return usage.inputTokens + (usage.cacheReadInputTokens ?? 0) + (usage.cacheWriteInputTokens ?? 0)
+      }
+
       await agent.invoke('Say hello in one word.')
-      const firstAssistant = agent.messages.find((m) => m.role === 'assistant' && m.metadata?.usage)
-      const firstInputTokens = firstAssistant?.metadata?.usage?.inputTokens ?? 0
+      const firstContextSize = contextSize(agent.messages.find((m) => m.role === 'assistant' && m.metadata?.usage))
 
       await agent.invoke('Now count from 1 to 10.')
       const assistants = agent.messages.filter((m) => m.role === 'assistant' && m.metadata?.usage)
-      const lastAssistant = assistants[assistants.length - 1]
-      const secondInputTokens = lastAssistant?.metadata?.usage?.inputTokens ?? 0
+      const secondContextSize = contextSize(assistants[assistants.length - 1])
 
-      expect(secondInputTokens).toBeGreaterThan(firstInputTokens)
+      expect(secondContextSize).toBeGreaterThan(firstContextSize)
     })
   })
 


### PR DESCRIPTION
## Description

`ContextInjector` prepended its per-call text into the latest user message, ahead of the stable conversation. Because that text is rebuilt on every call and the provider's cache point landed *after* it, the cached prefix diverged exactly at the injection site — so every turn re-ingested the whole conversation at full price. Measured against Bedrock, turn 2 of a two-turn conversation reused **zero** cached tokens.

Injected text is now appended behind a `cachePoint` boundary that marks where the reusable prefix ends, and Bedrock's auto mode honors a boundary already present instead of relocating it to the end. Placement belongs to whoever appends the volatile content, so the agentic token-usage middleware shares the same primitive — its live `<context-status>` count previously stranded itself inside the cached prefix even with the injector fixed.

`OpenAIModel` now warns and skips a `cachePoint` inside a message rather than raising `TypeError`, matching its own system-prompt path and the Gemini/Vercel providers. Without it, a provider-agnostic caller cannot mark ephemeral content without special-casing OpenAI.

## Related Issues

N/A

## Documentation PR

Included

## Type of Change

Bug fix

## Testing

Verified end to end against real Bedrock (`claude-sonnet-4-5`), A/B against the pre-fix placement with a unique nonce per arm so no stale cache entry could flatter the result:

| turn 2 | cacheRead | cacheWrite |
|---|---|---|
| before | **0** | 3702 |
| after | **3645** | 19 |

- [x] I ran `hatch run prepare`

## Risks / Callouts

**This changes billing shape for users who never enabled caching.** The boundary is honored by Bedrock and Anthropic even with no `cache_config` set, so `ContextInjector` now implies prompt caching on those providers. Bounds, measured:

The only loss case is a single-turn conversation, multi-turn always wins. I considered gating on a `Model` capability so the boundary is only emitted where the user opted in, but that forfeits the win for everyone who hasn't set `cache_config` — most users. **Flagging it as the reviewable trade-off:** if "no silent cost change" is a hard rule regardless of magnitude, the gate is the alternative.

**Bedrock's `_inject_cache_point` behavior change is broader than the injector needs.** It now honors a caller-placed cache point in the last user message (still stripping stale ones elsewhere, so the 4-cache-point cap can't be exhausted). That affects anyone hand-placing cache points, and an existing test asserting the old strip-everything behavior was updated.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.