### PR TITLE
docs(cedar): make environment-gating example fail closed

### DIFF
--- a/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.mdx
@@ -169,6 +169,13 @@ Block tools based on deployment context by forwarding environment metadata throu
 </Tab>
 </Tabs>
 
+Permit an allowlist of environments rather than denying `"production"`. An allowlist
+stays fail-closed: when `environment` is missing from
+<Syntax py="invocation_state" ts="invocationState" />, the enricher's fallback value
+falls outside the permitted set and the call is denied. A rule that denies
+`"production"` instead would permit that call, along with any spelling the rule doesn't
+match exactly — `"Production"`, `"prod"`, `"prod-us-east-1"`.
+
 ## File-based policies
 
 For production deployments, keep policies in `.cedar` files rather than inline strings:

--- a/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.py
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.py
@@ -255,7 +255,9 @@ def env_gating_example():
           )
           when {
             context.session has environment &&
-            context.session.environment != "production"
+            ["staging", "dev"].contains(
+              context.session.environment
+            )
           };
         """,
         context_enricher=lambda ctx: {
@@ -281,6 +283,10 @@ def env_gating_example():
         "Deploy the service",
         invocation_state={"environment": "production"},
     )
+
+    # denied when environment is absent: the enricher falls
+    # back to "unknown", which is outside the permitted set
+    agent("Deploy the service")
     # --8<-- [end:env_gating]
 
 

--- a/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.ts
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.ts
@@ -205,7 +205,7 @@ async function envGatingExample() {
     policies: `
       permit(principal, action == Action::"deploy", resource)
       when { context.session has environment &&
-             context.session.environment != "production" };
+             ["staging", "dev"].contains(context.session.environment) };
     `,
     contextEnricher: ({ invocationState }) => ({
       environment: String(invocationState.environment ?? 'unknown'),
@@ -226,6 +226,10 @@ async function envGatingExample() {
   await agent.invoke('Deploy the service', {
     invocationState: { environment: 'production' },
   })
+
+  // denied when environment is absent: the enricher falls back to
+  // 'unknown', which is outside the permitted set
+  await agent.invoke('Deploy the service')
   // --8<-- [end:env_gating]
 }
 


### PR DESCRIPTION
## Description

The environment-gating example on the Cedar Authorization page is fail-open: if `environment` is absent from `invocationState`, the `deploy` tool is **permitted**. It reads as a production guardrail but does not deny when it cannot establish where it is running.

Before:

```
permit(principal, action == Action::"deploy", resource)
when { context.session has environment &&
       context.session.environment != "production" };
```

Two problems compound:

1. **A denylist with a permissive default.** The enricher defaults a missing `environment` to `'unknown'`, and `'unknown' != "production"` is `true` — so the deploy is permitted. Any spelling that isn't byte-identical to `"production"` passes too: `"Production"`, `"prod"`, `"prod-us-east-1"`.
2. **The `has environment` guard is unreachable.** The enricher sets `environment` unconditionally via its `?? 'unknown'` fallback, so `has` is always `true`. It reads like a safety check but can never fire.

After — an allowlist, so anything unrecognised denies:

```
permit(principal, action == Action::"deploy", resource)
when { context.session has environment &&
       ["staging", "dev"].contains(context.session.environment) };
```

The enricher is unchanged: its `'unknown'` fallback now simply falls outside the permitted set. Also adds a third call to each snippet showing the no-environment case denying, and a short paragraph on why the example is written as an allowlist.

This aligns the example with two claims the same page already makes — *"The design is fail-closed"* and *"Cedar uses default-deny semantics"* — and with the role-based access control example, which already uses this shape (`role` defaults to `'none'`, and no `permit` matches `'none'`). The environment example was the one place the page taught default-permit.

## Related Issues

Closes #3695.

Related: #3696 is a separate finding on the same page (the RBAC example takes `role` from mutable, caller-supplied `invocationState` without noting the trust boundary), with its own PR. The two are independent — reasonable to triage together, and equally reasonable to accept one and not the other.

## Documentation PR

This is a documentation-only change. No SDK code is touched — `CedarAuthorization` behaves correctly; only the example policy was unsafe.

## Type of Change

Documentation update

## Testing

The policy change was verified by evaluating both policies with `cedarpy` against the exact context shape [`CedarAuthorization.before_tool_call` builds](https://github.com/strands-agents/harness-sdk/blob/38980ed4fc1c00e1b132f340faaac62e1a12e009/strands-py/src/strands/vended_interventions/cedar/cedar_authorization.py#L184-L198), mirroring the enricher's `'unknown'` fallback:

```
case                         docs policy    allowlist fix
environment='staging'        ALLOW          ALLOW
environment='production'     DENY           DENY
environment MISSING          ALLOW          DENY      <-- the bug
environment='Production'     ALLOW          DENY
environment='prod'           ALLOW          DENY
```

The happy path and the explicit-production denial are unchanged; the three fail-open cases now deny. The full script is in #3695.

Also checked: the Python snippet file parses, the new `await agent.invoke('Deploy the service')` call is valid against `invoke(args: InvokeArgs, options?: InvokeOptions)`, and all added lines are within the 90-character limit for `site/src/content/docs/`.

**What I could not run:** `npm run typecheck:snippets` and the site test suite both need `@strands-agents/sdk` built, and the workspace install fails in my environment — npm refuses the remote-tarball dependency `@aws/bedrock-token-generator` (fetched from a GitHub release URL rather than the registry). So those two checks are unverified locally and I'm relying on CI for them. The change is a string edit inside a template literal plus one extra `invoke` call, so the type surface is small, but I'd rather flag it than imply it was checked.

- [ ] I ran `hatch run prepare` — not applicable; no Python SDK code changed. The `.py` file here is a docs snippet under `site/`.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works — no test harness exists for doc snippet policies; the verification above is in the PR body and issue instead
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

Note: this PR was prepared with AI assistance (Claude Code). I have reviewed every line and can explain and defend the change.

---

Spotted while reviewing the interventions docs with the team at @clevvi.
