### PR TITLE
fix(test): move count_tokens fixture to gemini-3.1-flash-lite

### DIFF
--- a/strands-py/tests_integ/models/test_model_gemini.py
+++ b/strands-py/tests_integ/models/test_model_gemini.py
@@ -270,7 +270,7 @@ class TestCountTokens:
     @pytest.fixture
     def model(self):
         return GeminiModel(
-            model_id="gemini-2.5-flash-lite",
+            model_id="gemini-3.1-flash-lite",
             client_args={"api_key": os.environ["GOOGLE_API_KEY"]},
             use_native_token_count=True,
         )


### PR DESCRIPTION
Google restricted `gemini-2.5-flash-lite` to projects that had already used it. New API keys now get a `404 NOT_FOUND` from `countTokens`:

> This model models/gemini-2.5-flash-lite is no longer available to new users.

`GeminiModel.count_tokens` catches that, logs `native token counting failed, falling back to estimation`, and returns the heuristic estimate. `TestCountTokens::test_count_tokens_messages_only` asserts on the native-count debug log, so it fails — while `result > 0` still passes, which makes it look like the API call succeeded.

This switches the fixture to `gemini-3.1-flash-lite`, the cheapest [generally available](https://ai.google.dev/gemini-api/docs/models) model at $0.25/1M input, down from the $0.30 of `2.5-flash` and `3.5-flash-lite`. Confirmed it supports native `countTokens`, so the test exercises the real path rather than the fallback.

Test-only change. No public API or behavior changes.