### PR TITLE
test(models): retry inconclusive Mantle routing probes

### DIFF
--- a/strands-py/tests_integ/models/test_mantle_routing.py
+++ b/strands-py/tests_integ/models/test_mantle_routing.py
@@ -3,10 +3,11 @@
 Mantle serves each model from exactly one base path (``/v1`` or ``/openai/v1``), rejects
 the other with HTTP 400, and exposes no API that reports the routing, so
 :data:`strands.models._openai_bedrock._OPENAI_PATH_MODEL_PREFIXES` goes stale whenever Mantle
-onboards a model. For every model in the live catalog, this test probes the resolved path
-first and the alternate on failure. A 200 from the resolved path or a definitive rejection
-from the alternate confirms the mapping; other outcomes are retried and fail as
-undetermined when neither path supplies definitive routing evidence.
+onboards a model. For every model in the live catalog, this test asserts that the
+resolved path serves it, probing the other path only on failure to distinguish misrouted
+from unserved ids. Only HTTP 200 and 400 count as answers; any other status is retried
+and, if it persists, fails the test as undetermined. The integration-test retry policy
+gives transient external-service failures one more sweep before they hold the gate.
 
 Failure means the table needs updating, not that the SDK is broken for existing models.
 """
@@ -22,6 +23,7 @@ from typing import NoReturn
 import pytest
 
 from strands.models._openai_bedrock import _resolve_mantle_base_path, resolve_bedrock_client_args
+from tests_integ.conftest import retry_on_flaky
 
 _REGION = "us-east-1"
 _BASE = f"https://bedrock-mantle.{_REGION}.api.aws"
@@ -125,6 +127,11 @@ def _serves(base_path: str, model_id: str, token: str) -> bool | None:
     return False if determined else None
 
 
+@retry_on_flaky(
+    "Mantle models can be transiently unavailable during a catalog sweep",
+    max_attempts=2,
+    retry_on=["Mantle never returned a definitive 200/400"],
+)
 @pytest.mark.timeout(600)
 def test_mantle_base_path_table_matches_live_catalog():
     """Every live Mantle model is routed to the base path it is actually served from.
@@ -155,10 +162,6 @@ def test_mantle_base_path_table_matches_live_catalog():
         on_other = _serves(other, model_id, _mint_token())
         if on_other:
             return model_id, "misrouted", resolved
-        # A definitive rejection from the alternate path confirms the routing table even
-        # when model invocation on the resolved path is transiently unavailable.
-        if on_resolved is None and on_other is False:
-            return model_id, "ok", resolved
         if on_resolved is None or on_other is None:
             return model_id, "undetermined", resolved
         return model_id, "unserved", resolved
@@ -172,9 +175,9 @@ def test_mantle_base_path_table_matches_live_catalog():
     # Checked first so an inconclusive probe cannot read as a clean sweep.
     undetermined = ids("undetermined")
     assert not undetermined, (
-        "Mantle did not return enough definitive 200/400 responses to verify routing for "
-        "these models (transient 429/5xx/timeout, or permanent 401/403/404; check model "
-        f"entitlement): {undetermined}"
+        "Mantle never returned a definitive 200/400 for these models, so their routing "
+        "could not be verified (transient 429/5xx/timeout, or permanent 401/403/404; "
+        f"check model entitlement): {undetermined}"
     )
 
     misrouted = ids("misrouted")
@@ -190,27 +193,4 @@ def test_mantle_base_path_table_matches_live_catalog():
         "path, so OpenAIModel cannot reach them at all. They likely speak another "
         "protocol (as anthropic.* does via /anthropic/v1/messages) and need adding to "
         f"_NOT_OPENAI_COMPATIBLE_PREFIXES: {unserved}"
-    )
-
-
-@pytest.mark.timeout(240)
-@pytest.mark.parametrize(
-    "model_id",
-    ["xai.grok-4.3", "google.gemma-4-31b", "google.gemma-3-27b-it", "openai.gpt-oss-120b"],
-)
-def test_mantle_regression_model_uses_resolved_base_path(model_id):
-    """Each regression-case model confirms the resolved path or rejects the alternate."""
-    token = _token_or_skip()
-    if model_id not in _list_models(token):
-        pytest.skip(f"{model_id} is not in the {_REGION} catalog")
-
-    resolved = _resolve_mantle_base_path(model_id)
-    on_resolved = _serves(resolved, model_id, token)
-    if on_resolved is True:
-        return
-
-    other = "/openai/v1" if resolved == "/v1" else "/v1"
-    on_other = _serves(other, model_id, token)
-    assert on_resolved is None and on_other is False, (
-        f"{model_id} did not confirm routing to {resolved}: resolved={on_resolved}, alternate={on_other}"
     )

--- a/strands-py/tests_integ/models/test_mantle_routing.py
+++ b/strands-py/tests_integ/models/test_mantle_routing.py
@@ -3,10 +3,10 @@
 Mantle serves each model from exactly one base path (``/v1`` or ``/openai/v1``), rejects
 the other with HTTP 400, and exposes no API that reports the routing, so
 :data:`strands.models._openai_bedrock._OPENAI_PATH_MODEL_PREFIXES` goes stale whenever Mantle
-onboards a model. For every model in the live catalog, this test asserts that the
-resolved path serves it, probing the other path only on failure to distinguish misrouted
-from unserved ids. Only HTTP 200 and 400 count as answers; any other status is retried
-and, if it persists, fails the test as undetermined rather than passing as "no drift".
+onboards a model. For every model in the live catalog, this test probes the resolved path
+first and the alternate on failure. A 200 from the resolved path or a definitive rejection
+from the alternate confirms the mapping; other outcomes are retried and fail as
+undetermined when neither path supplies definitive routing evidence.
 
 Failure means the table needs updating, not that the SDK is broken for existing models.
 """
@@ -155,6 +155,10 @@ def test_mantle_base_path_table_matches_live_catalog():
         on_other = _serves(other, model_id, _mint_token())
         if on_other:
             return model_id, "misrouted", resolved
+        # A definitive rejection from the alternate path confirms the routing table even
+        # when model invocation on the resolved path is transiently unavailable.
+        if on_resolved is None and on_other is False:
+            return model_id, "ok", resolved
         if on_resolved is None or on_other is None:
             return model_id, "undetermined", resolved
         return model_id, "unserved", resolved
@@ -168,9 +172,9 @@ def test_mantle_base_path_table_matches_live_catalog():
     # Checked first so an inconclusive probe cannot read as a clean sweep.
     undetermined = ids("undetermined")
     assert not undetermined, (
-        "Mantle never returned a definitive 200/400 for these models, so their routing "
-        "could not be verified (transient 429/5xx/timeout, or permanent 401/403/404; "
-        f"check model entitlement): {undetermined}"
+        "Mantle did not return enough definitive 200/400 responses to verify routing for "
+        "these models (transient 429/5xx/timeout, or permanent 401/403/404; check model "
+        f"entitlement): {undetermined}"
     )
 
     misrouted = ids("misrouted")
@@ -194,10 +198,19 @@ def test_mantle_base_path_table_matches_live_catalog():
     "model_id",
     ["xai.grok-4.3", "google.gemma-4-31b", "google.gemma-3-27b-it", "openai.gpt-oss-120b"],
 )
-def test_mantle_resolved_base_path_is_served(model_id):
-    """The resolved base path actually serves each regression-case model."""
+def test_mantle_regression_model_uses_resolved_base_path(model_id):
+    """Each regression-case model confirms the resolved path or rejects the alternate."""
     token = _token_or_skip()
     if model_id not in _list_models(token):
         pytest.skip(f"{model_id} is not in the {_REGION} catalog")
 
-    assert _serves(_resolve_mantle_base_path(model_id), model_id, token) is True
+    resolved = _resolve_mantle_base_path(model_id)
+    on_resolved = _serves(resolved, model_id, token)
+    if on_resolved is True:
+        return
+
+    other = "/openai/v1" if resolved == "/v1" else "/v1"
+    on_other = _serves(other, model_id, token)
+    assert on_resolved is None and on_other is False, (
+        f"{model_id} did not confirm routing to {resolved}: resolved={on_resolved}, alternate={on_other}"
+    )

--- a/strands-ts/test/integ/models/openai/mantle-routing.test.node.ts
+++ b/strands-ts/test/integ/models/openai/mantle-routing.test.node.ts
@@ -4,10 +4,11 @@
  * Mantle serves each model from exactly one base path (`/v1` or `/openai/v1`), rejects
  * the other with HTTP 400, and exposes no API that reports the routing, so
  * `OPENAI_PATH_MODEL_PREFIXES` in `mantle.ts` goes stale whenever Mantle onboards a model.
- * For every model in the live catalog, this test probes the resolved path first and the
- * alternate on failure. A 200 from the resolved path or a definitive rejection from the
- * alternate confirms the mapping; other outcomes are retried and fail as undetermined
- * when neither path supplies definitive routing evidence.
+ * For every model in the live catalog, this test asserts that the resolved path serves
+ * it, probing the other path only on failure to distinguish misrouted from unserved ids.
+ * Only HTTP 200 and 400 count as answers; any other status is retried and, if it persists,
+ * fails the test as undetermined. The integration-test retry policy gives transient
+ * external-service failures one more sweep before they hold the gate.
  *
  * Failure means the table needs updating, not that the SDK is broken for existing models.
  */
@@ -143,10 +144,6 @@ describe.skipIf(bedrock.skip)('Bedrock Mantle base-path routing', () => {
         const onOther = await serves(other, modelId, await mintToken())
         if (onOther === true) {
           verdicts[modelId] = 'misrouted'
-        } else if (onResolved === null && onOther === false) {
-          // A definitive rejection from the alternate path confirms the routing table even
-          // when model invocation on the resolved path is transiently unavailable.
-          verdicts[modelId] = 'ok'
         } else if (onResolved === null || onOther === null) {
           verdicts[modelId] = 'undetermined'
         } else {
@@ -165,8 +162,8 @@ describe.skipIf(bedrock.skip)('Bedrock Mantle base-path routing', () => {
     // Checked first so an inconclusive probe cannot read as a clean sweep.
     expect(
       ids('undetermined'),
-      'Mantle did not return enough definitive 200/400 responses to verify routing for ' +
-        'these models (transient 429/5xx/timeout, or permanent 401/403/404; check model entitlement)'
+      'Mantle never returned a definitive 200/400 for these models, so their routing could ' +
+        'not be verified (transient 429/5xx/timeout, or permanent 401/403/404; check model entitlement)'
     ).toEqual({})
 
     expect(
@@ -184,32 +181,4 @@ describe.skipIf(bedrock.skip)('Bedrock Mantle base-path routing', () => {
         'NOT_OPENAI_COMPATIBLE_PREFIXES'
     ).toEqual({})
   }, 600_000)
-
-  it.for(['xai.grok-4.3', 'google.gemma-4-31b', 'google.gemma-3-27b-it', 'openai.gpt-oss-120b'])(
-    'routes %s to the resolved base path',
-    { timeout: 240_000 },
-    async (modelId, ctx) => {
-      const token = await mintToken()
-      const models = await listModels(token)
-      if (models === null) {
-        ctx.skip('account lacks bedrock-mantle:ListModels')
-        return
-      }
-      if (!models.includes(modelId)) {
-        ctx.skip(`${modelId} is not in the ${REGION} catalog`)
-        return
-      }
-
-      const resolved = resolveMantleBasePath(modelId)
-      const onResolved = await serves(resolved, modelId, token)
-      if (onResolved === true) return
-
-      const other = resolved === '/v1' ? '/openai/v1' : '/v1'
-      const onOther = await serves(other, modelId, token)
-      expect({ onResolved, onOther }, `${modelId} did not confirm routing to ${resolved}`).toEqual({
-        onResolved: null,
-        onOther: false,
-      })
-    }
-  )
 })

--- a/strands-ts/test/integ/models/openai/mantle-routing.test.node.ts
+++ b/strands-ts/test/integ/models/openai/mantle-routing.test.node.ts
@@ -4,10 +4,10 @@
  * Mantle serves each model from exactly one base path (`/v1` or `/openai/v1`), rejects
  * the other with HTTP 400, and exposes no API that reports the routing, so
  * `OPENAI_PATH_MODEL_PREFIXES` in `mantle.ts` goes stale whenever Mantle onboards a model.
- * For every model in the live catalog, this test asserts that the resolved path serves
- * it, probing the other path only on failure to distinguish misrouted from unserved ids.
- * Only HTTP 200 and 400 count as answers; any other status is retried and, if it
- * persists, fails the test as undetermined rather than passing as "no drift".
+ * For every model in the live catalog, this test probes the resolved path first and the
+ * alternate on failure. A 200 from the resolved path or a definitive rejection from the
+ * alternate confirms the mapping; other outcomes are retried and fail as undetermined
+ * when neither path supplies definitive routing evidence.
  *
  * Failure means the table needs updating, not that the SDK is broken for existing models.
  */
@@ -143,6 +143,10 @@ describe.skipIf(bedrock.skip)('Bedrock Mantle base-path routing', () => {
         const onOther = await serves(other, modelId, await mintToken())
         if (onOther === true) {
           verdicts[modelId] = 'misrouted'
+        } else if (onResolved === null && onOther === false) {
+          // A definitive rejection from the alternate path confirms the routing table even
+          // when model invocation on the resolved path is transiently unavailable.
+          verdicts[modelId] = 'ok'
         } else if (onResolved === null || onOther === null) {
           verdicts[modelId] = 'undetermined'
         } else {
@@ -161,8 +165,8 @@ describe.skipIf(bedrock.skip)('Bedrock Mantle base-path routing', () => {
     // Checked first so an inconclusive probe cannot read as a clean sweep.
     expect(
       ids('undetermined'),
-      'Mantle never returned a definitive 200/400 for these models, so their routing could ' +
-        'not be verified (transient 429/5xx/timeout, or permanent 401/403/404; check model entitlement)'
+      'Mantle did not return enough definitive 200/400 responses to verify routing for ' +
+        'these models (transient 429/5xx/timeout, or permanent 401/403/404; check model entitlement)'
     ).toEqual({})
 
     expect(
@@ -182,7 +186,7 @@ describe.skipIf(bedrock.skip)('Bedrock Mantle base-path routing', () => {
   }, 600_000)
 
   it.for(['xai.grok-4.3', 'google.gemma-4-31b', 'google.gemma-3-27b-it', 'openai.gpt-oss-120b'])(
-    'serves %s from the resolved base path',
+    'routes %s to the resolved base path',
     { timeout: 240_000 },
     async (modelId, ctx) => {
       const token = await mintToken()
@@ -196,7 +200,16 @@ describe.skipIf(bedrock.skip)('Bedrock Mantle base-path routing', () => {
         return
       }
 
-      expect(await serves(resolveMantleBasePath(modelId), modelId, token)).toBe(true)
+      const resolved = resolveMantleBasePath(modelId)
+      const onResolved = await serves(resolved, modelId, token)
+      if (onResolved === true) return
+
+      const other = resolved === '/v1' ? '/openai/v1' : '/v1'
+      const onOther = await serves(other, modelId, token)
+      expect({ onResolved, onOther }, `${modelId} did not confirm routing to ${resolved}`).toEqual({
+        onResolved: null,
+        onOther: false,
+      })
     }
   )
 })


### PR DESCRIPTION
## Description

The Mantle routing drift tests can fail on transient model outages even after request-level retries, blocking unrelated PRs. Use each SDK's standard integration retry policy for one additional sweep while preserving misrouted and unserved failures; the live catalog sweep also replaces the redundant hard-coded regression model cases.

## Related Issues

Follow-up to #3691. Observed in #3677.

## Documentation PR

Not required; this is a test-only reliability fix.

## Type of Change

Bug fix

## Testing

- `ruff format --check`, `ruff check`, and `python3 -m py_compile` for the Python Mantle integration test
- TypeScript build, lint, formatting, type-check, browser bundle, and 3,997 unit tests
- The full pre-push command was blocked by local infrastructure: Rust 1.92 cannot build the current `litellm` dependency, and the configured CodeArtifact registry returns 404 for `npm audit`

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
