### PR TITLE
fix(bedrock): raise a clear error for unsupported S3 location sources

### DIFF
--- a/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
@@ -424,6 +424,11 @@ For a complete list of input types, please refer to the [API Reference](@api/pyt
 
 As an alternative to providing media content as bytes, Amazon Bedrock supports referencing documents, images, and videos stored in Amazon S3 directly. This is useful when working with large files or when your content is already stored in S3.
 
+:::caution[Amazon Nova Models Only]
+
+Only Amazon Nova models accept S3 location sources. Other model families, including Anthropic Claude, accept inline bytes only and reject S3 locations with a `ValidationException`. Supply the media as bytes when using those models.
+:::
+
 :::note[IAM Permissions Required]
 
 To use S3 locations, the IAM role or user making the Bedrock API call must have `s3:GetObject` permission on the S3 bucket and objects being referenced.
@@ -436,7 +441,7 @@ To use S3 locations, the IAM role or user making the Bedrock API call must have 
 from strands import Agent
 from strands.models import BedrockModel
 
-agent = Agent(model=BedrockModel())
+agent = Agent(model=BedrockModel(model_id="amazon.nova-pro-v1:0"))
 
 response = agent(
     [

--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -61,6 +61,12 @@ _MODELS_INCLUDE_STATUS = [
     "anthropic.claude",
 ]
 
+# Model families that accept S3 location sources (documents, images, videos) in the Converse
+# API. Other families reject them with a ValidationException.
+_MODELS_SUPPORT_S3_LOCATION = [
+    "amazon.nova",
+]
+
 # Cache of model IDs for which CountTokens API calls should be skipped.
 _SKIP_COUNT_TOKENS_MODELS: set[str] = set()
 
@@ -270,6 +276,10 @@ class BedrockModel(Model):
 
         Returns:
             A Bedrock converse stream request.
+
+        Raises:
+            ValueError: If a message carries an S3 location source and the model does not
+                support one.
         """
         if not tool_specs:
             has_tool_content = any(
@@ -590,9 +600,45 @@ class BedrockModel(Model):
         else:  # "auto"
             return any(model in self.config["model_id"] for model in _MODELS_INCLUDE_STATUS)
 
+    @property
+    def _supports_s3_location(self) -> bool | None:
+        """Whether this model accepts S3 location sources in the Bedrock Converse API.
+
+        Only Amazon Nova models accept S3 location sources for documents, images, and videos.
+        Other families (Anthropic Claude, Meta Llama, Mistral, Cohere) accept inline bytes only
+        and reject S3 location sources with a ValidationException.
+
+        Returns:
+            True if the model accepts S3 location sources, False if it does not, and None if the
+            model id is an ARN whose resource id does not identify the model family.
+        """
+        model_id = self.config["model_id"].lower()
+        if model_id.startswith("arn:"):
+            # An inference profile ARN ends in <region>.<model id>, so the family is read from
+            # that suffix. The leading colon keeps application inference profiles out, whose id
+            # is opaque, as it is for a provisioned throughput, custom, or imported model.
+            _, separator, profile_id = model_id.partition(":inference-profile/")
+            if not separator:
+                return None
+
+            model_id = profile_id
+
+        return any(prefix in model_id for prefix in _MODELS_SUPPORT_S3_LOCATION)
+
     def _handle_location(self, location: SourceLocation) -> dict[str, Any] | None:
-        """Convert location content block to Bedrock format if its an S3Location."""
+        """Convert location content block to Bedrock format if its an S3Location.
+
+        Raises:
+            ValueError: If the location is an S3Location and the model does not support one.
+        """
         if location["type"] == "s3":
+            # An undetermined model family is passed through for Bedrock to accept or reject.
+            if self._supports_s3_location is False:
+                raise ValueError(
+                    f"model_id=<{self.config['model_id']}> | model does not support s3 location sources | "
+                    "supply the media as bytes or use an Amazon Nova model"
+                )
+
             s3_location = cast(S3Location, location)
             formatted_document_s3: dict[str, Any] = {"uri": s3_location["uri"]}
             if "bucketOwner" in s3_location:

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -67,6 +67,13 @@ def model(bedrock_client, model_id):
 
 
 @pytest.fixture
+def nova_model(bedrock_client):
+    _ = bedrock_client
+
+    return BedrockModel(model_id="amazon.nova-pro-v1:0")
+
+
+@pytest.fixture
 def messages():
     return [{"role": "user", "content": [{"text": "test"}]}]
 
@@ -2177,7 +2184,7 @@ def test_format_request_filters_image_content_blocks(model, model_id):
     assert "metadata" not in image_block
 
 
-def test_format_request_image_s3_location_only(model, model_id):
+def test_format_request_image_s3_location_only(nova_model):
     """Test that image with only s3Location is properly formatted."""
     messages = [
         {
@@ -2195,7 +2202,7 @@ def test_format_request_image_s3_location_only(model, model_id):
         }
     ]
 
-    formatted_request = model.format_request(messages)
+    formatted_request = nova_model.format_request(messages)
     image_source = formatted_request["messages"][0]["content"][0]["image"]["source"]
 
     assert image_source == {"s3Location": {"uri": "s3://my-bucket/image.png"}}
@@ -2223,7 +2230,7 @@ def test_format_request_image_bytes_only(model, model_id):
     assert image_source == {"bytes": b"image_data"}
 
 
-def test_format_request_document_s3_location(model, model_id):
+def test_format_request_document_s3_location(nova_model):
     """Test that document with s3Location is properly formatted."""
     messages = [
         {
@@ -2255,7 +2262,7 @@ def test_format_request_document_s3_location(model, model_id):
         }
     ]
 
-    formatted_request = model.format_request(messages)
+    formatted_request = nova_model.format_request(messages)
     document = formatted_request["messages"][0]["content"][0]["document"]
     document_with_bucket_owner = formatted_request["messages"][0]["content"][1]["document"]
 
@@ -2316,7 +2323,7 @@ def test_format_request_unsupported_location(model, caplog):
     assert "Non s3 location sources are not supported by Bedrock | skipping content block" in caplog.text
 
 
-def test_format_request_video_s3_location(model, model_id):
+def test_format_request_video_s3_location(nova_model):
     """Test that video with s3Location is properly formatted."""
     messages = [
         {
@@ -2334,10 +2341,114 @@ def test_format_request_video_s3_location(model, model_id):
         }
     ]
 
-    formatted_request = model.format_request(messages)
+    formatted_request = nova_model.format_request(messages)
     video_source = formatted_request["messages"][0]["content"][0]["video"]["source"]
 
     assert video_source == {"s3Location": {"uri": "s3://my-bucket/video.mp4"}}
+
+
+S3_LOCATION = {"type": "s3", "uri": "s3://my-bucket/report.pdf"}
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        {"document": {"name": "report.pdf", "format": "pdf", "source": {"location": S3_LOCATION}}},
+        {"image": {"format": "png", "source": {"location": S3_LOCATION}}},
+        {"video": {"format": "mp4", "source": {"location": S3_LOCATION}}},
+    ],
+)
+def test_format_request_s3_location_unsupported_model_raises(bedrock_client, content):
+    """S3 location sources on a model family that rejects them raise instead of being dropped.
+
+    Guards https://github.com/strands-agents/sdk-python/issues/1744: Bedrock accepts S3 location
+    sources for Amazon Nova only, and its ValidationException for other families does not mention
+    S3, so the caller gets a clear error naming the model instead.
+    """
+    _ = bedrock_client
+    model = BedrockModel(model_id="anthropic.claude-sonnet-4-20250514-v1:0")
+
+    with pytest.raises(ValueError, match="model does not support s3 location sources") as exc_info:
+        model.format_request([{"role": "user", "content": [content]}])
+
+    assert "anthropic.claude-sonnet-4-20250514-v1:0" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    ("model_id", "supported"),
+    [
+        ("us.amazon.nova-pro-v1:0", True),
+        ("eu.amazon.nova-lite-v1:0", True),
+        ("us.anthropic.claude-sonnet-4-6", False),
+    ],
+)
+def test_format_request_s3_location_cross_region_profile_id(bedrock_client, model_id, supported):
+    """A cross-region inference profile id is a plain model id, so its family still gates S3."""
+    _ = bedrock_client
+    model = BedrockModel(model_id=model_id)
+    messages = [
+        {
+            "role": "user",
+            "content": [{"document": {"name": "report.pdf", "format": "pdf", "source": {"location": S3_LOCATION}}}],
+        }
+    ]
+
+    if not supported:
+        with pytest.raises(ValueError, match="model does not support s3 location sources"):
+            model.format_request(messages)
+        return
+
+    formatted_request = model.format_request(messages)
+    document = formatted_request["messages"][0]["content"][0]["document"]
+
+    assert document["source"] == {"s3Location": {"uri": "s3://my-bucket/report.pdf"}}
+
+
+def test_format_request_s3_location_inference_profile_arn_unsupported_model_raises(bedrock_client):
+    """An inference profile ARN names its model family, so an unsupported family still raises."""
+    _ = bedrock_client
+    model_id = "arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-sonnet-4-6"
+    model = BedrockModel(model_id=model_id)
+
+    messages = [
+        {
+            "role": "user",
+            "content": [{"document": {"name": "report.pdf", "format": "pdf", "source": {"location": S3_LOCATION}}}],
+        }
+    ]
+
+    with pytest.raises(ValueError, match="model does not support s3 location sources"):
+        model.format_request(messages)
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        # An inference profile ARN names a supported family.
+        "arn:aws:bedrock:us-west-2:123456789012:inference-profile/us.amazon.nova-pro-v1:0",
+        # Every other resource type has an opaque id, leaving the family undetermined.
+        "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123def456",
+        "arn:aws:bedrock:us-west-2:123456789012:provisioned-model/abcdefghijkl",
+        "arn:aws:bedrock:us-east-1:123456789012:custom-model/amazon.nova-pro-v1:0/abc123",
+        "arn:aws:bedrock:us-east-1:123456789012:imported-model/abc123def456",
+    ],
+)
+def test_format_request_s3_location_arn_model_id_passes_through(bedrock_client, model_id):
+    """A supported or undetermined family sends the S3 location to Bedrock unchanged."""
+    _ = bedrock_client
+    model = BedrockModel(model_id=model_id)
+
+    messages = [
+        {
+            "role": "user",
+            "content": [{"document": {"name": "report.pdf", "format": "pdf", "source": {"location": S3_LOCATION}}}],
+        }
+    ]
+
+    formatted_request = model.format_request(messages)
+    document = formatted_request["messages"][0]["content"][0]["document"]
+
+    assert document["source"] == {"s3Location": {"uri": "s3://my-bucket/report.pdf"}}
 
 
 @pytest.mark.parametrize("video_format", ["3gp", "3g2", "3gpp"])


### PR DESCRIPTION
## Description

Bedrock's Converse API only accepts an S3 location media source for Amazon Nova models. Every other family (Claude, Llama, Mistral, Cohere) rejects it with a ValidationException that never mentions S3, so the message reads like a malformed content block (`messages.0.content.0.document.source.type: Field required`), not an unsupported-feature error. Since the SDK defaults to Claude, the documented S3-location example fails this way today.

This raises a `ValueError` naming the model and the fix (pass bytes, or use a Nova model) whenever a non-Nova model gets an S3 location source. A model addressed by an inference-profile ARN is classified by the model id embedded in the ARN. Every other ARN resource type (application-inference-profile, provisioned-model, custom-model, imported-model) has an opaque id that doesn't identify the family, so those pass through unchanged and Bedrock decides.

The documented S3-location example now uses a Nova model id, with a caution callout noting the Nova-only constraint.

## Related Issues

Fixes #1744

## Documentation PR

Included here under `site/`.

## Type of Change

Bug fix

## Testing

`hatch` wasn't available in my environment, so I ran the underlying checks directly from `strands-py/`:

| Check | Result |
|---|---|
| `python -m pytest tests/strands/models/test_bedrock.py -q` | 193 passed |
| `python -m ruff check` / `ruff format --check` (both changed Python files) | clean |
| `python -m mypy src/strands/models/bedrock.py` | clean |
| Full test suite | 4084 passed vs. 4072 on a clean `main`, same 51 pre-existing unrelated errors (missing optional dep locally) |

Nine new test cases: a non-Nova plain model id raises with the model id and fix named in the message; a Nova plain model id still works; a Claude inference-profile ARN raises, with the family read from the ARN's embedded model id; a Nova inference-profile ARN works; and application-inference-profile, provisioned-model, custom-model, and imported-model ARNs all pass through unchanged, since none of their ids identify the model family.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.