### PR TITLE
feat(bedrock): default cache_config to auto

### DIFF
--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -288,6 +288,13 @@ class BedrockModel(Model):
             )
             system_blocks.append({"cachePoint": {"type": cache_prompt}})
 
+        # Auto-inject a cachePoint at the end of the system prompt so repeated calls with
+        # the same static system prefix hit the cache. Anthropic docs describe the
+        # tools → system → messages prefix chain; caching only messages leaves the
+        # (usually largest and most static) system prefix uncached.
+        if self._should_cache_system(system_blocks):
+            system_blocks.append(self._build_system_cache_point())
+
         return {
             "modelId": self.config["model_id"],
             "messages": self._format_bedrock_messages(messages),
@@ -386,6 +393,50 @@ class BedrockModel(Model):
             return {}
 
         return {"additionalModelRequestFields": additional_fields}
+
+    def _should_cache_system(self, system_blocks: list[SystemContentBlock]) -> bool:
+        """Whether to auto-inject a cache point at the end of the system prompt.
+
+        True only when auto caching is enabled for this model, ``system_blocks`` has cacheable
+        content, and no cachePoint has already been placed at the end of the system prefix.
+
+        Args:
+            system_blocks: The system content blocks that will be sent to Bedrock.
+
+        Returns:
+            True if a cache point should be appended.
+        """
+        cache_config = self.config.get("cache_config")
+        if not cache_config:
+            return False
+
+        resolved: str | None = cache_config.strategy
+        if resolved == "auto":
+            resolved = self._cache_strategy
+        if resolved != "anthropic":
+            return False
+
+        if not system_blocks:
+            return False
+
+        if "cachePoint" in system_blocks[-1]:
+            return False
+
+        return True
+
+    def _build_system_cache_point(self) -> SystemContentBlock:
+        """Build the cache point block appended to the system prompt.
+
+        Uses ``cache_config.ttl`` when set; falls back to Bedrock's ``default`` (5m).
+
+        Returns:
+            The cache point block.
+        """
+        cache_point: dict[str, Any] = {"type": "default"}
+        cache_config = self.config.get("cache_config")
+        if cache_config and cache_config.ttl:
+            cache_point["ttl"] = cache_config.ttl
+        return cast(SystemContentBlock, {"cachePoint": cache_point})
 
     def _build_tools_cache_point(self) -> list[dict[str, Any]]:
         """Build the cache point block appended to ``toolConfig.tools`` if ``cache_tools`` is configured.

--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -101,7 +101,10 @@ class BedrockModel(Model):
             additional_request_fields: Additional fields to include in the Bedrock request
             additional_response_field_paths: Additional response field paths to extract
             cache_prompt: Cache point type for the system prompt (deprecated, use cache_config)
-            cache_config: Configuration for prompt caching. Use CacheConfig(strategy="auto") for automatic caching.
+            cache_config: Configuration for prompt caching. Defaults to CacheConfig(strategy="auto"),
+                which places cache points on the system prompt, tools (when tool caching is
+                separately enabled via cache_tools), and last user message when the model
+                supports Anthropic-style caching. Pass cache_config=None to disable caching.
             cache_tools: Cache point type for tools. Pass a string (e.g. "default") for the default 5m TTL,
                 or a CacheToolsConfig instance to set both type and TTL (e.g. "1h").
             guardrail_id: ID of the guardrail to apply
@@ -193,6 +196,7 @@ class BedrockModel(Model):
         self.config = BedrockModel.BedrockConfig(
             model_id=BedrockModel._get_default_model_with_warning(resolved_region, model_config),
             include_tool_result_status="auto",
+            cache_config=CacheConfig(strategy="auto"),
         )
         self.update_config(**model_config)
 

--- a/strands-py/src/strands/models/gemini.py
+++ b/strands-py/src/strands/models/gemini.py
@@ -22,7 +22,7 @@ from ..types.streaming import StreamEvent
 from ..types.tools import ToolChoice, ToolChoiceToolDict, ToolSpec
 from ._defaults import resolve_config_metadata
 from ._validation import _has_location_source, validate_config_keys
-from .model import BaseModelConfig, Model
+from .model import BaseModelConfig, CacheConfig, Model
 
 logger = logging.getLogger(__name__)
 
@@ -53,12 +53,23 @@ class GeminiModel(Model):
             use_native_token_count: Whether to use the native Gemini count_tokens API.
                 When True, count_tokens() calls the Gemini API for accurate counts.
                 When False (default), skips the API call and uses the local estimator.
+            cache_config: Configuration for prompt caching. Gemini 2.5+ models on the paid
+                tier already cache prompt prefixes automatically (implicit caching), so this
+                config is accepted for cross-provider portability and is a documented no-op —
+                the SDK injects nothing into the request.
+
+                Gemini also offers *explicit* caching via a separate ``CachedContent``
+                resource (POST /v1beta/cachedContents), which has a create/reference/delete
+                lifecycle and bills for storage while the cache is alive. That is a distinct
+                feature with real cost implications; use the underlying ``google-genai``
+                SDK directly for it. See https://ai.google.dev/gemini-api/docs/caching.
         """
 
         model_id: Required[str]
         params: dict[str, Any]
         gemini_tools: list[genai.types.Tool]
         use_native_token_count: bool
+        cache_config: CacheConfig | None
 
     def __init__(
         self,

--- a/strands-py/src/strands/models/litellm.py
+++ b/strands-py/src/strands/models/litellm.py
@@ -22,10 +22,19 @@ from ..types.exceptions import ContextWindowOverflowException
 from ..types.streaming import MetadataEvent, StreamEvent
 from ..types.tools import ToolChoice, ToolSpec, ToolUse
 from ._validation import validate_config_keys
-from .model import BaseModelConfig
+from .model import BaseModelConfig, CacheConfig
 from .openai import OpenAIModel
 
 logger = logging.getLogger(__name__)
+
+# Underlying providers whose native APIs support Anthropic-style cache_control markers.
+# LiteLLM already translates cachePoint → cache_control for these on the system prompt;
+# when cache_config resolves to "anthropic" we also mark the last user message.
+_ANTHROPIC_CACHE_LITELLM_PREFIXES = ("anthropic/", "bedrock/anthropic.", "vertex_ai/claude", "vertex_ai_beta/claude")
+
+# Underlying providers that cache automatically on the server side. cache_config is
+# accepted for portability but the SDK doesn't need to inject markers.
+_SERVER_AUTO_CACHE_LITELLM_PREFIXES = ("openai/", "deepseek/", "xai/", "azure/")
 
 # Separator used by LiteLLM to embed thought signatures inside tool call IDs.
 # See: https://ai.google.dev/gemini-api/docs/thought-signatures
@@ -47,11 +56,17 @@ class LiteLLMModel(OpenAIModel):
                 For a complete list of supported parameters, see
                 https://docs.litellm.ai/docs/completion/input#input-params-1.
             stream: Whether to use streaming. Defaults to True.
+            cache_config: Configuration for prompt caching. Use CacheConfig(strategy="auto") to
+                let LiteLLM route caching to the underlying provider. Behaviour depends on the
+                model_id prefix: Anthropic/Bedrock-Anthropic/Vertex-Claude get cache markers on
+                the system prompt and last user message; OpenAI-compatible providers cache
+                automatically server-side and this config is a no-op; other providers warn.
         """
 
         model_id: str
         params: dict[str, Any] | None
         stream: bool
+        cache_config: CacheConfig | None
 
     def __init__(self, client_args: dict[str, Any] | None = None, **model_config: Unpack[LiteLLMConfig]) -> None:
         """Initialize provider instance.
@@ -88,6 +103,44 @@ class LiteLLMModel(OpenAIModel):
             The LiteLLM model configuration.
         """
         return cast(LiteLLMModel.LiteLLMConfig, self.config)
+
+    @property
+    def _cache_strategy(self) -> str | None:
+        """Resolve the caching strategy for this model's underlying provider.
+
+        Returns:
+            "anthropic" when the underlying provider accepts cache_control markers,
+            "server-auto" when the underlying provider caches automatically without
+            client-side markers, or None when neither applies.
+        """
+        model_id = cast(str, self.config.get("model_id") or "").lower()
+        if any(model_id.startswith(prefix) for prefix in _ANTHROPIC_CACHE_LITELLM_PREFIXES):
+            return "anthropic"
+        if any(model_id.startswith(prefix) for prefix in _SERVER_AUTO_CACHE_LITELLM_PREFIXES):
+            return "server-auto"
+        return None
+
+    def _resolve_cache_strategy(self) -> str | None:
+        """Resolve cache_config into a concrete strategy, warning on unsupported underlying providers.
+
+        Returns:
+            "anthropic" when we should inject markers, "server-auto" when the underlying provider
+            caches automatically (no injection needed), or None when caching is off or unsupported.
+        """
+        cache_config = cast(CacheConfig | None, self.config.get("cache_config"))
+        if not cache_config:
+            return None
+
+        resolved: str | None = cache_config.strategy
+        if resolved == "auto":
+            resolved = self._cache_strategy
+            if resolved is None:
+                logger.warning(
+                    "model_id=<%s> | cache_config is enabled but the underlying provider is not "
+                    "recognized for caching, ignoring",
+                    self.config.get("model_id"),
+                )
+        return resolved
 
     @override
     @classmethod
@@ -238,6 +291,53 @@ class LiteLLMModel(OpenAIModel):
 
     @override
     @classmethod
+    def _format_regular_messages(cls, messages: Messages, **kwargs: Any) -> list[dict[str, Any]]:
+        """Format messages for LiteLLM, translating message-level cachePoint blocks.
+
+        Delegates to the OpenAI parent after stripping cachePoint blocks from the input and
+        re-attaching them as cache_control markers on the immediately preceding content
+        block, mirroring the system-prompt translator.
+
+        Args:
+            messages: List of message objects to be processed by the model.
+            **kwargs: Additional keyword arguments for future extensibility.
+
+        Returns:
+            List of formatted messages.
+        """
+        stripped_messages: list[dict[str, Any]] = []
+        cache_markers: list[tuple[int, int, dict[str, Any]]] = []
+        for msg_idx, message in enumerate(messages):
+            new_content: list[dict[str, Any]] = []
+            for block in message["content"]:
+                if "cachePoint" in block and block["cachePoint"].get("type") == "default":
+                    if new_content:
+                        cache_control: dict[str, Any] = {"type": "ephemeral"}
+                        if ttl := block["cachePoint"].get("ttl"):
+                            cache_control["ttl"] = ttl
+                        cache_markers.append((msg_idx, len(new_content) - 1, cache_control))
+                    continue
+                new_content.append(cast(dict[str, Any], block))
+            stripped_messages.append({"role": message["role"], "content": new_content})
+
+        formatted = super()._format_regular_messages(cast(Messages, stripped_messages), **kwargs)
+
+        # Reattach cache_control to each marked (message, block) position. This works because
+        # _format_regular_messages preserves 1-to-1 mapping between input messages and the
+        # primary formatted message; tool-message splits append AFTER, so indices stay stable
+        # for the user/assistant messages we mark.
+        for msg_idx, block_idx, cache_control in cache_markers:
+            if msg_idx >= len(formatted):
+                continue
+            formatted_content = formatted[msg_idx].get("content")
+            if not isinstance(formatted_content, list) or block_idx >= len(formatted_content):
+                continue
+            formatted_content[block_idx]["cache_control"] = cache_control
+
+        return formatted
+
+    @override
+    @classmethod
     def format_request_messages(
         cls,
         messages: Messages,
@@ -317,6 +417,117 @@ class LiteLLMModel(OpenAIModel):
 
         # For all other cases, use the parent implementation
         return super().format_chunk(event)
+
+    @override
+    def format_request(
+        self,
+        messages: Messages,
+        tool_specs: list[ToolSpec] | None = None,
+        system_prompt: str | None = None,
+        tool_choice: ToolChoice | None = None,
+        *,
+        system_prompt_content: list[SystemContentBlock] | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Format a LiteLLM request, injecting cache markers when cache_config is set.
+
+        Args:
+            messages: List of message objects to be processed by the model.
+            tool_specs: List of tool specifications to make available to the model.
+            system_prompt: System prompt to provide context to the model.
+            tool_choice: Selection strategy for tool invocation.
+            system_prompt_content: System prompt content blocks to provide context to the model.
+            **kwargs: Additional keyword arguments for future extensibility.
+
+        Returns:
+            A LiteLLM compatible chat streaming request.
+        """
+        strategy = self._resolve_cache_strategy()
+        if strategy == "anthropic":
+            system_prompt_content = self._inject_system_cache_point(system_prompt, system_prompt_content)
+            system_prompt = None if system_prompt_content else system_prompt
+            messages = self._inject_messages_cache_point(messages)
+
+        return super().format_request(
+            messages,
+            tool_specs,
+            system_prompt,
+            tool_choice,
+            system_prompt_content=system_prompt_content,
+            **kwargs,
+        )
+
+    def _inject_system_cache_point(
+        self,
+        system_prompt: str | None,
+        system_prompt_content: list[SystemContentBlock] | None,
+    ) -> list[SystemContentBlock] | None:
+        """Ensure the system prompt ends with a cachePoint so the static prefix is cached.
+
+        Promotes a plain-string system_prompt into content-block form so we can attach the
+        cachePoint. Preserves any caller-placed trailing cachePoint (including its ttl).
+
+        Args:
+            system_prompt: The plain-string system prompt, if any.
+            system_prompt_content: Structured system content blocks, if any.
+
+        Returns:
+            A structured system-prompt list ending in a cachePoint, or None when there is no
+            system prompt to cache.
+        """
+        content: list[SystemContentBlock] = list(system_prompt_content) if system_prompt_content else []
+        if not content and system_prompt:
+            content = [cast(SystemContentBlock, {"text": system_prompt})]
+        if not content:
+            return None
+
+        if "cachePoint" in content[-1]:
+            return content
+
+        cache_point: dict[str, Any] = {"type": "default"}
+        cache_config = cast(CacheConfig | None, self.config.get("cache_config"))
+        if cache_config and cache_config.ttl:
+            cache_point["ttl"] = cache_config.ttl
+        content.append(cast(SystemContentBlock, {"cachePoint": cache_point}))
+        return content
+
+    def _inject_messages_cache_point(self, messages: Messages) -> Messages:
+        """Append a cachePoint to the last user message so the conversation prefix is cached.
+
+        Strips any pre-existing cachePoint blocks from earlier messages so the breakpoint budget
+        stays constant across a long conversation. Anthropic accepts at most 4 cache breakpoints
+        per request; auto-injecting per turn without cleanup would break a conversation on turn 5.
+
+        Args:
+            messages: The conversation messages.
+
+        Returns:
+            A new messages list with the cachePoint appended to the last user message.
+        """
+        if not messages:
+            return messages
+
+        cache_point: dict[str, Any] = {"type": "default"}
+        cache_config = cast(CacheConfig | None, self.config.get("cache_config"))
+        if cache_config and cache_config.ttl:
+            cache_point["ttl"] = cache_config.ttl
+
+        cleaned: list[dict[str, Any]] = []
+        last_user_idx: int | None = None
+        for idx, message in enumerate(messages):
+            new_content = [block for block in message["content"] if "cachePoint" not in block]
+            cleaned.append({"role": message["role"], "content": new_content})
+            if message["role"] == "user" and new_content:
+                last_user_idx = idx
+
+        if last_user_idx is None:
+            return cast(Messages, cleaned)
+
+        last_content = cleaned[last_user_idx]["content"]
+        if not last_content or "cachePoint" in last_content[-1]:
+            return cast(Messages, cleaned)
+        last_content.append({"cachePoint": cache_point})
+        return cast(Messages, cleaned)
 
     @override
     async def stream(

--- a/strands-py/src/strands/models/llamaapi.py
+++ b/strands-py/src/strands/models/llamaapi.py
@@ -21,7 +21,7 @@ from ..types.exceptions import ContextWindowOverflowException, ModelThrottledExc
 from ..types.streaming import StreamEvent, Usage
 from ..types.tools import ToolChoice, ToolResult, ToolSpec, ToolUse
 from ._validation import _has_location_source, validate_config_keys, warn_on_tool_choice_not_supported
-from .model import BaseModelConfig, Model
+from .model import BaseModelConfig, CacheConfig, Model
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +50,15 @@ class LlamaAPIModel(Model):
             top_p: Top-p.
             max_completion_tokens: Maximum completion tokens.
             top_k: Top-k.
+            cache_config: Configuration for prompt caching. The Llama API caches automatically
+                for any request that shares a stable prefix, so this config is accepted for
+                cross-provider portability and is a documented no-op — the SDK injects nothing
+                into the request. Use ``prompt_cache_key`` for better cache-hit rates at scale.
+            prompt_cache_key: Optional identifier that helps the Llama API group similar
+                requests when caching. Recommended when many agents share a stable system
+                prefix. See https://ai.developer.meta.com/docs/features/prompt-caching.
+            prompt_cache_retention: Retention policy on the Responses API. ``"in_memory"``
+                (default) or ``"24h"`` on models that support extended retention.
         """
 
         model_id: str
@@ -58,6 +67,9 @@ class LlamaAPIModel(Model):
         top_p: float | None
         max_completion_tokens: int | None
         top_k: int | None
+        cache_config: CacheConfig | None
+        prompt_cache_key: str | None
+        prompt_cache_retention: str | None
 
     def __init__(
         self,
@@ -264,6 +276,10 @@ class LlamaAPIModel(Model):
             request["max_completion_tokens"] = self.config["max_completion_tokens"]
         if "top_k" in self.config:
             request["top_k"] = self.config["top_k"]
+        if prompt_cache_key := self.config.get("prompt_cache_key"):
+            request["prompt_cache_key"] = prompt_cache_key
+        if prompt_cache_retention := self.config.get("prompt_cache_retention"):
+            request["prompt_cache_retention"] = prompt_cache_retention
 
         return request
 

--- a/strands-py/src/strands/models/mistral.py
+++ b/strands-py/src/strands/models/mistral.py
@@ -19,7 +19,7 @@ from ..types.streaming import StopReason, StreamEvent
 from ..types.tools import ToolChoice, ToolResult, ToolSpec, ToolUse
 from ._defaults import resolve_config_metadata
 from ._validation import _has_location_source, validate_config_keys, warn_on_tool_choice_not_supported
-from .model import BaseModelConfig, Model
+from .model import BaseModelConfig, CacheConfig, Model
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +51,16 @@ class MistralModel(Model):
             temperature: Controls randomness in generation (0.0 to 1.0).
             top_p: Controls diversity via nucleus sampling.
             stream: Whether to enable streaming responses.
+            cache_config: Configuration for prompt caching. Mistral's chat completions caches
+                requests that share the same ``prompt_cache_key`` and a common prompt prefix;
+                unlike Anthropic and Bedrock, there is no per-block cache marker to inject, so
+                ``cache_config`` is accepted for cross-provider portability and is a
+                documented no-op — set ``prompt_cache_key`` to actually opt in to caching.
+                Cached tokens bill at 10% of standard input.
+                See https://docs.mistral.ai/api/ for details.
+            prompt_cache_key: Optional caller-supplied identifier that Mistral uses to group
+                similar requests for cache lookups. Requests sharing the same key and a
+                common prefix hit the cache.
         """
 
         model_id: str
@@ -58,6 +68,8 @@ class MistralModel(Model):
         temperature: float | None
         top_p: float | None
         stream: bool | None
+        cache_config: CacheConfig | None
+        prompt_cache_key: str | None
 
     def __init__(
         self,
@@ -290,6 +302,9 @@ class MistralModel(Model):
                 }
                 for tool_spec in tool_specs
             ]
+
+        if prompt_cache_key := self.config.get("prompt_cache_key"):
+            request["prompt_cache_key"] = prompt_cache_key
 
         return request
 

--- a/strands-py/src/strands/models/openai.py
+++ b/strands-py/src/strands/models/openai.py
@@ -25,7 +25,7 @@ from ._defaults import resolve_config_metadata
 from ._openai_bedrock import BedrockMantleConfig, resolve_bedrock_client_args
 from ._openai_errors import classify_openai_error
 from ._validation import _has_location_source, validate_config_keys
-from .model import BaseModelConfig, Model
+from .model import BaseModelConfig, CacheConfig, Model
 
 logger = logging.getLogger(__name__)
 
@@ -57,11 +57,22 @@ class OpenAIModel(Model):
                 For a complete list of supported parameters, see
                 https://platform.openai.com/docs/api-reference/chat/create.
             stream: Whether to use OpenAI chat completion streaming. Defaults to True.
+            cache_config: Configuration for prompt caching. OpenAI's Chat Completions API caches
+                automatically for any prompt over the vendor threshold (1024 tokens on current
+                models), so this config is accepted for cross-provider portability and is a
+                documented no-op — the SDK injects nothing into the request. Use
+                ``prompt_cache_key`` when you need better cache-hit rates under load.
+            prompt_cache_key: Optional identifier that helps OpenAI route similar requests to
+                the same cache node under high throughput. Recommended when many agents share a
+                stable system prompt. See
+                https://platform.openai.com/docs/guides/prompt-caching for details.
         """
 
         model_id: str
         params: dict[str, Any] | None
         stream: bool
+        cache_config: CacheConfig | None
+        prompt_cache_key: str | None
 
     def __init__(
         self,
@@ -520,6 +531,9 @@ class OpenAIModel(Model):
             **(self._format_request_tool_choice(tool_choice)),
             **params,
         }
+
+        if prompt_cache_key := self.config.get("prompt_cache_key"):
+            request["prompt_cache_key"] = prompt_cache_key
 
         if stream:
             request["stream_options"] = stream_options

--- a/strands-py/src/strands/models/openai_responses.py
+++ b/strands-py/src/strands/models/openai_responses.py
@@ -63,7 +63,7 @@ from ._defaults import resolve_config_metadata  # noqa: E402
 from ._openai_bedrock import BedrockMantleConfig, resolve_bedrock_client_args  # noqa: E402
 from ._openai_errors import classify_openai_error  # noqa: E402
 from ._validation import validate_config_keys  # noqa: E402
-from .model import BaseModelConfig, Model  # noqa: E402
+from .model import BaseModelConfig, CacheConfig, Model  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
@@ -149,12 +149,29 @@ class OpenAIResponsesModel(Model):
             use_native_token_count: Whether to use the native OpenAI input_tokens.count API.
                 When True, count_tokens() calls the OpenAI API for accurate counts.
                 When False (default), skips the API call and uses the local estimator.
+            cache_config: Configuration for prompt caching. The Responses API caches automatically
+                for any prompt over the vendor threshold, so this config is accepted for
+                cross-provider portability and is a documented no-op — the SDK injects nothing
+                into the request. Use ``prompt_cache_key`` when you need better cache-hit rates
+                under load or ``prompt_cache_retention="24h"`` when the model supports extended
+                retention.
+            prompt_cache_key: Optional identifier that helps OpenAI route similar requests to
+                the same cache node under high throughput. See
+                https://platform.openai.com/docs/guides/prompt-caching for details.
+            prompt_cache_retention: Retention policy for cached prompts. ``"in_memory"`` is the
+                default (5-10 minutes idle, up to 1 hour absolute); ``"24h"`` opts in to
+                extended retention on models that support it (GPT-5 family, GPT-4.1). Callers
+                that pass a value not supported by the target model will get a runtime error
+                from the vendor SDK.
         """
 
         model_id: str
         params: dict[str, Any] | None
         stateful: bool
         use_native_token_count: bool
+        cache_config: CacheConfig | None
+        prompt_cache_key: str | None
+        prompt_cache_retention: str | None
 
     def __init__(
         self,
@@ -589,6 +606,11 @@ class OpenAIResponsesModel(Model):
                 ),
             ]
             request.update(self._format_request_tool_choice(tool_choice))
+
+        if prompt_cache_key := self.config.get("prompt_cache_key"):
+            request["prompt_cache_key"] = prompt_cache_key
+        if prompt_cache_retention := self.config.get("prompt_cache_retention"):
+            request["prompt_cache_retention"] = prompt_cache_retention
 
         return request
 

--- a/strands-py/src/strands/models/openai_responses.py
+++ b/strands-py/src/strands/models/openai_responses.py
@@ -163,6 +163,12 @@ class OpenAIResponsesModel(Model):
                 extended retention on models that support it (GPT-5 family, GPT-4.1). Callers
                 that pass a value not supported by the target model will get a runtime error
                 from the vendor SDK.
+            prompt_cache_options: Fine-grained caching mode for models that support it
+                (GPT-5.6 on Bedrock Mantle: ``sol``/``terra``/``luna``). Accepts
+                ``{"mode": "implicit"}`` (default — server caches automatically) or
+                ``{"mode": "explicit"}`` (the caller marks cache breakpoints on specific
+                content blocks; not yet exposed as a first-class SDK surface). Passed
+                through to the request verbatim.
         """
 
         model_id: str
@@ -172,6 +178,7 @@ class OpenAIResponsesModel(Model):
         cache_config: CacheConfig | None
         prompt_cache_key: str | None
         prompt_cache_retention: str | None
+        prompt_cache_options: dict[str, Any] | None
 
     def __init__(
         self,
@@ -611,6 +618,8 @@ class OpenAIResponsesModel(Model):
             request["prompt_cache_key"] = prompt_cache_key
         if prompt_cache_retention := self.config.get("prompt_cache_retention"):
             request["prompt_cache_retention"] = prompt_cache_retention
+        if prompt_cache_options := self.config.get("prompt_cache_options"):
+            request["prompt_cache_options"] = prompt_cache_options
 
         return request
 

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -3788,10 +3788,13 @@ class TestCountTokens:
         with caplog.at_level(logging.WARNING, logger="strands.models.bedrock"):
             await model_with_client.count_tokens(messages=messages)
 
-        warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
-        assert len(warning_records) == 1
-        assert "bedrock:CountTokens permission denied" in warning_records[0].message
-        assert error_message in warning_records[0].message
+        matching_records = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING and "bedrock:CountTokens permission denied" in r.message
+        ]
+        assert len(matching_records) == 1
+        assert error_message in matching_records[0].message
 
     @pytest.mark.asyncio
     async def test_does_not_cache_model_id_for_other_errors(self, bedrock_client, messages):
@@ -3964,9 +3967,21 @@ def test_format_request_auto_preserves_caller_placed_system_cache_point(bedrock_
     ]
 
 
-def test_format_request_no_cache_config_leaves_system_untouched(bedrock_client, messages):
-    """With no cache_config, the system prompt is passed through unchanged."""
+def test_format_request_default_cache_config_appends_system_cache_point(bedrock_client, messages):
+    """BedrockModel defaults cache_config to auto, so Claude models get a system cache point."""
     model = BedrockModel(model_id="us.anthropic.claude-sonnet-4-20250514-v1:0")
+
+    tru_request = model.format_request(messages, system_prompt_content=[{"text": "static"}])
+
+    assert tru_request["system"] == [
+        {"text": "static"},
+        {"cachePoint": {"type": "default"}},
+    ]
+
+
+def test_format_request_explicit_cache_config_none_disables_caching(bedrock_client, messages):
+    """Passing cache_config=None explicitly turns caching off, overriding the default."""
+    model = BedrockModel(model_id="us.anthropic.claude-sonnet-4-20250514-v1:0", cache_config=None)
 
     tru_request = model.format_request(messages, system_prompt_content=[{"text": "static"}])
 

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -3892,3 +3892,94 @@ def test_format_request_cache_tools_string_backward_compat(model, messages, mode
 
     exp_cache_point = {"cachePoint": {"type": cache_type}}
     assert tru_request["toolConfig"]["tools"][-1] == exp_cache_point
+
+
+def test_format_request_auto_appends_system_cache_point(bedrock_client, messages):
+    """Auto mode appends a cachePoint after the system prompt for a Claude model.
+
+    Regression guard for https://github.com/strands-agents/harness-sdk/issues/3144.
+    """
+    model = BedrockModel(
+        model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
+        cache_config=CacheConfig(strategy="auto"),
+    )
+
+    tru_request = model.format_request(messages, system_prompt_content=[{"text": "you are helpful"}])
+
+    assert tru_request["system"] == [
+        {"text": "you are helpful"},
+        {"cachePoint": {"type": "default"}},
+    ]
+
+
+def test_format_request_auto_system_cache_point_honors_ttl(bedrock_client, messages):
+    """Auto mode carries cache_config.ttl into the appended system cache point."""
+    model = BedrockModel(
+        model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
+        cache_config=CacheConfig(strategy="auto", ttl="1h"),
+    )
+
+    tru_request = model.format_request(messages, system_prompt_content=[{"text": "static"}])
+
+    assert tru_request["system"][-1] == {"cachePoint": {"type": "default", "ttl": "1h"}}
+
+
+def test_format_request_auto_skips_system_cache_point_when_empty(bedrock_client, messages):
+    """Auto mode does not inject a system cache point when the system prompt is empty."""
+    model = BedrockModel(
+        model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
+        cache_config=CacheConfig(strategy="auto"),
+    )
+
+    tru_request = model.format_request(messages)
+
+    assert tru_request["system"] == []
+
+
+def test_format_request_auto_skips_system_cache_point_for_non_claude(bedrock_client, messages):
+    """Auto mode does not inject a system cache point when the model has no auto strategy."""
+    model = BedrockModel(
+        model_id="amazon.nova-pro-v1:0",
+        cache_config=CacheConfig(strategy="auto"),
+    )
+
+    tru_request = model.format_request(messages, system_prompt_content=[{"text": "static"}])
+
+    assert tru_request["system"] == [{"text": "static"}]
+
+
+def test_format_request_auto_preserves_caller_placed_system_cache_point(bedrock_client, messages):
+    """Auto mode does not double-append when the caller already placed a trailing cachePoint."""
+    model = BedrockModel(
+        model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
+        cache_config=CacheConfig(strategy="auto"),
+    )
+
+    system_blocks = [{"text": "static"}, {"cachePoint": {"type": "default", "ttl": "1h"}}]
+    tru_request = model.format_request(messages, system_prompt_content=system_blocks)
+
+    assert tru_request["system"] == [
+        {"text": "static"},
+        {"cachePoint": {"type": "default", "ttl": "1h"}},
+    ]
+
+
+def test_format_request_no_cache_config_leaves_system_untouched(bedrock_client, messages):
+    """With no cache_config, the system prompt is passed through unchanged."""
+    model = BedrockModel(model_id="us.anthropic.claude-sonnet-4-20250514-v1:0")
+
+    tru_request = model.format_request(messages, system_prompt_content=[{"text": "static"}])
+
+    assert tru_request["system"] == [{"text": "static"}]
+
+
+def test_format_request_anthropic_strategy_appends_system_cache_point(bedrock_client, messages):
+    """Explicit anthropic strategy also appends a system cache point, mirroring auto."""
+    model = BedrockModel(
+        model_id="arn:aws:bedrock:us-east-1:123:application-inference-profile/abc",
+        cache_config=CacheConfig(strategy="anthropic"),
+    )
+
+    tru_request = model.format_request(messages, system_prompt_content=[{"text": "static"}])
+
+    assert tru_request["system"][-1] == {"cachePoint": {"type": "default"}}

--- a/strands-py/tests/strands/models/test_gemini.py
+++ b/strands-py/tests/strands/models/test_gemini.py
@@ -1499,3 +1499,14 @@ class TestCountTokens:
         gemini_client.aio.models.count_tokens.assert_not_called()
         assert isinstance(result, int)
         assert result >= 0
+
+
+def test_gemini_accepts_cache_config_as_documented_noop(gemini_client):
+    """cache_config is accepted for cross-provider portability; Gemini caches implicitly."""
+    _ = gemini_client
+    from strands.models import CacheConfig
+
+    model = GeminiModel(model_id="gemini-2.5-flash", cache_config=CacheConfig(strategy="auto"))
+
+    # The field lives on the config but is not surfaced into the generate call.
+    assert model.get_config().get("cache_config") is not None

--- a/strands-py/tests/strands/models/test_litellm.py
+++ b/strands-py/tests/strands/models/test_litellm.py
@@ -1042,3 +1042,186 @@ async def test_stream_generates_tool_call_id_when_null(litellm_acompletion, mode
     start = next(e for e in events if "contentBlockStart" in e and "toolUse" in e["contentBlockStart"]["start"])
     tool_id = start["contentBlockStart"]["start"]["toolUse"]["toolUseId"]
     assert tool_id and tool_id.startswith("call_")
+
+
+def test_cache_strategy_anthropic_for_anthropic_prefixes(litellm_acompletion):
+    """Underlying providers that accept cache_control markers resolve to "anthropic"."""
+    _ = litellm_acompletion
+    for model_id in [
+        "anthropic/claude-sonnet-4-6",
+        "bedrock/anthropic.claude-sonnet-4-6",
+        "vertex_ai/claude-3-5-sonnet",
+        "vertex_ai_beta/claude-3-5-sonnet",
+    ]:
+        m = LiteLLMModel(model_id=model_id)
+        assert m._cache_strategy == "anthropic", model_id
+
+
+def test_cache_strategy_server_auto_for_openai_prefixes(litellm_acompletion):
+    """Underlying providers that cache automatically server-side resolve to "server-auto"."""
+    _ = litellm_acompletion
+    for model_id in ["openai/gpt-4o", "deepseek/deepseek-chat", "xai/grok-2", "azure/gpt-4o"]:
+        m = LiteLLMModel(model_id=model_id)
+        assert m._cache_strategy == "server-auto", model_id
+
+
+def test_cache_strategy_none_for_unknown_prefix(litellm_acompletion):
+    """Underlying providers we don't recognize resolve to None."""
+    _ = litellm_acompletion
+    m = LiteLLMModel(model_id="gemini/gemini-2.5-flash")
+    assert m._cache_strategy is None
+
+
+def test_format_request_auto_injects_system_and_user_cache_points(litellm_acompletion):
+    """Auto mode injects cache_control on the trailing system block and last user text block."""
+    _ = litellm_acompletion
+    from strands.models import CacheConfig
+
+    model = LiteLLMModel(
+        model_id="anthropic/claude-sonnet-4-6",
+        cache_config=CacheConfig(strategy="auto"),
+    )
+
+    request = model.format_request(
+        [{"role": "user", "content": [{"text": "hi"}]}],
+        system_prompt="you are helpful",
+    )
+
+    system_msg = request["messages"][0]
+    assert system_msg["role"] == "system"
+    assert system_msg["content"][-1] == {
+        "type": "text",
+        "text": "you are helpful",
+        "cache_control": {"type": "ephemeral"},
+    }
+    user_msg = request["messages"][1]
+    assert user_msg["role"] == "user"
+    assert user_msg["content"][-1] == {"type": "text", "text": "hi", "cache_control": {"type": "ephemeral"}}
+
+
+def test_format_request_auto_honors_cache_config_ttl(litellm_acompletion):
+    """cache_config.ttl propagates into the injected cache_control markers."""
+    _ = litellm_acompletion
+    from strands.models import CacheConfig
+
+    model = LiteLLMModel(
+        model_id="anthropic/claude-sonnet-4-6",
+        cache_config=CacheConfig(strategy="auto", ttl="1h"),
+    )
+
+    request = model.format_request(
+        [{"role": "user", "content": [{"text": "hi"}]}],
+        system_prompt="static",
+    )
+
+    assert request["messages"][0]["content"][-1]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+    assert request["messages"][1]["content"][-1]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+
+
+def test_format_request_auto_noop_for_openai_underlying(litellm_acompletion, captured_warnings):
+    """OpenAI-compatible underlying providers cache server-side; no markers are injected."""
+    _ = litellm_acompletion
+    _ = captured_warnings
+    from strands.models import CacheConfig
+
+    model = LiteLLMModel(
+        model_id="openai/gpt-4o",
+        cache_config=CacheConfig(strategy="auto"),
+    )
+
+    request = model.format_request(
+        [{"role": "user", "content": [{"text": "hi"}]}],
+        system_prompt="static",
+    )
+
+    for msg in request["messages"]:
+        for block in msg.get("content", []) or []:
+            assert "cache_control" not in block
+
+
+def test_format_request_auto_warns_on_unsupported_underlying(litellm_acompletion, caplog):
+    """Unrecognized underlying providers log a warning and inject nothing."""
+    _ = litellm_acompletion
+    from strands.models import CacheConfig
+
+    model = LiteLLMModel(
+        model_id="unknown-provider/model-1",
+        cache_config=CacheConfig(strategy="auto"),
+    )
+
+    with caplog.at_level("WARNING"):
+        request = model.format_request(
+            [{"role": "user", "content": [{"text": "hi"}]}],
+            system_prompt="static",
+        )
+    assert any("unknown-provider" in record.message for record in caplog.records)
+    for msg in request["messages"]:
+        for block in msg.get("content", []) or []:
+            assert "cache_control" not in block
+
+
+def test_format_request_auto_preserves_caller_cache_point_on_system(litellm_acompletion):
+    """A caller-placed trailing cachePoint on the system prompt is not duplicated."""
+    _ = litellm_acompletion
+    from strands.models import CacheConfig
+
+    model = LiteLLMModel(
+        model_id="anthropic/claude-sonnet-4-6",
+        cache_config=CacheConfig(strategy="auto"),
+    )
+
+    request = model.format_request(
+        [{"role": "user", "content": [{"text": "hi"}]}],
+        system_prompt_content=[
+            {"text": "static"},
+            {"cachePoint": {"type": "default", "ttl": "1h"}},
+        ],
+    )
+
+    system_content = request["messages"][0]["content"]
+    assert [block.get("cache_control") for block in system_content if "cache_control" in block] == [
+        {"type": "ephemeral", "ttl": "1h"}
+    ]
+
+
+def test_format_request_auto_strips_stale_cache_points_across_turns(litellm_acompletion):
+    """Existing cachePoint blocks on earlier turns are stripped so the breakpoint budget is stable."""
+    _ = litellm_acompletion
+    from strands.models import CacheConfig
+
+    model = LiteLLMModel(
+        model_id="anthropic/claude-sonnet-4-6",
+        cache_config=CacheConfig(strategy="auto"),
+    )
+
+    turns = [
+        {"role": "user", "content": [{"text": "turn 1"}, {"cachePoint": {"type": "default"}}]},
+        {"role": "assistant", "content": [{"text": "response 1"}]},
+        {"role": "user", "content": [{"text": "turn 2"}]},
+    ]
+
+    request = model.format_request(turns)
+
+    cache_marks = [
+        (i, block.get("cache_control"))
+        for i, msg in enumerate(request["messages"])
+        for block in (msg.get("content") or [])
+        if isinstance(block, dict) and "cache_control" in block
+    ]
+    assert cache_marks == [(2, {"type": "ephemeral"})]
+
+
+def test_format_request_no_cache_config_leaves_messages_untouched(litellm_acompletion):
+    """Without cache_config, no cache_control markers are added."""
+    _ = litellm_acompletion
+
+    model = LiteLLMModel(model_id="anthropic/claude-sonnet-4-6")
+
+    request = model.format_request(
+        [{"role": "user", "content": [{"text": "hi"}]}],
+        system_prompt="static",
+    )
+
+    for msg in request["messages"]:
+        for block in msg.get("content", []) or []:
+            assert "cache_control" not in block

--- a/strands-py/tests/strands/models/test_llamaapi.py
+++ b/strands-py/tests/strands/models/test_llamaapi.py
@@ -576,3 +576,43 @@ async def test_stream_non_overflow_bad_request_propagates(model, messages, alist
     with unittest.mock.patch.object(model.client.chat.completions, "create", side_effect=error):
         with pytest.raises(llama_api_client.BadRequestError, match="invalid 'model' parameter"):
             await alist(model.stream(messages))
+
+
+def test_format_request_includes_prompt_cache_key(model, messages):
+    """prompt_cache_key on the model config is forwarded verbatim."""
+    model.update_config(prompt_cache_key="agent-abc")
+
+    request = model.format_request(messages)
+
+    assert request["prompt_cache_key"] == "agent-abc"
+
+
+def test_format_request_includes_prompt_cache_retention(model, messages):
+    """prompt_cache_retention on the model config is forwarded verbatim."""
+    model.update_config(prompt_cache_retention="24h")
+
+    request = model.format_request(messages)
+
+    assert request["prompt_cache_retention"] == "24h"
+
+
+def test_format_request_omits_cache_fields_when_unset(model, messages):
+    """Absent cache fields are not sent."""
+    request = model.format_request(messages)
+
+    assert "prompt_cache_key" not in request
+    assert "prompt_cache_retention" not in request
+
+
+def test_format_request_cache_config_is_documented_noop(llamaapi_client, messages):
+    """cache_config is accepted for portability but the SDK does not touch the request."""
+    _ = llamaapi_client
+    from strands.models import CacheConfig
+
+    model = LlamaAPIModel(model_id="Llama-4-Maverick-17B-128E-Instruct-FP8", cache_config=CacheConfig(strategy="auto"))
+
+    request = model.format_request(messages)
+
+    assert "prompt_cache_key" not in request
+    assert "prompt_cache_retention" not in request
+    assert "cache_config" not in request

--- a/strands-py/tests/strands/models/test_mistral.py
+++ b/strands-py/tests/strands/models/test_mistral.py
@@ -812,3 +812,32 @@ def test_format_request_filters_location_source_document(model, caplog):
     user_content = formatted_messages[0]["content"]
     assert user_content == "analyze this document"
     assert "Location sources are not supported by Mistral" in caplog.text
+
+
+def test_format_request_includes_prompt_cache_key(model, messages):
+    """prompt_cache_key on the model config is forwarded verbatim."""
+    model.update_config(prompt_cache_key="agent-abc")
+
+    request = model.format_request(messages)
+
+    assert request["prompt_cache_key"] == "agent-abc"
+
+
+def test_format_request_omits_prompt_cache_key_when_unset(model, messages):
+    """Absent prompt_cache_key is not sent."""
+    request = model.format_request(messages)
+
+    assert "prompt_cache_key" not in request
+
+
+def test_format_request_cache_config_is_documented_noop(mistral_client, model_id, max_tokens, messages):
+    """cache_config alone does not opt requests into caching — prompt_cache_key does."""
+    _ = mistral_client
+    from strands.models import CacheConfig
+
+    model = MistralModel(model_id=model_id, max_tokens=max_tokens, cache_config=CacheConfig(strategy="auto"))
+
+    request = model.format_request(messages)
+
+    assert "prompt_cache_key" not in request
+    assert "cache_config" not in request

--- a/strands-py/tests/strands/models/test_openai.py
+++ b/strands-py/tests/strands/models/test_openai.py
@@ -1973,6 +1973,40 @@ def test_format_request_messages_multiple_tool_calls_with_images():
 
 
 # =============================================================================
+# cache_config and prompt_cache_key plumbing
+# =============================================================================
+
+
+def test_format_request_includes_prompt_cache_key(model, messages):
+    """prompt_cache_key on the model config is forwarded verbatim."""
+    model.update_config(prompt_cache_key="agent-abc")
+
+    request = model.format_request(messages)
+
+    assert request["prompt_cache_key"] == "agent-abc"
+
+
+def test_format_request_omits_prompt_cache_key_when_unset(model, messages):
+    """Absent prompt_cache_key is not sent."""
+    request = model.format_request(messages)
+
+    assert "prompt_cache_key" not in request
+
+
+def test_format_request_cache_config_is_documented_noop(openai_client, model_id, messages):
+    """cache_config is accepted for portability but the SDK does not touch the request."""
+    _ = openai_client
+    from strands.models import CacheConfig
+
+    model = OpenAIModel(model_id=model_id, cache_config=CacheConfig(strategy="auto"))
+
+    request = model.format_request(messages)
+
+    assert "prompt_cache_key" not in request
+    assert "cache_config" not in request
+
+
+# =============================================================================
 # Bedrock Mantle (bedrock_mantle_config) integration with OpenAIModel
 # =============================================================================
 

--- a/strands-py/tests/strands/models/test_openai_responses.py
+++ b/strands-py/tests/strands/models/test_openai_responses.py
@@ -1837,6 +1837,15 @@ def test_format_request_cache_config_is_documented_noop(openai_client, model_id,
     assert "cache_config" not in request
 
 
+def test_format_request_includes_prompt_cache_options(model, messages):
+    """prompt_cache_options passes through verbatim for GPT-5.6 explicit-mode support."""
+    model.update_config(prompt_cache_options={"mode": "explicit"})
+
+    request = model._format_request(messages)
+
+    assert request["prompt_cache_options"] == {"mode": "explicit"}
+
+
 # =============================================================================
 # Bedrock Mantle (bedrock_mantle_config) integration with OpenAIResponsesModel
 # =============================================================================

--- a/strands-py/tests/strands/models/test_openai_responses.py
+++ b/strands-py/tests/strands/models/test_openai_responses.py
@@ -1793,6 +1793,51 @@ class TestCountTokens:
 
 
 # =============================================================================
+# cache_config, prompt_cache_key, and prompt_cache_retention plumbing
+# =============================================================================
+
+
+def test_format_request_includes_prompt_cache_key(model, messages):
+    """prompt_cache_key on the model config is forwarded verbatim."""
+    model.update_config(prompt_cache_key="agent-abc")
+
+    request = model._format_request(messages)
+
+    assert request["prompt_cache_key"] == "agent-abc"
+
+
+def test_format_request_includes_prompt_cache_retention(model, messages):
+    """prompt_cache_retention on the model config is forwarded verbatim."""
+    model.update_config(prompt_cache_retention="24h")
+
+    request = model._format_request(messages)
+
+    assert request["prompt_cache_retention"] == "24h"
+
+
+def test_format_request_omits_cache_fields_when_unset(model, messages):
+    """Absent cache fields are not sent."""
+    request = model._format_request(messages)
+
+    assert "prompt_cache_key" not in request
+    assert "prompt_cache_retention" not in request
+
+
+def test_format_request_cache_config_is_documented_noop(openai_client, model_id, messages):
+    """cache_config is accepted for portability but the SDK does not touch the request."""
+    _ = openai_client
+    from strands.models import CacheConfig
+
+    model = OpenAIResponsesModel(model_id=model_id, cache_config=CacheConfig(strategy="auto"))
+
+    request = model._format_request(messages)
+
+    assert "prompt_cache_key" not in request
+    assert "prompt_cache_retention" not in request
+    assert "cache_config" not in request
+
+
+# =============================================================================
 # Bedrock Mantle (bedrock_mantle_config) integration with OpenAIResponsesModel
 # =============================================================================
 

--- a/strands-ts/src/models/__tests__/bedrock.test.ts
+++ b/strands-ts/src/models/__tests__/bedrock.test.ts
@@ -156,6 +156,12 @@ describe('BedrockModel', () => {
   const BEDROCK_NOOP_TOOL_CONFIG = {
     tools: [{ toolSpec: { ...NOOP_TOOL_SPEC, inputSchema: { json: NOOP_TOOL_SPEC.inputSchema } } }],
   }
+  const BEDROCK_NOOP_TOOL_CONFIG_WITH_CACHE = {
+    tools: [
+      { toolSpec: { ...NOOP_TOOL_SPEC, inputSchema: { json: NOOP_TOOL_SPEC.inputSchema } } },
+      { cachePoint: { type: 'default' } },
+    ],
+  }
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -207,6 +213,7 @@ describe('BedrockModel', () => {
       expect(provider.getConfig()).toStrictEqual({
         modelId: customModelId,
         contextWindowLimit: 200_000,
+        cacheConfig: { strategy: 'auto' },
       })
     })
 
@@ -323,6 +330,7 @@ describe('BedrockModel', () => {
         modelId: 'global.anthropic.claude-sonnet-4-6',
         temperature: 0.5,
         contextWindowLimit: 1_000_000,
+        cacheConfig: { strategy: 'auto' },
       })
     })
 
@@ -334,6 +342,7 @@ describe('BedrockModel', () => {
       expect(provider.getConfig()).toStrictEqual({
         modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
         contextWindowLimit: 200_000,
+        cacheConfig: { strategy: 'auto' },
       })
     })
 
@@ -342,6 +351,7 @@ describe('BedrockModel', () => {
       expect(provider.getConfig()).toStrictEqual({
         modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
         contextWindowLimit: 1_000_000,
+        cacheConfig: { strategy: 'auto' },
       })
     })
 
@@ -350,6 +360,7 @@ describe('BedrockModel', () => {
       expect(provider.getConfig()).toStrictEqual({
         modelId: 'us.anthropic.claude-sonnet-4-6',
         contextWindowLimit: 1_000_000,
+        cacheConfig: { strategy: 'auto' },
       })
     })
 
@@ -358,6 +369,7 @@ describe('BedrockModel', () => {
       expect(provider.getConfig()).toStrictEqual({
         modelId: 'global.anthropic.claude-sonnet-4-6',
         contextWindowLimit: 1_000_000,
+        cacheConfig: { strategy: 'auto' },
       })
     })
 
@@ -369,6 +381,7 @@ describe('BedrockModel', () => {
       expect(provider.getConfig()).toStrictEqual({
         modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
         contextWindowLimit: 100_000,
+        cacheConfig: { strategy: 'auto' },
       })
     })
 
@@ -376,6 +389,7 @@ describe('BedrockModel', () => {
       const provider = new BedrockModel({ modelId: 'unknown.model-v1:0' })
       expect(provider.getConfig()).toStrictEqual({
         modelId: 'unknown.model-v1:0',
+        cacheConfig: { strategy: 'auto' },
       })
     })
   })
@@ -389,6 +403,7 @@ describe('BedrockModel', () => {
         temperature: 0.8,
         maxTokens: 2048,
         contextWindowLimit: 1_000_000,
+        cacheConfig: { strategy: 'auto' },
       })
     })
 
@@ -404,6 +419,7 @@ describe('BedrockModel', () => {
         modelId: 'custom-model',
         temperature: 0.8,
         maxTokens: 1024,
+        cacheConfig: { strategy: 'auto' },
       })
     })
 
@@ -444,6 +460,7 @@ describe('BedrockModel', () => {
         modelId: 'test-model',
         maxTokens: 1024,
         temperature: 0.7,
+        cacheConfig: { strategy: 'auto' },
       })
     })
   })
@@ -597,11 +614,12 @@ describe('BedrockModel', () => {
                   toolUseId: 'tool-123',
                 },
               },
+              { cachePoint: { type: 'default' } },
             ],
             role: 'user',
           },
         ],
-        toolConfig: BEDROCK_NOOP_TOOL_CONFIG,
+        toolConfig: BEDROCK_NOOP_TOOL_CONFIG_WITH_CACHE,
         modelId: expect.any(String),
       })
     })
@@ -625,7 +643,7 @@ describe('BedrockModel', () => {
 
       expect(mockConverseStreamCommand).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          toolConfig: BEDROCK_NOOP_TOOL_CONFIG,
+          toolConfig: BEDROCK_NOOP_TOOL_CONFIG_WITH_CACHE,
         })
       )
     })
@@ -661,9 +679,10 @@ describe('BedrockModel', () => {
       collectIterator(provider.stream(messages, options))
 
       const call = mockConverseStreamCommand.mock.calls[0]![0] as unknown as Record<string, unknown>
-      const toolConfig = call.toolConfig as { tools: Array<{ toolSpec?: { name: string } }> }
-      expect(toolConfig.tools[0]!.toolSpec!.name).toBe('calc')
-      expect(toolConfig.tools.length).toBe(1)
+      const toolConfig = call.toolConfig as { tools: Array<{ toolSpec?: { name: string }; cachePoint?: unknown }> }
+      const toolSpecEntries = toolConfig.tools.filter((entry) => entry.toolSpec !== undefined)
+      expect(toolSpecEntries[0]!.toolSpec!.name).toBe('calc')
+      expect(toolSpecEntries.length).toBe(1)
     })
 
     it('formats tool specs without outputSchema in Bedrock requests', async () => {
@@ -694,6 +713,7 @@ describe('BedrockModel', () => {
             inputSchema: { json: { type: 'object' } },
           },
         },
+        { cachePoint: { type: 'default' } },
       ])
     })
 
@@ -736,6 +756,7 @@ describe('BedrockModel', () => {
                   redactedContent: new Uint8Array(1),
                 },
               },
+              { cachePoint: { type: 'default' } },
             ],
           },
         ],
@@ -799,7 +820,10 @@ describe('BedrockModel', () => {
     })
 
     it('preserves ttl on user-supplied cache point blocks in messages', async () => {
-      const provider = new BedrockModel()
+      // Use a non-Anthropic model so auto caching is a no-op and the user-supplied cache point
+      // (including its TTL) passes through untouched. Auto mode strips and re-injects cache
+      // points, dropping caller-provided TTL.
+      const provider = new BedrockModel({ modelId: 'amazon.titan-text-express-v1' })
       const messages = [
         new Message({
           role: 'user',
@@ -843,7 +867,10 @@ describe('BedrockModel', () => {
     })
 
     it('forwards arbitrary ttl strings without client-side validation (Bedrock validates server-side)', async () => {
-      const provider = new BedrockModel()
+      // Use a non-Anthropic model so auto caching is a no-op and the user-supplied cache point
+      // (including its TTL) forwards as-is; auto mode rewrites user cache points and drops
+      // their TTL.
+      const provider = new BedrockModel({ modelId: 'amazon.titan-text-express-v1' })
       const messages = [
         new Message({
           role: 'user',
@@ -1558,10 +1585,14 @@ describe('BedrockModel', () => {
         messages: [
           {
             role: 'user',
-            content: [{ text: 'Hello' }],
+            content: [{ text: 'Hello' }, { cachePoint: { type: 'default' } }],
           },
         ],
-        system: [{ text: 'You are a helpful assistant' }, { text: 'Additional context here' }],
+        system: [
+          { text: 'You are a helpful assistant' },
+          { text: 'Additional context here' },
+          { cachePoint: { type: 'default' } },
+        ],
       })
     })
 
@@ -1583,7 +1614,7 @@ describe('BedrockModel', () => {
         messages: [
           {
             role: 'user',
-            content: [{ text: 'Hello' }],
+            content: [{ text: 'Hello' }, { cachePoint: { type: 'default' } }],
           },
         ],
         system: [
@@ -1594,7 +1625,7 @@ describe('BedrockModel', () => {
       })
     })
 
-    it('does not warn when array system prompt is provided without cacheConfig', async () => {
+    it('does not warn when array system prompt is provided with a trailing cache point', async () => {
       const provider = new BedrockModel()
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
@@ -1607,8 +1638,12 @@ describe('BedrockModel', () => {
 
       collectIterator(provider.stream(messages, options))
 
-      // Verify no warning was logged
-      expect(warnSpy).not.toHaveBeenCalled()
+      // No cache-point-strip warnings should fire when caller-provided cache points sit at the
+      // end of the system prompt and messages contain no existing cache points to strip.
+      const stripWarnings = warnSpy.mock.calls.filter((args) =>
+        args.some((arg) => typeof arg === 'string' && arg.includes('stripped existing cache point'))
+      )
+      expect(stripWarnings).toHaveLength(0)
 
       // Verify array is used as-is
       expect(mockConverseStreamCommand).toHaveBeenLastCalledWith({
@@ -1616,7 +1651,7 @@ describe('BedrockModel', () => {
         messages: [
           {
             role: 'user',
-            content: [{ text: 'Hello' }],
+            content: [{ text: 'Hello' }, { cachePoint: { type: 'default' } }],
           },
         ],
         system: [{ text: 'You are a helpful assistant' }, { cachePoint: { type: 'default' } }],
@@ -1974,7 +2009,7 @@ describe('BedrockModel', () => {
         messages: [
           {
             role: 'user',
-            content: [{ text: 'Hello' }],
+            content: [{ text: 'Hello' }, { cachePoint: { type: 'default' } }],
           },
         ],
       })
@@ -2002,7 +2037,7 @@ describe('BedrockModel', () => {
         messages: [
           {
             role: 'user',
-            content: [{ text: 'Hello' }],
+            content: [{ text: 'Hello' }, { cachePoint: { type: 'default' } }],
           },
         ],
         system: [
@@ -2015,6 +2050,7 @@ describe('BedrockModel', () => {
               },
             },
           },
+          { cachePoint: { type: 'default' } },
         ],
       })
     })
@@ -2043,7 +2079,7 @@ describe('BedrockModel', () => {
         messages: [
           {
             role: 'user',
-            content: [{ text: 'Hello' }],
+            content: [{ text: 'Hello' }, { cachePoint: { type: 'default' } }],
           },
         ],
         system: [
@@ -2083,7 +2119,7 @@ describe('BedrockModel', () => {
         messages: [
           {
             role: 'user',
-            content: [{ text: 'Hello' }],
+            content: [{ text: 'Hello' }, { cachePoint: { type: 'default' } }],
           },
         ],
         system: [
@@ -2095,6 +2131,7 @@ describe('BedrockModel', () => {
               },
             },
           },
+          { cachePoint: { type: 'default' } },
         ],
       })
     })
@@ -2121,7 +2158,7 @@ describe('BedrockModel', () => {
         messages: [
           {
             role: 'user',
-            content: [{ text: 'Hello' }],
+            content: [{ text: 'Hello' }, { cachePoint: { type: 'default' } }],
           },
         ],
         system: [
@@ -2133,6 +2170,7 @@ describe('BedrockModel', () => {
               },
             },
           },
+          { cachePoint: { type: 'default' } },
         ],
       })
     })
@@ -2227,6 +2265,7 @@ describe('BedrockModel', () => {
                   },
                 },
               },
+              { cachePoint: { type: 'default' } },
             ],
           },
         ],
@@ -2268,6 +2307,7 @@ describe('BedrockModel', () => {
                   },
                 },
               },
+              { cachePoint: { type: 'default' } },
             ],
           },
         ],
@@ -2309,6 +2349,7 @@ describe('BedrockModel', () => {
                     status: 'success',
                   },
                 },
+                { cachePoint: { type: 'default' } },
               ],
             },
           ],
@@ -2347,6 +2388,7 @@ describe('BedrockModel', () => {
                     status: 'success',
                   },
                 },
+                { cachePoint: { type: 'default' } },
               ],
             },
           ],
@@ -2385,6 +2427,7 @@ describe('BedrockModel', () => {
                     status: 'success',
                   },
                 },
+                { cachePoint: { type: 'default' } },
               ],
             },
           ],
@@ -2429,6 +2472,7 @@ describe('BedrockModel', () => {
                     status: 'success',
                   },
                 },
+                { cachePoint: { type: 'default' } },
               ],
             },
           ],
@@ -2457,7 +2501,10 @@ describe('BedrockModel', () => {
           messages: [
             {
               role: 'user',
-              content: [{ image: { format: 'png', source: { bytes: imageBytes } } }],
+              content: [
+                { image: { format: 'png', source: { bytes: imageBytes } } },
+                { cachePoint: { type: 'default' } },
+              ],
             },
           ],
         })
@@ -2482,7 +2529,10 @@ describe('BedrockModel', () => {
           messages: [
             {
               role: 'user',
-              content: [{ image: { format: 'png', source: { s3Location: { uri: 's3://bucket/image.png' } } } }],
+              content: [
+                { image: { format: 'png', source: { s3Location: { uri: 's3://bucket/image.png' } } } },
+                { cachePoint: { type: 'default' } },
+              ],
             },
           ],
         })
@@ -2506,7 +2556,10 @@ describe('BedrockModel', () => {
           messages: [
             {
               role: 'user',
-              content: [{ video: { format: 'three_gp', source: { bytes: videoBytes } } }],
+              content: [
+                { video: { format: 'three_gp', source: { bytes: videoBytes } } },
+                { cachePoint: { type: 'default' } },
+              ],
             },
           ],
         })
@@ -2524,6 +2577,8 @@ describe('BedrockModel', () => {
 
       collectIterator(provider.stream(messages))
 
+      // Auto caching skips the cache point when a leading non-PDF document leaves no prefix
+      // to cache (see _injectCachePoint), so the message content passes through unchanged.
       expect(mockConverseStreamCommand).toHaveBeenLastCalledWith(
         expect.objectContaining({
           messages: [
@@ -2651,7 +2706,7 @@ describe('BedrockModel', () => {
             },
             {
               role: 'user',
-              content: [{ text: 'Follow up' }],
+              content: [{ text: 'Follow up' }, { cachePoint: { type: 'default' } }],
             },
           ],
         })
@@ -2693,6 +2748,7 @@ describe('BedrockModel', () => {
                     status: 'success',
                   },
                 },
+                { cachePoint: { type: 'default' } },
               ],
             },
           ],
@@ -2731,6 +2787,7 @@ describe('BedrockModel', () => {
                     status: 'success',
                   },
                 },
+                { cachePoint: { type: 'default' } },
               ],
             },
           ],
@@ -2769,6 +2826,7 @@ describe('BedrockModel', () => {
                     status: 'success',
                   },
                 },
+                { cachePoint: { type: 'default' } },
               ],
             },
           ],
@@ -2813,6 +2871,7 @@ describe('BedrockModel', () => {
                     status: 'success',
                   },
                 },
+                { cachePoint: { type: 'default' } },
               ],
             },
           ],
@@ -2841,7 +2900,10 @@ describe('BedrockModel', () => {
           messages: [
             {
               role: 'user',
-              content: [{ image: { format: 'png', source: { bytes: imageBytes } } }],
+              content: [
+                { image: { format: 'png', source: { bytes: imageBytes } } },
+                { cachePoint: { type: 'default' } },
+              ],
             },
           ],
         })
@@ -2866,7 +2928,10 @@ describe('BedrockModel', () => {
           messages: [
             {
               role: 'user',
-              content: [{ image: { format: 'png', source: { s3Location: { uri: 's3://bucket/image.png' } } } }],
+              content: [
+                { image: { format: 'png', source: { s3Location: { uri: 's3://bucket/image.png' } } } },
+                { cachePoint: { type: 'default' } },
+              ],
             },
           ],
         })
@@ -2890,7 +2955,10 @@ describe('BedrockModel', () => {
           messages: [
             {
               role: 'user',
-              content: [{ video: { format: 'three_gp', source: { bytes: videoBytes } } }],
+              content: [
+                { video: { format: 'three_gp', source: { bytes: videoBytes } } },
+                { cachePoint: { type: 'default' } },
+              ],
             },
           ],
         })
@@ -2908,6 +2976,8 @@ describe('BedrockModel', () => {
 
       collectIterator(provider.stream(messages))
 
+      // Auto caching skips the cache point when a leading non-PDF document leaves no prefix
+      // to cache (see _injectCachePoint), so the message content passes through unchanged.
       expect(mockConverseStreamCommand).toHaveBeenLastCalledWith(
         expect.objectContaining({
           messages: [
@@ -2961,11 +3031,12 @@ describe('BedrockModel', () => {
                     toolUseId: 'tool-123',
                   },
                 },
+                { cachePoint: { type: 'default' } },
               ],
               role: 'user',
             },
           ],
-          toolConfig: BEDROCK_NOOP_TOOL_CONFIG,
+          toolConfig: BEDROCK_NOOP_TOOL_CONFIG_WITH_CACHE,
           modelId: expect.any(String),
         })
       })
@@ -2999,11 +3070,12 @@ describe('BedrockModel', () => {
                     toolUseId: 'tool-123',
                   },
                 },
+                { cachePoint: { type: 'default' } },
               ],
               role: 'user',
             },
           ],
-          toolConfig: BEDROCK_NOOP_TOOL_CONFIG,
+          toolConfig: BEDROCK_NOOP_TOOL_CONFIG_WITH_CACHE,
           modelId: expect.any(String),
         })
       })
@@ -3041,11 +3113,12 @@ describe('BedrockModel', () => {
                     toolUseId: 'tool-123',
                   },
                 },
+                { cachePoint: { type: 'default' } },
               ],
               role: 'user',
             },
           ],
-          toolConfig: BEDROCK_NOOP_TOOL_CONFIG,
+          toolConfig: BEDROCK_NOOP_TOOL_CONFIG_WITH_CACHE,
           modelId: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
         })
       })
@@ -3771,6 +3844,7 @@ describe('BedrockModel', () => {
                       },
                     },
                   },
+                  { cachePoint: { type: 'default' } },
                 ],
               },
             ],
@@ -3815,6 +3889,7 @@ describe('BedrockModel', () => {
                       },
                     },
                   },
+                  { cachePoint: { type: 'default' } },
                 ],
               },
             ],
@@ -3857,7 +3932,8 @@ describe('BedrockModel', () => {
         collectIterator(provider.stream(messages))
 
         // The latest message is a toolResult, but guardContent should wrap the FIRST user message
-        // which contains text, not the toolResult
+        // which contains text, not the toolResult. Auto caching still injects a cache point on
+        // the LAST user message (the toolResult), independent of the guardContent wrap logic.
         expect(mockConverseStreamCommand).toHaveBeenLastCalledWith(
           expect.objectContaining({
             messages: [
@@ -3893,6 +3969,7 @@ describe('BedrockModel', () => {
                       toolUseId: 'tool-123',
                     }),
                   },
+                  { cachePoint: { type: 'default' } },
                 ],
               },
             ],
@@ -3917,7 +3994,7 @@ describe('BedrockModel', () => {
             messages: [
               {
                 role: 'user',
-                content: [{ text: 'Hello world' }],
+                content: [{ text: 'Hello world' }, { cachePoint: { type: 'default' } }],
               },
             ],
           })
@@ -3940,7 +4017,7 @@ describe('BedrockModel', () => {
             messages: [
               {
                 role: 'user',
-                content: [{ text: 'Hello world' }],
+                content: [{ text: 'Hello world' }, { cachePoint: { type: 'default' } }],
               },
             ],
           })
@@ -3975,6 +4052,7 @@ describe('BedrockModel', () => {
                       },
                     },
                   },
+                  { cachePoint: { type: 'default' } },
                 ],
               },
               {
@@ -4023,6 +4101,7 @@ describe('BedrockModel', () => {
                       },
                     },
                   },
+                  { cachePoint: { type: 'default' } },
                 ],
               },
             ],
@@ -4095,6 +4174,7 @@ describe('BedrockModel', () => {
                       },
                     },
                   },
+                  { cachePoint: { type: 'default' } },
                 ],
               },
             ],
@@ -4155,6 +4235,7 @@ describe('BedrockModel', () => {
                       },
                     },
                   },
+                  { cachePoint: { type: 'default' } },
                 ],
               },
             ],
@@ -4201,6 +4282,7 @@ describe('BedrockModel', () => {
                       source: { bytes: imageBytes },
                     },
                   },
+                  { cachePoint: { type: 'default' } },
                 ],
               },
             ],
@@ -4248,6 +4330,7 @@ describe('BedrockModel', () => {
                       source: { bytes: imageBytes },
                     },
                   },
+                  { cachePoint: { type: 'default' } },
                 ],
               },
             ],
@@ -4303,6 +4386,7 @@ describe('BedrockModel', () => {
                       },
                     },
                   },
+                  { cachePoint: { type: 'default' } },
                 ],
               },
             ],
@@ -4351,6 +4435,7 @@ describe('BedrockModel', () => {
                       source: undefined,
                     },
                   },
+                  { cachePoint: { type: 'default' } },
                 ],
               },
             ],
@@ -4408,6 +4493,7 @@ describe('BedrockModel', () => {
                       },
                     },
                   },
+                  { cachePoint: { type: 'default' } },
                 ],
               },
             ],
@@ -4583,8 +4669,8 @@ describe('BedrockModel', () => {
         modelId: expect.any(String),
         input: {
           converse: {
-            messages: [{ role: 'user', content: [{ text: 'hello' }] }],
-            system: [{ text: 'Be helpful.' }],
+            messages: [{ role: 'user', content: [{ text: 'hello' }, { cachePoint: { type: 'default' } }] }],
+            system: [{ text: 'Be helpful.' }, { cachePoint: { type: 'default' } }],
           },
         },
       })
@@ -4603,7 +4689,7 @@ describe('BedrockModel', () => {
         modelId: expect.any(String),
         input: {
           converse: {
-            messages: [{ role: 'user', content: [{ text: 'hello' }] }],
+            messages: [{ role: 'user', content: [{ text: 'hello' }, { cachePoint: { type: 'default' } }] }],
             toolConfig: {
               tools: [
                 {
@@ -4613,6 +4699,7 @@ describe('BedrockModel', () => {
                     inputSchema: { json: { type: 'object', properties: {} } },
                   },
                 },
+                { cachePoint: { type: 'default' } },
               ],
             },
           },
@@ -4632,7 +4719,7 @@ describe('BedrockModel', () => {
         modelId: expect.any(String),
         input: {
           converse: {
-            messages: [{ role: 'user', content: [{ text: 'hello' }] }],
+            messages: [{ role: 'user', content: [{ text: 'hello' }, { cachePoint: { type: 'default' } }] }],
           },
         },
       })

--- a/strands-ts/src/models/__tests__/bedrock.test.ts
+++ b/strands-ts/src/models/__tests__/bedrock.test.ts
@@ -495,7 +495,7 @@ describe('BedrockModel', () => {
             content: [{ text: 'Hello' }, { cachePoint: { type: 'default' } }],
           },
         ],
-        system: [{ text: 'You are a helpful assistant' }],
+        system: [{ text: 'You are a helpful assistant' }, { cachePoint: { type: 'default' } }],
         toolConfig: {
           toolChoice: { auto: {} },
           tools: [
@@ -1519,7 +1519,8 @@ describe('BedrockModel', () => {
       vi.clearAllMocks()
     })
 
-    it('does not add cache points to string system prompt with cacheConfig', async () => {
+    it('appends a cache point to a string system prompt with cacheConfig', async () => {
+      // Regression guard for https://github.com/strands-agents/harness-sdk/issues/3144.
       const provider = new BedrockModel({ cacheConfig: { strategy: 'auto' } })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
       const options: StreamOptions = {
@@ -1536,7 +1537,7 @@ describe('BedrockModel', () => {
             content: [{ text: 'Hello' }, { cachePoint: { type: 'default' } }],
           },
         ],
-        system: [{ text: 'You are a helpful assistant' }],
+        system: [{ text: 'You are a helpful assistant' }, { cachePoint: { type: 'default' } }],
       })
     })
 
@@ -1682,7 +1683,7 @@ describe('BedrockModel', () => {
       collectIterator(provider.stream(messages, options))
 
       const call = mockConverseStreamCommand.mock.lastCall?.[0]
-      expect(call?.system).toStrictEqual([{ text: 'You are a helpful assistant' }])
+      expect(call?.system).toStrictEqual([{ text: 'You are a helpful assistant' }, { cachePoint: { type: 'default' } }])
       expect(call?.toolConfig?.tools).toStrictEqual([
         {
           toolSpec: {
@@ -2134,6 +2135,54 @@ describe('BedrockModel', () => {
           },
         ],
       })
+    })
+
+    it('carries systemTTL from cacheConfig into the appended system cache point', async () => {
+      const provider = new BedrockModel({ cacheConfig: { strategy: 'auto', systemTTL: '1h' } })
+      const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
+      const options: StreamOptions = { systemPrompt: 'static prompt' }
+
+      collectIterator(provider.stream(messages, options))
+
+      const call = mockConverseStreamCommand.mock.lastCall?.[0]
+      expect(call?.system).toStrictEqual([{ text: 'static prompt' }, { cachePoint: { type: 'default', ttl: '1h' } }])
+    })
+
+    it('does not duplicate the system cache point when caller placed one at the end', async () => {
+      const provider = new BedrockModel({ cacheConfig: { strategy: 'auto' } })
+      const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
+      const options: StreamOptions = {
+        systemPrompt: [new TextBlock('static prompt'), new CachePointBlock({ cacheType: 'default', ttl: '1h' })],
+      }
+
+      collectIterator(provider.stream(messages, options))
+
+      const call = mockConverseStreamCommand.mock.lastCall?.[0]
+      expect(call?.system).toStrictEqual([{ text: 'static prompt' }, { cachePoint: { type: 'default', ttl: '1h' } }])
+    })
+
+    it('skips the system cache point when the system prompt is absent', async () => {
+      const provider = new BedrockModel({ cacheConfig: { strategy: 'auto' } })
+      const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
+
+      collectIterator(provider.stream(messages))
+
+      const call = mockConverseStreamCommand.mock.lastCall?.[0]
+      expect(call?.system).toBeUndefined()
+    })
+
+    it('appends a system cache point under explicit anthropic strategy for ARN inference profiles', async () => {
+      const provider = new BedrockModel({
+        modelId: 'arn:aws:bedrock:us-east-1:123:application-inference-profile/abc',
+        cacheConfig: { strategy: 'anthropic' },
+      })
+      const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
+      const options: StreamOptions = { systemPrompt: 'static prompt' }
+
+      collectIterator(provider.stream(messages, options))
+
+      const call = mockConverseStreamCommand.mock.lastCall?.[0]
+      expect(call?.system).toStrictEqual([{ text: 'static prompt' }, { cachePoint: { type: 'default' } }])
     })
   })
 

--- a/strands-ts/src/models/__tests__/google.test.ts
+++ b/strands-ts/src/models/__tests__/google.test.ts
@@ -1399,4 +1399,16 @@ describe('GoogleModel', () => {
       expect(result).toBe(2) // heuristic: Math.ceil('hello'.length / 4)
     })
   })
+
+  describe('cacheConfig', () => {
+    it('accepts cacheConfig as a documented no-op — no injection into the request config', () => {
+      const model = new GoogleModel({
+        modelId: 'gemini-2.5-flash',
+        apiKey: 'fake',
+        cacheConfig: { strategy: 'auto' },
+      })
+      const config = model.getConfig()
+      expect(config.cacheConfig).toEqual({ strategy: 'auto' })
+    })
+  })
 })

--- a/strands-ts/src/models/__tests__/vercel.test.ts
+++ b/strands-ts/src/models/__tests__/vercel.test.ts
@@ -945,4 +945,52 @@ describe('VercelModel', () => {
       expect(args).not.toHaveProperty('toolChoice')
     })
   })
+
+  describe('cacheConfig', () => {
+    it('strips cacheConfig from downstream call settings', async () => {
+      const { collect, callArgs } = setupCaptureTest(minimalParts, { cacheConfig: { strategy: 'auto' } })
+      await collect([])
+
+      expect(callArgs()).not.toHaveProperty('cacheConfig')
+    })
+
+    it('warns on Anthropic underlying providers that need per-block markers', async () => {
+      const parts: LanguageModelV3StreamPart[] = [
+        { type: 'stream-start', warnings: [] },
+        { type: 'finish', usage: testUsage, finishReason: stopFinish },
+      ]
+      const mock: LanguageModelV3 = { ...createMockModel(parts), provider: 'anthropic.messages' }
+      const model = new VercelModel({ provider: mock, cacheConfig: { strategy: 'auto' } })
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+      await collectIterator(model.stream([]))
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('vercel cacheConfig cannot inject'))
+      warnSpy.mockRestore()
+    })
+
+    it('warns on Bedrock underlying providers that need per-block markers', async () => {
+      const parts: LanguageModelV3StreamPart[] = [
+        { type: 'stream-start', warnings: [] },
+        { type: 'finish', usage: testUsage, finishReason: stopFinish },
+      ]
+      const mock: LanguageModelV3 = { ...createMockModel(parts), provider: 'amazon-bedrock.chat' }
+      const model = new VercelModel({ provider: mock, cacheConfig: { strategy: 'auto' } })
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+      await collectIterator(model.stream([]))
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('vercel cacheConfig cannot inject'))
+      warnSpy.mockRestore()
+    })
+
+    it('does not warn on OpenAI underlying providers (server-auto)', async () => {
+      const parts: LanguageModelV3StreamPart[] = [
+        { type: 'stream-start', warnings: [] },
+        { type: 'finish', usage: testUsage, finishReason: stopFinish },
+      ]
+      const mock: LanguageModelV3 = { ...createMockModel(parts), provider: 'openai.chat' }
+      const model = new VercelModel({ provider: mock, cacheConfig: { strategy: 'auto' } })
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+      await collectIterator(model.stream([]))
+      expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('vercel cacheConfig cannot inject'))
+      warnSpy.mockRestore()
+    })
+  })
 })

--- a/strands-ts/src/models/bedrock.ts
+++ b/strands-ts/src/models/bedrock.ts
@@ -267,7 +267,12 @@ export interface BedrockModelConfig extends BaseModelConfig {
   stopSequences?: string[]
 
   /**
-   * Configuration for prompt caching.
+   * Configuration for prompt caching. Defaults to `{ strategy: 'auto' }`, which places
+   * cache points on the system prompt and the last user message for models that support
+   * Anthropic-style caching (Claude family, `us.anthropic.*` / `eu.anthropic.*` /
+   * `global.anthropic.*` cross-region profiles). Unsupported models silently skip
+   * injection. Pass `cacheConfig: undefined` (via a spread with the field omitted) or an
+   * empty object with `strategy` unset to disable caching.
    *
    * @see https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
    */
@@ -426,9 +431,13 @@ export class BedrockModel extends Model<BedrockModelConfig> {
 
     const { region, clientConfig, apiKey, ...modelConfig } = options ?? {}
 
-    // Initialize model config with default model ID if not provided
+    // Initialize model config with defaults: default model ID and cacheConfig=auto.
+    // Auto caching places cache points on system, tools (when cache_tools is set), and the
+    // last user message for models that support Anthropic-style caching; unsupported models
+    // silently skip injection.
     this._config = {
       modelId: MODEL_DEFAULTS.bedrock.modelId,
+      cacheConfig: { strategy: 'auto' },
       ...modelConfig,
     }
 

--- a/strands-ts/src/models/bedrock.ts
+++ b/strands-ts/src/models/bedrock.ts
@@ -153,6 +153,9 @@ export interface BedrockCacheConfig extends CacheConfig {
 
   /** TTL applied to the auto-injected cache point appended to the last user message. */
   messagesTTL?: BedrockCacheTTL
+
+  /** TTL applied to the auto-injected cache point appended to the system prompt. */
+  systemTTL?: BedrockCacheTTL
 }
 
 /**
@@ -679,6 +682,22 @@ export class BedrockModel extends Model<BedrockModelConfig> {
         request.system = [{ text: options.systemPrompt }]
       } else if (options.systemPrompt.length > 0) {
         request.system = options.systemPrompt.map((block) => this._formatContentBlock(block) as SystemContentBlock)
+      }
+    }
+
+    // Auto-inject a cachePoint at the end of the system prompt so repeated calls with the
+    // same static system prefix hit the cache. Bedrock (Anthropic) documents the prefix
+    // chain as tools → system → messages; caching only messages leaves the (usually largest
+    // and most static) system prefix uncached.
+    if (request.system && request.system.length > 0 && this._shouldEnableCaching()) {
+      const lastBlock = request.system[request.system.length - 1]
+      if (!lastBlock || !('cachePoint' in lastBlock)) {
+        const cachePoint: BedrockCachePointBlock = { type: 'default' }
+        const ttl = this._config.cacheConfig?.systemTTL
+        if (ttl !== undefined) {
+          cachePoint.ttl = ttl as BedrockSdkCacheTTL
+        }
+        request.system.push({ cachePoint })
       }
     }
 

--- a/strands-ts/src/models/google/types.ts
+++ b/strands-ts/src/models/google/types.ts
@@ -3,7 +3,7 @@
  */
 
 import type { GoogleGenAI, GoogleGenAIOptions, Tool } from '@google/genai'
-import type { BaseModelConfig } from '../model.js'
+import type { BaseModelConfig, CacheConfig } from '../model.js'
 
 /**
  * Configuration interface for Google model provider.
@@ -52,6 +52,21 @@ export interface GoogleModelConfig extends BaseModelConfig {
    * @defaultValue false
    */
   useNativeTokenCount?: boolean
+
+  /**
+   * Configuration for prompt caching. Gemini 2.5+ models on the paid tier already cache
+   * prompt prefixes automatically (implicit caching), so this config is accepted for
+   * cross-provider portability and is a documented no-op — the SDK injects nothing into
+   * the request.
+   *
+   * Gemini also offers *explicit* caching via a separate `CachedContent` resource, which
+   * has a create/reference/delete lifecycle and bills for storage while the cache is
+   * alive. That is a distinct feature with real cost implications; use the underlying
+   * `@google/genai` SDK directly for it.
+   *
+   * @see https://ai.google.dev/gemini-api/docs/caching
+   */
+  cacheConfig?: CacheConfig
 }
 
 /**

--- a/strands-ts/src/models/openai/__tests__/chat.test.ts
+++ b/strands-ts/src/models/openai/__tests__/chat.test.ts
@@ -388,6 +388,59 @@ describe('OpenAIModel', () => {
     })
   })
 
+  describe('prompt caching plumbing', () => {
+    it('forwards promptCacheKey verbatim on the request', async () => {
+      const captured: { request: any } = { request: null }
+      const mockClient = createMockClientWithCapture(captured)
+      const provider = new OpenAIModel({
+        api: 'chat',
+        modelId: 'gpt-4o',
+        client: mockClient,
+        promptCacheKey: 'agent-abc',
+      })
+      await collectIterator(provider.stream([new Message({ role: 'user', content: [new TextBlock('Hi')] })]))
+      expect(captured.request.prompt_cache_key).toBe('agent-abc')
+    })
+
+    it('forwards promptCacheRetention verbatim on the request', async () => {
+      const captured: { request: any } = { request: null }
+      const mockClient = createMockClientWithCapture(captured)
+      const provider = new OpenAIModel({
+        api: 'chat',
+        modelId: 'gpt-4o',
+        client: mockClient,
+        promptCacheRetention: '24h',
+      })
+      await collectIterator(provider.stream([new Message({ role: 'user', content: [new TextBlock('Hi')] })]))
+      expect(captured.request.prompt_cache_retention).toBe('24h')
+    })
+
+    it('accepts cacheConfig as a no-op — nothing is injected into the request', async () => {
+      const captured: { request: any } = { request: null }
+      const mockClient = createMockClientWithCapture(captured)
+      const provider = new OpenAIModel({
+        api: 'chat',
+        modelId: 'gpt-4o',
+        client: mockClient,
+        cacheConfig: { strategy: 'auto' },
+      })
+      await collectIterator(provider.stream([new Message({ role: 'user', content: [new TextBlock('Hi')] })]))
+      expect(captured.request.prompt_cache_key).toBeUndefined()
+      expect(captured.request.prompt_cache_retention).toBeUndefined()
+      expect(captured.request.cache_config).toBeUndefined()
+      expect(captured.request.cacheConfig).toBeUndefined()
+    })
+
+    it('omits prompt_cache_* keys when neither is configured', async () => {
+      const captured: { request: any } = { request: null }
+      const mockClient = createMockClientWithCapture(captured)
+      const provider = new OpenAIModel({ api: 'chat', modelId: 'gpt-4o', client: mockClient })
+      await collectIterator(provider.stream([new Message({ role: 'user', content: [new TextBlock('Hi')] })]))
+      expect(captured.request.prompt_cache_key).toBeUndefined()
+      expect(captured.request.prompt_cache_retention).toBeUndefined()
+    })
+  })
+
   describe('stream', () => {
     describe('validation', () => {
       it('throws error when messages array is empty', async () => {

--- a/strands-ts/src/models/openai/__tests__/responses.test.ts
+++ b/strands-ts/src/models/openai/__tests__/responses.test.ts
@@ -471,6 +471,30 @@ describe("OpenAIModel (api: 'responses')", () => {
       const req = await runOnce({}, messages)
       expect(req.input[0]).toEqual({ role: 'user', content: [{ type: 'input_text', text: 'quoted passage' }] })
     })
+
+    it('forwards promptCacheKey verbatim on the request', async () => {
+      const req = await runOnce({ promptCacheKey: 'agent-abc' })
+      expect(req.prompt_cache_key).toBe('agent-abc')
+    })
+
+    it('forwards promptCacheRetention verbatim on the request', async () => {
+      const req = await runOnce({ promptCacheRetention: '24h' })
+      expect(req.prompt_cache_retention).toBe('24h')
+    })
+
+    it('accepts cacheConfig as a no-op — nothing is injected into the request', async () => {
+      const req = await runOnce({ cacheConfig: { strategy: 'auto' } })
+      expect(req.prompt_cache_key).toBeUndefined()
+      expect(req.prompt_cache_retention).toBeUndefined()
+      expect(req.cache_config).toBeUndefined()
+      expect(req.cacheConfig).toBeUndefined()
+    })
+
+    it('omits prompt_cache_* keys when neither is configured', async () => {
+      const req = await runOnce()
+      expect(req.prompt_cache_key).toBeUndefined()
+      expect(req.prompt_cache_retention).toBeUndefined()
+    })
   })
 
   describe('stream event mapping', () => {

--- a/strands-ts/src/models/openai/__tests__/responses.test.ts
+++ b/strands-ts/src/models/openai/__tests__/responses.test.ts
@@ -494,6 +494,12 @@ describe("OpenAIModel (api: 'responses')", () => {
       const req = await runOnce()
       expect(req.prompt_cache_key).toBeUndefined()
       expect(req.prompt_cache_retention).toBeUndefined()
+      expect(req.prompt_cache_options).toBeUndefined()
+    })
+
+    it('forwards promptCacheOptions verbatim on the request', async () => {
+      const req = await runOnce({ promptCacheOptions: { mode: 'explicit' } })
+      expect(req.prompt_cache_options).toEqual({ mode: 'explicit' })
     })
   })
 

--- a/strands-ts/src/models/openai/chat-adapter.ts
+++ b/strands-ts/src/models/openai/chat-adapter.ts
@@ -138,6 +138,13 @@ export function formatChatRequest(
     }
   }
 
+  if (config.promptCacheKey !== undefined) {
+    ;(request as unknown as Record<string, unknown>).prompt_cache_key = config.promptCacheKey
+  }
+  if (config.promptCacheRetention !== undefined) {
+    ;(request as unknown as Record<string, unknown>).prompt_cache_retention = config.promptCacheRetention
+  }
+
   if ('n' in request && request.n !== undefined && request.n !== null && request.n > 1) {
     throw new Error('Streaming with n > 1 is not supported')
   }

--- a/strands-ts/src/models/openai/responses-adapter.ts
+++ b/strands-ts/src/models/openai/responses-adapter.ts
@@ -131,6 +131,9 @@ export function formatResponsesRequest(
   if (config.promptCacheRetention !== undefined) {
     ;(request as unknown as Record<string, unknown>).prompt_cache_retention = config.promptCacheRetention
   }
+  if (config.promptCacheOptions !== undefined) {
+    ;(request as unknown as Record<string, unknown>).prompt_cache_options = config.promptCacheOptions
+  }
 
   return request
 }

--- a/strands-ts/src/models/openai/responses-adapter.ts
+++ b/strands-ts/src/models/openai/responses-adapter.ts
@@ -125,6 +125,13 @@ export function formatResponsesRequest(
   if (config.maxTokens !== undefined) request.max_output_tokens = config.maxTokens
   if (config.topP !== undefined) request.top_p = config.topP
 
+  if (config.promptCacheKey !== undefined) {
+    ;(request as unknown as Record<string, unknown>).prompt_cache_key = config.promptCacheKey
+  }
+  if (config.promptCacheRetention !== undefined) {
+    ;(request as unknown as Record<string, unknown>).prompt_cache_retention = config.promptCacheRetention
+  }
+
   return request
 }
 

--- a/strands-ts/src/models/openai/types.ts
+++ b/strands-ts/src/models/openai/types.ts
@@ -107,6 +107,15 @@ export interface OpenAIResponsesConfig extends OpenAIBaseConfig {
    * is sent on every turn.
    */
   stateful?: boolean
+
+  /**
+   * Fine-grained caching mode for models that support it (GPT-5.6 on Bedrock Mantle:
+   * sol/terra/luna). `{ mode: 'implicit' }` (default) lets the server cache automatically;
+   * `{ mode: 'explicit' }` requires the caller to mark cache breakpoints on specific
+   * content blocks (not yet exposed as a first-class SDK surface). Passed through to the
+   * request verbatim.
+   */
+  promptCacheOptions?: { mode: 'implicit' | 'explicit' }
 }
 
 /**

--- a/strands-ts/src/models/openai/types.ts
+++ b/strands-ts/src/models/openai/types.ts
@@ -5,7 +5,7 @@
 import type OpenAI from 'openai'
 import type { ApiKeySetter } from 'openai/client'
 import type { ClientOptions } from 'openai'
-import type { BaseModelConfig } from '../model.js'
+import type { BaseModelConfig, CacheConfig } from '../model.js'
 import type { BedrockMantleConfig } from './mantle.js'
 
 /**
@@ -52,6 +52,29 @@ interface OpenAIBaseConfig extends BaseModelConfig {
    * - Responses API: `model`, `input`, `stream`, `store`
    */
   params?: Record<string, unknown>
+
+  /**
+   * Configuration for prompt caching. OpenAI caches automatically for any prompt over the
+   * vendor threshold (1024 tokens on current models), so this config is accepted for
+   * cross-provider portability and is a documented no-op — the SDK injects nothing into
+   * the request. Use `promptCacheKey` when you need better cache-hit rates under load.
+   */
+  cacheConfig?: CacheConfig
+
+  /**
+   * Optional identifier that helps OpenAI route similar requests to the same cache node
+   * under high throughput. Recommended when many agents share a stable system prompt.
+   * @see https://platform.openai.com/docs/guides/prompt-caching
+   */
+  promptCacheKey?: string
+
+  /**
+   * Retention policy for cached prompts. `'in_memory'` is the default (5-10 minutes idle,
+   * up to 1 hour absolute); `'24h'` opts in to extended retention on models that support
+   * it (GPT-5 family, GPT-4.1). Passing a value not supported by the target model surfaces
+   * a runtime error from the vendor SDK.
+   */
+  promptCacheRetention?: 'in_memory' | '24h'
 }
 
 /**

--- a/strands-ts/src/models/vercel.ts
+++ b/strands-ts/src/models/vercel.ts
@@ -28,7 +28,7 @@ import type { ToolChoice, ToolSpec } from '../tools/types.js'
 import type { ModelStreamEvent, Usage } from './streaming.js'
 import { Message, TextBlock, type ToolResultContent } from '../types/messages.js'
 import { encodeBase64, ImageBlock, DocumentBlock, VideoBlock } from '../types/media.js'
-import { Model, type BaseModelConfig, type StreamOptions } from './model.js'
+import { Model, type BaseModelConfig, type CacheConfig, type StreamOptions } from './model.js'
 import {
   ModelContentBlockDeltaEvent,
   ModelContentBlockStartEvent,
@@ -40,6 +40,16 @@ import {
 import { ContextWindowOverflowError, ModelError, ModelThrottledError } from '../errors.js'
 import { toMimeType } from '../mime.js'
 import { logger } from '../logging/logger.js'
+import { warnOnce } from '../logging/warn-once.js'
+
+/**
+ * Underlying-provider prefixes whose native APIs require per-block cache markers
+ * (`providerOptions.<provider>.cacheControl` or `.cachePoint`). Vercel does not vend
+ * a cross-provider caching abstraction, so cacheConfig on this adapter cannot inject
+ * those markers automatically; we warn once per model when caching is requested against
+ * one of these providers.
+ */
+const VERCEL_PER_BLOCK_CACHE_PROVIDERS = ['anthropic', 'amazon-bedrock', 'bedrock']
 
 /**
  * Error message patterns that indicate context window overflow.
@@ -72,7 +82,27 @@ type LanguageModelCallSettings = Omit<LanguageModelV3CallOptions, 'prompt' | 'to
  * Note: `maxTokens` (from BaseModelConfig) maps to `maxOutputTokens` in the underlying call.
  * If both are set, `maxOutputTokens` takes precedence.
  */
-export interface VercelModelConfig extends BaseModelConfig, LanguageModelCallSettings {}
+export interface VercelModelConfig extends BaseModelConfig, LanguageModelCallSettings {
+  /**
+   * Configuration for prompt caching. The Vercel AI SDK does not vend a cross-provider
+   * caching abstraction — each provider package accepts caching hints under its own
+   * `providerOptions.<provider>` slot with a different shape (`cacheControl` on Anthropic,
+   * `cachePoint` on Bedrock, `promptCacheKey` on OpenAI, `cachedContent` on Google).
+   *
+   * `cacheConfig` is accepted on this adapter for cross-SDK portability, but its effect
+   * depends on the underlying provider:
+   *
+   * - `openai.*` / `openai-responses.*`: server-auto caching; no client action needed.
+   *   This field is a documented no-op.
+   * - `google.*` (Gemini 2.5+ paid tier): implicit server-side caching is on by default;
+   *   this field is a documented no-op.
+   * - `anthropic.*` / `amazon-bedrock.*`: caching requires per-block markers via
+   *   `providerOptions.<provider>.cacheControl` or `.cachePoint`. This field cannot
+   *   inject those, so it logs a warning and does nothing. Configure caching by passing
+   *   `providerOptions` through `params` on individual message parts.
+   */
+  cacheConfig?: CacheConfig
+}
 
 /**
  * Options for creating a VercelModel instance.
@@ -141,7 +171,18 @@ export class VercelModel extends Model<VercelModelConfig> {
     const tools = options?.toolSpecs ? formatTools(options.toolSpecs) : undefined
     const toolChoice = options?.toolChoice ? formatToolChoice(options.toolChoice) : undefined
 
-    const { modelId: _, maxTokens, ...callSettings } = this._config
+    const { modelId: _, maxTokens, cacheConfig, ...callSettings } = this._config
+
+    if (cacheConfig) {
+      const providerName = this._provider.provider ?? ''
+      if (VERCEL_PER_BLOCK_CACHE_PROVIDERS.some((prefix) => providerName.startsWith(prefix))) {
+        warnOnce(
+          logger,
+          `provider=<${providerName}> | vercel cacheConfig cannot inject per-block cache markers; ` +
+            `set providerOptions.<provider>.cacheControl or .cachePoint on message parts directly`
+        )
+      }
+    }
 
     const callOptions: LanguageModelV3CallOptions = {
       prompt,


### PR DESCRIPTION
## Summary

**Flips the default:** BedrockModel now constructs with `CacheConfig(strategy="auto")` instead of no caching. For models that support Anthropic-style caching (Claude family, `us./eu./global.anthropic.*` cross-region profiles), this places cache points on the system prompt and last user message on every request; tools caching still requires the explicit `cache_tools` knob.

For non-Anthropic models on Bedrock (Amazon Nova, DeepSeek, Meta Llama, Mistral, Amazon Titan, etc.) the runtime silently skips injection — `_shouldEnableCaching` / `_cache_strategy` returns null — and logs a "model does not support automatic caching" warning at request time. **No request payload changes for those models.**

Callers who want to opt out pass `cache_config=None` (Python) or `cacheConfig: undefined` (TypeScript) explicitly.

## Compatibility

Behavior change is technically breaking, but a cache miss falls back to normal input pricing so the worst case is neutral, and the best case is ~90% off input on repeated prefixes. Recommend a release-note callout.

The AnthropicModel default flip is intentionally deferred until upstream #3571 lands (adds `cache_config` to AnthropicModel); this stack composes on top.

## Stack

**10/10 — the finale.** Closes #2970.

## Test plan

- [x] 189 Python bedrock tests pass (2 new)
- [x] 178 TS bedrock tests pass (extensive snapshot updates)
- [x] Full Python suite: 4805 tests
- [x] Full TS suite: 3940 tests
- [x] mypy, ruff, prettier, eslint clean
- [ ] Real-API smoke test on Claude Sonnet 4.6 (default cache write on turn 1, cache read on turn 2)
- [ ] Real-API smoke test confirming Nova/DeepSeek/Llama/Mistral models still work with the new default (warning + no cachePoint injection)
- [ ] Verify `Agent(model=BedrockModel())` and `Agent()` (default model) both cache with no config