### PR TITLE
feat(storage-ts): accept storage as optional top-level Agent parameter

### DIFF
--- a/strands-ts/src/agent/__tests__/agent.context-manager.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.context-manager.test.ts
@@ -57,11 +57,12 @@ describe('Agent contextManager', () => {
       expect(conversationManager._compressionThreshold).toBe(0.85)
     })
 
-    it('adds ContextOffloader plugin with benchmark defaults', () => {
+    it('adds ContextOffloader plugin with benchmark defaults', async () => {
       const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'hi' })
       const agent = new Agent({ model, contextManager: 'auto' })
-      const pending = getPending(agent)
-      const offloader = pending.find((p: any) => p.name === 'strands:context-offloader') as any
+      await agent.invoke('hi')
+      const plugins = internals(agent)._pluginRegistry._plugins
+      const offloader = plugins.get('strands:context-offloader') as any
       expect(offloader).toBeDefined()
       expect(offloader._maxResultTokens).toBe(1500)
       expect(offloader._previewTokens).toBe(750)

--- a/strands-ts/src/agent/__tests__/agent.storage.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.storage.test.ts
@@ -90,9 +90,7 @@ describe('Agent storage', () => {
       const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'hi' })
       const sessionManager = new SessionManager({ sessionId: 'test-session' })
       const agent = new Agent({ model, sessionManager })
-      await expect(agent.invoke('hi')).rejects.toThrow(
-        'SessionManager requires a storage backend'
-      )
+      await expect(agent.invoke('hi')).rejects.toThrow('SessionManager requires a storage backend')
     })
   })
 

--- a/strands-ts/src/agent/__tests__/agent.storage.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.storage.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import { Agent } from '../agent.js'
+import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
+import { InMemoryStorage } from '../../storage/in-memory-storage.js'
+import { NAMESPACED } from '../../storage/storage.js'
+import { ContextOffloader } from '../../vended-plugins/context-offloader/plugin.js'
+import { SessionManager } from '../../session/session-manager.js'
+
+function internals(agent: Agent): any {
+  return agent as any
+}
+
+describe('Agent storage', () => {
+  describe('agent-level storage flows to ContextOffloader', () => {
+    it('auto-created offloader uses agent storage when provided', async () => {
+      const storage = new InMemoryStorage()
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'hi' })
+      const agent = new Agent({ model, contextManager: 'auto', storage })
+      await agent.invoke('hi')
+      const plugins = internals(agent)._pluginRegistry._plugins
+      const offloader = plugins.get('strands:context-offloader') as any
+      expect(offloader._storage).toBeDefined()
+      expect(NAMESPACED in offloader._storage).toBe(true)
+
+      await offloader._storage.write('test-key', new TextEncoder().encode('test-value'))
+      const stored = await storage.read('offloader/test-key')
+      expect(stored).not.toBeNull()
+      expect(new TextDecoder().decode(stored!)).toBe('test-value')
+    })
+
+    it('auto-created offloader falls back to InMemoryStorage when no agent storage', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'hi' })
+      const agent = new Agent({ model, contextManager: 'auto' })
+      await agent.invoke('hi')
+      const plugins = internals(agent)._pluginRegistry._plugins
+      const offloader = plugins.get('strands:context-offloader') as any
+      expect(offloader._storage).toBeDefined()
+      expect(NAMESPACED in offloader._storage).toBe(true)
+    })
+
+    it('explicit offloader storage overrides agent storage', async () => {
+      const agentStorage = new InMemoryStorage()
+      const offloaderStorage = new InMemoryStorage()
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'hi' })
+      const agent = new Agent({
+        model,
+        storage: agentStorage,
+        plugins: [new ContextOffloader({ storage: offloaderStorage, maxResultTokens: 1500, previewTokens: 750 })],
+        contextManager: 'auto',
+      })
+      await agent.invoke('hi')
+      const plugins = internals(agent)._pluginRegistry._plugins
+      const offloader = plugins.get('strands:context-offloader') as any
+
+      await offloader._storage.write('test-key', new TextEncoder().encode('test-value'))
+      const inOffloader = await offloaderStorage.read('offloader/test-key')
+      expect(inOffloader).not.toBeNull()
+      const inAgent = await agentStorage.read('offloader/test-key')
+      expect(inAgent).toBeNull()
+    })
+  })
+
+  describe('agent-level storage flows to SessionManager', () => {
+    it('session manager resolves storage from agent when not explicitly provided', async () => {
+      const storage = new InMemoryStorage()
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'hi' })
+      const sessionManager = new SessionManager({ sessionId: 'test-session' })
+      const agent = new Agent({ model, storage, sessionManager })
+      await agent.invoke('hi')
+
+      const keys = await storage.list('session/')
+      expect(keys.length).toBeGreaterThan(0)
+    })
+
+    it('explicit session manager storage overrides agent storage', async () => {
+      const agentStorage = new InMemoryStorage()
+      const sessionStorage = new InMemoryStorage()
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'hi' })
+      const sessionManager = new SessionManager({ sessionId: 'test-session', storage: sessionStorage })
+      const agent = new Agent({ model, storage: agentStorage, sessionManager })
+      await agent.invoke('hi')
+
+      const sessionKeys = await sessionStorage.list('session/')
+      expect(sessionKeys.length).toBeGreaterThan(0)
+      const agentKeys = await agentStorage.list('session/')
+      expect(agentKeys.length).toBe(0)
+    })
+
+    it('throws when session manager has no storage and agent has no storage', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'hi' })
+      const sessionManager = new SessionManager({ sessionId: 'test-session' })
+      const agent = new Agent({ model, sessionManager })
+      await expect(agent.invoke('hi')).rejects.toThrow(
+        'SessionManager requires a storage backend'
+      )
+    })
+  })
+
+  describe('agent.storage property', () => {
+    it('returns the configured storage', () => {
+      const storage = new InMemoryStorage()
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'hi' })
+      const agent = new Agent({ model, storage })
+      expect(agent.storage).toBe(storage)
+    })
+
+    it('returns undefined when no storage configured', () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'hi' })
+      const agent = new Agent({ model })
+      expect(agent.storage).toBeUndefined()
+    })
+  })
+})

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -48,7 +48,7 @@ import { NullConversationManager } from '../conversation-manager/null-conversati
 import { ConversationManager } from '../conversation-manager/conversation-manager.js'
 import { ContextOffloader } from '../vended-plugins/context-offloader/plugin.js'
 import { AgentDelegation } from './agent-delegation.js'
-import { InMemoryStorage } from '../storage/in-memory-storage.js'
+import type { Storage } from '../storage/storage.js'
 import { HookRegistryImplementation } from '../hooks/registry.js'
 import { createMiddlewareInterrupt } from '../middleware/interrupt.js'
 import { MiddlewareRegistry, InvokeModelStage, AgentStreamStage } from '../middleware/index.js'
@@ -231,9 +231,9 @@ export type AgentConfig = {
    * If `conversationManager` is also provided, the user's conversation manager is used instead.
    * Defaults to undefined (SlidingWindowConversationManager, no offloader).
    *
-   * @remarks The offloader uses in-memory storage that does not persist across process
-   * restarts. For agents using `sessionManager`, provide an explicit `ContextOffloader`
-   * with durable storage via the `plugins` parameter.
+   * @remarks The offloader uses in-memory storage by default. When an agent-level
+   * `storage` is provided, the offloader uses that instead. Alternatively, provide
+   * an explicit `ContextOffloader` with its own storage via the `plugins` parameter.
    */
   contextManager?: ContextManagerStrategy
   /**
@@ -322,6 +322,16 @@ export type AgentConfig = {
    * default changes.
    */
   sandbox?: Sandbox | false
+  /**
+   * Default storage backend for agent subsystems.
+   *
+   * When provided, subsystems that do not have their own explicit storage
+   * (e.g., SessionManager, ContextOffloader) resolve from this value. Each
+   * subsystem auto-namespaces under its own prefix (`session/`, `offloader/`)
+   * to avoid key collisions. Storage specified directly on a subsystem always
+   * takes precedence over this agent-level default.
+   */
+  storage?: Storage
 }
 
 /**
@@ -450,6 +460,11 @@ export class Agent implements LocalAgent, InvokableAgent {
    */
   public readonly memoryManager?: MemoryManager | undefined
 
+  /**
+   * Default storage backend for agent subsystems.
+   */
+  public readonly storage?: Storage | undefined
+
   private readonly _sandbox: Sandbox | false | undefined
 
   /**
@@ -500,6 +515,7 @@ export class Agent implements LocalAgent, InvokableAgent {
     this.id = config?.id ?? DEFAULT_AGENT_ID
     if (config?.description !== undefined) this.description = config.description
     this.sessionManager = config?.sessionManager
+    this.storage = config?.storage
     this.memoryManager =
       config?.memoryManager instanceof MemoryManager
         ? config.memoryManager
@@ -579,7 +595,6 @@ export class Agent implements LocalAgent, InvokableAgent {
       ...((config?.contextManager === 'auto' || config?.contextManager === 'agentic') && !hasOffloader
         ? [
             new ContextOffloader({
-              storage: new InMemoryStorage(),
               maxResultTokens:
                 config?.contextManager === 'agentic'
                   ? AGENTIC_CONTEXT_MANAGER_MAX_RESULT_TOKENS

--- a/strands-ts/src/session/session-manager.ts
+++ b/strands-ts/src/session/session-manager.ts
@@ -63,8 +63,11 @@ export interface SessionManagerConfig {
    * Accepts either:
    * - A unified {@link Storage} instance (recommended) — wrapped internally with {@link SnapshotStorageAdapter}
    * - A legacy `{ snapshot: SnapshotStorage }` object
+   *
+   * When omitted, resolves from the agent-level `storage` during initialization.
+   * If no agent-level storage is available either, an error is thrown.
    */
-  storage: Storage | { snapshot: SnapshotStorage }
+  storage?: Storage | { snapshot: SnapshotStorage }
   /** Unique session identifier. Defaults to `'default-session'`. */
   sessionId?: string
   /** When to save snapshot_latest. Default: `'invocation'` (after each agent invocation completes). See {@link SaveLatestStrategy} for details. */
@@ -99,7 +102,8 @@ export interface SessionManagerConfig {
  */
 export class SessionManager implements Plugin, MultiAgentPlugin {
   private readonly _sessionId: string
-  private readonly _storage: { snapshot: SnapshotStorage }
+  private _storage!: { snapshot: SnapshotStorage }
+  private readonly _configStorage?: Storage | { snapshot: SnapshotStorage } | undefined
   private readonly _saveLatestOn: SaveLatestStrategy
   private readonly _snapshotTrigger?: SnapshotTriggerCallback | undefined
   private readonly _multiAgentSaveLatestOn: MultiAgentSaveLatestStrategy
@@ -114,7 +118,10 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
 
   constructor(config: SessionManagerConfig) {
     this._sessionId = validateIdentifier(config.sessionId ?? 'default-session')
-    this._storage = { snapshot: this._resolveSnapshotStorage(config.storage) }
+    this._configStorage = config.storage
+    if (config.storage) {
+      this._storage = { snapshot: this._resolveSnapshotStorage(config.storage) }
+    }
     this._saveLatestOn = config.saveLatestOn ?? 'invocation'
     this._multiAgentSaveLatestOn = config.multiAgentSaveLatestOn ?? 'node'
     this._snapshotTrigger = config.snapshotTrigger
@@ -132,6 +139,14 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
 
   /** Initializes the plugin by registering lifecycle hook callbacks. */
   public initAgent(agent: LocalAgent): void {
+    if (!this._configStorage) {
+      if (!agent.storage) {
+        throw new Error(
+          'SessionManager requires a storage backend. Provide storage in SessionManagerConfig or set storage on the Agent.'
+        )
+      }
+      this._storage = { snapshot: this._resolveSnapshotStorage(agent.storage) }
+    }
     agent.addHook(InitializedEvent, async (event) => {
       await this._onAgentInitialized(event)
     })
@@ -293,6 +308,11 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
 
   /** Initializes the multi-agent plugin by registering orchestrator lifecycle hooks. */
   public initMultiAgent(orchestrator: MultiAgent): void {
+    if (!this._storage) {
+      throw new Error(
+        'SessionManager requires a storage backend. Provide storage in SessionManagerConfig when using with multi-agent orchestrators.'
+      )
+    }
     orchestrator.addHook(BeforeMultiAgentInvocationEvent, async (event) => {
       await this._onBeforeMultiAgentInvocation(event)
     })

--- a/strands-ts/src/session/session-manager.ts
+++ b/strands-ts/src/session/session-manager.ts
@@ -128,6 +128,11 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
   }
 
   private get _snapshotStorage(): SnapshotStorage {
+    if (!this._storage) {
+      throw new Error(
+        'SessionManager requires a storage backend. Provide storage in SessionManagerConfig or set storage on the Agent.'
+      )
+    }
     return this._storage.snapshot
   }
 

--- a/strands-ts/src/types/agent.ts
+++ b/strands-ts/src/types/agent.ts
@@ -1,4 +1,5 @@
 import type { Sandbox } from '../sandbox/base.js'
+import type { Storage } from '../storage/storage.js'
 import type { StateStore } from '../state-store.js'
 import type { ContentBlock, ContentBlockData, Message, MessageData, StopReason, SystemPrompt } from './messages.js'
 import type { Interrupt } from '../interrupt.js'
@@ -284,6 +285,15 @@ export interface LocalAgent {
    * environment (e.g. browsers, where no host default is registered).
    */
   readonly sandbox: Sandbox
+
+  /**
+   * Default storage backend for agent subsystems.
+   *
+   * When set, subsystems that do not have their own explicit storage (e.g.,
+   * SessionManager, ContextOffloader) resolve from this. Each subsystem
+   * auto-namespaces under its own prefix to avoid key collisions.
+   */
+  readonly storage?: Storage | undefined
 
   /**
    * Aggregated metrics for the agent's loop execution.

--- a/strands-ts/src/vended-memory-stores/test-memory-store/store.ts
+++ b/strands-ts/src/vended-memory-stores/test-memory-store/store.ts
@@ -102,8 +102,10 @@ function tokenOverlapScore(queryTokens: Set<string>, content: string): number {
  * Each {@link add} rewrites the whole file, so this fits modest volumes, not fit for high volume
  * production workloads. Use a managed store like {@link BedrockKnowledgeBaseStore} for that.
  *
- * Persistence is backed by the unified `Storage` interface: `persist: true` (the default) uses a
- * `LocalFileStorage`, `persist: false` an ephemeral `InMemoryStorage`.
+ * Persistence is backed by the unified `Storage` interface internally: `persist: true` (the default)
+ * uses a `LocalFileStorage`, `persist: false` an ephemeral `InMemoryStorage`. Unlike other
+ * subsystems (SessionManager, ContextOffloader), this store does not accept an external `Storage`
+ * or resolve from the agent-level `storage` — it manages its own backend via `persist` and `path`.
  *
  * The on-disk format is shared with the Python SDK's `TestMemoryStore`: records use the same
  * camelCase keys (`id`, `content`, `metadata`, `createdAt`) and the same timestamp shape, so a

--- a/strands-ts/src/vended-plugins/context-offloader/plugin.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/plugin.ts
@@ -13,6 +13,7 @@ import { logger } from '../../logging/logger.js'
 import type { JSONValue } from '../../types/json.js'
 import { FileStorage, InMemoryStorage as LegacyInMemoryStorage, type Storage as OffloaderStorage } from './storage.js'
 import { NAMESPACED, namespace, type Storage } from '../../storage/storage.js'
+import { InMemoryStorage } from '../../storage/in-memory-storage.js'
 import { isSearchableContent, searchContent } from './search.js'
 import { AgentAsTool } from '../../agent/agent-as-tool.js'
 
@@ -163,8 +164,11 @@ export interface ContextOffloaderConfig {
    * unless the storage is already namespaced. If the resolved storage exposes a
    * `forSandbox(sandbox)` method (as `LocalFileStorage` and its namespace views do),
    * the plugin auto-routes I/O through the agent's sandbox.
+   *
+   * When omitted, resolves from the agent-level `storage` during initialization.
+   * If no agent-level storage is available either, falls back to in-memory storage.
    */
-  storage: Storage | OffloaderStorage
+  storage?: Storage | OffloaderStorage
   /** Token threshold above which tool results are offloaded. Defaults to 2,500. */
   maxResultTokens?: number
   /** Number of tokens to keep as an inline preview. Defaults to 1,000. */
@@ -209,8 +213,8 @@ export class ContextOffloader implements Plugin {
 
   private static readonly _DEFAULT_EVICT_AFTER_CYCLES = 20
 
-  private readonly _sandboxableStorage: { forSandbox(sandbox: Sandbox): Storage } | undefined
-  private readonly _storage: Storage | OffloaderStorage
+  private _sandboxableStorage: { forSandbox(sandbox: Sandbox): Storage } | undefined
+  private _storage!: Storage | OffloaderStorage
   private readonly _maxResultTokens: number
   private readonly _previewTokens: number
   private readonly _includeRetrievalTool: boolean
@@ -233,26 +237,35 @@ export class ContextOffloader implements Plugin {
       throw new Error('evictAfterCycles must be a positive integer')
     }
 
-    if (isOffloaderStorage(config.storage)) {
-      this._storage = config.storage
-    } else if (NAMESPACED in config.storage) {
-      this._storage = config.storage
-    } else if (config.storage.namespace) {
-      this._storage = config.storage.namespace('offloader')
-    } else {
-      this._storage = namespace(config.storage, 'offloader')
+    if (config.storage) {
+      this._resolveAndSetStorage(config.storage)
     }
-    this._sandboxableStorage =
-      !isOffloaderStorage(this._storage) && 'forSandbox' in this._storage
-        ? (this._storage as { forSandbox(sandbox: Sandbox): Storage })
-        : undefined
     this._maxResultTokens = maxResultTokens
     this._previewTokens = previewTokens
     this._includeRetrievalTool = config.includeRetrievalTool ?? true
     this._evictAfterCycles = evictAfterCycles
   }
 
+  private _resolveAndSetStorage(storage: Storage | OffloaderStorage): void {
+    if (isOffloaderStorage(storage)) {
+      this._storage = storage
+    } else if (NAMESPACED in storage) {
+      this._storage = storage
+    } else if (storage.namespace) {
+      this._storage = storage.namespace('offloader')
+    } else {
+      this._storage = namespace(storage, 'offloader')
+    }
+    this._sandboxableStorage =
+      !isOffloaderStorage(this._storage) && 'forSandbox' in this._storage
+        ? (this._storage as { forSandbox(sandbox: Sandbox): Storage })
+        : undefined
+  }
+
   initAgent(agent: LocalAgent): void {
+    if (!this._storage) {
+      this._resolveAndSetStorage(agent.storage ?? new InMemoryStorage())
+    }
     if (this._storage instanceof LegacyInMemoryStorage) {
       this._storage._bind(agent, this._evictAfterCycles)
     }


### PR DESCRIPTION
## Description

Adds an optional `storage` parameter to the Agent. Subsystems without their own explicit storage resolve from it during `initAgent`. Each subsystem namespaces under its own prefix (`session/`, `offloader/`) to avoid key collisions. Explicit storage on a subsystem always wins.

Non-breaking: `storage` on SessionManager and ContextOffloader becomes optional with the same defaults as before (InMemoryStorage for offloader, throws for SessionManager if no backend available).

## Related Issues

## Documentation PR

## Type of Change

New feature

## Testing

- [x] `npm run type-check && npm test` passes
- [x] 8 new unit tests covering resolution order, fallback, override, and error cases

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.