### PR TITLE
fix(ci): label fork PRs by verifying the artifact's claim against the PR head

### DIFF
--- a/.github/scripts/pr-metrics/apply-labels.mjs
+++ b/.github/scripts/pr-metrics/apply-labels.mjs
@@ -106,7 +106,10 @@ export async function resolvePrNumber({ github, context, core, claimed }) {
       throw error
     }
     if (head === run.head_sha && headRepoId != null && headRepoId === run.head_repository?.id) return claimed
-    core.warning(`artifact claimed PR #${claimed}, whose head ${head} is not ${run.head_sha}; not labeling`)
+    core.warning(
+      `artifact claimed PR #${claimed}, whose head ${head} (repo ${headRepoId}) does not match ` +
+        `the run's ${run.head_sha} (repo ${run.head_repository?.id}); not labeling`
+    )
     return null
   }
   // The artifact's claim is only honored if the API independently agrees the PR

--- a/.github/scripts/pr-metrics/apply-labels.mjs
+++ b/.github/scripts/pr-metrics/apply-labels.mjs
@@ -84,6 +84,7 @@ export async function resolvePrNumber({ github, context, core, claimed }) {
     // claimed PR's actual head is the commit this run analyzed, which makes the
     // metrics correct for that PR by definition.
     let head
+    let headRepoId
     try {
       const { data } = await github.rest.pulls.get({
         owner: context.repo.owner,
@@ -91,6 +92,9 @@ export async function resolvePrNumber({ github, context, core, claimed }) {
         pull_number: claimed,
       })
       head = data.head.sha
+      // A commit object can be pushed into any repository, so the SHA alone only
+      // proves the tree. The head repository is what pins the claim to this PR.
+      headRepoId = data.head.repo?.id
     } catch (error) {
       // Only a 404 refutes the claim. Anything else (5xx, rate limit, network)
       // is a transient lookup failure — rethrow so the run fails visibly and
@@ -101,7 +105,7 @@ export async function resolvePrNumber({ github, context, core, claimed }) {
       }
       throw error
     }
-    if (head === run.head_sha) return claimed
+    if (head === run.head_sha && headRepoId != null && headRepoId === run.head_repository?.id) return claimed
     core.warning(`artifact claimed PR #${claimed}, whose head ${head} is not ${run.head_sha}; not labeling`)
     return null
   }

--- a/.github/scripts/pr-metrics/apply-labels.mjs
+++ b/.github/scripts/pr-metrics/apply-labels.mjs
@@ -91,9 +91,15 @@ export async function resolvePrNumber({ github, context, core, claimed }) {
         pull_number: claimed,
       })
       head = data.head.sha
-    } catch {
-      core.warning(`artifact claimed PR #${claimed}, which could not be looked up; not labeling`)
-      return null
+    } catch (error) {
+      // Only a 404 refutes the claim. Anything else (5xx, rate limit, network)
+      // is a transient lookup failure — rethrow so the run fails visibly and
+      // can be re-run, instead of silently skipping the labels.
+      if (error.status === 404) {
+        core.warning(`artifact claimed PR #${claimed}, which does not exist; not labeling`)
+        return null
+      }
+      throw error
     }
     if (head === run.head_sha) return claimed
     core.warning(`artifact claimed PR #${claimed}, whose head ${head} is not ${run.head_sha}; not labeling`)

--- a/.github/scripts/pr-metrics/apply-labels.mjs
+++ b/.github/scripts/pr-metrics/apply-labels.mjs
@@ -74,7 +74,29 @@ export async function resolvePrNumber({ github, context, core, claimed }) {
   }
 
   if (candidates.length === 0) {
-    core.info(`no pull request found for head sha ${run.head_sha}`)
+    if (claimed === null) {
+      core.info(`no pull request found for head sha ${run.head_sha}`)
+      return null
+    }
+    // Fork PRs reach here: they populate neither `workflow_run.pull_requests`
+    // nor the commit-association API, since the head commit exists only in the
+    // fork. Verify the claim directly instead — honoring it only when the
+    // claimed PR's actual head is the commit this run analyzed, which makes the
+    // metrics correct for that PR by definition.
+    let head
+    try {
+      const { data } = await github.rest.pulls.get({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        pull_number: claimed,
+      })
+      head = data.head.sha
+    } catch {
+      core.warning(`artifact claimed PR #${claimed}, which could not be looked up; not labeling`)
+      return null
+    }
+    if (head === run.head_sha) return claimed
+    core.warning(`artifact claimed PR #${claimed}, whose head ${head} is not ${run.head_sha}; not labeling`)
     return null
   }
   // The artifact's claim is only honored if the API independently agrees the PR

--- a/.github/scripts/pr-metrics/pr-metrics.test.mjs
+++ b/.github/scripts/pr-metrics/pr-metrics.test.mjs
@@ -352,6 +352,7 @@ const stubGithub = (associated, prHeads = {}) => ({
     pulls: {
       get: async ({ pull_number: pullNumber }) => {
         const sha = prHeads[pullNumber]
+        if (sha instanceof Error) throw sha
         if (!sha) throw Object.assign(new Error('Not Found'), { status: 404 })
         return { data: { head: { sha } } }
       },
@@ -431,6 +432,24 @@ test('resolvePrNumber refuses a claim naming a PR that does not exist', async ()
     claimed: 99999,
   })
   assert.equal(number, null)
+  assert.match(core.warnings[0], /not labeling/)
+})
+
+// A transient lookup failure must fail the run visibly rather than silently
+// skipping the labels — silent skipping is the bug this path exists to fix.
+test('resolvePrNumber rethrows transient lookup failures instead of refusing', async () => {
+  const core = stubCore()
+  const transient = Object.assign(new Error('Service Unavailable'), { status: 503 })
+  await assert.rejects(
+    resolvePrNumber({
+      github: stubGithub([], { 3704: transient }),
+      context: stubContext([], 'abc123'),
+      core,
+      claimed: 3704,
+    }),
+    /Service Unavailable/
+  )
+  assert.deepEqual(core.warnings, [])
 })
 
 test('resolvePrNumber refuses when a commit maps to several PRs and nothing is claimed', async () => {

--- a/.github/scripts/pr-metrics/pr-metrics.test.mjs
+++ b/.github/scripts/pr-metrics/pr-metrics.test.mjs
@@ -339,11 +339,16 @@ const stubCore = () => {
   const warnings = []
   return { warnings, info: () => {}, warning: (m) => warnings.push(m) }
 }
-const stubContext = (pullRequests, headSha = 'abc123') => ({
+const FORK_REPO_ID = 42
+const stubContext = (pullRequests, headSha = 'abc123', headRepoId = FORK_REPO_ID) => ({
   repo: { owner: 'o', repo: 'r' },
-  payload: { workflow_run: { head_sha: headSha, pull_requests: pullRequests } },
+  payload: {
+    workflow_run: { head_sha: headSha, head_repository: { id: headRepoId }, pull_requests: pullRequests },
+  },
 })
 // Only reached when the event carries no associated PRs, as on a fork.
+// prHeads values are 'sha' strings (head repo defaults to the fork's), an
+// Error to throw, or `{ sha, repoId }` to control the head repository.
 const stubGithub = (associated, prHeads = {}) => ({
   rest: {
     repos: {
@@ -351,10 +356,11 @@ const stubGithub = (associated, prHeads = {}) => ({
     },
     pulls: {
       get: async ({ pull_number: pullNumber }) => {
-        const sha = prHeads[pullNumber]
-        if (sha instanceof Error) throw sha
-        if (!sha) throw Object.assign(new Error('Not Found'), { status: 404 })
-        return { data: { head: { sha } } }
+        const entry = prHeads[pullNumber]
+        if (entry instanceof Error) throw entry
+        if (!entry) throw Object.assign(new Error('Not Found'), { status: 404 })
+        const { sha, repoId = FORK_REPO_ID } = typeof entry === 'string' ? { sha: entry } : entry
+        return { data: { head: { sha, repo: { id: repoId } } } }
       },
     },
   },
@@ -415,6 +421,20 @@ test('resolvePrNumber refuses a claim whose PR head does not match the run', asy
   const core = stubCore()
   const number = await resolvePrNumber({
     github: stubGithub([], { 3704: 'different-sha' }),
+    context: stubContext([], 'abc123'),
+    core,
+    claimed: 3704,
+  })
+  assert.equal(number, null)
+  assert.match(core.warnings[0], /not labeling/)
+})
+
+// A commit object can be pushed into any repository, so a matching SHA alone
+// does not tie the claim to this PR — the head repository must match too.
+test('resolvePrNumber refuses a claim whose head repository differs despite a matching sha', async () => {
+  const core = stubCore()
+  const number = await resolvePrNumber({
+    github: stubGithub([], { 3704: { sha: 'abc123', repoId: 999 } }),
     context: stubContext([], 'abc123'),
     core,
     claimed: 3704,

--- a/.github/scripts/pr-metrics/pr-metrics.test.mjs
+++ b/.github/scripts/pr-metrics/pr-metrics.test.mjs
@@ -344,10 +344,17 @@ const stubContext = (pullRequests, headSha = 'abc123') => ({
   payload: { workflow_run: { head_sha: headSha, pull_requests: pullRequests } },
 })
 // Only reached when the event carries no associated PRs, as on a fork.
-const stubGithub = (associated) => ({
+const stubGithub = (associated, prHeads = {}) => ({
   rest: {
     repos: {
       listPullRequestsAssociatedWithCommit: async () => ({ data: associated.map((number) => ({ number })) }),
+    },
+    pulls: {
+      get: async ({ pull_number: pullNumber }) => {
+        const sha = prHeads[pullNumber]
+        if (!sha) throw Object.assign(new Error('Not Found'), { status: 404 })
+        return { data: { head: { sha } } }
+      },
     },
   },
 })
@@ -386,6 +393,44 @@ test('resolvePrNumber falls back to the head sha for forks', async () => {
     claimed: 7,
   })
   assert.equal(number, 7)
+})
+
+// Fork PRs populate neither `workflow_run.pull_requests` nor the
+// commit-association API — the head commit exists only in the fork — so the
+// claim is verified directly against the claimed PR's actual head.
+test('resolvePrNumber verifies the claim via the PR head when no association exists', async () => {
+  const core = stubCore()
+  const number = await resolvePrNumber({
+    github: stubGithub([], { 3704: 'abc123' }),
+    context: stubContext([], 'abc123'),
+    core,
+    claimed: 3704,
+  })
+  assert.equal(number, 3704)
+  assert.deepEqual(core.warnings, [])
+})
+
+test('resolvePrNumber refuses a claim whose PR head does not match the run', async () => {
+  const core = stubCore()
+  const number = await resolvePrNumber({
+    github: stubGithub([], { 3704: 'different-sha' }),
+    context: stubContext([], 'abc123'),
+    core,
+    claimed: 3704,
+  })
+  assert.equal(number, null)
+  assert.match(core.warnings[0], /not labeling/)
+})
+
+test('resolvePrNumber refuses a claim naming a PR that does not exist', async () => {
+  const core = stubCore()
+  const number = await resolvePrNumber({
+    github: stubGithub([], {}),
+    context: stubContext([], 'abc123'),
+    core,
+    claimed: 99999,
+  })
+  assert.equal(number, null)
 })
 
 test('resolvePrNumber refuses when a commit maps to several PRs and nothing is claimed', async () => {


### PR DESCRIPTION
## Description

Fork PRs were never labeled by the PR metrics labeler (#3634). The label workflow ran green but silently applied nothing:

```
no pull request found for head sha e111a73c5b4eb66850ce4e4fc927b17fc876add6
```

**Root cause:** both PR-association sources are empty for forks. `workflow_run.pull_requests` is documented to be empty for fork PRs, and `listPullRequestsAssociatedWithCommit` on the base repository returns `[]` for a commit that exists only in the fork — verified with a full-permission token, so it is not a scoping issue. `resolvePrNumber` then returned null *before ever consulting the PR number the artifact records*.

Observed live on #3704: the analyze job produced a perfectly valid artifact (`size/l`, `complexity/high` 57, claiming PR 3704) and the label job succeeded — with zero labels applied. Same-repository PRs were unaffected (labels apply correctly, verified in run logs).

**Fix:** when no association exists, verify the artifact's claim directly — `pulls.get(claimed)` and honor the claim only if that PR's actual head is the commit this run analyzed.

This does not weaken the trust model. An artifact claiming a different PR only succeeds if that PR's current head **is** the same commit — in which case the metrics were computed on that exact tree and are correct for it by definition. A mismatched head, an unknown PR number, or a lookup failure all refuse and warn, preserving the fail-closed posture.

## Type of Change

Bug fix

## Testing

- Wrote the failing tests first: two new `resolvePrNumber` cases modeling the exact live failure (empty associations + valid claim) failed against main's code, pass with the fix. A third covers a claim naming a nonexistent PR.
- **Replayed the fix against the live failing case through the real GitHub API**: an adapter backed by `gh api`, fed the exact payload of failing run `31179138365` (head sha `e111a73c5…`, empty `pull_requests`, claim `3704`) resolves to `3704`.
- Full suite: 38 tests, 34 pass, 4 skipped (TypeScript analyzer cases without the pinned tools install; they run in CI). Prettier clean.
- Not exercised end-to-end on a real fork PR pre-merge — the label workflow runs from the default branch, so the fix only takes effect after merge. The next fork PR push will confirm; #3704 is a ready-made test case.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.