### PR TITLE
fix(vended-tools): keep the pre-rename name on the deprecated bash aliases

### DIFF
--- a/strands-py/src/strands/vended_tools/__init__.py
+++ b/strands-py/src/strands/vended_tools/__init__.py
@@ -41,8 +41,16 @@ _RENAME_RATIONALE = (
 
 @deprecated(f"make_bash is deprecated and will be removed in v2.0.0. Use make_shell instead. {_RENAME_RATIONALE}")
 def make_bash(**kwargs: Any) -> "DecoratedFunctionTool":
-    """Deprecated alias for :func:`make_shell`."""
+    """Deprecated alias for :func:`make_shell`.
+
+    Defaults the tool name to ``"bash"`` so callers keyed on the pre-rename name
+    (hooks, prompts, tool lists) keep working until the alias is removed.
+    """
+    kwargs.setdefault("name", "bash")
     return make_shell(**kwargs)
+
+
+_bash: "DecoratedFunctionTool | None" = None
 
 
 def __getattr__(name: str) -> Any:
@@ -54,7 +62,12 @@ def __getattr__(name: str) -> Any:
             DeprecationWarning,
             stacklevel=2,
         )
-        return shell
+        # A shell tool that still registers under the pre-rename name, so string
+        # matches on "bash" (hooks, defaults lists, prompts) survive the upgrade.
+        global _bash
+        if _bash is None:
+            _bash = make_shell(name="bash")
+        return _bash
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/strands-py/src/strands/vended_tools/__init__.py
+++ b/strands-py/src/strands/vended_tools/__init__.py
@@ -40,17 +40,9 @@ _RENAME_RATIONALE = (
 
 
 @deprecated(f"make_bash is deprecated and will be removed in v2.0.0. Use make_shell instead. {_RENAME_RATIONALE}")
-def make_bash(**kwargs: Any) -> "DecoratedFunctionTool":
-    """Deprecated alias for :func:`make_shell`.
-
-    Defaults the tool name to ``"bash"`` so callers keyed on the pre-rename name
-    (hooks, prompts, tool lists) keep working until the alias is removed.
-    """
-    kwargs.setdefault("name", "bash")
-    return make_shell(**kwargs)
-
-
-_bash: "DecoratedFunctionTool | None" = None
+def make_bash(*, name: str = "bash", **kwargs: Any) -> "DecoratedFunctionTool":
+    """Deprecated alias for :func:`make_shell` that keeps the pre-rename default name."""
+    return make_shell(name=name, **kwargs)
 
 
 def __getattr__(name: str) -> Any:
@@ -62,12 +54,9 @@ def __getattr__(name: str) -> Any:
             DeprecationWarning,
             stacklevel=2,
         )
-        # A shell tool that still registers under the pre-rename name, so string
-        # matches on "bash" (hooks, defaults lists, prompts) survive the upgrade.
-        global _bash
-        if _bash is None:
-            _bash = make_shell(name="bash")
-        return _bash
+        from .shell.shell import bash
+
+        return bash
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/strands-py/src/strands/vended_tools/shell/shell.py
+++ b/strands-py/src/strands/vended_tools/shell/shell.py
@@ -73,3 +73,9 @@ def make_shell(
 
 shell = make_shell()
 """Default shell tool. Reads the sandbox from the agent's context at call time."""
+
+bash = make_shell(name="bash")
+"""Deprecated pre-rename instance of :data:`shell`, kept so callers matching on the
+tool name ``"bash"`` keep working until removal in v2.0.0. Reach it through
+``strands.vended_tools.bash``, which emits the ``DeprecationWarning``; it is
+deliberately absent from ``__all__`` and the docs."""

--- a/strands-py/tests/strands/vended_tools/test_shell.py
+++ b/strands-py/tests/strands/vended_tools/test_shell.py
@@ -107,20 +107,44 @@ class TestToolMetadata:
 
 
 class TestDeprecatedBashAliases:
-    """The ``bash`` name is retained until v2.0.0 but warns and resolves to ``shell``."""
+    """The ``bash`` aliases are retained until v2.0.0, warn, and keep the pre-rename name.
 
-    def test_bash_alias_warns_and_returns_shell(self):
+    Keeping ``tool_name == "bash"`` is what makes the alias backwards compatible:
+    consumers key registries, hooks, and defaults lists on the runtime name, so an
+    alias that returned a tool named ``shell`` would still break them (see
+    awsarron/stan#6).
+    """
+
+    def test_bash_alias_warns_and_keeps_its_name(self):
         import strands.vended_tools as vended_tools
 
         with pytest.deprecated_call(match="bash is deprecated"):
-            assert vended_tools.bash is shell
+            tool = vended_tools.bash
+        assert tool.tool_name == "bash"
 
-    def test_make_bash_alias_warns_and_builds_a_shell_tool(self):
+    def test_bash_alias_returns_the_same_instance_each_time(self):
+        import strands.vended_tools as vended_tools
+
+        with pytest.deprecated_call(match="bash is deprecated"):
+            first = vended_tools.bash
+        with pytest.deprecated_call(match="bash is deprecated"):
+            second = vended_tools.bash
+        assert first is second
+
+    def test_bash_alias_matches_shell_apart_from_the_name(self):
+        import strands.vended_tools as vended_tools
+
+        with pytest.deprecated_call(match="bash is deprecated"):
+            tool = vended_tools.bash
+        assert tool.tool_spec["description"] == shell.tool_spec["description"]
+        assert tool.tool_spec["inputSchema"] == shell.tool_spec["inputSchema"]
+
+    def test_make_bash_alias_warns_and_builds_a_bash_named_tool(self):
         import strands.vended_tools as vended_tools
 
         with pytest.deprecated_call(match="make_bash is deprecated"):
             tool = vended_tools.make_bash()
-        assert tool.tool_name == "shell"
+        assert tool.tool_name == "bash"
 
     def test_make_bash_alias_forwards_arguments(self):
         import strands.vended_tools as vended_tools

--- a/strands-py/tests/strands/vended_tools/test_shell.py
+++ b/strands-py/tests/strands/vended_tools/test_shell.py
@@ -136,8 +136,7 @@ class TestDeprecatedBashAliases:
 
         with pytest.deprecated_call(match="bash is deprecated"):
             tool = vended_tools.bash
-        assert tool.tool_spec["description"] == shell.tool_spec["description"]
-        assert tool.tool_spec["inputSchema"] == shell.tool_spec["inputSchema"]
+        assert tool.tool_spec == {**shell.tool_spec, "name": "bash"}
 
     def test_make_bash_alias_warns_and_builds_a_bash_named_tool(self):
         import strands.vended_tools as vended_tools

--- a/strands-ts/src/vended-tools/bash/README.md
+++ b/strands-ts/src/vended-tools/bash/README.md
@@ -8,8 +8,7 @@ A robust tool for executing bash shell commands in Node.js environments with per
 > builds a stateless tool that routes commands through a
 > [Sandbox](../../sandbox/base.ts), which runs `sh` locally and in Docker or the
 > remote login shell over SSH; commands passed to it must not rely on
-> bash-specific syntax. `makeBash` is a deprecated alias of `makeShell` that keeps
-> the pre-rename tool name `bash`; it will be removed in v2.0.0.
+> bash-specific syntax.
 
 ## ⚠️ Security Warning
 

--- a/strands-ts/src/vended-tools/bash/README.md
+++ b/strands-ts/src/vended-tools/bash/README.md
@@ -8,8 +8,8 @@ A robust tool for executing bash shell commands in Node.js environments with per
 > builds a stateless tool that routes commands through a
 > [Sandbox](../../sandbox/base.ts), which runs `sh` locally and in Docker or the
 > remote login shell over SSH; commands passed to it must not rely on
-> bash-specific syntax. `makeBash` is a deprecated alias of `makeShell` and will
-> be removed in v2.0.0.
+> bash-specific syntax. `makeBash` is a deprecated alias of `makeShell` that keeps
+> the pre-rename tool name `bash`; it will be removed in v2.0.0.
 
 ## ⚠️ Security Warning
 

--- a/strands-ts/src/vended-tools/bash/__tests__/bash.test.node.ts
+++ b/strands-ts/src/vended-tools/bash/__tests__/bash.test.node.ts
@@ -544,11 +544,19 @@ describe.skipIf(process.platform === 'win32')('makeShell', () => {
 })
 
 describe('deprecated makeBash alias', () => {
-  it('is the same factory as makeShell', () => {
-    expect(makeBash).toBe(makeShell)
+  // Consumers key registries, hooks, and defaults lists on the runtime name, so an
+  // alias that returned a tool named 'shell' would still break them (see awsarron/stan#6).
+  it('keeps the pre-rename tool name', () => {
+    expect(makeBash().name).toBe('bash')
   })
 
-  it('still builds a working sandbox-routed tool', () => {
-    expect(makeBash().name).toBe('shell')
+  it('matches makeShell apart from the name', () => {
+    const bashTool = makeBash()
+    const shellTool = makeShell()
+    expect(bashTool.description).toBe(shellTool.description)
+  })
+
+  it('an explicit name still wins', () => {
+    expect(makeBash({ name: 'sandbox_bash' }).name).toBe('sandbox_bash')
   })
 })

--- a/strands-ts/src/vended-tools/bash/__tests__/bash.test.node.ts
+++ b/strands-ts/src/vended-tools/bash/__tests__/bash.test.node.ts
@@ -551,9 +551,7 @@ describe('deprecated makeBash alias', () => {
   })
 
   it('matches makeShell apart from the name', () => {
-    const bashTool = makeBash()
-    const shellTool = makeShell()
-    expect(bashTool.description).toBe(shellTool.description)
+    expect(makeBash().toolSpec).toEqual({ ...makeShell().toolSpec, name: 'bash' })
   })
 
   it('an explicit name still wins', () => {

--- a/strands-ts/src/vended-tools/bash/make-shell.ts
+++ b/strands-ts/src/vended-tools/bash/make-shell.ts
@@ -67,8 +67,20 @@ export function makeShell(
  * @deprecated makeBash is deprecated and will be removed in v2.0.0. Use makeShell instead. The tool
  * routes commands through the sandbox, which runs sh or the remote login shell rather than bash
  * specifically.
+ *
+ * Defaults the tool name to `'bash'` so callers keyed on the pre-rename name (hooks, prompts,
+ * tool lists) keep working until the alias is removed.
  */
-export const makeBash = makeShell
+export function makeBash(options?: MakeShellOptions): ReturnType<typeof tool>
+export function makeBash(sandbox: Sandbox | undefined, options?: MakeShellOptions): ReturnType<typeof tool>
+export function makeBash(
+  sandboxOrOptions?: Sandbox | MakeShellOptions,
+  maybeOptions?: MakeShellOptions
+): ReturnType<typeof tool> {
+  const boundSandbox = sandboxOrOptions instanceof Sandbox ? sandboxOrOptions : undefined
+  const options = sandboxOrOptions instanceof Sandbox || maybeOptions ? (maybeOptions ?? {}) : (sandboxOrOptions ?? {})
+  return makeShell(boundSandbox, { name: 'bash', ...options })
+}
 
 /**
  * @deprecated MakeBashOptions is deprecated and will be removed in v2.0.0. Use MakeShellOptions instead.

--- a/strands-ts/src/vended-tools/bash/make-shell.ts
+++ b/strands-ts/src/vended-tools/bash/make-shell.ts
@@ -77,9 +77,10 @@ export function makeBash(
   sandboxOrOptions?: Sandbox | MakeShellOptions,
   maybeOptions?: MakeShellOptions
 ): ReturnType<typeof tool> {
-  const boundSandbox = sandboxOrOptions instanceof Sandbox ? sandboxOrOptions : undefined
-  const options = sandboxOrOptions instanceof Sandbox || maybeOptions ? (maybeOptions ?? {}) : (sandboxOrOptions ?? {})
-  return makeShell(boundSandbox, { name: 'bash', ...options })
+  if (sandboxOrOptions instanceof Sandbox) {
+    return makeShell(sandboxOrOptions, { name: 'bash', ...maybeOptions })
+  }
+  return makeShell({ name: 'bash', ...(maybeOptions ?? sandboxOrOptions) })
 }
 
 /**

--- a/strands-ts/src/vended-tools/bash/make-shell.ts
+++ b/strands-ts/src/vended-tools/bash/make-shell.ts
@@ -32,14 +32,22 @@ export interface MakeShellOptions {
  * Otherwise, the tool reads from `context.agent.sandbox` at call time.
  * Used by sandbox implementations in `getTools()` and by users who want a customized shell tool.
  */
+function resolveShellArgs(
+  sandboxOrOptions?: Sandbox | MakeShellOptions,
+  maybeOptions?: MakeShellOptions
+): { boundSandbox: Sandbox | undefined; options: MakeShellOptions } {
+  const boundSandbox = sandboxOrOptions instanceof Sandbox ? sandboxOrOptions : undefined
+  const options = sandboxOrOptions instanceof Sandbox || maybeOptions ? (maybeOptions ?? {}) : (sandboxOrOptions ?? {})
+  return { boundSandbox, options }
+}
+
 export function makeShell(options?: MakeShellOptions): ReturnType<typeof tool>
 export function makeShell(sandbox: Sandbox | undefined, options?: MakeShellOptions): ReturnType<typeof tool>
 export function makeShell(
   sandboxOrOptions?: Sandbox | MakeShellOptions,
   maybeOptions?: MakeShellOptions
 ): ReturnType<typeof tool> {
-  const boundSandbox = sandboxOrOptions instanceof Sandbox ? sandboxOrOptions : undefined
-  const options = sandboxOrOptions instanceof Sandbox || maybeOptions ? (maybeOptions ?? {}) : (sandboxOrOptions ?? {})
+  const { boundSandbox, options } = resolveShellArgs(sandboxOrOptions, maybeOptions)
 
   return tool({
     name: options.name ?? 'shell',
@@ -77,10 +85,8 @@ export function makeBash(
   sandboxOrOptions?: Sandbox | MakeShellOptions,
   maybeOptions?: MakeShellOptions
 ): ReturnType<typeof tool> {
-  if (sandboxOrOptions instanceof Sandbox) {
-    return makeShell(sandboxOrOptions, { name: 'bash', ...maybeOptions })
-  }
-  return makeShell({ name: 'bash', ...(maybeOptions ?? sandboxOrOptions) })
+  const { boundSandbox, options } = resolveShellArgs(sandboxOrOptions, maybeOptions)
+  return makeShell(boundSandbox, { name: 'bash', ...options })
 }
 
 /**


### PR DESCRIPTION
## Description

The `bash` to `shell` rename (#3574) preserved import-level compatibility, but the deprecated alias returned a tool whose runtime `tool_name` is `"shell"`. Consumers key registries, hooks, and defaults lists on that name, so code holding the string `"bash"` broke on upgrade even though its import kept working. [awsarron/stan#6](https://github.com/awsarron/stan/pull/6) hit exactly this: every default `harness_agent()` call raised `Unknown built-in tool 'bash'`, killing 206/206 trials in a benchmark run.

Per review feedback, the design is "both tools exist, in their own homes": `bash` is a real instance with the pre-rename name, deprecation-warned and kept out of the docs, and the sandbox-routed shell tool now has its own directory instead of living inside `bash/`.

- **Python**: `bash = make_shell(name="bash")` and `make_bash` (which declares `name="bash"` in its signature; an explicit `name` still wins) are defined in `shell/shell.py` next to `shell` and `make_shell`. The package `__init__` keeps only the `__getattr__` that emits the `DeprecationWarning` for the `bash` instance (an instance cannot carry `@deprecated`), and `bash` is deliberately absent from both `__all__`s.
- **TypeScript**: new `vended-tools/shell/` directory holds `makeShell`, `makeBash` (defaults `name: 'bash'`), the `Shell*` errors, and their tests, with a `./vended-tools/shell` subpath export. `vended-tools/bash/` keeps the persistent host `bash` tool and re-exports the shell names, so imports through the pre-rename path keep working until v2.0.0. `Shell*` errors still extend `Bash*` errors, so pre-rename catch clauses keep matching. Both factories resolve their sandbox/options arguments through one shared `resolveShellArgs` helper.

The canonical `shell` / `make_shell` / `makeShell` surfaces are untouched, and everything deprecated is still removed together in v2.0.0, so the rename's end state is unchanged; the aliases just stop being a trap in the meantime.

Not covered, deliberately: the Docker/SSH sandbox-vended tool is still named `sandbox_shell`. There is no alias symbol a consumer opts into on that path, so restoring `sandbox_bash` would undo the rename rather than shim it.

## Type of Change

Bug fix

One behavior note: `vended_tools.bash is shell` was `True` since #3574 and is now `False`, because a single instance cannot carry two names. Pre-rename there was no `shell` to compare against, so no pre-rename code can depend on that identity; only code written against the deprecation window itself could.

## Testing

- **Python**: `tests/strands/vended_tools/test_shell.py` → 19 passed. Alias tests assert `tool_name == "bash"`, stable identity across accesses, that the whole `tool_spec` equals `shell`'s apart from the name, and that an explicit `name` overrides the default.
- **TypeScript**: `bash.test.node.ts` + the new `shell.test.node.ts` + the Docker/SSH sandbox unit tests → 86 passed, no type errors; `tsc --noEmit` over `src/` is clean. The sandbox implementations and their tests now import from `vended-tools/shell/`.
- Reproduced the stan failure shape end to end on this branch: `from strands.vended_tools import bash` warns, `bash.tool_name == "bash"`, and a `{t.tool_name: t}` registry lookup for `"bash"` succeeds again.
- Not run locally: prettier/eslint (registry auth unavailable in this environment); the vitest run type-checks the changed files.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
