### PR TITLE
fix(openai): send message-content documents as file_data, not file_url

### DIFF
--- a/strands-py/src/strands/models/openai_responses.py
+++ b/strands-py/src/strands/models/openai_responses.py
@@ -709,7 +709,10 @@ class OpenAIResponsesModel(Model):
         if "document" in content:
             doc = content["document"]
             data_url = _encode_media_to_data_url(doc["source"]["bytes"], doc["format"], "document")
-            return {"type": "input_file", "file_url": data_url}
+            name = doc.get("name", "document")
+            suffix = f".{doc['format']}"
+            filename = name if name.endswith(suffix) else f"{name}{suffix}"
+            return {"type": "input_file", "filename": filename, "file_data": data_url}
 
         if "image" in content:
             img = content["image"]

--- a/strands-py/tests/strands/models/test_openai_responses.py
+++ b/strands-py/tests/strands/models/test_openai_responses.py
@@ -121,7 +121,8 @@ def test_update_config(model, model_id):
             },
             {
                 "type": "input_file",
-                "file_url": "data:application/pdf;base64,ZG9jdW1lbnQ=",
+                "filename": "test doc.pdf",
+                "file_data": "data:application/pdf;base64,ZG9jdW1lbnQ=",
             },
         ),
         # Image


### PR DESCRIPTION


## Description
Follow up to https://github.com/strands-agents/harness-sdk/pull/3674

The Responses API rejects data: URIs in file_url with 400 "Failed to download file" — file_url is for fetchable URLs only. Use file_data with a filename for inline embedded bytes, matching the tool-result fix in #3674.

## Related Issues

#3674

## Documentation PR

N/A
<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix


## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [ ] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
