### PR TITLE
docs: add business KPI best practice to metrics page

### DIFF
--- a/site/src/content/docs/user-guide/observability-evaluation/metrics.mdx
+++ b/site/src/content/docs/user-guide/observability-evaluation/metrics.mdx
@@ -357,4 +357,6 @@ Traces are separate from `AgentMetrics` and are accessed via `result.traces`. No
 
 4. **Benchmark Latency Metrics**: Monitor latency values to establish performance baselines. Compare these metrics across different agent configurations to identify optimal setups.
 
-5. **Regular Metrics Reviews**: Schedule periodic reviews of agent metrics to identify trends and opportunities for optimization. Look for gradual changes in performance that might indicate drift in tool behavior or model responses.
+5. **Combine Technical Metrics with Business KPIs**: In addition to technical metrics, collect and analyze KPIs that measure business outcomes, such as resolution rate, escalation rate, customer satisfaction, and task completion. Track both types of metrics with equal weight to gain a more complete view of overall agent performance. For more information, see the [AWS Well-Architected Framework Agentic AI Lens Design Principles for Operational Excellence](https://docs.aws.amazon.com/wellarchitected/latest/agentic-ai-lens/operational-excellence-design-principles.html).
+
+6. **Regular Metrics Reviews**: Schedule periodic reviews of agent metrics to identify trends and opportunities for optimization. Look for gradual changes in performance that might indicate drift in tool behavior or model responses.


### PR DESCRIPTION
## Description

This PR adds a best practice to the metrics page recommending that teams track business-outcome KPIs (for example, resolution rate, escalation rate, task completion, and customer satisfaction) alongside SDK-generated technical metrics.

Currently, the metrics page primarily focuses on SDK-emitted metrics, which may leave readers with the impression that metrics are limited to what the SDK tracks. In contrast, the Observability page already describes a broader set of metrics, including customer feedback and retention data. As a result, the metrics page's best practices do not reflect that broader scope. This addition aligns with the "Operate by KPIs that map to business outcomes" design principle in the AWS Well-Architected Framework Agentic AI Lens, which is linked for further guidance.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->
Documentation update


## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
