### PR TITLE
fix(site): reject redundant languages in astro frontmatter

### DIFF
--- a/.agents/references/mdx-authoring.md
+++ b/.agents/references/mdx-authoring.md
@@ -153,9 +153,7 @@ Optional fields (validated by Zod in `site/src/content.config.ts`):
 
 These render contextual banners automatically (experimental → community → languages). Anything not in this table is silently stripped by Zod at build time, so don't invent fields like `contentType` or `lastReviewed` — add them to the schema first if they'd be useful.
 
-**`languages` field usage:**
-- Set `languages: python` or `languages: typescript` when a feature is available in only one SDK language. This renders a "Language Support" banner.
-- **Do not** set `languages: [python, typescript]` — listing all supported languages is redundant and the build will reject it. Omit the field entirely when a feature is available in all languages.
+Do not set `languages: [python, typescript]` — listing all supported languages is redundant. Omit the field when a feature is available in all languages.
 
 ## TypeScript Snippet Scoping
 

--- a/.agents/references/mdx-authoring.md
+++ b/.agents/references/mdx-authoring.md
@@ -153,6 +153,10 @@ Optional fields (validated by Zod in `site/src/content.config.ts`):
 
 These render contextual banners automatically (experimental → community → languages). Anything not in this table is silently stripped by Zod at build time, so don't invent fields like `contentType` or `lastReviewed` — add them to the schema first if they'd be useful.
 
+**`languages` field usage:**
+- Set `languages: python` or `languages: typescript` when a feature is available in only one SDK language. This renders a "Language Support" banner.
+- **Do not** set `languages: [python, typescript]` — listing all supported languages is redundant and the build will reject it. Omit the field entirely when a feature is available in all languages.
+
 ## TypeScript Snippet Scoping
 
 When a `.ts` file has multiple snippets using the same variable names, wrap each snippet body in a function. Place markers **inside** the function so only the snippet body — not the function declaration — appears in docs:

--- a/site/src/components/overrides/MarkdownContent.astro
+++ b/site/src/components/overrides/MarkdownContent.astro
@@ -12,6 +12,12 @@ const { languages, community, experimental } = starlightRoute.entry.data;
 // the back strip is their route to the /integrations catalog.
 const isIntegrationsPage =
   starlightRoute.id === 'docs/integrations' || starlightRoute.id.startsWith('docs/integrations/');
+
+const ALL_SDK_LANGUAGES = ['python', 'typescript']
+const langArray = languages
+  ? (Array.isArray(languages) ? languages : [languages]).map((l: string) => l.toLowerCase())
+  : []
+const coversAllLanguages = ALL_SDK_LANGUAGES.every((l) => langArray.includes(l))
 ---
 
 <div class="sl-markdown-content">
@@ -20,7 +26,7 @@ const isIntegrationsPage =
   {community && <CommunityContributionAside />}
   {/* Language support aside is omitted for community pages — the CommunityContributionAside already
       contextualizes the page, and language support is listed in the community catalog table instead. */}
-  {languages && !community && <LanguageSupportAside languages={languages} />}
+  {languages && !community && !coversAllLanguages && <LanguageSupportAside languages={languages} />}
   <slot />
   <PageTags />
 </div>

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -5,6 +5,24 @@ import { glob, file } from 'astro/loaders'
 import { pathToDocsSlug } from './util/links'
 import { TagSchema } from './config/tags'
 
+export const ALL_SDK_LANGUAGES = ['python', 'typescript'] as const
+
+export const docsLanguagesSchema = z
+  .union([z.string(), z.array(z.string())])
+  .optional()
+  .superRefine((val, ctx) => {
+    if (!val) return
+    const langs = Array.isArray(val) ? val.map((l) => l.toLowerCase()) : [val.toLowerCase()]
+    if (ALL_SDK_LANGUAGES.every((l) => langs.includes(l))) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          'languages must not list all supported SDKs (python and typescript) — ' +
+          'omit the field entirely when a feature is available in all languages',
+      })
+    }
+  })
+
 const authorSchema = z.object({
   name: z.string(),
   role: z.string(),
@@ -220,8 +238,7 @@ export const collections = {
     schema: docsSchema({
       // We have certain flags/behavior based on the following properties; see CMS-README.md for more info
       extend: z.object({
-        // Can be a single value or an array of supported values
-        languages: z.union([z.string(), z.array(z.string())]).optional(),
+        languages: docsLanguagesSchema,
         community: z.boolean().default(false),
         experimental: z.boolean().default(false),
         // Category for TypeScript API docs (classes, interfaces, type-aliases, functions)

--- a/site/test/languages-schema.test.ts
+++ b/site/test/languages-schema.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { docsLanguagesSchema } from '../src/content.config'
+
+describe('docsLanguagesSchema', () => {
+  it('accepts a single language string', () => {
+    expect(docsLanguagesSchema.safeParse('python').success).toBe(true)
+    expect(docsLanguagesSchema.safeParse('typescript').success).toBe(true)
+  })
+
+  it('accepts a single-element array', () => {
+    expect(docsLanguagesSchema.safeParse(['python']).success).toBe(true)
+    expect(docsLanguagesSchema.safeParse(['typescript']).success).toBe(true)
+  })
+
+  it('accepts undefined (field omitted)', () => {
+    expect(docsLanguagesSchema.safeParse(undefined).success).toBe(true)
+  })
+
+  it('rejects an array listing all SDK languages', () => {
+    const result = docsLanguagesSchema.safeParse(['python', 'typescript'])
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain('omit the field entirely')
+    }
+  })
+
+  it('rejects regardless of order', () => {
+    expect(docsLanguagesSchema.safeParse(['typescript', 'python']).success).toBe(false)
+  })
+
+  it('rejects regardless of case', () => {
+    expect(docsLanguagesSchema.safeParse(['Python', 'TypeScript']).success).toBe(false)
+  })
+})


### PR DESCRIPTION


## Description

Adds a build-time linter to prevent doc pages from setting `languages: [python, typescript]` in frontmatter. Since Python and TypeScript are the only SDK languages, listing both is redundant and renders a misleading "Language Support" banner. Three layers of prevention:

1. **Zod schema validation** (`content.config.ts`) — fails the build with a clear error message
2. **Runtime filter** (`MarkdownContent.astro`) — suppresses the banner as a safety net
3. **Agent guidance** (`mdx-authoring.md`) — one-line note so doc writers don't make the mistake

## Related Issues

Follows up on #3637 (manual removal of redundant language banners)

## Documentation PR

Documentation guidance update is included in this PR (`.agents/references/mdx-authoring.md`).

## Type of Change

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] Unit test added (`site/test/languages-schema.test.ts`) — 6 cases covering valid/invalid inputs
- [x] Full test suite passes (528 tests)
- [x] TypeScript typecheck passes

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.