### PR TITLE
fix(test): move count_tokens fixture off retired gemini-2.0-flash

### DIFF
--- a/strands-py/tests_integ/models/test_model_gemini.py
+++ b/strands-py/tests_integ/models/test_model_gemini.py
@@ -269,8 +269,9 @@ def test_agent_with_reasoning_content(model, assistant_agent):
 class TestCountTokens:
     @pytest.fixture
     def model(self):
+        # Flash-Lite is the cheapest GA model and countTokens is model-agnostic here.
         return GeminiModel(
-            model_id="gemini-2.0-flash",
+            model_id="gemini-2.5-flash-lite",
             client_args={"api_key": os.environ["GOOGLE_API_KEY"]},
             use_native_token_count=True,
         )

--- a/strands-py/tests_integ/models/test_model_gemini.py
+++ b/strands-py/tests_integ/models/test_model_gemini.py
@@ -269,7 +269,6 @@ def test_agent_with_reasoning_content(model, assistant_agent):
 class TestCountTokens:
     @pytest.fixture
     def model(self):
-        # Flash-Lite is the cheapest GA model and countTokens is model-agnostic here.
         return GeminiModel(
             model_id="gemini-2.5-flash-lite",
             client_args={"api_key": os.environ["GOOGLE_API_KEY"]},

--- a/strands-py/tests_integ/test_multiagent_graph.py
+++ b/strands-py/tests_integ/test_multiagent_graph.py
@@ -741,6 +741,26 @@ async def test_diamond_graph_conditional_convergence():
     This tests the deadlock fix: merger should still execute even though slow_path's
     incoming edge evaluates to False.
     """
+    entry_agent = Agent(
+        name="entry",
+        model="us.amazon.nova-lite-v1:0",
+        system_prompt="Say 'routed'.",
+    )
+    fast_agent = Agent(
+        name="fast",
+        model="us.amazon.nova-lite-v1:0",
+        system_prompt="Say 'fast result'.",
+    )
+    slow_agent = Agent(
+        name="slow",
+        model="us.amazon.nova-lite-v1:0",
+        system_prompt="Say 'slow result'.",
+    )
+    merger_agent = Agent(
+        name="merger",
+        model="us.amazon.nova-lite-v1:0",
+        system_prompt="Merge results. Say 'merged'.",
+    )
 
     def is_fast_mode(state: GraphState, *, invocation_state: dict, **kwargs) -> bool:
         return invocation_state.get("mode") == "fast"
@@ -748,54 +768,26 @@ async def test_diamond_graph_conditional_convergence():
     def is_slow_mode(state: GraphState, *, invocation_state: dict, **kwargs) -> bool:
         return invocation_state.get("mode") == "slow"
 
-    def build_graph():
-        """Build the diamond graph with fresh agents.
-
-        Each mode gets its own agents so the run starts from an empty conversation
-        history. Replaying the same terse prompt on a reused agent lets the model read
-        its own prior reply as a topic to expand on, which can run until max_tokens.
-        """
-        entry_agent = Agent(
-            name="entry",
-            model="us.amazon.nova-lite-v1:0",
-            system_prompt="Say 'routed'.",
-        )
-        fast_agent = Agent(
-            name="fast",
-            model="us.amazon.nova-lite-v1:0",
-            system_prompt="Say 'fast result'.",
-        )
-        slow_agent = Agent(
-            name="slow",
-            model="us.amazon.nova-lite-v1:0",
-            system_prompt="Say 'slow result'.",
-        )
-        merger_agent = Agent(
-            name="merger",
-            model="us.amazon.nova-lite-v1:0",
-            system_prompt="Merge results. Say 'merged'.",
-        )
-
-        builder = GraphBuilder()
-        builder.add_node(entry_agent, "entry")
-        builder.add_node(fast_agent, "fast")
-        builder.add_node(slow_agent, "slow")
-        builder.add_node(merger_agent, "merger")
-        builder.add_edge("entry", "fast", condition=is_fast_mode)
-        builder.add_edge("entry", "slow", condition=is_slow_mode)
-        builder.add_edge("fast", "merger")
-        builder.add_edge("slow", "merger")
-        builder.set_entry_point("entry")
-        return builder.build()
+    builder = GraphBuilder()
+    builder.add_node(entry_agent, "entry")
+    builder.add_node(fast_agent, "fast")
+    builder.add_node(slow_agent, "slow")
+    builder.add_node(merger_agent, "merger")
+    builder.add_edge("entry", "fast", condition=is_fast_mode)
+    builder.add_edge("entry", "slow", condition=is_slow_mode)
+    builder.add_edge("fast", "merger")
+    builder.add_edge("slow", "merger")
+    builder.set_entry_point("entry")
+    graph = builder.build()
 
     # Fast mode: entry -> fast -> merger (slow skipped, merger not deadlocked)
-    result = await build_graph().invoke_async("Process", invocation_state={"mode": "fast"})
+    result = await graph.invoke_async("Process", invocation_state={"mode": "fast"})
     assert result.status == Status.COMPLETED
     executed_nodes = {n.node_id for n in result.execution_order}
     assert executed_nodes == {"entry", "fast", "merger"}
 
     # Slow mode: entry -> slow -> merger (fast skipped)
-    result = await build_graph().invoke_async("Process", invocation_state={"mode": "slow"})
+    result = await graph.invoke_async("Process", invocation_state={"mode": "slow"})
     assert result.status == Status.COMPLETED
     executed_nodes = {n.node_id for n in result.execution_order}
     assert executed_nodes == {"entry", "slow", "merger"}

--- a/strands-py/tests_integ/test_multiagent_graph.py
+++ b/strands-py/tests_integ/test_multiagent_graph.py
@@ -741,26 +741,6 @@ async def test_diamond_graph_conditional_convergence():
     This tests the deadlock fix: merger should still execute even though slow_path's
     incoming edge evaluates to False.
     """
-    entry_agent = Agent(
-        name="entry",
-        model="us.amazon.nova-lite-v1:0",
-        system_prompt="Say 'routed'.",
-    )
-    fast_agent = Agent(
-        name="fast",
-        model="us.amazon.nova-lite-v1:0",
-        system_prompt="Say 'fast result'.",
-    )
-    slow_agent = Agent(
-        name="slow",
-        model="us.amazon.nova-lite-v1:0",
-        system_prompt="Say 'slow result'.",
-    )
-    merger_agent = Agent(
-        name="merger",
-        model="us.amazon.nova-lite-v1:0",
-        system_prompt="Merge results. Say 'merged'.",
-    )
 
     def is_fast_mode(state: GraphState, *, invocation_state: dict, **kwargs) -> bool:
         return invocation_state.get("mode") == "fast"
@@ -768,26 +748,45 @@ async def test_diamond_graph_conditional_convergence():
     def is_slow_mode(state: GraphState, *, invocation_state: dict, **kwargs) -> bool:
         return invocation_state.get("mode") == "slow"
 
-    builder = GraphBuilder()
-    builder.add_node(entry_agent, "entry")
-    builder.add_node(fast_agent, "fast")
-    builder.add_node(slow_agent, "slow")
-    builder.add_node(merger_agent, "merger")
-    builder.add_edge("entry", "fast", condition=is_fast_mode)
-    builder.add_edge("entry", "slow", condition=is_slow_mode)
-    builder.add_edge("fast", "merger")
-    builder.add_edge("slow", "merger")
-    builder.set_entry_point("entry")
-    graph = builder.build()
+    def build_graph():
+        """Build the diamond graph with fresh agents.
+
+        Each mode gets its own agents so the run starts from an empty conversation
+        history. Replaying the same terse prompt on a reused agent lets the model read
+        its own prior reply as a topic to expand on, which can run until max_tokens.
+        """
+        agents = {
+            node_id: Agent(
+                name=node_id,
+                model="us.amazon.nova-lite-v1:0",
+                system_prompt=f"Reply with exactly one word: {word}. Do not explain or add anything else.",
+            )
+            for node_id, word in (
+                ("entry", "routed"),
+                ("fast", "fast"),
+                ("slow", "slow"),
+                ("merger", "merged"),
+            )
+        }
+
+        builder = GraphBuilder()
+        for node_id, agent in agents.items():
+            builder.add_node(agent, node_id)
+        builder.add_edge("entry", "fast", condition=is_fast_mode)
+        builder.add_edge("entry", "slow", condition=is_slow_mode)
+        builder.add_edge("fast", "merger")
+        builder.add_edge("slow", "merger")
+        builder.set_entry_point("entry")
+        return builder.build()
 
     # Fast mode: entry -> fast -> merger (slow skipped, merger not deadlocked)
-    result = await graph.invoke_async("Process", invocation_state={"mode": "fast"})
+    result = await build_graph().invoke_async("Process", invocation_state={"mode": "fast"})
     assert result.status == Status.COMPLETED
     executed_nodes = {n.node_id for n in result.execution_order}
     assert executed_nodes == {"entry", "fast", "merger"}
 
     # Slow mode: entry -> slow -> merger (fast skipped)
-    result = await graph.invoke_async("Process", invocation_state={"mode": "slow"})
+    result = await build_graph().invoke_async("Process", invocation_state={"mode": "slow"})
     assert result.status == Status.COMPLETED
     executed_nodes = {n.node_id for n in result.execution_order}
     assert executed_nodes == {"entry", "slow", "merger"}

--- a/strands-py/tests_integ/test_multiagent_graph.py
+++ b/strands-py/tests_integ/test_multiagent_graph.py
@@ -755,23 +755,32 @@ async def test_diamond_graph_conditional_convergence():
         history. Replaying the same terse prompt on a reused agent lets the model read
         its own prior reply as a topic to expand on, which can run until max_tokens.
         """
-        agents = {
-            node_id: Agent(
-                name=node_id,
-                model="us.amazon.nova-lite-v1:0",
-                system_prompt=f"Reply with exactly one word: {word}. Do not explain or add anything else.",
-            )
-            for node_id, word in (
-                ("entry", "routed"),
-                ("fast", "fast"),
-                ("slow", "slow"),
-                ("merger", "merged"),
-            )
-        }
+        entry_agent = Agent(
+            name="entry",
+            model="us.amazon.nova-lite-v1:0",
+            system_prompt="Say 'routed'.",
+        )
+        fast_agent = Agent(
+            name="fast",
+            model="us.amazon.nova-lite-v1:0",
+            system_prompt="Say 'fast result'.",
+        )
+        slow_agent = Agent(
+            name="slow",
+            model="us.amazon.nova-lite-v1:0",
+            system_prompt="Say 'slow result'.",
+        )
+        merger_agent = Agent(
+            name="merger",
+            model="us.amazon.nova-lite-v1:0",
+            system_prompt="Merge results. Say 'merged'.",
+        )
 
         builder = GraphBuilder()
-        for node_id, agent in agents.items():
-            builder.add_node(agent, node_id)
+        builder.add_node(entry_agent, "entry")
+        builder.add_node(fast_agent, "fast")
+        builder.add_node(slow_agent, "slow")
+        builder.add_node(merger_agent, "merger")
         builder.add_edge("entry", "fast", condition=is_fast_mode)
         builder.add_edge("entry", "slow", condition=is_slow_mode)
         builder.add_edge("fast", "merger")


### PR DESCRIPTION
## Description

`TestCountTokens` was pinned to `gemini-2.0-flash`, which Google [shut down on June 1, 2026](https://ai.google.dev/gemini-api/docs/deprecations). `countTokens` now returns 404, the provider falls back to estimation, and `test_count_tokens_messages_only` fails its `"falling back" not in caplog.text` assertion.

Moved to `gemini-2.5-flash-lite`: GA with no announced shutdown, and at [$0.10 in / $0.40 out per 1M tokens](https://ai.google.dev/gemini-api/docs/pricing) the cheapest text model on offer. Same rate `2.0-flash` charged, and under the `2.5-flash` used elsewhere in this file ($0.30 / $2.50).

`test_count_tokens_with_tools_greater_than_without` shares this fixture and was passing only because both sides of its comparison fell back to estimation. It now exercises the native count path.

## Related Issues

Failing run: https://github.com/strands-agents/harness-sdk/actions/runs/31457761253/job/93675032483

The same run also shows `test_multiagent_graph.py::test_diamond_graph_conditional_convergence` failing with `MaxTokensReachedException`. That is unrelated flakiness from agents being reused across two graph invocations, and is deliberately left out of this PR.

## Documentation PR

Not needed.

## Type of Change

Bug fix

## Testing

`hatch fmt --linter --check` passes (ruff + mypy). The fixture is only exercised by the Gemini integration tests, which need `GOOGLE_API_KEY`, so verification comes from the integ job on this PR.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.