### PR TITLE
feat(litellm): route cache_config per underlying provider

### DIFF
--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -288,6 +288,13 @@ class BedrockModel(Model):
             )
             system_blocks.append({"cachePoint": {"type": cache_prompt}})
 
+        # Auto-inject a cachePoint at the end of the system prompt so repeated calls with
+        # the same static system prefix hit the cache. Anthropic docs describe the
+        # tools → system → messages prefix chain; caching only messages leaves the
+        # (usually largest and most static) system prefix uncached.
+        if self._should_cache_system(system_blocks):
+            system_blocks.append(self._build_system_cache_point())
+
         return {
             "modelId": self.config["model_id"],
             "messages": self._format_bedrock_messages(messages),
@@ -386,6 +393,50 @@ class BedrockModel(Model):
             return {}
 
         return {"additionalModelRequestFields": additional_fields}
+
+    def _should_cache_system(self, system_blocks: list[SystemContentBlock]) -> bool:
+        """Whether to auto-inject a cache point at the end of the system prompt.
+
+        True only when auto caching is enabled for this model, ``system_blocks`` has cacheable
+        content, and no cachePoint has already been placed at the end of the system prefix.
+
+        Args:
+            system_blocks: The system content blocks that will be sent to Bedrock.
+
+        Returns:
+            True if a cache point should be appended.
+        """
+        cache_config = self.config.get("cache_config")
+        if not cache_config:
+            return False
+
+        resolved: str | None = cache_config.strategy
+        if resolved == "auto":
+            resolved = self._cache_strategy
+        if resolved != "anthropic":
+            return False
+
+        if not system_blocks:
+            return False
+
+        if "cachePoint" in system_blocks[-1]:
+            return False
+
+        return True
+
+    def _build_system_cache_point(self) -> SystemContentBlock:
+        """Build the cache point block appended to the system prompt.
+
+        Uses ``cache_config.ttl`` when set; falls back to Bedrock's ``default`` (5m).
+
+        Returns:
+            The cache point block.
+        """
+        cache_point: dict[str, Any] = {"type": "default"}
+        cache_config = self.config.get("cache_config")
+        if cache_config and cache_config.ttl:
+            cache_point["ttl"] = cache_config.ttl
+        return cast(SystemContentBlock, {"cachePoint": cache_point})
 
     def _build_tools_cache_point(self) -> list[dict[str, Any]]:
         """Build the cache point block appended to ``toolConfig.tools`` if ``cache_tools`` is configured.

--- a/strands-py/src/strands/models/litellm.py
+++ b/strands-py/src/strands/models/litellm.py
@@ -22,10 +22,19 @@ from ..types.exceptions import ContextWindowOverflowException
 from ..types.streaming import MetadataEvent, StreamEvent
 from ..types.tools import ToolChoice, ToolSpec, ToolUse
 from ._validation import validate_config_keys
-from .model import BaseModelConfig
+from .model import BaseModelConfig, CacheConfig
 from .openai import OpenAIModel
 
 logger = logging.getLogger(__name__)
+
+# Underlying providers whose native APIs support Anthropic-style cache_control markers.
+# LiteLLM already translates cachePoint → cache_control for these on the system prompt;
+# when cache_config resolves to "anthropic" we also mark the last user message.
+_ANTHROPIC_CACHE_LITELLM_PREFIXES = ("anthropic/", "bedrock/anthropic.", "vertex_ai/claude", "vertex_ai_beta/claude")
+
+# Underlying providers that cache automatically on the server side. cache_config is
+# accepted for portability but the SDK doesn't need to inject markers.
+_SERVER_AUTO_CACHE_LITELLM_PREFIXES = ("openai/", "deepseek/", "xai/", "azure/")
 
 # Separator used by LiteLLM to embed thought signatures inside tool call IDs.
 # See: https://ai.google.dev/gemini-api/docs/thought-signatures
@@ -47,11 +56,17 @@ class LiteLLMModel(OpenAIModel):
                 For a complete list of supported parameters, see
                 https://docs.litellm.ai/docs/completion/input#input-params-1.
             stream: Whether to use streaming. Defaults to True.
+            cache_config: Configuration for prompt caching. Use CacheConfig(strategy="auto") to
+                let LiteLLM route caching to the underlying provider. Behaviour depends on the
+                model_id prefix: Anthropic/Bedrock-Anthropic/Vertex-Claude get cache markers on
+                the system prompt and last user message; OpenAI-compatible providers cache
+                automatically server-side and this config is a no-op; other providers warn.
         """
 
         model_id: str
         params: dict[str, Any] | None
         stream: bool
+        cache_config: CacheConfig | None
 
     def __init__(self, client_args: dict[str, Any] | None = None, **model_config: Unpack[LiteLLMConfig]) -> None:
         """Initialize provider instance.
@@ -88,6 +103,44 @@ class LiteLLMModel(OpenAIModel):
             The LiteLLM model configuration.
         """
         return cast(LiteLLMModel.LiteLLMConfig, self.config)
+
+    @property
+    def _cache_strategy(self) -> str | None:
+        """Resolve the caching strategy for this model's underlying provider.
+
+        Returns:
+            "anthropic" when the underlying provider accepts cache_control markers,
+            "server-auto" when the underlying provider caches automatically without
+            client-side markers, or None when neither applies.
+        """
+        model_id = cast(str, self.config.get("model_id") or "").lower()
+        if any(model_id.startswith(prefix) for prefix in _ANTHROPIC_CACHE_LITELLM_PREFIXES):
+            return "anthropic"
+        if any(model_id.startswith(prefix) for prefix in _SERVER_AUTO_CACHE_LITELLM_PREFIXES):
+            return "server-auto"
+        return None
+
+    def _resolve_cache_strategy(self) -> str | None:
+        """Resolve cache_config into a concrete strategy, warning on unsupported underlying providers.
+
+        Returns:
+            "anthropic" when we should inject markers, "server-auto" when the underlying provider
+            caches automatically (no injection needed), or None when caching is off or unsupported.
+        """
+        cache_config = cast(CacheConfig | None, self.config.get("cache_config"))
+        if not cache_config:
+            return None
+
+        resolved: str | None = cache_config.strategy
+        if resolved == "auto":
+            resolved = self._cache_strategy
+            if resolved is None:
+                logger.warning(
+                    "model_id=<%s> | cache_config is enabled but the underlying provider is not "
+                    "recognized for caching, ignoring",
+                    self.config.get("model_id"),
+                )
+        return resolved
 
     @override
     @classmethod
@@ -238,6 +291,53 @@ class LiteLLMModel(OpenAIModel):
 
     @override
     @classmethod
+    def _format_regular_messages(cls, messages: Messages, **kwargs: Any) -> list[dict[str, Any]]:
+        """Format messages for LiteLLM, translating message-level cachePoint blocks.
+
+        Delegates to the OpenAI parent after stripping cachePoint blocks from the input and
+        re-attaching them as cache_control markers on the immediately preceding content
+        block, mirroring the system-prompt translator.
+
+        Args:
+            messages: List of message objects to be processed by the model.
+            **kwargs: Additional keyword arguments for future extensibility.
+
+        Returns:
+            List of formatted messages.
+        """
+        stripped_messages: list[dict[str, Any]] = []
+        cache_markers: list[tuple[int, int, dict[str, Any]]] = []
+        for msg_idx, message in enumerate(messages):
+            new_content: list[dict[str, Any]] = []
+            for block in message["content"]:
+                if "cachePoint" in block and block["cachePoint"].get("type") == "default":
+                    if new_content:
+                        cache_control: dict[str, Any] = {"type": "ephemeral"}
+                        if ttl := block["cachePoint"].get("ttl"):
+                            cache_control["ttl"] = ttl
+                        cache_markers.append((msg_idx, len(new_content) - 1, cache_control))
+                    continue
+                new_content.append(cast(dict[str, Any], block))
+            stripped_messages.append({"role": message["role"], "content": new_content})
+
+        formatted = super()._format_regular_messages(cast(Messages, stripped_messages), **kwargs)
+
+        # Reattach cache_control to each marked (message, block) position. This works because
+        # _format_regular_messages preserves 1-to-1 mapping between input messages and the
+        # primary formatted message; tool-message splits append AFTER, so indices stay stable
+        # for the user/assistant messages we mark.
+        for msg_idx, block_idx, cache_control in cache_markers:
+            if msg_idx >= len(formatted):
+                continue
+            formatted_content = formatted[msg_idx].get("content")
+            if not isinstance(formatted_content, list) or block_idx >= len(formatted_content):
+                continue
+            formatted_content[block_idx]["cache_control"] = cache_control
+
+        return formatted
+
+    @override
+    @classmethod
     def format_request_messages(
         cls,
         messages: Messages,
@@ -317,6 +417,117 @@ class LiteLLMModel(OpenAIModel):
 
         # For all other cases, use the parent implementation
         return super().format_chunk(event)
+
+    @override
+    def format_request(
+        self,
+        messages: Messages,
+        tool_specs: list[ToolSpec] | None = None,
+        system_prompt: str | None = None,
+        tool_choice: ToolChoice | None = None,
+        *,
+        system_prompt_content: list[SystemContentBlock] | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Format a LiteLLM request, injecting cache markers when cache_config is set.
+
+        Args:
+            messages: List of message objects to be processed by the model.
+            tool_specs: List of tool specifications to make available to the model.
+            system_prompt: System prompt to provide context to the model.
+            tool_choice: Selection strategy for tool invocation.
+            system_prompt_content: System prompt content blocks to provide context to the model.
+            **kwargs: Additional keyword arguments for future extensibility.
+
+        Returns:
+            A LiteLLM compatible chat streaming request.
+        """
+        strategy = self._resolve_cache_strategy()
+        if strategy == "anthropic":
+            system_prompt_content = self._inject_system_cache_point(system_prompt, system_prompt_content)
+            system_prompt = None if system_prompt_content else system_prompt
+            messages = self._inject_messages_cache_point(messages)
+
+        return super().format_request(
+            messages,
+            tool_specs,
+            system_prompt,
+            tool_choice,
+            system_prompt_content=system_prompt_content,
+            **kwargs,
+        )
+
+    def _inject_system_cache_point(
+        self,
+        system_prompt: str | None,
+        system_prompt_content: list[SystemContentBlock] | None,
+    ) -> list[SystemContentBlock] | None:
+        """Ensure the system prompt ends with a cachePoint so the static prefix is cached.
+
+        Promotes a plain-string system_prompt into content-block form so we can attach the
+        cachePoint. Preserves any caller-placed trailing cachePoint (including its ttl).
+
+        Args:
+            system_prompt: The plain-string system prompt, if any.
+            system_prompt_content: Structured system content blocks, if any.
+
+        Returns:
+            A structured system-prompt list ending in a cachePoint, or None when there is no
+            system prompt to cache.
+        """
+        content: list[SystemContentBlock] = list(system_prompt_content) if system_prompt_content else []
+        if not content and system_prompt:
+            content = [cast(SystemContentBlock, {"text": system_prompt})]
+        if not content:
+            return None
+
+        if "cachePoint" in content[-1]:
+            return content
+
+        cache_point: dict[str, Any] = {"type": "default"}
+        cache_config = cast(CacheConfig | None, self.config.get("cache_config"))
+        if cache_config and cache_config.ttl:
+            cache_point["ttl"] = cache_config.ttl
+        content.append(cast(SystemContentBlock, {"cachePoint": cache_point}))
+        return content
+
+    def _inject_messages_cache_point(self, messages: Messages) -> Messages:
+        """Append a cachePoint to the last user message so the conversation prefix is cached.
+
+        Strips any pre-existing cachePoint blocks from earlier messages so the breakpoint budget
+        stays constant across a long conversation. Anthropic accepts at most 4 cache breakpoints
+        per request; auto-injecting per turn without cleanup would break a conversation on turn 5.
+
+        Args:
+            messages: The conversation messages.
+
+        Returns:
+            A new messages list with the cachePoint appended to the last user message.
+        """
+        if not messages:
+            return messages
+
+        cache_point: dict[str, Any] = {"type": "default"}
+        cache_config = cast(CacheConfig | None, self.config.get("cache_config"))
+        if cache_config and cache_config.ttl:
+            cache_point["ttl"] = cache_config.ttl
+
+        cleaned: list[dict[str, Any]] = []
+        last_user_idx: int | None = None
+        for idx, message in enumerate(messages):
+            new_content = [block for block in message["content"] if "cachePoint" not in block]
+            cleaned.append({"role": message["role"], "content": new_content})
+            if message["role"] == "user" and new_content:
+                last_user_idx = idx
+
+        if last_user_idx is None:
+            return cast(Messages, cleaned)
+
+        last_content = cleaned[last_user_idx]["content"]
+        if not last_content or "cachePoint" in last_content[-1]:
+            return cast(Messages, cleaned)
+        last_content.append({"cachePoint": cache_point})
+        return cast(Messages, cleaned)
 
     @override
     async def stream(

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -3892,3 +3892,94 @@ def test_format_request_cache_tools_string_backward_compat(model, messages, mode
 
     exp_cache_point = {"cachePoint": {"type": cache_type}}
     assert tru_request["toolConfig"]["tools"][-1] == exp_cache_point
+
+
+def test_format_request_auto_appends_system_cache_point(bedrock_client, messages):
+    """Auto mode appends a cachePoint after the system prompt for a Claude model.
+
+    Regression guard for https://github.com/strands-agents/harness-sdk/issues/3144.
+    """
+    model = BedrockModel(
+        model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
+        cache_config=CacheConfig(strategy="auto"),
+    )
+
+    tru_request = model.format_request(messages, system_prompt_content=[{"text": "you are helpful"}])
+
+    assert tru_request["system"] == [
+        {"text": "you are helpful"},
+        {"cachePoint": {"type": "default"}},
+    ]
+
+
+def test_format_request_auto_system_cache_point_honors_ttl(bedrock_client, messages):
+    """Auto mode carries cache_config.ttl into the appended system cache point."""
+    model = BedrockModel(
+        model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
+        cache_config=CacheConfig(strategy="auto", ttl="1h"),
+    )
+
+    tru_request = model.format_request(messages, system_prompt_content=[{"text": "static"}])
+
+    assert tru_request["system"][-1] == {"cachePoint": {"type": "default", "ttl": "1h"}}
+
+
+def test_format_request_auto_skips_system_cache_point_when_empty(bedrock_client, messages):
+    """Auto mode does not inject a system cache point when the system prompt is empty."""
+    model = BedrockModel(
+        model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
+        cache_config=CacheConfig(strategy="auto"),
+    )
+
+    tru_request = model.format_request(messages)
+
+    assert tru_request["system"] == []
+
+
+def test_format_request_auto_skips_system_cache_point_for_non_claude(bedrock_client, messages):
+    """Auto mode does not inject a system cache point when the model has no auto strategy."""
+    model = BedrockModel(
+        model_id="amazon.nova-pro-v1:0",
+        cache_config=CacheConfig(strategy="auto"),
+    )
+
+    tru_request = model.format_request(messages, system_prompt_content=[{"text": "static"}])
+
+    assert tru_request["system"] == [{"text": "static"}]
+
+
+def test_format_request_auto_preserves_caller_placed_system_cache_point(bedrock_client, messages):
+    """Auto mode does not double-append when the caller already placed a trailing cachePoint."""
+    model = BedrockModel(
+        model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
+        cache_config=CacheConfig(strategy="auto"),
+    )
+
+    system_blocks = [{"text": "static"}, {"cachePoint": {"type": "default", "ttl": "1h"}}]
+    tru_request = model.format_request(messages, system_prompt_content=system_blocks)
+
+    assert tru_request["system"] == [
+        {"text": "static"},
+        {"cachePoint": {"type": "default", "ttl": "1h"}},
+    ]
+
+
+def test_format_request_no_cache_config_leaves_system_untouched(bedrock_client, messages):
+    """With no cache_config, the system prompt is passed through unchanged."""
+    model = BedrockModel(model_id="us.anthropic.claude-sonnet-4-20250514-v1:0")
+
+    tru_request = model.format_request(messages, system_prompt_content=[{"text": "static"}])
+
+    assert tru_request["system"] == [{"text": "static"}]
+
+
+def test_format_request_anthropic_strategy_appends_system_cache_point(bedrock_client, messages):
+    """Explicit anthropic strategy also appends a system cache point, mirroring auto."""
+    model = BedrockModel(
+        model_id="arn:aws:bedrock:us-east-1:123:application-inference-profile/abc",
+        cache_config=CacheConfig(strategy="anthropic"),
+    )
+
+    tru_request = model.format_request(messages, system_prompt_content=[{"text": "static"}])
+
+    assert tru_request["system"][-1] == {"cachePoint": {"type": "default"}}

--- a/strands-py/tests/strands/models/test_litellm.py
+++ b/strands-py/tests/strands/models/test_litellm.py
@@ -1042,3 +1042,186 @@ async def test_stream_generates_tool_call_id_when_null(litellm_acompletion, mode
     start = next(e for e in events if "contentBlockStart" in e and "toolUse" in e["contentBlockStart"]["start"])
     tool_id = start["contentBlockStart"]["start"]["toolUse"]["toolUseId"]
     assert tool_id and tool_id.startswith("call_")
+
+
+def test_cache_strategy_anthropic_for_anthropic_prefixes(litellm_acompletion):
+    """Underlying providers that accept cache_control markers resolve to "anthropic"."""
+    _ = litellm_acompletion
+    for model_id in [
+        "anthropic/claude-sonnet-4-6",
+        "bedrock/anthropic.claude-sonnet-4-6",
+        "vertex_ai/claude-3-5-sonnet",
+        "vertex_ai_beta/claude-3-5-sonnet",
+    ]:
+        m = LiteLLMModel(model_id=model_id)
+        assert m._cache_strategy == "anthropic", model_id
+
+
+def test_cache_strategy_server_auto_for_openai_prefixes(litellm_acompletion):
+    """Underlying providers that cache automatically server-side resolve to "server-auto"."""
+    _ = litellm_acompletion
+    for model_id in ["openai/gpt-4o", "deepseek/deepseek-chat", "xai/grok-2", "azure/gpt-4o"]:
+        m = LiteLLMModel(model_id=model_id)
+        assert m._cache_strategy == "server-auto", model_id
+
+
+def test_cache_strategy_none_for_unknown_prefix(litellm_acompletion):
+    """Underlying providers we don't recognize resolve to None."""
+    _ = litellm_acompletion
+    m = LiteLLMModel(model_id="gemini/gemini-2.5-flash")
+    assert m._cache_strategy is None
+
+
+def test_format_request_auto_injects_system_and_user_cache_points(litellm_acompletion):
+    """Auto mode injects cache_control on the trailing system block and last user text block."""
+    _ = litellm_acompletion
+    from strands.models import CacheConfig
+
+    model = LiteLLMModel(
+        model_id="anthropic/claude-sonnet-4-6",
+        cache_config=CacheConfig(strategy="auto"),
+    )
+
+    request = model.format_request(
+        [{"role": "user", "content": [{"text": "hi"}]}],
+        system_prompt="you are helpful",
+    )
+
+    system_msg = request["messages"][0]
+    assert system_msg["role"] == "system"
+    assert system_msg["content"][-1] == {
+        "type": "text",
+        "text": "you are helpful",
+        "cache_control": {"type": "ephemeral"},
+    }
+    user_msg = request["messages"][1]
+    assert user_msg["role"] == "user"
+    assert user_msg["content"][-1] == {"type": "text", "text": "hi", "cache_control": {"type": "ephemeral"}}
+
+
+def test_format_request_auto_honors_cache_config_ttl(litellm_acompletion):
+    """cache_config.ttl propagates into the injected cache_control markers."""
+    _ = litellm_acompletion
+    from strands.models import CacheConfig
+
+    model = LiteLLMModel(
+        model_id="anthropic/claude-sonnet-4-6",
+        cache_config=CacheConfig(strategy="auto", ttl="1h"),
+    )
+
+    request = model.format_request(
+        [{"role": "user", "content": [{"text": "hi"}]}],
+        system_prompt="static",
+    )
+
+    assert request["messages"][0]["content"][-1]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+    assert request["messages"][1]["content"][-1]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+
+
+def test_format_request_auto_noop_for_openai_underlying(litellm_acompletion, captured_warnings):
+    """OpenAI-compatible underlying providers cache server-side; no markers are injected."""
+    _ = litellm_acompletion
+    _ = captured_warnings
+    from strands.models import CacheConfig
+
+    model = LiteLLMModel(
+        model_id="openai/gpt-4o",
+        cache_config=CacheConfig(strategy="auto"),
+    )
+
+    request = model.format_request(
+        [{"role": "user", "content": [{"text": "hi"}]}],
+        system_prompt="static",
+    )
+
+    for msg in request["messages"]:
+        for block in msg.get("content", []) or []:
+            assert "cache_control" not in block
+
+
+def test_format_request_auto_warns_on_unsupported_underlying(litellm_acompletion, caplog):
+    """Unrecognized underlying providers log a warning and inject nothing."""
+    _ = litellm_acompletion
+    from strands.models import CacheConfig
+
+    model = LiteLLMModel(
+        model_id="unknown-provider/model-1",
+        cache_config=CacheConfig(strategy="auto"),
+    )
+
+    with caplog.at_level("WARNING"):
+        request = model.format_request(
+            [{"role": "user", "content": [{"text": "hi"}]}],
+            system_prompt="static",
+        )
+    assert any("unknown-provider" in record.message for record in caplog.records)
+    for msg in request["messages"]:
+        for block in msg.get("content", []) or []:
+            assert "cache_control" not in block
+
+
+def test_format_request_auto_preserves_caller_cache_point_on_system(litellm_acompletion):
+    """A caller-placed trailing cachePoint on the system prompt is not duplicated."""
+    _ = litellm_acompletion
+    from strands.models import CacheConfig
+
+    model = LiteLLMModel(
+        model_id="anthropic/claude-sonnet-4-6",
+        cache_config=CacheConfig(strategy="auto"),
+    )
+
+    request = model.format_request(
+        [{"role": "user", "content": [{"text": "hi"}]}],
+        system_prompt_content=[
+            {"text": "static"},
+            {"cachePoint": {"type": "default", "ttl": "1h"}},
+        ],
+    )
+
+    system_content = request["messages"][0]["content"]
+    assert [block.get("cache_control") for block in system_content if "cache_control" in block] == [
+        {"type": "ephemeral", "ttl": "1h"}
+    ]
+
+
+def test_format_request_auto_strips_stale_cache_points_across_turns(litellm_acompletion):
+    """Existing cachePoint blocks on earlier turns are stripped so the breakpoint budget is stable."""
+    _ = litellm_acompletion
+    from strands.models import CacheConfig
+
+    model = LiteLLMModel(
+        model_id="anthropic/claude-sonnet-4-6",
+        cache_config=CacheConfig(strategy="auto"),
+    )
+
+    turns = [
+        {"role": "user", "content": [{"text": "turn 1"}, {"cachePoint": {"type": "default"}}]},
+        {"role": "assistant", "content": [{"text": "response 1"}]},
+        {"role": "user", "content": [{"text": "turn 2"}]},
+    ]
+
+    request = model.format_request(turns)
+
+    cache_marks = [
+        (i, block.get("cache_control"))
+        for i, msg in enumerate(request["messages"])
+        for block in (msg.get("content") or [])
+        if isinstance(block, dict) and "cache_control" in block
+    ]
+    assert cache_marks == [(2, {"type": "ephemeral"})]
+
+
+def test_format_request_no_cache_config_leaves_messages_untouched(litellm_acompletion):
+    """Without cache_config, no cache_control markers are added."""
+    _ = litellm_acompletion
+
+    model = LiteLLMModel(model_id="anthropic/claude-sonnet-4-6")
+
+    request = model.format_request(
+        [{"role": "user", "content": [{"text": "hi"}]}],
+        system_prompt="static",
+    )
+
+    for msg in request["messages"]:
+        for block in msg.get("content", []) or []:
+            assert "cache_control" not in block

--- a/strands-ts/src/models/__tests__/bedrock.test.ts
+++ b/strands-ts/src/models/__tests__/bedrock.test.ts
@@ -495,7 +495,7 @@ describe('BedrockModel', () => {
             content: [{ text: 'Hello' }, { cachePoint: { type: 'default' } }],
           },
         ],
-        system: [{ text: 'You are a helpful assistant' }],
+        system: [{ text: 'You are a helpful assistant' }, { cachePoint: { type: 'default' } }],
         toolConfig: {
           toolChoice: { auto: {} },
           tools: [
@@ -1519,7 +1519,8 @@ describe('BedrockModel', () => {
       vi.clearAllMocks()
     })
 
-    it('does not add cache points to string system prompt with cacheConfig', async () => {
+    it('appends a cache point to a string system prompt with cacheConfig', async () => {
+      // Regression guard for https://github.com/strands-agents/harness-sdk/issues/3144.
       const provider = new BedrockModel({ cacheConfig: { strategy: 'auto' } })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
       const options: StreamOptions = {
@@ -1536,7 +1537,7 @@ describe('BedrockModel', () => {
             content: [{ text: 'Hello' }, { cachePoint: { type: 'default' } }],
           },
         ],
-        system: [{ text: 'You are a helpful assistant' }],
+        system: [{ text: 'You are a helpful assistant' }, { cachePoint: { type: 'default' } }],
       })
     })
 
@@ -1682,7 +1683,7 @@ describe('BedrockModel', () => {
       collectIterator(provider.stream(messages, options))
 
       const call = mockConverseStreamCommand.mock.lastCall?.[0]
-      expect(call?.system).toStrictEqual([{ text: 'You are a helpful assistant' }])
+      expect(call?.system).toStrictEqual([{ text: 'You are a helpful assistant' }, { cachePoint: { type: 'default' } }])
       expect(call?.toolConfig?.tools).toStrictEqual([
         {
           toolSpec: {
@@ -2134,6 +2135,54 @@ describe('BedrockModel', () => {
           },
         ],
       })
+    })
+
+    it('carries systemTTL from cacheConfig into the appended system cache point', async () => {
+      const provider = new BedrockModel({ cacheConfig: { strategy: 'auto', systemTTL: '1h' } })
+      const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
+      const options: StreamOptions = { systemPrompt: 'static prompt' }
+
+      collectIterator(provider.stream(messages, options))
+
+      const call = mockConverseStreamCommand.mock.lastCall?.[0]
+      expect(call?.system).toStrictEqual([{ text: 'static prompt' }, { cachePoint: { type: 'default', ttl: '1h' } }])
+    })
+
+    it('does not duplicate the system cache point when caller placed one at the end', async () => {
+      const provider = new BedrockModel({ cacheConfig: { strategy: 'auto' } })
+      const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
+      const options: StreamOptions = {
+        systemPrompt: [new TextBlock('static prompt'), new CachePointBlock({ cacheType: 'default', ttl: '1h' })],
+      }
+
+      collectIterator(provider.stream(messages, options))
+
+      const call = mockConverseStreamCommand.mock.lastCall?.[0]
+      expect(call?.system).toStrictEqual([{ text: 'static prompt' }, { cachePoint: { type: 'default', ttl: '1h' } }])
+    })
+
+    it('skips the system cache point when the system prompt is absent', async () => {
+      const provider = new BedrockModel({ cacheConfig: { strategy: 'auto' } })
+      const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
+
+      collectIterator(provider.stream(messages))
+
+      const call = mockConverseStreamCommand.mock.lastCall?.[0]
+      expect(call?.system).toBeUndefined()
+    })
+
+    it('appends a system cache point under explicit anthropic strategy for ARN inference profiles', async () => {
+      const provider = new BedrockModel({
+        modelId: 'arn:aws:bedrock:us-east-1:123:application-inference-profile/abc',
+        cacheConfig: { strategy: 'anthropic' },
+      })
+      const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
+      const options: StreamOptions = { systemPrompt: 'static prompt' }
+
+      collectIterator(provider.stream(messages, options))
+
+      const call = mockConverseStreamCommand.mock.lastCall?.[0]
+      expect(call?.system).toStrictEqual([{ text: 'static prompt' }, { cachePoint: { type: 'default' } }])
     })
   })
 

--- a/strands-ts/src/models/bedrock.ts
+++ b/strands-ts/src/models/bedrock.ts
@@ -153,6 +153,9 @@ export interface BedrockCacheConfig extends CacheConfig {
 
   /** TTL applied to the auto-injected cache point appended to the last user message. */
   messagesTTL?: BedrockCacheTTL
+
+  /** TTL applied to the auto-injected cache point appended to the system prompt. */
+  systemTTL?: BedrockCacheTTL
 }
 
 /**
@@ -679,6 +682,22 @@ export class BedrockModel extends Model<BedrockModelConfig> {
         request.system = [{ text: options.systemPrompt }]
       } else if (options.systemPrompt.length > 0) {
         request.system = options.systemPrompt.map((block) => this._formatContentBlock(block) as SystemContentBlock)
+      }
+    }
+
+    // Auto-inject a cachePoint at the end of the system prompt so repeated calls with the
+    // same static system prefix hit the cache. Bedrock (Anthropic) documents the prefix
+    // chain as tools → system → messages; caching only messages leaves the (usually largest
+    // and most static) system prefix uncached.
+    if (request.system && request.system.length > 0 && this._shouldEnableCaching()) {
+      const lastBlock = request.system[request.system.length - 1]
+      if (!lastBlock || !('cachePoint' in lastBlock)) {
+        const cachePoint: BedrockCachePointBlock = { type: 'default' }
+        const ttl = this._config.cacheConfig?.systemTTL
+        if (ttl !== undefined) {
+          cachePoint.ttl = ttl as BedrockSdkCacheTTL
+        }
+        request.system.push({ cachePoint })
       }
     }
 


### PR DESCRIPTION
## Summary

LiteLLM wraps many provider APIs behind one interface, so an SDK-level `cache_config` has to route to whatever the underlying provider actually supports:

- **Anthropic-family** (`anthropic/`, `bedrock/anthropic.`, `vertex_ai/claude`, `vertex_ai_beta/claude`) accept `cache_control` markers. Auto mode injects a `cachePoint` on the last stable system block and the last user message; the existing translator turns them into `cache_control: ephemeral` markers before dispatch.
- **OpenAI-compatible** providers (`openai/`, `deepseek/`, `xai/`, `azure/`) cache automatically server-side. `cache_config` is accepted for portability and is a documented no-op.
- **Unrecognized** underlying providers warn once per resolution and skip injection.

Cache breakpoints on earlier turns are stripped before injection so a long conversation stays within Anthropic's 4-breakpoint request budget.

## Stack

3/9 — stacks on top of #3681. Related: #2970.

## Test plan

- [x] 62 Python litellm tests pass (10 new)
- [x] mypy, ruff clean
- [ ] Real-API smoke test on `anthropic/claude-sonnet-4-6`, `bedrock/anthropic.claude-sonnet-4-6`, `openai/gpt-4o`, `gemini/gemini-2.5-flash`