### PR TITLE
docs: add prescriptive guidance for keeping cognitive complexity low

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ Before designing a feature or changing an API, read the relevant context in `tea
 ## Writing Code
 
 - **Code conventions**: Follow the conventions in the sub-project's own `AGENTS.md` (`strands-py/AGENTS.md`, `strands-ts/AGENTS.md`, `site/AGENTS.md`) — they define the style, patterns, and directory layout for that toolchain.
-- **Write flat control flow**: every PR is labeled with the [cognitive complexity](https://www.sonarsource.com/docs/CognitiveComplexity.pdf) of the most complex function it touches, and nesting is what drives the score. Return early with guard clauses, extract nested logic into named helpers, and prefer lookup tables over `if`/`elif` ladders. Techniques and thresholds: [CONTRIBUTING.md](./CONTRIBUTING.md#keeping-complexity-low). Check before pushing with `npm run complexity` (or `hatch run complexity` from `strands-py/`).
+- **Design and write for low complexity**: every PR is labeled with the [cognitive complexity](https://www.sonarsource.com/docs/CognitiveComplexity.pdf) of the most complex function it touches. Decompose before writing (one function one job, decisions separate from I/O, variants as data), write flat control flow (guard clauses, extracted helpers, lookup tables over branch ladders), and keep refactors in their own PR. Full guidance: [team/COMPLEXITY.md](./team/COMPLEXITY.md). Check before pushing with `npm run complexity` (or `hatch run complexity` from `strands-py/`).
 - **Branching**: `git checkout -b agent-tasks/{ISSUE_NUMBER}`
 - **Commits**: Use [conventional commits](https://www.conventionalcommits.org/) — `feat:`, `fix:`, `refactor:`, `docs:`, etc.
 - **CI**: The `ci.yml` merge gate detects which paths changed and runs only relevant checks.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ Before designing a feature or changing an API, read the relevant context in `tea
 ## Writing Code
 
 - **Code conventions**: Follow the conventions in the sub-project's own `AGENTS.md` (`strands-py/AGENTS.md`, `strands-ts/AGENTS.md`, `site/AGENTS.md`) — they define the style, patterns, and directory layout for that toolchain.
+- **Write flat control flow**: every PR is labeled with the [cognitive complexity](https://www.sonarsource.com/docs/CognitiveComplexity.pdf) of the most complex function it touches, and nesting is what drives the score. Return early with guard clauses, extract nested logic into named helpers, and prefer lookup tables over `if`/`elif` ladders. Techniques and thresholds: [CONTRIBUTING.md](./CONTRIBUTING.md#keeping-complexity-low). Check before pushing with `npm run complexity` (or `hatch run complexity` from `strands-py/`).
 - **Branching**: `git checkout -b agent-tasks/{ISSUE_NUMBER}`
 - **Commits**: Use [conventional commits](https://www.conventionalcommits.org/) — `feat:`, `fix:`, `refactor:`, `docs:`, etc.
 - **CI**: The `ci.yml` merge gate detects which paths changed and runs only relevant checks.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ Before designing a feature or changing an API, read the relevant context in `tea
 ## Writing Code
 
 - **Code conventions**: Follow the conventions in the sub-project's own `AGENTS.md` (`strands-py/AGENTS.md`, `strands-ts/AGENTS.md`, `site/AGENTS.md`) — they define the style, patterns, and directory layout for that toolchain.
-- **Design and write for low complexity**: every PR is labeled with the [cognitive complexity](https://www.sonarsource.com/docs/CognitiveComplexity.pdf) of the most complex function it touches. Decompose before writing (one function one job, decisions separate from I/O, variants as data), write flat control flow (guard clauses, extracted helpers, lookup tables over branch ladders), and keep refactors in their own PR. Full guidance: [team/COMPLEXITY.md](./team/COMPLEXITY.md). Check before pushing with `npm run complexity` (or `hatch run complexity` from `strands-py/`).
+- **Write for low complexity**: every PR is labeled with the [cognitive complexity](https://www.sonarsource.com/docs/CognitiveComplexity.pdf) of the most complex function it touches, and nesting drives the score. Write flat control flow (guard clauses, extracted helpers, lookup tables over branch ladders) and keep refactors in their own PR. Why we measure and how the score works: [team/COMPLEXITY.md](./team/COMPLEXITY.md). Check before pushing with `npm run complexity` (or `hatch run complexity` from `strands-py/`).
 - **Branching**: `git checkout -b agent-tasks/{ISSUE_NUMBER}`
 - **Commits**: Use [conventional commits](https://www.conventionalcommits.org/) — `feat:`, `fix:`, `refactor:`, `docs:`, etc.
 - **CI**: The `ci.yml` merge gate detects which paths changed and runs only relevant checks.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,6 +219,44 @@ splitting, not a rule; sometimes a complex function is the honest solution.
 
 A docs-only or test-only PR touches no SDK source and gets no complexity label.
 
+#### Keeping complexity low
+
+Two things drive the score, and knowing them is most of the battle:
+
+1. Every break in linear flow costs one point: `if`, `else`, loops,
+   `catch`/`except`, ternaries, `switch`/`match`, recursion, and each run of
+   mixed boolean operators.
+2. **Nesting multiplies the cost.** Each structure also pays one point per
+   level of nesting it sits inside. An `if` at the top of a function costs 1;
+   the same `if` three levels deep costs 4.
+
+Because nesting is the multiplier, flattening is the highest-leverage move:
+
+- **Return early.** Guard clauses (`if not valid: return`) remove a nesting
+  level from everything that follows. Avoid `else` after a `return`.
+- **Extract nested logic into named helpers.** The nesting penalty resets to
+  zero inside the helper, the name documents intent, and the label keys on the
+  most complex single function you touched, so splitting one deep function into
+  three shallow ones directly lowers it.
+- **Prefer lookup tables over branch ladders.** A dict or `Map` from value to
+  handler replaces an `if`/`elif` or `switch` chain with zero branches.
+- **Keep boolean sequences uniform and name the pieces.** `a and b and c` costs
+  one point; mixing `and`/`or` costs more. `is_retryable = ...` beats a long
+  inline condition twice over: cheaper and self-describing.
+- **Handle errors at the edges.** One `try` around a coherent block costs less
+  than error handling threaded through nested branches.
+- **In async code, await sequentially** instead of nesting callbacks or `then`
+  chains.
+
+For calibration: the median function in both SDKs scores 1 to 2, and
+`complexity/low` (10 or less) covers roughly nine out of ten existing
+functions, so the thresholds leave generous room for ordinary logic. Some code
+is honestly complex, though. Protocol event converters and state machines often
+land at `high` because the domain has that many cases, and flattening them
+further would hurt readability. When that is your situation, keep the function
+and say so in the PR description rather than contorting the code to move a
+label.
+
 ## Using AI Tools
 
 We love AI. We build with coding agents every day, and you're welcome to use them too — they're a great way to move fast and explore a codebase.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,43 +219,11 @@ splitting, not a rule; sometimes a complex function is the honest solution.
 
 A docs-only or test-only PR touches no SDK source and gets no complexity label.
 
-#### Keeping complexity low
-
-Two things drive the score, and knowing them is most of the battle:
-
-1. Every break in linear flow costs one point: `if`, `else`, loops,
-   `catch`/`except`, ternaries, `switch`/`match`, recursion, and each run of
-   mixed boolean operators.
-2. **Nesting multiplies the cost.** Each structure also pays one point per
-   level of nesting it sits inside. An `if` at the top of a function costs 1;
-   the same `if` three levels deep costs 4.
-
-Because nesting is the multiplier, flattening is the highest-leverage move:
-
-- **Return early.** Guard clauses (`if not valid: return`) remove a nesting
-  level from everything that follows. Avoid `else` after a `return`.
-- **Extract nested logic into named helpers.** The nesting penalty resets to
-  zero inside the helper, the name documents intent, and the label keys on the
-  most complex single function you touched, so splitting one deep function into
-  three shallow ones directly lowers it.
-- **Prefer lookup tables over branch ladders.** A dict or `Map` from value to
-  handler replaces an `if`/`elif` or `switch` chain with zero branches.
-- **Keep boolean sequences uniform and name the pieces.** `a and b and c` costs
-  one point; mixing `and`/`or` costs more. `is_retryable = ...` beats a long
-  inline condition twice over: cheaper and self-describing.
-- **Handle errors at the edges.** One `try` around a coherent block costs less
-  than error handling threaded through nested branches.
-- **In async code, await sequentially** instead of nesting callbacks or `then`
-  chains.
-
-For calibration: the median function in both SDKs scores 1 to 2, and
-`complexity/low` (10 or less) covers roughly nine out of ten existing
-functions, so the thresholds leave generous room for ordinary logic. Some code
-is honestly complex, though. Protocol event converters and state machines often
-land at `high` because the domain has that many cases, and flattening them
-further would hurt readability. When that is your situation, keep the function
-and say so in the PR description rather than contorting the code to move a
-label.
+The labels exist because review attention is the scarcest resource this
+project has: they let maintainers triage which PRs need an unhurried senior
+read, and they give you the same signal locally before a reviewer sees it. The
+reasoning, the scoring model, and the practices that keep code under the
+thresholds live in [team/COMPLEXITY.md](./team/COMPLEXITY.md).
 
 ## Using AI Tools
 

--- a/team/COMPLEXITY.md
+++ b/team/COMPLEXITY.md
@@ -119,19 +119,8 @@ the label against the code; a sentence of context settles it.
 
 ## Check before you push
 
-From the repository root:
-
-```bash
-npm run complexity:setup   # once, to install the analyzers
-npm run complexity         # the labels your branch will receive
-```
-
-Python contributors can use hatch instead, from `strands-py/`:
-
-```bash
-cd strands-py
-hatch run complexity
-```
-
-The output lists the most complex functions your diff touches, so you know
-exactly which one drives the label.
+The commands live in
+[CONTRIBUTING.md](../CONTRIBUTING.md#pr-size-and-complexity): `npm run
+complexity` from the repository root, or `hatch run complexity` from
+`strands-py/`. The output lists the most complex functions your diff touches,
+so you know exactly which one drives the label.

--- a/team/COMPLEXITY.md
+++ b/team/COMPLEXITY.md
@@ -1,0 +1,137 @@
+# Code Complexity
+
+Every PR is labeled with the [cognitive complexity](https://www.sonarsource.com/docs/CognitiveComplexity.pdf)
+of the most complex function it touches: `complexity/low` (10 or less),
+`complexity/medium` (11 to 25), or `complexity/high` (above 25). This document
+is the reasoning behind that label and the practices that keep code under it.
+
+## Why we measure it, publicly
+
+**It is our first tenet made measurable.** "Simple at any scale" is easy to
+agree with and hard to hold: complexity arrives one reasonable-looking `if` at
+a time. Cognitive complexity is an imperfect but reproducible proxy for how
+hard control flow is to follow, applied at the moment complexity actually
+enters the codebase: the PR.
+
+**Review attention is the scarcest resource we have.** This repository
+routinely carries around two hundred open PRs. The labels let maintainers
+triage at a glance: a `size/s complexity/low` PR can be reviewed between
+meetings, while `complexity/high` deserves an unhurried senior read. Without
+the label, that triage happens anyway, just later and more expensively, inside
+the review.
+
+**A metric depersonalizes the conversation.** "Please split this function" is
+an easier request to make and to receive when it points at a number both
+sides can reproduce locally, rather than at one reviewer's taste. The same
+command CI uses runs on your machine and produces the same result
+(see [Check before you push](#check-before-you-push)).
+
+**Authors see it before reviewers do.** The label is computed from your diff,
+scoped to functions you actually touched. A pre-existing hotspot elsewhere in
+a file you edited does not count against you, so the signal is about your
+change, and it reaches you first.
+
+The label is advisory. It never blocks a merge, and
+[some code is honestly complex](#when-high-is-honest).
+
+## How the score works
+
+Two rules produce the whole number:
+
+1. Every break in linear flow costs one point: `if`, `else`, loops,
+   `catch`/`except`, ternaries, `switch`/`match`, recursion, and each run of
+   mixed boolean operators.
+2. **Nesting multiplies the cost.** Each structure also pays one point per
+   level of nesting it sits inside. An `if` at the top of a function costs 1;
+   the same `if` three levels deep costs 4.
+
+For calibration: the median function in both SDKs scores 1 to 2, and
+`complexity/low` covers roughly nine out of ten existing functions. The
+thresholds leave generous room for ordinary logic.
+
+## Design it simple
+
+The cheapest complexity to remove is the kind never written. Before the first
+line:
+
+- **One function, one job.** If an accurate name for the function needs the
+  word "and", it is two functions.
+- **Separate deciding from doing.** Compute what should happen with pure
+  logic that returns a value or a plan, then act on it in a thin outer layer.
+  Pure decision functions score flat and test without mocks.
+- **Keep I/O at the edges.** Network, disk, and model calls belong in the
+  outer shell; the core transforms data. Interleaving them forces error
+  handling into every branch, and every branch pays nesting.
+- **Represent variants as data, not conditionals.** If several call sites
+  branch on the same kind, encode the variants once in a table, a dataclass,
+  or a discriminated union, and let each site look up instead of re-deriving.
+- **Let the tests push back.** A unit that needs heavy mocking or long setup
+  to test is telling you it does too much. Splitting it usually lowers the
+  score as a side effect.
+
+## Write it flat
+
+Because nesting is the multiplier, flattening is the highest-leverage
+technique while writing:
+
+- **Return early.** Guard clauses (`if not valid: return`) remove a nesting
+  level from everything that follows. Avoid `else` after a `return`.
+- **Extract nested logic into named helpers.** The nesting penalty resets to
+  zero inside the helper, the name documents intent, and the label keys on the
+  most complex single function you touched, so splitting one deep function
+  into three shallow ones directly lowers it.
+- **Prefer lookup tables over branch ladders.** A dict or `Map` from value to
+  handler replaces an `if`/`elif` or `switch` chain with zero branches.
+- **Keep boolean sequences uniform and name the pieces.** `a and b and c`
+  costs one point; mixing `and`/`or` costs more. `is_retryable = ...` beats a
+  long inline condition twice over: cheaper and self-describing.
+- **Handle errors at the edges.** One `try` around a coherent block costs
+  less than error handling threaded through nested branches.
+- **In async code, await sequentially** instead of nesting callbacks or
+  `then` chains.
+
+These are not hypothetical. A deliberately nested dispatch function scoring 23
+drops to a maximum of 4 across three functions when rewritten with exactly
+these techniques, with behavior unchanged.
+
+## Keep the change simple
+
+Complexity is also a property of the diff, not just the code:
+
+- **Make the change easy, then make the easy change.** If a feature needs
+  restructuring first, land the preparatory refactor as its own PR and the
+  small behavior change on top. Two easy reviews beat one hard one, and the
+  refactor PR proves itself with unchanged tests.
+- **When your change lands in an already-complex function, extract rather
+  than deepen.** Pull the piece you need to touch into a helper and change it
+  there. Do not refactor the parts you are not touching; drive-by rewrites
+  make the diff harder to trust.
+- **Do not fear thorough tests.** The `size/*` label excludes test files, so
+  testing generously never pushes your PR into a bigger bucket.
+
+## When high is honest
+
+Protocol event converters, state machines, and exhaustive format mappings
+often land at `high` because the domain genuinely has that many cases, and
+flattening them further would hurt readability. When that is your situation,
+keep the function's shape and say so in the PR description. Reviewers weigh
+the label against the code; a sentence of context settles it.
+
+## Check before you push
+
+From the repository root:
+
+```bash
+npm run complexity:setup   # once, to install the analyzers
+npm run complexity         # the labels your branch will receive
+```
+
+Python contributors can use hatch instead, from `strands-py/`:
+
+```bash
+cd strands-py
+hatch run complexity
+```
+
+The output lists the most complex functions your diff touches, so you know
+exactly which one drives the label.

--- a/team/COMPLEXITY.md
+++ b/team/COMPLEXITY.md
@@ -49,46 +49,35 @@ For calibration: the median function in both SDKs scores 1 to 2, and
 `complexity/low` covers roughly nine out of ten existing functions. The
 thresholds leave generous room for ordinary logic.
 
-## Design it simple
+## Working with the score
 
-The cheapest complexity to remove is the kind never written. Before the first
-line:
+This is not a rewrite of general code etiquette; each point here is listed
+because of how the scoring model prices it.
 
-- **One function, one job.** If an accurate name for the function needs the
-  word "and", it is two functions.
-- **Separate deciding from doing.** Compute what should happen with pure
-  logic that returns a value or a plan, then act on it in a thin outer layer.
-  Pure decision functions score flat and test without mocks.
-- **Keep I/O at the edges.** Network, disk, and model calls belong in the
-  outer shell; the core transforms data. Interleaving them forces error
-  handling into every branch, and every branch pays nesting.
-- **Represent variants as data, not conditionals.** If several call sites
-  branch on the same kind, encode the variants once in a table, a dataclass,
-  or a discriminated union, and let each site look up instead of re-deriving.
-- **Let the tests push back.** A unit that needs heavy mocking or long setup
-  to test is telling you it does too much. Splitting it usually lowers the
-  score as a side effect.
+Two design choices pay off before any code exists. Pure decision logic
+separated from I/O scores flat, because interleaving them forces error
+handling into every branch and every branch pays nesting. And variants encoded
+once as data (a table, a dataclass, a discriminated union) let every call site
+look up instead of re-deriving the branch ladder, which the model charges for
+at each site.
 
-## Write it flat
-
-Because nesting is the multiplier, flattening is the highest-leverage
-technique while writing:
+While writing, nesting is the multiplier, so flattening is the
+highest-leverage technique:
 
 - **Return early.** Guard clauses (`if not valid: return`) remove a nesting
   level from everything that follows. Avoid `else` after a `return`.
 - **Extract nested logic into named helpers.** The nesting penalty resets to
-  zero inside the helper, the name documents intent, and the label keys on the
-  most complex single function you touched, so splitting one deep function
-  into three shallow ones directly lowers it.
+  zero inside the helper, and the label keys on the most complex single
+  function you touched, so splitting one deep function into three shallow
+  ones directly lowers it.
 - **Prefer lookup tables over branch ladders.** A dict or `Map` from value to
   handler replaces an `if`/`elif` or `switch` chain with zero branches.
 - **Keep boolean sequences uniform and name the pieces.** `a and b and c`
-  costs one point; mixing `and`/`or` costs more. `is_retryable = ...` beats a
-  long inline condition twice over: cheaper and self-describing.
+  costs one point; mixing `and`/`or` costs more.
 - **Handle errors at the edges.** One `try` around a coherent block costs
   less than error handling threaded through nested branches.
 - **In async code, await sequentially** instead of nesting callbacks or
-  `then` chains.
+  `then` chains, which each pay the nesting increment.
 
 These are not hypothetical. A deliberately nested dispatch function scoring 23
 drops to a maximum of 4 across three functions when rewritten with exactly

--- a/team/README.md
+++ b/team/README.md
@@ -12,6 +12,7 @@ This folder contains internal documentation about how the Strands team builds an
 | [FEATURE_LIFECYCLE.md](./FEATURE_LIFECYCLE.md) | How features are added, marked experimental, and deprecated under semantic versioning |
 | [PR.md](./PR.md) | Pull request description guidelines (applies to both SDKs) |
 | [COMPATIBILITY.md](./COMPATIBILITY.md) | What changes are not considered breaking under semantic versioning (both SDKs) |
+| [COMPLEXITY.md](./COMPLEXITY.md) | Why PRs are labeled by cognitive complexity and how to keep code under the thresholds |
 | [AGENT_GUIDELINES.md](./AGENT_GUIDELINES.md) | Guidelines for AI agents that interact with Strands repositories |
 | [designs/](./designs/) | Design proposals for significant features (RFC-style) |
 


### PR DESCRIPTION
## Description

Adds prescriptive, public guidance for the `complexity/*` label, structured so each document carries only what its readers need:

**`team/COMPLEXITY.md` (new)** is the canonical document, placed in `team/` because that is where this repository keeps its reasoning. It covers:

- **Why the metric is public**: it is the "Simple at any scale" tenet made measurable; it lets maintainers triage scarce review attention across ~200 open PRs; a reproducible number depersonalizes the "please split this" conversation; and authors see the signal locally before any reviewer does.
- **The scoring model**: one point per break in linear flow, plus one per nesting level, so nesting is the multiplier. Calibrated against this repo (median function scores 1 to 2; `low` covers ~90% of existing functions).
- **Guidance at three altitudes**, not just flattening:
  - *Design it simple*: one function one job, separate deciding from doing, I/O at the edges, variants as data, tests as a pressure gauge.
  - *Write it flat*: guard clauses, extracted helpers, lookup tables over branch ladders, uniform named booleans, errors at the edges, sequential await.
  - *Keep the change simple*: preparatory refactors as their own PR ("make the change easy, then make the easy change"), extract rather than deepen when landing in an already-complex function, and test generously since `size/*` excludes tests.
- **When high is honest**: protocol converters and state machines may correctly stay complex; say so in the description instead of contorting code to move a label.

**CONTRIBUTING.md** stays small: what the labels are, one paragraph on why, how to run the check locally, and a pointer to the team doc.

**AGENTS.md** gets one Writing Code bullet so agents see the expectation before writing, linking to the team doc.

## Type of Change

Documentation update

## Testing

The techniques are verified against the real analyzer rather than asserted. A deliberately nested `process()` scores **23** with complexipy; rewritten with exactly the documented techniques (guard clauses, a dispatch table, one extraction) and unchanged behavior, the maximum touched function scores **4**:

```
nested.py    process      complexity=23
flat.py      process      complexity=4
flat.py      _convert     complexity=3
```

Calibration numbers come from measuring both SDKs during threshold selection (strands-py p50=1, p90=12; strands-ts p50=2, p90=9). All cross-document links and in-document anchors verified against rendered heading slugs. Docs-only change; no code paths to exercise.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
