### PR TITLE
docs(community): add Zep memory integration

### DIFF
--- a/site/src/content/catalog/zep-strands.yaml
+++ b/site/src/content/catalog/zep-strands.yaml
@@ -1,0 +1,9 @@
+name: zep-strands
+description: Long-term memory for Strands agents backed by Zep's temporal knowledge graph, with context injection, server-side extraction, and graph search.
+integrationType: memory-store
+languages:
+  python:
+    package: zep-strands
+github: https://github.com/getzep/zep
+docsUrl: https://help.getzep.com/strands-memory/
+addedDate: 2026-08-10


### PR DESCRIPTION
## Integration submission

**Package name:** zep-strands
**Integration type:** memory-store
**Languages published:** Python
**GitHub repo:** https://github.com/getzep/zep
**What it does:** Provides a native Strands `MemoryStore` backed by Zep's temporal knowledge graph, giving agents long-term memory through context injection before each user turn, server-side extraction from conversations, and on-demand graph search.
**Relationship to service:** official vendor integration (published and documented by Zep)
**Docs link included:** docsUrl: https://help.getzep.com/strands-memory/

### Submitter checklist

#### Package
- [x] This is a reusable integration (library/plugin/provider), not an example agent or application built with Strands
- [x] Published to PyPI and/or npm under the exact `package` name in my entry (registry links are derived from it) — or this is a guide-only entry (no `package` in any language block) with a `docsUrl` pointing at the vendor's Strands guide
- [x] GitHub repository is public and includes a license

#### Entry
- [x] Description accurately states what the package does in one sentence
- [x] `integrationType` matches what the package actually is
- [x] All URLs are working (`github`, and `docsUrl` if set)
- [x] `addedDate` is set to today (the date I opened this PR)
- [x] `featured` and `badges` are left unset — those are granted by the Strands team

#### Docs (only if setting a `docsUrl`)
- [x] The linked page documents using this integration with Strands Agents

#### Conduct
- [ ] I am the package maintainer, or I have the maintainer's explicit consent to list it
- [x] Entry uses the package's real name with no trademark misuse

Note: this entry lists Zep's own published integration (the `zep-strands` package and its Strands guide are authored and hosted by Zep), added from the Strands side rather than by the package maintainer.
