### PR TITLE
feat(storage-py): add top level storage

### DIFF
--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -67,6 +67,7 @@ from ..plugins.registry import _PluginRegistry
 from ..sandbox import Sandbox
 from ..sandbox.not_a_sandbox_local_environment import NotASandboxLocalEnvironment
 from ..session.session_manager import SessionManager
+from ..storage import Storage
 from ..telemetry.metrics import EventLoopMetrics
 from ..telemetry.tracer import get_tracer, serialize
 from ..tools._caller import _ToolCaller
@@ -192,6 +193,7 @@ class Agent(AgentBase):
         concurrent_invocation_mode: ConcurrentInvocationMode = ConcurrentInvocationMode.THROW,
         checkpointing: bool = False,
         sandbox: Sandbox | None = None,
+        storage: Storage | None = None,
     ):
         """Initialize the Agent with the specified configuration.
 
@@ -243,9 +245,10 @@ class Agent(AgentBase):
                 using benchmark-validated defaults. If ``conversation_manager`` is also provided,
                 the user's conversation manager is used instead. Defaults to None (no context management).
 
-                Note: The offloader uses in-memory storage that does not persist across process
-                restarts. For agents using ``session_manager``, provide an explicit
-                ``ContextOffloader`` with durable storage via the ``plugins`` parameter.
+                Note: The offloader uses in-memory storage by default. When an agent-level
+                ``storage`` is provided, the offloader uses that instead. Alternatively,
+                provide an explicit ``ContextOffloader`` with its own storage via the
+                ``plugins`` parameter.
             plugins: List of Plugin instances to extend agent functionality.
                 Plugins are initialized with the agent instance after construction and can register hooks,
                 modify agent attributes, or perform other setup tasks.
@@ -292,6 +295,12 @@ class Agent(AgentBase):
                 ``context.agent.sandbox``. Defaults to ``None``, which falls back to a
                 :class:`~strands.sandbox.NotASandboxLocalEnvironment` that runs on the host
                 with no isolation.
+            storage: Default storage backend for agent subsystems.
+                When provided, subsystems that do not have their own explicit storage
+                (e.g., ContextOffloader) resolve from this value. Each subsystem
+                auto-namespaces under its own prefix (e.g., ``offloader/``) to avoid key
+                collisions. Storage specified directly on a subsystem always takes
+                precedence over this agent-level default. Defaults to None.
 
         Raises:
             ValueError: If agent id contains path separators.
@@ -302,6 +311,7 @@ class Agent(AgentBase):
             raise TypeError(f"sandbox must be a Sandbox instance or None, got {type(sandbox).__name__}")
         # Resolve once: configured sandbox, or this agent's own host default (not shared across agents).
         self._sandbox: Sandbox = sandbox or NotASandboxLocalEnvironment()
+        self._storage: Storage | None = storage
         # initializing self._system_prompt for backwards compatibility
         self._system_prompt, self._system_prompt_content = split_system_prompt(system_prompt)
         self._default_structured_output_model = structured_output_model
@@ -532,7 +542,7 @@ class Agent(AgentBase):
         if context_manager is None:
             return None, None
 
-        from ..vended_plugins.context_offloader import ContextOffloader, InMemoryStorage
+        from ..vended_plugins.context_offloader import ContextOffloader
         from .conversation_manager import SummarizingConversationManager
 
         if context_manager == "auto":
@@ -559,7 +569,6 @@ class Agent(AgentBase):
         if not has_offloader:
             resolved_plugins.append(
                 ContextOffloader(
-                    storage=InMemoryStorage(),
                     max_result_tokens=offloader_max_result_tokens,
                     preview_tokens=_CONTEXT_MANAGER_PREVIEW_TOKENS,
                 )
@@ -631,6 +640,11 @@ class Agent(AgentBase):
         configured.
         """
         return self._sandbox
+
+    @property
+    def storage(self) -> Storage | None:
+        """Default storage backend for agent subsystems."""
+        return self._storage
 
     @property
     def system_prompt(self) -> str | None:

--- a/strands-py/src/strands/session/repository_session_manager.py
+++ b/strands-py/src/strands/session/repository_session_manager.py
@@ -26,7 +26,13 @@ logger = logging.getLogger(__name__)
 
 
 class RepositorySessionManager(SessionManager):
-    """Session manager for persisting agents in a SessionRepository."""
+    """Session manager for persisting agents in a SessionRepository.
+
+    This manager uses a :class:`SessionRepository` (a structured per-message CRUD interface),
+    not the unified :class:`~strands.storage.storage.Storage` protocol. It does not resolve
+    from the agent-level ``storage`` parameter. For snapshot-based persistence that integrates
+    with agent-level storage, use :class:`~strands.session.snapshot_session_manager.SnapshotSessionManager`.
+    """
 
     def __init__(
         self,
@@ -166,6 +172,8 @@ class RepositorySessionManager(SessionManager):
             "model_state": copy.deepcopy(current_model_state),
         }
 
+    _warned_storage_ignored: bool = False
+
     def initialize(self, agent: "Agent", **kwargs: Any) -> None:
         """Initialize an agent with a session.
 
@@ -173,6 +181,13 @@ class RepositorySessionManager(SessionManager):
             agent: Agent to initialize from the session
             **kwargs: Additional keyword arguments for future extensibility.
         """
+        if not RepositorySessionManager._warned_storage_ignored and agent.storage is not None:
+            RepositorySessionManager._warned_storage_ignored = True
+            logger.warning(
+                "agent_id=<%s> | agent-level storage is set but RepositorySessionManager does not use it;"
+                " use SnapshotSessionManager for unified storage integration",
+                agent.agent_id,
+            )
         if agent.agent_id in self._latest_agent_message:
             raise SessionException("The `agent_id` of an agent must be unique in a session.")
         self._latest_agent_message[agent.agent_id] = None

--- a/strands-py/src/strands/session/repository_session_manager.py
+++ b/strands-py/src/strands/session/repository_session_manager.py
@@ -34,6 +34,9 @@ class RepositorySessionManager(SessionManager):
     with agent-level storage, use :class:`~strands.session.snapshot_session_manager.SnapshotSessionManager`.
     """
 
+    # Process-global to avoid repeated log noise when multiple instances see agent-level storage.
+    _warned_storage_ignored: bool = False
+
     def __init__(
         self,
         session_id: str,
@@ -171,8 +174,6 @@ class RepositorySessionManager(SessionManager):
             "conversation_manager_state": copy.deepcopy(current_conversation_manager_state),
             "model_state": copy.deepcopy(current_model_state),
         }
-
-    _warned_storage_ignored: bool = False
 
     def initialize(self, agent: "Agent", **kwargs: Any) -> None:
         """Initialize an agent with a session.

--- a/strands-py/src/strands/session/snapshot_session_manager.py
+++ b/strands-py/src/strands/session/snapshot_session_manager.py
@@ -215,9 +215,10 @@ class SnapshotSessionManager(SessionManager):
 
         Args:
             session_id: Unique session identifier. Must not contain path separators.
-            storage: Unified storage backend that persists snapshot blobs. Defaults to
-                :class:`~strands.storage.local_file_storage.LocalFileStorage`, which writes
-                under the local filesystem.
+            storage: Unified storage backend that persists snapshot blobs. When None,
+                resolves from the agent-level ``storage`` during initialization; if no
+                agent-level storage is available, falls back to
+                :class:`~strands.storage.local_file_storage.LocalFileStorage`.
             save_latest_on: When to overwrite ``snapshot_latest``. See :data:`SaveLatestStrategy`.
             snapshot_trigger: Optional callback invoked after each invocation; when it
                 returns True an immutable snapshot is appended for checkpointing. An immutable
@@ -239,9 +240,19 @@ class SnapshotSessionManager(SessionManager):
             # Silently accepting an unknown value would register no save hooks — the session
             # would persist nothing with no error.
             raise ValueError(f"save_latest_on must be one of {_SAVE_LATEST_STRATEGIES}, got {save_latest_on!r}")
-        self._storage = _resolve_storage(storage if storage is not None else LocalFileStorage())
+        self._storage: Storage | None = _resolve_storage(storage) if storage is not None else None
         self._save_latest_on: SaveLatestStrategy = save_latest_on
         self._snapshot_trigger = snapshot_trigger
+
+    @property
+    def _resolved_storage(self) -> Storage:
+        """Return the resolved storage, raising if not yet initialized."""
+        if self._storage is None:
+            raise RuntimeError(
+                "SnapshotSessionManager requires a storage backend. "
+                "Provide storage in the constructor or set storage on the Agent."
+            )
+        return self._storage
 
     def register_hooks(self, registry: HookRegistry, **kwargs: Any) -> None:
         """Register lifecycle callbacks for snapshot persistence.
@@ -289,6 +300,8 @@ class SnapshotSessionManager(SessionManager):
             agent: Agent to restore.
             **kwargs: Additional keyword arguments for future extensibility.
         """
+        if self._storage is None:
+            self._storage = _resolve_storage(agent.storage if agent.storage is not None else LocalFileStorage())
         run_async(lambda: self._initialize_async(agent))
 
     def sync_agent(self, agent: "Agent", **kwargs: Any) -> None:
@@ -354,7 +367,7 @@ class SnapshotSessionManager(SessionManager):
             _validate_snapshot_id(start_after)
 
         history_prefix = f"{_snapshots_prefix(self.session_id, agent.agent_id)}{_IMMUTABLE_HISTORY}/"
-        keys = await self._storage.list(history_prefix)
+        keys = await self._resolved_storage.list(history_prefix)
         ids = sorted(match.group(1) for key in keys if (match := _SNAPSHOT_REGEX.search(key)))
         if start_after is not None:
             ids = [snapshot_id for snapshot_id in ids if snapshot_id > start_after]
@@ -396,17 +409,19 @@ class SnapshotSessionManager(SessionManager):
         """
         data = _serialize_snapshot(self._capture(agent))
         snapshot_id = None if is_latest else _new_snapshot_id()
-        await self._storage.write(_snapshot_key(self.session_id, agent.agent_id, snapshot_id=snapshot_id), data)
+        key = _snapshot_key(self.session_id, agent.agent_id, snapshot_id=snapshot_id)
+        await self._resolved_storage.write(key, data)
         return snapshot_id
 
     async def delete_session(self) -> None:
         """Delete all snapshots for this session."""
-        keys = await self._storage.list(_session_prefix(self.session_id))
+        storage = self._resolved_storage
+        keys = await storage.list(_session_prefix(self.session_id))
         semaphore = asyncio.Semaphore(_DELETE_CONCURRENCY)
 
         async def _delete(key: str) -> None:
             async with semaphore:
-                await self._storage.delete(key)
+                await storage.delete(key)
 
         await asyncio.gather(*(_delete(key) for key in keys))
 
@@ -436,7 +451,8 @@ class SnapshotSessionManager(SessionManager):
 
     async def _restore(self, agent: "Agent", *, snapshot_id: str | None = None) -> bool:
         """Load a snapshot into the agent. Returns False if none exists."""
-        data = await self._storage.read(_snapshot_key(self.session_id, agent.agent_id, snapshot_id=snapshot_id))
+        key = _snapshot_key(self.session_id, agent.agent_id, snapshot_id=snapshot_id)
+        data = await self._resolved_storage.read(key)
         if data is None:
             return False
         agent.load_snapshot(_deserialize_snapshot(data))
@@ -454,8 +470,10 @@ class SnapshotSessionManager(SessionManager):
         but never a ``snapshot_latest`` pointing at history that was never written.
         """
         data = _serialize_snapshot(self._capture(agent))
-        await self._storage.write(_snapshot_key(self.session_id, agent.agent_id, snapshot_id=_new_snapshot_id()), data)
-        await self._storage.write(_snapshot_key(self.session_id, agent.agent_id, snapshot_id=None), data)
+        await self._resolved_storage.write(
+            _snapshot_key(self.session_id, agent.agent_id, snapshot_id=_new_snapshot_id()), data
+        )
+        await self._resolved_storage.write(_snapshot_key(self.session_id, agent.agent_id, snapshot_id=None), data)
 
     async def _on_message_added(self, event: MessageAddedEvent) -> None:
         """Save latest after each message under the ``"message"`` strategy."""

--- a/strands-py/src/strands/session/snapshot_session_manager.py
+++ b/strands-py/src/strands/session/snapshot_session_manager.py
@@ -296,6 +296,9 @@ class SnapshotSessionManager(SessionManager):
     def initialize(self, agent: "Agent", **kwargs: Any) -> None:
         """Restore the agent from its latest snapshot, if one exists.
 
+        Storage is resolved on the first call and cached; a single manager instance should not be
+        shared across agents with differing storage backends.
+
         Args:
             agent: Agent to restore.
             **kwargs: Additional keyword arguments for future extensibility.

--- a/strands-py/src/strands/vended_memory_stores/test_memory_store/store.py
+++ b/strands-py/src/strands/vended_memory_stores/test_memory_store/store.py
@@ -84,9 +84,12 @@ class TestMemoryStore(MemoryStore):
     of entries), not production workloads — use a managed store like ``BedrockKnowledgeBaseStore`` for
     that. Writes within one event loop are serialized; concurrent writers across processes are not.
 
-    Persistence is backed by the unified :class:`~strands.storage.Storage` interface: ``persist=True``
-    (the default) uses a :class:`~strands.storage.LocalFileStorage`, ``persist=False`` an ephemeral
-    :class:`~strands.storage.InMemoryStorage`.
+    Persistence is backed by the unified :class:`~strands.storage.Storage` interface internally:
+    ``persist=True`` (the default) uses a :class:`~strands.storage.LocalFileStorage`, ``persist=False``
+    an ephemeral :class:`~strands.storage.InMemoryStorage`. Unlike other subsystems
+    (SnapshotSessionManager, ContextOffloader), this store does not accept an external ``Storage``
+    or resolve from the agent-level ``storage`` — it manages its own backend via ``persist`` and
+    ``path``.
 
     The on-disk format is shared with the TypeScript SDK's ``TestMemoryStore``: records use the same
     camelCase keys (``id``, ``content``, ``metadata``, ``createdAt``) and the same timestamp shape, so

--- a/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
@@ -308,7 +308,7 @@ class ContextOffloader(Plugin):
             return self._storage
         storage = self._storage_by_agent.get(agent)
         if storage is None:
-            storage = self._storage.for_sandbox(agent.sandbox)
+            storage = self._storage.for_sandbox(agent.sandbox)  # type: ignore[union-attr]
             self._storage_by_agent[agent] = storage
         return storage
 

--- a/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
@@ -223,7 +223,7 @@ class ContextOffloader(Plugin):
 
     def __init__(
         self,
-        storage: Storage | _LegacyStorage,
+        storage: Storage | _LegacyStorage | None = None,
         max_result_tokens: int = _DEFAULT_MAX_RESULT_TOKENS,
         preview_tokens: int = _DEFAULT_PREVIEW_TOKENS,
         *,
@@ -235,8 +235,10 @@ class ContextOffloader(Plugin):
 
         Args:
             storage: Backend for storing offloaded content. Accepts either a unified
-                ``Storage`` (from ``strands.storage``) or a legacy offloader ``Storage``
-                (from this module).
+                ``Storage`` (from ``strands.storage``), a legacy offloader ``Storage``
+                (from this module), or None. When None, resolves from the agent-level
+                storage during initialization; if no agent-level storage is available,
+                falls back to in-memory storage.
             max_result_tokens: Offload results whose estimated token count exceeds this
                 threshold. Defaults to ``_DEFAULT_MAX_RESULT_TOKENS`` (2,500).
             preview_tokens: Number of tokens to keep as a text preview in context.
@@ -265,8 +267,8 @@ class ContextOffloader(Plugin):
         if evict_after_cycles is not None and (not isinstance(evict_after_cycles, int) or evict_after_cycles < 1):
             raise ValueError("evict_after_cycles must be a positive integer or None")
 
-        self._raw_storage: Storage | _LegacyStorage = storage
-        self._storage: Storage | _LegacyStorage = self._resolve_storage(storage)
+        self._raw_storage: Storage | _LegacyStorage | None = storage
+        self._storage: Storage | _LegacyStorage | None = self._resolve_storage(storage) if storage is not None else None
         self._storage_by_agent: weakref.WeakKeyDictionary[Agent, Storage | _LegacyStorage] = weakref.WeakKeyDictionary()
         self._max_result_tokens = max_result_tokens
         self._preview_tokens = preview_tokens
@@ -296,7 +298,12 @@ class ContextOffloader(Plugin):
 
         Returns:
             The storage instance for this agent.
+
+        Raises:
+            RuntimeError: If called before init_agent has resolved storage.
         """
+        if self._storage is None:
+            raise RuntimeError("ContextOffloader storage not initialized; call init_agent first")
         if not hasattr(self._storage, "for_sandbox"):
             return self._storage
         storage = self._storage_by_agent.get(agent)
@@ -307,6 +314,11 @@ class ContextOffloader(Plugin):
 
     def init_agent(self, agent: Agent) -> None:
         """Conditionally register the retrieval tool and bind storage."""
+        if self._storage is None:
+            if agent.storage is not None:
+                self._storage = self._resolve_storage(agent.storage)
+            else:
+                self._storage = InMemoryStorage()
         if isinstance(self._storage, InMemoryStorage):
             self._storage._bind(id(agent))
         # Bind file-based storage to this agent's sandbox up front (no-op for other backends).
@@ -318,6 +330,8 @@ class ContextOffloader(Plugin):
     @hook
     async def _on_before_model_call(self, event: BeforeModelCallEvent) -> None:
         """Trigger eviction of stale entries based on the agent's cycle count."""
+        if self._storage is None:
+            return
         cycle = event.agent.event_loop_metrics.cycle_count
         if isinstance(self._storage, InMemoryStorage):
             self._storage._evict(cycle)
@@ -600,7 +614,7 @@ class ContextOffloader(Plugin):
 
     def _track_stored_cycle(self, agent: Agent, ref: str, cycle: int) -> None:
         """Record the cycle at which a key was stored (unified Storage eviction)."""
-        if not _is_offloader_storage(self._storage):
+        if self._storage is not None and not _is_offloader_storage(self._storage):
             agent_cycles = self._stored_cycles.get(agent)
             if agent_cycles is None:
                 agent_cycles = {}
@@ -623,9 +637,7 @@ class ContextOffloader(Plugin):
         """
         cycle = agent.event_loop_metrics.cycle_count
         self._track_stored_cycle(agent, reference, cycle)
-        logger.debug(
-            "reference=<%s>, cycle=<%d> | retrieve refreshed eviction cycle", reference, cycle
-        )
+        logger.debug("reference=<%s>, cycle=<%d> | retrieve refreshed eviction cycle", reference, cycle)
 
     def _slice_preview(self, text: str) -> str:
         """Slice text to approximately preview_tokens using character-based estimation.

--- a/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/plugin.py
@@ -313,7 +313,11 @@ class ContextOffloader(Plugin):
         return storage
 
     def init_agent(self, agent: Agent) -> None:
-        """Conditionally register the retrieval tool and bind storage."""
+        """Conditionally register the retrieval tool and bind storage.
+
+        Storage is resolved on the first call and cached for the instance lifetime; a single
+        ContextOffloader should not be shared across agents with differing storage backends.
+        """
         if self._storage is None:
             if agent.storage is not None:
                 self._storage = self._resolve_storage(agent.storage)

--- a/strands-py/tests/strands/agent/test_agent_storage.py
+++ b/strands-py/tests/strands/agent/test_agent_storage.py
@@ -1,7 +1,7 @@
 """Tests for agent-level default storage."""
 
 import logging
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -17,99 +17,11 @@ from tests.fixtures.mocked_model_provider import MockedModelProvider
 SIMPLE_RESPONSE = [{"role": "assistant", "content": [{"text": "ok"}]}]
 
 
-class TestAgentStorageProperty:
-    def test_storage_defaults_to_none(self):
-        agent = Agent(model=MockedModelProvider(SIMPLE_RESPONSE))
-        assert agent.storage is None
+@pytest.fixture
+def mock_agent_for_session():
+    """Return a mock agent suitable for SnapshotSessionManager.initialize."""
 
-    def test_storage_returns_configured_value(self):
-        storage = MagicMock()
-        storage.write = AsyncMock()
-        storage.read = AsyncMock(return_value=None)
-        storage.delete = AsyncMock()
-        storage.list = AsyncMock(return_value=[])
-        agent = Agent(model=MockedModelProvider(SIMPLE_RESPONSE), storage=storage)
-        assert agent.storage is storage
-
-
-class TestOffloaderResolvesAgentStorage:
-    def test_offloader_uses_agent_storage_when_no_explicit_storage(self):
-        storage = UnifiedInMemoryStorage()
-        offloader = ContextOffloader(include_retrieval_tool=False)
-        agent = MagicMock()
-        agent.storage = storage
-
-        offloader.init_agent(agent)
-
-        assert offloader._storage is not None
-        assert isinstance(offloader._storage, _NamespacedStorage)
-        assert offloader._storage._namespaced is _NAMESPACED
-
-    def test_offloader_falls_back_to_in_memory_when_no_agent_storage(self):
-        offloader = ContextOffloader(include_retrieval_tool=False)
-        agent = MagicMock()
-        agent.storage = None
-
-        offloader.init_agent(agent)
-
-        assert offloader._storage is not None
-        assert isinstance(offloader._storage, OffloaderInMemoryStorage)
-
-    def test_explicit_offloader_storage_overrides_agent_storage(self):
-        agent_storage = UnifiedInMemoryStorage()
-        explicit_storage = OffloaderInMemoryStorage()
-        offloader = ContextOffloader(storage=explicit_storage, include_retrieval_tool=False)
-        agent = MagicMock()
-        agent.storage = agent_storage
-
-        offloader.init_agent(agent)
-
-        assert offloader._storage is explicit_storage
-
-    def test_explicit_unified_storage_overrides_agent_storage(self):
-        agent_storage = UnifiedInMemoryStorage()
-        explicit_storage = UnifiedInMemoryStorage()
-        offloader = ContextOffloader(storage=explicit_storage, include_retrieval_tool=False)
-        agent = MagicMock()
-        agent.storage = agent_storage
-
-        offloader.init_agent(agent)
-
-        assert offloader._storage is not agent_storage
-        assert isinstance(offloader._storage, _NamespacedStorage)
-
-    def test_offloader_namespaces_agent_storage_under_offloader(self):
-        storage = UnifiedInMemoryStorage()
-        offloader = ContextOffloader(include_retrieval_tool=False)
-        agent = MagicMock()
-        agent.storage = storage
-
-        offloader.init_agent(agent)
-
-        assert isinstance(offloader._storage, _NamespacedStorage)
-        assert offloader._storage._prefix == "offloader/"
-
-
-class TestContextManagerUsesAgentStorage:
-    def test_auto_context_manager_offloader_resolves_agent_storage(self):
-        storage = UnifiedInMemoryStorage()
-        agent = Agent(model=MockedModelProvider(SIMPLE_RESPONSE), storage=storage, context_manager="auto")
-
-        offloader = None
-        for plugin in agent._plugin_registry._plugins.values():
-            if isinstance(plugin, ContextOffloader):
-                offloader = plugin
-                break
-
-        assert offloader is not None
-        assert isinstance(offloader._storage, _NamespacedStorage)
-        assert offloader._storage._prefix == "offloader/"
-
-
-class TestSnapshotSessionManagerResolvesAgentStorage:
-    def test_session_manager_uses_agent_storage_when_no_explicit_storage(self):
-        storage = UnifiedInMemoryStorage()
-        session_mgr = SnapshotSessionManager("test-session")
+    def _make(storage=None):
         agent = MagicMock()
         agent.storage = storage
         agent.agent_id = "agent-1"
@@ -118,73 +30,177 @@ class TestSnapshotSessionManagerResolvesAgentStorage:
         agent.model.stateful = False
         agent.take_snapshot = MagicMock(return_value=MagicMock())
         agent.load_snapshot = MagicMock()
+        return agent
 
-        session_mgr.initialize(agent)
-
-        assert session_mgr._storage is not None
-        assert isinstance(session_mgr._storage, _NamespacedStorage)
-
-    def test_session_manager_falls_back_to_local_file_when_no_agent_storage(self):
-        session_mgr = SnapshotSessionManager("test-session")
-        agent = MagicMock()
-        agent.storage = None
-        agent.agent_id = "agent-1"
-        agent.messages = []
-        agent.model = MagicMock()
-        agent.model.stateful = False
-        agent.take_snapshot = MagicMock(return_value=MagicMock())
-        agent.load_snapshot = MagicMock()
-
-        session_mgr.initialize(agent)
-
-        assert session_mgr._storage is not None
-        assert isinstance(session_mgr._storage, _NamespacedStorage)
-
-    def test_explicit_session_storage_overrides_agent_storage(self):
-        agent_storage = UnifiedInMemoryStorage()
-        explicit_storage = UnifiedInMemoryStorage()
-        session_mgr = SnapshotSessionManager("test-session", storage=explicit_storage)
-        agent = MagicMock()
-        agent.storage = agent_storage
-        agent.agent_id = "agent-1"
-        agent.messages = []
-        agent.model = MagicMock()
-        agent.model.stateful = False
-        agent.take_snapshot = MagicMock(return_value=MagicMock())
-        agent.load_snapshot = MagicMock()
-
-        session_mgr.initialize(agent)
-
-        assert isinstance(session_mgr._storage, _NamespacedStorage)
-        # Should be wrapping the explicit storage, not the agent storage
-        assert session_mgr._storage._storage is explicit_storage
+    return _make
 
 
-class TestSnapshotSessionManagerResolvedStorageGuard:
-    def test_resolved_storage_raises_when_not_initialized(self):
-        session_mgr = SnapshotSessionManager("test-session")
-
-        with pytest.raises(RuntimeError, match="SnapshotSessionManager requires a storage backend"):
-            _ = session_mgr._resolved_storage
+# --- Agent.storage property ---
 
 
-class TestOffloaderStorageGuard:
-    def test_storage_for_agent_raises_when_not_initialized(self):
-        offloader = ContextOffloader(include_retrieval_tool=False)
-        agent = MagicMock()
+def test_storage_defaults_to_none():
+    agent = Agent(model=MockedModelProvider(SIMPLE_RESPONSE))
+    assert agent.storage is None
 
-        with pytest.raises(RuntimeError, match="ContextOffloader storage not initialized"):
-            offloader._storage_for_agent(agent)
 
-    @pytest.mark.asyncio
-    async def test_on_before_model_call_returns_early_when_storage_is_none(self):
-        offloader = ContextOffloader(include_retrieval_tool=False)
-        event = MagicMock()
+def test_storage_returns_configured_value():
+    storage = MagicMock()
+    agent = Agent(model=MockedModelProvider(SIMPLE_RESPONSE), storage=storage)
+    assert agent.storage is storage
 
-        await offloader._on_before_model_call(event)
+
+# --- ContextOffloader resolves agent-level storage ---
+
+
+def test_offloader_uses_agent_storage_when_no_explicit_storage():
+    storage = UnifiedInMemoryStorage()
+    offloader = ContextOffloader(include_retrieval_tool=False)
+    agent = MagicMock()
+    agent.storage = storage
+
+    offloader.init_agent(agent)
+
+    assert offloader._storage is not None
+    assert isinstance(offloader._storage, _NamespacedStorage)
+    assert offloader._storage._namespaced is _NAMESPACED
+
+
+def test_offloader_falls_back_to_in_memory_when_no_agent_storage():
+    offloader = ContextOffloader(include_retrieval_tool=False)
+    agent = MagicMock()
+    agent.storage = None
+
+    offloader.init_agent(agent)
+
+    assert offloader._storage is not None
+    assert isinstance(offloader._storage, OffloaderInMemoryStorage)
+
+
+def test_explicit_offloader_storage_overrides_agent_storage():
+    agent_storage = UnifiedInMemoryStorage()
+    explicit_storage = OffloaderInMemoryStorage()
+    offloader = ContextOffloader(storage=explicit_storage, include_retrieval_tool=False)
+    agent = MagicMock()
+    agent.storage = agent_storage
+
+    offloader.init_agent(agent)
+
+    assert offloader._storage is explicit_storage
+
+
+def test_explicit_unified_storage_overrides_agent_storage():
+    agent_storage = UnifiedInMemoryStorage()
+    explicit_storage = UnifiedInMemoryStorage()
+    offloader = ContextOffloader(storage=explicit_storage, include_retrieval_tool=False)
+    agent = MagicMock()
+    agent.storage = agent_storage
+
+    offloader.init_agent(agent)
+
+    assert offloader._storage is not agent_storage
+    assert isinstance(offloader._storage, _NamespacedStorage)
+
+
+def test_offloader_namespaces_agent_storage_under_offloader():
+    storage = UnifiedInMemoryStorage()
+    offloader = ContextOffloader(include_retrieval_tool=False)
+    agent = MagicMock()
+    agent.storage = storage
+
+    offloader.init_agent(agent)
+
+    assert isinstance(offloader._storage, _NamespacedStorage)
+    assert offloader._storage._prefix == "offloader/"
+
+
+# --- context_manager="auto" integration ---
+
+
+def test_auto_context_manager_offloader_resolves_agent_storage():
+    storage = UnifiedInMemoryStorage()
+    agent = Agent(model=MockedModelProvider(SIMPLE_RESPONSE), storage=storage, context_manager="auto")
+
+    offloader = None
+    for plugin in agent._plugin_registry._plugins.values():
+        if isinstance(plugin, ContextOffloader):
+            offloader = plugin
+            break
+
+    assert offloader is not None
+    assert isinstance(offloader._storage, _NamespacedStorage)
+    assert offloader._storage._prefix == "offloader/"
+
+
+# --- SnapshotSessionManager resolves agent-level storage ---
+
+
+def test_session_manager_uses_agent_storage_when_no_explicit_storage(mock_agent_for_session):
+    storage = UnifiedInMemoryStorage()
+    session_mgr = SnapshotSessionManager("test-session")
+
+    session_mgr.initialize(mock_agent_for_session(storage=storage))
+
+    assert session_mgr._storage is not None
+    assert isinstance(session_mgr._storage, _NamespacedStorage)
+
+
+def test_session_manager_falls_back_to_local_file_when_no_agent_storage(mock_agent_for_session):
+    session_mgr = SnapshotSessionManager("test-session")
+
+    session_mgr.initialize(mock_agent_for_session(storage=None))
+
+    assert session_mgr._storage is not None
+    assert isinstance(session_mgr._storage, _NamespacedStorage)
+
+
+def test_explicit_session_storage_overrides_agent_storage(mock_agent_for_session):
+    agent_storage = UnifiedInMemoryStorage()
+    explicit_storage = UnifiedInMemoryStorage()
+    session_mgr = SnapshotSessionManager("test-session", storage=explicit_storage)
+
+    session_mgr.initialize(mock_agent_for_session(storage=agent_storage))
+
+    assert isinstance(session_mgr._storage, _NamespacedStorage)
+    assert session_mgr._storage._storage is explicit_storage
+
+
+# --- Guard path coverage ---
+
+
+def test_resolved_storage_raises_when_not_initialized():
+    session_mgr = SnapshotSessionManager("test-session")
+
+    with pytest.raises(RuntimeError, match="SnapshotSessionManager requires a storage backend"):
+        _ = session_mgr._resolved_storage
+
+
+def test_storage_for_agent_raises_when_not_initialized():
+    offloader = ContextOffloader(include_retrieval_tool=False)
+    agent = MagicMock()
+
+    with pytest.raises(RuntimeError, match="ContextOffloader storage not initialized"):
+        offloader._storage_for_agent(agent)
+
+
+@pytest.mark.asyncio
+async def test_on_before_model_call_returns_early_when_storage_is_none():
+    offloader = ContextOffloader(include_retrieval_tool=False)
+    event = MagicMock()
+    event.agent = MagicMock()
+    event.agent.event_loop_metrics = MagicMock()
+    event.agent.event_loop_metrics.cycle_count = 1
+
+    await offloader._on_before_model_call(event)
+
+    assert offloader._storage is None
+
+
+# --- RepositorySessionManager warn-once ---
 
 
 class TestRepositorySessionManagerWarnOnce:
+    """Uses setup_method to reset the process-global flag between tests."""
+
     def setup_method(self):
         RepositorySessionManager._warned_storage_ignored = False
 

--- a/strands-py/tests/strands/agent/test_agent_storage.py
+++ b/strands-py/tests/strands/agent/test_agent_storage.py
@@ -1,0 +1,156 @@
+"""Tests for agent-level default storage."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from strands import Agent
+from strands.session.snapshot_session_manager import SnapshotSessionManager
+from strands.storage.in_memory_storage import InMemoryStorage as UnifiedInMemoryStorage
+from strands.storage.storage import _NAMESPACED, _NamespacedStorage
+from strands.vended_plugins.context_offloader import ContextOffloader
+from strands.vended_plugins.context_offloader.storage import InMemoryStorage as OffloaderInMemoryStorage
+from tests.fixtures.mocked_model_provider import MockedModelProvider
+
+SIMPLE_RESPONSE = [{"role": "assistant", "content": [{"text": "ok"}]}]
+
+
+class TestAgentStorageProperty:
+    def test_storage_defaults_to_none(self):
+        agent = Agent(model=MockedModelProvider(SIMPLE_RESPONSE))
+        assert agent.storage is None
+
+    def test_storage_returns_configured_value(self):
+        storage = MagicMock()
+        storage.write = AsyncMock()
+        storage.read = AsyncMock(return_value=None)
+        storage.delete = AsyncMock()
+        storage.list = AsyncMock(return_value=[])
+        agent = Agent(model=MockedModelProvider(SIMPLE_RESPONSE), storage=storage)
+        assert agent.storage is storage
+
+
+class TestOffloaderResolvesAgentStorage:
+    def test_offloader_uses_agent_storage_when_no_explicit_storage(self):
+        storage = UnifiedInMemoryStorage()
+        offloader = ContextOffloader(include_retrieval_tool=False)
+        agent = MagicMock()
+        agent.storage = storage
+
+        offloader.init_agent(agent)
+
+        assert offloader._storage is not None
+        assert isinstance(offloader._storage, _NamespacedStorage)
+        assert offloader._storage._namespaced is _NAMESPACED
+
+    def test_offloader_falls_back_to_in_memory_when_no_agent_storage(self):
+        offloader = ContextOffloader(include_retrieval_tool=False)
+        agent = MagicMock()
+        agent.storage = None
+
+        offloader.init_agent(agent)
+
+        assert offloader._storage is not None
+        assert isinstance(offloader._storage, OffloaderInMemoryStorage)
+
+    def test_explicit_offloader_storage_overrides_agent_storage(self):
+        agent_storage = UnifiedInMemoryStorage()
+        explicit_storage = OffloaderInMemoryStorage()
+        offloader = ContextOffloader(storage=explicit_storage, include_retrieval_tool=False)
+        agent = MagicMock()
+        agent.storage = agent_storage
+
+        offloader.init_agent(agent)
+
+        assert offloader._storage is explicit_storage
+
+    def test_explicit_unified_storage_overrides_agent_storage(self):
+        agent_storage = UnifiedInMemoryStorage()
+        explicit_storage = UnifiedInMemoryStorage()
+        offloader = ContextOffloader(storage=explicit_storage, include_retrieval_tool=False)
+        agent = MagicMock()
+        agent.storage = agent_storage
+
+        offloader.init_agent(agent)
+
+        assert offloader._storage is not agent_storage
+        assert isinstance(offloader._storage, _NamespacedStorage)
+
+    def test_offloader_namespaces_agent_storage_under_offloader(self):
+        storage = UnifiedInMemoryStorage()
+        offloader = ContextOffloader(include_retrieval_tool=False)
+        agent = MagicMock()
+        agent.storage = storage
+
+        offloader.init_agent(agent)
+
+        assert isinstance(offloader._storage, _NamespacedStorage)
+        assert offloader._storage._prefix == "offloader/"
+
+
+class TestContextManagerUsesAgentStorage:
+    def test_auto_context_manager_offloader_resolves_agent_storage(self):
+        storage = UnifiedInMemoryStorage()
+        agent = Agent(model=MockedModelProvider(SIMPLE_RESPONSE), storage=storage, context_manager="auto")
+
+        offloader = None
+        for plugin in agent._plugin_registry._plugins.values():
+            if isinstance(plugin, ContextOffloader):
+                offloader = plugin
+                break
+
+        assert offloader is not None
+        assert isinstance(offloader._storage, _NamespacedStorage)
+        assert offloader._storage._prefix == "offloader/"
+
+
+class TestSnapshotSessionManagerResolvesAgentStorage:
+    def test_session_manager_uses_agent_storage_when_no_explicit_storage(self):
+        storage = UnifiedInMemoryStorage()
+        session_mgr = SnapshotSessionManager("test-session")
+        agent = MagicMock()
+        agent.storage = storage
+        agent.agent_id = "agent-1"
+        agent.messages = []
+        agent.model = MagicMock()
+        agent.model.stateful = False
+        agent.take_snapshot = MagicMock(return_value=MagicMock())
+        agent.load_snapshot = MagicMock()
+
+        session_mgr.initialize(agent)
+
+        assert session_mgr._storage is not None
+        assert isinstance(session_mgr._storage, _NamespacedStorage)
+
+    def test_session_manager_falls_back_to_local_file_when_no_agent_storage(self):
+        session_mgr = SnapshotSessionManager("test-session")
+        agent = MagicMock()
+        agent.storage = None
+        agent.agent_id = "agent-1"
+        agent.messages = []
+        agent.model = MagicMock()
+        agent.model.stateful = False
+        agent.take_snapshot = MagicMock(return_value=MagicMock())
+        agent.load_snapshot = MagicMock()
+
+        session_mgr.initialize(agent)
+
+        assert session_mgr._storage is not None
+        assert isinstance(session_mgr._storage, _NamespacedStorage)
+
+    def test_explicit_session_storage_overrides_agent_storage(self):
+        agent_storage = UnifiedInMemoryStorage()
+        explicit_storage = UnifiedInMemoryStorage()
+        session_mgr = SnapshotSessionManager("test-session", storage=explicit_storage)
+        agent = MagicMock()
+        agent.storage = agent_storage
+        agent.agent_id = "agent-1"
+        agent.messages = []
+        agent.model = MagicMock()
+        agent.model.stateful = False
+        agent.take_snapshot = MagicMock(return_value=MagicMock())
+        agent.load_snapshot = MagicMock()
+
+        session_mgr.initialize(agent)
+
+        assert isinstance(session_mgr._storage, _NamespacedStorage)
+        # Should be wrapping the explicit storage, not the agent storage
+        assert session_mgr._storage._storage is explicit_storage

--- a/strands-py/tests/strands/agent/test_agent_storage.py
+++ b/strands-py/tests/strands/agent/test_agent_storage.py
@@ -1,8 +1,12 @@
 """Tests for agent-level default storage."""
 
+import logging
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
 from strands import Agent
+from strands.session.repository_session_manager import RepositorySessionManager
 from strands.session.snapshot_session_manager import SnapshotSessionManager
 from strands.storage.in_memory_storage import InMemoryStorage as UnifiedInMemoryStorage
 from strands.storage.storage import _NAMESPACED, _NamespacedStorage
@@ -154,3 +158,75 @@ class TestSnapshotSessionManagerResolvesAgentStorage:
         assert isinstance(session_mgr._storage, _NamespacedStorage)
         # Should be wrapping the explicit storage, not the agent storage
         assert session_mgr._storage._storage is explicit_storage
+
+
+class TestSnapshotSessionManagerResolvedStorageGuard:
+    def test_resolved_storage_raises_when_not_initialized(self):
+        session_mgr = SnapshotSessionManager("test-session")
+
+        with pytest.raises(RuntimeError, match="SnapshotSessionManager requires a storage backend"):
+            _ = session_mgr._resolved_storage
+
+
+class TestOffloaderStorageGuard:
+    def test_storage_for_agent_raises_when_not_initialized(self):
+        offloader = ContextOffloader(include_retrieval_tool=False)
+        agent = MagicMock()
+
+        with pytest.raises(RuntimeError, match="ContextOffloader storage not initialized"):
+            offloader._storage_for_agent(agent)
+
+    @pytest.mark.asyncio
+    async def test_on_before_model_call_returns_early_when_storage_is_none(self):
+        offloader = ContextOffloader(include_retrieval_tool=False)
+        event = MagicMock()
+
+        await offloader._on_before_model_call(event)
+
+
+class TestRepositorySessionManagerWarnOnce:
+    def setup_method(self):
+        RepositorySessionManager._warned_storage_ignored = False
+
+    def test_warns_when_agent_has_storage(self, caplog):
+        repository = MagicMock()
+        repository.read_session = MagicMock(return_value=None)
+        repository.create_session = MagicMock()
+        session_mgr = RepositorySessionManager("test-session", session_repository=repository)
+
+        agent = MagicMock()
+        agent.storage = UnifiedInMemoryStorage()
+        agent.agent_id = "agent-1"
+        agent.messages = []
+
+        with caplog.at_level(logging.WARNING):
+            session_mgr.initialize(agent)
+
+        assert "agent-level storage is set but RepositorySessionManager does not use it" in caplog.text
+
+    def test_warns_only_once(self, caplog):
+        repository = MagicMock()
+        repository.read_session = MagicMock(return_value=None)
+        repository.create_session = MagicMock()
+        session_mgr = RepositorySessionManager("test-session", session_repository=repository)
+
+        agent = MagicMock()
+        agent.storage = UnifiedInMemoryStorage()
+        agent.agent_id = "agent-1"
+        agent.messages = []
+
+        with caplog.at_level(logging.WARNING):
+            session_mgr.initialize(agent)
+
+        caplog.clear()
+
+        session_mgr2 = RepositorySessionManager("test-session-2", session_repository=repository)
+        agent2 = MagicMock()
+        agent2.storage = UnifiedInMemoryStorage()
+        agent2.agent_id = "agent-2"
+        agent2.messages = []
+
+        with caplog.at_level(logging.WARNING):
+            session_mgr2.initialize(agent2)
+
+        assert "agent-level storage is set but RepositorySessionManager does not use it" not in caplog.text


### PR DESCRIPTION

## Description

Adds `storage` as an optional top-level parameter on `Agent`. When set, subsystems that don't have their own explicit storage resolve from the agent-level value, auto-namespaced under their own prefix to avoid key collisions. Explicit storage on a subsystem always takes precedence.

**What resolves from agent-level storage:**
- **ContextOffloader** — `storage` param is now optional; when omitted, resolves from `agent.storage` (namespaced under `offloader/`), falling back to `InMemoryStorage`.
- **SnapshotSessionManager** — `storage` param is now optional; when omitted, resolves from `agent.storage` (namespaced under `session/`), falling back to `LocalFileStorage`.

**What does NOT resolve from agent-level storage:**
- **RepositorySessionManager** — uses `SessionRepository` (a structured per-message CRUD ABC), not the unified `Storage` protocol. A warn-once is emitted if both are configured, pointing users to `SnapshotSessionManager`.

This is the Python SDK counterpart to the TypeScript change in #3660.

## Related Issues

#3660

## Documentation PR

No site/ changes needed — this is an additive optional parameter with no breaking behavior change.

## Type of Change

New feature

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [ ] I ran `hatch run prepare`


## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [ ] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.