### PR TITLE
fix(site): rebuild the test content snapshot when content changes

### DIFF
--- a/site/test/global-setup.ts
+++ b/site/test/global-setup.ts
@@ -1,36 +1,29 @@
 import { execFileSync } from 'node:child_process'
-import { copyFileSync, mkdirSync, readdirSync, realpathSync, rmSync, statSync } from 'node:fs'
-import { dirname, join } from 'node:path'
+import { readdirSync, realpathSync, statSync } from 'node:fs'
+import { join } from 'node:path'
 
 const DATA_STORE_PATH = '.astro/data-store.json'
-// `astro sync` writes the store under the cache dir (Astro's default is
-// node_modules/.astro), while the test environment reads the dev-mode path
-// above; see getDataStoreFile in astro/dist/content/paths.js.
-const SYNC_DATA_STORE_PATH = 'node_modules/.astro/data-store.json'
 const TIMEOUT_MS = 120_000
 
-// Everything the content-layer snapshot is derived from: the collection
-// sources and the schemas that shape them.
+// sync writes the store under cacheDir (getDataStoreFile in astro/dist/content/paths.js), so pointing
+// cacheDir at .astro targets the path the tests read. Child process: getViteConfig aliases in-process
+// 'astro' imports to a types-only stub.
+const SYNC_SCRIPT = "const { sync } = await import('astro'); await sync({ cacheDir: './.astro' })"
+
+// Everything the content-layer snapshot is derived from.
 const CONTENT_SOURCES = ['src/content', 'src/content.config.ts']
 
-/**
- * Newest mtime under a path, following symlinks (docs `_generated` dirs point
- * into .build/api-docs). Directory mtimes are included so a deleted file,
- * which bumps only its parent directory, still counts as a change. Broken
- * symlinks and unreadable paths report 0: nothing there to be newer than the
- * snapshot. `visited` holds resolved directory paths so a symlink cycle
- * terminates instead of overflowing the stack.
- */
+// Follows symlinks (docs `_generated` dirs point into .build/api-docs); `visited` breaks cycles.
+// Directory mtimes are included so a deleted file, which bumps only its parent dir, registers.
 function newestMtime(path: string, visited: Set<string>): number {
   let stat
-  let resolved
   try {
     stat = statSync(path)
-    resolved = realpathSync(path)
   } catch {
     return 0
   }
   if (!stat.isDirectory()) return stat.mtimeMs
+  const resolved = realpathSync(path)
   if (visited.has(resolved)) return 0
   visited.add(resolved)
   let newest = stat.mtimeMs
@@ -40,11 +33,8 @@ function newestMtime(path: string, visited: Set<string>): number {
   return newest
 }
 
-/**
- * getCollection() reads the content-layer snapshot in DATA_STORE_PATH, not
- * the content files themselves, so a snapshot older than the content would
- * make every collection test silently assert against outdated entries.
- */
+// getCollection() reads the snapshot in DATA_STORE_PATH, not the content
+// files, so a stale snapshot silently tests against outdated entries.
 function isDataStoreFresh(): boolean {
   let storeStat
   try {
@@ -57,20 +47,12 @@ function isDataStoreFresh(): boolean {
   return CONTENT_SOURCES.every((source) => newestMtime(source, new Set()) <= storeStat.mtimeMs)
 }
 
-export async function setup() {
+export function setup() {
   if (isDataStoreFresh()) return
 
   console.log('[global-setup] Data store missing or stale — running astro sync...')
 
-  // `astro sync` runs to completion and exits, so unlike a watch-mode dev
-  // server there is no process left to clean up (an unkilled dev server would
-  // keep rewriting the store from a stale worktree state). The stale dev-path
-  // store is removed first so a sync failure fails the tests loudly instead
-  // of leaving them reading the outdated snapshot.
-  rmSync(DATA_STORE_PATH, { force: true })
-  execFileSync('npx', ['astro', 'sync'], { stdio: 'inherit', timeout: TIMEOUT_MS })
-  mkdirSync(dirname(DATA_STORE_PATH), { recursive: true })
-  copyFileSync(SYNC_DATA_STORE_PATH, DATA_STORE_PATH)
+  execFileSync('node', ['--input-type=module', '-e', SYNC_SCRIPT], { stdio: 'inherit', timeout: TIMEOUT_MS })
 
   console.log('[global-setup] Data store ready.')
 }

--- a/site/test/global-setup.ts
+++ b/site/test/global-setup.ts
@@ -53,6 +53,7 @@ export function setup() {
   console.log('[global-setup] Data store missing or stale — running astro sync...')
 
   execFileSync('node', ['--input-type=module', '-e', SYNC_SCRIPT], { stdio: 'inherit', timeout: TIMEOUT_MS })
+  if (!isDataStoreFresh()) throw new Error(`astro sync did not refresh ${DATA_STORE_PATH}`)
 
   console.log('[global-setup] Data store ready.')
 }

--- a/site/test/global-setup.ts
+++ b/site/test/global-setup.ts
@@ -1,59 +1,70 @@
-import { existsSync, readFileSync } from 'node:fs'
-import { spawn } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
+import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync } from 'node:fs'
+import { dirname, join } from 'node:path'
 
 const DATA_STORE_PATH = '.astro/data-store.json'
-const TIMEOUT_MS = 60_000
-const SYNCED_MARKER = 'Synced content'
+// `astro sync` writes the store under the cache dir (Astro's default is
+// node_modules/.astro), while the test environment reads the dev-mode path
+// above; see getDataStoreFile in astro/dist/content/paths.js.
+const SYNC_DATA_STORE_PATH = 'node_modules/.astro/data-store.json'
+const TIMEOUT_MS = 120_000
 
-function isDataStorePopulated(): boolean {
+// Everything the content-layer snapshot is derived from: the collection
+// sources and the schemas that shape them.
+const CONTENT_SOURCES = ['src/content', 'src/content.config.ts']
+
+/**
+ * Newest mtime under a path, following symlinks (docs `_generated` dirs point
+ * into .build/api-docs). Directory mtimes are included so a deleted file,
+ * which bumps only its parent directory, still counts as a change. Broken
+ * symlinks and unreadable paths report 0: nothing there to be newer than the
+ * snapshot.
+ */
+function newestMtime(path: string): number {
+  let stat
+  try {
+    stat = statSync(path)
+  } catch {
+    return 0
+  }
+  if (!stat.isDirectory()) return stat.mtimeMs
+  let newest = stat.mtimeMs
+  for (const entry of readdirSync(path)) {
+    newest = Math.max(newest, newestMtime(join(path, entry)))
+  }
+  return newest
+}
+
+/**
+ * getCollection() reads the content-layer snapshot in DATA_STORE_PATH, not
+ * the content files themselves, so a snapshot older than the content would
+ * make every collection test silently assert against outdated entries.
+ */
+function isDataStoreFresh(): boolean {
   if (!existsSync(DATA_STORE_PATH)) return false
   try {
-    return readFileSync(DATA_STORE_PATH, 'utf-8').trim().length > 100
+    if (readFileSync(DATA_STORE_PATH, 'utf-8').trim().length <= 100) return false
+    const storeMtime = statSync(DATA_STORE_PATH).mtimeMs
+    return CONTENT_SOURCES.every((source) => newestMtime(source) <= storeMtime)
   } catch {
     return false
   }
 }
 
 export async function setup() {
-  if (isDataStorePopulated()) return
+  if (isDataStoreFresh()) return
 
-  console.log('[global-setup] Data store not populated — starting astro dev temporarily...')
+  console.log('[global-setup] Data store missing or stale — running astro sync...')
 
-  const server = spawn('npx', ['astro', 'dev'], {
-    stdio: ['ignore', 'pipe', 'pipe'],
-    detached: true,
-  })
-
-  try {
-    await new Promise<void>((resolve, reject) => {
-      const timer = setTimeout(() => reject(new Error('Timed out waiting for "Synced content"')), TIMEOUT_MS)
-
-      const onData = (chunk: Buffer) => {
-        process.stdout.write(chunk)
-        if (chunk.toString().includes(SYNCED_MARKER)) {
-          clearTimeout(timer)
-          resolve()
-        }
-      }
-
-      server.stdout.on('data', onData)
-      server.stderr.on('data', onData)
-      server.on('error', (err) => {
-        clearTimeout(timer)
-        reject(err)
-      })
-      server.on('close', (code) => {
-        if (code !== null) {
-          clearTimeout(timer)
-          reject(new Error(`Astro dev server exited with code ${code}`))
-        }
-      })
-    })
-  } finally {
-    if (server.pid != null) {
-      process.kill(-server.pid, 'SIGTERM')
-    }
-  }
+  // `astro sync` runs to completion and exits, so unlike a watch-mode dev
+  // server there is no process left to clean up (an unkilled dev server would
+  // keep rewriting the store from a stale worktree state). The stale dev-path
+  // store is removed first so a sync failure fails the tests loudly instead
+  // of leaving them reading the outdated snapshot.
+  rmSync(DATA_STORE_PATH, { force: true })
+  execFileSync('npx', ['astro', 'sync'], { stdio: 'inherit', timeout: TIMEOUT_MS })
+  mkdirSync(dirname(DATA_STORE_PATH), { recursive: true })
+  copyFileSync(SYNC_DATA_STORE_PATH, DATA_STORE_PATH)
 
   console.log('[global-setup] Data store ready.')
 }

--- a/site/test/global-setup.ts
+++ b/site/test/global-setup.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process'
-import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync } from 'node:fs'
+import { copyFileSync, mkdirSync, readdirSync, realpathSync, rmSync, statSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 
 const DATA_STORE_PATH = '.astro/data-store.json'
@@ -18,19 +18,24 @@ const CONTENT_SOURCES = ['src/content', 'src/content.config.ts']
  * into .build/api-docs). Directory mtimes are included so a deleted file,
  * which bumps only its parent directory, still counts as a change. Broken
  * symlinks and unreadable paths report 0: nothing there to be newer than the
- * snapshot.
+ * snapshot. `visited` holds resolved directory paths so a symlink cycle
+ * terminates instead of overflowing the stack.
  */
-function newestMtime(path: string): number {
+function newestMtime(path: string, visited: Set<string>): number {
   let stat
+  let resolved
   try {
     stat = statSync(path)
+    resolved = realpathSync(path)
   } catch {
     return 0
   }
   if (!stat.isDirectory()) return stat.mtimeMs
+  if (visited.has(resolved)) return 0
+  visited.add(resolved)
   let newest = stat.mtimeMs
   for (const entry of readdirSync(path)) {
-    newest = Math.max(newest, newestMtime(join(path, entry)))
+    newest = Math.max(newest, newestMtime(join(path, entry), visited))
   }
   return newest
 }
@@ -41,14 +46,15 @@ function newestMtime(path: string): number {
  * make every collection test silently assert against outdated entries.
  */
 function isDataStoreFresh(): boolean {
-  if (!existsSync(DATA_STORE_PATH)) return false
+  let storeStat
   try {
-    if (readFileSync(DATA_STORE_PATH, 'utf-8').trim().length <= 100) return false
-    const storeMtime = statSync(DATA_STORE_PATH).mtimeMs
-    return CONTENT_SOURCES.every((source) => newestMtime(source) <= storeMtime)
+    storeStat = statSync(DATA_STORE_PATH)
   } catch {
     return false
   }
+  // A store this small cannot hold real collections; treat it as absent.
+  if (storeStat.size <= 100) return false
+  return CONTENT_SOURCES.every((source) => newestMtime(source, new Set()) <= storeStat.mtimeMs)
 }
 
 export async function setup() {


### PR DESCRIPTION
## Description

The site's vitest global setup decides whether the content-layer snapshot (`.astro/data-store.json`, which `getCollection()` reads instead of the content files) is usable by checking only that it exists and is non-empty. It never compares it against the content, so after adding, editing, or removing a file under `src/content/`, `npm test` silently asserts against the previous state of the collections. This surfaced on #3766: new catalog entries existed on disk but the collection tests kept seeing the old set.

Two changes:

- The setup re-syncs when the snapshot is older than the newest mtime under `src/content/` or `src/content.config.ts` (directory mtimes included, so deletions count).
- The re-sync runs Astro's programmatic `sync` with `cacheDir` pointed at `.astro`, so the store is written directly to the path the test environment reads. Sync runs to completion, so the watch-mode `astro dev` spawn and its flaky teardown (ESRCH races in `process.kill(-pid)`, orphaned watchers) are gone. It runs in a small `node -e` child process because `getViteConfig` aliases in-process `astro` imports to a types-only stub. After syncing, the setup re-checks freshness and throws if the store was not refreshed, so a no-op sync fails the run instead of silently testing stale data.

## Related Issues

N/A (discovered while working on #3766)

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [ ] I ran `hatch run prepare`

Site-only change, verified with the site checks: `npm test` (530 tests), `npm run typecheck`, and Prettier. Exercised every setup path: fresh store (no sync), stale via `touch`, stale via adding a catalog file (the entry appears in the store), stale via removing it (the entry leaves the store), and a cold start with the store deleted (full rebuild, as in CI).

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
