### PR TITLE
fix(agent): resume nested agent-as-tool interrupts across rehydration

### DIFF
--- a/site/src/content/docs/user-guide/concepts/interrupts.mdx
+++ b/site/src/content/docs/user-guide/concepts/interrupts.mdx
@@ -481,10 +481,7 @@ Interrupts are supported in multi-agent patterns, enabling human-in-the-loop wor
 
 ### Agents as Tools
 
-An agent exposed as a tool with [Agents as Tools](./multi-agent/agents-as-tools.md) propagates its interrupts up to the orchestrator, so the orchestrator's caller sees them and answers them like any other interrupt. Two things are worth knowing:
-
-- **Interrupt ids are namespaced by the tool call.** A sub-agent's interrupt arrives with an id derived from the orchestrator's tool call, so two sub-agents interrupting in the same turn stay distinct. Treat the id as opaque: pass it back unchanged to resume, and use `name` and `reason` for anything you show a human.
-- **Where the interrupted turn is kept depends on `preserve_context`.** With the default `preserve_context=False` the orchestrator carries the sub-agent's interrupted turn, so the resume survives the orchestrator and sub-agent being rebuilt from storage. With `preserve_context=True` the sub-agent owns its own state and needs its own session manager for the resume to survive a restart.
+An agent exposed as a tool with [Agents as Tools](./multi-agent/agents-as-tools.md) propagates its interrupts up to the orchestrator, so the orchestrator's caller sees them and answers them like any other interrupt. A sub-agent's interrupt arrives with an id scoped to the orchestrator's tool call, which keeps two sub-agents interrupting in the same turn distinct. Treat the id as opaque: pass it back unchanged to resume, and use `name` and `reason` for anything you show a human.
 
 ### Swarm
 

--- a/site/src/content/docs/user-guide/concepts/interrupts.mdx
+++ b/site/src/content/docs/user-guide/concepts/interrupts.mdx
@@ -479,6 +479,13 @@ To collect additional information from a user during an MCP tool call, use elici
 
 Interrupts are supported in multi-agent patterns, enabling human-in-the-loop workflows across agent orchestration systems. The interfaces mirror those used for single-agent interrupts. You can raise interrupts from `BeforeNodeCallEvent` hooks executed before each node or from within the nodes themselves. Session management is also supported, allowing you to persist and resume your interrupted multi-agents.
 
+### Agents as Tools
+
+An agent exposed as a tool with [Agents as Tools](./multi-agent/agents-as-tools.md) propagates its interrupts up to the orchestrator, so the orchestrator's caller sees them and answers them like any other interrupt. Two things are worth knowing:
+
+- **Interrupt ids are namespaced by the tool call.** A sub-agent's interrupt arrives with an id derived from the orchestrator's tool call, so two sub-agents interrupting in the same turn stay distinct. Treat the id as opaque: pass it back unchanged to resume, and use `name` and `reason` for anything you show a human.
+- **Where the interrupted turn is kept depends on `preserve_context`.** With the default `preserve_context=False` the orchestrator carries the sub-agent's interrupted turn, so the resume survives the orchestrator and sub-agent being rebuilt from storage. With `preserve_context=True` the sub-agent owns its own state and needs its own session manager for the resume to survive a restart.
+
 ### Swarm
 
 A [Swarm](./multi-agent/swarm.md) is a collaborative agent orchestration system where multiple agents work together as a team to solve complex tasks. The following example demonstrates interrupting your swarm invocation through a `BeforeNodeCallEvent` hook.

--- a/site/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.mdx
@@ -154,6 +154,8 @@ orchestrator = Agent(
 </Tab>
 </Tabs>
 
+Interrupts raised inside a sub-agent resume automatically, but where the interrupted turn is kept depends on this setting. With the default <Syntax py="preserve_context=False" ts="preserveContext: false" />, the orchestrator carries the sub-agent's interrupted turn, so a resume works even when every agent is rebuilt from storage on the next request. With <Syntax py="preserve_context=True" ts="preserveContext: true" /> the sub-agent owns its own state: give it its own session manager if the resume has to survive a restart, otherwise the interrupt can only be resumed by the same process that raised it.
+
 ### Creating Custom Agent Tools
 
 For more control over how the agent is invoked — such as custom pre/post-processing, error handling, or passing multiple parameters — you can create a custom tool that wraps an agent:

--- a/site/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agents-as-tools.mdx
@@ -154,7 +154,9 @@ orchestrator = Agent(
 </Tab>
 </Tabs>
 
-Interrupts raised inside a sub-agent resume automatically, but where the interrupted turn is kept depends on this setting. With the default <Syntax py="preserve_context=False" ts="preserveContext: false" />, the orchestrator carries the sub-agent's interrupted turn, so a resume works even when every agent is rebuilt from storage on the next request. With <Syntax py="preserve_context=True" ts="preserveContext: true" /> the sub-agent owns its own state: give it its own session manager if the resume has to survive a restart, otherwise the interrupt can only be resumed by the same process that raised it.
+#### Advanced: Interrupts and Session State
+
+[Interrupts](../interrupts.md) raised inside a sub-agent resume automatically, and this setting decides who keeps the interrupted turn while it waits. With the default <Syntax py="preserve_context=False" ts="preserveContext: false" /> the orchestrator keeps it, so a resume works even when every agent is rebuilt from storage on the next request. With <Syntax py="preserve_context=True" ts="preserveContext: true" /> the sub-agent owns its own state: give it its own session manager if the resume has to survive a restart, otherwise the interrupt can only be resumed by the process that raised it.
 
 ### Creating Custom Agent Tools
 

--- a/strands-py/src/strands/agent/_agent_as_tool.py
+++ b/strands-py/src/strands/agent/_agent_as_tool.py
@@ -9,17 +9,17 @@ from __future__ import annotations
 import copy
 import logging
 import threading
-from collections.abc import Collection
 from typing import TYPE_CHECKING, Any
 from urllib.parse import quote
 
 from typing_extensions import override
 
 from ..agent.state import AgentState
-from ..interrupt import Interrupt
+from ..interrupt import Interrupt, _InterruptState
 from ..types._events import AgentAsToolStreamEvent, ToolInterruptEvent, ToolResultEvent
 from ..types._snapshot import Snapshot
 from ..types.content import Messages
+from ..types.exceptions import SnapshotException
 from ..types.interrupt import InterruptResponseContent
 from ..types.tools import AgentTool, ToolGenerator, ToolSpec, ToolUse
 
@@ -28,94 +28,40 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_PARKED_TURNS_KEY = "sub_agent_continuations"
-"""Key under which an orchestrator's interrupt context holds interrupted sub-agent turns, keyed by tool use id."""
+_INTERRUPTED_TURNS_KEY = "sub_agent_interrupted_turns"
+"""Key under which an orchestrator's interrupt context holds interrupted sub-agent turns, keyed by tool use ID."""
 
 _NAMESPACE_TAG = "v1:agent_as_tool:"
-"""Reserved marker opening every namespaced sub-agent interrupt id.
+"""Reserved marker opening every namespaced sub-agent interrupt ID.
 
 Written by the SDK and never derived from model output, so a namespace prefix cannot collide with an
-interrupt id the SDK generates itself - all of which open with the ``v1:`` scheme marker.
+interrupt ID the SDK generates itself - all of which open with the ``v1:`` scheme marker.
 """
-
-
-def _namespace_prefix(tool_use_id: str) -> str:
-    """Build the prefix that namespaces a sub-agent interrupt id to one agent-as-tool call.
-
-    Two sub-agents invoked in the same turn can raise the same interrupt id, because each derives it
-    from its own tool use id. The prefix keeps them distinct in the orchestrator's interrupt record and
-    keeps the sub-agent-local id recoverable by stripping it back off.
-
-    Tool use ids and interrupt ids are both model-derived, so the prefix defends against both ways one
-    call's prefix can match another id: the tool use id is percent-encoded, because otherwise one
-    containing the separator matches another call's ids, and the prefix opens with a reserved marker,
-    because otherwise a tool use id of ``v1`` matches every interrupt the orchestrator raised itself.
-
-    Args:
-        tool_use_id: Tool use ID of the agent-as-tool call.
-
-    Returns:
-        Prefix, separator included, for interrupt IDs belonging to that call.
-    """
-    return f"{_NAMESPACE_TAG}{quote(tool_use_id, safe='')}:"
-
-
-def _namespace_interrupts(tool_use_id: str, interrupts: list[Interrupt]) -> list[Interrupt]:
-    """Copy sub-agent interrupts with their ids namespaced to one agent-as-tool call.
-
-    Only the id changes: ``name`` and ``reason`` are what a human or an approval UI reads, so they are
-    passed through untouched.
-
-    Args:
-        tool_use_id: Tool use ID of the agent-as-tool call.
-        interrupts: Interrupts raised inside the sub-agent.
-
-    Returns:
-        Orchestrator-visible copies carrying namespaced ids.
-    """
-    prefix = _namespace_prefix(tool_use_id)
-    return [
-        Interrupt(id=f"{prefix}{interrupt.id}", name=interrupt.name, reason=interrupt.reason)
-        for interrupt in interrupts
-    ]
-
-
-def _parked_turn_interrupt_ids(turn: dict[str, Any]) -> set[str]:
-    """Get the sub-agent-local ids of the interrupts a parked turn is still waiting on.
-
-    Args:
-        turn: Serialized snapshot of an interrupted sub-agent turn.
-
-    Returns:
-        Interrupt IDs the sub-agent will raise again when the turn is reinstated.
-    """
-    interrupt_state: dict[str, Any] = (turn.get("data") or {}).get("interrupt_state") or {}
-    interrupts: dict[str, Any] = interrupt_state.get("interrupts") or {}
-    return set(interrupts)
 
 
 class _ParentCall:
     """The orchestrator's record of one agent-as-tool call.
 
-    Binds the orchestrator running a call to that call's interrupt id namespace, so propagation and
-    resume both read and write the orchestrator's persisted interrupt state in terms of *this* call:
-    the interrupts it has pending, the answers addressed to it, and the sub-agent turn it parked.
+    An interrupt raised inside a sub-agent has to reach the orchestrator's caller, and the human's
+    response has to travel back down - across a boundary where either agent may have been rebuilt from
+    storage, so the two no longer share an in-memory ``Interrupt``. Both directions therefore go through
+    the orchestrator's own persisted interrupt state, and everything here is scoped to one tool call
+    within it: the interrupts that call has pending, the responses addressed to it, and the interrupted
+    sub-agent turn stored for it.
+
+    Interrupt IDs are namespaced with a prefix derived from the tool use ID, because two sub-agents
+    invoked in the same turn can raise the same ID - each derives it from its own tool use ID. Both are
+    model-derived, so the prefix guards against either one matching another call's IDs: the tool use ID
+    is percent-encoded, or one containing the separator would match, and the prefix opens with a
+    reserved marker, or a tool use ID of ``v1`` would match every interrupt the orchestrator itself
+    raised.
     """
 
     def __init__(self, parent: Agent, tool_use_id: str) -> None:
         """Bind to an orchestrator and one of its tool calls."""
         self._parent = parent
         self._tool_use_id = tool_use_id
-        self._prefix = _namespace_prefix(tool_use_id)
-
-    @classmethod
-    def resolve(cls, invocation_state: dict[str, Any], tool_use_id: str) -> _ParentCall | None:
-        """Bind to the orchestrator running this tool call, if the invocation state carries one.
-
-        A tool invoked directly rather than by an agent has no orchestrator, and cannot interrupt.
-        """
-        parent: Agent | None = invocation_state.get("agent")
-        return cls(parent, tool_use_id) if parent is not None else None
+        self._prefix = f"{_NAMESPACE_TAG}{quote(tool_use_id, safe='')}:"
 
     @property
     def tool_use_id(self) -> str:
@@ -123,42 +69,58 @@ class _ParentCall:
         return self._tool_use_id
 
     @property
-    def awaiting_resume(self) -> bool:
-        """Whether the orchestrator is parked on an interrupt raised by this call.
+    def is_resuming(self) -> bool:
+        """Whether the orchestrator is holding an interrupt raised by this call.
 
         Keyed on the orchestrator rather than on the sub-agent, so a sub-agent shared with another
-        caller cannot adopt a pending turn belonging to someone else.
+        caller cannot adopt an interrupted turn belonging to someone else.
         """
         if not self._parent._interrupt_state.activated:
             return False
 
         return any(interrupt_id.startswith(self._prefix) for interrupt_id in self._parent._interrupt_state.interrupts)
 
-    def pending_interrupts(self, local_ids: Collection[str] | None = None) -> list[Interrupt]:
-        """Get the namespaced interrupts the orchestrator holds for this call.
+    def namespace(self, interrupts: list[Interrupt]) -> list[Interrupt]:
+        """Copy sub-agent interrupts with their IDs namespaced to this call.
+
+        Only the ID changes: ``name`` and ``reason`` are what a human or an approval UI reads.
 
         Args:
-            local_ids: Restrict the result to interrupts whose sub-agent-local id is in this
-                collection. The orchestrator keeps every id it has been handed until its own turn
-                ends, including ones the sub-agent has since finished with, so a caller that wants
-                the interrupts the sub-agent is actually still waiting on has to say which those are.
+            interrupts: Interrupts raised inside the sub-agent.
 
         Returns:
-            Interrupts the orchestrator holds for this call, in the order it recorded them.
+            Orchestrator-visible copies carrying namespaced IDs.
         """
+        return [
+            Interrupt(id=f"{self._prefix}{interrupt.id}", name=interrupt.name, reason=interrupt.reason)
+            for interrupt in interrupts
+        ]
+
+    def pending_interrupts(self) -> list[Interrupt]:
+        """Get the interrupts this call's stored turn is still waiting on.
+
+        The orchestrator keeps every ID it has been handed until its own turn ends, including ones the
+        sub-agent has since finished with, so the stored turn decides which are still live. Empty when
+        no turn is stored, because then there is nothing to raise again.
+
+        Returns:
+            Interrupts that have to outlive a failed restore.
+        """
+        turn = self.interrupted_turn() or {}
+        interrupt_state: dict[str, Any] = (turn.get("data") or {}).get("interrupt_state") or {}
+        awaited_ids = set(interrupt_state.get("interrupts") or {})
         return [
             interrupt
             for interrupt_id, interrupt in self._parent._interrupt_state.interrupts.items()
-            if interrupt_id.startswith(self._prefix)
-            and (local_ids is None or interrupt_id[len(self._prefix) :] in local_ids)
+            if interrupt_id.startswith(self._prefix) and interrupt_id[len(self._prefix) :] in awaited_ids
         ]
 
     def responses(self) -> list[InterruptResponseContent]:
-        """Map the answers addressed to this call back to sub-agent-local interrupt ids.
+        """Map the responses addressed to this call back to sub-agent-local interrupt IDs.
 
-        The orchestrator persists the human's answers as data, so this survives a rehydration boundary
+        The orchestrator persists the human's responses as data, so this survives a rehydration boundary
         where orchestrator and sub-agent no longer share an in-memory ``Interrupt``. An empty list means
-        no answer belongs to this call, and the sub-agent re-raises its interrupt and stays pending.
+        no response belongs to this call, and the sub-agent re-raises its interrupt and stays pending.
 
         Returns:
             Interrupt response content blocks addressed to the sub-agent.
@@ -178,21 +140,21 @@ class _ParentCall:
 
         return responses
 
-    def parked_turn(self) -> dict[str, Any] | None:
-        """Get the interrupted sub-agent turn parked for this call, if there is one."""
-        parked: dict[str, Any] = self._parent._interrupt_state.context.get(_PARKED_TURNS_KEY) or {}
-        turn: dict[str, Any] | None = parked.get(self._tool_use_id)
+    def interrupted_turn(self) -> dict[str, Any] | None:
+        """Get the interrupted sub-agent turn stored for this call, if there is one."""
+        stored: dict[str, Any] = self._parent._interrupt_state.context.get(_INTERRUPTED_TURNS_KEY) or {}
+        turn: dict[str, Any] | None = stored.get(self._tool_use_id)
         return turn
 
-    def park_turn(self, turn: dict[str, Any]) -> None:
-        """Park an interrupted sub-agent turn on the orchestrator's own interrupt record."""
-        parked: dict[str, Any] = self._parent._interrupt_state.context.setdefault(_PARKED_TURNS_KEY, {})
-        parked[self._tool_use_id] = turn
+    def store_interrupted_turn(self, turn: dict[str, Any]) -> None:
+        """Store an interrupted sub-agent turn on the orchestrator's own interrupt record."""
+        stored: dict[str, Any] = self._parent._interrupt_state.context.setdefault(_INTERRUPTED_TURNS_KEY, {})
+        stored[self._tool_use_id] = turn
 
-    def drop_parked_turn(self) -> None:
-        """Free the parked turn once it has been reinstated."""
-        parked: dict[str, Any] = self._parent._interrupt_state.context.get(_PARKED_TURNS_KEY) or {}
-        parked.pop(self._tool_use_id, None)
+    def clear_interrupted_turn(self) -> None:
+        """Free the stored turn once it has been restored."""
+        stored: dict[str, Any] = self._parent._interrupt_state.context.get(_INTERRUPTED_TURNS_KEY) or {}
+        stored.pop(self._tool_use_id, None)
 
 
 class _AgentAsTool(AgentTool):
@@ -338,7 +300,9 @@ class _AgentAsTool(AgentTool):
             prompt = str(tool_input)
 
         tool_use_id = tool_use["toolUseId"]
-        parent_call = _ParentCall.resolve(invocation_state, tool_use_id)
+        # A tool invoked directly rather than by an agent has no orchestrator, and cannot interrupt.
+        parent = invocation_state.get("agent")
+        parent_call = _ParentCall(parent, tool_use_id) if parent is not None else None
 
         # Serialize access to the underlying agent. _reset_agent_state() mutates
         # the agent before stream_async acquires its own lock, so a concurrent
@@ -360,30 +324,29 @@ class _AgentAsTool(AgentTool):
 
         try:
             # Determine if we are resuming the sub-agent from an interrupt.
-            if parent_call is not None and parent_call.awaiting_resume:
-                if not self._reinstate_turn(parent_call) and not self._agent._interrupt_state.activated:
-                    # Only the interrupts the parked turn is still waiting on: the orchestrator also
-                    # holds ids the sub-agent has already finished with, and handing one of those back
-                    # would send the caller to an interrupt that no longer exists on the sub-agent.
-                    parked_turn = parent_call.parked_turn()
-                    pending = (
-                        parent_call.pending_interrupts(local_ids=_parked_turn_interrupt_ids(parked_turn))
-                        if parked_turn is not None
-                        else []
-                    )
+            if parent_call is not None and parent_call.is_resuming:
+                # The interrupted turn comes from one of two places: an ephemeral sub-agent's turn is
+                # stored on the orchestrator, so restoring it reads the orchestrator's interrupt record,
+                # while a preserve_context=True sub-agent restores its own from its session manager and
+                # so arrives already activated.
+                restored = self._restore_interrupted_turn(parent_call) or self._agent._interrupt_state.activated
+
+                if not restored:
+                    pending = parent_call.pending_interrupts()
                     if pending:
-                        # The answer cannot be applied yet, but the turn is still parked, so raise the
-                        # interrupt again instead of failing the call: the orchestrator parks it once more,
+                        # The response cannot be applied yet, but the turn is still stored, so raise the
+                        # interrupt again instead of failing the call: the orchestrator holds it once more,
                         # keeping both the turn and the pending interrupt for another attempt. Failing here
                         # would end the orchestrator's turn, and the event loop clears the whole interrupt
-                        # record when a turn ends - taking the parked turn and the human's answer with it.
+                        # record when a turn ends - taking the stored turn and the response with it.
                         logger.error(
-                            "tool_name=<%s>, agent_name=<%s>, tool_use_id=<%s> | cannot apply the interrupt "
-                            "response yet, raising the interrupt again so it survives to be answered once "
-                            "more",
+                            "tool_name=<%s>, agent_name=<%s>, tool_use_id=<%s>, interrupt_ids=<%s> | the "
+                            "interrupted turn could not be restored, so the response cannot be applied yet: "
+                            "raising the interrupt again so it survives to be answered once more",
                             self._tool_name,
                             self._agent_name,
                             tool_use_id,
+                            [interrupt.id for interrupt in pending],
                         )
                         yield ToolInterruptEvent(tool_use, pending)
                         return
@@ -434,9 +397,13 @@ class _AgentAsTool(AgentTool):
 
             # Propagate sub-agent interrupts to the parent agent.
             if result.stop_reason == "interrupt" and result.interrupts:
+                # Namespacing and storing both need the orchestrator the response will come back
+                # through. A tool invoked directly has none, and cannot interrupt in the first place.
+                interrupts = list(result.interrupts)
                 if parent_call is not None:
-                    self._park_turn(parent_call)
-                yield ToolInterruptEvent(tool_use, _namespace_interrupts(tool_use_id, list(result.interrupts)))
+                    self._store_interrupted_turn(parent_call)
+                    interrupts = parent_call.namespace(interrupts)
+                yield ToolInterruptEvent(tool_use, interrupts)
                 return
 
             if result.structured_output:
@@ -476,14 +443,15 @@ class _AgentAsTool(AgentTool):
     def _reset_agent_state(self, tool_use_id: str) -> None:
         """Reset the wrapped agent to its initial state.
 
-        Restores messages and state to the values captured at construction time.
-        This mirrors the pattern used by ``GraphNode.reset_executor_state()``.
+        Restores messages, state and interrupt state to the values captured at construction time. This
+        mirrors the pattern used by ``GraphNode.reset_executor_state()``. Only reached on a fresh call,
+        so any interrupt state the agent is still carrying belongs to a turn nobody is resuming.
 
         The reset is unconditional, so exposing one ``Agent`` instance as a tool to several
-        orchestrators at once lets one orchestrator's call clear a turn another one has parked on an
-        interrupt. The parked orchestrator still resumes correctly, because it reinstates the turn
-        from its own interrupt record, but the other call fails; give each orchestrator its own
-        sub-agent instance instead of sharing one.
+        orchestrators at once lets one orchestrator's call clear a turn another one is holding an
+        interrupt for. That orchestrator still resumes correctly, because it restores the turn from its
+        own interrupt record, but give each orchestrator its own sub-agent instance rather than sharing
+        one.
 
         Args:
             tool_use_id: Tool use ID for logging context.
@@ -495,6 +463,7 @@ class _AgentAsTool(AgentTool):
         )
         self._agent.messages = copy.deepcopy(self._initial_messages)
         self._agent.state = AgentState(self._initial_state.get())
+        self._agent._interrupt_state = _InterruptState()
 
     @property
     def _agent_name(self) -> str:
@@ -513,23 +482,25 @@ class _AgentAsTool(AgentTool):
         Returns:
             Text for the failed tool result.
         """
-        if parent_call.parked_turn() is not None:
-            return (
-                f"Agent '{self._tool_name}' did NOT run and the human's response was NOT applied: its "
-                "interrupted turn failed to load. Do not report the requested action as completed or "
-                "successful. Tell the user it failed and ask them to respond again. See the logged error "
-                "for the cause."
+        if parent_call.interrupted_turn() is not None:
+            cause = "its interrupted turn failed to load. See the logged error for the cause"
+        elif self._preserve_context:
+            cause = (
+                "its interrupted turn did not survive the restart. A sub-agent used with "
+                "preserve_context=True keeps its own state, so it needs its own session manager for that "
+                "state to survive"
             )
+        else:
+            cause = "its interrupted turn is no longer available"
 
         return (
-            f"Agent '{self._tool_name}' did NOT run and the human's response was NOT applied: its "
-            "interrupted turn did not survive the restart. A sub-agent used with preserve_context=True "
-            "keeps its own state, so it needs its own session manager for that state to survive. Do not "
-            "report the requested action as completed or successful; tell the user it failed."
+            f"Agent '{self._tool_name}' did NOT run and the human's response was NOT applied: {cause}. "
+            "Do not report the requested action as completed or successful. Tell the user it failed and "
+            "ask them to respond again."
         )
 
-    def _park_turn(self, parent_call: _ParentCall) -> None:
-        """Park the sub-agent's interrupted turn on the orchestrator so a later request can reinstate it.
+    def _store_interrupted_turn(self, parent_call: _ParentCall) -> None:
+        """Store the sub-agent's interrupted turn on the orchestrator so a later request can restore it.
 
         Only for ``preserve_context=False`` sub-agents: they are ephemeral by contract and are rejected at
         construction if they have a session manager, so the orchestrator carries the turn for them and
@@ -555,40 +526,42 @@ class _AgentAsTool(AgentTool):
 
         # Copied because the snapshot carries the sub-agent's live interrupt context by reference, and the
         # sub-agent keeps being used after this.
-        parent_call.park_turn(copy.deepcopy(self._agent.take_snapshot(preset="session").to_dict()))
+        parent_call.store_interrupted_turn(copy.deepcopy(self._agent.take_snapshot(preset="session").to_dict()))
         logger.debug(
-            "tool_name=<%s>, tool_use_id=<%s> | parked interrupted sub-agent turn for resume",
+            "tool_name=<%s>, tool_use_id=<%s> | stored interrupted sub-agent turn for resume",
             self._tool_name,
             parent_call.tool_use_id,
         )
 
-    def _reinstate_turn(self, parent_call: _ParentCall) -> bool:
-        """Rebuild the sub-agent's interrupted turn from the turn the orchestrator parked.
+    def _restore_interrupted_turn(self, parent_call: _ParentCall) -> bool:
+        """Rebuild the sub-agent's interrupted turn from the turn the orchestrator stored.
 
-        The turn is freed once it loads: a sub-agent that interrupts again parks a fresh one.
+        The turn is freed once it loads: a sub-agent that interrupts again stores a fresh one.
 
         Args:
             parent_call: The orchestrator's record of this call.
 
         Returns:
-            True if the interrupted turn was reinstated onto the sub-agent.
+            True if the interrupted turn was restored onto the sub-agent.
         """
-        turn = parent_call.parked_turn()
+        turn = parent_call.interrupted_turn()
         if turn is None:
             return False
 
         try:
             self._agent.load_snapshot(Snapshot.from_dict(turn))
-        except Exception as error:
-            # Keep the parked turn: a load can fail for a reason a later attempt survives, such as a schema
-            # version the running SDK does not accept yet, and this is the only copy of the turn the human
-            # already answered. The caller re-raises the interrupt so the turn stays parked with it. A
-            # failure after the first field was applied leaves the sub-agent mismatched. It is not
-            # invoked unless it is itself still activated from an earlier turn in this process, and an
-            # ephemeral sub-agent is reset on its next fresh call.
+        except (SnapshotException, ValueError, KeyError, TypeError) as error:
+            # The ways a turn written by another build of the SDK fails to load: an unsupported schema
+            # version or scope, a state a component rejects, or a field that has since been renamed or
+            # retyped. Anything else is a bug rather than stale data, and is left to propagate.
+            #
+            # Keep the stored turn: a load can fail for a reason a later attempt survives, and this is
+            # the only copy of the turn the human already answered. The caller raises the interrupt again
+            # so the turn stays stored with it. A failure after the first field was applied leaves the
+            # sub-agent mismatched. It is not invoked unless it is itself still activated from an earlier
+            # turn in this process, and an ephemeral sub-agent is reset on its next fresh call.
             logger.error(
-                "tool_name=<%s>, agent_name=<%s>, tool_use_id=<%s> | failed to reinstate interrupted "
-                "sub-agent turn: %s",
+                "tool_name=<%s>, agent_name=<%s>, tool_use_id=<%s> | failed to restore interrupted sub-agent turn: %s",
                 self._tool_name,
                 self._agent_name,
                 parent_call.tool_use_id,
@@ -596,7 +569,7 @@ class _AgentAsTool(AgentTool):
             )
             return False
 
-        parent_call.drop_parked_turn()
+        parent_call.clear_interrupted_turn()
         return True
 
     @override

--- a/strands-py/src/strands/agent/_agent_as_tool.py
+++ b/strands-py/src/strands/agent/_agent_as_tool.py
@@ -27,8 +27,146 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_CONTINUATIONS_KEY = "sub_agent_continuations"
+_PARKED_TURNS_KEY = "sub_agent_continuations"
 """Key under which an orchestrator's interrupt context holds interrupted sub-agent turns, keyed by tool use id."""
+
+_NAMESPACE_TAG = "v1:agent_as_tool:"
+"""Reserved marker opening every namespaced sub-agent interrupt id.
+
+Written by the SDK and never derived from model output, so a namespace prefix cannot collide with an
+interrupt id the SDK generates itself - all of which open with the ``v1:`` scheme marker.
+"""
+
+
+def _namespace_prefix(tool_use_id: str) -> str:
+    """Build the prefix that namespaces a sub-agent interrupt id to one agent-as-tool call.
+
+    Two sub-agents invoked in the same turn can raise the same interrupt id, because each derives it
+    from its own tool use id. The prefix keeps them distinct in the orchestrator's interrupt record and
+    keeps the sub-agent-local id recoverable by stripping it back off.
+
+    Tool use ids and interrupt ids are both model-derived, so the prefix defends against both ways one
+    call's prefix can match another id: the tool use id is percent-encoded, because otherwise one
+    containing the separator matches another call's ids, and the prefix opens with a reserved marker,
+    because otherwise a tool use id of ``v1`` matches every interrupt the orchestrator raised itself.
+
+    Args:
+        tool_use_id: Tool use ID of the agent-as-tool call.
+
+    Returns:
+        Prefix, separator included, for interrupt IDs belonging to that call.
+    """
+    return f"{_NAMESPACE_TAG}{quote(tool_use_id, safe='')}:"
+
+
+def _namespace_interrupts(tool_use_id: str, interrupts: list[Interrupt]) -> list[Interrupt]:
+    """Copy sub-agent interrupts with their ids namespaced to one agent-as-tool call.
+
+    Only the id changes: ``name`` and ``reason`` are what a human or an approval UI reads, so they are
+    passed through untouched.
+
+    Args:
+        tool_use_id: Tool use ID of the agent-as-tool call.
+        interrupts: Interrupts raised inside the sub-agent.
+
+    Returns:
+        Orchestrator-visible copies carrying namespaced ids.
+    """
+    prefix = _namespace_prefix(tool_use_id)
+    return [
+        Interrupt(id=f"{prefix}{interrupt.id}", name=interrupt.name, reason=interrupt.reason)
+        for interrupt in interrupts
+    ]
+
+
+class _ParentCall:
+    """The orchestrator's record of one agent-as-tool call.
+
+    Binds the orchestrator running a call to that call's interrupt id namespace, so propagation and
+    resume both read and write the orchestrator's persisted interrupt state in terms of *this* call:
+    the interrupts it has pending, the answers addressed to it, and the sub-agent turn it parked.
+    """
+
+    def __init__(self, parent: Agent, tool_use_id: str) -> None:
+        """Bind to an orchestrator and one of its tool calls."""
+        self._parent = parent
+        self._tool_use_id = tool_use_id
+        self._prefix = _namespace_prefix(tool_use_id)
+
+    @classmethod
+    def resolve(cls, invocation_state: dict[str, Any], tool_use_id: str) -> _ParentCall | None:
+        """Bind to the orchestrator running this tool call, if the invocation state carries one.
+
+        A tool invoked directly rather than by an agent has no orchestrator, and cannot interrupt.
+        """
+        parent: Agent | None = invocation_state.get("agent")
+        return cls(parent, tool_use_id) if parent is not None else None
+
+    @property
+    def tool_use_id(self) -> str:
+        """Tool use ID of the call."""
+        return self._tool_use_id
+
+    @property
+    def awaiting_resume(self) -> bool:
+        """Whether the orchestrator is parked on an interrupt raised by this call.
+
+        Keyed on the orchestrator rather than on the sub-agent, so a sub-agent shared with another
+        caller cannot adopt a pending turn belonging to someone else.
+        """
+        if not self._parent._interrupt_state.activated:
+            return False
+
+        return any(interrupt_id.startswith(self._prefix) for interrupt_id in self._parent._interrupt_state.interrupts)
+
+    def pending_interrupts(self) -> list[Interrupt]:
+        """Get the namespaced interrupts the orchestrator holds for this call."""
+        return [
+            interrupt
+            for interrupt_id, interrupt in self._parent._interrupt_state.interrupts.items()
+            if interrupt_id.startswith(self._prefix)
+        ]
+
+    def responses(self) -> list[InterruptResponseContent]:
+        """Map the answers addressed to this call back to sub-agent-local interrupt ids.
+
+        The orchestrator persists the human's answers as data, so this survives a rehydration boundary
+        where orchestrator and sub-agent no longer share an in-memory ``Interrupt``. An empty list means
+        no answer belongs to this call, and the sub-agent re-raises its interrupt and stays pending.
+
+        Returns:
+            Interrupt response content blocks addressed to the sub-agent.
+        """
+        responses: list[InterruptResponseContent] = []
+        for response in self._parent._interrupt_state.context.get("responses") or []:
+            interrupt_id = response["interruptResponse"]["interruptId"]
+            if interrupt_id.startswith(self._prefix):
+                responses.append(
+                    {
+                        "interruptResponse": {
+                            "interruptId": interrupt_id[len(self._prefix) :],
+                            "response": response["interruptResponse"]["response"],
+                        }
+                    }
+                )
+
+        return responses
+
+    def parked_turn(self) -> dict[str, Any] | None:
+        """Get the interrupted sub-agent turn parked for this call, if there is one."""
+        parked: dict[str, Any] = self._parent._interrupt_state.context.get(_PARKED_TURNS_KEY) or {}
+        turn: dict[str, Any] | None = parked.get(self._tool_use_id)
+        return turn
+
+    def park_turn(self, turn: dict[str, Any]) -> None:
+        """Park an interrupted sub-agent turn on the orchestrator's own interrupt record."""
+        parked: dict[str, Any] = self._parent._interrupt_state.context.setdefault(_PARKED_TURNS_KEY, {})
+        parked[self._tool_use_id] = turn
+
+    def drop_parked_turn(self) -> None:
+        """Free the parked turn once it has been reinstated."""
+        parked: dict[str, Any] = self._parent._interrupt_state.context.get(_PARKED_TURNS_KEY) or {}
+        parked.pop(self._tool_use_id, None)
 
 
 class _AgentAsTool(AgentTool):
@@ -74,6 +212,12 @@ class _AgentAsTool(AgentTool):
                 values they had at construction time before each call, ensuring every
                 invocation starts from the same baseline regardless of any external
                 interactions with the agent. Defaults to False.
+
+                Interrupts raised inside the sub-agent resume automatically. When False, the
+                orchestrator carries the sub-agent's interrupted turn, so the resume survives a
+                process restart. When True the sub-agent owns its state: give it its own session
+                manager if the resume has to survive a restart, otherwise the interrupt resumes
+                only within the same process.
         """
         super().__init__()
         self._agent = agent
@@ -168,6 +312,7 @@ class _AgentAsTool(AgentTool):
             prompt = str(tool_input)
 
         tool_use_id = tool_use["toolUseId"]
+        parent_call = _ParentCall.resolve(invocation_state, tool_use_id)
 
         # Serialize access to the underlying agent. _reset_agent_state() mutates
         # the agent before stream_async acquires its own lock, so a concurrent
@@ -189,25 +334,43 @@ class _AgentAsTool(AgentTool):
 
         try:
             # Determine if we are resuming the sub-agent from an interrupt.
-            if self._parent_awaiting_resume(invocation_state, tool_use_id):
-                restored = self._restore_continuation(invocation_state, tool_use_id)
-                if not restored and not self._is_sub_agent_interrupted():
+            if parent_call is not None and parent_call.awaiting_resume:
+                if not self._reinstate_turn(parent_call) and not self._agent._interrupt_state.activated:
+                    pending = parent_call.pending_interrupts()
+                    if parent_call.parked_turn() is not None and pending:
+                        # The answer cannot be applied yet, but the turn is still parked, so raise the
+                        # interrupt again instead of failing the call: the orchestrator parks it once more,
+                        # keeping both the turn and the pending interrupt for another attempt. Failing here
+                        # would end the orchestrator's turn, and the event loop clears the whole interrupt
+                        # record when a turn ends - taking the parked turn and the human's answer with it.
+                        logger.error(
+                            "tool_name=<%s>, agent_name=<%s>, tool_use_id=<%s> | cannot apply the interrupt "
+                            "response yet, raising the interrupt again so it survives to be answered once "
+                            "more",
+                            self._tool_name,
+                            self._agent_name,
+                            tool_use_id,
+                        )
+                        yield ToolInterruptEvent(tool_use, pending)
+                        return
+
                     logger.error(
-                        "tool_name=<%s>, tool_use_id=<%s> | cannot resume: the sub-agent's interrupted turn "
-                        "is not available, so the interrupt response cannot be applied",
+                        "tool_name=<%s>, agent_name=<%s>, tool_use_id=<%s> | cannot resume: the sub-agent's "
+                        "interrupted turn is not available, so the interrupt response cannot be applied",
                         self._tool_name,
+                        self._agent_name,
                         tool_use_id,
                     )
                     yield ToolResultEvent(
                         {
                             "toolUseId": tool_use_id,
                             "status": "error",
-                            "content": [{"text": self._unresumable_message(invocation_state, tool_use_id)}],
+                            "content": [{"text": self._unresumable_message(parent_call)}],
                         }
                     )
                     return
 
-                prompt = self._interrupt_responses(invocation_state, tool_use_id)
+                prompt = parent_call.responses()
                 logger.debug(
                     "tool_name=<%s>, tool_use_id=<%s> | resuming sub-agent from interrupt",
                     self._tool_name,
@@ -237,9 +400,9 @@ class _AgentAsTool(AgentTool):
 
             # Propagate sub-agent interrupts to the parent agent.
             if result.stop_reason == "interrupt" and result.interrupts:
-                interrupts = list(result.interrupts)
-                self._stash_continuation(invocation_state, tool_use_id)
-                yield ToolInterruptEvent(tool_use, self._namespace_interrupts(tool_use_id, interrupts))
+                if parent_call is not None:
+                    self._park_turn(parent_call)
+                yield ToolInterruptEvent(tool_use, _namespace_interrupts(tool_use_id, list(result.interrupts)))
                 return
 
             if result.structured_output:
@@ -299,206 +462,111 @@ class _AgentAsTool(AgentTool):
         self._agent.messages = copy.deepcopy(self._initial_messages)
         self._agent.state = AgentState(self._initial_state.get())
 
-    def _is_sub_agent_interrupted(self) -> bool:
-        """Check whether the wrapped agent is in an activated interrupt state."""
-        return self._agent._interrupt_state.activated
+    @property
+    def _agent_name(self) -> str:
+        """Name of the wrapped agent, for logs and UI display."""
+        return getattr(self._agent, "name", "unknown")
 
-    @staticmethod
-    def _namespace_prefix(tool_use_id: str) -> str:
-        """Build the prefix that namespaces a sub-agent interrupt id to this tool call.
+    def _unresumable_message(self, parent_call: _ParentCall) -> str:
+        """Explain to the orchestrator's model why the interrupted turn could not be reinstated.
 
-        The tool use ID is percent-encoded so the prefix cannot contain the separator. Tool use IDs and
-        interrupt IDs are both model-derived strings: with a raw prefix, a tool use ID ending in the
-        separator plus the start of another call's interrupt IDs would match that call's answers and
-        route them to the wrong sub-agent.
+        The model decides what the user is told, and the human's approval is gone either way, so the
+        message has to rule out reporting the guarded action as done.
 
         Args:
-            tool_use_id: Tool use ID of this agent-as-tool call.
+            parent_call: The orchestrator's record of this call.
 
         Returns:
-            Prefix, separator included, for interrupt IDs belonging to this call.
+            Text for the failed tool result.
         """
-        return f"{quote(tool_use_id, safe='')}:"
-
-    @staticmethod
-    def _namespace_interrupts(tool_use_id: str, interrupts: list[Interrupt]) -> list[Interrupt]:
-        """Copy sub-agent interrupts with their ids namespaced by this tool call.
-
-        A sub-agent derives an interrupt id from its own toolUseId, so two sub-agents invoked in the
-        same turn can raise the same id. Namespacing keeps them distinct at the orchestrator level and
-        keeps the sub-agent-local id recoverable by stripping the prefix.
-
-        Args:
-            tool_use_id: Tool use ID of this agent-as-tool call.
-            interrupts: Interrupts raised inside the sub-agent.
-
-        Returns:
-            Orchestrator-visible copies carrying namespaced ids.
-        """
-        prefix = _AgentAsTool._namespace_prefix(tool_use_id)
-        return [
-            Interrupt(id=f"{prefix}{interrupt.id}", name=interrupt.name, reason=interrupt.reason)
-            for interrupt in interrupts
-        ]
-
-    @staticmethod
-    def _parent_agent(invocation_state: dict[str, Any]) -> Agent | None:
-        """Get the orchestrator running this tool call, if the invocation state carries one."""
-        parent: Agent | None = invocation_state.get("agent")
-        return parent
-
-    @staticmethod
-    def _parent_awaiting_resume(invocation_state: dict[str, Any], tool_use_id: str) -> bool:
-        """Check whether the orchestrator is waiting on an interrupt raised by this tool call.
-
-        Keyed on the orchestrator rather than on the sub-agent so a sub-agent that shares a session
-        with another caller cannot adopt a pending turn that belongs to someone else.
-
-        Args:
-            invocation_state: Context for the tool invocation.
-            tool_use_id: Tool use ID of this agent-as-tool call.
-
-        Returns:
-            True if the orchestrator holds an interrupt raised by this call.
-        """
-        parent = _AgentAsTool._parent_agent(invocation_state)
-        if parent is None or not parent._interrupt_state.activated:
-            return False
-
-        prefix = _AgentAsTool._namespace_prefix(tool_use_id)
-        return any(interrupt_id.startswith(prefix) for interrupt_id in parent._interrupt_state.interrupts)
-
-    @staticmethod
-    def _interrupt_responses(invocation_state: dict[str, Any], tool_use_id: str) -> list[InterruptResponseContent]:
-        """Map the orchestrator's interrupt responses back to sub-agent-local ids.
-
-        The orchestrator persists the human's answers as data, so this survives a rehydration
-        boundary where orchestrator and sub-agent no longer share an in-memory ``Interrupt``. An
-        empty list means none of the answers belong to this call, and the sub-agent re-raises its
-        interrupt and stays pending.
-
-        Args:
-            invocation_state: Context for the tool invocation.
-            tool_use_id: Tool use ID of this agent-as-tool call.
-
-        Returns:
-            Interrupt response content blocks addressed to the sub-agent.
-        """
-        parent = _AgentAsTool._parent_agent(invocation_state)
-        if parent is None:
-            return []
-
-        prefix = _AgentAsTool._namespace_prefix(tool_use_id)
-        responses: list[InterruptResponseContent] = []
-        for response in parent._interrupt_state.context.get("responses") or []:
-            interrupt_id = response["interruptResponse"]["interruptId"]
-            if interrupt_id.startswith(prefix):
-                responses.append(
-                    {
-                        "interruptResponse": {
-                            "interruptId": interrupt_id[len(prefix) :],
-                            "response": response["interruptResponse"]["response"],
-                        }
-                    }
-                )
-
-        return responses
-
-    @staticmethod
-    def _stored_continuation(invocation_state: dict[str, Any], tool_use_id: str) -> dict[str, Any] | None:
-        """Get the interrupted turn the orchestrator holds for this tool call, if there is one."""
-        parent = _AgentAsTool._parent_agent(invocation_state)
-        if parent is None:
-            return None
-
-        continuations: dict[str, Any] = parent._interrupt_state.context.get(_CONTINUATIONS_KEY) or {}
-        continuation: dict[str, Any] | None = continuations.get(tool_use_id)
-        return continuation
-
-    def _unresumable_message(self, invocation_state: dict[str, Any], tool_use_id: str) -> str:
-        """Explain why the interrupted turn could not be reinstated, for the failed tool result."""
-        if self._stored_continuation(invocation_state, tool_use_id) is not None:
+        if parent_call.parked_turn() is not None:
             return (
-                f"Agent '{self._tool_name}' could not resume its interrupted turn: the stored turn failed to "
-                "load, so the interrupt response was not applied. See the logged error for the cause."
+                f"Agent '{self._tool_name}' did NOT run and the human's response was NOT applied: its "
+                "interrupted turn failed to load. Do not report the requested action as completed or "
+                "successful. Tell the user it failed and ask them to respond again. See the logged error "
+                "for the cause."
             )
 
         return (
-            f"Agent '{self._tool_name}' could not resume its interrupted turn. A sub-agent used with "
-            "preserve_context=True keeps its own state, so it needs a session manager for that state to "
-            "survive rehydration."
+            f"Agent '{self._tool_name}' did NOT run and the human's response was NOT applied: its "
+            "interrupted turn did not survive the restart. A sub-agent used with preserve_context=True "
+            "keeps its own state, so it needs its own session manager for that state to survive. Do not "
+            "report the requested action as completed or successful; tell the user it failed."
         )
 
-    def _stash_continuation(self, invocation_state: dict[str, Any], tool_use_id: str) -> None:
-        """Store the sub-agent's interrupted turn in the orchestrator's interrupt context.
+    def _park_turn(self, parent_call: _ParentCall) -> None:
+        """Park the sub-agent's interrupted turn on the orchestrator so a later request can reinstate it.
 
-        Only for ``preserve_context=False`` sub-agents: they are ephemeral by contract and are rejected
-        at construction if they have a session manager, so the orchestrator holds the turn for them and
-        Strands persists it
-        with the orchestrator's own interrupt record. A sub-agent that preserves context owns its
-        state and keeps it in its own session.
+        Only for ``preserve_context=False`` sub-agents: they are ephemeral by contract and are rejected at
+        construction if they have a session manager, so the orchestrator carries the turn for them and
+        Strands persists it with the orchestrator's own interrupt record. A sub-agent that preserves
+        context owns its state and keeps its turn in its own session; without a session manager that turn
+        is held only in memory, which is worth warning about now rather than when the answer arrives and
+        cannot be applied.
 
         Args:
-            invocation_state: Context for the tool invocation.
-            tool_use_id: Tool use ID of this agent-as-tool call.
+            parent_call: The orchestrator's record of this call.
         """
         if self._preserve_context:
+            if getattr(self._agent, "_session_manager", None) is None:
+                logger.warning(
+                    "tool_name=<%s>, agent_name=<%s>, tool_use_id=<%s> | interrupted sub-agent uses "
+                    "preserve_context=True with no session manager, so its interrupted turn is held only in "
+                    "memory: the interrupt resumes in this process but not after a restart",
+                    self._tool_name,
+                    self._agent_name,
+                    parent_call.tool_use_id,
+                )
             return
 
-        parent = self._parent_agent(invocation_state)
-        if parent is None:
-            return
-
-        continuations: dict[str, Any] = parent._interrupt_state.context.setdefault(_CONTINUATIONS_KEY, {})
-        continuations[tool_use_id] = self._agent.take_snapshot(preset="session").to_dict()
+        # Copied because the snapshot carries the sub-agent's live interrupt context by reference, and the
+        # sub-agent keeps being used after this.
+        parent_call.park_turn(copy.deepcopy(self._agent.take_snapshot(preset="session").to_dict()))
         logger.debug(
-            "tool_name=<%s>, tool_use_id=<%s> | stored interrupted sub-agent turn for resume",
+            "tool_name=<%s>, tool_use_id=<%s> | parked interrupted sub-agent turn for resume",
             self._tool_name,
-            tool_use_id,
+            parent_call.tool_use_id,
         )
 
-    def _restore_continuation(self, invocation_state: dict[str, Any], tool_use_id: str) -> bool:
-        """Rebuild the sub-agent's interrupted turn from the orchestrator's interrupt context.
+    def _reinstate_turn(self, parent_call: _ParentCall) -> bool:
+        """Rebuild the sub-agent's interrupted turn from the turn the orchestrator parked.
 
-        The turn is consumed: a sub-agent that interrupts again stores a fresh one.
+        The turn is freed once it loads: a sub-agent that interrupts again parks a fresh one.
 
         Args:
-            invocation_state: Context for the tool invocation.
-            tool_use_id: Tool use ID of this agent-as-tool call.
+            parent_call: The orchestrator's record of this call.
 
         Returns:
-            True if the interrupted turn was restored onto the sub-agent.
+            True if the interrupted turn was reinstated onto the sub-agent.
         """
-        parent = self._parent_agent(invocation_state)
-        if parent is None:
-            return False
-
-        continuation = self._stored_continuation(invocation_state, tool_use_id)
-        if continuation is None:
+        turn = parent_call.parked_turn()
+        if turn is None:
             return False
 
         try:
-            self._agent.load_snapshot(Snapshot.from_dict(continuation))
+            self._agent.load_snapshot(Snapshot.from_dict(turn))
         except Exception as error:
-            # Leave the stored turn in place: a load can fail for a reason a later attempt survives,
-            # such as a schema version the running SDK does not accept yet, and dropping it here would
-            # destroy the only copy of the turn the human already answered. A failure after the first
-            # field has been applied leaves the sub-agent itself mismatched; the caller reports the
-            # error without invoking it, and an ephemeral sub-agent is reset on its next fresh call.
+            # Keep the parked turn: a load can fail for a reason a later attempt survives, such as a schema
+            # version the running SDK does not accept yet, and this is the only copy of the turn the human
+            # already answered. The caller re-raises the interrupt so the turn stays parked with it. A
+            # failure after the first field was applied leaves the sub-agent mismatched; it is not invoked,
+            # and an ephemeral sub-agent is reset on its next fresh call.
             logger.error(
-                "tool_name=<%s>, tool_use_id=<%s> | failed to restore interrupted sub-agent turn: %s",
+                "tool_name=<%s>, agent_name=<%s>, tool_use_id=<%s> | failed to reinstate interrupted "
+                "sub-agent turn: %s",
                 self._tool_name,
-                tool_use_id,
+                self._agent_name,
+                parent_call.tool_use_id,
                 error,
             )
             return False
 
-        parent._interrupt_state.context[_CONTINUATIONS_KEY].pop(tool_use_id, None)
+        parent_call.drop_parked_turn()
         return True
 
     @override
     def get_display_properties(self) -> dict[str, str]:
         """Get properties for UI display."""
         properties = super().get_display_properties()
-        properties["Agent"] = getattr(self._agent, "name", "unknown")
+        properties["Agent"] = self._agent_name
         return properties

--- a/strands-py/src/strands/agent/_agent_as_tool.py
+++ b/strands-py/src/strands/agent/_agent_as_tool.py
@@ -482,7 +482,9 @@ class _AgentAsTool(AgentTool):
         except Exception as error:
             # Leave the stored turn in place: a load can fail for a reason a later attempt survives,
             # such as a schema version the running SDK does not accept yet, and dropping it here would
-            # destroy the only copy of the turn the human already answered.
+            # destroy the only copy of the turn the human already answered. A failure after the first
+            # field has been applied leaves the sub-agent itself mismatched; the caller reports the
+            # error without invoking it, and an ephemeral sub-agent is reset on its next fresh call.
             logger.error(
                 "tool_name=<%s>, tool_use_id=<%s> | failed to restore interrupted sub-agent turn: %s",
                 self._tool_name,
@@ -491,7 +493,7 @@ class _AgentAsTool(AgentTool):
             )
             return False
 
-        del parent._interrupt_state.context[_CONTINUATIONS_KEY][tool_use_id]
+        parent._interrupt_state.context[_CONTINUATIONS_KEY].pop(tool_use_id, None)
         return True
 
     @override

--- a/strands-py/src/strands/agent/_agent_as_tool.py
+++ b/strands-py/src/strands/agent/_agent_as_tool.py
@@ -14,7 +14,9 @@ from typing import TYPE_CHECKING, Any
 from typing_extensions import override
 
 from ..agent.state import AgentState
+from ..interrupt import Interrupt
 from ..types._events import AgentAsToolStreamEvent, ToolInterruptEvent, ToolResultEvent
+from ..types._snapshot import Snapshot
 from ..types.content import Messages
 from ..types.interrupt import InterruptResponseContent
 from ..types.tools import AgentTool, ToolGenerator, ToolSpec, ToolUse
@@ -23,6 +25,9 @@ if TYPE_CHECKING:
     from .agent import Agent
 
 logger = logging.getLogger(__name__)
+
+_CONTINUATIONS_KEY = "sub_agent_continuations"
+"""Key under which an orchestrator's interrupt context holds interrupted sub-agent turns, keyed by tool use id."""
 
 
 class _AgentAsTool(AgentTool):
@@ -183,8 +188,33 @@ class _AgentAsTool(AgentTool):
 
         try:
             # Determine if we are resuming the sub-agent from an interrupt.
-            if self._is_sub_agent_interrupted():
-                prompt = self._build_interrupt_responses()
+            if self._parent_awaiting_resume(invocation_state, tool_use_id):
+                restored = self._restore_continuation(invocation_state, tool_use_id)
+                if not restored and not self._is_sub_agent_interrupted():
+                    logger.error(
+                        "tool_name=<%s>, tool_use_id=<%s> | cannot resume: the sub-agent's interrupted turn "
+                        "is not available, so the interrupt response cannot be applied",
+                        self._tool_name,
+                        tool_use_id,
+                    )
+                    yield ToolResultEvent(
+                        {
+                            "toolUseId": tool_use_id,
+                            "status": "error",
+                            "content": [
+                                {
+                                    "text": (
+                                        f"Agent '{self._tool_name}' could not resume its interrupted turn. A "
+                                        "sub-agent used with preserve_context=True keeps its own state, so it "
+                                        "needs a session manager for that state to survive rehydration."
+                                    )
+                                }
+                            ],
+                        }
+                    )
+                    return
+
+                prompt = self._interrupt_responses(invocation_state, tool_use_id)
                 logger.debug(
                     "tool_name=<%s>, tool_use_id=<%s> | resuming sub-agent from interrupt",
                     self._tool_name,
@@ -214,7 +244,9 @@ class _AgentAsTool(AgentTool):
 
             # Propagate sub-agent interrupts to the parent agent.
             if result.stop_reason == "interrupt" and result.interrupts:
-                yield ToolInterruptEvent(tool_use, list(result.interrupts))
+                interrupts = list(result.interrupts)
+                self._stash_continuation(invocation_state, tool_use_id)
+                yield ToolInterruptEvent(tool_use, self._namespace_interrupts(tool_use_id, interrupts))
                 return
 
             if result.structured_output:
@@ -272,21 +304,149 @@ class _AgentAsTool(AgentTool):
         """Check whether the wrapped agent is in an activated interrupt state."""
         return self._agent._interrupt_state.activated
 
-    def _build_interrupt_responses(self) -> list[InterruptResponseContent]:
-        """Build interrupt response payloads from the sub-agent's interrupt state.
+    @staticmethod
+    def _namespace_interrupts(tool_use_id: str, interrupts: list[Interrupt]) -> list[Interrupt]:
+        """Copy sub-agent interrupts with their ids namespaced by this tool call.
 
-        The parent agent's ``_interrupt_state.resume()`` sets ``.response`` on the shared
-        ``Interrupt`` objects (registered by the executor), so we re-package them in the
-        format expected by ``Agent.stream_async``.
+        A sub-agent derives an interrupt id from its own toolUseId, so two sub-agents invoked in the
+        same turn can raise the same id. Prefixing with the outer ``tool_use_id`` keeps them distinct
+        at the orchestrator level and keeps the sub-agent-local id recoverable by stripping the prefix.
+
+        Args:
+            tool_use_id: Tool use ID of this agent-as-tool call.
+            interrupts: Interrupts raised inside the sub-agent.
 
         Returns:
-            List of interrupt response content blocks for resuming the sub-agent.
+            Orchestrator-visible copies carrying namespaced ids.
         """
         return [
-            {"interruptResponse": {"interruptId": interrupt.id, "response": interrupt.response}}
-            for interrupt in self._agent._interrupt_state.interrupts.values()
-            if interrupt.response is not None
+            Interrupt(id=f"{tool_use_id}:{interrupt.id}", name=interrupt.name, reason=interrupt.reason)
+            for interrupt in interrupts
         ]
+
+    @staticmethod
+    def _parent_agent(invocation_state: dict[str, Any]) -> Agent | None:
+        """Get the orchestrator running this tool call, if the invocation state carries one."""
+        parent: Agent | None = invocation_state.get("agent")
+        return parent
+
+    def _parent_awaiting_resume(self, invocation_state: dict[str, Any], tool_use_id: str) -> bool:
+        """Check whether the orchestrator is waiting on an interrupt raised by this tool call.
+
+        Keyed on the orchestrator rather than on the sub-agent so a sub-agent that shares a session
+        with another caller cannot adopt a pending turn that belongs to someone else.
+
+        Args:
+            invocation_state: Context for the tool invocation.
+            tool_use_id: Tool use ID of this agent-as-tool call.
+
+        Returns:
+            True if the orchestrator holds an interrupt raised by this call.
+        """
+        parent = self._parent_agent(invocation_state)
+        if parent is None or not parent._interrupt_state.activated:
+            return False
+
+        prefix = f"{tool_use_id}:"
+        return any(interrupt_id.startswith(prefix) for interrupt_id in parent._interrupt_state.interrupts)
+
+    def _interrupt_responses(
+        self, invocation_state: dict[str, Any], tool_use_id: str
+    ) -> list[InterruptResponseContent]:
+        """Map the orchestrator's interrupt responses back to sub-agent-local ids.
+
+        The orchestrator persists the human's answers as data, so this survives a rehydration
+        boundary where orchestrator and sub-agent no longer share an in-memory ``Interrupt``. An
+        empty list means none of the answers belong to this call, and the sub-agent re-raises its
+        interrupt and stays pending.
+
+        Args:
+            invocation_state: Context for the tool invocation.
+            tool_use_id: Tool use ID of this agent-as-tool call.
+
+        Returns:
+            Interrupt response content blocks addressed to the sub-agent.
+        """
+        parent = self._parent_agent(invocation_state)
+        if parent is None:
+            return []
+
+        prefix = f"{tool_use_id}:"
+        responses: list[InterruptResponseContent] = []
+        for response in parent._interrupt_state.context.get("responses") or []:
+            interrupt_id = response["interruptResponse"]["interruptId"]
+            if interrupt_id.startswith(prefix):
+                responses.append(
+                    {
+                        "interruptResponse": {
+                            "interruptId": interrupt_id[len(prefix) :],
+                            "response": response["interruptResponse"]["response"],
+                        }
+                    }
+                )
+
+        return responses
+
+    def _stash_continuation(self, invocation_state: dict[str, Any], tool_use_id: str) -> None:
+        """Store the sub-agent's interrupted turn in the orchestrator's interrupt context.
+
+        Only for ``preserve_context=False`` sub-agents: they are ephemeral by contract and may not
+        have a session manager, so the orchestrator holds the turn for them and Strands persists it
+        with the orchestrator's own interrupt record. A sub-agent that preserves context owns its
+        state and keeps it in its own session.
+
+        Args:
+            invocation_state: Context for the tool invocation.
+            tool_use_id: Tool use ID of this agent-as-tool call.
+        """
+        if self._preserve_context:
+            return
+
+        parent = self._parent_agent(invocation_state)
+        if parent is None:
+            return
+
+        continuations: dict[str, Any] = parent._interrupt_state.context.setdefault(_CONTINUATIONS_KEY, {})
+        continuations[tool_use_id] = self._agent.take_snapshot(preset="session").to_dict()
+        logger.debug(
+            "tool_name=<%s>, tool_use_id=<%s> | stored interrupted sub-agent turn for resume",
+            self._tool_name,
+            tool_use_id,
+        )
+
+    def _restore_continuation(self, invocation_state: dict[str, Any], tool_use_id: str) -> bool:
+        """Rebuild the sub-agent's interrupted turn from the orchestrator's interrupt context.
+
+        The turn is consumed: a sub-agent that interrupts again stores a fresh one.
+
+        Args:
+            invocation_state: Context for the tool invocation.
+            tool_use_id: Tool use ID of this agent-as-tool call.
+
+        Returns:
+            True if the interrupted turn was restored onto the sub-agent.
+        """
+        parent = self._parent_agent(invocation_state)
+        if parent is None:
+            return False
+
+        continuations = parent._interrupt_state.context.get(_CONTINUATIONS_KEY) or {}
+        continuation = continuations.pop(tool_use_id, None)
+        if continuation is None:
+            return False
+
+        try:
+            self._agent.load_snapshot(Snapshot.from_dict(continuation))
+        except Exception as error:
+            logger.error(
+                "tool_name=<%s>, tool_use_id=<%s> | failed to restore interrupted sub-agent turn: %s",
+                self._tool_name,
+                tool_use_id,
+                error,
+            )
+            return False
+
+        return True
 
     @override
     def get_display_properties(self) -> dict[str, str]:

--- a/strands-py/src/strands/agent/_agent_as_tool.py
+++ b/strands-py/src/strands/agent/_agent_as_tool.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import copy
 import logging
 import threading
+from collections.abc import Collection
 from typing import TYPE_CHECKING, Any
 from urllib.parse import quote
 
@@ -79,6 +80,20 @@ def _namespace_interrupts(tool_use_id: str, interrupts: list[Interrupt]) -> list
     ]
 
 
+def _parked_turn_interrupt_ids(turn: dict[str, Any]) -> set[str]:
+    """Get the sub-agent-local ids of the interrupts a parked turn is still waiting on.
+
+    Args:
+        turn: Serialized snapshot of an interrupted sub-agent turn.
+
+    Returns:
+        Interrupt IDs the sub-agent will raise again when the turn is reinstated.
+    """
+    interrupt_state: dict[str, Any] = (turn.get("data") or {}).get("interrupt_state") or {}
+    interrupts: dict[str, Any] = interrupt_state.get("interrupts") or {}
+    return set(interrupts)
+
+
 class _ParentCall:
     """The orchestrator's record of one agent-as-tool call.
 
@@ -119,12 +134,23 @@ class _ParentCall:
 
         return any(interrupt_id.startswith(self._prefix) for interrupt_id in self._parent._interrupt_state.interrupts)
 
-    def pending_interrupts(self) -> list[Interrupt]:
-        """Get the namespaced interrupts the orchestrator holds for this call."""
+    def pending_interrupts(self, local_ids: Collection[str] | None = None) -> list[Interrupt]:
+        """Get the namespaced interrupts the orchestrator holds for this call.
+
+        Args:
+            local_ids: Restrict the result to interrupts whose sub-agent-local id is in this
+                collection. The orchestrator keeps every id it has been handed until its own turn
+                ends, including ones the sub-agent has since finished with, so a caller that wants
+                the interrupts the sub-agent is actually still waiting on has to say which those are.
+
+        Returns:
+            Interrupts the orchestrator holds for this call, in the order it recorded them.
+        """
         return [
             interrupt
             for interrupt_id, interrupt in self._parent._interrupt_state.interrupts.items()
             if interrupt_id.startswith(self._prefix)
+            and (local_ids is None or interrupt_id[len(self._prefix) :] in local_ids)
         ]
 
     def responses(self) -> list[InterruptResponseContent]:
@@ -336,8 +362,16 @@ class _AgentAsTool(AgentTool):
             # Determine if we are resuming the sub-agent from an interrupt.
             if parent_call is not None and parent_call.awaiting_resume:
                 if not self._reinstate_turn(parent_call) and not self._agent._interrupt_state.activated:
-                    pending = parent_call.pending_interrupts()
-                    if parent_call.parked_turn() is not None and pending:
+                    # Only the interrupts the parked turn is still waiting on: the orchestrator also
+                    # holds ids the sub-agent has already finished with, and handing one of those back
+                    # would send the caller to an interrupt that no longer exists on the sub-agent.
+                    parked_turn = parent_call.parked_turn()
+                    pending = (
+                        parent_call.pending_interrupts(local_ids=_parked_turn_interrupt_ids(parked_turn))
+                        if parked_turn is not None
+                        else []
+                    )
+                    if pending:
                         # The answer cannot be applied yet, but the turn is still parked, so raise the
                         # interrupt again instead of failing the call: the orchestrator parks it once more,
                         # keeping both the turn and the pending interrupt for another attempt. Failing here
@@ -549,8 +583,9 @@ class _AgentAsTool(AgentTool):
             # Keep the parked turn: a load can fail for a reason a later attempt survives, such as a schema
             # version the running SDK does not accept yet, and this is the only copy of the turn the human
             # already answered. The caller re-raises the interrupt so the turn stays parked with it. A
-            # failure after the first field was applied leaves the sub-agent mismatched; it is not invoked,
-            # and an ephemeral sub-agent is reset on its next fresh call.
+            # failure after the first field was applied leaves the sub-agent mismatched. It is not
+            # invoked unless it is itself still activated from an earlier turn in this process, and an
+            # ephemeral sub-agent is reset on its next fresh call.
             logger.error(
                 "tool_name=<%s>, agent_name=<%s>, tool_use_id=<%s> | failed to reinstate interrupted "
                 "sub-agent turn: %s",

--- a/strands-py/src/strands/agent/_agent_as_tool.py
+++ b/strands-py/src/strands/agent/_agent_as_tool.py
@@ -10,6 +10,7 @@ import copy
 import logging
 import threading
 from typing import TYPE_CHECKING, Any
+from urllib.parse import quote
 
 from typing_extensions import override
 
@@ -281,6 +282,12 @@ class _AgentAsTool(AgentTool):
         Restores messages and state to the values captured at construction time.
         This mirrors the pattern used by ``GraphNode.reset_executor_state()``.
 
+        The reset is unconditional, so exposing one ``Agent`` instance as a tool to several
+        orchestrators at once lets one orchestrator's call clear a turn another one has parked on an
+        interrupt. The parked orchestrator still resumes correctly, because it reinstates the turn
+        from its own interrupt record, but the other call fails; give each orchestrator its own
+        sub-agent instance instead of sharing one.
+
         Args:
             tool_use_id: Tool use ID for logging context.
         """
@@ -297,12 +304,29 @@ class _AgentAsTool(AgentTool):
         return self._agent._interrupt_state.activated
 
     @staticmethod
+    def _namespace_prefix(tool_use_id: str) -> str:
+        """Build the prefix that namespaces a sub-agent interrupt id to this tool call.
+
+        The tool use ID is percent-encoded so the prefix cannot contain the separator. Tool use IDs and
+        interrupt IDs are both model-derived strings: with a raw prefix, a tool use ID ending in the
+        separator plus the start of another call's interrupt IDs would match that call's answers and
+        route them to the wrong sub-agent.
+
+        Args:
+            tool_use_id: Tool use ID of this agent-as-tool call.
+
+        Returns:
+            Prefix, separator included, for interrupt IDs belonging to this call.
+        """
+        return f"{quote(tool_use_id, safe='')}:"
+
+    @staticmethod
     def _namespace_interrupts(tool_use_id: str, interrupts: list[Interrupt]) -> list[Interrupt]:
         """Copy sub-agent interrupts with their ids namespaced by this tool call.
 
         A sub-agent derives an interrupt id from its own toolUseId, so two sub-agents invoked in the
-        same turn can raise the same id. Prefixing with the outer ``tool_use_id`` keeps them distinct
-        at the orchestrator level and keeps the sub-agent-local id recoverable by stripping the prefix.
+        same turn can raise the same id. Namespacing keeps them distinct at the orchestrator level and
+        keeps the sub-agent-local id recoverable by stripping the prefix.
 
         Args:
             tool_use_id: Tool use ID of this agent-as-tool call.
@@ -311,8 +335,9 @@ class _AgentAsTool(AgentTool):
         Returns:
             Orchestrator-visible copies carrying namespaced ids.
         """
+        prefix = _AgentAsTool._namespace_prefix(tool_use_id)
         return [
-            Interrupt(id=f"{tool_use_id}:{interrupt.id}", name=interrupt.name, reason=interrupt.reason)
+            Interrupt(id=f"{prefix}{interrupt.id}", name=interrupt.name, reason=interrupt.reason)
             for interrupt in interrupts
         ]
 
@@ -340,7 +365,7 @@ class _AgentAsTool(AgentTool):
         if parent is None or not parent._interrupt_state.activated:
             return False
 
-        prefix = f"{tool_use_id}:"
+        prefix = _AgentAsTool._namespace_prefix(tool_use_id)
         return any(interrupt_id.startswith(prefix) for interrupt_id in parent._interrupt_state.interrupts)
 
     @staticmethod
@@ -363,7 +388,7 @@ class _AgentAsTool(AgentTool):
         if parent is None:
             return []
 
-        prefix = f"{tool_use_id}:"
+        prefix = _AgentAsTool._namespace_prefix(tool_use_id)
         responses: list[InterruptResponseContent] = []
         for response in parent._interrupt_state.context.get("responses") or []:
             interrupt_id = response["interruptResponse"]["interruptId"]

--- a/strands-py/src/strands/agent/_agent_as_tool.py
+++ b/strands-py/src/strands/agent/_agent_as_tool.py
@@ -201,15 +201,7 @@ class _AgentAsTool(AgentTool):
                         {
                             "toolUseId": tool_use_id,
                             "status": "error",
-                            "content": [
-                                {
-                                    "text": (
-                                        f"Agent '{self._tool_name}' could not resume its interrupted turn. A "
-                                        "sub-agent used with preserve_context=True keeps its own state, so it "
-                                        "needs a session manager for that state to survive rehydration."
-                                    )
-                                }
-                            ],
+                            "content": [{"text": self._unresumable_message(invocation_state, tool_use_id)}],
                         }
                     )
                     return
@@ -330,7 +322,8 @@ class _AgentAsTool(AgentTool):
         parent: Agent | None = invocation_state.get("agent")
         return parent
 
-    def _parent_awaiting_resume(self, invocation_state: dict[str, Any], tool_use_id: str) -> bool:
+    @staticmethod
+    def _parent_awaiting_resume(invocation_state: dict[str, Any], tool_use_id: str) -> bool:
         """Check whether the orchestrator is waiting on an interrupt raised by this tool call.
 
         Keyed on the orchestrator rather than on the sub-agent so a sub-agent that shares a session
@@ -343,16 +336,15 @@ class _AgentAsTool(AgentTool):
         Returns:
             True if the orchestrator holds an interrupt raised by this call.
         """
-        parent = self._parent_agent(invocation_state)
+        parent = _AgentAsTool._parent_agent(invocation_state)
         if parent is None or not parent._interrupt_state.activated:
             return False
 
         prefix = f"{tool_use_id}:"
         return any(interrupt_id.startswith(prefix) for interrupt_id in parent._interrupt_state.interrupts)
 
-    def _interrupt_responses(
-        self, invocation_state: dict[str, Any], tool_use_id: str
-    ) -> list[InterruptResponseContent]:
+    @staticmethod
+    def _interrupt_responses(invocation_state: dict[str, Any], tool_use_id: str) -> list[InterruptResponseContent]:
         """Map the orchestrator's interrupt responses back to sub-agent-local ids.
 
         The orchestrator persists the human's answers as data, so this survives a rehydration
@@ -367,7 +359,7 @@ class _AgentAsTool(AgentTool):
         Returns:
             Interrupt response content blocks addressed to the sub-agent.
         """
-        parent = self._parent_agent(invocation_state)
+        parent = _AgentAsTool._parent_agent(invocation_state)
         if parent is None:
             return []
 
@@ -387,11 +379,37 @@ class _AgentAsTool(AgentTool):
 
         return responses
 
+    @staticmethod
+    def _stored_continuation(invocation_state: dict[str, Any], tool_use_id: str) -> dict[str, Any] | None:
+        """Get the interrupted turn the orchestrator holds for this tool call, if there is one."""
+        parent = _AgentAsTool._parent_agent(invocation_state)
+        if parent is None:
+            return None
+
+        continuations: dict[str, Any] = parent._interrupt_state.context.get(_CONTINUATIONS_KEY) or {}
+        continuation: dict[str, Any] | None = continuations.get(tool_use_id)
+        return continuation
+
+    def _unresumable_message(self, invocation_state: dict[str, Any], tool_use_id: str) -> str:
+        """Explain why the interrupted turn could not be reinstated, for the failed tool result."""
+        if self._stored_continuation(invocation_state, tool_use_id) is not None:
+            return (
+                f"Agent '{self._tool_name}' could not resume its interrupted turn: the stored turn failed to "
+                "load, so the interrupt response was not applied. See the logged error for the cause."
+            )
+
+        return (
+            f"Agent '{self._tool_name}' could not resume its interrupted turn. A sub-agent used with "
+            "preserve_context=True keeps its own state, so it needs a session manager for that state to "
+            "survive rehydration."
+        )
+
     def _stash_continuation(self, invocation_state: dict[str, Any], tool_use_id: str) -> None:
         """Store the sub-agent's interrupted turn in the orchestrator's interrupt context.
 
-        Only for ``preserve_context=False`` sub-agents: they are ephemeral by contract and may not
-        have a session manager, so the orchestrator holds the turn for them and Strands persists it
+        Only for ``preserve_context=False`` sub-agents: they are ephemeral by contract and are rejected
+        at construction if they have a session manager, so the orchestrator holds the turn for them and
+        Strands persists it
         with the orchestrator's own interrupt record. A sub-agent that preserves context owns its
         state and keeps it in its own session.
 
@@ -430,14 +448,16 @@ class _AgentAsTool(AgentTool):
         if parent is None:
             return False
 
-        continuations = parent._interrupt_state.context.get(_CONTINUATIONS_KEY) or {}
-        continuation = continuations.pop(tool_use_id, None)
+        continuation = self._stored_continuation(invocation_state, tool_use_id)
         if continuation is None:
             return False
 
         try:
             self._agent.load_snapshot(Snapshot.from_dict(continuation))
         except Exception as error:
+            # Leave the stored turn in place: a load can fail for a reason a later attempt survives,
+            # such as a schema version the running SDK does not accept yet, and dropping it here would
+            # destroy the only copy of the turn the human already answered.
             logger.error(
                 "tool_name=<%s>, tool_use_id=<%s> | failed to restore interrupted sub-agent turn: %s",
                 self._tool_name,
@@ -446,6 +466,7 @@ class _AgentAsTool(AgentTool):
             )
             return False
 
+        del parent._interrupt_state.context[_CONTINUATIONS_KEY][tool_use_id]
         return True
 
     @override

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -980,6 +980,12 @@ class Agent(AgentBase):
                 invocation starts from the same baseline regardless of any external
                 interactions with the agent. Defaults to False.
 
+                Interrupts raised inside the sub-agent resume automatically. When False, the
+                orchestrator carries the sub-agent's interrupted turn, so the resume survives a
+                process restart. When True the sub-agent owns its state: give it its own session
+                manager if the resume has to survive a restart, otherwise the interrupt resumes
+                only within the same process.
+
         Returns:
             A tool wrapping this agent.
 

--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -12,7 +12,7 @@ import copy
 import logging
 import uuid
 from collections.abc import AsyncGenerator, Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final
 
 from opentelemetry import trace as trace_api
 
@@ -701,12 +701,20 @@ def _make_invoke_model_terminal(
     return terminal
 
 
+_LOOP_OWNED_CONTEXT_KEYS: Final = ("tool_use_message", "tool_results", "responses")
+"""Interrupt-context keys the event loop owns and refreshes on every park.
+
+Every other key in an agent's interrupt context belongs to whoever put it there - an agent-as-tool
+parks an ephemeral sub-agent's interrupted turn that way - and has to survive parking.
+"""
+
+
 def _park_interrupt_context(agent: "Agent", message: Message, tool_results: list[ToolResult]) -> None:
     """Rebuild an agent's interrupt context for a parked turn, keeping keys the event loop does not own.
 
     ``tool_use_message`` and ``tool_results`` describe this park, and ``responses`` belongs to the
     resume that has just been consumed, so all three are refreshed here. Any other key belongs to
-    whoever put it there — an agent-as-tool stores the interrupted turn of an ephemeral sub-agent this
+    whoever put it there — an agent-as-tool parks the interrupted turn of an ephemeral sub-agent this
     way — and has to survive so it is still there on the next resume.
 
     Args:
@@ -715,9 +723,7 @@ def _park_interrupt_context(agent: "Agent", message: Message, tool_results: list
         tool_results: Results of the tools that did complete.
     """
     carried = {
-        key: value
-        for key, value in agent._interrupt_state.context.items()
-        if key not in ("tool_use_message", "tool_results", "responses")
+        key: value for key, value in agent._interrupt_state.context.items() if key not in _LOOP_OWNED_CONTEXT_KEYS
     }
     agent._interrupt_state.context = {**carried, "tool_use_message": message, "tool_results": tool_results}
 

--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -701,6 +701,27 @@ def _make_invoke_model_terminal(
     return terminal
 
 
+def _park_interrupt_context(agent: "Agent", message: Message, tool_results: list[ToolResult]) -> None:
+    """Rebuild an agent's interrupt context for a parked turn, keeping keys the event loop does not own.
+
+    ``tool_use_message`` and ``tool_results`` describe this park, and ``responses`` belongs to the
+    resume that has just been consumed, so all three are refreshed here. Any other key belongs to
+    whoever put it there — an agent-as-tool stores the interrupted turn of an ephemeral sub-agent this
+    way — and has to survive so it is still there on the next resume.
+
+    Args:
+        agent: Agent whose turn is being parked.
+        message: Tool use message that triggered the interrupt.
+        tool_results: Results of the tools that did complete.
+    """
+    carried = {
+        key: value
+        for key, value in agent._interrupt_state.context.items()
+        if key not in ("tool_use_message", "tool_results", "responses")
+    }
+    agent._interrupt_state.context = {**carried, "tool_use_message": message, "tool_results": tool_results}
+
+
 async def _stop_for_interrupts(
     agent: "Agent",
     message: Message,
@@ -719,7 +740,7 @@ async def _stop_for_interrupts(
     so interrupt persistence logic lives in one place.
     """
     # Session state stored on AfterInvocationEvent.
-    agent._interrupt_state.context = {"tool_use_message": message, "tool_results": tool_results}
+    _park_interrupt_context(agent, message, tool_results)
     agent._interrupt_state.activate()
 
     agent.event_loop_metrics.end_cycle(cycle_start_time, cycle_trace)
@@ -860,7 +881,7 @@ async def _handle_tool_execution(
         except Exception:
             # Persist pending interrupts before re-raising so they aren't lost.
             if interrupts:
-                agent._interrupt_state.context = {"tool_use_message": message, "tool_results": tool_results}
+                _park_interrupt_context(agent, message, tool_results)
                 agent._interrupt_state.activate()
             raise
 

--- a/strands-py/src/strands/interrupt.py
+++ b/strands-py/src/strands/interrupt.py
@@ -13,7 +13,8 @@ class Interrupt:
     """Represents an interrupt that can pause agent execution for human-in-the-loop workflows.
 
     Attributes:
-        id: Unique identifier.
+        id: Unique identifier. Treat as opaque: pass it back to resume the agent, do not parse or
+            construct it.
         name: User defined name.
         reason: User provided reason for raising the interrupt.
         response: Human response provided when resuming the agent after an interrupt.

--- a/strands-py/tests/strands/agent/test_agent_as_tool.py
+++ b/strands-py/tests/strands/agent/test_agent_as_tool.py
@@ -985,3 +985,38 @@ def test_nested_interrupt_resumes_after_rehydration(tmp_path):
     tru_executions = executions
     exp_executions = ["prod-db"]
     assert tru_executions == exp_executions
+
+
+@pytest.mark.asyncio
+async def test_stream_resume_keeps_stored_turn_when_it_cannot_be_loaded(fake_agent, orchestrator, caplog):
+    """A stored turn that fails to load is kept, so a later attempt can still apply the human's answer."""
+    unloadable = Agent(name="fake_agent", callback_handler=None).take_snapshot(preset="session").to_dict()
+    unloadable["schema_version"] = "0.0"
+
+    orchestrator._interrupt_state.interrupts["tool-123:interrupt-1"] = Interrupt(
+        id="tool-123:interrupt-1", name="approval", reason="r"
+    )
+    orchestrator._interrupt_state.context.update(
+        {
+            "responses": [{"interruptResponse": {"interruptId": "tool-123:interrupt-1", "response": "APPROVE"}}],
+            "sub_agent_continuations": {"tool-123": unloadable},
+        }
+    )
+    orchestrator._interrupt_state.activate()
+
+    fake_agent.stream_async = MagicMock()
+    tool = _AgentAsTool(fake_agent, name="fake_agent", description="desc", preserve_context=False)
+    tool_use = {"toolUseId": "tool-123", "name": "fake_agent", "input": {"input": "go"}}
+
+    with caplog.at_level("ERROR"):
+        events = [event async for event in tool.stream(tool_use, {"agent": orchestrator})]
+
+    fake_agent.stream_async.assert_not_called()
+    assert len(events) == 1
+    assert events[0]["tool_result"]["status"] == "error"
+    assert "stored turn failed to load" in events[0]["tool_result"]["content"][0]["text"]
+    assert "failed to restore interrupted sub-agent turn" in caplog.text
+
+    tru_continuations = orchestrator._interrupt_state.context["sub_agent_continuations"]
+    exp_continuations = {"tool-123": unloadable}
+    assert tru_continuations == exp_continuations

--- a/strands-py/tests/strands/agent/test_agent_as_tool.py
+++ b/strands-py/tests/strands/agent/test_agent_as_tool.py
@@ -1,11 +1,13 @@
 """Tests for _AgentAsTool - the agent-as-tool adapter."""
 
+import json
+import pathlib
 from unittest.mock import MagicMock
 
 import pytest
 
 import strands
-from strands.agent._agent_as_tool import _AgentAsTool
+from strands.agent._agent_as_tool import _AgentAsTool, _namespace_interrupts, _namespace_prefix, _ParentCall
 from strands.agent.agent import Agent
 from strands.agent.agent_result import AgentResult
 from strands.hooks import BeforeToolCallEvent, HookProvider, HookRegistry
@@ -36,6 +38,14 @@ def mock_agent():
 def fake_agent():
     """A real Agent instance for tests that need Agent-specific features."""
     return Agent(name="fake_agent", callback_handler=None)
+
+
+def namespaced_id(tool_use_id, local_id):
+    """The orchestrator-visible id for a sub-agent-local interrupt id.
+
+    Built from the adapter's own helper so these tests pin behaviour rather than the id format.
+    """
+    return f"{_namespace_prefix(tool_use_id)}{local_id}"
 
 
 def interrupt_result_for(interrupt_id):
@@ -520,7 +530,7 @@ async def test_stream_interrupt_yields_tool_interrupt_event(tool, mock_agent, to
     assert events[0].tool_use_id == "tool-123"
 
     tru_interrupts = events[0].interrupts
-    exp_interrupts = [Interrupt(id="tool-123:interrupt-1", name="approval", reason="need approval")]
+    exp_interrupts = [Interrupt(id=namespaced_id("tool-123", "interrupt-1"), name="approval", reason="need approval")]
     assert tru_interrupts == exp_interrupts
 
 
@@ -555,11 +565,10 @@ async def test_stream_interrupt_resume_forwards_responses(fake_agent, orchestrat
     fake_agent._interrupt_state.interrupts["interrupt-1"] = Interrupt(id="interrupt-1", name="approval", reason="r")
     fake_agent._interrupt_state.activate()
 
-    orchestrator._interrupt_state.interrupts["tool-123:interrupt-1"] = Interrupt(
-        id="tool-123:interrupt-1", name="approval", reason="r"
-    )
+    parent_id = namespaced_id("tool-123", "interrupt-1")
+    orchestrator._interrupt_state.interrupts[parent_id] = Interrupt(id=parent_id, name="approval", reason="r")
     orchestrator._interrupt_state.context["responses"] = [
-        {"interruptResponse": {"interruptId": "tool-123:interrupt-1", "response": "APPROVE"}}
+        {"interruptResponse": {"interruptId": parent_id, "response": "APPROVE"}}
     ]
     orchestrator._interrupt_state.activate()
 
@@ -588,6 +597,9 @@ async def test_stream_interrupt_resume_forwards_responses(fake_agent, orchestrat
 @pytest.mark.asyncio
 async def test_stream_interrupt_resume_skips_state_reset(fake_agent, orchestrator):
     """Resuming an interrupt keeps the sub-agent's interrupted turn instead of resetting it."""
+    # Built while the sub-agent has no messages, so its reset baseline is empty and a reset would show.
+    tool = _AgentAsTool(fake_agent, name="fake_agent", description="desc", preserve_context=False)
+
     fake_agent.messages = [
         {"role": "user", "content": [{"text": "initial"}]},
         {"role": "assistant", "content": [{"text": "working on it"}]},
@@ -595,15 +607,12 @@ async def test_stream_interrupt_resume_skips_state_reset(fake_agent, orchestrato
     fake_agent._interrupt_state.interrupts["interrupt-1"] = Interrupt(id="interrupt-1", name="approval", reason="r")
     fake_agent._interrupt_state.activate()
 
-    orchestrator._interrupt_state.interrupts["tool-123:interrupt-1"] = Interrupt(
-        id="tool-123:interrupt-1", name="approval", reason="r"
-    )
+    parent_id = namespaced_id("tool-123", "interrupt-1")
+    orchestrator._interrupt_state.interrupts[parent_id] = Interrupt(id=parent_id, name="approval", reason="r")
     orchestrator._interrupt_state.context["responses"] = [
-        {"interruptResponse": {"interruptId": "tool-123:interrupt-1", "response": "APPROVE"}}
+        {"interruptResponse": {"interruptId": parent_id, "response": "APPROVE"}}
     ]
     orchestrator._interrupt_state.activate()
-
-    tool = _AgentAsTool(fake_agent, name="fake_agent", description="desc", preserve_context=False)
 
     normal_result = AgentResult(
         stop_reason="end_turn",
@@ -617,36 +626,36 @@ async def test_stream_interrupt_resume_skips_state_reset(fake_agent, orchestrato
     async for _ in tool.stream(tool_use, {"agent": orchestrator}):
         pass
 
-    assert len(fake_agent.messages) == 2
+    tru_messages = fake_agent.messages
+    exp_messages = [
+        {"role": "user", "content": [{"text": "initial"}]},
+        {"role": "assistant", "content": [{"text": "working on it"}]},
+    ]
+    assert tru_messages == exp_messages
+
+    tru_prompt = fake_agent.stream_async.call_args[0][0]
+    exp_prompt = [{"interruptResponse": {"interruptId": "interrupt-1", "response": "APPROVE"}}]
+    assert tru_prompt == exp_prompt
 
 
-@pytest.mark.asyncio
-async def test_is_sub_agent_interrupted_false_by_default(tool):
-    """_is_sub_agent_interrupted returns False when no interrupts are active."""
-    assert tool._is_sub_agent_interrupted() is False
-
-
-@pytest.mark.asyncio
-async def test_is_sub_agent_interrupted_true_when_activated(fake_agent):
-    """_is_sub_agent_interrupted returns True when the sub-agent's interrupt state is activated."""
-    tool = _AgentAsTool(fake_agent, name="fake_agent", description="desc", preserve_context=True)
-    assert tool._is_sub_agent_interrupted() is False
-
-    fake_agent._interrupt_state.activate()
-    assert tool._is_sub_agent_interrupted() is True
-
-
-@pytest.mark.asyncio
-async def test_interrupt_responses_maps_only_this_calls_answers(fake_agent, orchestrator):
+def test_parent_call_responses_maps_only_this_calls_answers(orchestrator):
     """Only answers addressed to this tool call are mapped, and the local id keeps its own colons."""
-    tool = _AgentAsTool(fake_agent, name="fake_agent", description="desc", preserve_context=True)
-
     orchestrator._interrupt_state.context["responses"] = [
-        {"interruptResponse": {"interruptId": "tool-123:v1:before_tool_call:sub-1:abc", "response": "APPROVE"}},
-        {"interruptResponse": {"interruptId": "tool-456:v1:before_tool_call:sub-2:def", "response": "DENY"}},
+        {
+            "interruptResponse": {
+                "interruptId": namespaced_id("tool-123", "v1:before_tool_call:sub-1:abc"),
+                "response": "APPROVE",
+            }
+        },
+        {
+            "interruptResponse": {
+                "interruptId": namespaced_id("tool-456", "v1:before_tool_call:sub-2:def"),
+                "response": "DENY",
+            }
+        },
     ]
 
-    tru_responses = tool._interrupt_responses({"agent": orchestrator}, "tool-123")
+    tru_responses = _ParentCall(orchestrator, "tool-123").responses()
     exp_responses = [{"interruptResponse": {"interruptId": "v1:before_tool_call:sub-1:abc", "response": "APPROVE"}}]
     assert tru_responses == exp_responses
 
@@ -793,12 +802,11 @@ async def test_stream_resume_restores_ephemeral_sub_agent_from_continuation(orch
     interrupted._interrupt_state.interrupts["interrupt-1"] = Interrupt(id="interrupt-1", name="approval", reason="r")
     interrupted._interrupt_state.activate()
 
-    orchestrator._interrupt_state.interrupts["tool-123:interrupt-1"] = Interrupt(
-        id="tool-123:interrupt-1", name="approval", reason="r"
-    )
+    parent_id = namespaced_id("tool-123", "interrupt-1")
+    orchestrator._interrupt_state.interrupts[parent_id] = Interrupt(id=parent_id, name="approval", reason="r")
     orchestrator._interrupt_state.context.update(
         {
-            "responses": [{"interruptResponse": {"interruptId": "tool-123:interrupt-1", "response": "APPROVE"}}],
+            "responses": [{"interruptResponse": {"interruptId": parent_id, "response": "APPROVE"}}],
             "sub_agent_continuations": {"tool-123": interrupted.take_snapshot(preset="session").to_dict()},
         }
     )
@@ -840,11 +848,10 @@ async def test_stream_resume_leaves_unanswered_sub_agent_pending(fake_agent, orc
     fake_agent._interrupt_state.interrupts["interrupt-1"] = Interrupt(id="interrupt-1", name="approval", reason="r")
     fake_agent._interrupt_state.activate()
 
-    orchestrator._interrupt_state.interrupts["tool-123:interrupt-1"] = Interrupt(
-        id="tool-123:interrupt-1", name="approval", reason="r"
-    )
+    parent_id = namespaced_id("tool-123", "interrupt-1")
+    orchestrator._interrupt_state.interrupts[parent_id] = Interrupt(id=parent_id, name="approval", reason="r")
     orchestrator._interrupt_state.context["responses"] = [
-        {"interruptResponse": {"interruptId": "tool-999:interrupt-1", "response": "APPROVE"}}
+        {"interruptResponse": {"interruptId": namespaced_id("tool-999", "interrupt-1"), "response": "APPROVE"}}
     ]
     orchestrator._interrupt_state.activate()
 
@@ -870,9 +877,8 @@ async def test_stream_ignores_interrupt_belonging_to_another_call(fake_agent, or
     fake_agent._interrupt_state.interrupts["interrupt-1"] = Interrupt(id="interrupt-1", name="approval", reason="r")
     fake_agent._interrupt_state.activate()
 
-    orchestrator._interrupt_state.interrupts["tool-999:interrupt-1"] = Interrupt(
-        id="tool-999:interrupt-1", name="approval", reason="r"
-    )
+    other_call_id = namespaced_id("tool-999", "interrupt-1")
+    orchestrator._interrupt_state.interrupts[other_call_id] = Interrupt(id=other_call_id, name="approval", reason="r")
     orchestrator._interrupt_state.activate()
 
     fake_agent.stream_async = MagicMock(return_value=_mock_stream_async(agent_result))
@@ -893,11 +899,10 @@ async def test_stream_ignores_interrupt_belonging_to_another_call(fake_agent, or
 @pytest.mark.asyncio
 async def test_stream_resume_without_restorable_turn_reports_an_error(fake_agent, orchestrator, caplog):
     """A context-preserving sub-agent that lost its interrupted turn fails loudly instead of silently."""
-    orchestrator._interrupt_state.interrupts["tool-123:interrupt-1"] = Interrupt(
-        id="tool-123:interrupt-1", name="approval", reason="r"
-    )
+    parent_id = namespaced_id("tool-123", "interrupt-1")
+    orchestrator._interrupt_state.interrupts[parent_id] = Interrupt(id=parent_id, name="approval", reason="r")
     orchestrator._interrupt_state.context["responses"] = [
-        {"interruptResponse": {"interruptId": "tool-123:interrupt-1", "response": "APPROVE"}}
+        {"interruptResponse": {"interruptId": parent_id, "response": "APPROVE"}}
     ]
     orchestrator._interrupt_state.activate()
 
@@ -915,11 +920,26 @@ async def test_stream_resume_without_restorable_turn_reports_an_error(fake_agent
     assert "cannot resume" in caplog.text
 
 
-def test_nested_interrupt_resumes_after_rehydration(tmp_path):
-    """Regression test for https://github.com/strands-agents/harness-sdk/issues/3076.
+def tool_use_message(tool_use_id, name, tool_input):
+    """An assistant message calling one tool."""
+    return {
+        "role": "assistant",
+        "content": [{"toolUse": {"toolUseId": tool_use_id, "name": name, "input": tool_input}}],
+    }
 
-    A stateless handler rebuilds the orchestrator and its sub-agent on every request, so resuming a
-    nested interrupt has to work from persisted data rather than a shared in-memory ``Interrupt``.
+
+def text_message(text):
+    """An assistant message carrying plain text."""
+    return {"role": "assistant", "content": [{"text": text}]}
+
+
+@pytest.fixture
+def confirmable_action():
+    """A tool guarded by a confirmation interrupt, plus the record of what it actually ran.
+
+    Returns:
+        The tool, a hook provider that interrupts before the tool runs, and the list of targets the
+        tool executed on.
     """
     executions = []
 
@@ -939,14 +959,45 @@ def test_nested_interrupt_resumes_after_rehydration(tmp_path):
             if event.interrupt("confirm_dangerous", reason="confirm?") != "APPROVE":
                 event.cancel_tool = "not approved"
 
-    def tool_use_message(tool_use_id, name, tool_input):
-        return {
-            "role": "assistant",
-            "content": [{"toolUse": {"toolUseId": tool_use_id, "name": name, "input": tool_input}}],
-        }
+    return dangerous_action, ConfirmHook(), executions
 
-    def text_message(text):
-        return {"role": "assistant", "content": [{"text": text}]}
+
+def set_parked_turn_schema_version(storage_dir, schema_version):
+    """Rewrite the schema version of every parked sub-agent turn in a persisted session.
+
+    Reproduces the version skew the reinstate path guards against: a turn written by one build of the
+    SDK that the build now running will not load.
+
+    Returns:
+        Number of parked turns rewritten.
+    """
+    rewritten = 0
+    for path in pathlib.Path(storage_dir).rglob("agent.json"):
+        record = json.loads(path.read_text())
+        parked = (
+            record.get("_internal_state", {})
+            .get("interrupt_state", {})
+            .get("context", {})
+            .get("sub_agent_continuations")
+        )
+        if not parked:
+            continue
+
+        for turn in parked.values():
+            turn["schema_version"] = schema_version
+            rewritten += 1
+        path.write_text(json.dumps(record))
+
+    return rewritten
+
+
+def test_nested_interrupt_resumes_after_rehydration(tmp_path, confirmable_action):
+    """Regression test for https://github.com/strands-agents/harness-sdk/issues/3076.
+
+    A stateless handler rebuilds the orchestrator and its sub-agent on every request, so resuming a
+    nested interrupt has to work from persisted data rather than a shared in-memory ``Interrupt``.
+    """
+    dangerous_action, confirm_hook, executions = confirmable_action
 
     def build_orchestrator(sub_agent_responses, orchestrator_responses):
         sub_agent = Agent(
@@ -954,7 +1005,7 @@ def test_nested_interrupt_resumes_after_rehydration(tmp_path):
             agent_id="worker",
             model=MockedModelProvider(sub_agent_responses),
             tools=[dangerous_action],
-            hooks=[ConfirmHook()],
+            hooks=[confirm_hook],
             callback_handler=None,
         )
         return Agent(
@@ -987,18 +1038,134 @@ def test_nested_interrupt_resumes_after_rehydration(tmp_path):
     assert tru_executions == exp_executions
 
 
+def test_nested_interrupt_resumes_after_rehydration_with_a_sub_agent_session_manager(tmp_path, confirmable_action):
+    """A context-preserving sub-agent that owns a session manager resumes across a process boundary.
+
+    This is the configuration issue #3076 describes literally: ``preserve_context=True``, with both the
+    orchestrator and the sub-agent rebuilt from the session store. The orchestrator parks no turn for a
+    sub-agent that preserves context, so the resume runs entirely off the sub-agent's own session plus
+    the answer the orchestrator carries as data.
+    """
+    dangerous_action, confirm_hook, executions = confirmable_action
+
+    def build_orchestrator(sub_agent_responses, orchestrator_responses):
+        sub_agent = Agent(
+            name="worker",
+            agent_id="worker",
+            model=MockedModelProvider(sub_agent_responses),
+            tools=[dangerous_action],
+            hooks=[confirm_hook],
+            callback_handler=None,
+            session_manager=FileSessionManager("session-sub", storage_dir=str(tmp_path)),
+        )
+        return Agent(
+            name="orchestrator",
+            agent_id="orchestrator",
+            model=MockedModelProvider(orchestrator_responses),
+            tools=[sub_agent.as_tool(preserve_context=True)],
+            callback_handler=None,
+            session_manager=FileSessionManager("session-orch", storage_dir=str(tmp_path)),
+        )
+
+    orchestrator = build_orchestrator(
+        [tool_use_message("sub-1", "dangerous_action", {"target": "prod-db"}), text_message("done")],
+        [tool_use_message("orch-1", "worker", {"input": "go"}), text_message("all done")],
+    )
+    interrupted_result = orchestrator("do the thing that needs confirmation")
+
+    assert interrupted_result.stop_reason == "interrupt"
+    assert executions == []
+    interrupt_id = interrupted_result.interrupts[0].id
+
+    resumed_orchestrator = build_orchestrator([text_message("done")], [text_message("all done")])
+    tru_result = resumed_orchestrator([{"interruptResponse": {"interruptId": interrupt_id, "response": "APPROVE"}}])
+
+    assert tru_result.stop_reason == "end_turn"
+
+    tru_executions = executions
+    exp_executions = ["prod-db"]
+    assert tru_executions == exp_executions
+
+
+def test_nested_interrupt_survives_a_parked_turn_that_fails_to_load(tmp_path, confirmable_action):
+    """A parked turn that fails to load once is not lost: answering again still runs the confirmed tool.
+
+    Keeping the parked turn only helps if the interrupt stays pending with it, because the event loop
+    clears an agent's whole interrupt record as soon as a turn ends. So the failed reinstate has to
+    leave the orchestrator parked rather than report a failed tool call.
+    """
+    dangerous_action, confirm_hook, executions = confirmable_action
+
+    def build_orchestrator(sub_agent_responses, orchestrator_responses):
+        sub_agent = Agent(
+            name="worker",
+            agent_id="worker",
+            model=MockedModelProvider(sub_agent_responses),
+            tools=[dangerous_action],
+            hooks=[confirm_hook],
+            callback_handler=None,
+        )
+        return Agent(
+            name="orchestrator",
+            agent_id="orchestrator",
+            model=MockedModelProvider(orchestrator_responses),
+            tools=[sub_agent.as_tool()],
+            callback_handler=None,
+            session_manager=FileSessionManager("session-retry", storage_dir=str(tmp_path)),
+        )
+
+    orchestrator = build_orchestrator(
+        [tool_use_message("sub-1", "dangerous_action", {"target": "prod-db"}), text_message("done")],
+        [tool_use_message("orch-1", "worker", {"input": "go"}), text_message("all done")],
+    )
+    interrupted_result = orchestrator("do the thing that needs confirmation")
+
+    assert interrupted_result.stop_reason == "interrupt"
+    interrupt_id = interrupted_result.interrupts[0].id
+
+    # The running build cannot read the parked turn, e.g. mid-rollout across two SDK versions.
+    assert set_parked_turn_schema_version(tmp_path, "0.0") == 1
+
+    unloadable_result = build_orchestrator([text_message("done")], [text_message("all done")])(
+        [{"interruptResponse": {"interruptId": interrupt_id, "response": "APPROVE"}}]
+    )
+
+    assert unloadable_result.stop_reason == "interrupt"
+    assert [interrupt.id for interrupt in unloadable_result.interrupts] == [interrupt_id]
+    assert executions == []
+
+    # The turn is readable again, and the same answer now applies.
+    assert set_parked_turn_schema_version(tmp_path, "1.0") == 1
+
+    tru_result = build_orchestrator([text_message("done")], [text_message("all done")])(
+        [{"interruptResponse": {"interruptId": interrupt_id, "response": "APPROVE"}}]
+    )
+
+    assert tru_result.stop_reason == "end_turn"
+
+    tru_executions = executions
+    exp_executions = ["prod-db"]
+    assert tru_executions == exp_executions
+
+
 @pytest.mark.asyncio
-async def test_stream_resume_keeps_stored_turn_when_it_cannot_be_loaded(fake_agent, orchestrator, caplog):
-    """A stored turn that fails to load is kept, so a later attempt can still apply the human's answer."""
+async def test_stream_resume_reraises_the_interrupt_when_the_parked_turn_cannot_be_loaded(
+    fake_agent, orchestrator, caplog
+):
+    """A parked turn that fails to load raises the interrupt again rather than failing the call.
+
+    Yielding a result here would end the orchestrator's turn, and the event loop clears the whole
+    interrupt record when a turn ends - so the parked turn and the human's answer have to be carried by
+    a still-pending interrupt to survive for another attempt.
+    """
     unloadable = Agent(name="fake_agent", callback_handler=None).take_snapshot(preset="session").to_dict()
     unloadable["schema_version"] = "0.0"
 
-    orchestrator._interrupt_state.interrupts["tool-123:interrupt-1"] = Interrupt(
-        id="tool-123:interrupt-1", name="approval", reason="r"
-    )
+    parent_id = namespaced_id("tool-123", "interrupt-1")
+    orchestrator._interrupt_state.interrupts[parent_id] = Interrupt(id=parent_id, name="approval", reason="r")
     orchestrator._interrupt_state.context.update(
         {
-            "responses": [{"interruptResponse": {"interruptId": "tool-123:interrupt-1", "response": "APPROVE"}}],
+            "responses": [{"interruptResponse": {"interruptId": parent_id, "response": "APPROVE"}}],
             "sub_agent_continuations": {"tool-123": unloadable},
         }
     )
@@ -1013,54 +1180,52 @@ async def test_stream_resume_keeps_stored_turn_when_it_cannot_be_loaded(fake_age
 
     fake_agent.stream_async.assert_not_called()
     assert len(events) == 1
-    assert events[0]["tool_result"]["status"] == "error"
-    assert "stored turn failed to load" in events[0]["tool_result"]["content"][0]["text"]
-    assert "failed to restore interrupted sub-agent turn" in caplog.text
+
+    tru_interrupt_ids = [interrupt.id for interrupt in events[0]["tool_interrupt_event"]["interrupts"]]
+    exp_interrupt_ids = [parent_id]
+    assert tru_interrupt_ids == exp_interrupt_ids
+    assert "failed to reinstate interrupted sub-agent turn" in caplog.text
 
     tru_continuations = orchestrator._interrupt_state.context["sub_agent_continuations"]
     exp_continuations = {"tool-123": unloadable}
     assert tru_continuations == exp_continuations
 
 
-def test_namespaced_interrupt_ids_are_not_captured_by_another_call(fake_agent, orchestrator):
+def test_namespaced_interrupt_ids_are_not_captured_by_another_call(orchestrator):
     """One tool call cannot match another call's answers, whatever the model made the ids look like.
 
     Tool use IDs are model-derived, so one call's ID can end in the separator plus the start of
     another call's interrupt IDs. Without escaping, that call would match the other's answers.
     """
-    tool = _AgentAsTool(fake_agent, name="fake_agent", description="desc", preserve_context=True)
     local_id = "v1:before_tool_call:sub-1:abc"
 
-    answered = _AgentAsTool._namespace_interrupts("ob", [Interrupt(id=local_id, name="approval", reason="r")])[0]
+    answered = _namespace_interrupts("ob", [Interrupt(id=local_id, name="approval", reason="r")])[0]
     orchestrator._interrupt_state.interrupts[answered.id] = answered
     orchestrator._interrupt_state.context["responses"] = [
         {"interruptResponse": {"interruptId": answered.id, "response": "APPROVE"}}
     ]
     orchestrator._interrupt_state.activate()
 
-    invocation_state = {"agent": orchestrator}
-
-    tru_answered = tool._interrupt_responses(invocation_state, "ob")
+    tru_answered = _ParentCall(orchestrator, "ob").responses()
     exp_answered = [{"interruptResponse": {"interruptId": local_id, "response": "APPROVE"}}]
     assert tru_answered == exp_answered
 
-    tru_other = tool._interrupt_responses(invocation_state, "ob:v1")
+    tru_other = _ParentCall(orchestrator, "ob:v1").responses()
     exp_other = []
     assert tru_other == exp_other
 
-    assert tool._parent_awaiting_resume(invocation_state, "ob") is True
-    assert tool._parent_awaiting_resume(invocation_state, "ob:v1") is False
+    assert _ParentCall(orchestrator, "ob").awaiting_resume is True
+    assert _ParentCall(orchestrator, "ob:v1").awaiting_resume is False
 
 
-def test_namespaced_interrupt_ids_round_trip_a_separator_bearing_tool_use_id(fake_agent, orchestrator):
+def test_namespaced_interrupt_ids_round_trip_a_separator_bearing_tool_use_id(orchestrator):
     """A tool use ID containing the separator is encoded in the prefix and still round-trips."""
-    tool = _AgentAsTool(fake_agent, name="fake_agent", description="desc", preserve_context=True)
     local_id = "v1:before_tool_call:sub-2:def"
 
-    namespaced = _AgentAsTool._namespace_interrupts("ob:v1", [Interrupt(id=local_id, name="approval", reason="r")])[0]
+    namespaced = _namespace_interrupts("ob:v1", [Interrupt(id=local_id, name="approval", reason="r")])[0]
 
     tru_namespaced_id = namespaced.id
-    exp_namespaced_id = f"ob%3Av1:{local_id}"
+    exp_namespaced_id = f"v1:agent_as_tool:ob%3Av1:{local_id}"
     assert tru_namespaced_id == exp_namespaced_id
 
     orchestrator._interrupt_state.interrupts[namespaced.id] = namespaced
@@ -1069,6 +1234,47 @@ def test_namespaced_interrupt_ids_round_trip_a_separator_bearing_tool_use_id(fak
     ]
     orchestrator._interrupt_state.activate()
 
-    tru_responses = tool._interrupt_responses({"agent": orchestrator}, "ob:v1")
+    tru_responses = _ParentCall(orchestrator, "ob:v1").responses()
     exp_responses = [{"interruptResponse": {"interruptId": local_id, "response": "APPROVE"}}]
     assert tru_responses == exp_responses
+
+
+def test_namespaced_interrupt_ids_are_not_captured_by_a_tool_use_id_of_the_scheme_marker(orchestrator):
+    """A tool use ID of ``v1`` cannot capture the interrupts the orchestrator raised itself.
+
+    Every interrupt id the SDK generates opens with the ``v1:`` scheme marker, and percent-encoding
+    leaves ``v1`` untouched, so a namespace prefix built from the tool use id alone would match all of
+    them and hand the orchestrator's own answers down to a sub-agent.
+    """
+    own_interrupt = Interrupt(id="v1:before_tool_call:orch-1:abc", name="confirm_orch", reason="r")
+    orchestrator._interrupt_state.interrupts[own_interrupt.id] = own_interrupt
+    orchestrator._interrupt_state.context["responses"] = [
+        {"interruptResponse": {"interruptId": own_interrupt.id, "response": "APPROVE"}}
+    ]
+    orchestrator._interrupt_state.activate()
+
+    parent_call = _ParentCall(orchestrator, "v1")
+
+    assert parent_call.awaiting_resume is False
+    assert parent_call.responses() == []
+    assert parent_call.pending_interrupts() == []
+
+
+@pytest.mark.asyncio
+async def test_stream_interrupt_warns_when_a_context_preserving_sub_agent_has_no_session_manager(
+    fake_agent, orchestrator, interrupt_result, caplog
+):
+    """A context-preserving sub-agent with nowhere to keep its turn is flagged as the interrupt parks.
+
+    Warning here rather than on the resume tells the caller before a human is asked for a response that
+    could not be applied after a restart.
+    """
+    fake_agent.stream_async = MagicMock(return_value=_mock_stream_async(interrupt_result))
+    tool = _AgentAsTool(fake_agent, name="fake_agent", description="desc", preserve_context=True)
+    tool_use = {"toolUseId": "tool-123", "name": "fake_agent", "input": {"input": "go"}}
+
+    with caplog.at_level("WARNING"):
+        async for _ in tool.stream(tool_use, {"agent": orchestrator}):
+            pass
+
+    assert "preserve_context=True with no session manager" in caplog.text

--- a/strands-py/tests/strands/agent/test_agent_as_tool.py
+++ b/strands-py/tests/strands/agent/test_agent_as_tool.py
@@ -1053,11 +1053,16 @@ def test_namespaced_interrupt_ids_are_not_captured_by_another_call(fake_agent, o
 
 
 def test_namespaced_interrupt_ids_round_trip_a_separator_bearing_tool_use_id(fake_agent, orchestrator):
-    """A tool use ID containing the separator still maps its own answers back to the local ID."""
+    """A tool use ID containing the separator is encoded in the prefix and still round-trips."""
     tool = _AgentAsTool(fake_agent, name="fake_agent", description="desc", preserve_context=True)
     local_id = "v1:before_tool_call:sub-2:def"
 
     namespaced = _AgentAsTool._namespace_interrupts("ob:v1", [Interrupt(id=local_id, name="approval", reason="r")])[0]
+
+    tru_namespaced_id = namespaced.id
+    exp_namespaced_id = f"ob%3Av1:{local_id}"
+    assert tru_namespaced_id == exp_namespaced_id
+
     orchestrator._interrupt_state.interrupts[namespaced.id] = namespaced
     orchestrator._interrupt_state.context["responses"] = [
         {"interruptResponse": {"interruptId": namespaced.id, "response": "APPROVE"}}

--- a/strands-py/tests/strands/agent/test_agent_as_tool.py
+++ b/strands-py/tests/strands/agent/test_agent_as_tool.py
@@ -4,11 +4,16 @@ from unittest.mock import MagicMock
 
 import pytest
 
+import strands
 from strands.agent._agent_as_tool import _AgentAsTool
+from strands.agent.agent import Agent
 from strands.agent.agent_result import AgentResult
+from strands.hooks import BeforeToolCallEvent, HookProvider, HookRegistry
 from strands.interrupt import Interrupt, _InterruptState
+from strands.session.file_session_manager import FileSessionManager
 from strands.telemetry.metrics import EventLoopMetrics
 from strands.types._events import AgentAsToolStreamEvent, ToolInterruptEvent, ToolResultEvent, ToolStreamEvent
+from tests.fixtures.mocked_model_provider import MockedModelProvider
 
 
 async def _mock_stream_async(result, intermediate_events=None):
@@ -30,9 +35,26 @@ def mock_agent():
 @pytest.fixture
 def fake_agent():
     """A real Agent instance for tests that need Agent-specific features."""
-    from strands.agent.agent import Agent
-
     return Agent(name="fake_agent", callback_handler=None)
+
+
+def interrupt_result_for(interrupt_id):
+    """An interrupt result carrying a single sub-agent-local interrupt."""
+    return AgentResult(
+        stop_reason="interrupt",
+        message={"role": "assistant", "content": [{"text": "needs approval"}]},
+        metrics=EventLoopMetrics(),
+        state={},
+        interrupts=[Interrupt(id=interrupt_id, name="approval", reason="need approval")],
+    )
+
+
+@pytest.fixture
+def orchestrator():
+    """Stand-in orchestrator: agent-as-tool only reads its interrupt state via invocation_state."""
+    parent = MagicMock()
+    parent._interrupt_state = _InterruptState()
+    return parent
 
 
 @pytest.fixture
@@ -488,15 +510,18 @@ def interrupt_result():
 
 @pytest.mark.asyncio
 async def test_stream_interrupt_yields_tool_interrupt_event(tool, mock_agent, tool_use, interrupt_result):
-    """When the sub-agent returns an interrupt result, _AgentAsTool should yield ToolInterruptEvent."""
+    """A sub-agent interrupt propagates upward with its id namespaced by this tool call."""
     mock_agent.stream_async.return_value = _mock_stream_async(interrupt_result)
 
     events = [event async for event in tool.stream(tool_use, {})]
 
     assert len(events) == 1
     assert isinstance(events[0], ToolInterruptEvent)
-    assert events[0].interrupts == interrupt_result.interrupts
     assert events[0].tool_use_id == "tool-123"
+
+    tru_interrupts = events[0].interrupts
+    exp_interrupts = [Interrupt(id="tool-123:interrupt-1", name="approval", reason="need approval")]
+    assert tru_interrupts == exp_interrupts
 
 
 @pytest.mark.asyncio
@@ -525,13 +550,18 @@ async def test_stream_interrupt_forwards_intermediate_events(tool, mock_agent, t
 
 
 @pytest.mark.asyncio
-async def test_stream_interrupt_resume_forwards_responses(fake_agent):
-    """On resume, _AgentAsTool should forward interrupt responses to the sub-agent."""
-    interrupt = Interrupt(id="interrupt-1", name="approval", reason="need approval", response="APPROVE")
-
-    # Put the sub-agent in an activated interrupt state with the response already set
-    fake_agent._interrupt_state.interrupts["interrupt-1"] = interrupt
+async def test_stream_interrupt_resume_forwards_responses(fake_agent, orchestrator):
+    """Resume maps the orchestrator's interrupt responses back to sub-agent-local ids."""
+    fake_agent._interrupt_state.interrupts["interrupt-1"] = Interrupt(id="interrupt-1", name="approval", reason="r")
     fake_agent._interrupt_state.activate()
+
+    orchestrator._interrupt_state.interrupts["tool-123:interrupt-1"] = Interrupt(
+        id="tool-123:interrupt-1", name="approval", reason="r"
+    )
+    orchestrator._interrupt_state.context["responses"] = [
+        {"interruptResponse": {"interruptId": "tool-123:interrupt-1", "response": "APPROVE"}}
+    ]
+    orchestrator._interrupt_state.activate()
 
     normal_result = AgentResult(
         stop_reason="end_turn",
@@ -544,37 +574,36 @@ async def test_stream_interrupt_resume_forwards_responses(fake_agent):
     tool = _AgentAsTool(fake_agent, name="fake_agent", description="desc", preserve_context=True)
     tool_use = {"toolUseId": "tool-123", "name": "fake_agent", "input": {"input": "do something"}}
 
-    events = [event async for event in tool.stream(tool_use, {})]
+    events = [event async for event in tool.stream(tool_use, {"agent": orchestrator})]
 
-    # Should have called stream_async with interrupt responses, not the original prompt
-    call_args = fake_agent.stream_async.call_args
-    agent_input = call_args[0][0]
-    assert isinstance(agent_input, list)
-    assert len(agent_input) == 1
-    assert agent_input[0]["interruptResponse"]["interruptId"] == "interrupt-1"
-    assert agent_input[0]["interruptResponse"]["response"] == "APPROVE"
+    tru_prompt = fake_agent.stream_async.call_args[0][0]
+    exp_prompt = [{"interruptResponse": {"interruptId": "interrupt-1", "response": "APPROVE"}}]
+    assert tru_prompt == exp_prompt
 
-    # Should produce a normal result
-    result_events = [e for e in events if isinstance(e, ToolResultEvent)]
+    result_events = [event for event in events if isinstance(event, ToolResultEvent)]
     assert len(result_events) == 1
     assert result_events[0]["tool_result"]["status"] == "success"
 
 
 @pytest.mark.asyncio
-async def test_stream_interrupt_resume_skips_state_reset(fake_agent):
-    """When resuming from interrupt with preserve_context=False, state reset should be skipped."""
-    fake_agent.messages = [{"role": "user", "content": [{"text": "initial"}]}]
-    fake_agent.state.set("key", "value")
-
-    tool = _AgentAsTool(fake_agent, name="fake_agent", description="desc", preserve_context=False)
-
-    # Simulate the sub-agent being in interrupt state after a previous invocation
-    interrupt = Interrupt(id="interrupt-1", name="approval", reason="need approval", response="APPROVE")
-    fake_agent._interrupt_state.interrupts["interrupt-1"] = interrupt
+async def test_stream_interrupt_resume_skips_state_reset(fake_agent, orchestrator):
+    """Resuming an interrupt keeps the sub-agent's interrupted turn instead of resetting it."""
+    fake_agent.messages = [
+        {"role": "user", "content": [{"text": "initial"}]},
+        {"role": "assistant", "content": [{"text": "working on it"}]},
+    ]
+    fake_agent._interrupt_state.interrupts["interrupt-1"] = Interrupt(id="interrupt-1", name="approval", reason="r")
     fake_agent._interrupt_state.activate()
 
-    # Mutate messages to simulate sub-agent progress before interrupt
-    fake_agent.messages.append({"role": "assistant", "content": [{"text": "working on it"}]})
+    orchestrator._interrupt_state.interrupts["tool-123:interrupt-1"] = Interrupt(
+        id="tool-123:interrupt-1", name="approval", reason="r"
+    )
+    orchestrator._interrupt_state.context["responses"] = [
+        {"interruptResponse": {"interruptId": "tool-123:interrupt-1", "response": "APPROVE"}}
+    ]
+    orchestrator._interrupt_state.activate()
+
+    tool = _AgentAsTool(fake_agent, name="fake_agent", description="desc", preserve_context=False)
 
     normal_result = AgentResult(
         stop_reason="end_turn",
@@ -585,10 +614,9 @@ async def test_stream_interrupt_resume_skips_state_reset(fake_agent):
     fake_agent.stream_async = MagicMock(return_value=_mock_stream_async(normal_result))
 
     tool_use = {"toolUseId": "tool-123", "name": "fake_agent", "input": {"input": "do something"}}
-    async for _ in tool.stream(tool_use, {}):
+    async for _ in tool.stream(tool_use, {"agent": orchestrator}):
         pass
 
-    # Messages should NOT have been reset — the sub-agent needs its conversation history intact
     assert len(fake_agent.messages) == 2
 
 
@@ -609,19 +637,18 @@ async def test_is_sub_agent_interrupted_true_when_activated(fake_agent):
 
 
 @pytest.mark.asyncio
-async def test_build_interrupt_responses(fake_agent):
-    """_build_interrupt_responses packages sub-agent interrupts into response content blocks."""
+async def test_interrupt_responses_maps_only_this_calls_answers(fake_agent, orchestrator):
+    """Only answers addressed to this tool call are mapped, and the local id keeps its own colons."""
     tool = _AgentAsTool(fake_agent, name="fake_agent", description="desc", preserve_context=True)
 
-    interrupt_a = Interrupt(id="id-a", name="a", reason="r", response="yes")
-    interrupt_b = Interrupt(id="id-b", name="b", reason="r", response=None)
-    fake_agent._interrupt_state.interrupts = {"id-a": interrupt_a, "id-b": interrupt_b}
+    orchestrator._interrupt_state.context["responses"] = [
+        {"interruptResponse": {"interruptId": "tool-123:v1:before_tool_call:sub-1:abc", "response": "APPROVE"}},
+        {"interruptResponse": {"interruptId": "tool-456:v1:before_tool_call:sub-2:def", "response": "DENY"}},
+    ]
 
-    responses = tool._build_interrupt_responses()
-
-    # Only interrupt_a has a response
-    assert len(responses) == 1
-    assert responses[0] == {"interruptResponse": {"interruptId": "id-a", "response": "yes"}}
+    tru_responses = tool._interrupt_responses({"agent": orchestrator}, "tool-123")
+    exp_responses = [{"interruptResponse": {"interruptId": "v1:before_tool_call:sub-1:abc", "response": "APPROVE"}}]
+    assert tru_responses == exp_responses
 
 
 # --- concurrency ---
@@ -720,3 +747,241 @@ def test_agent_mixed_with_regular_tools_in_tools_list():
 
     assert "my_tool" in parent.tool_names
     assert "helper_agent" in parent.tool_names
+
+
+@pytest.mark.asyncio
+async def test_stream_interrupt_stores_continuation_for_ephemeral_sub_agent(fake_agent, orchestrator, interrupt_result):
+    """An ephemeral sub-agent's interrupted turn is stored in the orchestrator's interrupt context."""
+    fake_agent.messages = [{"role": "user", "content": [{"text": "go"}]}]
+    fake_agent.stream_async = MagicMock(return_value=_mock_stream_async(interrupt_result))
+    tool = _AgentAsTool(fake_agent, name="fake_agent", description="desc", preserve_context=False)
+    tool_use = {"toolUseId": "tool-123", "name": "fake_agent", "input": {"input": "go"}}
+
+    async for _ in tool.stream(tool_use, {"agent": orchestrator}):
+        pass
+
+    continuations = orchestrator._interrupt_state.context["sub_agent_continuations"]
+    assert list(continuations) == ["tool-123"]
+
+    tru_messages = continuations["tool-123"]["data"]["messages"]
+    exp_messages = [{"role": "user", "content": [{"text": "go"}]}]
+    assert tru_messages == exp_messages
+
+
+@pytest.mark.asyncio
+async def test_stream_interrupt_stores_no_continuation_when_context_is_preserved(
+    fake_agent, orchestrator, interrupt_result
+):
+    """A context-preserving sub-agent owns its state, so the orchestrator stores nothing for it."""
+    fake_agent.stream_async = MagicMock(return_value=_mock_stream_async(interrupt_result))
+    tool = _AgentAsTool(fake_agent, name="fake_agent", description="desc", preserve_context=True)
+    tool_use = {"toolUseId": "tool-123", "name": "fake_agent", "input": {"input": "go"}}
+
+    async for _ in tool.stream(tool_use, {"agent": orchestrator}):
+        pass
+
+    tru_context = orchestrator._interrupt_state.context
+    exp_context = {}
+    assert tru_context == exp_context
+
+
+@pytest.mark.asyncio
+async def test_stream_resume_restores_ephemeral_sub_agent_from_continuation(orchestrator):
+    """An ephemeral sub-agent rebuilt from scratch resumes from the stored continuation."""
+    interrupted = Agent(name="fake_agent", callback_handler=None)
+    interrupted.messages = [{"role": "user", "content": [{"text": "go"}]}]
+    interrupted._interrupt_state.interrupts["interrupt-1"] = Interrupt(id="interrupt-1", name="approval", reason="r")
+    interrupted._interrupt_state.activate()
+
+    orchestrator._interrupt_state.interrupts["tool-123:interrupt-1"] = Interrupt(
+        id="tool-123:interrupt-1", name="approval", reason="r"
+    )
+    orchestrator._interrupt_state.context.update(
+        {
+            "responses": [{"interruptResponse": {"interruptId": "tool-123:interrupt-1", "response": "APPROVE"}}],
+            "sub_agent_continuations": {"tool-123": interrupted.take_snapshot(preset="session").to_dict()},
+        }
+    )
+    orchestrator._interrupt_state.activate()
+
+    rebuilt = Agent(name="fake_agent", callback_handler=None)
+    normal_result = AgentResult(
+        stop_reason="end_turn",
+        message={"role": "assistant", "content": [{"text": "done"}]},
+        metrics=EventLoopMetrics(),
+        state={},
+    )
+    rebuilt.stream_async = MagicMock(return_value=_mock_stream_async(normal_result))
+
+    tool = _AgentAsTool(rebuilt, name="fake_agent", description="desc", preserve_context=False)
+    tool_use = {"toolUseId": "tool-123", "name": "fake_agent", "input": {"input": "go"}}
+
+    async for _ in tool.stream(tool_use, {"agent": orchestrator}):
+        pass
+
+    tru_messages = rebuilt.messages
+    exp_messages = [{"role": "user", "content": [{"text": "go"}]}]
+    assert tru_messages == exp_messages
+    assert list(rebuilt._interrupt_state.interrupts) == ["interrupt-1"]
+
+    tru_prompt = rebuilt.stream_async.call_args[0][0]
+    exp_prompt = [{"interruptResponse": {"interruptId": "interrupt-1", "response": "APPROVE"}}]
+    assert tru_prompt == exp_prompt
+
+    # The continuation is consumed; a sub-agent that interrupts again stores a fresh one.
+    tru_continuations = orchestrator._interrupt_state.context["sub_agent_continuations"]
+    exp_continuations = {}
+    assert tru_continuations == exp_continuations
+
+
+@pytest.mark.asyncio
+async def test_stream_resume_leaves_unanswered_sub_agent_pending(fake_agent, orchestrator):
+    """A sub-agent whose interrupt was not answered is re-invoked with no responses so it re-raises."""
+    fake_agent._interrupt_state.interrupts["interrupt-1"] = Interrupt(id="interrupt-1", name="approval", reason="r")
+    fake_agent._interrupt_state.activate()
+
+    orchestrator._interrupt_state.interrupts["tool-123:interrupt-1"] = Interrupt(
+        id="tool-123:interrupt-1", name="approval", reason="r"
+    )
+    orchestrator._interrupt_state.context["responses"] = [
+        {"interruptResponse": {"interruptId": "tool-999:interrupt-1", "response": "APPROVE"}}
+    ]
+    orchestrator._interrupt_state.activate()
+
+    fake_agent.stream_async = MagicMock(return_value=_mock_stream_async(interrupt_result_for("interrupt-1")))
+    tool = _AgentAsTool(fake_agent, name="fake_agent", description="desc", preserve_context=True)
+    tool_use = {"toolUseId": "tool-123", "name": "fake_agent", "input": {"input": "go"}}
+
+    async for _ in tool.stream(tool_use, {"agent": orchestrator}):
+        pass
+
+    tru_prompt = fake_agent.stream_async.call_args[0][0]
+    exp_prompt = []
+    assert tru_prompt == exp_prompt
+
+
+@pytest.mark.asyncio
+async def test_stream_ignores_interrupt_belonging_to_another_call(fake_agent, orchestrator, agent_result):
+    """An interrupt the orchestrator holds for a different tool call is not adopted by this one."""
+    tool = _AgentAsTool(fake_agent, name="fake_agent", description="desc", preserve_context=False)
+
+    # The sub-agent still carries another caller's parked turn, e.g. after restoring a shared session.
+    fake_agent.messages = [{"role": "user", "content": [{"text": "another caller's turn"}]}]
+    fake_agent._interrupt_state.interrupts["interrupt-1"] = Interrupt(id="interrupt-1", name="approval", reason="r")
+    fake_agent._interrupt_state.activate()
+
+    orchestrator._interrupt_state.interrupts["tool-999:interrupt-1"] = Interrupt(
+        id="tool-999:interrupt-1", name="approval", reason="r"
+    )
+    orchestrator._interrupt_state.activate()
+
+    fake_agent.stream_async = MagicMock(return_value=_mock_stream_async(agent_result))
+    tool_use = {"toolUseId": "tool-123", "name": "fake_agent", "input": {"input": "go"}}
+
+    async for _ in tool.stream(tool_use, {"agent": orchestrator}):
+        pass
+
+    tru_prompt = fake_agent.stream_async.call_args[0][0]
+    exp_prompt = "go"
+    assert tru_prompt == exp_prompt
+
+    tru_messages = fake_agent.messages
+    exp_messages = []
+    assert tru_messages == exp_messages
+
+
+@pytest.mark.asyncio
+async def test_stream_resume_without_restorable_turn_reports_an_error(fake_agent, orchestrator, caplog):
+    """A context-preserving sub-agent that lost its interrupted turn fails loudly instead of silently."""
+    orchestrator._interrupt_state.interrupts["tool-123:interrupt-1"] = Interrupt(
+        id="tool-123:interrupt-1", name="approval", reason="r"
+    )
+    orchestrator._interrupt_state.context["responses"] = [
+        {"interruptResponse": {"interruptId": "tool-123:interrupt-1", "response": "APPROVE"}}
+    ]
+    orchestrator._interrupt_state.activate()
+
+    fake_agent.stream_async = MagicMock()
+    tool = _AgentAsTool(fake_agent, name="fake_agent", description="desc", preserve_context=True)
+    tool_use = {"toolUseId": "tool-123", "name": "fake_agent", "input": {"input": "go"}}
+
+    with caplog.at_level("ERROR"):
+        events = [event async for event in tool.stream(tool_use, {"agent": orchestrator})]
+
+    fake_agent.stream_async.assert_not_called()
+    assert len(events) == 1
+    assert events[0]["tool_result"]["status"] == "error"
+    assert "session manager" in events[0]["tool_result"]["content"][0]["text"]
+    assert "cannot resume" in caplog.text
+
+
+def test_nested_interrupt_resumes_after_rehydration(tmp_path):
+    """Regression test for https://github.com/strands-agents/harness-sdk/issues/3076.
+
+    A stateless handler rebuilds the orchestrator and its sub-agent on every request, so resuming a
+    nested interrupt has to work from persisted data rather than a shared in-memory ``Interrupt``.
+    """
+    executions = []
+
+    @strands.tool
+    def dangerous_action(target: str) -> str:
+        """Perform an action that requires confirmation."""
+        executions.append(target)
+        return f"done: {target}"
+
+    class ConfirmHook(HookProvider):
+        def register_hooks(self, registry: HookRegistry, **kwargs) -> None:
+            registry.add_callback(BeforeToolCallEvent, self._confirm)
+
+        def _confirm(self, event: BeforeToolCallEvent) -> None:
+            if event.tool_use["name"] != "dangerous_action":
+                return
+            if event.interrupt("confirm_dangerous", reason="confirm?") != "APPROVE":
+                event.cancel_tool = "not approved"
+
+    def tool_use_message(tool_use_id, name, tool_input):
+        return {
+            "role": "assistant",
+            "content": [{"toolUse": {"toolUseId": tool_use_id, "name": name, "input": tool_input}}],
+        }
+
+    def text_message(text):
+        return {"role": "assistant", "content": [{"text": text}]}
+
+    def build_orchestrator(sub_agent_responses, orchestrator_responses):
+        sub_agent = Agent(
+            name="worker",
+            agent_id="worker",
+            model=MockedModelProvider(sub_agent_responses),
+            tools=[dangerous_action],
+            hooks=[ConfirmHook()],
+            callback_handler=None,
+        )
+        return Agent(
+            name="orchestrator",
+            agent_id="orchestrator",
+            model=MockedModelProvider(orchestrator_responses),
+            tools=[sub_agent.as_tool()],
+            callback_handler=None,
+            session_manager=FileSessionManager("session-3076", storage_dir=str(tmp_path)),
+        )
+
+    orchestrator = build_orchestrator(
+        [tool_use_message("sub-1", "dangerous_action", {"target": "prod-db"}), text_message("done")],
+        [tool_use_message("orch-1", "worker", {"input": "go"}), text_message("all done")],
+    )
+    interrupted_result = orchestrator("do the thing that needs confirmation")
+
+    assert interrupted_result.stop_reason == "interrupt"
+    assert executions == []
+    interrupt_id = interrupted_result.interrupts[0].id
+
+    # Process boundary: every agent is rebuilt and only the session survives.
+    resumed_orchestrator = build_orchestrator([text_message("done")], [text_message("all done")])
+    tru_result = resumed_orchestrator([{"interruptResponse": {"interruptId": interrupt_id, "response": "APPROVE"}}])
+
+    assert tru_result.stop_reason == "end_turn"
+
+    tru_executions = executions
+    exp_executions = ["prod-db"]
+    assert tru_executions == exp_executions

--- a/strands-py/tests/strands/agent/test_agent_as_tool.py
+++ b/strands-py/tests/strands/agent/test_agent_as_tool.py
@@ -1020,3 +1020,50 @@ async def test_stream_resume_keeps_stored_turn_when_it_cannot_be_loaded(fake_age
     tru_continuations = orchestrator._interrupt_state.context["sub_agent_continuations"]
     exp_continuations = {"tool-123": unloadable}
     assert tru_continuations == exp_continuations
+
+
+def test_namespaced_interrupt_ids_are_not_captured_by_another_call(fake_agent, orchestrator):
+    """One tool call cannot match another call's answers, whatever the model made the ids look like.
+
+    Tool use IDs are model-derived, so one call's ID can end in the separator plus the start of
+    another call's interrupt IDs. Without escaping, that call would match the other's answers.
+    """
+    tool = _AgentAsTool(fake_agent, name="fake_agent", description="desc", preserve_context=True)
+    local_id = "v1:before_tool_call:sub-1:abc"
+
+    answered = _AgentAsTool._namespace_interrupts("ob", [Interrupt(id=local_id, name="approval", reason="r")])[0]
+    orchestrator._interrupt_state.interrupts[answered.id] = answered
+    orchestrator._interrupt_state.context["responses"] = [
+        {"interruptResponse": {"interruptId": answered.id, "response": "APPROVE"}}
+    ]
+    orchestrator._interrupt_state.activate()
+
+    invocation_state = {"agent": orchestrator}
+
+    tru_answered = tool._interrupt_responses(invocation_state, "ob")
+    exp_answered = [{"interruptResponse": {"interruptId": local_id, "response": "APPROVE"}}]
+    assert tru_answered == exp_answered
+
+    tru_other = tool._interrupt_responses(invocation_state, "ob:v1")
+    exp_other = []
+    assert tru_other == exp_other
+
+    assert tool._parent_awaiting_resume(invocation_state, "ob") is True
+    assert tool._parent_awaiting_resume(invocation_state, "ob:v1") is False
+
+
+def test_namespaced_interrupt_ids_round_trip_a_separator_bearing_tool_use_id(fake_agent, orchestrator):
+    """A tool use ID containing the separator still maps its own answers back to the local ID."""
+    tool = _AgentAsTool(fake_agent, name="fake_agent", description="desc", preserve_context=True)
+    local_id = "v1:before_tool_call:sub-2:def"
+
+    namespaced = _AgentAsTool._namespace_interrupts("ob:v1", [Interrupt(id=local_id, name="approval", reason="r")])[0]
+    orchestrator._interrupt_state.interrupts[namespaced.id] = namespaced
+    orchestrator._interrupt_state.context["responses"] = [
+        {"interruptResponse": {"interruptId": namespaced.id, "response": "APPROVE"}}
+    ]
+    orchestrator._interrupt_state.activate()
+
+    tru_responses = tool._interrupt_responses({"agent": orchestrator}, "ob:v1")
+    exp_responses = [{"interruptResponse": {"interruptId": local_id, "response": "APPROVE"}}]
+    assert tru_responses == exp_responses

--- a/strands-py/tests/strands/agent/test_agent_as_tool.py
+++ b/strands-py/tests/strands/agent/test_agent_as_tool.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 
 import strands
-from strands.agent._agent_as_tool import _AgentAsTool, _namespace_interrupts, _namespace_prefix, _ParentCall
+from strands.agent._agent_as_tool import _INTERRUPTED_TURNS_KEY, _AgentAsTool, _ParentCall
 from strands.agent.agent import Agent
 from strands.agent.agent_result import AgentResult
 from strands.hooks import BeforeToolCallEvent, HookProvider, HookRegistry
@@ -43,9 +43,10 @@ def fake_agent():
 def namespaced_id(tool_use_id, local_id):
     """The orchestrator-visible id for a sub-agent-local interrupt id.
 
-    Built from the adapter's own helper so these tests pin behaviour rather than the id format.
+    Built through the adapter's own namespacing so these tests pin behaviour, not the id format.
     """
-    return f"{_namespace_prefix(tool_use_id)}{local_id}"
+    interrupt = Interrupt(id=local_id, name="approval", reason="r")
+    return _ParentCall(MagicMock(), tool_use_id).namespace([interrupt])[0].id
 
 
 def interrupt_result_for(interrupt_id):
@@ -519,11 +520,11 @@ def interrupt_result():
 
 
 @pytest.mark.asyncio
-async def test_stream_interrupt_yields_tool_interrupt_event(tool, mock_agent, tool_use, interrupt_result):
+async def test_stream_interrupt_yields_tool_interrupt_event(tool, mock_agent, tool_use, interrupt_result, orchestrator):
     """A sub-agent interrupt propagates upward with its id namespaced by this tool call."""
     mock_agent.stream_async.return_value = _mock_stream_async(interrupt_result)
 
-    events = [event async for event in tool.stream(tool_use, {})]
+    events = [event async for event in tool.stream(tool_use, {"agent": orchestrator})]
 
     assert len(events) == 1
     assert isinstance(events[0], ToolInterruptEvent)
@@ -535,23 +536,25 @@ async def test_stream_interrupt_yields_tool_interrupt_event(tool, mock_agent, to
 
 
 @pytest.mark.asyncio
-async def test_stream_interrupt_no_tool_result_appended(tool, mock_agent, tool_use, interrupt_result):
+async def test_stream_interrupt_no_tool_result_appended(tool, mock_agent, tool_use, interrupt_result, orchestrator):
     """ToolInterruptEvent should not produce a ToolResultEvent."""
     mock_agent.stream_async.return_value = _mock_stream_async(interrupt_result)
 
-    events = [event async for event in tool.stream(tool_use, {})]
+    events = [event async for event in tool.stream(tool_use, {"agent": orchestrator})]
 
     result_events = [e for e in events if isinstance(e, ToolResultEvent)]
     assert result_events == []
 
 
 @pytest.mark.asyncio
-async def test_stream_interrupt_forwards_intermediate_events(tool, mock_agent, tool_use, interrupt_result):
+async def test_stream_interrupt_forwards_intermediate_events(
+    tool, mock_agent, tool_use, interrupt_result, orchestrator
+):
     """Intermediate events should still be yielded before the interrupt."""
     intermediate = [{"data": "partial"}]
     mock_agent.stream_async.return_value = _mock_stream_async(interrupt_result, intermediate)
 
-    events = [event async for event in tool.stream(tool_use, {})]
+    events = [event async for event in tool.stream(tool_use, {"agent": orchestrator})]
 
     stream_events = [e for e in events if isinstance(e, AgentAsToolStreamEvent)]
     interrupt_events = [e for e in events if isinstance(e, ToolInterruptEvent)]
@@ -759,7 +762,9 @@ def test_agent_mixed_with_regular_tools_in_tools_list():
 
 
 @pytest.mark.asyncio
-async def test_stream_interrupt_stores_continuation_for_ephemeral_sub_agent(fake_agent, orchestrator, interrupt_result):
+async def test_stream_interrupt_stores_interrupted_turn_for_ephemeral_sub_agent(
+    fake_agent, orchestrator, interrupt_result
+):
     """An ephemeral sub-agent's interrupted turn is stored in the orchestrator's interrupt context."""
     fake_agent.messages = [{"role": "user", "content": [{"text": "go"}]}]
     fake_agent.stream_async = MagicMock(return_value=_mock_stream_async(interrupt_result))
@@ -769,18 +774,16 @@ async def test_stream_interrupt_stores_continuation_for_ephemeral_sub_agent(fake
     async for _ in tool.stream(tool_use, {"agent": orchestrator}):
         pass
 
-    continuations = orchestrator._interrupt_state.context["sub_agent_continuations"]
-    assert list(continuations) == ["tool-123"]
+    stored_turns = orchestrator._interrupt_state.context[_INTERRUPTED_TURNS_KEY]
+    assert list(stored_turns) == ["tool-123"]
 
-    tru_messages = continuations["tool-123"]["data"]["messages"]
+    tru_messages = stored_turns["tool-123"]["data"]["messages"]
     exp_messages = [{"role": "user", "content": [{"text": "go"}]}]
     assert tru_messages == exp_messages
 
 
 @pytest.mark.asyncio
-async def test_stream_interrupt_stores_no_continuation_when_context_is_preserved(
-    fake_agent, orchestrator, interrupt_result
-):
+async def test_stream_interrupt_stores_no_turn_when_context_is_preserved(fake_agent, orchestrator, interrupt_result):
     """A context-preserving sub-agent owns its state, so the orchestrator stores nothing for it."""
     fake_agent.stream_async = MagicMock(return_value=_mock_stream_async(interrupt_result))
     tool = _AgentAsTool(fake_agent, name="fake_agent", description="desc", preserve_context=True)
@@ -795,8 +798,8 @@ async def test_stream_interrupt_stores_no_continuation_when_context_is_preserved
 
 
 @pytest.mark.asyncio
-async def test_stream_resume_restores_ephemeral_sub_agent_from_continuation(orchestrator):
-    """An ephemeral sub-agent rebuilt from scratch resumes from the stored continuation."""
+async def test_stream_resume_restores_ephemeral_sub_agent_from_a_stored_turn(orchestrator):
+    """An ephemeral sub-agent rebuilt from scratch resumes from the stored turn."""
     interrupted = Agent(name="fake_agent", callback_handler=None)
     interrupted.messages = [{"role": "user", "content": [{"text": "go"}]}]
     interrupted._interrupt_state.interrupts["interrupt-1"] = Interrupt(id="interrupt-1", name="approval", reason="r")
@@ -807,7 +810,7 @@ async def test_stream_resume_restores_ephemeral_sub_agent_from_continuation(orch
     orchestrator._interrupt_state.context.update(
         {
             "responses": [{"interruptResponse": {"interruptId": parent_id, "response": "APPROVE"}}],
-            "sub_agent_continuations": {"tool-123": interrupted.take_snapshot(preset="session").to_dict()},
+            _INTERRUPTED_TURNS_KEY: {"tool-123": interrupted.take_snapshot(preset="session").to_dict()},
         }
     )
     orchestrator._interrupt_state.activate()
@@ -836,10 +839,10 @@ async def test_stream_resume_restores_ephemeral_sub_agent_from_continuation(orch
     exp_prompt = [{"interruptResponse": {"interruptId": "interrupt-1", "response": "APPROVE"}}]
     assert tru_prompt == exp_prompt
 
-    # The continuation is consumed; a sub-agent that interrupts again stores a fresh one.
-    tru_continuations = orchestrator._interrupt_state.context["sub_agent_continuations"]
-    exp_continuations = {}
-    assert tru_continuations == exp_continuations
+    # The stored turn is consumed; a sub-agent that interrupts again stores a fresh one.
+    tru_stored_turns = orchestrator._interrupt_state.context[_INTERRUPTED_TURNS_KEY]
+    exp_stored_turns = {}
+    assert tru_stored_turns == exp_stored_turns
 
 
 @pytest.mark.asyncio
@@ -872,7 +875,7 @@ async def test_stream_ignores_interrupt_belonging_to_another_call(fake_agent, or
     """An interrupt the orchestrator holds for a different tool call is not adopted by this one."""
     tool = _AgentAsTool(fake_agent, name="fake_agent", description="desc", preserve_context=False)
 
-    # The sub-agent still carries another caller's parked turn, e.g. after restoring a shared session.
+    # The sub-agent still carries another caller's stored turn, e.g. after restoring a shared session.
     fake_agent.messages = [{"role": "user", "content": [{"text": "another caller's turn"}]}]
     fake_agent._interrupt_state.interrupts["interrupt-1"] = Interrupt(id="interrupt-1", name="approval", reason="r")
     fake_agent._interrupt_state.activate()
@@ -962,28 +965,25 @@ def confirmable_action():
     return dangerous_action, ConfirmHook(), executions
 
 
-def set_parked_turn_schema_version(storage_dir, schema_version):
-    """Rewrite the schema version of every parked sub-agent turn in a persisted session.
+def set_stored_turn_schema_version(storage_dir, schema_version):
+    """Rewrite the schema version of every stored sub-agent turn in a persisted session.
 
     Reproduces the version skew the reinstate path guards against: a turn written by one build of the
     SDK that the build now running will not load.
 
     Returns:
-        Number of parked turns rewritten.
+        Number of stored turns rewritten.
     """
     rewritten = 0
     for path in pathlib.Path(storage_dir).rglob("agent.json"):
         record = json.loads(path.read_text())
-        parked = (
-            record.get("_internal_state", {})
-            .get("interrupt_state", {})
-            .get("context", {})
-            .get("sub_agent_continuations")
+        stored = (
+            record.get("_internal_state", {}).get("interrupt_state", {}).get("context", {}).get(_INTERRUPTED_TURNS_KEY)
         )
-        if not parked:
+        if not stored:
             continue
 
-        for turn in parked.values():
+        for turn in stored.values():
             turn["schema_version"] = schema_version
             rewritten += 1
         path.write_text(json.dumps(record))
@@ -1088,12 +1088,12 @@ def test_nested_interrupt_resumes_after_rehydration_with_a_sub_agent_session_man
     assert tru_executions == exp_executions
 
 
-def test_nested_interrupt_survives_a_parked_turn_that_fails_to_load(tmp_path, confirmable_action):
-    """A parked turn that fails to load once is not lost: answering again still runs the confirmed tool.
+def test_nested_interrupt_survives_a_stored_turn_that_fails_to_load(tmp_path, confirmable_action):
+    """A stored turn that fails to load once is not lost: answering again still runs the confirmed tool.
 
-    Keeping the parked turn only helps if the interrupt stays pending with it, because the event loop
+    Keeping the stored turn only helps if the interrupt stays pending with it, because the event loop
     clears an agent's whole interrupt record as soon as a turn ends. So the failed reinstate has to
-    leave the orchestrator parked rather than report a failed tool call.
+    leave the orchestrator holding the interrupt rather than report a failed tool call.
     """
     dangerous_action, confirm_hook, executions = confirmable_action
 
@@ -1124,8 +1124,8 @@ def test_nested_interrupt_survives_a_parked_turn_that_fails_to_load(tmp_path, co
     assert interrupted_result.stop_reason == "interrupt"
     interrupt_id = interrupted_result.interrupts[0].id
 
-    # The running build cannot read the parked turn, e.g. mid-rollout across two SDK versions.
-    assert set_parked_turn_schema_version(tmp_path, "0.0") == 1
+    # The running build cannot read the stored turn, e.g. mid-rollout across two SDK versions.
+    assert set_stored_turn_schema_version(tmp_path, "0.0") == 1
 
     unloadable_result = build_orchestrator([text_message("done")], [text_message("all done")])(
         [{"interruptResponse": {"interruptId": interrupt_id, "response": "APPROVE"}}]
@@ -1136,7 +1136,7 @@ def test_nested_interrupt_survives_a_parked_turn_that_fails_to_load(tmp_path, co
     assert executions == []
 
     # The turn is readable again, and the same answer now applies.
-    assert set_parked_turn_schema_version(tmp_path, "1.0") == 1
+    assert set_stored_turn_schema_version(tmp_path, "1.0") == 1
 
     tru_result = build_orchestrator([text_message("done")], [text_message("all done")])(
         [{"interruptResponse": {"interruptId": interrupt_id, "response": "APPROVE"}}]
@@ -1150,13 +1150,13 @@ def test_nested_interrupt_survives_a_parked_turn_that_fails_to_load(tmp_path, co
 
 
 @pytest.mark.asyncio
-async def test_stream_resume_reraises_the_interrupt_when_the_parked_turn_cannot_be_loaded(
+async def test_stream_resume_reraises_the_interrupt_when_the_stored_turn_cannot_be_loaded(
     fake_agent, orchestrator, caplog
 ):
-    """A parked turn that fails to load raises the interrupt again rather than failing the call.
+    """A stored turn that fails to load raises the interrupt again rather than failing the call.
 
     Yielding a result here would end the orchestrator's turn, and the event loop clears the whole
-    interrupt record when a turn ends - so the parked turn and the human's answer have to be carried by
+    interrupt record when a turn ends - so the stored turn and the human's answer have to be carried by
     a still-pending interrupt to survive for another attempt.
     """
     interrupted = Agent(name="fake_agent", callback_handler=None)
@@ -1170,7 +1170,7 @@ async def test_stream_resume_reraises_the_interrupt_when_the_parked_turn_cannot_
     orchestrator._interrupt_state.context.update(
         {
             "responses": [{"interruptResponse": {"interruptId": parent_id, "response": "APPROVE"}}],
-            "sub_agent_continuations": {"tool-123": unloadable},
+            _INTERRUPTED_TURNS_KEY: {"tool-123": unloadable},
         }
     )
     orchestrator._interrupt_state.activate()
@@ -1188,11 +1188,11 @@ async def test_stream_resume_reraises_the_interrupt_when_the_parked_turn_cannot_
     tru_interrupt_ids = [interrupt.id for interrupt in events[0]["tool_interrupt_event"]["interrupts"]]
     exp_interrupt_ids = [parent_id]
     assert tru_interrupt_ids == exp_interrupt_ids
-    assert "failed to reinstate interrupted sub-agent turn" in caplog.text
+    assert "failed to restore interrupted sub-agent turn" in caplog.text
 
-    tru_continuations = orchestrator._interrupt_state.context["sub_agent_continuations"]
-    exp_continuations = {"tool-123": unloadable}
-    assert tru_continuations == exp_continuations
+    tru_stored_turns = orchestrator._interrupt_state.context[_INTERRUPTED_TURNS_KEY]
+    exp_stored_turns = {"tool-123": unloadable}
+    assert tru_stored_turns == exp_stored_turns
 
 
 def test_namespaced_interrupt_ids_are_not_captured_by_another_call(orchestrator):
@@ -1203,7 +1203,7 @@ def test_namespaced_interrupt_ids_are_not_captured_by_another_call(orchestrator)
     """
     local_id = "v1:before_tool_call:sub-1:abc"
 
-    answered = _namespace_interrupts("ob", [Interrupt(id=local_id, name="approval", reason="r")])[0]
+    answered = _ParentCall(orchestrator, "ob").namespace([Interrupt(id=local_id, name="approval", reason="r")])[0]
     orchestrator._interrupt_state.interrupts[answered.id] = answered
     orchestrator._interrupt_state.context["responses"] = [
         {"interruptResponse": {"interruptId": answered.id, "response": "APPROVE"}}
@@ -1218,15 +1218,15 @@ def test_namespaced_interrupt_ids_are_not_captured_by_another_call(orchestrator)
     exp_other = []
     assert tru_other == exp_other
 
-    assert _ParentCall(orchestrator, "ob").awaiting_resume is True
-    assert _ParentCall(orchestrator, "ob:v1").awaiting_resume is False
+    assert _ParentCall(orchestrator, "ob").is_resuming is True
+    assert _ParentCall(orchestrator, "ob:v1").is_resuming is False
 
 
 def test_namespaced_interrupt_ids_round_trip_a_separator_bearing_tool_use_id(orchestrator):
     """A tool use ID containing the separator is encoded in the prefix and still round-trips."""
     local_id = "v1:before_tool_call:sub-2:def"
 
-    namespaced = _namespace_interrupts("ob:v1", [Interrupt(id=local_id, name="approval", reason="r")])[0]
+    namespaced = _ParentCall(orchestrator, "ob:v1").namespace([Interrupt(id=local_id, name="approval", reason="r")])[0]
 
     tru_namespaced_id = namespaced.id
     exp_namespaced_id = f"v1:agent_as_tool:ob%3Av1:{local_id}"
@@ -1259,7 +1259,7 @@ def test_namespaced_interrupt_ids_are_not_captured_by_a_tool_use_id_of_the_schem
 
     parent_call = _ParentCall(orchestrator, "v1")
 
-    assert parent_call.awaiting_resume is False
+    assert parent_call.is_resuming is False
     assert parent_call.responses() == []
     assert parent_call.pending_interrupts() == []
 
@@ -1285,15 +1285,15 @@ async def test_stream_interrupt_warns_when_a_context_preserving_sub_agent_has_no
 
 
 @pytest.mark.asyncio
-async def test_stream_resume_reraises_only_the_interrupts_the_parked_turn_still_awaits(
+async def test_stream_resume_reraises_only_the_interrupts_the_stored_turn_still_awaits(
     fake_agent, orchestrator, caplog
 ):
     """Re-raising skips an interrupt the sub-agent has already finished with.
 
     The orchestrator keeps every interrupt id it was handed until its own turn ends, so after a
-    sub-agent interrupts twice its first id is still recorded there while the parked turn has moved on.
+    sub-agent interrupts twice its first id is still recorded there while the stored turn has moved on.
     Handing that id back would point the caller at an interrupt the reinstated sub-agent does not hold,
-    and answering it fails the call - taking the parked turn and the pending answer with it.
+    and answering it fails the call - taking the stored turn and the pending answer with it.
     """
     interrupted = Agent(name="fake_agent", callback_handler=None)
     interrupted._interrupt_state.interrupts["interrupt-2"] = Interrupt(id="interrupt-2", name="approval", reason="r")
@@ -1310,7 +1310,7 @@ async def test_stream_resume_reraises_only_the_interrupts_the_parked_turn_still_
     orchestrator._interrupt_state.context.update(
         {
             "responses": [{"interruptResponse": {"interruptId": awaited_id, "response": "APPROVE"}}],
-            "sub_agent_continuations": {"tool-123": unloadable},
+            _INTERRUPTED_TURNS_KEY: {"tool-123": unloadable},
         }
     )
     orchestrator._interrupt_state.activate()
@@ -1333,10 +1333,10 @@ async def test_stream_resume_reraises_only_the_interrupts_the_parked_turn_still_
 async def test_stream_interrupt_parks_a_turn_that_is_isolated_from_the_sub_agent(
     fake_agent, orchestrator, interrupt_result
 ):
-    """A parked turn is a copy: later work on the same sub-agent instance cannot alter it.
+    """A stored turn is a copy: later work on the same sub-agent instance cannot alter it.
 
     A snapshot carries the sub-agent's interrupt context by reference, so an orchestrator reusing one
-    sub-agent instance would otherwise see its parked turn rewritten under it.
+    sub-agent instance would otherwise see its stored turn rewritten under it.
     """
     fake_agent.stream_async = MagicMock(return_value=_mock_stream_async(interrupt_result))
     tool = _AgentAsTool(fake_agent, name="fake_agent", description="desc", preserve_context=False)
@@ -1349,20 +1349,20 @@ async def test_stream_interrupt_parks_a_turn_that_is_isolated_from_the_sub_agent
         {"interruptResponse": {"interruptId": "later", "response": "DENY"}}
     ]
 
-    tru_parked_context = orchestrator._interrupt_state.context["sub_agent_continuations"]["tool-123"]["data"][
+    tru_stored_context = orchestrator._interrupt_state.context[_INTERRUPTED_TURNS_KEY]["tool-123"]["data"][
         "interrupt_state"
     ]["context"]
-    exp_parked_context = {}
-    assert tru_parked_context == exp_parked_context
+    exp_stored_context = {}
+    assert tru_stored_context == exp_stored_context
 
 
 def test_nested_interrupt_that_reraises_twice_runs_each_confirmed_action_once(tmp_path, confirmable_action):
     """A sub-agent that interrupts twice keeps both confirmations distinct across a failed reinstate.
 
     The orchestrator holds every interrupt id it was handed until its own turn ends, so by the second
-    interrupt the first id is still recorded while the parked turn has moved past it. Re-raising has to
-    offer only what the parked turn still awaits, otherwise the caller answers a dead id and the call
-    fails - losing the parked turn and the answer with it.
+    interrupt the first id is still recorded while the stored turn has moved past it. Re-raising has to
+    offer only what the stored turn still awaits, otherwise the caller answers a dead id and the call
+    fails - losing the stored turn and the answer with it.
     """
     dangerous_action, confirm_hook, executions = confirmable_action
 
@@ -1407,8 +1407,8 @@ def test_nested_interrupt_that_reraises_twice_runs_each_confirmed_action_once(tm
     assert executions == ["first"]
     second_id = second_interrupt.interrupts[0].id
 
-    # The parked turn cannot be read, so the second confirmation has to survive to be answered again.
-    assert set_parked_turn_schema_version(tmp_path, "0.0") == 1
+    # The stored turn cannot be read, so the second confirmation has to survive to be answered again.
+    assert set_stored_turn_schema_version(tmp_path, "0.0") == 1
 
     reraised = approve(build_orchestrator([text_message("sub done")], [text_message("all done")]), second_id)
 
@@ -1417,7 +1417,7 @@ def test_nested_interrupt_that_reraises_twice_runs_each_confirmed_action_once(tm
     assert tru_reraised_ids == exp_reraised_ids
     assert executions == ["first"]
 
-    assert set_parked_turn_schema_version(tmp_path, "1.0") == 1
+    assert set_stored_turn_schema_version(tmp_path, "1.0") == 1
 
     tru_result = approve(build_orchestrator([text_message("sub done")], [text_message("all done")]), second_id)
 
@@ -1426,3 +1426,25 @@ def test_nested_interrupt_that_reraises_twice_runs_each_confirmed_action_once(tm
     tru_executions = executions
     exp_executions = ["first", "second"]
     assert tru_executions == exp_executions
+
+
+@pytest.mark.asyncio
+async def test_stream_resets_stale_interrupt_state_on_a_fresh_call(fake_agent, orchestrator, agent_result):
+    """A fresh call clears interrupt state the sub-agent is still carrying from an abandoned turn.
+
+    An ephemeral sub-agent is reset to its construction baseline before each call, and interrupt state
+    nobody is resuming belongs to that baseline as much as its messages do: left in place, the sub-agent
+    would refuse the fresh prompt because it believes it is mid-interrupt.
+    """
+    tool = _AgentAsTool(fake_agent, name="fake_agent", description="desc", preserve_context=False)
+
+    fake_agent._interrupt_state.interrupts["stale-1"] = Interrupt(id="stale-1", name="approval", reason="r")
+    fake_agent._interrupt_state.activate()
+    fake_agent.stream_async = MagicMock(return_value=_mock_stream_async(agent_result))
+
+    tool_use = {"toolUseId": "tool-123", "name": "fake_agent", "input": {"input": "go"}}
+    async for _ in tool.stream(tool_use, {"agent": orchestrator}):
+        pass
+
+    assert fake_agent._interrupt_state.activated is False
+    assert fake_agent._interrupt_state.interrupts == {}

--- a/strands-py/tests/strands/agent/test_agent_as_tool.py
+++ b/strands-py/tests/strands/agent/test_agent_as_tool.py
@@ -1041,7 +1041,8 @@ def test_nested_interrupt_resumes_after_rehydration(tmp_path, confirmable_action
 def test_nested_interrupt_resumes_after_rehydration_with_a_sub_agent_session_manager(tmp_path, confirmable_action):
     """A context-preserving sub-agent that owns a session manager resumes across a process boundary.
 
-    This is the configuration issue #3076 describes literally: ``preserve_context=True``, with both the
+    This is the configuration https://github.com/strands-agents/harness-sdk/issues/3076 describes
+    literally: ``preserve_context=True``, with both the
     orchestrator and the sub-agent rebuilt from the session store. The orchestrator parks no turn for a
     sub-agent that preserves context, so the resume runs entirely off the sub-agent's own session plus
     the answer the orchestrator carries as data.
@@ -1158,7 +1159,10 @@ async def test_stream_resume_reraises_the_interrupt_when_the_parked_turn_cannot_
     interrupt record when a turn ends - so the parked turn and the human's answer have to be carried by
     a still-pending interrupt to survive for another attempt.
     """
-    unloadable = Agent(name="fake_agent", callback_handler=None).take_snapshot(preset="session").to_dict()
+    interrupted = Agent(name="fake_agent", callback_handler=None)
+    interrupted._interrupt_state.interrupts["interrupt-1"] = Interrupt(id="interrupt-1", name="approval", reason="r")
+    interrupted._interrupt_state.activate()
+    unloadable = interrupted.take_snapshot(preset="session").to_dict()
     unloadable["schema_version"] = "0.0"
 
     parent_id = namespaced_id("tool-123", "interrupt-1")
@@ -1278,3 +1282,147 @@ async def test_stream_interrupt_warns_when_a_context_preserving_sub_agent_has_no
             pass
 
     assert "preserve_context=True with no session manager" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_stream_resume_reraises_only_the_interrupts_the_parked_turn_still_awaits(
+    fake_agent, orchestrator, caplog
+):
+    """Re-raising skips an interrupt the sub-agent has already finished with.
+
+    The orchestrator keeps every interrupt id it was handed until its own turn ends, so after a
+    sub-agent interrupts twice its first id is still recorded there while the parked turn has moved on.
+    Handing that id back would point the caller at an interrupt the reinstated sub-agent does not hold,
+    and answering it fails the call - taking the parked turn and the pending answer with it.
+    """
+    interrupted = Agent(name="fake_agent", callback_handler=None)
+    interrupted._interrupt_state.interrupts["interrupt-2"] = Interrupt(id="interrupt-2", name="approval", reason="r")
+    interrupted._interrupt_state.activate()
+    unloadable = interrupted.take_snapshot(preset="session").to_dict()
+    unloadable["schema_version"] = "0.0"
+
+    consumed_id = namespaced_id("tool-123", "interrupt-1")
+    awaited_id = namespaced_id("tool-123", "interrupt-2")
+    orchestrator._interrupt_state.interrupts[consumed_id] = Interrupt(
+        id=consumed_id, name="approval", reason="r", response="APPROVE"
+    )
+    orchestrator._interrupt_state.interrupts[awaited_id] = Interrupt(id=awaited_id, name="approval", reason="r")
+    orchestrator._interrupt_state.context.update(
+        {
+            "responses": [{"interruptResponse": {"interruptId": awaited_id, "response": "APPROVE"}}],
+            "sub_agent_continuations": {"tool-123": unloadable},
+        }
+    )
+    orchestrator._interrupt_state.activate()
+
+    fake_agent.stream_async = MagicMock()
+    tool = _AgentAsTool(fake_agent, name="fake_agent", description="desc", preserve_context=False)
+    tool_use = {"toolUseId": "tool-123", "name": "fake_agent", "input": {"input": "go"}}
+
+    with caplog.at_level("ERROR"):
+        events = [event async for event in tool.stream(tool_use, {"agent": orchestrator})]
+
+    fake_agent.stream_async.assert_not_called()
+
+    tru_interrupt_ids = [interrupt.id for interrupt in events[0]["tool_interrupt_event"]["interrupts"]]
+    exp_interrupt_ids = [awaited_id]
+    assert tru_interrupt_ids == exp_interrupt_ids
+
+
+@pytest.mark.asyncio
+async def test_stream_interrupt_parks_a_turn_that_is_isolated_from_the_sub_agent(
+    fake_agent, orchestrator, interrupt_result
+):
+    """A parked turn is a copy: later work on the same sub-agent instance cannot alter it.
+
+    A snapshot carries the sub-agent's interrupt context by reference, so an orchestrator reusing one
+    sub-agent instance would otherwise see its parked turn rewritten under it.
+    """
+    fake_agent.stream_async = MagicMock(return_value=_mock_stream_async(interrupt_result))
+    tool = _AgentAsTool(fake_agent, name="fake_agent", description="desc", preserve_context=False)
+    tool_use = {"toolUseId": "tool-123", "name": "fake_agent", "input": {"input": "go"}}
+
+    async for _ in tool.stream(tool_use, {"agent": orchestrator}):
+        pass
+
+    fake_agent._interrupt_state.context["responses"] = [
+        {"interruptResponse": {"interruptId": "later", "response": "DENY"}}
+    ]
+
+    tru_parked_context = orchestrator._interrupt_state.context["sub_agent_continuations"]["tool-123"]["data"][
+        "interrupt_state"
+    ]["context"]
+    exp_parked_context = {}
+    assert tru_parked_context == exp_parked_context
+
+
+def test_nested_interrupt_that_reraises_twice_runs_each_confirmed_action_once(tmp_path, confirmable_action):
+    """A sub-agent that interrupts twice keeps both confirmations distinct across a failed reinstate.
+
+    The orchestrator holds every interrupt id it was handed until its own turn ends, so by the second
+    interrupt the first id is still recorded while the parked turn has moved past it. Re-raising has to
+    offer only what the parked turn still awaits, otherwise the caller answers a dead id and the call
+    fails - losing the parked turn and the answer with it.
+    """
+    dangerous_action, confirm_hook, executions = confirmable_action
+
+    def build_orchestrator(sub_agent_responses, orchestrator_responses):
+        sub_agent = Agent(
+            name="worker",
+            agent_id="worker",
+            model=MockedModelProvider(sub_agent_responses),
+            tools=[dangerous_action],
+            hooks=[confirm_hook],
+            callback_handler=None,
+        )
+        return Agent(
+            name="orchestrator",
+            agent_id="orchestrator",
+            model=MockedModelProvider(orchestrator_responses),
+            tools=[sub_agent.as_tool()],
+            callback_handler=None,
+            session_manager=FileSessionManager("session-twice", storage_dir=str(tmp_path)),
+        )
+
+    def approve(orchestrator, interrupt_id):
+        return orchestrator([{"interruptResponse": {"interruptId": interrupt_id, "response": "APPROVE"}}])
+
+    first_interrupt = build_orchestrator(
+        [tool_use_message("sub-1", "dangerous_action", {"target": "first"}), text_message("sub done")],
+        [tool_use_message("orch-1", "worker", {"input": "go"}), text_message("all done")],
+    )("do both guarded steps")
+
+    assert first_interrupt.stop_reason == "interrupt"
+
+    # Answering the first confirmation runs it, then the sub-agent interrupts again for the second.
+    second_interrupt = approve(
+        build_orchestrator(
+            [tool_use_message("sub-2", "dangerous_action", {"target": "second"}), text_message("sub done")],
+            [text_message("all done")],
+        ),
+        first_interrupt.interrupts[0].id,
+    )
+
+    assert second_interrupt.stop_reason == "interrupt"
+    assert executions == ["first"]
+    second_id = second_interrupt.interrupts[0].id
+
+    # The parked turn cannot be read, so the second confirmation has to survive to be answered again.
+    assert set_parked_turn_schema_version(tmp_path, "0.0") == 1
+
+    reraised = approve(build_orchestrator([text_message("sub done")], [text_message("all done")]), second_id)
+
+    tru_reraised_ids = [interrupt.id for interrupt in reraised.interrupts]
+    exp_reraised_ids = [second_id]
+    assert tru_reraised_ids == exp_reraised_ids
+    assert executions == ["first"]
+
+    assert set_parked_turn_schema_version(tmp_path, "1.0") == 1
+
+    tru_result = approve(build_orchestrator([text_message("sub done")], [text_message("all done")]), second_id)
+
+    assert tru_result.stop_reason == "end_turn"
+
+    tru_executions = executions
+    exp_executions = ["first", "second"]
+    assert tru_executions == exp_executions

--- a/strands-py/tests/strands/event_loop/test_event_loop.py
+++ b/strands-py/tests/strands/event_loop/test_event_loop.py
@@ -1318,6 +1318,9 @@ async def test_event_loop_cycle_interrupts_preserved_when_after_tools_hook_raise
     agent.hooks.add_callback(AfterToolsEvent, raise_in_after_tools)
     model.stream.side_effect = [agenerator(tool_stream)]
 
+    # A key the loop does not own, e.g. an agent-as-tool's parked sub-agent turn.
+    agent._interrupt_state.context["sub_agent_continuations"] = {"tool-1": {"scope": "agent"}}
+
     with pytest.raises(EventLoopException, match="after tools hook failed"):
         await alist(strands.event_loop.event_loop.event_loop_cycle(agent, invocation_state={}))
 
@@ -1325,6 +1328,7 @@ async def test_event_loop_cycle_interrupts_preserved_when_after_tools_hook_raise
     assert agent._interrupt_state.activated
     assert agent._interrupt_state.context["tool_use_message"] == agent.messages[-1]
     assert agent._interrupt_state.context["tool_results"] == []
+    assert agent._interrupt_state.context["sub_agent_continuations"] == {"tool-1": {"scope": "agent"}}
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests/strands/event_loop/test_event_loop.py
+++ b/strands-py/tests/strands/event_loop/test_event_loop.py
@@ -1319,7 +1319,7 @@ async def test_event_loop_cycle_interrupts_preserved_when_after_tools_hook_raise
     model.stream.side_effect = [agenerator(tool_stream)]
 
     # A key the loop does not own, e.g. an agent-as-tool's parked sub-agent turn.
-    agent._interrupt_state.context["sub_agent_continuations"] = {"tool-1": {"scope": "agent"}}
+    agent._interrupt_state.context["sub_agent_interrupted_turns"] = {"tool-1": {"scope": "agent"}}
 
     with pytest.raises(EventLoopException, match="after tools hook failed"):
         await alist(strands.event_loop.event_loop.event_loop_cycle(agent, invocation_state={}))
@@ -1328,7 +1328,7 @@ async def test_event_loop_cycle_interrupts_preserved_when_after_tools_hook_raise
     assert agent._interrupt_state.activated
     assert agent._interrupt_state.context["tool_use_message"] == agent.messages[-1]
     assert agent._interrupt_state.context["tool_results"] == []
-    assert agent._interrupt_state.context["sub_agent_continuations"] == {"tool-1": {"scope": "agent"}}
+    assert agent._interrupt_state.context["sub_agent_interrupted_turns"] == {"tool-1": {"scope": "agent"}}
 
 
 @pytest.mark.asyncio
@@ -2385,7 +2385,7 @@ def test_park_interrupt_context_keeps_keys_the_event_loop_does_not_own():
             "tool_use_message": {"role": "assistant", "content": [{"text": "an earlier park"}]},
             "tool_results": [{"toolUseId": "tool-0", "status": "success", "content": []}],
             "responses": [{"interruptResponse": {"interruptId": "answered", "response": "APPROVE"}}],
-            "sub_agent_continuations": {"tool-1": {"scope": "agent"}},
+            "sub_agent_interrupted_turns": {"tool-1": {"scope": "agent"}},
         }
     )
     message = {"role": "assistant", "content": [{"toolUse": {"toolUseId": "tool-1", "name": "t", "input": {}}}]}
@@ -2397,6 +2397,6 @@ def test_park_interrupt_context_keeps_keys_the_event_loop_does_not_own():
     exp_context = {
         "tool_use_message": message,
         "tool_results": tool_results,
-        "sub_agent_continuations": {"tool-1": {"scope": "agent"}},
+        "sub_agent_interrupted_turns": {"tool-1": {"scope": "agent"}},
     }
     assert tru_context == exp_context

--- a/strands-py/tests/strands/event_loop/test_event_loop.py
+++ b/strands-py/tests/strands/event_loop/test_event_loop.py
@@ -2371,3 +2371,28 @@ async def test_event_loop_cycle_cancel_after_tools_stops_without_checkpointing(
 
     assert events[-1]["stop"][0] == "cancelled"
     assert model.stream.call_count == 1
+
+
+def test_park_interrupt_context_keeps_keys_the_event_loop_does_not_own():
+    """Parking a turn refreshes the loop's own interrupt-context keys and preserves everyone else's."""
+    agent = MagicMock()
+    agent._interrupt_state = _InterruptState(
+        context={
+            "tool_use_message": {"role": "assistant", "content": [{"text": "an earlier park"}]},
+            "tool_results": [{"toolUseId": "tool-0", "status": "success", "content": []}],
+            "responses": [{"interruptResponse": {"interruptId": "answered", "response": "APPROVE"}}],
+            "sub_agent_continuations": {"tool-1": {"scope": "agent"}},
+        }
+    )
+    message = {"role": "assistant", "content": [{"toolUse": {"toolUseId": "tool-1", "name": "t", "input": {}}}]}
+    tool_results = [{"toolUseId": "tool-2", "status": "success", "content": [{"text": "ok"}]}]
+
+    strands.event_loop.event_loop._park_interrupt_context(agent, message, tool_results)
+
+    tru_context = agent._interrupt_state.context
+    exp_context = {
+        "tool_use_message": message,
+        "tool_results": tool_results,
+        "sub_agent_continuations": {"tool-1": {"scope": "agent"}},
+    }
+    assert tru_context == exp_context


### PR DESCRIPTION
## Description

Resuming an interrupt raised inside a nested agent-as-tool only worked while the orchestrator and the sub-agent shared the same in-memory `Interrupt`. The resume path read the human's answer off the sub-agent's copy, which the tool executor had registered into the orchestrator by reference, so the two were literally the same object. Once either agent is rebuilt from storage — a stateless handler recreating every agent per request — they are two independent objects, and the answer written to the orchestrator's copy is invisible to the sub-agent's: the sub-agent re-raises the same interrupt forever and the approved tool never runs.

This implements the simplification agreed in #3008's thread, and supersedes the approach in that PR (no `ToolInterruptEvent` change, no `invocation_state` routing):

- **Answers travel as data.** Sub-agent interrupts propagate upward as copies whose ids are namespaced with a prefix derived from the outer tool use id, so ids stay unique when several sub-agents are invoked in one turn and the sub-agent-local id is recoverable by stripping the prefix. The prefix opens with an SDK-owned marker (`v1:agent_as_tool:`) and percent-encodes the tool use id, because both ids are model-derived: without the encoding a tool use id containing the separator matches another call's ids, and without the marker a tool use id of exactly `v1` matches every interrupt the orchestrator raised itself. On resume, the orchestrator's already-persisted `_interrupt_state.context["responses"]` are filtered by that prefix and mapped back to local ids.
- **An ephemeral sub-agent's interrupted turn is parked by the orchestrator.** `preserve_context=False` sub-agents cannot have a session manager (`_agent_as_tool.py` rejects that combination), so their turn is stored as one keyed entry in the orchestrator's own interrupt context and freed once it has been reinstated. A `preserve_context=True` sub-agent owns its state and keeps its turn in its own session; if it has none, that is warned about when the interrupt **parks** — before a human is asked for a response that could not be applied — and the resume reports an actionable error rather than silently dropping the answer.
- **A parked turn that cannot be reinstated keeps its interrupt pending.** The event loop clears an agent's whole interrupt record as soon as a turn ends, so a failed reinstate raises the interrupt again instead of failing the call: the turn stays parked behind a still-pending interrupt and the response can be applied on a later attempt. Only the interrupts the parked turn is *still waiting on* are re-raised — the orchestrator also holds ids the sub-agent has already finished with.
- **Parking an interrupt preserves interrupt-context keys the event loop does not own.** This matches how Graph/Swarm already treat their own interrupt context.

```
                                                          8 files changed, 1177 insertions(+), 88 deletions(-)
strands-py/src/strands/agent/_agent_as_tool.py           +329  -18
strands-py/src/strands/event_loop/event_loop.py           +30   -3
strands-py/src/strands/agent/agent.py                      +6    0
strands-py/src/strands/interrupt.py                        +2   -1
strands-py/tests/strands/agent/test_agent_as_tool.py     +772  -66
strands-py/tests/strands/event_loop/test_event_loop.py    +29    0
site/.../concepts/interrupts.mdx                           +7    0
site/.../concepts/multi-agent/agents-as-tools.mdx          +2    0
```

The adapter grew more than the behaviour change alone needs: seven static helpers that each re-derived the orchestrator and the id prefix from `invocation_state` were consolidated into one `_ParentCall` object, per the review note about internal helpers.

## Related Issues

Fixes #3076. Implements the design `mkmeral` settled on in #3008 and supersedes the snapshot-plumbing approach there. Co-authored with `seanalbert`, whose PR framed the problem and the stateless-Lambda use case (`Co-authored-by:` trailer is on the first commit).

## Documentation PR

Included here rather than deferred. `preserve_context` decides who keeps a sub-agent's interrupted turn, and therefore whether a resume survives a restart, but it was documented purely as conversation history — and `agents-as-tools.mdx` is the only place customers see `preserve_context=True`, in a snippet with no session manager, which is the one configuration that cannot resume after a restart. `interrupts.mdx` documented multi-agent nesting for Swarm and Graph only, so agents-as-tools now has its own section covering id namespacing and where the turn lives. `Interrupt.id` is now documented as opaque, matching every sibling handle in the SDK.

## Type of Change

Bug fix

## Testing

**Behaviour: the four agent-as-tool configurations, each across a process boundary**

| sub-agent config | restart between turns | outcome |
|---|---|---|
| `preserve_context=False`, no session manager | yes | resumes — turn reinstated from the orchestrator's interrupt context, tool runs once |
| `preserve_context=True` + its own `FileSessionManager` | yes | resumes — answer mapped as data; the sub-agent's own message log is untouched |
| `preserve_context=True`, no session manager | no (same process) | resumes in memory |
| `preserve_context=True`, no session manager | yes | does not resume — warns at park time, logs at ERROR, and returns a tool error that tells the model the action did not run |

A and B are now both pinned by end-to-end tests with a real `FileSessionManager` and every agent rebuilt between turns; B is the configuration issue #3076 describes literally, and it fails at the merge base (verified: `turn2 stop_reason=interrupt executions=[]` on `a10881c71`, `end_turn` / `['prod-db']` at this head).

**Gates** — run directly; `hatch` is not available in my environment, and this sandbox kills any single shell command at ~60s, so the suite was run in four chunks rather than one invocation:

```
$ python -m pytest tests -q -n 4          # in 4 chunks covering every directory under tests/
920 + 1361 + 1399 + 1165 = 4845 passed, 0 failed

$ ruff format --check <6 changed py files>     6 files already formatted
$ ruff check src tests                         All checks passed!
$ mypy ./src                                   Success: no issues found in 234 source files
```

`ruff format --check src tests` across the whole tree reports `13 files would be reformatted` — byte-identical at the merge base, so pre-existing and untouched by this PR.

**What the new tests pin down, and that they fail without the fix.** Every one of these was verified by reverting the specific hunk and watching the test fail:

| test | negative control |
|---|---|
| `test_nested_interrupt_resumes_after_rehydration` (#3076 regression) | fails on `main`: `assert [] == ['prod-db']` |
| `test_nested_interrupt_resumes_after_rehydration_with_a_sub_agent_session_manager` | fails at the merge base — loops instead of resuming |
| `test_nested_interrupt_survives_a_parked_turn_that_fails_to_load` | fails when the re-raise is reverted to a terminal error result |
| `test_nested_interrupt_that_reraises_twice_runs_each_confirmed_action_once` | fails when the re-raise is not filtered to what the parked turn awaits |
| `test_stream_resume_reraises_the_interrupt_when_the_parked_turn_cannot_be_loaded` | same two mutations |
| `test_stream_resume_reraises_only_the_interrupts_the_parked_turn_still_awaits` | fails on the unfiltered re-raise |
| `test_namespaced_interrupt_ids_are_not_captured_by_a_tool_use_id_of_the_scheme_marker` | fails with `_NAMESPACE_TAG = ""` |
| `test_namespaced_interrupt_ids_*` (2) | fail when the id escaping is reverted |
| `test_stream_interrupt_warns_when_a_context_preserving_sub_agent_has_no_session_manager` | fails without the park-time warning |
| `test_stream_interrupt_parks_a_turn_that_is_isolated_from_the_sub_agent` | fails without the deep copy |
| `test_event_loop_cycle_interrupts_preserved_when_after_tools_hook_raises` | fails when the after-tools rescue call site replaces the whole context |

Two tests were **fixed rather than added**, because they passed while the behaviour they named was untrue: `test_stream_resume_keeps_stored_turn_when_it_cannot_be_loaded` asserted an in-memory dict on a mock orchestrator and could not see that the event loop then cleared it (replaced by the re-raise test above), and `test_stream_interrupt_resume_skips_state_reset` constructed the tool *after* setting the sub-agent's messages, so its reset baseline equalled the expected result and a reset would have been invisible. Two tests for a removed one-line private accessor were deleted; the branch that used it is covered by the resume tests.

Also exercised by hand on this branch: partial answers, three-level nesting, two sub-agents whose local interrupt ids collide, a sub-agent with a `SummarizingConversationManager` and one with a stateful model (`conversation_manager_state` and `model_state` both intact after a real restart, against a genuinely fresh manager/model as the control), a `Graph` node whose agent has an interrupting agent-as-tool, and a check that nothing new reaches the caller.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Review loop ledger

| round | pass | findings | outcome |
|---|---|---|---|
| 1 | independent correctness review | 2 should-fix, 3 nits | both fixed (`b3dc2cd0`); 2 nits applied, 1 declined |
| 2 | adversarial testing, 5 probes | 1 routing bug, 1 doc gap | fixed (`40e08f22`) |
| 3 | verification of the fix commits | APPROVE, 2 notes + 1 nit | applied (`b097fc36`) |
| 4 | **six independent fresh-context passes** (correctness · adversarial · test-quality · API/DevX · issue-alignment · LLM-context) | **1 blocker**, 5 should-fix | all fixed or answered below (`65d3730`…`30f0355`) |
| 5 | **adversarial + test-quality review of those fixes** | **1 blocker in the fix itself**, 2 judgement calls, 2 nits | blocker fixed (`21fd240`); rest below |

Round 4 found what rounds 1–3 missed, and round 5 found a defect in round 4's own fix — a sub-agent that interrupts twice had its first, already-consumed interrupt id re-raised, which re-entered this very bug. Both are now fixed with tests that fail without them. Rounds 1–3 were dispatched by the same identity that wrote the code; rounds 4–5 were not given that assumption.

### Declined, with reasons

- **Broad `except Exception` in the reinstate path.** It guards deserializing persisted data possibly written by a different SDK version, where the failure modes are open-ended; narrowing it would let an unanticipated type escape into the adapter's generic handler, which reports a plain tool error at `WARNING` — exactly the silent loss of a human's approval this PR exists to prevent. It logs at ERROR and returns a specific message, and Graph/Swarm call `_InterruptState.from_dict` with no guard at all.
- **No issue link on tests written during development.** Per the root `AGENTS.md`, only a regression test for a *filed* bug links its issue; the two regression tests for #3076 do link it.
- **Stamping the tool name into a propagated interrupt's `name`.** It would make two sub-agents' interrupts easier to tell apart in an approval UI, but `name` is caller-visible and matched on, so prefixing it risks breaking name-based routing to fix a legibility problem. The tool call is already identifiable from the id, and a structured field is the better answer — worth its own change.
- **A retry cap on re-raising.** See the first residual: bounded retries end in discarding the human's answer, which is the destructive outcome this path exists to avoid.

## Residual / known limitations

- **A permanently unreadable parked turn re-prompts indefinitely.** If a reinstate can never succeed — e.g. a sub-agent's conversation-manager class changed while its turn was parked — every resume re-raises the interrupt, so the human is asked again each time and the only machine signal is the `ERROR` log. This is deliberate: the alternative is to give up after N attempts and discard an approval a human already gave, and a recoverable annoyance beats destroying the answer. An operator who fixes the underlying cause gets a working resume. **Worth a maintainer's opinion.**
- **Sharing one `Agent` instance as a tool across several orchestrators** is a foot-gun: `_reset_agent_state` is unconditional, so one orchestrator's call can clear a turn another has parked. The parked orchestrator still resumes correctly; the other call fails with a confusing error. Documented on that method rather than fixed, because making the reset aware of a foreign parked turn is a behaviour change deserving its own review.
- **A `load_snapshot` that fails after validation** leaves the sub-agent with some fields applied and others not. The parked turn is kept, the interrupt stays pending, and an ephemeral sub-agent is reset on its next fresh call, so it self-heals. It is not invoked in that state unless it is itself still activated from an earlier turn in this process; noted in the code.
- **Interrupt ids parked by an earlier revision of this branch** use the older prefix and are not recognised after the marker change: the resume treats the call as fresh and re-runs the sub-agent's turn. That only affects state persisted by a revision of this branch, which has never shipped, so no migration is included.
- **Not automated:** two sub-agent calls interrupting concurrently in one turn, three-level nesting, and a resume prompt mixing answers for a sub-agent's interrupts with the orchestrator's own. All three were exercised by hand and hold; they are the coverage I would add next.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.