### PR TITLE
fix(bidi): emit gemini usage metadata alongside content events

### DIFF
--- a/strands-py/src/strands/experimental/bidi/models/gemini_live.py
+++ b/strands-py/src/strands/experimental/bidi/models/gemini_live.py
@@ -19,7 +19,7 @@ from typing import Any, AsyncGenerator, cast
 
 from google import genai
 from google.genai import types as genai_types
-from google.genai.types import LiveConnectConfigOrDict, LiveServerMessage
+from google.genai.types import LiveConnectConfigOrDict, LiveServerContent, LiveServerMessage, UsageMetadata
 
 from ....types._events import ToolResultEvent, ToolUseStreamEvent
 from ....types.content import Messages
@@ -219,6 +219,9 @@ class BidiGeminiLiveModel(BidiModel):
         - modelTurn text: Text response from the model
         - usageMetadata: Token usage information
 
+        `usageMetadata` sits outside the `messageType` union, so it can accompany any other field and
+        is collected independently of the content events.
+
         Returns:
             List of event dicts (empty list if no events to emit).
 
@@ -230,93 +233,31 @@ class BidiGeminiLiveModel(BidiModel):
                 message.go_away.model_dump_json(), live_session_handle=self._live_session_handle
             )
 
+        events: list[BidiOutputEvent] = []
+
         if message.session_resumption_update:
             resumption_update = message.session_resumption_update
             if resumption_update.resumable and resumption_update.new_handle:
                 self._live_session_handle = resumption_update.new_handle
                 logger.debug("session_handle=<%s> | updating gemini session handle", self._live_session_handle)
-            return []
 
-        # Handle interruption first (from server_content)
-        if message.server_content and message.server_content.interrupted:
-            return [BidiInterruptionEvent(reason="user_speech")]
-
-        # Handle input transcription (user's speech) - emit as transcript event
-        if message.server_content and message.server_content.input_transcription:
-            input_transcript = message.server_content.input_transcription
-            # Check if the transcription object has text content
-            if hasattr(input_transcript, "text") and input_transcript.text:
-                transcription_text = input_transcript.text
-                logger.debug("text_length=<%d> | gemini input transcription detected", len(transcription_text))
-                return [
-                    BidiTranscriptStreamEvent(
-                        delta={"text": transcription_text},
-                        text=transcription_text,
-                        role="user",
-                        # TODO: https://github.com/googleapis/python-genai/issues/1504
-                        is_final=bool(input_transcript.finished),
-                        current_transcript=transcription_text,
-                    )
-                ]
-
-        # Handle output transcription (model's audio) - emit as transcript event
-        if message.server_content and message.server_content.output_transcription:
-            output_transcript = message.server_content.output_transcription
-            # Check if the transcription object has text content
-            if hasattr(output_transcript, "text") and output_transcript.text:
-                transcription_text = output_transcript.text
-                logger.debug("text_length=<%d> | gemini output transcription detected", len(transcription_text))
-                return [
-                    BidiTranscriptStreamEvent(
-                        delta={"text": transcription_text},
-                        text=transcription_text,
-                        role="assistant",
-                        # TODO: https://github.com/googleapis/python-genai/issues/1504
-                        is_final=bool(output_transcript.finished),
-                        current_transcript=transcription_text,
-                    )
-                ]
+        if message.server_content:
+            events.extend(self._convert_server_content(message.server_content, has_audio=bool(message.data)))
 
         # Handle audio output using SDK's built-in data property
-        # Check this BEFORE text to avoid triggering warning on mixed content
         if message.data:
             # Convert bytes to base64 string for JSON serializability
             audio_b64 = base64.b64encode(message.data).decode("utf-8")
-            return [
+            events.append(
                 BidiAudioStreamEvent(
                     audio=audio_b64,
                     format="pcm",
                     sample_rate=cast(AudioSampleRate, self.config["audio"]["output_rate"]),
                     channels=cast(AudioChannel, self.config["audio"]["channels"]),
                 )
-            ]
+            )
 
-        # Handle text output from model_turn (avoids warning by checking parts directly)
-        if message.server_content and message.server_content.model_turn:
-            model_turn = message.server_content.model_turn
-            if model_turn.parts:
-                # Concatenate all text parts (Gemini may send multiple parts)
-                text_parts = []
-                for part in model_turn.parts:
-                    # Check if part has text attribute and it's not empty
-                    if hasattr(part, "text") and part.text:
-                        text_parts.append(part.text)
-
-                if text_parts:
-                    full_text = " ".join(text_parts)
-                    return [
-                        BidiTranscriptStreamEvent(
-                            delta={"text": full_text},
-                            text=full_text,
-                            role="assistant",
-                            is_final=True,
-                            current_transcript=full_text,
-                        )
-                    ]
-
-        # Handle tool calls - return list to support multiple tool calls
         if message.tool_call and message.tool_call.function_calls:
-            tool_events: list[BidiOutputEvent] = []
             for func_call in message.tool_call.function_calls:
                 tool_use_event: ToolUse = {
                     "toolUseId": cast(str, func_call.id),
@@ -324,58 +265,121 @@ class BidiGeminiLiveModel(BidiModel):
                     "input": func_call.args or {},
                 }
                 # Create ToolUseStreamEvent for consistency with standard agent
-                tool_events.append(
+                events.append(
                     ToolUseStreamEvent(delta={"toolUse": tool_use_event}, current_tool_use=dict(tool_use_event))
                 )
-            return tool_events
 
-        # Handle usage metadata
-        if hasattr(message, "usage_metadata") and message.usage_metadata:
-            usage = message.usage_metadata
+        if message.usage_metadata:
+            events.append(self._convert_usage_metadata(message.usage_metadata))
 
-            # Build modality details from token details
-            modality_details = []
+        # setup_complete and generation_complete carry no content and are silently ignored
+        return events
 
-            # Process prompt tokens details
-            if usage.prompt_tokens_details:
-                for detail in usage.prompt_tokens_details:
-                    if detail.modality and detail.token_count:
+    def _convert_server_content(self, server_content: LiveServerContent, has_audio: bool) -> list[BidiOutputEvent]:
+        """Convert the server content of a Gemini Live message.
+
+        Args:
+            server_content: Server content to convert.
+            has_audio: Whether the enclosing message carries audio output. Text from `model_turn` is
+                skipped when it does, since the two represent the same response in different modalities.
+
+        Returns:
+            List of events derived from the server content.
+        """
+        events: list[BidiOutputEvent] = []
+
+        if server_content.interrupted:
+            events.append(BidiInterruptionEvent(reason="user_speech"))
+
+        # Transcriptions arrive independently of other fields and of each other
+        input_transcript = server_content.input_transcription
+        if input_transcript and input_transcript.text:
+            logger.debug("text_length=<%d> | gemini input transcription detected", len(input_transcript.text))
+            events.append(
+                BidiTranscriptStreamEvent(
+                    delta={"text": input_transcript.text},
+                    text=input_transcript.text,
+                    role="user",
+                    # TODO: https://github.com/googleapis/python-genai/issues/1504
+                    is_final=bool(input_transcript.finished),
+                    current_transcript=input_transcript.text,
+                )
+            )
+
+        output_transcript = server_content.output_transcription
+        if output_transcript and output_transcript.text:
+            logger.debug("text_length=<%d> | gemini output transcription detected", len(output_transcript.text))
+            events.append(
+                BidiTranscriptStreamEvent(
+                    delta={"text": output_transcript.text},
+                    text=output_transcript.text,
+                    role="assistant",
+                    # TODO: https://github.com/googleapis/python-genai/issues/1504
+                    is_final=bool(output_transcript.finished),
+                    current_transcript=output_transcript.text,
+                )
+            )
+
+        # Reading model_turn parts directly avoids the mixed-content warning raised by message.data
+        if not has_audio and server_content.model_turn and server_content.model_turn.parts:
+            # Concatenate all text parts (Gemini may send multiple parts)
+            text_parts = [part.text for part in server_content.model_turn.parts if part.text]
+            if text_parts:
+                full_text = " ".join(text_parts)
+                events.append(
+                    BidiTranscriptStreamEvent(
+                        delta={"text": full_text},
+                        text=full_text,
+                        role="assistant",
+                        is_final=True,
+                        current_transcript=full_text,
+                    )
+                )
+
+        return events
+
+    def _convert_usage_metadata(self, usage: UsageMetadata) -> BidiUsageEvent:
+        """Convert Gemini usage metadata into a usage event.
+
+        Args:
+            usage: Usage metadata reported by Gemini.
+
+        Returns:
+            Usage event carrying token counts and per-modality details.
+        """
+        modality_details: list[dict[str, Any]] = []
+
+        if usage.prompt_tokens_details:
+            for detail in usage.prompt_tokens_details:
+                if detail.modality and detail.token_count:
+                    modality_details.append(
+                        {
+                            "modality": str(detail.modality).lower(),
+                            "input_tokens": detail.token_count,
+                            "output_tokens": 0,
+                        }
+                    )
+
+        if usage.response_tokens_details:
+            for detail in usage.response_tokens_details:
+                if detail.modality and detail.token_count:
+                    # Find or create modality entry
+                    modality_str = str(detail.modality).lower()
+                    existing = next((m for m in modality_details if m["modality"] == modality_str), None)
+                    if existing:
+                        existing["output_tokens"] = detail.token_count
+                    else:
                         modality_details.append(
-                            {
-                                "modality": str(detail.modality).lower(),
-                                "input_tokens": detail.token_count,
-                                "output_tokens": 0,
-                            }
+                            {"modality": modality_str, "input_tokens": 0, "output_tokens": detail.token_count}
                         )
 
-            # Process response tokens details
-            if usage.response_tokens_details:
-                for detail in usage.response_tokens_details:
-                    if detail.modality and detail.token_count:
-                        # Find or create modality entry
-                        modality_str = str(detail.modality).lower()
-                        existing = next((m for m in modality_details if m["modality"] == modality_str), None)
-                        if existing:
-                            existing["output_tokens"] = detail.token_count
-                        else:
-                            modality_details.append(
-                                {"modality": modality_str, "input_tokens": 0, "output_tokens": detail.token_count}
-                            )
-
-            return [
-                BidiUsageEvent(
-                    input_tokens=usage.prompt_token_count or 0,
-                    output_tokens=usage.response_token_count or 0,
-                    total_tokens=usage.total_token_count or 0,
-                    modality_details=cast(list[ModalityUsage], modality_details) if modality_details else None,
-                    cache_read_input_tokens=usage.cached_content_token_count
-                    if usage.cached_content_token_count
-                    else None,
-                )
-            ]
-
-        # Silently ignore setup_complete and generation_complete messages
-        return []
+        return BidiUsageEvent(
+            input_tokens=usage.prompt_token_count or 0,
+            output_tokens=usage.response_token_count or 0,
+            total_tokens=usage.total_token_count or 0,
+            modality_details=cast(list[ModalityUsage], modality_details) if modality_details else None,
+            cache_read_input_tokens=usage.cached_content_token_count if usage.cached_content_token_count else None,
+        )
 
     async def send(
         self,

--- a/strands-py/tests/strands/experimental/bidi/models/test_gemini_live.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_gemini_live.py
@@ -571,9 +571,7 @@ async def test_event_conversion(mock_genai_client, model, live_message, server_c
 
 
 @pytest.mark.asyncio
-async def test_usage_metadata_emitted_alongside_audio(
-    mock_genai_client, model, live_message, usage_metadata
-):
+async def test_usage_metadata_emitted_alongside_audio(mock_genai_client, model, live_message, usage_metadata):
     """Usage metadata accompanying content is emitted, not dropped.
 
     Guards https://github.com/strands-agents/harness-sdk/issues/3745 — usageMetadata sits outside the
@@ -587,10 +585,13 @@ async def test_usage_metadata_emitted_alongside_audio(
     events = model._convert_gemini_live_event(message)
 
     assert [type(event) for event in events] == [BidiAudioStreamEvent, BidiUsageEvent]
-    usage_event = events[1]
-    assert usage_event.input_tokens == 10
-    assert usage_event.output_tokens == 20
-    assert usage_event.total_tokens == 30
+    assert events[1] == BidiUsageEvent(
+        input_tokens=10,
+        output_tokens=20,
+        total_tokens=30,
+        modality_details=None,
+        cache_read_input_tokens=None,
+    )
 
     await model.stop()
 
@@ -615,7 +616,15 @@ async def test_usage_metadata_emitted_alongside_session_resumption(
     events = model._convert_gemini_live_event(message)
 
     assert model._live_session_handle == "handle-1"
-    assert [type(event) for event in events] == [BidiUsageEvent]
+    assert events == [
+        BidiUsageEvent(
+            input_tokens=10,
+            output_tokens=20,
+            total_tokens=30,
+            modality_details=None,
+            cache_read_input_tokens=None,
+        )
+    ]
 
     await model.stop()
 
@@ -644,10 +653,15 @@ async def test_usage_metadata_modality_details(mock_genai_client, model, live_me
 
     events = model._convert_gemini_live_event(message)
 
-    assert [type(event) for event in events] == [BidiUsageEvent]
-    usage_event = events[0]
-    assert usage_event.modality_details == [{"modality": "audio", "input_tokens": 7, "output_tokens": 9}]
-    assert usage_event.cache_read_input_tokens == 4
+    assert events == [
+        BidiUsageEvent(
+            input_tokens=10,
+            output_tokens=20,
+            total_tokens=30,
+            modality_details=[{"modality": "audio", "input_tokens": 7, "output_tokens": 9}],
+            cache_read_input_tokens=4,
+        )
+    ]
 
     await model.stop()
 
@@ -668,9 +682,7 @@ async def test_interruption_emitted_alongside_other_server_content(
     mock_output_transcript.text = "partial reply"
     mock_output_transcript.finished = False
 
-    message = live_message(
-        server_content=server_content(interrupted=True, output_transcription=mock_output_transcript)
-    )
+    message = live_message(server_content=server_content(interrupted=True, output_transcription=mock_output_transcript))
 
     events = model._convert_gemini_live_event(message)
 

--- a/strands-py/tests/strands/experimental/bidi/models/test_gemini_live.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_gemini_live.py
@@ -23,6 +23,7 @@ from strands.experimental.bidi.types.events import (
     BidiInterruptionEvent,
     BidiTextInputEvent,
     BidiTranscriptStreamEvent,
+    BidiUsageEvent,
 )
 from strands.types._events import ToolResultEvent
 from strands.types.tools import ToolResult
@@ -47,6 +48,82 @@ def mock_genai_client():
         mock_client.aio.live.connect = unittest.mock.MagicMock(return_value=mock_live_session_cm)
 
         yield mock_client, mock_live_session, mock_live_session_cm
+
+
+@pytest.fixture
+def live_message():
+    """Build a LiveServerMessage-shaped mock with every field defaulted to None.
+
+    Bare Mocks auto-create truthy attributes, so unset fields would be misread as present.
+    """
+
+    def _build(**overrides):
+        message = unittest.mock.Mock()
+        message.data = None
+        message.go_away = None
+        message.session_resumption_update = None
+        message.tool_call = None
+        message.server_content = None
+        message.usage_metadata = None
+
+        for name, value in overrides.items():
+            setattr(message, name, value)
+
+        return message
+
+    return _build
+
+
+@pytest.fixture
+def server_content():
+    """Build a LiveServerContent-shaped mock with every field defaulted to None."""
+
+    def _build(**overrides):
+        content = unittest.mock.Mock()
+        content.interrupted = None
+        content.input_transcription = None
+        content.output_transcription = None
+        content.model_turn = None
+
+        for name, value in overrides.items():
+            setattr(content, name, value)
+
+        return content
+
+    return _build
+
+
+@pytest.fixture
+def usage_metadata():
+    """Build a UsageMetadata-shaped mock with token counts and no modality details."""
+
+    def _build(**overrides):
+        usage = unittest.mock.Mock()
+        usage.prompt_token_count = 10
+        usage.response_token_count = 20
+        usage.total_token_count = 30
+        usage.cached_content_token_count = None
+        usage.prompt_tokens_details = None
+        usage.response_tokens_details = None
+
+        for name, value in overrides.items():
+            setattr(usage, name, value)
+
+        return usage
+
+    return _build
+
+
+@pytest.fixture
+def text_part():
+    """Build a Part-shaped mock carrying text."""
+
+    def _build(text):
+        part = unittest.mock.Mock()
+        part.text = text
+        return part
+
+    return _build
 
 
 @pytest.fixture
@@ -348,16 +425,15 @@ async def test_receive_lifecycle_events(mock_genai_client, model, agenerator):
 
 
 @pytest.mark.asyncio
-async def test_receive_timeout(mock_genai_client, model, agenerator):
-    mock_resumption_response = unittest.mock.Mock()
-    mock_resumption_response.go_away = None
-    mock_resumption_response.session_resumption_update = unittest.mock.Mock()
-    mock_resumption_response.session_resumption_update.resumable = True
-    mock_resumption_response.session_resumption_update.new_handle = "h1"
+async def test_receive_timeout(mock_genai_client, model, agenerator, live_message):
+    mock_resumption_update = unittest.mock.Mock()
+    mock_resumption_update.resumable = True
+    mock_resumption_update.new_handle = "h1"
+    mock_resumption_response = live_message(session_resumption_update=mock_resumption_update)
 
-    mock_timeout_response = unittest.mock.Mock()
-    mock_timeout_response.go_away = unittest.mock.Mock()
-    mock_timeout_response.go_away.model_dump_json.return_value = "test timeout"
+    mock_go_away = unittest.mock.Mock()
+    mock_go_away.model_dump_json.return_value = "test timeout"
+    mock_timeout_response = live_message(go_away=mock_go_away)
 
     _, mock_live_session, _ = mock_genai_client
     mock_live_session.receive = unittest.mock.Mock(
@@ -376,31 +452,15 @@ async def test_receive_timeout(mock_genai_client, model, agenerator):
 
 
 @pytest.mark.asyncio
-async def test_event_conversion(mock_genai_client, model):
+async def test_event_conversion(mock_genai_client, model, live_message, server_content, text_part):
     """Test conversion of all Gemini Live event types to standard format."""
     _, _, _ = mock_genai_client
     await model.start()
 
     # Test text output (converted to transcript via model_turn.parts)
-    mock_text = unittest.mock.Mock()
-    mock_text.data = None
-    mock_text.go_away = None
-    mock_text.session_resumption_update = None
-    mock_text.tool_call = None
-
-    # Create proper server_content structure with model_turn
-    mock_server_content = unittest.mock.Mock()
-    mock_server_content.interrupted = False
-    mock_server_content.input_transcription = None
-    mock_server_content.output_transcription = None
-
     mock_model_turn = unittest.mock.Mock()
-    mock_part = unittest.mock.Mock()
-    mock_part.text = "Hello from Gemini"
-    mock_model_turn.parts = [mock_part]
-    mock_server_content.model_turn = mock_model_turn
-
-    mock_text.server_content = mock_server_content
+    mock_model_turn.parts = [text_part("Hello from Gemini")]
+    mock_text = live_message(server_content=server_content(model_turn=mock_model_turn))
 
     text_events = model._convert_gemini_live_event(mock_text)
     assert isinstance(text_events, list)
@@ -415,26 +475,9 @@ async def test_event_conversion(mock_genai_client, model):
     assert text_event.current_transcript == "Hello from Gemini"
 
     # Test multiple text parts (should concatenate)
-    mock_multi_text = unittest.mock.Mock()
-    mock_multi_text.data = None
-    mock_multi_text.go_away = None
-    mock_multi_text.session_resumption_update = None
-    mock_multi_text.tool_call = None
-
-    mock_server_content_multi = unittest.mock.Mock()
-    mock_server_content_multi.interrupted = False
-    mock_server_content_multi.input_transcription = None
-    mock_server_content_multi.output_transcription = None
-
     mock_model_turn_multi = unittest.mock.Mock()
-    mock_part1 = unittest.mock.Mock()
-    mock_part1.text = "Hello"
-    mock_part2 = unittest.mock.Mock()
-    mock_part2.text = "from Gemini"
-    mock_model_turn_multi.parts = [mock_part1, mock_part2]
-    mock_server_content_multi.model_turn = mock_model_turn_multi
-
-    mock_multi_text.server_content = mock_server_content_multi
+    mock_model_turn_multi.parts = [text_part("Hello"), text_part("from Gemini")]
+    mock_multi_text = live_message(server_content=server_content(model_turn=mock_model_turn_multi))
 
     multi_text_events = model._convert_gemini_live_event(mock_multi_text)
     assert isinstance(multi_text_events, list)
@@ -444,13 +487,7 @@ async def test_event_conversion(mock_genai_client, model):
     assert multi_text_event.text == "Hello from Gemini"  # Concatenated with space
 
     # Test audio output (base64 encoded)
-    mock_audio = unittest.mock.Mock()
-    mock_audio.text = None
-    mock_audio.data = b"audio_data"
-    mock_audio.go_away = None
-    mock_audio.session_resumption_update = None
-    mock_audio.tool_call = None
-    mock_audio.server_content = None
+    mock_audio = live_message(data=b"audio_data")
 
     audio_events = model._convert_gemini_live_event(mock_audio)
     assert isinstance(audio_events, list)
@@ -472,13 +509,7 @@ async def test_event_conversion(mock_genai_client, model):
     mock_tool_call = unittest.mock.Mock()
     mock_tool_call.function_calls = [mock_func_call]
 
-    mock_tool = unittest.mock.Mock()
-    mock_tool.text = None
-    mock_tool.data = None
-    mock_tool.go_away = None
-    mock_tool.session_resumption_update = None
-    mock_tool.tool_call = mock_tool_call
-    mock_tool.server_content = None
+    mock_tool = live_message(tool_call=mock_tool_call)
 
     tool_events = model._convert_gemini_live_event(mock_tool)
     # Should return a list of ToolUseStreamEvent
@@ -505,13 +536,7 @@ async def test_event_conversion(mock_genai_client, model):
     mock_tool_call_multi = unittest.mock.Mock()
     mock_tool_call_multi.function_calls = [mock_func_call_1, mock_func_call_2]
 
-    mock_tool_multi = unittest.mock.Mock()
-    mock_tool_multi.text = None
-    mock_tool_multi.data = None
-    mock_tool_multi.go_away = None
-    mock_tool_multi.session_resumption_update = None
-    mock_tool_multi.tool_call = mock_tool_call_multi
-    mock_tool_multi.server_content = None
+    mock_tool_multi = live_message(tool_call=mock_tool_call_multi)
 
     tool_events_multi = model._convert_gemini_live_event(mock_tool_multi)
     # Should return a list with two ToolUseStreamEvent
@@ -529,18 +554,7 @@ async def test_event_conversion(mock_genai_client, model):
     assert tool_events_multi[1]["delta"]["toolUse"]["input"] == {"location": "Seattle"}
 
     # Test interruption
-    mock_server_content = unittest.mock.Mock()
-    mock_server_content.interrupted = True
-    mock_server_content.input_transcription = None
-    mock_server_content.output_transcription = None
-
-    mock_interrupt = unittest.mock.Mock()
-    mock_interrupt.text = None
-    mock_interrupt.data = None
-    mock_interrupt.go_away = None
-    mock_interrupt.session_resumption_update = None
-    mock_interrupt.tool_call = None
-    mock_interrupt.server_content = mock_server_content
+    mock_interrupt = live_message(server_content=server_content(interrupted=True))
 
     interrupt_events = model._convert_gemini_live_event(mock_interrupt)
     assert isinstance(interrupt_events, list)
@@ -549,6 +563,148 @@ async def test_event_conversion(mock_genai_client, model):
     assert isinstance(interrupt_event, BidiInterruptionEvent)
     assert interrupt_event.get("type") == "bidi_interruption"
     assert interrupt_event.reason == "user_speech"
+
+    await model.stop()
+
+
+# Usage Metadata Tests
+
+
+@pytest.mark.asyncio
+async def test_usage_metadata_emitted_alongside_audio(
+    mock_genai_client, model, live_message, usage_metadata
+):
+    """Usage metadata accompanying content is emitted, not dropped.
+
+    Guards https://github.com/strands-agents/harness-sdk/issues/3745 — usageMetadata sits outside the
+    messageType union, so it can ride along with any content field.
+    """
+    _, _, _ = mock_genai_client
+    await model.start()
+
+    message = live_message(data=b"audio_data", usage_metadata=usage_metadata())
+
+    events = model._convert_gemini_live_event(message)
+
+    assert [type(event) for event in events] == [BidiAudioStreamEvent, BidiUsageEvent]
+    usage_event = events[1]
+    assert usage_event.input_tokens == 10
+    assert usage_event.output_tokens == 20
+    assert usage_event.total_tokens == 30
+
+    await model.stop()
+
+
+@pytest.mark.asyncio
+async def test_usage_metadata_emitted_alongside_session_resumption(
+    mock_genai_client, model, live_message, usage_metadata
+):
+    """Session resumption tracks the handle and still emits co-attached usage metadata.
+
+    Guards https://github.com/strands-agents/harness-sdk/issues/3745 — this branch previously
+    returned early, discarding usage outright.
+    """
+    _, _, _ = mock_genai_client
+    await model.start()
+
+    mock_resumption_update = unittest.mock.Mock()
+    mock_resumption_update.resumable = True
+    mock_resumption_update.new_handle = "handle-1"
+    message = live_message(session_resumption_update=mock_resumption_update, usage_metadata=usage_metadata())
+
+    events = model._convert_gemini_live_event(message)
+
+    assert model._live_session_handle == "handle-1"
+    assert [type(event) for event in events] == [BidiUsageEvent]
+
+    await model.stop()
+
+
+@pytest.mark.asyncio
+async def test_usage_metadata_modality_details(mock_genai_client, model, live_message, usage_metadata):
+    """Prompt and response token details merge into per-modality usage."""
+    _, _, _ = mock_genai_client
+    await model.start()
+
+    prompt_detail = unittest.mock.Mock()
+    prompt_detail.modality = "AUDIO"
+    prompt_detail.token_count = 7
+
+    response_detail = unittest.mock.Mock()
+    response_detail.modality = "AUDIO"
+    response_detail.token_count = 9
+
+    message = live_message(
+        usage_metadata=usage_metadata(
+            prompt_tokens_details=[prompt_detail],
+            response_tokens_details=[response_detail],
+            cached_content_token_count=4,
+        )
+    )
+
+    events = model._convert_gemini_live_event(message)
+
+    assert [type(event) for event in events] == [BidiUsageEvent]
+    usage_event = events[0]
+    assert usage_event.modality_details == [{"modality": "audio", "input_tokens": 7, "output_tokens": 9}]
+    assert usage_event.cache_read_input_tokens == 4
+
+    await model.stop()
+
+
+@pytest.mark.asyncio
+async def test_interruption_emitted_alongside_other_server_content(
+    mock_genai_client, model, live_message, server_content
+):
+    """An interruption is emitted even when other server content fields are set.
+
+    Guards https://github.com/strands-agents/harness-sdk/issues/3745 — interrupted may co-occur with
+    other serverContent fields and must not swallow them.
+    """
+    _, _, _ = mock_genai_client
+    await model.start()
+
+    mock_output_transcript = unittest.mock.Mock()
+    mock_output_transcript.text = "partial reply"
+    mock_output_transcript.finished = False
+
+    message = live_message(
+        server_content=server_content(interrupted=True, output_transcription=mock_output_transcript)
+    )
+
+    events = model._convert_gemini_live_event(message)
+
+    assert [type(event) for event in events] == [BidiInterruptionEvent, BidiTranscriptStreamEvent]
+
+    await model.stop()
+
+
+@pytest.mark.asyncio
+async def test_audio_takes_precedence_over_model_turn_text(
+    mock_genai_client, model, live_message, server_content, text_part
+):
+    """Audio output suppresses model_turn text, avoiding a duplicate event for one response."""
+    _, _, _ = mock_genai_client
+    await model.start()
+
+    mock_model_turn = unittest.mock.Mock()
+    mock_model_turn.parts = [text_part("Hello from Gemini")]
+    message = live_message(data=b"audio_data", server_content=server_content(model_turn=mock_model_turn))
+
+    events = model._convert_gemini_live_event(message)
+
+    assert [type(event) for event in events] == [BidiAudioStreamEvent]
+
+    await model.stop()
+
+
+@pytest.mark.asyncio
+async def test_empty_message_emits_nothing(mock_genai_client, model, live_message):
+    """A message carrying no content and no usage yields no events."""
+    _, _, _ = mock_genai_client
+    await model.start()
+
+    assert model._convert_gemini_live_event(live_message()) == []
 
     await model.stop()
 
@@ -660,7 +816,7 @@ def test_tool_formatting(model, tool_spec):
 
 
 @pytest.mark.asyncio
-async def test_custom_audio_rates_in_events(mock_genai_client, model_id, api_key):
+async def test_custom_audio_rates_in_events(mock_genai_client, model_id, api_key, live_message):
     """Test that audio events use configured sample rates and channels."""
     _, _, _ = mock_genai_client
 
@@ -670,13 +826,7 @@ async def test_custom_audio_rates_in_events(mock_genai_client, model_id, api_key
     await model.start()
 
     # Test audio output event uses custom configuration
-    mock_audio = unittest.mock.Mock()
-    mock_audio.text = None
-    mock_audio.data = b"audio_data"
-    mock_audio.go_away = None
-    mock_audio.session_resumption_update = None
-    mock_audio.tool_call = None
-    mock_audio.server_content = None
+    mock_audio = live_message(data=b"audio_data")
 
     audio_events = model._convert_gemini_live_event(mock_audio)
     assert len(audio_events) == 1
@@ -691,7 +841,7 @@ async def test_custom_audio_rates_in_events(mock_genai_client, model_id, api_key
 
 
 @pytest.mark.asyncio
-async def test_default_audio_rates_in_events(mock_genai_client, model_id, api_key):
+async def test_default_audio_rates_in_events(mock_genai_client, model_id, api_key, live_message):
     """Test that audio events use default sample rates when no custom config."""
     _, _, _ = mock_genai_client
 
@@ -700,13 +850,7 @@ async def test_default_audio_rates_in_events(mock_genai_client, model_id, api_ke
     await model.start()
 
     # Test audio output event uses defaults
-    mock_audio = unittest.mock.Mock()
-    mock_audio.text = None
-    mock_audio.data = b"audio_data"
-    mock_audio.go_away = None
-    mock_audio.session_resumption_update = None
-    mock_audio.tool_call = None
-    mock_audio.server_content = None
+    mock_audio = live_message(data=b"audio_data")
 
     audio_events = model._convert_gemini_live_event(mock_audio)
     assert len(audio_events) == 1


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

Gemini's Live API sends token usage in a usageMetadata field that sits outside the messageType union. Per the Gemini Live Api reference: 
> "Server messages may have a usageMetadata field but will otherwise include exactly one of the other fields." So usage can accompany audio, a tool call, or aresumption update.

`BidiGeminiLiveModel._convert_gemini_live_event`'s implementation was such that any message with both content and usage lost the usage. The loss is silent and cumulative:
  `_BidiAgentLoop._run_model` accumulates session token counters solely from BidiUsageEvent, so every dropped event undercounts the session with no error. This restructures the converter to accumulate into a list. Control messages stay exclusive content messages append, and usage is evaluated unconditionally at the end. 
  
  The list-accumulating shape also unblocks emitting multiple events per message, needed for the missing BidiResponseStartEvent / BidiResponseCompleteEvent for google gemini live model provider change left to a follow-up.
## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix


## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [ ] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
