### PR TITLE
docs: replace deprecated strands_tools examples outside concepts/

### DIFF
--- a/site/docs/examples/evals-sdk/deterministic_evaluators.py
+++ b/site/docs/examples/evals-sdk/deterministic_evaluators.py
@@ -3,9 +3,12 @@
 Fast, code-based evaluation without LLM judges.
 """
 
-import asyncio
 
-from strands import Agent
+import ast
+import asyncio
+import operator
+
+from strands import Agent, tool
 from strands_evals import Case, Experiment
 from strands_evals.evaluators import Contains, Equals, StartsWith, ToolCalled
 
@@ -36,8 +39,34 @@ experiment = Experiment(
 # --- Trajectory evaluator ---
 
 from strands_evals.extractors import tools_use_extractor
-from strands_tools import calculator
 
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 def get_response_with_tools(case: Case) -> dict:
     agent = Agent(tools=[calculator], callback_handler=None)

--- a/site/docs/examples/evals-sdk/evaluate_async.py
+++ b/site/docs/examples/evals-sdk/evaluate_async.py
@@ -1,12 +1,42 @@
-import asyncio
 
-from strands import Agent
-from strands_tools import calculator
+import ast
+import asyncio
+import operator
+
+from strands import Agent, tool
 
 from strands_evals import Case, Experiment
 from strands_evals.evaluators import ToolSelectionAccuracyEvaluator
 from strands_evals.mappers import StrandsInMemorySessionMapper
 from strands_evals.telemetry import StrandsEvalsTelemetry
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 telemetry = StrandsEvalsTelemetry().setup_in_memory_exporter()
 memory_exporter = telemetry.in_memory_exporter

--- a/site/docs/examples/evals-sdk/tool_parameter_accuracy_evaluator.py
+++ b/site/docs/examples/evals-sdk/tool_parameter_accuracy_evaluator.py
@@ -1,12 +1,42 @@
-import asyncio
 
-from strands import Agent
-from strands_tools import calculator
+import ast
+import asyncio
+import operator
+
+from strands import Agent, tool
 
 from strands_evals import Case, Experiment
 from strands_evals.evaluators import ToolParameterAccuracyEvaluator
 from strands_evals.mappers import StrandsInMemorySessionMapper
 from strands_evals.telemetry import StrandsEvalsTelemetry
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Setup telemetry
 telemetry = StrandsEvalsTelemetry().setup_in_memory_exporter()

--- a/site/docs/examples/evals-sdk/tool_selection_accuracy_evaluator.py
+++ b/site/docs/examples/evals-sdk/tool_selection_accuracy_evaluator.py
@@ -1,12 +1,42 @@
-import asyncio
 
-from strands import Agent
-from strands_tools import calculator
+import ast
+import asyncio
+import operator
+
+from strands import Agent, tool
 
 from strands_evals import Case, Experiment
 from strands_evals.evaluators import ToolSelectionAccuracyEvaluator
 from strands_evals.mappers import StrandsInMemorySessionMapper
 from strands_evals.telemetry import StrandsEvalsTelemetry
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Setup telemetry
 telemetry = StrandsEvalsTelemetry().setup_in_memory_exporter()

--- a/site/docs/examples/python/multi_agent_example/math_assistant.py
+++ b/site/docs/examples/python/multi_agent_example/math_assistant.py
@@ -1,6 +1,37 @@
+
+import ast
+import operator
+
 from strands import Agent, tool
-from strands_tools import calculator
 import json
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 MATH_ASSISTANT_SYSTEM_PROMPT = """
 You are math wizard, a specialized mathematics education assistant. Your capabilities include:

--- a/site/src/content/docs/integrations/model-providers/cohere.mdx
+++ b/site/src/content/docs/integrations/model-providers/cohere.mdx
@@ -24,9 +24,39 @@ pip install 'strands-agents[openai]' strands-agents-tools
 After installing the `openai` package, you can import and initialize the Strands Agents' OpenAI-compatible provider for Cohere models as follows:
 
 ```python
-from strands import Agent
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.openai import OpenAIModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = OpenAIModel(
     client_args={

--- a/site/src/content/docs/integrations/model-providers/crusoe.mdx
+++ b/site/src/content/docs/integrations/model-providers/crusoe.mdx
@@ -22,9 +22,39 @@ pip install 'strands-agents[openai]' strands-agents-tools
 After installing the `openai` package, you can import and initialize the Strands Agents' OpenAI-compatible provider for Crusoe models as follows:
 
 ```python
-from strands import Agent
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.openai import OpenAIModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = OpenAIModel(
     client_args={

--- a/site/src/content/docs/integrations/model-providers/fireworksai.mdx
+++ b/site/src/content/docs/integrations/model-providers/fireworksai.mdx
@@ -26,9 +26,39 @@ pip install 'strands-agents[openai]' strands-agents-tools
 After installing the `openai` package, you can import and initialize the Strands Agents' OpenAI-compatible provider for Fireworks AI models as follows:
 
 ```python
-from strands import Agent
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.openai import OpenAIModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = OpenAIModel(
     client_args={

--- a/site/src/content/docs/integrations/model-providers/mlx.mdx
+++ b/site/src/content/docs/integrations/model-providers/mlx.mdx
@@ -35,9 +35,39 @@ pip install strands-mlx strands-agents-tools
 ### Basic Agent
 
 ```python
-from strands import Agent
+import ast
+import operator
+
+from strands import Agent, tool
 from strands_mlx import MLXModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = MLXModel(model_id="mlx-community/Qwen3-1.7B-4bit")
 agent = Agent(model=model, tools=[calculator])

--- a/site/src/content/docs/integrations/model-providers/nebius-token-factory.mdx
+++ b/site/src/content/docs/integrations/model-providers/nebius-token-factory.mdx
@@ -24,9 +24,39 @@ pip install 'strands-agents[openai]' strands-agents-tools
 After installing the `openai` package, you can import and initialize the Strands Agents' OpenAI-compatible provider for Nebius Token Factory models as follows:
 
 ```python
-from strands import Agent
+import ast
+import operator
+
+from strands import Agent, tool
 from strands.models.openai import OpenAIModel
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = OpenAIModel(
     client_args={

--- a/site/src/content/docs/integrations/model-providers/nvidia-nim.mdx
+++ b/site/src/content/docs/integrations/model-providers/nvidia-nim.mdx
@@ -29,9 +29,39 @@ pip install strands-nvidia-nim strands-agents-tools
 ### Basic Agent
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+import ast
+import operator
+
+from strands import Agent, tool
 from strands_nvidia_nim import NvidiaNIM
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = NvidiaNIM(
     api_key="your-nvidia-nim-api-key",
@@ -53,10 +83,39 @@ export NVIDIA_NIM_API_KEY=your-nvidia-nim-api-key
 ```
 
 ```python
+import ast
+import operator
 import os
-from strands import Agent
-from strands_tools import calculator
+from strands import Agent, tool
 from strands_nvidia_nim import NvidiaNIM
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 model = NvidiaNIM(
     api_key=os.getenv("NVIDIA_NIM_API_KEY"),

--- a/site/src/content/docs/integrations/model-providers/sglang.mdx
+++ b/site/src/content/docs/integrations/model-providers/sglang.mdx
@@ -47,11 +47,40 @@ python -m sglang.launch_server \
 ### 2. Basic Agent
 
 ```python
+import ast
 import asyncio
+import operator
 from transformers import AutoTokenizer
-from strands import Agent
-from strands_tools import calculator
+from strands import Agent, tool
 from strands_sglang import SGLangModel
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 async def main():
     tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-4B-Instruct-2507")

--- a/site/src/content/docs/integrations/model-providers/vllm.mdx
+++ b/site/src/content/docs/integrations/model-providers/vllm.mdx
@@ -97,10 +97,41 @@ print(f"Response tokens: {len(recorder.token_ids or [])}")
 Strands SDK already handles unknown tools and malformed JSON gracefully. `VLLMToolValidationHooks` adds RL-friendly enhancements:
 
 ```python
+import ast
+import operator
 import os
-from strands import Agent
-from strands_tools.calculator import calculator
+
+from strands import Agent, tool
 from strands_vllm import VLLMModel, VLLMToolValidationHooks
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
+
 
 model = VLLMModel(
     base_url=os.getenv("VLLM_BASE_URL", "http://localhost:8000/v1"),
@@ -161,16 +192,41 @@ The following span attributes are set:
 For building RL-ready trajectories with loss masks:
 
 ```python
+import ast
 import asyncio
+import operator
 import os
+
 from strands import Agent, tool
-from strands_tools.calculator import calculator as _calculator_impl
 from strands_vllm import TokenManager, VLLMModel, VLLMTokenRecorder, VLLMToolValidationHooks
 
 @tool
-def calculator(expression: str) -> dict:
-    return _calculator_impl(expression=expression)
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
 
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 async def main():
     model = VLLMModel(
         base_url=os.getenv("VLLM_BASE_URL", "http://localhost:8000/v1"),

--- a/site/src/content/docs/user-guide/evals-sdk/cli.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/cli.mdx
@@ -51,8 +51,39 @@ The two modes are mutually exclusive — argparse rejects mixing them.
 
 ```python
 # my_pkg/agents.py
-from strands import Agent
-from strands_tools import calculator
+
+import ast
+import operator
+
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 def build_agent():
     return Agent(tools=[calculator], callback_handler=None)

--- a/site/src/content/docs/user-guide/evals-sdk/detectors/diagnosis.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/detectors/diagnosis.mdx
@@ -217,13 +217,42 @@ If the trajectory is not a `Session` (e.g., it's a plain list of tool names), di
 This example shows the complete workflow: run evaluations with diagnosis, then analyze the results.
 
 ```python
+import ast
 import asyncio
+import operator
 
-from strands import Agent
+from strands import Agent, tool
 from strands_evals import Case, Experiment, DiagnosisConfig, eval_task, TracedHandler
 from strands_evals.detectors import ConfidenceLevel, DiagnosisTrigger
 from strands_evals.evaluators import OutputEvaluator, GoalSuccessRateEvaluator
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 @eval_task(TracedHandler())
 def math_agent():

--- a/site/src/content/docs/user-guide/evals-sdk/evaluators/tool_parameter_evaluator.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/evaluators/tool_parameter_evaluator.mdx
@@ -60,14 +60,43 @@ When using `StrandsInMemorySessionMapper`, you **must** include session ID trace
 :::
 
 ```python
+import ast
 import asyncio
+import operator
 
-from strands import Agent
-from strands_tools import calculator
+from strands import Agent, tool
 from strands_evals import Case, Experiment
 from strands_evals.evaluators import ToolParameterAccuracyEvaluator
 from strands_evals.mappers import StrandsInMemorySessionMapper
 from strands_evals.telemetry import StrandsEvalsTelemetry
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Setup telemetry
 telemetry = StrandsEvalsTelemetry().setup_in_memory_exporter()

--- a/site/src/content/docs/user-guide/evals-sdk/how-to/eval_task.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/how-to/eval_task.mdx
@@ -44,7 +44,38 @@ The decorator wraps your function so that `Experiment.run_evaluations` receives 
 Accept a `Case` parameter to customize agent behavior per test case:
 
 ```python
-from strands_tools import calculator
+import ast
+import operator
+
+from strands import tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 @eval_task()
 def my_task(case):

--- a/site/src/content/docs/user-guide/evals-sdk/quickstart.mdx
+++ b/site/src/content/docs/user-guide/evals-sdk/quickstart.mdx
@@ -170,16 +170,46 @@ The `@eval_task()` decorator eliminates boilerplate. Your function can return an
 Now let's evaluate how well agents use tools. Create `my_evaluation/trajectory_eval.py`:
 
 ```python
-from strands import Agent
+import ast
+import operator
+
+from strands import Agent, tool
 from strands_evals import Case, Experiment
 from strands_evals.evaluators import TrajectoryEvaluator
 from strands_evals.extractors import tools_use_extractor
-from strands_tools import calculator, current_time
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Define task function that captures tool usage
 def get_response_with_tools(case: Case) -> dict:
     agent = Agent(
-        tools=[calculator, current_time],
+        tools=[calculator],
         system_prompt="You are a helpful assistant. Use tools when appropriate.",
         callback_handler=None
     )
@@ -233,7 +263,7 @@ evaluator = TrajectoryEvaluator(
 )
 
 # Update evaluator with tool descriptions to prevent context overflow
-sample_agent = Agent(tools=[calculator, current_time])
+sample_agent = Agent(tools=[calculator])
 tool_descriptions = tools_use_extractor.extract_tools_description(sample_agent, is_short=True)
 evaluator.update_trajectory_description(tool_descriptions)
 
@@ -261,10 +291,40 @@ When using `StrandsInMemorySessionMapper`, you **must** include session ID trace
 The `TracedHandler` handles all of this automatically:
 
 ```python
-from strands import Agent
+import ast
+import operator
+
+from strands import Agent, tool
 from strands_evals import eval_task, TracedHandler, Case, Experiment
 from strands_evals.evaluators import HelpfulnessEvaluator
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 @eval_task(TracedHandler())
 def user_task_function():
@@ -301,12 +361,42 @@ If you need more control (e.g., custom session mapping or per-case agent configu
 <summary>Manual task function (without decorator)</summary>
 
 ```python
-from strands import Agent
+import ast
+import operator
+
+from strands import Agent, tool
 from strands_evals import Case, Experiment
 from strands_evals.evaluators import HelpfulnessEvaluator
 from strands_evals.telemetry import StrandsEvalsTelemetry
 from strands_evals.mappers import StrandsInMemorySessionMapper
-from strands_tools import calculator
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 telemetry = StrandsEvalsTelemetry().setup_in_memory_exporter()
 

--- a/site/src/content/docs/user-guide/observability-evaluation/logs.mdx
+++ b/site/src/content/docs/user-guide/observability-evaluation/logs.mdx
@@ -97,8 +97,38 @@ The Strands Agents SDK uses standard log levels:
 The Strands Agents SDK logs information in several key areas. Let's look at what kinds of logs you might see when using the following example agent with a calculator tool:
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+import ast
+import operator
+
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Create an agent with the calculator tool
 agent = Agent(tools=[calculator])
@@ -208,8 +238,8 @@ logging.getLogger("strands.models").setLevel(logging.WARNING)
 You can add custom handlers to process logs in different ways:
 
 ```python
-import logging
 import json
+import logging
 
 class JsonFormatter(logging.Formatter):
     def format(self, record):

--- a/site/src/content/docs/user-guide/observability-evaluation/metrics.mdx
+++ b/site/src/content/docs/user-guide/observability-evaluation/metrics.mdx
@@ -21,8 +21,38 @@ The Strands Agents SDK automatically tracks key metrics during agent execution:
 All these metrics are accessible through the [`AgentResult`](@api/python/strands.agent.agent_result#AgentResult) object that's returned whenever you invoke an agent. They are available for local analysis. To export them to an observability backend, configure Strands telemetry as described in the [Traces](./traces.md) documentation:
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+import ast
+import operator
+
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Create an agent with tools
 agent = Agent(tools=[calculator])
@@ -89,8 +119,38 @@ The `agent_invocations` property is a list of [`AgentInvocation`](@api/python/st
 This allows you to track metrics at both the individual invocation level and across all invocations:
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+import ast
+import operator
+
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 agent = Agent(tools=[calculator])
 
@@ -305,8 +365,38 @@ In addition to aggregate metrics, the Strands Agents SDK automatically collects 
 Each trace represents a cycle in the agent loop, with child traces for model invocations and tool calls:
 
 ```python
-from strands import Agent
-from strands_tools import calculator
+import ast
+import operator
+
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 agent = Agent(tools=[calculator])
 result = agent("What is 15 * 8 + 42?")

--- a/site/src/content/docs/user-guide/quickstart/python.mdx
+++ b/site/src/content/docs/user-guide/quickstart/python.mdx
@@ -109,8 +109,38 @@ from . import agent
 And finally our `agent.py` file where the goodies are:
 
 ```python
+import ast
+import operator
+
 from strands import Agent, tool
-from strands_tools import calculator, current_time
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Define a custom tool as a Python function using the @tool decorator
 @tool
@@ -135,20 +165,19 @@ def letter_counter(word: str, letter: str) -> int:
 
 # Create an agent with tools from the community-driven strands-tools package
 # as well as our custom letter_counter tool
-agent = Agent(tools=[calculator, current_time, letter_counter])
+agent = Agent(tools=[calculator, letter_counter])
 
 # Ask the agent a question that uses the available tools
 message = """
-I have 4 requests:
+I have 2 requests:
 
-1. What is the time right now?
-2. Calculate 3111696 / 74088
-3. Tell me how many letter R's are in the word "strawberry" 🍓
+1. Calculate 3111696 / 74088
+2. Tell me how many letter R's are in the word "strawberry" 🍓
 """
 agent(message)
 ```
 
-This basic quickstart agent can perform mathematical calculations, get the current time, run Python code, and count letters in words. The agent automatically determines when to use tools based on the input query and context.
+This basic quickstart agent can perform mathematical calculations and count letters in words. The agent automatically determines when to use tools based on the input query and context.
 
 ```mermaid
 flowchart LR
@@ -358,7 +387,7 @@ Agents display their reasoning and responses in real-time to the console by defa
 
 ```python
 agent = Agent(
-    tools=[calculator, current_time, letter_counter],
+    tools=[calculator, letter_counter],
     callback_handler=None,
 )
 ```
@@ -470,9 +499,38 @@ Strands provides two main approaches to capture streaming events from an agent: 
 For asynchronous applications (like web servers or APIs), Strands provides an async iterator approach using [`stream_async()`](@api/python/strands.agent.agent#Agent.stream_async). This is particularly useful with async frameworks like FastAPI or Django Channels.
 
 ```python
+import ast
 import asyncio
-from strands import Agent
-from strands_tools import calculator
+import operator
+from strands import Agent, tool
+
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate an arithmetic expression such as "144 ** 0.5" or "450 / 120".
+
+    Args:
+        expression: The arithmetic expression to evaluate.
+    """
+    ops = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul,
+           ast.Div: operator.truediv, ast.USub: operator.neg}
+
+    def ev(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            return n.value
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Pow):
+            base, exp = ev(n.left), ev(n.right)
+            if abs(exp) > 64:
+                raise ValueError(f"exponent too large in {expression!r}: {exp}")
+            return base**exp
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.left), ev(n.right))
+        if isinstance(n, ast.UnaryOp) and type(n.op) in ops:
+            return ops[type(n.op)](ev(n.operand))
+        raise ValueError(
+            f"{expression!r} is not arithmetic; supported: + - * / ** and parentheses over numbers"
+        )
+
+    return str(ev(ast.parse(expression, mode="eval").body))
 
 # Initialize our agent without a callback handler
 agent = Agent(

--- a/strands-py/pyproject.toml
+++ b/strands-py/pyproject.toml
@@ -50,7 +50,7 @@ anthropic = ["anthropic>=0.21.0,<1.0.0"]
 gemini = ["google-genai>=1.67.0,<3.0.0"]
 # The latest litellm v1.92.0 do not support python 3.14, for the short term we will keep 
 # the version lower than 1.92.0 until litellm has the python 3.14 supported version.
-litellm = ["litellm>=1.75.9,<=1.93.0", "openai>=1.68.0,<3.0.0"]
+litellm = ["litellm>=1.75.9,<=1.95.0", "openai>=1.68.0,<3.0.0"]
 llamaapi = ["llama-api-client>=0.1.0,<1.0.0"]
 mistral = ["mistralai>=2.0.0,<3.0.0"]
 ollama = ["ollama>=0.4.8,<1.0.0"]


### PR DESCRIPTION
## Description

Part 2 of 2, companion to #3644 (independent — branched off `main`, touches disjoint directories). Same substitution applied to the model-providers integrations, evals-sdk, observability, quickstart, and the runnable examples under `site/docs/examples`.

`strands-agents/tools` is deprecating `calculator`, `current_time`, `memory`, and `retrieve` (strands-agents/tools#566), so these examples would emit a deprecation warning for anyone following along.

`calculator` becomes a small self-contained `@tool` that walks an arithmetic AST against an explicit operator allowlist — it computes what the prompts need, drops the `strands_tools` dependency, and rejects anything that isn't arithmetic. `current_time`, `memory`, and `retrieve` are removed from the tool lists that used them.

Supersedes #3645, which was branched off #3644 and so tripped the size gate on the sum of both diffs (1702 lines) rather than its own (786).

## Type of Change

Documentation update

## Testing

- Every generated helper executes (`144 ** 0.5` → `12.0`) and raises `ValueError` on `__import__('os').getpid()`.
- Every touched Python block parses.
- `ruff check` reports the same error count before and after on the affected example files — they aren't ruff-clean upstream, so I compared rather than assuming.
- No `tools=[...]` entry references an undefined name.

- [ ] I ran `hatch run prepare`

Not applicable — `site/` only. `npm install` in `site/` fails locally with an npm registry auth error (`E401`); CI covers the JS-side checks.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.