### PR TITLE
docs(openai): document OpenRouter configuration

### DIFF
--- a/site/src/content/docs/user-guide/concepts/model-providers/openai.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/openai.mdx
@@ -91,6 +91,45 @@ model = OpenAIModel(
 </Tab>
 </Tabs>
 
+### OpenRouter
+
+To route a Strands agent through [OpenRouter](https://openrouter.ai/), point the OpenAI
+client at OpenRouter's compatible endpoint and use an OpenRouter model ID. Create an
+[API key](https://openrouter.ai/settings/keys), set `OPENROUTER_API_KEY`, and choose a
+model from the [OpenRouter catalog](https://openrouter.ai/models).
+
+<Tabs>
+<Tab label="Python">
+
+```python
+import os
+
+from strands import Agent
+from strands.models.openai import OpenAIModel
+
+model = OpenAIModel(
+    client_args={
+        "api_key": os.environ["OPENROUTER_API_KEY"],
+        "base_url": "https://openrouter.ai/api/v1",
+    },
+    model_id="openai/gpt-5.4",
+)
+
+agent = Agent(model=model)
+response = agent("Explain tool calling in one sentence.")
+print(response)
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/model-providers/openai_imports.ts:openrouter_imports"
+
+--8<-- "user-guide/concepts/model-providers/openai.ts:openrouter"
+```
+</Tab>
+</Tabs>
+
 ## Configuration
 
 ### Client Configuration

--- a/site/src/content/docs/user-guide/concepts/model-providers/openai.ts
+++ b/site/src/content/docs/user-guide/concepts/model-providers/openai.ts
@@ -44,6 +44,24 @@ async function customServer() {
   // --8<-- [end:custom_server]
 }
 
+// OpenRouter
+async function openRouter() {
+  // --8<-- [start:openrouter]
+  const model = new OpenAIModel({
+    api: 'chat',
+    apiKey: process.env.OPENROUTER_API_KEY || '<OPENROUTER_API_KEY>',
+    clientConfig: {
+      baseURL: 'https://openrouter.ai/api/v1',
+    },
+    modelId: 'openai/gpt-5.4',
+  })
+
+  const agent = new Agent({ model })
+  const response = await agent.invoke('Explain tool calling in one sentence.')
+  console.log(response)
+  // --8<-- [end:openrouter]
+}
+
 // Custom client
 async function customClient() {
   // --8<-- [start:custom_client]

--- a/site/src/content/docs/user-guide/concepts/model-providers/openai_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/model-providers/openai_imports.ts
@@ -5,6 +5,11 @@ import { Agent } from '@strands-agents/sdk'
 import { OpenAIModel } from '@strands-agents/sdk/models/openai'
 // --8<-- [end:basic_usage_imports]
 
+// --8<-- [start:openrouter_imports]
+import { Agent } from '@strands-agents/sdk'
+import { OpenAIModel } from '@strands-agents/sdk/models/openai'
+// --8<-- [end:openrouter_imports]
+
 // --8<-- [start:custom_client_imports]
 import OpenAI from 'openai'
 import { Agent } from '@strands-agents/sdk'


### PR DESCRIPTION
## Description

Documents how to connect the OpenAI provider to OpenRouter through its
OpenAI-compatible endpoint. The guide now includes self-contained Python and
TypeScript examples, environment-based API key configuration, and links to the
OpenRouter model catalog.

Resolves #3737

## Related Issues

#3737

## Documentation PR

This is a documentation-only update under `site/`.

## Type of Change

Documentation update

## Testing

- `npm run typecheck:snippets`
- Repository pre-commit checks: SDK build, unit tests with coverage, ESLint,
  Prettier, and TypeScript type checks
- Astro rendered the updated OpenAI page and both language tabs successfully;
  the full build then stopped on pre-existing unresolved API-reference links

- [ ] I ran `hatch run prepare` (not applicable to this documentation-only change)

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.