### PR TITLE
fix(context-offloader): report retrieval failures as tool errors

### DIFF
--- a/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
@@ -387,12 +387,16 @@ class ContextOffloader(Plugin):
             context_lines: Lines before AND after each match (like grep -C). Default: 5.
                 Without pattern/line_range, returns first N lines.
             tool_context: Injected by the framework. Not user-facing.
+
+        Raises:
+            ValueError: If the reference is unknown, the content is binary and pattern/line_range/context_lines
+                were supplied, or line_range falls outside the content.
         """
         storage = self._storage_for_agent(tool_context.agent)
         try:
             content_bytes, content_type = await _retrieve_content(storage, reference)
-        except KeyError:
-            return f"Error: reference not found: {reference}"
+        except KeyError as error:
+            raise ValueError(f"reference not found: {reference}") from error
 
         # Refresh the eviction cycle so actively-retrieved content survives
         # eviction for unified Storage backends, matching InMemoryStorage.retrieve.
@@ -402,8 +406,8 @@ class ContextOffloader(Plugin):
             return self._decode_full_content(content_bytes, content_type, reference)
 
         if not _is_searchable_content(content_type):
-            return (
-                f"Error: cannot search binary content ({content_type}). "
+            raise ValueError(
+                f"cannot search binary content ({content_type}). "
                 "Omit pattern/line_range/context_lines to retrieve the full content."
             )
 

--- a/strands-py/src/strands/vended_plugins/context_offloader/search.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/search.py
@@ -49,7 +49,10 @@ def _search_content(
         max_chars: Maximum output size in characters; results are truncated beyond this.
 
     Returns:
-        Formatted search results with line numbers, or an error/empty message.
+        Formatted search results with line numbers, or a message reporting empty content or no matches.
+
+    Raises:
+        ValueError: If line_range is not a 1-indexed, non-empty range within the content.
     """
     lines = text.split("\n")
     total_lines = len(lines)
@@ -63,11 +66,11 @@ def _search_content(
     if line_range is not None:
         start, end = line_range
         if start < 1:
-            return f"Error: line_range.start ({start}) must be >= 1."
+            raise ValueError(f"line_range.start ({start}) must be >= 1.")
         if start > end:
-            return f"Error: line_range.start ({start}) must be <= line_range.end ({end})."
+            raise ValueError(f"line_range.start ({start}) must be <= line_range.end ({end}).")
         if start > total_lines:
-            return f"Error: line_range.start ({start}) is beyond content length ({total_lines} lines)."
+            raise ValueError(f"line_range.start ({start}) is beyond content length ({total_lines} lines).")
         scope_start = start - 1
         scope_end = min(end - 1, total_lines - 1)
 

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_plugin.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_plugin.py
@@ -509,8 +509,8 @@ class TestRetrievalTool:
 
     @pytest.mark.asyncio
     async def test_retrieve_missing_reference(self, plugin, tool_context):
-        result = await plugin.retrieve_offloaded_content(reference="nonexistent", tool_context=tool_context)
-        assert "Error: reference not found" in result
+        with pytest.raises(ValueError, match="reference not found: nonexistent"):
+            await plugin.retrieve_offloaded_content(reference="nonexistent", tool_context=tool_context)
 
     @pytest.mark.asyncio
     async def test_retrieve_image_content(self, plugin, storage, tool_context):
@@ -612,14 +612,11 @@ class TestRetrievalToolSearch:
         assert "line 11" not in result
 
     @pytest.mark.asyncio
-    async def test_returns_error_for_binary_content(self, plugin, storage, tool_context):
+    async def test_raises_for_binary_content(self, plugin, storage, tool_context):
         ref = await storage.store("k1", b"\x89PNG", "image/png")
 
-        result = await plugin.retrieve_offloaded_content(
-            reference=ref, pattern="test", tool_context=tool_context
-        )
-
-        assert "Error: cannot search binary content (image/png)" in result
+        with pytest.raises(ValueError, match=r"cannot search binary content \(image/png\)"):
+            await plugin.retrieve_offloaded_content(reference=ref, pattern="test", tool_context=tool_context)
 
     @pytest.mark.asyncio
     async def test_falls_back_to_literal_on_invalid_regex(self, plugin, storage, tool_context):
@@ -635,12 +632,11 @@ class TestRetrievalToolSearch:
         assert "> 3| foo (bar again" in result
 
     @pytest.mark.asyncio
-    async def test_returns_error_for_missing_reference(self, plugin, tool_context):
-        result = await plugin.retrieve_offloaded_content(
-            reference="nonexistent", pattern="test", tool_context=tool_context
-        )
-
-        assert "Error: reference not found" in result
+    async def test_raises_for_missing_reference(self, plugin, tool_context):
+        with pytest.raises(ValueError, match="reference not found: nonexistent"):
+            await plugin.retrieve_offloaded_content(
+                reference="nonexistent", pattern="test", tool_context=tool_context
+            )
 
     @pytest.mark.asyncio
     async def test_searches_json_content(self, plugin, storage, tool_context):
@@ -700,11 +696,10 @@ class TestRetrievalToolSearch:
         content = "line 1\nline 2\nline 3"
         ref = await storage.store("k1", content.encode("utf-8"), "text/plain")
 
-        result = await plugin.retrieve_offloaded_content(
-            reference=ref, line_range={"start": 100, "end": 200}, tool_context=tool_context
-        )
-
-        assert "beyond content length (3 lines)" in result
+        with pytest.raises(ValueError, match=r"beyond content length \(3 lines\)"):
+            await plugin.retrieve_offloaded_content(
+                reference=ref, line_range={"start": 100, "end": 200}, tool_context=tool_context
+            )
 
     @pytest.mark.asyncio
     async def test_clamps_line_range_end(self, plugin, storage, tool_context):
@@ -744,6 +739,98 @@ class TestRetrievalToolSearch:
         result = await plugin.retrieve_offloaded_content(reference=ref, tool_context=tool_context)
 
         assert result == "hello world"
+
+
+class TestRetrievalToolErrorStatus:
+    """Retrieval failures surface as tool results with status "error" (#3493).
+
+    A failure reported as status "success" is indistinguishable to the model from
+    content that was retrieved successfully.
+    """
+
+    @pytest.fixture
+    def storage(self):
+        return InMemoryStorage()
+
+    @pytest.fixture
+    def plugin(self, storage):
+        return ContextOffloader(storage=storage, max_result_tokens=25, preview_tokens=10, include_retrieval_tool=True)
+
+    @pytest.fixture
+    def mock_agent(self):
+        return MagicMock()
+
+    @staticmethod
+    async def _tool_result(plugin, mock_agent, alist, tool_input):
+        """Invoke the tool the way the event loop does and return the tool result the model sees."""
+        tool_use = ToolUse(toolUseId="retrieve_1", name="retrieve_offloaded_content", input=tool_input)
+        events = await alist(plugin.retrieve_offloaded_content.stream(tool_use, {"agent": mock_agent}))
+        return events[-1].tool_result
+
+    @pytest.mark.asyncio
+    async def test_missing_reference_reports_error_status(self, plugin, mock_agent, alist):
+        tru_result = await self._tool_result(plugin, mock_agent, alist, {"reference": "nope"})
+
+        exp_result = {
+            "toolUseId": "retrieve_1",
+            "status": "error",
+            "content": [{"text": "Error: reference not found: nope"}],
+        }
+        assert tru_result == exp_result
+
+    @pytest.mark.asyncio
+    async def test_binary_content_search_reports_error_status(self, plugin, storage, mock_agent, alist):
+        ref = await storage.store("k1", b"\x89PNG", "image/png")
+
+        tru_result = await self._tool_result(plugin, mock_agent, alist, {"reference": ref, "pattern": "test"})
+
+        exp_result = {
+            "toolUseId": "retrieve_1",
+            "status": "error",
+            "content": [
+                {
+                    "text": (
+                        "Error: cannot search binary content (image/png). "
+                        "Omit pattern/line_range/context_lines to retrieve the full content."
+                    )
+                }
+            ],
+        }
+        assert tru_result == exp_result
+
+    @pytest.mark.asyncio
+    async def test_out_of_range_line_range_reports_error_status(self, plugin, storage, mock_agent, alist):
+        ref = await storage.store("k1", b"line 1\nline 2", "text/plain")
+
+        tru_result = await self._tool_result(
+            plugin, mock_agent, alist, {"reference": ref, "line_range": {"start": 100, "end": 200}}
+        )
+
+        exp_result = {
+            "toolUseId": "retrieve_1",
+            "status": "error",
+            "content": [{"text": "Error: line_range.start (100) is beyond content length (2 lines)."}],
+        }
+        assert tru_result == exp_result
+
+    @pytest.mark.asyncio
+    async def test_successful_retrieval_reports_success_status(self, plugin, storage, mock_agent, alist):
+        ref = await storage.store("k1", b"hello world", "text/plain")
+
+        tru_result = await self._tool_result(plugin, mock_agent, alist, {"reference": ref})
+
+        exp_result = {"toolUseId": "retrieve_1", "status": "success", "content": [{"text": "hello world"}]}
+        assert tru_result == exp_result
+
+    @pytest.mark.asyncio
+    async def test_search_without_matches_reports_success_status(self, plugin, storage, mock_agent, alist):
+        """A search that finds nothing has succeeded — only genuine failures report an error."""
+        ref = await storage.store("k1", b"hello\nworld", "text/plain")
+
+        tru_result = await self._tool_result(plugin, mock_agent, alist, {"reference": ref, "pattern": "absent"})
+
+        assert tru_result["status"] == "success"
+        assert "No matches found for pattern 'absent'" in tru_result["content"][0]["text"]
 
 
 class TestInlineGuidance:

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_search.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_search.py
@@ -1,5 +1,7 @@
 """Tests for the search module."""
 
+import pytest
+
 from strands.vended_plugins.context_offloader.search import _is_searchable_content, _search_content
 
 
@@ -31,20 +33,20 @@ class TestSearchContentLineRangeValidation:
     text = "line 1\nline 2\nline 3\nline 4\nline 5"
 
     def test_start_less_than_one(self):
-        result = _search_content(self.text, line_range=(0, 3), context_lines=5, max_chars=10_000)
-        assert "must be >= 1" in result
+        with pytest.raises(ValueError, match="must be >= 1"):
+            _search_content(self.text, line_range=(0, 3), context_lines=5, max_chars=10_000)
 
     def test_negative_start(self):
-        result = _search_content(self.text, line_range=(-2, 3), context_lines=5, max_chars=10_000)
-        assert "must be >= 1" in result
+        with pytest.raises(ValueError, match="must be >= 1"):
+            _search_content(self.text, line_range=(-2, 3), context_lines=5, max_chars=10_000)
 
     def test_start_greater_than_end(self):
-        result = _search_content(self.text, line_range=(5, 2), context_lines=5, max_chars=10_000)
-        assert "must be <= line_range.end" in result
+        with pytest.raises(ValueError, match="must be <= line_range.end"):
+            _search_content(self.text, line_range=(5, 2), context_lines=5, max_chars=10_000)
 
     def test_start_beyond_total_lines(self):
-        result = _search_content(self.text, line_range=(100, 200), context_lines=5, max_chars=10_000)
-        assert "beyond content length (5 lines)" in result
+        with pytest.raises(ValueError, match=r"beyond content length \(5 lines\)"):
+            _search_content(self.text, line_range=(100, 200), context_lines=5, max_chars=10_000)
 
     def test_clamps_end_to_total_lines(self):
         result = _search_content(self.text, line_range=(3, 999), context_lines=5, max_chars=10_000)


### PR DESCRIPTION
## Description

`ContextOffloader`'s `retrieve_offloaded_content` tool reported its own failures to the model as successes.

The failure paths `return`ed a plain string — `"Error: reference not found: nope"` — and `DecoratedFunctionTool._wrap_tool_result` classifies *any* `str` return as `status: "success"`. Only a raised exception reaches the decorator's error handling. So a retrieval that failed came back indistinguishable from content that was retrieved successfully, and nothing in the tool result marked the call as failed. The reporter hit this in a deployed AgentCore runtime: the model sent a reference in a form the tool doesn't accept, and the not-found came back as a success.

Three paths now raise `ValueError` instead of returning a string: the unknown reference, the binary-content guard, and the invalid `line_range` validations in `_search_content`. `ValueError` specifically, because the decorator renders it as `f"Error: {msg}"` — so **the text the model sees is byte-identical to before; only `status` changes.**

Informational messages that are *not* failures stay successes: a search that finds no matches, and empty content, are results rather than errors.

**Behavior change for direct callers:** the decorator's `__call__` invokes the undecorated function, so code calling `plugin.retrieve_offloaded_content(...)` directly now gets a `ValueError` where it previously got a string. The tool is intended for model invocation through the event loop, where the decorator converts the raise into an error-status `ToolResult`. (There is no CHANGELOG file in the repo, so this description is the record of that contract change.)

The TypeScript SDK has the identical bug (`vended-plugins/context-offloader/plugin.ts:362,376` and `search.ts:137,140`, with `function-tool.ts`'s `_wrapInToolResult` making the same success classification). That fix is deliberately **not** in this PR — cross-sub-project changes belong in separate PRs per `AGENTS.md`. Happy to file the companion issue/PR on request.

## Related Issues

Fixes #3493

## Documentation PR

No docs changes needed. The `site/` pages for this plugin document the retrieval tool's return *formats*, not its success/error status contract — I grepped for the affected strings and for `retrieve_offloaded_content` across `site/src/content/docs` and found nothing describing the old behavior.

## Type of Change

Bug fix

## Testing

Verified with the reporter's own repro script, extended to cover all three paths plus two controls. Before, every failure came back `status: "success"`; after:

```
missing ref     : {'toolUseId': 't1', 'status': 'error',   'content': [{'text': 'Error: reference not found: nope'}]}
binary search   : {'toolUseId': 't2', 'status': 'error',   'content': [{'text': 'Error: cannot search binary content (image/png). Omit pattern/line_range/context_lines to retrieve the full content.'}]}
bad line_range  : {'toolUseId': 't3', 'status': 'error',   'content': [{'text': 'Error: line_range.start (100) is beyond content length (2 lines).'}]}
success control : {'toolUseId': 't4', 'status': 'success', 'content': [{'text': 'hello world'}]}
no-match control: {'toolUseId': 't5', 'status': 'success', 'content': [{'text': "No matches found for pattern 'absent' (searched 1 lines)."}]}
```

New regression tests assert the whole `ToolResult` through `.stream()` — the path the event loop actually uses — including the two controls that must stay `success`. An independent reviewer confirmed these are real regression tests by running them against pre-fix source: **11 of 11 new/modified assertions fail without the fix.**

<details>
<summary>Full verification evidence (test suite, ruff, mypy)</summary>

**Offloader suite**

```
$ python -m pytest tests/strands/vended_plugins/context_offloader/ -q
182 passed in 1.29s
```

**Full Python suite** (`-n 4`)

```
$ python -m pytest tests/ -q -n 4
4844 passed, 43 warnings in 119.80s (0:01:59)
```

An earlier run of the same suite showed `1 failed, 4843 passed`, failing on
`tests/strands/multiagent/test_graph.py::test_graph_streaming_parallel_events`. That is a
pre-existing flake under parallel execution, not related to this change: it passes in isolation on
both `origin/main` and this branch, it passed on the re-run above, and this diff touches only
`vended_plugins/context_offloader/` (4 files, no multiagent code).

**ruff** — note CI's pin is `ruff>=0.13.0,<0.17.0`; 0.16.x reformats files that are already clean on
`origin/main`, so I verified with 0.15.0, under which the pristine base is clean:

```
$ python -m ruff format --check src/ tests/     # 0 unformatted
$ python -m ruff check src/ tests/
All checks passed!
```

**mypy** — identical on base and branch, so this change introduces no new errors. All 9 are missing
optional `mypy_boto3_*` stub packages in my local env, in files this PR does not touch:

```
origin/main : Found 9 errors in 3 files (checked 234 source files)
this branch : Found 9 errors in 3 files (checked 234 source files)
```

</details>

<details>
<summary>Adversarial probing of the new error paths — no blockers found</summary>

The specific worry was that raising where the code used to return could escape into the event loop,
or that an oversized error message could collide with the plugin's own offload hook (there is prior
art in this plugin of an oversized replacement message escalating to an unhandled
`EventLoopException`). Neither reproduced:

```
1 huge-ref (200KB)     : status=error, no crash
2 non-UTF8 as text/*   : status=error  "Error: 'utf-8' codec can't decode byte 0xff ..."
3 malformed JSON       : status=error  "Error: Expecting property name enclosed in ..."
4 line_range floats    : status=error  (pydantic validation)
4 line_range end=-5    : status=error  "Error: line_range.start (2) must be <= line_range.end (-5)."
5 offload hook, 100KB error result, include_retrieval_tool=True  : survived (skipped by early return)
5 offload hook, 100KB error result, include_retrieval_tool=False : survived (offloaded to a 393-byte preview)
```

`UnicodeDecodeError` and `json.JSONDecodeError` both subclass `ValueError`, so the decode/parse paths
already routed through the decorator's clean `ValueError` branch before and after this change.

Two **pre-existing** sharp edges surfaced that this PR does not touch and deliberately leaves alone:
`line_range: {"start": true}` is coerced by pydantic to `1` and searches successfully, and an
unbounded `reference` is echoed verbatim into the message (a 200KB reference yields a 200KB result —
equally true before this fix, when it was a 200KB *success*). Both are candidates for a follow-up,
not regressions here.

</details>

<details>
<summary>Review loop ledger</summary>

I wrote this change, so I am the worst judge of it — it went through independent fresh-context review
rather than my own re-reading.

**Round 1 — independent correctness reviewer** (fresh context, no `write`/`edit` tools): **APPROVE**,
0 blockers, 2 items. It independently verified the call path
(`tools/executors/_executor.py:461` → `DecoratedFunctionTool.stream()` → `tools/decorator.py:645`),
confirmed no escape path, confirmed `ValueError` is the repo convention (`strands.types.exceptions`
has nothing for "tool got bad input"; root `AGENTS.md:156` and `stop.py`/`sleep.py`/`file_editor.py`
all establish bare `ValueError`), confirmed no remaining `return f"Error: ..."` paths, and proved the
tests fail on pre-fix source (11/11).

| # | Finding | Severity | Disposition |
| --- | --- | --- | --- |
| 1 | Breaking change for direct callers of `retrieve_offloaded_content` is undocumented | should-fix | **Fixed** — called out in the Description above. The reviewer read the branch, not this PR body, where it was already stated; there is no CHANGELOG file to update. |
| 2 | The added `Raises:` section lands in the **model-facing** tool description (`_extract_description_from_docstring` strips only `Args:`), naming a Python type the model never sees and partly restating `Constraints:`. `experimental/tools/stop/stop.py:100-110` deliberately keeps `Raises:` off the `@tool` docstring. | question | **Deferred to maintainer, not changed.** Genuine tension: `strands-py/AGENTS.md` requires `Raises:` on a public function that raises as part of its contract, and this *is* a public method — but `stop.py` shows the repo's practice for model-facing `@tool` docstrings is to omit it. I did not want to resolve a convention conflict unilaterally in a bugfix PR. `mkmeral` — say the word and I'll drop the section. |

**Adversarial pass:** two attempts at a dedicated adversarial reviewer both **timed out** (900s) in my
sandbox and returned nothing, so I ran those checks myself instead — results in the section above.
Stating that plainly rather than implying a pass I did not get.

**Round 2:** not run, deliberately. Round 1 produced no code changes (item 1 was already documented,
item 2 is a deferred maintainer decision), so there is no new code for a fresh reviewer to verify.
Had I changed a line in response, a new reviewer would have checked it rather than me re-reading my
own fix.

</details>

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

Opened by `strandly-the-agent` at a maintainer's request. A human should review before merge.