### PR TITLE
docs(changelog): sync strands-agents/evals backfill

### DIFF
--- a/site/src/content/changelog/evals/v1.1.0.md
+++ b/site/src/content/changelog/evals/v1.1.0.md
@@ -1,0 +1,17 @@
+---
+sdk: evals
+version: "1.1.0"
+tag: v1.1.0
+date: 2026-08-07
+releaseUrl: https://github.com/strands-agents/evals/releases/tag/v1.1.0
+packageUrl: https://pypi.org/project/strands-agents-evals/1.1.0/
+entries:
+  - { type: other, breaking: false, scope: null, areas: [community], title: "update ruff requirement from <0.16.0,>=0.13.0 to >=0.13.0,<0.17.0", pr: 327, prUrl: "https://github.com/strands-agents/evals/pull/327", commit: "0d23f47", commitUrl: "https://github.com/strands-agents/evals/commit/0d23f47", author: "dependabot[bot]" }
+  - { type: feat, breaking: false, scope: evaluators, areas: [evaluators], title: "allow custom tools on judge-based evaluators (Trajectory, Output, Multimodal)", pr: 324, prUrl: "https://github.com/strands-agents/evals/pull/324", commit: "c5461d0", commitUrl: "https://github.com/strands-agents/evals/commit/c5461d0", author: pdebjyot }
+  - { type: feat, breaking: false, scope: null, areas: [tracing], title: "add ADK mapper", pr: 326, prUrl: "https://github.com/strands-agents/evals/pull/326", commit: "0bf1252", commitUrl: "https://github.com/strands-agents/evals/commit/0bf1252", author: liramon2 }
+  - { type: fix, breaking: false, scope: null, areas: [evaluators, tracing], title: "include prior tool results in session_history for tool-level evaluators", pr: 338, prUrl: "https://github.com/strands-agents/evals/pull/338", commit: "cc0a391", commitUrl: "https://github.com/strands-agents/evals/commit/cc0a391", author: liramon2 }
+  - { type: feat, breaking: false, scope: null, areas: [tracing], title: "add integration tests for ADK mapper", pr: 339, prUrl: "https://github.com/strands-agents/evals/pull/339", commit: "5b91a80", commitUrl: "https://github.com/strands-agents/evals/commit/5b91a80", author: liramon2 }
+  - { type: fix, breaking: false, scope: null, areas: [evaluators, tracing], title: "scope tools to owning agent in multi-agent traces", pr: 336, prUrl: "https://github.com/strands-agents/evals/pull/336", commit: "234eae6", commitUrl: "https://github.com/strands-agents/evals/commit/234eae6", author: liramon2 }
+  - { type: fix, breaking: false, scope: test, areas: [tracing], title: "update ADK multi-agent integ test for single-trace design", pr: 352, prUrl: "https://github.com/strands-agents/evals/pull/352", commit: "cf78be1", commitUrl: "https://github.com/strands-agents/evals/commit/cf78be1", author: liramon2 }
+  - { type: fix, breaking: false, scope: redteam, areas: [redteam], title: "reset target session between PAIR/SequentialBreak iterations", pr: 292, prUrl: "https://github.com/strands-agents/evals/pull/292", commit: "21d3f73", commitUrl: "https://github.com/strands-agents/evals/commit/21d3f73", author: kevmyung }
+---


### PR DESCRIPTION
Automated evals changelog backstop.