### PR TITLE
fix(bedrock-kb): unwrap NumericValue metadata back to the stored number

### DIFF
--- a/strands-ts/src/vended-memory-stores/bedrock-knowledge-base/__tests__/bedrock-knowledge-base-store.test.node.ts
+++ b/strands-ts/src/vended-memory-stores/bedrock-knowledge-base/__tests__/bedrock-knowledge-base-store.test.node.ts
@@ -338,6 +338,66 @@ describe('BedrockKnowledgeBaseStore', () => {
       ])
     })
 
+    // Bedrock returns a stored integer as `3.0`, which `@aws-sdk/core` preserves as a
+    // NumericValue `{ string, type: 'bigDecimal' }` in the untyped metadata document.
+    // Guards against #3692: the caller must read back the number they stored.
+    it('unwraps NumericValue metadata back into the number that was stored', async () => {
+      const { store, runtime } = makeStore()
+      runtime.send.mockResolvedValue({
+        retrievalResults: [
+          {
+            content: { text: 'fact' },
+            metadata: {
+              priority: 'high',
+              verified: true,
+              ratio: 2.5,
+              version: { string: '3.0', type: 'bigDecimal' },
+              delta: { string: '-12.0', type: 'bigDecimal' },
+              zero: { string: '0.0', type: 'bigDecimal' },
+            },
+          },
+        ],
+      })
+
+      const [entry] = await store.search('q')
+      expect(entry?.metadata).toStrictEqual({
+        priority: 'high',
+        verified: true,
+        ratio: 2.5,
+        version: 3,
+        delta: -12,
+        zero: 0,
+      })
+    })
+
+    it('passes through objects that are not parseable NumericValues rather than coercing them', async () => {
+      const { store, runtime } = makeStore()
+      const unparseable = { string: 'not-a-number', type: 'bigDecimal' }
+      // Number('Infinity') parses, so it needs an explicit guard: returning it
+      // would put a non-JSON value into metadata.
+      const infinite = { string: 'Infinity', type: 'bigDecimal' }
+      const unknownTag = { string: 'x', type: 'someFutureType' }
+      const notAWrapper = { string: 'no type field' }
+      const wrapperOfWrongTypes = { string: 3, type: 7 }
+      runtime.send.mockResolvedValue({
+        retrievalResults: [
+          {
+            content: { text: 'fact' },
+            metadata: { unparseable, infinite, unknownTag, notAWrapper, wrapperOfWrongTypes },
+          },
+        ],
+      })
+
+      const [entry] = await store.search('q')
+      expect(entry?.metadata).toStrictEqual({
+        unparseable,
+        infinite,
+        unknownTag,
+        notAWrapper,
+        wrapperOfWrongTypes,
+      })
+    })
+
     it('defaults missing content to an empty string and omits absent metadata', async () => {
       const { store, runtime } = makeStore()
       runtime.send.mockResolvedValue({ retrievalResults: [{}] })

--- a/strands-ts/src/vended-memory-stores/bedrock-knowledge-base/__tests__/bedrock-knowledge-base-store.test.node.ts
+++ b/strands-ts/src/vended-memory-stores/bedrock-knowledge-base/__tests__/bedrock-knowledge-base-store.test.node.ts
@@ -338,9 +338,10 @@ describe('BedrockKnowledgeBaseStore', () => {
       ])
     })
 
-    // Bedrock returns a stored integer as `3.0`, which `@aws-sdk/core` preserves as a
-    // NumericValue `{ string, type: 'bigDecimal' }` in the untyped metadata document.
-    // Guards against #3692: the caller must read back the number they stored.
+    // Bedrock returns a stored integer as `3.0`, which `@aws-sdk/core` may preserve as a
+    // NumericValue `{ string, type: 'bigDecimal' }` in the untyped metadata document
+    // (aws/aws-sdk-js-v3#8246). Guards against #3692: the caller must read back the number
+    // they stored.
     it('unwraps NumericValue metadata back into the number that was stored', async () => {
       const { store, runtime } = makeStore()
       runtime.send.mockResolvedValue({

--- a/strands-ts/src/vended-memory-stores/bedrock-knowledge-base/__tests__/bedrock-knowledge-base-store.test.node.ts
+++ b/strands-ts/src/vended-memory-stores/bedrock-knowledge-base/__tests__/bedrock-knowledge-base-store.test.node.ts
@@ -351,6 +351,7 @@ describe('BedrockKnowledgeBaseStore', () => {
               priority: 'high',
               verified: true,
               ratio: 2.5,
+              tags: ['a', 'b'],
               version: { string: '3.0', type: 'bigDecimal' },
               delta: { string: '-12.0', type: 'bigDecimal' },
               zero: { string: '0.0', type: 'bigDecimal' },
@@ -364,6 +365,7 @@ describe('BedrockKnowledgeBaseStore', () => {
         priority: 'high',
         verified: true,
         ratio: 2.5,
+        tags: ['a', 'b'],
         version: 3,
         delta: -12,
         zero: 0,
@@ -376,6 +378,8 @@ describe('BedrockKnowledgeBaseStore', () => {
       // Number('Infinity') parses, so it needs an explicit guard: returning it
       // would put a non-JSON value into metadata.
       const infinite = { string: 'Infinity', type: 'bigDecimal' }
+      // Number('') and Number('  ') are 0, so a blank payload needs its own guard to stay untouched.
+      const blank = { string: '  ', type: 'bigDecimal' }
       const unknownTag = { string: 'x', type: 'someFutureType' }
       const notAWrapper = { string: 'no type field' }
       const wrapperOfWrongTypes = { string: 3, type: 7 }
@@ -383,7 +387,7 @@ describe('BedrockKnowledgeBaseStore', () => {
         retrievalResults: [
           {
             content: { text: 'fact' },
-            metadata: { unparseable, infinite, unknownTag, notAWrapper, wrapperOfWrongTypes },
+            metadata: { unparseable, infinite, blank, unknownTag, notAWrapper, wrapperOfWrongTypes },
           },
         ],
       })
@@ -392,6 +396,7 @@ describe('BedrockKnowledgeBaseStore', () => {
       expect(entry?.metadata).toStrictEqual({
         unparseable,
         infinite,
+        blank,
         unknownTag,
         notAWrapper,
         wrapperOfWrongTypes,

--- a/strands-ts/src/vended-memory-stores/bedrock-knowledge-base/store.ts
+++ b/strands-ts/src/vended-memory-stores/bedrock-knowledge-base/store.ts
@@ -48,16 +48,10 @@ function toAttributeValue(value: JSONValue): MetadataAttributeValue | undefined 
 }
 
 /**
- * Restores a retrieved numeric metadata attribute to the number the caller stored.
- *
- * `Retrieve` types `metadata` as an untyped document, and `@aws-sdk/core` represents a document
- * number it cannot hold losslessly in a JS number as a `NumericValue`
- * `{ string: '3.0', type: 'bigDecimal' }`. Bedrock serializes NUMBER attributes with a trailing
- * fraction (a stored `3` arrives as `3.0`), which affected `@aws-sdk/core` versions wrap
- * (aws/aws-sdk-js-v3#8246); everything else arrives bare. Unwrapping to a JS number is lossless
- * because `toAttributeValue` only writes JS numbers.
- *
- * A value that is not a `NumericValue` or does not parse to a finite number is returned untouched.
+ * Restores a retrieved numeric metadata attribute to the number the caller stored. Affected
+ * `@aws-sdk/core` versions surface Bedrock NUMBER attributes as a `NumericValue` wrapper
+ * `{ string: '3.0', type: 'bigDecimal' }` (aws/aws-sdk-js-v3#8246). A value that is not a
+ * `NumericValue` or does not parse to a finite number is returned untouched.
  */
 function fromAttributeValue(value: JSONValue): JSONValue {
   if (value === null || typeof value !== 'object' || Array.isArray(value)) return value

--- a/strands-ts/src/vended-memory-stores/bedrock-knowledge-base/store.ts
+++ b/strands-ts/src/vended-memory-stores/bedrock-knowledge-base/store.ts
@@ -48,6 +48,26 @@ function toAttributeValue(value: JSONValue): MetadataAttributeValue | undefined 
 }
 
 /**
+ * Restores a retrieved numeric metadata attribute to the number the caller stored.
+ *
+ * Bedrock serializes a NUMBER attribute with a trailing fraction — a stored `3` arrives in the
+ * `Retrieve` response as `3.0` — and `Retrieve` types `metadata` as an untyped document. Because
+ * `'3.0'` does not round-trip through a JS number exactly, `@aws-sdk/core` (3.977+) preserves it
+ * as a `NumericValue` — `{ string: '3.0', type: 'bigDecimal' }` — instead of parsing it, so
+ * without this a caller who stored `{ version: 3 }` reads back an object. Strings, booleans, and
+ * numbers whose text round-trips (e.g. `2.5`) arrive bare.
+ *
+ * A value that is not a `NumericValue` or does not parse to a finite number is returned untouched.
+ */
+function fromAttributeValue(value: JSONValue): JSONValue {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return value
+  const { string: encoded, type } = value as { string?: JSONValue; type?: JSONValue }
+  if (typeof encoded !== 'string' || type !== 'bigDecimal') return value
+  const parsed = Number(encoded)
+  return Number.isFinite(parsed) ? parsed : value
+}
+
+/**
  * S3 ingestion settings for {@link BedrockKnowledgeBaseStore}, required when `dataSourceType` is `'S3'`.
  *
  * An S3 data source indexes objects from a bucket — there is no inline-text path — so `add` uploads
@@ -344,7 +364,7 @@ export class BedrockKnowledgeBaseStore implements MemoryStore {
       const metadata: Record<string, JSONValue> = {}
       if (result.metadata) {
         for (const [key, value] of Object.entries(result.metadata)) {
-          metadata[key] = value as JSONValue
+          metadata[key] = fromAttributeValue(value as JSONValue)
         }
       }
       if (result.location) {

--- a/strands-ts/src/vended-memory-stores/bedrock-knowledge-base/store.ts
+++ b/strands-ts/src/vended-memory-stores/bedrock-knowledge-base/store.ts
@@ -47,12 +47,7 @@ function toAttributeValue(value: JSONValue): MetadataAttributeValue | undefined 
   return undefined
 }
 
-/**
- * Restores a retrieved numeric metadata attribute to the number the caller stored. Affected
- * `@aws-sdk/core` versions surface Bedrock NUMBER attributes as a `NumericValue` wrapper
- * `{ string: '3.0', type: 'bigDecimal' }` (aws/aws-sdk-js-v3#8246). A value that is not a
- * `NumericValue` or does not parse to a finite number is returned untouched.
- */
+/** Unwraps the `NumericValue` wrapper (aws/aws-sdk-js-v3#8246) to the stored number; anything else passes through. */
 function fromAttributeValue(value: JSONValue): JSONValue {
   if (value === null || typeof value !== 'object' || Array.isArray(value)) return value
   const { string: encoded, type } = value as { string?: JSONValue; type?: JSONValue }

--- a/strands-ts/src/vended-memory-stores/bedrock-knowledge-base/store.ts
+++ b/strands-ts/src/vended-memory-stores/bedrock-knowledge-base/store.ts
@@ -50,12 +50,12 @@ function toAttributeValue(value: JSONValue): MetadataAttributeValue | undefined 
 /**
  * Restores a retrieved numeric metadata attribute to the number the caller stored.
  *
- * Bedrock serializes a NUMBER attribute with a trailing fraction — a stored `3` arrives in the
- * `Retrieve` response as `3.0` — and `Retrieve` types `metadata` as an untyped document. Because
- * `'3.0'` does not round-trip through a JS number exactly, `@aws-sdk/core` (3.977+) preserves it
- * as a `NumericValue` — `{ string: '3.0', type: 'bigDecimal' }` — instead of parsing it, so
- * without this a caller who stored `{ version: 3 }` reads back an object. Strings, booleans, and
- * numbers whose text round-trips (e.g. `2.5`) arrive bare.
+ * `Retrieve` types `metadata` as an untyped document, and `@aws-sdk/core` represents a document
+ * number it cannot hold losslessly in a JS number as a `NumericValue`
+ * `{ string: '3.0', type: 'bigDecimal' }`. Bedrock serializes NUMBER attributes with a trailing
+ * fraction (a stored `3` arrives as `3.0`), which affected `@aws-sdk/core` versions wrap
+ * (aws/aws-sdk-js-v3#8246); everything else arrives bare. Unwrapping to a JS number is lossless
+ * because `toAttributeValue` only writes JS numbers.
  *
  * A value that is not a `NumericValue` or does not parse to a finite number is returned untouched.
  */

--- a/strands-ts/src/vended-memory-stores/bedrock-knowledge-base/store.ts
+++ b/strands-ts/src/vended-memory-stores/bedrock-knowledge-base/store.ts
@@ -63,6 +63,8 @@ function fromAttributeValue(value: JSONValue): JSONValue {
   if (value === null || typeof value !== 'object' || Array.isArray(value)) return value
   const { string: encoded, type } = value as { string?: JSONValue; type?: JSONValue }
   if (typeof encoded !== 'string' || type !== 'bigDecimal') return value
+  // Number('') and Number('  ') are 0, which would coerce a blank payload instead of preserving it.
+  if (encoded.trim() === '') return value
   const parsed = Number(encoded)
   return Number.isFinite(parsed) ? parsed : value
 }


### PR DESCRIPTION
## Description

`BedrockKnowledgeBaseStore.search()` returns integer metadata as a wrapper object instead of the number that was stored:

```ts
await store.add('some fact', { version: 3 })
const [entry] = await store.search('some fact')

entry.metadata?.version  // { string: '3.0', type: 'bigDecimal' }, should be 3
```

The wrapper is `NumericValue` from `@smithy/core/serde`. Bedrock serializes a NUMBER attribute with a trailing fraction (a stored `3` arrives in the `Retrieve` response as `3.0`), and `@aws-sdk/core` 3.977.0 through 3.977.5 preserved any document number whose JSON text does not round-trip exactly, rather than parsing it. `Retrieve` types `metadata` as a document, so integers started arriving wrapped after #3174 floated the shared `@aws-sdk/core` from 3.975.1 to 3.977.4. Full root-cause validation, including raw wire captures and an A/B test across the two core versions, is in #3692.

AWS has confirmed the trailing-fraction wrapping as a regression, fixed it in `@aws-sdk/core` 3.977.6, and deprecated 3.977.0 through 3.977.5 (aws/aws-sdk-js-v3#8246). This unwrap is still the right store behavior rather than a temporary workaround: consumers control their own dependency trees and many will hold a deprecated core version in a lockfile for a long time, and even patched versions intentionally emit `NumericValue` for decimals that cannot be held losslessly in a JS number (verified against 3.977.6). Unwrapping is lossless for this store because `toAttributeValue` only ever writes JS numbers. Separately, bumping the repo's own `@aws-sdk/core` to 3.977.6 or later would make CI green on its own; that is a routine dependency bump and is left out of this PR.

The fix is one private helper on the read path: unwrap a parseable `NumericValue` back to the number, pass everything else through untouched. Only integers were affected, so only the number path is handled. Strings, booleans, and non-integer numbers already arrive bare, and boto3 parses the same response into plain primitives, so the Python store needs no change.

The two failing integration assertions (`toBe(3)`, `toBe(7)`) are left as is: they state the correct contract and now pass.

## Related Issues

Fixes #3692 (supersedes #3653)

## Documentation PR

No documentation changes needed.

## Type of Change

Bug fix

## Testing

- Unit: 72 passed, including 2 new tests covering the unwrap and the pass-through of unparseable and unknown shapes. Reverting the call site reproduces the exact CI assertion failure, confirming the tests catch the bug.
- Integration, against a live knowledge base replicating the CI stack (fresh S3 Vectors KB in us-east-1, CUSTOM and S3 data sources): all 13 tests in `bedrock-knowledge-base-store.test.node.ts` pass with this change; the two metadata tests fail without it with the exact CI error.
- Gates: build, type-check, eslint, prettier all clean (pre-commit runs the full suite).

- [x] I ran the pre-commit checks (build, unit tests with coverage, lint, format, type-check)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

