### PR TITLE
docs(cedar): note the role trust boundary, add entity-based RBAC example

### DIFF
--- a/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.mdx
@@ -73,6 +73,45 @@ For multi-tenant agents where each request carries user identity, use <Syntax py
 
 When <Syntax py="principal_resolver" ts="principalResolver" /> returns <Syntax py="None" ts="undefined" /> (no identity found), the handler denies all tool calls for that request.
 
+:::caution[Role data is only as trustworthy as its source]
+<Syntax py="invocation_state" ts="invocationState" /> is supplied by your application, and
+it is mutable — tools and hooks may write to it during an invocation, and
+<Syntax py="context_enricher" ts="contextEnricher" /> reads it again before every tool
+call.
+
+Set `role` from something you have already verified at the point you invoke the agent — a
+validated token claim, a directory lookup — and never forward a role supplied by the
+client. Where roles are stable rather than request-scoped, keep them out of the request
+entirely and put them in the entity store instead.
+:::
+
+### Roles as entities
+
+Cedar can resolve roles from the entity hierarchy rather than from context. Membership is
+fixed when you construct the handler, so nothing reachable from a request can change it:
+
+<Tabs>
+<Tab label="Python">
+
+```python
+--8<-- "user-guide/concepts/agents/interventions/cedar-authorization.py:role_entities"
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/agents/interventions/cedar-authorization_imports.ts:role_entities_imports"
+
+--8<-- "user-guide/concepts/agents/interventions/cedar-authorization.ts:role_entities"
+```
+</Tab>
+</Tabs>
+
+Here `bob` is denied `delete_record` even though the request claims `role: "admin"`,
+because no policy reads `context.session.role`. Prefer this form when roles change rarely
+and are owned by your application; prefer the context form when they are genuinely
+per-request.
+
 ## Rate limiting
 
 Cedar policies can reference `context.session.call_count`, which tracks how many times each tool has been invoked successfully during the session:

--- a/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.py
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.py
@@ -130,6 +130,97 @@ def role_based_example():
     # --8<-- [end:role_based]
 
 
+def role_entities_example():
+    # --8<-- [start:role_entities]
+    from strands import Agent, tool
+    from strands.vended_interventions.cedar import (
+        CedarAuthorization,
+    )
+
+    @tool
+    def search(query: str) -> str:
+        """Search for information."""
+        return f"Results for: {query}"
+
+    @tool
+    def delete_record(record_id: str) -> str:
+        """Delete a record by ID."""
+        return f"Deleted {record_id}"
+
+    cedar = CedarAuthorization(
+        policies="""
+          permit(
+            principal in Role::"admin",
+            action,
+            resource
+          );
+
+          permit(
+            principal in Role::"analyst",
+            action == Action::"search",
+            resource
+          );
+        """,
+        # Role membership is fixed here, not read
+        # from the request
+        entities=[
+            {
+                "uid": {"type": "Role", "id": "admin"},
+                "attrs": {},
+                "parents": [],
+            },
+            {
+                "uid": {"type": "Role", "id": "analyst"},
+                "attrs": {},
+                "parents": [],
+            },
+            {
+                "uid": {"type": "User", "id": "alice"},
+                "attrs": {},
+                "parents": [
+                    {"type": "Role", "id": "admin"}
+                ],
+            },
+            {
+                "uid": {"type": "User", "id": "bob"},
+                "attrs": {},
+                "parents": [
+                    {"type": "Role", "id": "analyst"}
+                ],
+            },
+        ],
+        principal_resolver=lambda state: (
+            {"type": "User", "id": state["user_id"]}
+            if state.get("user_id")
+            else None
+        ),
+    )
+
+    agent = Agent(
+        tools=[search, delete_record],
+        interventions=[cedar],
+    )
+
+    # alice is a member of Role::"admin", so any tool
+    # is permitted
+    agent(
+        "Delete record 42",
+        invocation_state={"user_id": "alice"},
+    )
+
+    # bob is a member of Role::"analyst", so delete_record
+    # is denied. The claimed role is ignored: no policy
+    # reads context.session.role
+    agent(
+        "Delete record 42",
+        invocation_state={
+            "user_id": "bob",
+            "role": "admin",
+        },
+    )
+    # --8<-- [end:role_entities]
+
+
 def rate_limit_example():
     # --8<-- [start:rate_limit]
     from strands import Agent, tool

--- a/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.ts
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.ts
@@ -86,6 +86,67 @@ async function roleBasedExample() {
   // --8<-- [end:role_based]
 }
 
+async function roleEntitiesExample() {
+  // --8<-- [start:role_entities]
+  const searchTool = tool({
+    name: 'search',
+    description: 'Search for information',
+    inputSchema: z.object({ query: z.string() }),
+    callback: (input) => `Results for: ${input.query}`,
+  })
+
+  const deleteTool = tool({
+    name: 'delete_record',
+    description: 'Delete a record by ID',
+    inputSchema: z.object({ record_id: z.string() }),
+    callback: (input) => `Deleted ${input.record_id}`,
+  })
+
+  const cedar = new CedarAuthorization({
+    policies: `
+      permit(principal in Role::"admin", action, resource);
+
+      permit(principal in Role::"analyst", action == Action::"search", resource);
+    `,
+    // Role membership is fixed here, not read from the request
+    entities: [
+      { uid: { type: 'Role', id: 'admin' }, attrs: {}, parents: [] },
+      { uid: { type: 'Role', id: 'analyst' }, attrs: {}, parents: [] },
+      {
+        uid: { type: 'User', id: 'alice' },
+        attrs: {},
+        parents: [{ type: 'Role', id: 'admin' }],
+      },
+      {
+        uid: { type: 'User', id: 'bob' },
+        attrs: {},
+        parents: [{ type: 'Role', id: 'analyst' }],
+      },
+    ],
+    principalResolver: (state) => {
+      if (!state.user_id) return undefined
+      return { type: 'User', id: String(state.user_id) }
+    },
+  })
+
+  const agent = new Agent({
+    tools: [searchTool, deleteTool],
+    interventions: [cedar],
+  })
+
+  // alice is a member of Role::"admin", so any tool is permitted
+  await agent.invoke('Delete record 42', {
+    invocationState: { user_id: 'alice' },
+  })
+
+  // bob is a member of Role::"analyst", so delete_record is denied.
+  // The claimed role is ignored: no policy reads context.session.role
+  await agent.invoke('Delete record 42', {
+    invocationState: { user_id: 'bob', role: 'admin' },
+  })
+  // --8<-- [end:role_entities]
+}
+
 async function rateLimitExample() {
   // --8<-- [start:rate_limit]
   const sendEmailTool = tool({
@@ -265,6 +326,7 @@ async function hotReloadExample() {
 // suppress unused warnings
 void basicExample
 void roleBasedExample
+void roleEntitiesExample
 void rateLimitExample
 void schemaValidationExample
 void namespaceExample

--- a/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization_imports.ts
@@ -12,6 +12,12 @@ import { CedarAuthorization } from '@strands-agents/sdk/vended-interventions/ced
 import { z } from 'zod'
 // --8<-- [end:role_based_imports]
 
+// --8<-- [start:role_entities_imports]
+import { Agent, tool } from '@strands-agents/sdk'
+import { CedarAuthorization } from '@strands-agents/sdk/vended-interventions/cedar'
+import { z } from 'zod'
+// --8<-- [end:role_entities_imports]
+
 // --8<-- [start:rate_limit_imports]
 import { Agent, tool } from '@strands-agents/sdk'
 import { CedarAuthorization } from '@strands-agents/sdk/vended-interventions/cedar'


### PR DESCRIPTION
## Description

The role-based access control example sources the authorization role from `invocationState` via `contextEnricher`, without stating the trust boundary that implies. Two things follow that the page doesn't say:

1. **`invocationState` is application-supplied.** An app that forwards a request body or header into it lets the caller assert its own role.
2. **It is mutable mid-invocation.** Per [`types/agent.ts`](https://github.com/strands-agents/harness-sdk/blob/38980ed4fc1c00e1b132f340faaac62e1a12e009/strands-ts/src/types/agent.ts#L68-L88): *"mutations by hooks or tools are visible to subsequent hooks, tools, and recursive loop cycles"* and *"Mutable — hooks and tools may read and write."* The enricher [reads it fresh on every `beforeToolCall`](https://github.com/strands-agents/harness-sdk/blob/38980ed4fc1c00e1b132f340faaac62e1a12e009/strands-ts/src/vended-interventions/cedar/cedar.ts#L184-L190), so a tool that writes `invocationState.role` changes the role governing every later tool call in that invocation.

Neither is an SDK defect — this is documented, intended behaviour for `invocationState` generally. It just isn't a property you want silently underneath an authorization decision, and this page is the pattern people copy for exactly the case where it matters.

This PR does two things:

**1. A `:::caution` callout** naming the boundary: set `role` from something already verified at invoke time (a validated token claim, a directory lookup), never forward a client-supplied role, and don't assume it's stable across tool calls.

**2. A new "Roles as entities" subsection** showing Cedar's other option — resolving roles from the entity hierarchy rather than context:

```
permit(principal in Role::"admin", action, resource);
permit(principal in Role::"analyst", action == Action::"search", resource);
```

Membership is fixed when the handler is constructed, so nothing reachable from a request can change it. In the example `bob` is denied `delete_record` even though the request claims `role: "admin"`, because no policy reads `context.session.role`. The handler already accepts `entities`; the page previously only showed it in passing in the namespace example.

**The context-based example stays as the lead.** It's simpler, and roles often genuinely are request-scoped. The new section is framed as the right tool when roles are stable and owned by the application, not as a replacement.

### On the obvious counter-argument

The principal itself comes from the same `invocationState` (`state.user_id`), so "don't trust `invocationState`" proves too much — distrust it entirely and the handler has no identity to work with. That's why this PR doesn't tell readers to distrust it. It names the boundary once and shows the option that doesn't depend on it.

## Related Issues

Closes #3696.

Related: #3695 / #3697 is a separate finding on the same page (the environment-gating example is fail-open when `environment` is unset). The two are independent — reasonable to triage together, and equally reasonable to accept one and not the other.

## Documentation PR

This is a documentation-only change. No SDK code is touched.

## Type of Change

Documentation update

## Testing

The new example's policy and entities were verified by extracting them **verbatim from the committed snippet file** and evaluating them with `cedarpy` against the exact request shape [`CedarAuthorization.before_tool_call` builds](https://github.com/strands-agents/harness-sdk/blob/38980ed4fc1c00e1b132f340faaac62e1a12e009/strands-py/src/strands/vended_interventions/cedar/cedar_authorization.py#L184-L198) — so this tests what the docs actually publish, not a retyped copy:

```
case                                 tool            expected   actual   ok
alice (admin entity)                 delete_record   ALLOW      ALLOW    PASS
alice (admin entity)                 search          ALLOW      ALLOW    PASS
bob (analyst entity)                 search          ALLOW      ALLOW    PASS
bob -> delete_record                 delete_record   DENY       DENY     PASS
bob CLAIMS role=admin                delete_record   DENY       DENY     PASS
mallory (no entity) CLAIMS admin     delete_record   DENY       DENY     PASS

ALL PASS
```

The last two are the ones that matter: a request asserting `role: "admin"` does not change the decision. The script is in #3696.

Also checked: the Python snippet file parses; the new `--8<--` references resolve to real `[start:…]`/`[end:…]` pairs in both the body and imports files; Prettier is clean on the new TypeScript; added prose lines are within the 90-character limit for `site/src/content/docs/`; and the diff is additions only, with no reformatting of surrounding code.

**What I could not run:** `npm run typecheck:snippets` and the site test suite both need `@strands-agents/sdk` built, and the workspace install fails in my environment — npm refuses the remote-tarball dependency `@aws/bedrock-token-generator` (fetched from a GitHub release URL rather than the registry). Those two checks are unverified locally and I'm relying on CI. Worth a reviewer's eye in particular on whether `parents: [{ type: 'Role', id: 'admin' }]` satisfies the `EntityJson` type in the TypeScript snippet — it is correct at the Cedar level (proven above via `cedarpy`) and the file carries `// @ts-nocheck`, but I could not run `tsc` against it.

- [ ] I ran `hatch run prepare` — not applicable; no Python SDK code changed. The `.py` file here is a docs snippet under `site/`.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works — no test harness exists for doc snippet policies; the verification above is in the PR body and issue instead
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

Note: this PR was prepared with AI assistance (Claude Code). I have reviewed every line and can explain and defend the change.

---

Spotted while reviewing the interventions docs with the team at @clevvi.
