### PR TITLE
fix(catalog): point strands-stigmer docsUrl at stigmer.network

### DIFF
--- a/site/src/content/catalog/strands-stigmer.yaml
+++ b/site/src/content/catalog/strands-stigmer.yaml
@@ -5,5 +5,5 @@ languages:
   python:
     package: strands-stigmer
 github: https://github.com/LNSHRIVAS/stigmer
-docsUrl: https://github.com/LNSHRIVAS/stigmer/tree/master/strands-stigmer
+docsUrl: https://stigmer.network
 addedDate: 2026-08-05

--- a/site/src/content/catalog/strands-stigmer.yaml
+++ b/site/src/content/catalog/strands-stigmer.yaml
@@ -5,5 +5,5 @@ languages:
   python:
     package: strands-stigmer
 github: https://github.com/LNSHRIVAS/stigmer
-docsUrl: https://stigmer.network
+docsUrl: https://stigmer.network/strands-stigmer/
 addedDate: 2026-08-05


### PR DESCRIPTION
Small follow-up to #3636. The reviewer flagged that the merged \docsUrl\ is pinned to \/tree/master/...\, which breaks if the default branch is ever renamed. Pointing it at \https://stigmer.network\ instead is more durable and is the canonical docs home.

\\\yaml
-docsUrl: https://github.com/LNSHRIVAS/stigmer/tree/master/strands-stigmer
+docsUrl: https://stigmer.network
\\\
