### PR TITLE
ci(docs-preview): link catalog and standalone page changes in the preview comment

### DIFF
--- a/.github/workflows/docs-deploy-preview.yml
+++ b/.github/workflows/docs-deploy-preview.yml
@@ -126,7 +126,8 @@ jobs:
             const toUrlPath = (filename) => {
               const docsMatch = filename.match(/^site\/src\/content\/docs\/(.+)\.mdx$/);
               if (docsMatch) {
-                return `/docs/${docsMatch[1].replace(/\/index$/, '')}/`;
+                const route = docsMatch[1].replace(/(^|\/)index$/, '');
+                return route ? `/docs/${route}/` : '/docs/';
               }
               // Catalog entries all render on the /integrations/ page
               if (/^site\/src\/content\/catalog\/.+\.ya?ml$/.test(filename)) {
@@ -135,7 +136,7 @@ jobs:
               // Static Astro pages; dynamic [param] routes have no single URL
               const pageMatch = filename.match(/^site\/src\/pages\/(.+)\.astro$/);
               if (pageMatch && !pageMatch[1].includes('[')) {
-                const route = pageMatch[1].replace(/\/?index$/, '');
+                const route = pageMatch[1].replace(/(^|\/)index$/, '');
                 return route ? `/${route}/` : '/';
               }
               return null;

--- a/.github/workflows/docs-deploy-preview.yml
+++ b/.github/workflows/docs-deploy-preview.yml
@@ -121,17 +121,36 @@ jobs:
               pull_number: prNumber,
             });
 
-            // Build preview links for changed doc pages
-            const docFiles = files
-              .filter(f => f.filename.startsWith('site/src/content/docs/') && f.filename.endsWith('.mdx'))
-              .filter(f => f.status !== 'removed');
+            // Map a changed file to the site path it renders at, or null if it
+            // has no page of its own.
+            const toUrlPath = (filename) => {
+              const docsMatch = filename.match(/^site\/src\/content\/docs\/(.+)\.mdx$/);
+              if (docsMatch) {
+                return `/docs/${docsMatch[1].replace(/\/index$/, '')}/`;
+              }
+              // Catalog entries all render on the /integrations/ page
+              if (/^site\/src\/content\/catalog\/.+\.ya?ml$/.test(filename)) {
+                return '/integrations/';
+              }
+              // Static Astro pages; dynamic [param] routes have no single URL
+              const pageMatch = filename.match(/^site\/src\/pages\/(.+)\.astro$/);
+              if (pageMatch && !pageMatch[1].includes('[')) {
+                const route = pageMatch[1].replace(/\/?index$/, '');
+                return route ? `/${route}/` : '/';
+              }
+              return null;
+            };
 
-            const previewLinks = docFiles.map(f => {
-              const urlPath = f.filename
-                .replace('site/src/content/docs/', '/docs/')
-                .replace(/\/index\.mdx$/, '/')
-                .replace(/\.mdx$/, '/');
-              const label = urlPath.replace(/^\/docs\//, '').replace(/\/$/, '');
+            // Build preview links for changed pages
+            const urlPaths = [...new Set(
+              files
+                .filter(f => f.status !== 'removed')
+                .map(f => toUrlPath(f.filename))
+                .filter(Boolean)
+            )].sort();
+
+            const previewLinks = urlPaths.map(urlPath => {
+              const label = urlPath.replace(/^\/(docs\/)?/, '').replace(/\/$/, '') || 'home';
               return `- [${label}](${baseUrl}${urlPath})`;
             });
 


### PR DESCRIPTION
## Description

The preview comment posted by this workflow only knows how to map `site/src/content/docs/**/*.mdx` files to URLs, so PRs whose main deliverable is anything else get unhelpful links. #3766 (catalog entries plus `integrations.astro`) got the generic quickstart fallback instead of a link to `/integrations/`, and #3520 got links for its 14 lesson pages but none for the `/community/` hub the PR is actually about.

The comment step now maps three sources to preview links: docs pages as before, catalog entries (they all render on `/integrations/`, deduplicated to one link), and static Astro pages under `src/pages/`. Dynamic `[param]` routes are skipped since they have no single URL.

## Related Issues

N/A

## Documentation PR

N/A: CI-only change.

## Type of Change

Bug fix

## Testing

Ran the new mapping against the real changed-file lists of #3766 and #3520: the former now yields a single `/integrations/` link and the latter adds `/community/` alongside the lesson links. Confirmed the generated URLs return HTTP 200 on the existing preview deployments for both PRs. Workflow YAML parses.

- [ ] I ran `hatch run prepare` (not applicable: workflow-only change)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
