### PR TITLE
fix(openai): classify Bedrock Mantle context-overflow errors

### DIFF
--- a/strands-py/src/strands/models/_openai_errors.py
+++ b/strands-py/src/strands/models/_openai_errors.py
@@ -1,5 +1,6 @@
 """Shared error classification for OpenAI model providers."""
 
+import re
 from typing import Literal
 
 OpenAIErrorKind = Literal["context_overflow", "throttling"]
@@ -14,9 +15,11 @@ _CONTEXT_WINDOW_OVERFLOW_PATTERNS = (
     "input is too long for requested model",
     "input length and `max_tokens` exceed context limit",
     "too many total text bytes",
-    "exceed customer model maximum",
     "exceeds the max_model_len",
 )
+# Providers phrase the token-budget overflow around "model maximum" differently: OpenAI says
+# "exceed customer model maximum", Bedrock Mantle drops the qualifier ("exceed model maximum").
+_CONTEXT_WINDOW_OVERFLOW_REGEX = re.compile(r"exceed(?:s|ed)?(?: customer)? model maximum")
 _RATE_LIMIT_PATTERNS = ("rate_limit_exceeded", "rate limit", "too many requests")
 
 
@@ -33,7 +36,11 @@ def classify_openai_error(error: BaseException) -> OpenAIErrorKind | None:
     ):
         return "throttling"
 
-    if code == "context_length_exceeded" or any(pattern in message for pattern in _CONTEXT_WINDOW_OVERFLOW_PATTERNS):
+    if (
+        code == "context_length_exceeded"
+        or any(pattern in message for pattern in _CONTEXT_WINDOW_OVERFLOW_PATTERNS)
+        or _CONTEXT_WINDOW_OVERFLOW_REGEX.search(message)
+    ):
         return "context_overflow"
 
     return None

--- a/strands-py/tests/strands/models/test_openai_errors.py
+++ b/strands-py/tests/strands/models/test_openai_errors.py
@@ -22,6 +22,9 @@ class OpenAICompatibleError(Exception):
         "too many total text bytes",
         "exceed customer model maximum",
         "the engine prompt length exceeds the max_model_len",
+        # Bedrock Mantle omits the "customer" qualifier
+        # (https://github.com/strands-agents/harness-sdk/issues/3718)
+        "prompt tokens (1200008) exceed model maximum (1050000) for openai.gpt-5.6-terra",
     ],
 )
 def test_classify_openai_error_context_overflow_message(message):
@@ -61,8 +64,16 @@ def test_classify_openai_error_throttling_precedes_context_overflow():
     assert classify_openai_error(error) == "throttling"
 
 
-def test_classify_openai_error_unknown():
-    assert classify_openai_error(OpenAICompatibleError("unrelated failure")) is None
+@pytest.mark.parametrize(
+    "message",
+    [
+        "unrelated failure",
+        "model maximum output tokens must be a positive integer",
+        "requested model openai.gpt-5.6-terra is not available in this region",
+    ],
+)
+def test_classify_openai_error_unknown(message):
+    assert classify_openai_error(OpenAICompatibleError(message)) is None
 
 
 def test_classify_openai_error_non_string_code():

--- a/strands-py/tests/strands/models/test_openai_errors.py
+++ b/strands-py/tests/strands/models/test_openai_errors.py
@@ -22,8 +22,6 @@ class OpenAICompatibleError(Exception):
         "too many total text bytes",
         "exceed customer model maximum",
         "the engine prompt length exceeds the max_model_len",
-        # Bedrock Mantle omits the "customer" qualifier
-        # (https://github.com/strands-agents/harness-sdk/issues/3718)
         "prompt tokens (1200008) exceed model maximum (1050000) for openai.gpt-5.6-terra",
     ],
 )


### PR DESCRIPTION
## Description

`classify_openai_error()` matched Bedrock Mantle's context-overflow message against a list of literal substrings that only contained the OpenAI phrasing `"exceed customer model maximum"`. Mantle drops the `customer` qualifier:

```
prompt tokens (1200008) exceed model maximum (1050000) for openai.gpt-5.6-terra
```

and it reports `code="validation_error"`, so neither the code check nor any substring matched. The classifier returned `None`, `OpenAIResponsesModel.stream()` re-raised the raw vendor error instead of a `ContextWindowOverflowException`, and `Agent._execute_event_loop_cycle`'s `reduce_context()` recovery path never ran. A conversation that the default `SlidingWindowConversationManager` could have trimmed and retried hard-failed instead.

Reproducer on `main`:

```python
from strands.models._openai_errors import classify_openai_error

class FakeError(Exception):
    pass

msg = "prompt tokens (1200008) exceed model maximum (1050000) for openai.gpt-5.6-terra"
print(classify_openai_error(FakeError(msg)))  # None
```

Rather than appending one more literal, the `"model maximum"` family is now matched with a regex that absorbs the qualifier and the verb inflection (`exceed` / `exceeds` / `exceeded`, with or without `customer`). This is the phrase most likely to keep drifting between OpenAI-compatible providers, and a per-provider literal means a patch release every time the wording moves. The other literals are untouched and still matched by plain substring containment, so no existing classification changes.

The regex deliberately still requires the `exceed…` verb — matching on `"model maximum"` alone would classify unrelated validation errors (for example `"model maximum output tokens must be a positive integer"`) as context overflow and trigger a spurious context trim on a failure that trimming cannot fix. There is a test pinning that.

## Related Issues

Fixes https://github.com/strands-agents/harness-sdk/issues/3718

## Documentation PR

No docs change needed — `_openai_errors.py` is internal and the pattern list is not documented.

## Type of Change

Bug fix

## Testing

`tests/strands/models/test_openai_errors.py` gains the real Mantle message to the overflow parametrization, and `test_classify_openai_error_unknown` is parametrized with two adjacent-but-unrelated provider messages so an over-greedy pattern is caught. Verified fail-before/pass-after against the stashed source change (the new case fails with `assert None == 'context_overflow'` without the fix), and mutated the regex both ways — widening it to `model maximum` fails the negative case, narrowing it to `exceed model maximum` fails the existing `exceed customer model maximum` case.

The full unit suite passes (4846 tests), and `hatch fmt --linter --check` is clean (`ruff check` plus `mypy ./src`, no issues in 234 source files).

- [ ] I ran `hatch run prepare` — ran `hatch fmt --formatter --check`, `hatch fmt --linter --check`, and `hatch test`; skipped the `--all` matrix since I only have one interpreter locally. `hatch fmt --formatter --check` flags 13 files, none of them touched here (pre-existing on `main` with the ruff version that resolves locally).

## Deliberately not changed

`strands-ts/src/models/openai/errors.ts` carries the same literal list and the same gap. Keeping this PR to one sub-project per the contribution guidelines; happy to open the TypeScript counterpart separately.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
