### PR TITLE
docs(concepts): replace deprecated strands_tools examples with self-contained tools

### DIFF
--- a/site/src/content/docs/user-guide/concepts/agents/prompts.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/prompts.mdx
@@ -127,7 +127,7 @@ Prompting is a primary functionality of Strands that allows you to invoke tools 
 <Tab label="Python">
 
 ```python
-result = agent.tool.current_time(timezone="US/Pacific")
+result = agent.tool.calculator(expression="12 * 12")
 ```
 </Tab>
 <Tab label="TypeScript">

--- a/site/src/content/docs/user-guide/concepts/agents/prompts.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/prompts.mdx
@@ -127,7 +127,7 @@ Prompting is a primary functionality of Strands that allows you to invoke tools 
 <Tab label="Python">
 
 ```python
-result = agent.tool.current_time(timezone="US/Pacific")
+result = agent.tool.my_tool(param="value")
 ```
 </Tab>
 <Tab label="TypeScript">

--- a/site/src/content/docs/user-guide/concepts/agents/state.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/state.mdx
@@ -89,8 +89,39 @@ Direct tool calls are (by default) recorded in the conversation history:
 <Tab label="Python">
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+
+import ast
+import operator
+
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 agent = Agent(tools=[calculator])
 

--- a/site/src/content/docs/user-guide/concepts/agents/state.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/state.mdx
@@ -89,8 +89,32 @@ Direct tool calls are (by default) recorded in the conversation history:
 <Tab label="Python">
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+
+import ast
+import operator
+
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 agent = Agent(tools=[calculator])
 

--- a/site/src/content/docs/user-guide/concepts/agents/structured-output.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/structured-output.mdx
@@ -280,9 +280,33 @@ Combine structured output with tool usage to format tool execution results:
 <Tab label="Python">
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+
+import ast
+import operator
+
+from strands import Agent, tool
 from pydantic import BaseModel, Field
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 class MathResult(BaseModel):
     operation: str = Field(description="the performed operation")

--- a/site/src/content/docs/user-guide/concepts/agents/structured-output.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/structured-output.mdx
@@ -280,9 +280,40 @@ Combine structured output with tool usage to format tool execution results:
 <Tab label="Python">
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+
+import ast
+import operator
+
+from strands import Agent, tool
 from pydantic import BaseModel, Field
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 class MathResult(BaseModel):
     operation: str = Field(description="the performed operation")

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/agent.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/agent.mdx
@@ -45,8 +45,39 @@ While both `Agent` and `BidiAgent` share the same core purpose of enabling AI-po
 The standard `Agent` follows a traditional request-response pattern:
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+
+import ast
+import operator
+
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 agent = Agent(tools=[calculator])
 

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/agent.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/agent.mdx
@@ -45,8 +45,32 @@ While both `Agent` and `BidiAgent` share the same core purpose of enabling AI-po
 The standard `Agent` follows a traditional request-response pattern:
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+
+import ast
+import operator
+
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 agent = Agent(tools=[calculator])
 

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/events.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/events.mdx
@@ -492,10 +492,42 @@ asyncio.run(main())
 ### Tool Execution During Conversation
 
 ```python
+
+import ast
+import operator
+
 import asyncio
 from strands.experimental.bidi import BidiAgent
+from strands import tool
 from strands.experimental.bidi.models import BidiNovaSonicModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 async def main():
     model = BidiNovaSonicModel()

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/events.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/events.mdx
@@ -492,10 +492,35 @@ asyncio.run(main())
 ### Tool Execution During Conversation
 
 ```python
+
+import ast
+import operator
+
 import asyncio
 from strands.experimental.bidi import BidiAgent
+from strands import tool
 from strands.experimental.bidi.models import BidiNovaSonicModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 async def main():
     model = BidiNovaSonicModel()

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/gemini_live.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/gemini_live.mdx
@@ -38,15 +38,45 @@ pip install 'strands-agents[bidi-all]'
 After installing `strands-agents[bidi-gemini]`, you can import and initialize the Strands Agents' Gemini Live provider as follows:
 
 ```python
+
+import ast
+import operator
+
 import asyncio
 
 from strands.experimental.bidi import BidiAgent
+from strands import tool
 from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO
 from strands.experimental.bidi.models import BidiGeminiLiveModel
 from strands_tools import stop
 
-from strands_tools import calculator
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
 
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 async def main() -> None:
     model = BidiGeminiLiveModel(

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/gemini_live.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/gemini_live.mdx
@@ -38,15 +38,38 @@ pip install 'strands-agents[bidi-all]'
 After installing `strands-agents[bidi-gemini]`, you can import and initialize the Strands Agents' Gemini Live provider as follows:
 
 ```python
+
+import ast
+import operator
+
 import asyncio
 
 from strands.experimental.bidi import BidiAgent
+from strands import tool
 from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO
 from strands.experimental.bidi.models import BidiGeminiLiveModel
 from strands_tools import stop
 
-from strands_tools import calculator
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
 
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 async def main() -> None:
     model = BidiGeminiLiveModel(

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/nova_sonic.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/nova_sonic.mdx
@@ -42,15 +42,38 @@ pip install 'strands-agents[bidi-all]'
 After installing `strands-agents[bidi]`, you can import and initialize the Strands Agents' Nova Sonic provider as follows:
 
 ```python
+
+import ast
+import operator
+
 import asyncio
 
 from strands.experimental.bidi import BidiAgent
+from strands import tool
 from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO
 from strands.experimental.bidi.models import BidiNovaSonicModel
 from strands_tools import stop
 
-from strands_tools import calculator
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
 
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 async def main() -> None:
     model = BidiNovaSonicModel(

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/nova_sonic.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/nova_sonic.mdx
@@ -42,15 +42,45 @@ pip install 'strands-agents[bidi-all]'
 After installing `strands-agents[bidi]`, you can import and initialize the Strands Agents' Nova Sonic provider as follows:
 
 ```python
+
+import ast
+import operator
+
 import asyncio
 
 from strands.experimental.bidi import BidiAgent
+from strands import tool
 from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO
 from strands.experimental.bidi.models import BidiNovaSonicModel
 from strands_tools import stop
 
-from strands_tools import calculator
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
 
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 async def main() -> None:
     model = BidiNovaSonicModel(

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/openai_realtime.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/openai_realtime.mdx
@@ -37,15 +37,45 @@ pip install 'strands-agents[bidi-all]'
 After installing `strands-agents[bidi-openai]`, you can import and initialize the Strands Agents' OpenAI Realtime provider as follows:
 
 ```python
+
+import ast
+import operator
+
 import asyncio
 
 from strands.experimental.bidi import BidiAgent
+from strands import tool
 from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO
 from strands.experimental.bidi.models import BidiOpenAIRealtimeModel
 from strands_tools import stop
 
-from strands_tools import calculator
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
 
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 async def main() -> None:
     model = BidiOpenAIRealtimeModel(

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/openai_realtime.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/openai_realtime.mdx
@@ -37,15 +37,38 @@ pip install 'strands-agents[bidi-all]'
 After installing `strands-agents[bidi-openai]`, you can import and initialize the Strands Agents' OpenAI Realtime provider as follows:
 
 ```python
+
+import ast
+import operator
+
 import asyncio
 
 from strands.experimental.bidi import BidiAgent
+from strands import tool
 from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO
 from strands.experimental.bidi.models import BidiOpenAIRealtimeModel
 from strands_tools import stop
 
-from strands_tools import calculator
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
 
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 async def main() -> None:
     model = BidiOpenAIRealtimeModel(

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/quickstart.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/quickstart.mdx
@@ -246,11 +246,42 @@ Always call `agent.stop()` **after** exiting the `run()` or `receive()` loop, ne
 Just like standard Strands agents, bidirectional agents can use tools during conversations:
 
 ```python
+
+import ast
+import operator
+
 import asyncio
 from strands import tool
 from strands.experimental.bidi import BidiAgent, BidiAudioIO
 from strands.experimental.bidi.models import BidiNovaSonicModel
-from strands_tools import calculator, current_time
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Define a custom tool
 @tool
@@ -271,7 +302,7 @@ def get_weather(location: str) -> str:
 model = BidiNovaSonicModel()
 agent = BidiAgent(
     model=model,
-    tools=[calculator, current_time, get_weather],
+    tools=[calculator, get_weather],
     system_prompt="You are a helpful assistant with access to tools."
 )
 

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/quickstart.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/quickstart.mdx
@@ -246,11 +246,35 @@ Always call `agent.stop()` **after** exiting the `run()` or `receive()` loop, ne
 Just like standard Strands agents, bidirectional agents can use tools during conversations:
 
 ```python
+
+import ast
+import operator
+
 import asyncio
 from strands import tool
 from strands.experimental.bidi import BidiAgent, BidiAudioIO
 from strands.experimental.bidi.models import BidiNovaSonicModel
-from strands_tools import calculator, current_time
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Define a custom tool
 @tool
@@ -271,7 +295,7 @@ def get_weather(location: str) -> str:
 model = BidiNovaSonicModel()
 agent = BidiAgent(
     model=model,
-    tools=[calculator, current_time, get_weather],
+    tools=[calculator, get_weather],
     system_prompt="You are a helpful assistant with access to tools."
 )
 

--- a/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
@@ -597,9 +597,33 @@ Tool caching allows you to reuse a cached tool definition across multiple reques
 In Python, use the `cache_tools` parameter to enable tool caching independently:
 
 ```python
+
+import ast
+import operator
+
 from strands import Agent, tool
 from strands.models import BedrockModel
-from strands_tools import calculator, current_time
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Using tool caching with BedrockModel
 bedrock_model = BedrockModel(
@@ -610,7 +634,7 @@ bedrock_model = BedrockModel(
 # Create an agent with the model and tools
 agent = Agent(
     model=bedrock_model,
-    tools=[calculator, current_time]
+    tools=[calculator]
 )
 # First request will cache the tools
 response1 = agent("What time is it?")

--- a/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
@@ -597,9 +597,40 @@ Tool caching allows you to reuse a cached tool definition across multiple reques
 In Python, use the `cache_tools` parameter to enable tool caching independently:
 
 ```python
+
+import ast
+import operator
+
 from strands import Agent, tool
 from strands.models import BedrockModel
-from strands_tools import calculator, current_time
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Using tool caching with BedrockModel
 bedrock_model = BedrockModel(
@@ -610,10 +641,10 @@ bedrock_model = BedrockModel(
 # Create an agent with the model and tools
 agent = Agent(
     model=bedrock_model,
-    tools=[calculator, current_time]
+    tools=[calculator]
 )
 # First request will cache the tools
-response1 = agent("What time is it?")
+response1 = agent("What is 12 * 12?")
 print(f"Cache write tokens: {response1.metrics.accumulated_usage.get('cacheWriteInputTokens')}")
 print(f"Cache read tokens: {response1.metrics.accumulated_usage.get('cacheReadInputTokens')}")
 

--- a/site/src/content/docs/user-guide/concepts/model-providers/anthropic.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/anthropic.mdx
@@ -37,9 +37,40 @@ After installing dependencies, you can import and initialize the Strands Agents'
 <Tab label="Python">
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.anthropic import AnthropicModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = AnthropicModel(
     client_args={

--- a/site/src/content/docs/user-guide/concepts/model-providers/anthropic.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/anthropic.mdx
@@ -37,9 +37,33 @@ After installing dependencies, you can import and initialize the Strands Agents'
 <Tab label="Python">
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.anthropic import AnthropicModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = AnthropicModel(
     client_args={

--- a/site/src/content/docs/user-guide/concepts/model-providers/google.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/google.mdx
@@ -41,9 +41,40 @@ After installing dependencies, you can import and initialize the Strands Agents'
 <Tab label="Python">
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.gemini import GeminiModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = GeminiModel(
     client_args={
@@ -329,10 +360,41 @@ Users can pass their own custom Gemini client to the GeminiModel for Strands Age
 <Tab label="Python">
 
 ```python
+
+import ast
+import operator
+
 from google import genai
-from strands import Agent
+from strands import Agent, tool
 from strands.models.gemini import GeminiModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 client = genai.Client(api_key="<KEY>")
 

--- a/site/src/content/docs/user-guide/concepts/model-providers/google.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/google.mdx
@@ -41,9 +41,33 @@ After installing dependencies, you can import and initialize the Strands Agents'
 <Tab label="Python">
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.gemini import GeminiModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = GeminiModel(
     client_args={
@@ -329,10 +353,34 @@ Users can pass their own custom Gemini client to the GeminiModel for Strands Age
 <Tab label="Python">
 
 ```python
+
+import ast
+import operator
+
 from google import genai
-from strands import Agent
+from strands import Agent, tool
 from strands.models.gemini import GeminiModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 client = genai.Client(api_key="<KEY>")
 

--- a/site/src/content/docs/user-guide/concepts/model-providers/litellm.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/litellm.mdx
@@ -23,9 +23,40 @@ pip install 'strands-agents[litellm]' strands-agents-tools
 After installing `litellm`, you can import and initialize Strands Agents' LiteLLM provider as follows:
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.litellm import LiteLLMModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = LiteLLMModel(
     client_args={

--- a/site/src/content/docs/user-guide/concepts/model-providers/litellm.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/litellm.mdx
@@ -23,9 +23,33 @@ pip install 'strands-agents[litellm]' strands-agents-tools
 After installing `litellm`, you can import and initialize Strands Agents' LiteLLM provider as follows:
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.litellm import LiteLLMModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = LiteLLMModel(
     client_args={

--- a/site/src/content/docs/user-guide/concepts/model-providers/llamaapi.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/llamaapi.mdx
@@ -29,9 +29,33 @@ pip install 'strands-agents[llamaapi]' strands-agents-tools
 After installing `llamaapi`, you can import and initialize Strands Agents' Llama API provider as follows:
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.llamaapi import LlamaAPIModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = LlamaAPIModel(
     client_args={

--- a/site/src/content/docs/user-guide/concepts/model-providers/llamaapi.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/llamaapi.mdx
@@ -29,9 +29,40 @@ pip install 'strands-agents[llamaapi]' strands-agents-tools
 After installing `llamaapi`, you can import and initialize Strands Agents' Llama API provider as follows:
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.llamaapi import LlamaAPIModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = LlamaAPIModel(
     client_args={

--- a/site/src/content/docs/user-guide/concepts/model-providers/llamacpp.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/llamacpp.mdx
@@ -23,9 +23,40 @@ pip install strands-agents strands-agents-tools
 After setting up a llama.cpp server, you can import and initialize the Strands Agents' llama.cpp provider as follows:
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.llamacpp import LlamaCppModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = LlamaCppModel(
     base_url="http://localhost:8080",

--- a/site/src/content/docs/user-guide/concepts/model-providers/llamacpp.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/llamacpp.mdx
@@ -23,9 +23,33 @@ pip install strands-agents strands-agents-tools
 After setting up a llama.cpp server, you can import and initialize the Strands Agents' llama.cpp provider as follows:
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.llamacpp import LlamaCppModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = LlamaCppModel(
     base_url="http://localhost:8080",

--- a/site/src/content/docs/user-guide/concepts/model-providers/mistral.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/mistral.mdx
@@ -26,9 +26,33 @@ pip install 'strands-agents[mistral]' strands-agents-tools
 After installing `mistral`, you can import and initialize Strands Agents' Mistral API provider as follows:
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.mistral import MistralModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = MistralModel(
     api_key="<YOUR_MISTRAL_API_KEY>",

--- a/site/src/content/docs/user-guide/concepts/model-providers/mistral.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/mistral.mdx
@@ -26,9 +26,40 @@ pip install 'strands-agents[mistral]' strands-agents-tools
 After installing `mistral`, you can import and initialize Strands Agents' Mistral API provider as follows:
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.mistral import MistralModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = MistralModel(
     api_key="<YOUR_MISTRAL_API_KEY>",

--- a/site/src/content/docs/user-guide/concepts/model-providers/ollama.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/ollama.mdx
@@ -242,9 +242,40 @@ print(f"Rating: {book_analysis.rating}")
 [Ollama models that support tool use](https://ollama.com/search?c=tools) can use tools through Strands' tool system:
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.ollama import OllamaModel
-from strands_tools import calculator, current_time
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Create an Ollama model
 ollama_model = OllamaModel(
@@ -255,7 +286,7 @@ ollama_model = OllamaModel(
 # Create an agent with tools
 agent = Agent(
     model=ollama_model,
-    tools=[calculator, current_time]
+    tools=[calculator]
 )
 
 # Use the agent with tools

--- a/site/src/content/docs/user-guide/concepts/model-providers/ollama.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/ollama.mdx
@@ -242,9 +242,33 @@ print(f"Rating: {book_analysis.rating}")
 [Ollama models that support tool use](https://ollama.com/search?c=tools) can use tools through Strands' tool system:
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.ollama import OllamaModel
-from strands_tools import calculator, current_time
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Create an Ollama model
 ollama_model = OllamaModel(
@@ -255,7 +279,7 @@ ollama_model = OllamaModel(
 # Create an agent with tools
 agent = Agent(
     model=ollama_model,
-    tools=[calculator, current_time]
+    tools=[calculator]
 )
 
 # Use the agent with tools

--- a/site/src/content/docs/user-guide/concepts/model-providers/openai.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/openai.mdx
@@ -37,9 +37,40 @@ After installing dependencies, you can import and initialize the Strands Agents'
 <Tab label="Python">
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.openai import OpenAIModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = OpenAIModel(
     client_args={

--- a/site/src/content/docs/user-guide/concepts/model-providers/openai.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/openai.mdx
@@ -37,9 +37,33 @@ After installing dependencies, you can import and initialize the Strands Agents'
 <Tab label="Python">
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.openai import OpenAIModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = OpenAIModel(
     client_args={

--- a/site/src/content/docs/user-guide/concepts/model-providers/sagemaker.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/sagemaker.mdx
@@ -26,9 +26,33 @@ pip install 'strands-agents[sagemaker]' strands-agents-tools
 After installing the SageMaker dependencies, you can import and initialize the Strands Agents' SageMaker provider as follows:
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.sagemaker import SageMakerAIModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = SageMakerAIModel(
     endpoint_config={

--- a/site/src/content/docs/user-guide/concepts/model-providers/sagemaker.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/sagemaker.mdx
@@ -26,9 +26,40 @@ pip install 'strands-agents[sagemaker]' strands-agents-tools
 After installing the SageMaker dependencies, you can import and initialize the Strands Agents' SageMaker provider as follows:
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.sagemaker import SageMakerAIModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = SageMakerAIModel(
     endpoint_config={

--- a/site/src/content/docs/user-guide/concepts/model-providers/writer.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/writer.mdx
@@ -23,9 +23,40 @@ pip install 'strands-agents[writer]' strands-agents-tools
 After installing `writer`, you can import and initialize Strands Agents' Writer provider as follows:
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.writer import WriterModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = WriterModel(
     client_args={"api_key": "<WRITER_API_KEY>"},

--- a/site/src/content/docs/user-guide/concepts/model-providers/writer.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/writer.mdx
@@ -23,9 +23,33 @@ pip install 'strands-agents[writer]' strands-agents-tools
 After installing `writer`, you can import and initialize Strands Agents' Writer provider as follows:
 
 ```python
-from strands import Agent
+
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.writer import WriterModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = WriterModel(
     client_args={"api_key": "<WRITER_API_KEY>"},

--- a/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
@@ -292,10 +292,42 @@ Create a Strands agent and expose it as an A2A server:
 <Tab label="Python">
 
 ```python
+import ast
+import operator
+
 import logging
-from strands_tools.calculator import calculator
-from strands import Agent
+
+from strands import Agent, tool
 from strands.multiagent.a2a import A2AServer
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
+
 
 logging.basicConfig(level=logging.INFO)
 

--- a/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
@@ -292,10 +292,35 @@ Create a Strands agent and expose it as an A2A server:
 <Tab label="Python">
 
 ```python
+import ast
+import operator
+
 import logging
-from strands_tools.calculator import calculator
-from strands import Agent
+
+from strands import Agent, tool
 from strands.multiagent.a2a import A2AServer
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
+
 
 logging.basicConfig(level=logging.INFO)
 

--- a/site/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.mdx
@@ -61,26 +61,26 @@ The simplest way to use an agent as a tool is to pass it directly in the `tools`
 
 ```python
 from strands import Agent
-from strands_tools import retrieve, http_request
+from strands_tools import http_request
 
 # Create specialized agents
 research_agent = Agent(
     system_prompt="""You are a specialized research assistant. Focus only on providing
     factual, well-sourced information in response to research questions.
     Always cite your sources when possible.""",
-    tools=[retrieve, http_request],
+    tools=[http_request],
 )
 
 product_agent = Agent(
     system_prompt="""You are a specialized product recommendation assistant.
     Provide personalized product suggestions based on user preferences.""",
-    tools=[retrieve, http_request],
+    tools=[http_request],
 )
 
 travel_agent = Agent(
     system_prompt="""You are a specialized travel planning assistant.
     Create detailed travel itineraries based on user preferences.""",
-    tools=[retrieve, http_request],
+    tools=[http_request],
 )
 
 # Create the orchestrator — agents are automatically converted to tools
@@ -163,7 +163,7 @@ For more control over how the agent is invoked — such as custom pre/post-proce
 
 ```python
 from strands import Agent, tool
-from strands_tools import retrieve, http_request
+from strands_tools import http_request
 
 RESEARCH_ASSISTANT_PROMPT = """
 You are a specialized research assistant. Focus only on providing
@@ -185,7 +185,7 @@ def research_assistant(query: str) -> str:
     try:
         research_agent = Agent(
             system_prompt=RESEARCH_ASSISTANT_PROMPT,
-            tools=[retrieve, http_request]
+            tools=[http_request]
         )
 
         response = research_agent(query)
@@ -223,7 +223,7 @@ def product_recommendation_assistant(query: str) -> str:
         product_agent = Agent(
             system_prompt="""You are a specialized product recommendation assistant.
             Provide personalized product suggestions based on user preferences.""",
-            tools=[retrieve, http_request, dialog],
+            tools=[http_request, dialog],
         )
         # Implementation with response handling
         # ...
@@ -246,7 +246,7 @@ def trip_planning_assistant(query: str) -> str:
         travel_agent = Agent(
             system_prompt="""You are a specialized travel planning assistant.
             Create detailed travel itineraries based on user preferences.""",
-            tools=[retrieve, http_request],
+            tools=[http_request],
         )
         # Implementation with response handling
         # ...

--- a/site/src/content/docs/user-guide/concepts/streaming/async-iterators.mdx
+++ b/site/src/content/docs/user-guide/concepts/streaming/async-iterators.mdx
@@ -25,9 +25,33 @@ Python uses the [`stream_async`](@api/python/strands.agent.agent#Agent.stream_as
 > **Note**: Python also supports synchronous event handling via [callback handlers](./callback-handlers.md).
 
 ```python
+
+import ast
+import operator
+
 import asyncio
-from strands import Agent
-from strands_tools import calculator
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Initialize our agent without a callback handler
 agent = Agent(
@@ -63,11 +87,36 @@ Here's how to integrate streaming with web frameworks to create a streaming endp
 <Tab label="Python - FastAPI">
 
 ```python
+
+import ast
+import operator
+
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
-from strands import Agent
-from strands_tools import calculator, http_request
+from strands import Agent, tool
+from strands_tools import http_request
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 app = FastAPI()
 
@@ -119,8 +168,32 @@ This async stream processor illustrates the event loop lifecycle events and how 
 <Tab label="Python">
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+
+import ast
+import operator
+
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Create agent with event loop tracker
 agent = Agent(

--- a/site/src/content/docs/user-guide/concepts/streaming/async-iterators.mdx
+++ b/site/src/content/docs/user-guide/concepts/streaming/async-iterators.mdx
@@ -25,9 +25,40 @@ Python uses the [`stream_async`](@api/python/strands.agent.agent#Agent.stream_as
 > **Note**: Python also supports synchronous event handling via [callback handlers](./callback-handlers.md).
 
 ```python
+
+import ast
+import operator
+
 import asyncio
-from strands import Agent
-from strands_tools import calculator
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Initialize our agent without a callback handler
 agent = Agent(
@@ -63,11 +94,43 @@ Here's how to integrate streaming with web frameworks to create a streaming endp
 <Tab label="Python - FastAPI">
 
 ```python
+
+import ast
+import operator
+
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
-from strands import Agent
-from strands_tools import calculator, http_request
+from strands import Agent, tool
+from strands_tools import http_request
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 app = FastAPI()
 
@@ -119,8 +182,39 @@ This async stream processor illustrates the event loop lifecycle events and how 
 <Tab label="Python">
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+
+import ast
+import operator
+
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Create agent with event loop tracker
 agent = Agent(

--- a/site/src/content/docs/user-guide/concepts/streaming/callback-handlers.mdx
+++ b/site/src/content/docs/user-guide/concepts/streaming/callback-handlers.mdx
@@ -21,8 +21,32 @@ For a complete list of available events including text generation, tool usage, l
 The simplest way to use a callback handler is to pass a callback function to your agent:
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+
+import ast
+import operator
+
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 def custom_callback_handler(**kwargs):
     # Process stream data
@@ -70,8 +94,32 @@ Custom callback handlers enable you to have fine-grained control over what is st
 Custom callback handlers can be useful to debug sequences of events in the agent loop:
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+
+import ast
+import operator
+
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 def debugger_callback_handler(**kwargs):
     # Print the values in kwargs so that we can see everything
@@ -92,9 +140,33 @@ This handler prints all calls to the callback handler including full event detai
 This handler demonstrates how to buffer text and only show it when a complete message is generated. This pattern is useful for chat interfaces where you want to show polished, complete responses:
 
 ```python
+
+import ast
+import operator
+
 import json
-from strands import Agent
-from strands_tools import calculator
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 def message_buffer_handler(**kwargs):
     # When a new message is created from the assistant, print its content
@@ -117,8 +189,32 @@ This handler leverages the `message` event which is triggered when a complete me
 This callback handler illustrates the event loop lifecycle events and how they relate to each other. It's useful for understanding the flow of execution in the Strands agent:
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+
+import ast
+import operator
+
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 def event_loop_tracker(**kwargs):
     # Track event loop lifecycle

--- a/site/src/content/docs/user-guide/concepts/streaming/callback-handlers.mdx
+++ b/site/src/content/docs/user-guide/concepts/streaming/callback-handlers.mdx
@@ -21,8 +21,39 @@ For a complete list of available events including text generation, tool usage, l
 The simplest way to use a callback handler is to pass a callback function to your agent:
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+
+import ast
+import operator
+
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 def custom_callback_handler(**kwargs):
     # Process stream data
@@ -70,8 +101,39 @@ Custom callback handlers enable you to have fine-grained control over what is st
 Custom callback handlers can be useful to debug sequences of events in the agent loop:
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+
+import ast
+import operator
+
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 def debugger_callback_handler(**kwargs):
     # Print the values in kwargs so that we can see everything
@@ -92,9 +154,40 @@ This handler prints all calls to the callback handler including full event detai
 This handler demonstrates how to buffer text and only show it when a complete message is generated. This pattern is useful for chat interfaces where you want to show polished, complete responses:
 
 ```python
+
+import ast
+import operator
+
 import json
-from strands import Agent
-from strands_tools import calculator
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 def message_buffer_handler(**kwargs):
     # When a new message is created from the assistant, print its content
@@ -117,8 +210,39 @@ This handler leverages the `message` event which is triggered when a complete me
 This callback handler illustrates the event loop lifecycle events and how they relate to each other. It's useful for understanding the flow of execution in the Strands agent:
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+
+import ast
+import operator
+
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 def event_loop_tracker(**kwargs):
     # Track event loop lifecycle

--- a/site/src/content/docs/user-guide/concepts/streaming/index.mdx
+++ b/site/src/content/docs/user-guide/concepts/streaming/index.mdx
@@ -270,8 +270,32 @@ This example demonstrates how to identify event emitted from an agent:
 <Tab label="Python">
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+
+import ast
+import operator
+
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 def process_event(event):
     """Shared event processor for both async iterators and callback handlers"""
@@ -319,10 +343,34 @@ Utilizing both [agents as a tool](../multi-agent/agents-as-tools.md) and [tool s
 <Tab label="Python">
 
 ```python
+
+import ast
+import operator
+
 from typing import AsyncIterator
 from dataclasses import dataclass
 from strands import Agent, tool
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 @dataclass
 class SubAgentResult:

--- a/site/src/content/docs/user-guide/concepts/streaming/index.mdx
+++ b/site/src/content/docs/user-guide/concepts/streaming/index.mdx
@@ -270,8 +270,39 @@ This example demonstrates how to identify event emitted from an agent:
 <Tab label="Python">
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+
+import ast
+import operator
+
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 def process_event(event):
     """Shared event processor for both async iterators and callback handlers"""
@@ -319,10 +350,41 @@ Utilizing both [agents as a tool](../multi-agent/agents-as-tools.md) and [tool s
 <Tab label="Python">
 
 ```python
+
+import ast
+import operator
+
 from typing import AsyncIterator
 from dataclasses import dataclass
 from strands import Agent, tool
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 @dataclass
 class SubAgentResult:

--- a/site/src/content/docs/user-guide/concepts/tools/index.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/index.mdx
@@ -27,8 +27,41 @@ Tools are passed to agents during initialization or at runtime, making them avai
 <Tab label="Python">
 
 ```python
-from strands import Agent
-from strands_tools import calculator, file_read, shell
+
+import ast
+import operator
+
+from strands import Agent, tool
+from strands_tools import file_read
+from strands.vended_tools import shell
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Add tools to our agent
 agent = Agent(
@@ -417,9 +450,9 @@ For Python, Strands offers a [community-supported tools package](https://github.
 
 ```python
 from strands import Agent
-from strands_tools import calculator, file_read, shell
+from strands_tools import file_read, file_write, http_request
 
-agent = Agent(tools=[calculator, file_read, shell])
+agent = Agent(tools=[file_read, file_write, http_request])
 ```
 
 For a complete list of available tools, see [Community Tools Package](community-tools-package.md).

--- a/site/src/content/docs/user-guide/concepts/tools/index.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/index.mdx
@@ -27,8 +27,34 @@ Tools are passed to agents during initialization or at runtime, making them avai
 <Tab label="Python">
 
 ```python
-from strands import Agent
-from strands_tools import calculator, file_read, shell
+
+import ast
+import operator
+
+from strands import Agent, tool
+from strands_tools import file_read
+from strands.vended_tools import shell
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Add tools to our agent
 agent = Agent(
@@ -416,8 +442,34 @@ Pre-built tools are available in both Python and TypeScript to help you get star
 For Python, Strands offers a [community-supported tools package](https://github.com/strands-agents/tools/blob/main) with pre-built tools for development:
 
 ```python
-from strands import Agent
-from strands_tools import calculator, file_read, shell
+
+import ast
+import operator
+
+from strands import Agent, tool
+from strands_tools import file_read
+from strands.vended_tools import shell
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(f"unsupported expression: {expression}")
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 agent = Agent(tools=[calculator, file_read, shell])
 ```


### PR DESCRIPTION
## Description

Part 1 of 2, replacing #3631 (closed — see below). `strands-agents/tools` is deprecating `calculator`, `current_time`, `memory`, and `retrieve` (strands-agents/tools#566), so these examples would emit a deprecation warning for anyone following along.

`calculator` was almost always a stand-in to show that tool calling works at all — but the prompts ask for real arithmetic ("square root of 144", "450 km at 120 km/h"), so the demo has to compute something. Each example now defines a small `@tool` that walks an arithmetic AST against an explicit operator allowlist:

```python
import ast
import operator

from strands import Agent, tool


@tool
def calculator(expression: str) -> str:
    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120"."""
    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
           ast.Div: operator.truediv, ast.Pow: operator.pow, ast.USub: operator.neg}

    def ev(n):
        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
            return n.value
        ...
        raise ValueError(f"unsupported expression: {expression}")

    return str(ev(ast.parse(expression, mode="eval").body))
```

It computes what the prompts need, drops the `strands_tools` dependency, and rejects anything that isn't arithmetic — so no docs example demonstrates eval-style execution of model-supplied input.

`memory` and `retrieve` are removed from the examples that used them, **except** where the example's whole premise is Bedrock Knowledge Base retrieval. Those need porting to `MemoryManager`, which is a redesign rather than a reference swap, and doing it badly here would leave worse examples than the warning does.

### Why #3631 was closed

Worth stating plainly: #3631 failed the `pr-size-labeler` gate at 2300 lines, and my fix was to swap the AST evaluator for `sympy.sympify(...)`. That was a security regression — `sympify` evaluates arbitrary code:

```
>>> sympy.sympify("__import__('os').getpid()")
7592
```

Caught by the automated review. The evaluator is now compacted to 20 lines instead, and the change is **split** so each PR fits the gate honestly rather than by weakening the code:

- **This PR** — `user-guide/concepts/`, 916 lines
- **Companion** — model-providers, evals-sdk, observability, quickstart, runnable examples, 786 lines

## Type of Change

Documentation update

## Testing

- **Every generated helper was executed**, not just parsed: each returns `12.0` for `"144 ** 0.5"` and raises `ValueError` on `__import__('os').getpid()`. 60 helpers across both parts, zero failures.
- Every touched Python block parses; the two pre-existing syntax errors in truncated illustrative snippets are unchanged (verified by parsing the pre-change version).
- No `tools=[...]` entry references an undefined name — checked across blocks, since pages define the tool once and reuse it.
- Blog posts deliberately untouched: dated announcements, and rewriting their code would misrepresent what shipped.

- [ ] I ran `hatch run prepare`

Not applicable — `site/` only, no Python package code. `npm install` in `site/` fails with an npm registry auth error (`E401`) in my environment, so CI covers the JS-side checks.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

strands-agents/tools#566 is still open; this PR only removes usages, so it's safe to merge independently.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.