### PR TITLE
refactor(vended-tools): treat bash as its own deprecated tool

### DIFF
--- a/site/src/content/docs/user-guide/concepts/sandbox/index.ts
+++ b/site/src/content/docs/user-guide/concepts/sandbox/index.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process'
 import { Agent, tool, type Tool } from '@strands-agents/sdk'
-import { makeShell } from '@strands-agents/sdk/vended-tools/bash'
+import { makeShell } from '@strands-agents/sdk/vended-tools/shell'
 import { makeFileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
 import { PosixShellSandbox } from '@strands-agents/sdk/sandbox'
 import type {

--- a/site/src/content/docs/user-guide/concepts/sandbox/index_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/sandbox/index_imports.ts
@@ -33,12 +33,12 @@ import { DockerSandbox } from '@strands-agents/sdk/sandbox/docker'
 // --8<-- [start:tool_override_imports]
 import { Agent } from '@strands-agents/sdk'
 import { DockerSandbox } from '@strands-agents/sdk/sandbox/docker'
-import { makeShell } from '@strands-agents/sdk/vended-tools/bash'
+import { makeShell } from '@strands-agents/sdk/vended-tools/shell'
 // --8<-- [end:tool_override_imports]
 
 // --8<-- [start:vend_tools_imports]
 import type { Tool } from '@strands-agents/sdk'
-import { makeShell } from '@strands-agents/sdk/vended-tools/bash'
+import { makeShell } from '@strands-agents/sdk/vended-tools/shell'
 import { makeFileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
 // --8<-- [end:vend_tools_imports]
 

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -208,7 +208,7 @@ agent("List all Python files in the current directory and count them")
 --8<-- "user-guide/concepts/tools/vended-tools.ts:bash_session"
 ```
 
-📖 [Full API Reference](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/bash/README.md)
+📖 Full API Reference: [shell](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/shell/README.md) · [bash (TypeScript only)](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/bash/README.md)
 
 ---
 

--- a/strands-py/src/strands/vended_tools/__init__.py
+++ b/strands-py/src/strands/vended_tools/__init__.py
@@ -21,28 +21,13 @@ Example Usage:
 """
 
 import warnings
-from typing import TYPE_CHECKING, Any
-
-from typing_extensions import deprecated
+from typing import Any
 
 from .file_editor import file_editor, make_file_editor
 from .http_request import http_request, make_http_request
 from .shell import make_shell, shell
+from .shell.shell import _RENAME_RATIONALE, make_bash  # noqa: F401  deprecated alias, kept importable until v2.0.0
 from .sleep import make_sleep, sleep
-
-if TYPE_CHECKING:
-    from ..tools.decorator import DecoratedFunctionTool
-
-_RENAME_RATIONALE = (
-    "The tool routes commands through the sandbox, which runs sh or the remote login shell "
-    "rather than bash specifically."
-)
-
-
-@deprecated(f"make_bash is deprecated and will be removed in v2.0.0. Use make_shell instead. {_RENAME_RATIONALE}")
-def make_bash(*, name: str = "bash", **kwargs: Any) -> "DecoratedFunctionTool":
-    """Deprecated alias for :func:`make_shell` that keeps the pre-rename default name."""
-    return make_shell(name=name, **kwargs)
 
 
 def __getattr__(name: str) -> Any:

--- a/strands-py/src/strands/vended_tools/__init__.py
+++ b/strands-py/src/strands/vended_tools/__init__.py
@@ -23,10 +23,10 @@ Example Usage:
 import warnings
 from typing import Any
 
+from ._bash import _RENAME_RATIONALE, make_bash  # noqa: F401  deprecated tool, kept importable until v2.0.0
 from .file_editor import file_editor, make_file_editor
 from .http_request import http_request, make_http_request
 from .shell import make_shell, shell
-from .shell.shell import _RENAME_RATIONALE, make_bash  # noqa: F401  deprecated alias, kept importable until v2.0.0
 from .sleep import make_sleep, sleep
 
 
@@ -39,7 +39,7 @@ def __getattr__(name: str) -> Any:
             DeprecationWarning,
             stacklevel=2,
         )
-        from .shell.shell import bash
+        from ._bash import bash
 
         return bash
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/strands-py/src/strands/vended_tools/_bash.py
+++ b/strands-py/src/strands/vended_tools/_bash.py
@@ -30,7 +30,13 @@ _RENAME_RATIONALE = (
 )
 
 
-@deprecated(f"make_bash is deprecated and will be removed in v2.0.0. Use make_shell instead. {_RENAME_RATIONALE}")
+# The message is a string literal rather than an f-string over _RENAME_RATIONALE
+# because PEP 702 checkers only honor @deprecated when the argument is a literal.
+@deprecated(
+    "make_bash is deprecated and will be removed in v2.0.0. Use make_shell instead. "
+    "The tool routes commands through the sandbox, which runs sh or the remote login shell "
+    "rather than bash specifically."
+)
 def make_bash(*, name: str = "bash", **kwargs: Any) -> DecoratedFunctionTool:
     """Deprecated alias for :func:`~strands.vended_tools.shell.make_shell` keeping the pre-rename default name."""
     return make_shell(name=name, **kwargs)

--- a/strands-py/src/strands/vended_tools/_bash.py
+++ b/strands-py/src/strands/vended_tools/_bash.py
@@ -1,0 +1,43 @@
+"""The deprecated ``bash`` tool: the pre-rename shape of :mod:`.shell`.
+
+``shell`` superseded ``bash`` because the tool routes commands through the
+sandbox, which runs ``sh`` or the remote login shell rather than bash
+specifically. The old tool keeps working under its old name until v2.0.0:
+``strands.vended_tools.bash`` resolves to the instance defined here (emitting a
+``DeprecationWarning`` on access), and :func:`make_bash` builds instances that
+default to the pre-rename tool name.
+
+This module is named ``_bash`` rather than ``bash`` because importing a public
+``bash`` submodule would bind it onto the package, silently shadowing the
+``__getattr__`` that emits the warning and handing callers a module where they
+expect a tool.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from typing_extensions import deprecated
+
+from .shell import make_shell
+
+if TYPE_CHECKING:
+    from ..tools.decorator import DecoratedFunctionTool
+
+_RENAME_RATIONALE = (
+    "The tool routes commands through the sandbox, which runs sh or the remote login shell "
+    "rather than bash specifically."
+)
+
+
+@deprecated(f"make_bash is deprecated and will be removed in v2.0.0. Use make_shell instead. {_RENAME_RATIONALE}")
+def make_bash(*, name: str = "bash", **kwargs: Any) -> DecoratedFunctionTool:
+    """Deprecated alias for :func:`~strands.vended_tools.shell.make_shell` keeping the pre-rename default name."""
+    return make_shell(name=name, **kwargs)
+
+
+bash = make_shell(name="bash")
+"""Deprecated pre-rename tool, kept so callers matching on the tool name ``"bash"``
+keep working until removal in v2.0.0. Reach it through ``strands.vended_tools.bash``,
+which emits the ``DeprecationWarning``; it is deliberately absent from ``__all__``
+and the docs."""

--- a/strands-py/src/strands/vended_tools/shell/__init__.py
+++ b/strands-py/src/strands/vended_tools/shell/__init__.py
@@ -10,10 +10,11 @@ Example Usage:
 """
 
 from .shell import make_shell, shell
-from .types import ShellExecutionError
+from .types import ShellExecutionError, ShellOutput
 
 __all__ = [
     "ShellExecutionError",
+    "ShellOutput",
     "make_shell",
     "shell",
 ]

--- a/strands-py/src/strands/vended_tools/shell/shell.py
+++ b/strands-py/src/strands/vended_tools/shell/shell.py
@@ -12,9 +12,7 @@ shell-specific syntax.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
-
-from typing_extensions import deprecated
+from typing import TYPE_CHECKING
 
 from ...sandbox.errors import SandboxTimeoutError
 from ...tools.decorator import tool
@@ -75,22 +73,3 @@ def make_shell(
 
 shell = make_shell()
 """Default shell tool. Reads the sandbox from the agent's context at call time."""
-
-
-_RENAME_RATIONALE = (
-    "The tool routes commands through the sandbox, which runs sh or the remote login shell "
-    "rather than bash specifically."
-)
-
-
-@deprecated(f"make_bash is deprecated and will be removed in v2.0.0. Use make_shell instead. {_RENAME_RATIONALE}")
-def make_bash(*, name: str = "bash", **kwargs: Any) -> DecoratedFunctionTool:
-    """Deprecated alias for :func:`make_shell` that keeps the pre-rename default name."""
-    return make_shell(name=name, **kwargs)
-
-
-bash = make_shell(name="bash")
-"""Deprecated pre-rename instance of :data:`shell`, kept so callers matching on the
-tool name ``"bash"`` keep working until removal in v2.0.0. Reach it through
-``strands.vended_tools.bash``, which emits the ``DeprecationWarning``; it is
-deliberately absent from ``__all__`` and the docs."""

--- a/strands-py/src/strands/vended_tools/shell/shell.py
+++ b/strands-py/src/strands/vended_tools/shell/shell.py
@@ -12,7 +12,9 @@ shell-specific syntax.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+
+from typing_extensions import deprecated
 
 from ...sandbox.errors import SandboxTimeoutError
 from ...tools.decorator import tool
@@ -73,6 +75,19 @@ def make_shell(
 
 shell = make_shell()
 """Default shell tool. Reads the sandbox from the agent's context at call time."""
+
+
+_RENAME_RATIONALE = (
+    "The tool routes commands through the sandbox, which runs sh or the remote login shell "
+    "rather than bash specifically."
+)
+
+
+@deprecated(f"make_bash is deprecated and will be removed in v2.0.0. Use make_shell instead. {_RENAME_RATIONALE}")
+def make_bash(*, name: str = "bash", **kwargs: Any) -> DecoratedFunctionTool:
+    """Deprecated alias for :func:`make_shell` that keeps the pre-rename default name."""
+    return make_shell(name=name, **kwargs)
+
 
 bash = make_shell(name="bash")
 """Deprecated pre-rename instance of :data:`shell`, kept so callers matching on the

--- a/strands-py/src/strands/vended_tools/shell/types.py
+++ b/strands-py/src/strands/vended_tools/shell/types.py
@@ -20,7 +20,7 @@ class ShellExecutionError(RuntimeError):
 
     Subclasses :class:`RuntimeError` so existing ``except RuntimeError`` handlers
     keep working, while giving callers a shell-specific type to branch on. Mirrors
-    ``ShellExecutionError`` in ``strands-ts/src/vended-tools/bash/types.ts``.
+    ``ShellExecutionError`` in ``strands-ts/src/vended-tools/shell/types.ts``.
     """
 
 

--- a/strands-py/tests/strands/vended_tools/test_shell.py
+++ b/strands-py/tests/strands/vended_tools/test_shell.py
@@ -158,6 +158,29 @@ class TestDeprecatedBashAliases:
 
         assert "make_shell" in vended_tools.make_bash.__deprecated__
 
+    def test_make_bash_deprecation_message_is_a_literal(self):
+        """PEP 702 checkers only honor @deprecated when the argument is a string literal.
+
+        An f-string over _RENAME_RATIONALE keeps the runtime warning and __deprecated__
+        attribute working while mypy silently reports nothing, so guard the source.
+        """
+        import ast
+        import inspect
+
+        import strands.vended_tools._bash as _bash
+
+        tree = ast.parse(inspect.getsource(_bash))
+        decorators = [
+            decorator
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and node.name == "make_bash"
+            for decorator in node.decorator_list
+            if isinstance(decorator, ast.Call) and getattr(decorator.func, "id", None) == "deprecated"
+        ]
+
+        assert len(decorators) == 1
+        assert isinstance(decorators[0].args[0], ast.Constant)
+
     def test_unknown_attribute_still_raises(self):
         import strands.vended_tools as vended_tools
 

--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -64,6 +64,10 @@
       "types": "./dist/src/vended-tools/http-request/index.d.ts",
       "default": "./dist/src/vended-tools/http-request/index.js"
     },
+    "./vended-tools/shell": {
+      "types": "./dist/src/vended-tools/shell/index.d.ts",
+      "default": "./dist/src/vended-tools/shell/index.js"
+    },
     "./vended-tools/bash": {
       "types": "./dist/src/vended-tools/bash/index.d.ts",
       "default": "./dist/src/vended-tools/bash/index.js"

--- a/strands-ts/src/sandbox/__tests__/docker.test.node.ts
+++ b/strands-ts/src/sandbox/__tests__/docker.test.node.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { DockerSandbox } from '../docker.js'
 import { streamProcess } from '../stream-process.js'
 import type { ExecutionResult } from '../types.js'
-import { SANDBOX_SHELL_DESCRIPTION } from '../../vended-tools/bash/types.js'
+import { SANDBOX_SHELL_DESCRIPTION } from '../../vended-tools/shell/types.js'
 
 const OK: ExecutionResult = { type: 'executionResult', exitCode: 0, stdout: '', stderr: '', outputFiles: [] }
 

--- a/strands-ts/src/sandbox/__tests__/ssh.test.node.ts
+++ b/strands-ts/src/sandbox/__tests__/ssh.test.node.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { SshSandbox } from '../ssh.js'
 import { streamProcess } from '../stream-process.js'
-import { SANDBOX_SHELL_DESCRIPTION } from '../../vended-tools/bash/types.js'
+import { SANDBOX_SHELL_DESCRIPTION } from '../../vended-tools/shell/types.js'
 
 vi.mock('../stream-process.js', () => ({
   streamProcess: vi.fn(async function* () {

--- a/strands-ts/src/sandbox/docker.ts
+++ b/strands-ts/src/sandbox/docker.ts
@@ -8,7 +8,7 @@ import { streamProcess } from './stream-process.js'
 import type { ExecutionResult, StreamChunk } from './types.js'
 import type { Tool } from '../tools/tool.js'
 import { makeFileEditor, DEFAULT_FILE_EDITOR_DESCRIPTION } from '../vended-tools/file-editor/index.js'
-import { makeShell, SANDBOX_SHELL_DESCRIPTION } from '../vended-tools/bash/index.js'
+import { makeShell, SANDBOX_SHELL_DESCRIPTION } from '../vended-tools/shell/index.js'
 
 /**
  * Options for constructing a {@link DockerSandbox}.

--- a/strands-ts/src/sandbox/ssh.ts
+++ b/strands-ts/src/sandbox/ssh.ts
@@ -9,7 +9,7 @@ import { streamProcess } from './stream-process.js'
 import type { ExecutionResult, StreamChunk } from './types.js'
 import type { Tool } from '../tools/tool.js'
 import { makeFileEditor, DEFAULT_FILE_EDITOR_DESCRIPTION } from '../vended-tools/file-editor/index.js'
-import { makeShell, SANDBOX_SHELL_DESCRIPTION } from '../vended-tools/bash/index.js'
+import { makeShell, SANDBOX_SHELL_DESCRIPTION } from '../vended-tools/shell/index.js'
 
 // Known-safe SSH options. Options that execute commands, tunnel traffic, or load
 // external config are excluded. Reviewed and approved by AppSec.

--- a/strands-ts/src/vended-tools/bash/README.md
+++ b/strands-ts/src/vended-tools/bash/README.md
@@ -2,13 +2,13 @@
 
 A robust tool for executing bash shell commands in Node.js environments with persistent session support.
 
-> **`bash` vs `makeShell`**: this directory exports two different tools. `bash`
-> spawns a persistent `bash` process directly on the host, so it requires bash and
-> keeps state across calls -- that is what this document describes. `makeShell`
-> builds a stateless tool that routes commands through a
-> [Sandbox](../../sandbox/base.ts), which runs `sh` locally and in Docker or the
-> remote login shell over SSH; commands passed to it must not rely on
-> bash-specific syntax.
+> **`bash` vs `makeShell`**: these are two different tools. `bash` spawns a
+> persistent `bash` process directly on the host, so it requires bash and keeps
+> state across calls -- that is what this document describes. `makeShell`, which
+> lives in [`../shell`](../shell/), builds a stateless tool that routes commands
+> through a [Sandbox](../../sandbox/base.ts), which runs `sh` locally and in
+> Docker or the remote login shell over SSH; commands passed to it must not rely
+> on bash-specific syntax.
 
 ## ⚠️ Security Warning
 

--- a/strands-ts/src/vended-tools/bash/__tests__/bash.test.node.ts
+++ b/strands-ts/src/vended-tools/bash/__tests__/bash.test.node.ts
@@ -8,10 +8,7 @@ import {
 import type { ToolContext } from '../../../index.js'
 import { StateStore } from '../../../state-store.js'
 import { createMockAgent } from '../../../__fixtures__/agent-helpers.js'
-import { TestSandbox } from '../../../__fixtures__/test-sandbox.node.js'
-import { realpathSync, mkdtempSync } from 'fs'
-import { tmpdir } from 'os'
-import { join } from 'path'
+import { realpathSync } from 'fs'
 
 // Skip tests on Windows (bash not available)
 describe.skipIf(process.platform === 'win32')('bash tool', () => {

--- a/strands-ts/src/vended-tools/bash/__tests__/bash.test.node.ts
+++ b/strands-ts/src/vended-tools/bash/__tests__/bash.test.node.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import {
-  bash,
-  BashTimeoutError,
-  BashSessionError,
-  type BashOutput,
-} from '../index.js'
+import { bash, BashTimeoutError, BashSessionError, type BashOutput } from '../index.js'
 import type { ToolContext } from '../../../index.js'
 import { StateStore } from '../../../state-store.js'
 import { createMockAgent } from '../../../__fixtures__/agent-helpers.js'
@@ -475,4 +470,3 @@ describe.skipIf(process.platform === 'win32')('bash tool', () => {
     })
   })
 })
-

--- a/strands-ts/src/vended-tools/bash/__tests__/bash.test.node.ts
+++ b/strands-ts/src/vended-tools/bash/__tests__/bash.test.node.ts
@@ -1,12 +1,8 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import {
   bash,
-  makeBash,
-  makeShell,
   BashTimeoutError,
   BashSessionError,
-  ShellTimeoutError,
-  ShellExecutionError,
   type BashOutput,
 } from '../index.js'
 import type { ToolContext } from '../../../index.js'
@@ -483,78 +479,3 @@ describe.skipIf(process.platform === 'win32')('bash tool', () => {
   })
 })
 
-describe.skipIf(process.platform === 'win32')('makeShell', () => {
-  const createSandboxShell = (): { sandboxShell: ReturnType<typeof makeShell>; context: ToolContext } => {
-    const workDir = mkdtempSync(join(tmpdir(), 'shell-sandbox-test-'))
-    const sandbox = new TestSandbox(workDir)
-    const sandboxShell = makeShell(sandbox)
-    const agent = createMockAgent()
-    const context: ToolContext = {
-      toolUse: { name: 'shell', toolUseId: 'test-id', input: {} },
-      agent,
-      invocationState: {},
-      interrupt: () => {
-        throw new Error('interrupt not available in mock context')
-      },
-    }
-    return { sandboxShell, context }
-  }
-
-  it('executes command via sandbox', async () => {
-    const { sandboxShell, context } = createSandboxShell()
-    const result = await sandboxShell.invoke({ command: 'echo "hello sandbox"' }, context)
-
-    expect((result as BashOutput).output).toContain('hello sandbox')
-    expect((result as BashOutput).error).toBe('')
-  })
-
-  it('captures stderr via sandbox', async () => {
-    const { sandboxShell, context } = createSandboxShell()
-    const result = await sandboxShell.invoke({ command: 'echo "oops" >&2' }, context)
-
-    expect((result as BashOutput).error).toContain('oops')
-  })
-
-  it('does not persist state between calls (stateless)', async () => {
-    const { sandboxShell, context } = createSandboxShell()
-    await sandboxShell.invoke({ command: 'export MY_VAR=hello' }, context)
-    const result = await sandboxShell.invoke({ command: 'echo "${MY_VAR:-empty}"' }, context)
-
-    expect((result as BashOutput).output.trim()).toBe('empty')
-  })
-
-  it('respects timeout', async () => {
-    const { sandboxShell, context } = createSandboxShell()
-    await expect(sandboxShell.invoke({ command: 'sleep 10', timeout: 0.1 }, context)).rejects.toThrow()
-  })
-
-  it('throws ShellTimeoutError on timeout', async () => {
-    const { sandboxShell, context } = createSandboxShell()
-    await expect(sandboxShell.invoke({ command: 'sleep 10', timeout: 0.1 }, context)).rejects.toThrow(ShellTimeoutError)
-  })
-
-  it('timeout error still matches the pre-rename BashTimeoutError', async () => {
-    const { sandboxShell, context } = createSandboxShell()
-    await expect(sandboxShell.invoke({ command: 'sleep 10', timeout: 0.1 }, context)).rejects.toThrow(BashTimeoutError)
-  })
-
-  it('ShellExecutionError still matches the pre-rename BashSessionError', () => {
-    expect(new ShellExecutionError('boom')).toBeInstanceOf(BashSessionError)
-  })
-})
-
-describe('deprecated makeBash alias', () => {
-  // Consumers key registries, hooks, and defaults lists on the runtime name, so an
-  // alias that returned a tool named 'shell' would still break them (see awsarron/stan#6).
-  it('keeps the pre-rename tool name', () => {
-    expect(makeBash().name).toBe('bash')
-  })
-
-  it('matches makeShell apart from the name', () => {
-    expect(makeBash().toolSpec).toEqual({ ...makeShell().toolSpec, name: 'bash' })
-  })
-
-  it('an explicit name still wins', () => {
-    expect(makeBash({ name: 'sandbox_bash' }).name).toBe('sandbox_bash')
-  })
-})

--- a/strands-ts/src/vended-tools/bash/index.ts
+++ b/strands-ts/src/vended-tools/bash/index.ts
@@ -1,20 +1,23 @@
 /**
- * Bash and sandbox-routed shell tools for Node.js environments.
+ * Persistent bash tool for Node.js environments.
  *
- * `bash` spawns a persistent bash process on the host. `makeShell` builds a
- * stateless tool that routes commands through a sandbox, which runs whichever
- * shell that sandbox provides.
+ * `bash` spawns a persistent bash process on the host and keeps state across
+ * calls. The stateless, sandbox-routed shell tool lives in `../shell`; its
+ * names are re-exported here so pre-rename imports through this path keep
+ * working until v2.0.0.
  */
 
+import { SANDBOX_SHELL_DESCRIPTION } from '../shell/types.js'
+
 export { bash } from './bash.js'
-export { makeShell, makeBash } from './make-shell.js'
-export type { MakeShellOptions, MakeBashOptions } from './make-shell.js'
-export {
-  SANDBOX_SHELL_DESCRIPTION,
-  SANDBOX_BASH_DESCRIPTION,
-  BashTimeoutError,
-  BashSessionError,
-  ShellTimeoutError,
-  ShellExecutionError,
-} from './types.js'
+export { BashTimeoutError, BashSessionError } from './types.js'
 export type { BashInput, BashOutput, ExecuteInput, RestartInput } from './types.js'
+
+export { makeShell, makeBash } from '../shell/make-shell.js'
+export type { MakeShellOptions, MakeBashOptions } from '../shell/make-shell.js'
+export { SANDBOX_SHELL_DESCRIPTION, ShellTimeoutError, ShellExecutionError } from '../shell/types.js'
+
+/**
+ * @deprecated SANDBOX_BASH_DESCRIPTION is deprecated and will be removed in v2.0.0. Use SANDBOX_SHELL_DESCRIPTION instead. The tool routes commands through the sandbox, which runs sh or the remote login shell rather than bash specifically.
+ */
+export const SANDBOX_BASH_DESCRIPTION = SANDBOX_SHELL_DESCRIPTION

--- a/strands-ts/src/vended-tools/bash/types.ts
+++ b/strands-ts/src/vended-tools/bash/types.ts
@@ -1,15 +1,9 @@
 /**
- * Type definitions for the bash and sandbox-routed shell tools.
+ * Type definitions for the persistent bash tool.
+ *
+ * The sandbox-routed shell tool's types live in `../shell/types.js`; its error
+ * classes extend the ones here so pre-rename catch clauses keep matching.
  */
-
-export const SANDBOX_SHELL_DESCRIPTION =
-  'Executes shell commands. Each call runs in a fresh shell; ' +
-  'state such as variables and the working directory does not persist across calls.'
-
-/**
- * @deprecated SANDBOX_BASH_DESCRIPTION is deprecated and will be removed in v2.0.0. Use SANDBOX_SHELL_DESCRIPTION instead. The tool routes commands through the sandbox, which runs sh or the remote login shell rather than bash specifically.
- */
-export const SANDBOX_BASH_DESCRIPTION = SANDBOX_SHELL_DESCRIPTION
 
 /**
  * Input parameters for execute operation.
@@ -85,31 +79,5 @@ export class BashSessionError extends Error {
   constructor(message: string) {
     super(message)
     this.name = 'BashSessionError'
-  }
-}
-
-/**
- * Error thrown when a sandbox-routed shell command exceeds its timeout.
- *
- * Extends {@link BashTimeoutError} so that callers who caught the previous error
- * type keep working; new code should catch this instead.
- */
-export class ShellTimeoutError extends BashTimeoutError {
-  constructor(message: string) {
-    super(message)
-    this.name = 'ShellTimeoutError'
-  }
-}
-
-/**
- * Error thrown when a sandbox-routed shell command fails.
- *
- * Extends {@link BashSessionError} so that callers who caught the previous error
- * type keep working; new code should catch this instead.
- */
-export class ShellExecutionError extends BashSessionError {
-  constructor(message: string) {
-    super(message)
-    this.name = 'ShellExecutionError'
   }
 }

--- a/strands-ts/src/vended-tools/index.ts
+++ b/strands-ts/src/vended-tools/index.ts
@@ -13,6 +13,7 @@
 
 export * from './bash/index.js'
 export * from './file-editor/index.js'
+export * from './shell/index.js'
 export * from './http-request/index.js'
 export * from './notebook/index.js'
 export * from './sleep/index.js'

--- a/strands-ts/src/vended-tools/shell/README.md
+++ b/strands-ts/src/vended-tools/shell/README.md
@@ -32,11 +32,11 @@ Without a bound sandbox, the tool reads `context.agent.sandbox` at call time.
 
 ### `makeShell(options?)` / `makeShell(sandbox, options?)`
 
-| Option        | Type      | Default    | Description                                              |
-| ------------- | --------- | ---------- | -------------------------------------------------------- |
-| `name`        | `string`  | `shell`    | Tool name.                                               |
-| `description` | `string`  | (built-in) | Description shown to the model.                          |
-| `inputSchema` | `z.ZodType` | (built-in) | Override the input schema.                             |
+| Option        | Type        | Default    | Description                     |
+| ------------- | ----------- | ---------- | ------------------------------- |
+| `name`        | `string`    | `shell`    | Tool name.                      |
+| `description` | `string`    | (built-in) | Description shown to the model. |
+| `inputSchema` | `z.ZodType` | (built-in) | Override the input schema.      |
 
 ### Input
 

--- a/strands-ts/src/vended-tools/shell/README.md
+++ b/strands-ts/src/vended-tools/shell/README.md
@@ -1,0 +1,68 @@
+# Shell Tool
+
+A stateless shell tool that routes commands through a [Sandbox](../../sandbox/base.ts).
+
+Each call runs in a fresh shell, so state such as variables and the working directory does not persist across calls. The sandbox decides which shell runs the command: `sh` locally and in Docker, the remote login shell over SSH. Commands must not rely on bash-specific syntax.
+
+> **`makeShell` vs `bash`**: these are two different tools. The persistent, host-spawned `bash` tool lives in [`../bash`](../bash/); it requires bash on the host and keeps state across calls. `makeShell` is the sandbox-routed tool the built-in Docker and SSH sandboxes vend from `getTools()`.
+
+## Usage
+
+```typescript
+import { Agent } from '@strands-agents/sdk'
+import { makeShell } from '@strands-agents/sdk/vended-tools/shell'
+
+const agent = new Agent({ tools: [makeShell()] })
+await agent.invoke('List all files in the working directory')
+```
+
+With a sandbox bound at creation time (how the built-in sandboxes vend it):
+
+```typescript
+import { DockerSandbox } from '@strands-agents/sdk/sandbox'
+import { makeShell } from '@strands-agents/sdk/vended-tools/shell'
+
+const sandbox = new DockerSandbox({ container: 'my-container' })
+const shellTool = makeShell(sandbox)
+```
+
+Without a bound sandbox, the tool reads `context.agent.sandbox` at call time.
+
+## API
+
+### `makeShell(options?)` / `makeShell(sandbox, options?)`
+
+| Option        | Type      | Default    | Description                                              |
+| ------------- | --------- | ---------- | -------------------------------------------------------- |
+| `name`        | `string`  | `shell`    | Tool name.                                               |
+| `description` | `string`  | (built-in) | Description shown to the model.                          |
+| `inputSchema` | `z.ZodType` | (built-in) | Override the input schema.                             |
+
+### Input
+
+```typescript
+{
+  command: string   // The shell command to execute
+  timeout?: number  // Timeout in seconds (default: 120)
+}
+```
+
+### Return Value
+
+```typescript
+interface ShellOutput {
+  output: string // Standard output (stdout)
+  error: string // Standard error (stderr) - empty string if no errors
+}
+```
+
+### Error Handling
+
+- **`ShellTimeoutError`**: thrown when a command exceeds its timeout
+- **`ShellExecutionError`**: thrown when the sandbox fails to execute the command
+
+Both extend the `Bash*` error types from [`../bash`](../bash/), so `catch` clauses written before the rename keep matching.
+
+### Deprecated aliases
+
+`makeBash` builds the same tool with the pre-rename default name `bash`; it will be removed in v2.0.0. Prefer `makeShell`.

--- a/strands-ts/src/vended-tools/shell/__tests__/shell.test.node.ts
+++ b/strands-ts/src/vended-tools/shell/__tests__/shell.test.node.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { makeBash, makeShell, ShellTimeoutError, ShellExecutionError } from '../index.js'
-import { BashTimeoutError, BashSessionError, type BashOutput } from '../../bash/types.js'
+import { makeBash, makeShell, ShellTimeoutError, ShellExecutionError, type ShellOutput } from '../index.js'
+import { BashTimeoutError, BashSessionError } from '../../bash/types.js'
 import type { ToolContext } from '../../../index.js'
 import { createMockAgent } from '../../../__fixtures__/agent-helpers.js'
 import { TestSandbox } from '../../../__fixtures__/test-sandbox.node.js'
@@ -29,15 +29,15 @@ describe.skipIf(process.platform === 'win32')('makeShell', () => {
     const { sandboxShell, context } = createSandboxShell()
     const result = await sandboxShell.invoke({ command: 'echo "hello sandbox"' }, context)
 
-    expect((result as BashOutput).output).toContain('hello sandbox')
-    expect((result as BashOutput).error).toBe('')
+    expect((result as ShellOutput).output).toContain('hello sandbox')
+    expect((result as ShellOutput).error).toBe('')
   })
 
   it('captures stderr via sandbox', async () => {
     const { sandboxShell, context } = createSandboxShell()
     const result = await sandboxShell.invoke({ command: 'echo "oops" >&2' }, context)
 
-    expect((result as BashOutput).error).toContain('oops')
+    expect((result as ShellOutput).error).toContain('oops')
   })
 
   it('does not persist state between calls (stateless)', async () => {
@@ -45,7 +45,7 @@ describe.skipIf(process.platform === 'win32')('makeShell', () => {
     await sandboxShell.invoke({ command: 'export MY_VAR=hello' }, context)
     const result = await sandboxShell.invoke({ command: 'echo "${MY_VAR:-empty}"' }, context)
 
-    expect((result as BashOutput).output.trim()).toBe('empty')
+    expect((result as ShellOutput).output.trim()).toBe('empty')
   })
 
   it('respects timeout', async () => {
@@ -81,5 +81,19 @@ describe('deprecated makeBash alias', () => {
 
   it('an explicit name still wins', () => {
     expect(makeBash({ name: 'sandbox_bash' }).name).toBe('sandbox_bash')
+  })
+})
+
+describe('pre-rename bash import path (kept until v2.0.0)', () => {
+  // The bash barrel re-exports the shell names so imports written before the
+  // rename keep working. Nothing else exercises that path, so assert it here.
+  it('still exposes every shell name', async () => {
+    const barrel = await import('../../bash/index.js')
+    expect(barrel.makeShell).toBe(makeShell)
+    expect(barrel.makeBash).toBe(makeBash)
+    expect(barrel.ShellTimeoutError).toBe(ShellTimeoutError)
+    expect(barrel.ShellExecutionError).toBe(ShellExecutionError)
+    expect(barrel.SANDBOX_SHELL_DESCRIPTION).toBeDefined()
+    expect(barrel.SANDBOX_BASH_DESCRIPTION).toBe(barrel.SANDBOX_SHELL_DESCRIPTION)
   })
 })

--- a/strands-ts/src/vended-tools/shell/__tests__/shell.test.node.ts
+++ b/strands-ts/src/vended-tools/shell/__tests__/shell.test.node.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import { makeBash, makeShell, ShellTimeoutError, ShellExecutionError } from '../index.js'
+import { BashTimeoutError, BashSessionError, type BashOutput } from '../../bash/types.js'
+import type { ToolContext } from '../../../index.js'
+import { createMockAgent } from '../../../__fixtures__/agent-helpers.js'
+import { TestSandbox } from '../../../__fixtures__/test-sandbox.node.js'
+import { mkdtempSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+describe.skipIf(process.platform === 'win32')('makeShell', () => {
+  const createSandboxShell = (): { sandboxShell: ReturnType<typeof makeShell>; context: ToolContext } => {
+    const workDir = mkdtempSync(join(tmpdir(), 'shell-sandbox-test-'))
+    const sandbox = new TestSandbox(workDir)
+    const sandboxShell = makeShell(sandbox)
+    const agent = createMockAgent()
+    const context: ToolContext = {
+      toolUse: { name: 'shell', toolUseId: 'test-id', input: {} },
+      agent,
+      invocationState: {},
+      interrupt: () => {
+        throw new Error('interrupt not available in mock context')
+      },
+    }
+    return { sandboxShell, context }
+  }
+
+  it('executes command via sandbox', async () => {
+    const { sandboxShell, context } = createSandboxShell()
+    const result = await sandboxShell.invoke({ command: 'echo "hello sandbox"' }, context)
+
+    expect((result as BashOutput).output).toContain('hello sandbox')
+    expect((result as BashOutput).error).toBe('')
+  })
+
+  it('captures stderr via sandbox', async () => {
+    const { sandboxShell, context } = createSandboxShell()
+    const result = await sandboxShell.invoke({ command: 'echo "oops" >&2' }, context)
+
+    expect((result as BashOutput).error).toContain('oops')
+  })
+
+  it('does not persist state between calls (stateless)', async () => {
+    const { sandboxShell, context } = createSandboxShell()
+    await sandboxShell.invoke({ command: 'export MY_VAR=hello' }, context)
+    const result = await sandboxShell.invoke({ command: 'echo "${MY_VAR:-empty}"' }, context)
+
+    expect((result as BashOutput).output.trim()).toBe('empty')
+  })
+
+  it('respects timeout', async () => {
+    const { sandboxShell, context } = createSandboxShell()
+    await expect(sandboxShell.invoke({ command: 'sleep 10', timeout: 0.1 }, context)).rejects.toThrow()
+  })
+
+  it('throws ShellTimeoutError on timeout', async () => {
+    const { sandboxShell, context } = createSandboxShell()
+    await expect(sandboxShell.invoke({ command: 'sleep 10', timeout: 0.1 }, context)).rejects.toThrow(ShellTimeoutError)
+  })
+
+  it('timeout error still matches the pre-rename BashTimeoutError', async () => {
+    const { sandboxShell, context } = createSandboxShell()
+    await expect(sandboxShell.invoke({ command: 'sleep 10', timeout: 0.1 }, context)).rejects.toThrow(BashTimeoutError)
+  })
+
+  it('ShellExecutionError still matches the pre-rename BashSessionError', () => {
+    expect(new ShellExecutionError('boom')).toBeInstanceOf(BashSessionError)
+  })
+})
+
+describe('deprecated makeBash alias', () => {
+  // Consumers key registries, hooks, and defaults lists on the runtime name, so an
+  // alias that returned a tool named 'shell' would still break them (see awsarron/stan#6).
+  it('keeps the pre-rename tool name', () => {
+    expect(makeBash().name).toBe('bash')
+  })
+
+  it('matches makeShell apart from the name', () => {
+    expect(makeBash().toolSpec).toEqual({ ...makeShell().toolSpec, name: 'bash' })
+  })
+
+  it('an explicit name still wins', () => {
+    expect(makeBash({ name: 'sandbox_bash' }).name).toBe('sandbox_bash')
+  })
+})

--- a/strands-ts/src/vended-tools/shell/index.ts
+++ b/strands-ts/src/vended-tools/shell/index.ts
@@ -12,3 +12,4 @@
 export { makeShell, makeBash } from './make-shell.js'
 export type { MakeShellOptions, MakeBashOptions } from './make-shell.js'
 export { SANDBOX_SHELL_DESCRIPTION, ShellTimeoutError, ShellExecutionError } from './types.js'
+export type { ShellOutput } from './types.js'

--- a/strands-ts/src/vended-tools/shell/index.ts
+++ b/strands-ts/src/vended-tools/shell/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Sandbox-routed shell tool.
+ *
+ * `makeShell` builds a stateless tool that routes commands through a
+ * [Sandbox](../../sandbox/base.ts), which runs `sh` locally and in Docker or
+ * the remote login shell over SSH. Each call runs in a fresh shell; state such
+ * as variables and the working directory does not persist across calls.
+ *
+ * The persistent, host-spawned `bash` tool lives in `../bash`.
+ */
+
+export { makeShell, makeBash } from './make-shell.js'
+export type { MakeShellOptions, MakeBashOptions } from './make-shell.js'
+export { SANDBOX_SHELL_DESCRIPTION, ShellTimeoutError, ShellExecutionError } from './types.js'

--- a/strands-ts/src/vended-tools/shell/make-shell.ts
+++ b/strands-ts/src/vended-tools/shell/make-shell.ts
@@ -85,7 +85,7 @@ export function makeBash(
   maybeOptions?: MakeShellOptions
 ): ReturnType<typeof tool> {
   const { boundSandbox, options } = resolveShellArgs(sandboxOrOptions, maybeOptions)
-  return makeShell(boundSandbox, { name: 'bash', ...options })
+  return makeShell(boundSandbox, { ...options, name: options.name ?? 'bash' })
 }
 
 /**

--- a/strands-ts/src/vended-tools/shell/make-shell.ts
+++ b/strands-ts/src/vended-tools/shell/make-shell.ts
@@ -1,8 +1,8 @@
 /**
  * Sandbox-bound shell tool factory.
  *
- * Separated from bash.ts to avoid pulling Node dependencies (child_process, Buffer)
- * into sandbox implementations that import this.
+ * Lives apart from the bash tool so sandbox implementations can import it
+ * without pulling in Node dependencies (child_process, Buffer).
  *
  * The command runs in whichever shell the sandbox provides -- `sh` for the Docker
  * and local environments, the remote login shell over SSH -- so it must not rely
@@ -13,7 +13,7 @@ import { tool } from '../../tools/tool-factory.js'
 import { z } from 'zod'
 import { SandboxTimeoutError } from '../../sandbox/errors.js'
 import { Sandbox } from '../../sandbox/base.js'
-import type { BashOutput } from './types.js'
+import type { BashOutput } from '../bash/types.js'
 import { ShellTimeoutError, ShellExecutionError, SANDBOX_SHELL_DESCRIPTION } from './types.js'
 
 const sandboxShellInputSchema = z.object({

--- a/strands-ts/src/vended-tools/shell/make-shell.ts
+++ b/strands-ts/src/vended-tools/shell/make-shell.ts
@@ -13,8 +13,7 @@ import { tool } from '../../tools/tool-factory.js'
 import { z } from 'zod'
 import { SandboxTimeoutError } from '../../sandbox/errors.js'
 import { Sandbox } from '../../sandbox/base.js'
-import type { BashOutput } from '../bash/types.js'
-import { ShellTimeoutError, ShellExecutionError, SANDBOX_SHELL_DESCRIPTION } from './types.js'
+import { ShellTimeoutError, ShellExecutionError, SANDBOX_SHELL_DESCRIPTION, type ShellOutput } from './types.js'
 
 const sandboxShellInputSchema = z.object({
   command: z.string().describe('The shell command to execute.'),
@@ -61,7 +60,7 @@ export function makeShell(
       const sandbox = boundSandbox ?? context.agent.sandbox
       try {
         const result = await sandbox.execute(input.command, { timeout: input.timeout ?? 120 })
-        return { output: result.stdout, error: result.stderr } as BashOutput
+        return { output: result.stdout, error: result.stderr } as ShellOutput
       } catch (err) {
         // Shell* extends Bash* so pre-rename catch clauses keep matching.
         if (err instanceof SandboxTimeoutError) throw new ShellTimeoutError(err.message)

--- a/strands-ts/src/vended-tools/shell/types.ts
+++ b/strands-ts/src/vended-tools/shell/types.ts
@@ -5,7 +5,7 @@
  * callers who caught the pre-rename error types keep working.
  */
 
-import { BashTimeoutError, BashSessionError } from '../bash/types.js'
+import { BashTimeoutError, BashSessionError, type BashOutput } from '../bash/types.js'
 
 export const SANDBOX_SHELL_DESCRIPTION =
   'Executes shell commands. Each call runs in a fresh shell; ' +
@@ -36,3 +36,10 @@ export class ShellExecutionError extends BashSessionError {
     this.name = 'ShellExecutionError'
   }
 }
+
+/**
+ * Output format for shell command execution. The same shape as the bash tool's
+ * output, so pre-rename consumers keep working; mirrors the Python SDK's
+ * `ShellOutput`.
+ */
+export type ShellOutput = BashOutput

--- a/strands-ts/src/vended-tools/shell/types.ts
+++ b/strands-ts/src/vended-tools/shell/types.ts
@@ -5,7 +5,7 @@
  * callers who caught the pre-rename error types keep working.
  */
 
-import { BashTimeoutError, BashSessionError, type BashOutput } from '../bash/types.js'
+import { BashTimeoutError, BashSessionError } from '../bash/types.js'
 
 export const SANDBOX_SHELL_DESCRIPTION =
   'Executes shell commands. Each call runs in a fresh shell; ' +
@@ -38,8 +38,24 @@ export class ShellExecutionError extends BashSessionError {
 }
 
 /**
- * Output format for shell command execution. The same shape as the bash tool's
- * output, so pre-rename consumers keep working; mirrors the Python SDK's
- * `ShellOutput`.
+ * Output format for shell command execution. Structurally identical to the bash
+ * tool's output, so pre-rename consumers keep working, but declared standalone;
+ * mirrors the Python SDK's `ShellOutput`.
  */
-export type ShellOutput = BashOutput
+export interface ShellOutput {
+  /**
+   * Standard output from the command.
+   */
+  output: string
+
+  /**
+   * Standard error from the command.
+   * Empty string if no errors occurred.
+   */
+  error: string
+
+  /**
+   * Allow indexing with string keys for JSONValue compatibility.
+   */
+  [key: string]: string
+}

--- a/strands-ts/src/vended-tools/shell/types.ts
+++ b/strands-ts/src/vended-tools/shell/types.ts
@@ -1,0 +1,38 @@
+/**
+ * Type definitions for the sandbox-routed shell tool.
+ *
+ * The Shell* errors extend the Bash* errors from `../bash/types.js` so that
+ * callers who caught the pre-rename error types keep working.
+ */
+
+import { BashTimeoutError, BashSessionError } from '../bash/types.js'
+
+export const SANDBOX_SHELL_DESCRIPTION =
+  'Executes shell commands. Each call runs in a fresh shell; ' +
+  'state such as variables and the working directory does not persist across calls.'
+
+/**
+ * Error thrown when a sandbox-routed shell command exceeds its timeout.
+ *
+ * Extends {@link BashTimeoutError} so that callers who caught the previous error
+ * type keep working; new code should catch this instead.
+ */
+export class ShellTimeoutError extends BashTimeoutError {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ShellTimeoutError'
+  }
+}
+
+/**
+ * Error thrown when a sandbox-routed shell command fails.
+ *
+ * Extends {@link BashSessionError} so that callers who caught the previous error
+ * type keep working; new code should catch this instead.
+ */
+export class ShellExecutionError extends BashSessionError {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ShellExecutionError'
+  }
+}


### PR DESCRIPTION
## Description

Follow-up to #3751, carrying the structural feedback from its review: the rename should read as **a new `shell` tool plus a deprecated `bash` tool**, with one tool per home and names matching contents, and tool-specific code out of the package `__init__`.

Two commits, rebased onto main after #3751 merged:

**`eef41fee5` — give the sandbox-routed shell its own directory (TypeScript)**
- New `vended-tools/shell/` holds `makeShell`, `makeBash`, the `Shell*` errors, and their tests, with a `./vended-tools/shell` subpath export.
- `vended-tools/bash/` keeps the persistent host `bash` tool and re-exports the shell names, so imports through the pre-rename path keep working until v2.0.0. `Shell*` errors still extend `Bash*` errors, so pre-rename catch clauses keep matching.
- The Docker/SSH sandbox implementations and their tests now import from `vended-tools/shell/`.

**`f7f86a83a` — treat bash as its own deprecated tool**
- **Python**: the deprecated surface (`bash` instance, `make_bash`, the rename rationale) moves out of `shell/shell.py` into its own module, `vended_tools/_bash.py`, leaving the shell module canonical-only. The module is `_bash` rather than `bash` because importing a public `bash` submodule would bind it onto the package, silently shadowing the `__getattr__` that emits the `DeprecationWarning` and handing callers a module where they expect a tool — the same trap #3574 called out when it declined to add a `bash.py` shim.
- **TypeScript**: `shell/types.ts` gains `ShellOutput` (aliasing the bash tool's output shape, mirroring the Python SDK's `ShellOutput`), so the shell module no longer reaches into `../bash` for its return type.

On the py/ts asymmetry raised in review (TypeScript has two tools, Python one): that is inherent, not structural. TypeScript's `bash` is a genuinely different tool — a persistent host-spawned bash process — with no Python counterpart. What this PR makes true in both SDKs is one directory per tool with names matching contents: `shell/` is the sandbox-routed tool everywhere, TypeScript's `bash/` is the persistent host tool, and Python's `_bash.py` is the deprecated pre-rename tool.

## Type of Change

Code refactoring (no public behavior change: same names, same warnings, same removal schedule)

## Testing

- **Python**: `tests/strands/vended_tools/test_shell.py` → 19 passed on the rebased branch; ruff clean. End-to-end: `from strands.vended_tools import bash` warns and returns a tool named `bash`, identity is stable across accesses, and `bash` stays out of `__all__`.
- **TypeScript**: `shell.test.node.ts` + `bash.test.node.ts` + the Docker/SSH sandbox unit tests → 86 passed, no type errors; `tsc --noEmit` over `src/` clean.
- Not run locally: prettier/eslint (registry auth unavailable in this environment).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
