### PR TITLE
docs(community): add Neo4j Agent Memory session manager

### DIFF
--- a/site/src/content/catalog/neo4j-agent-memory.yaml
+++ b/site/src/content/catalog/neo4j-agent-memory.yaml
@@ -1,0 +1,11 @@
+name: neo4j-agent-memory
+description: Neo4j graph memory for Strands agents — session persistence, entity and relationship extraction, and reasoning traces, on hosted NAMS or self-hosted Neo4j.
+integrationType: session-manager
+languages:
+  python:
+    package: neo4j-agent-memory[strands]
+  typescript:
+    package: "@neo4j-labs/agent-memory"
+github: https://github.com/neo4j-labs/agent-memory
+docsUrl: https://neo4j.com/labs/agent-memory/how-to/integrations/aws-strands/
+addedDate: 2026-08-11


### PR DESCRIPTION
## Integration submission

**Package name:** `neo4j-agent-memory` (PyPI, `[strands]` extra) / `@neo4j-labs/agent-memory` (npm)
**Integration type:** session-manager
**Languages published:** Python and TypeScript
**GitHub repo:** https://github.com/neo4j-labs/agent-memory
**What it does:** Persists Strands agent conversations into a Neo4j knowledge graph — `SessionManager` in Python, `SnapshotStorage` in TypeScript — and extracts entities, relationships, preferences, and reasoning traces from the stored turns so later sessions can query them as a graph. Runs against the hosted Neo4j Agent Memory Service (NAMS) or a self-hosted Neo4j instance.
**Relationship to service:** Official vendor integration (Neo4j Labs).
**Docs link included:** `docsUrl` → https://neo4j.com/labs/agent-memory/how-to/integrations/aws-strands/ — no on-site docs page added.

### Submitter checklist

#### Package
- [x] This is a reusable integration (library/plugin/provider), not an example agent or application built with Strands
- [x] Published to PyPI and/or npm under the exact `package` name in my entry (registry links are derived from it) — or this is a guide-only entry (no `package` in any language block) with a `docsUrl` pointing at the vendor's Strands guide
- [x] GitHub repository is public and includes a license

#### Entry
- [x] Description accurately states what the package does in one sentence
- [x] `integrationType` matches what the package actually is
- [x] All URLs are working (`github`, and `docsUrl` if set)
- [x] `addedDate` is set to today (the date I opened this PR)
- [x] `featured` and `badges` are left unset — those are granted by the Strands team

#### Docs (only if setting a `docsUrl`)
- [x] The linked page documents using this integration with Strands Agents

#### Conduct
- [x] I am the package maintainer, or I have the maintainer's explicit consent to list it
- [x] Entry uses the package's real name with no trademark misuse

---

### Notes for reviewers

Verified before opening:

- PyPI `neo4j-agent-memory` 0.5.0 publishes the `strands` extra; npm `@neo4j-labs/agent-memory` 0.4.1 ships the `./integrations/strands` subpath export.
- `npm run build` (883 pages, no broken links), `npm test` (528 passed), and `npm run typecheck` all pass in `site/`.
- `docsUrl` points at the Python integration guide. A TypeScript guide lives at https://neo4j.com/labs/agent-memory/how-to/typescript/strands/ ; the two pages will be cross-linked on our side so either entry point serves both SDKs.

A long-term-memory `MemoryStore` implementation is in progress in the same package. When it ships I'll submit a separate `memory-store` entry, mirroring the `agentcore-memory` / `agentcore-memory-store` split.
