### PR TITLE
fix(agent): warn when structured output drops non-text system prompt blocks

### DIFF
--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -1065,6 +1065,7 @@ class Agent(AgentBase, LocalAgent):
             category=DeprecationWarning,
             stacklevel=2,
         )
+        self._warn_on_dropped_system_prompt_blocks()
         await self.hooks.invoke_callbacks_async(BeforeInvocationEvent(agent=self, invocation_state={}))
         with self.tracer.tracer.start_as_current_span(
             "execute_structured_output", kind=trace_api.SpanKind.CLIENT
@@ -1810,6 +1811,28 @@ class Agent(AgentBase, LocalAgent):
 
         self._checkpoint = Checkpoint.from_dict(payload["checkpoint"])
         return True
+
+    def _warn_on_dropped_system_prompt_blocks(self) -> None:
+        """Warn that non-text system prompt blocks do not reach the model on the structured output path.
+
+        `Model.structured_output` only accepts the flattened `system_prompt` string, so blocks such as
+        `cachePoint` are discarded. The loss is otherwise invisible: nothing errors, prompt caching simply
+        never happens.
+        """
+        if not self._system_prompt_content:
+            return
+
+        dropped = sorted({key for block in self._system_prompt_content for key in block if key != "text"})
+        if not dropped:
+            return
+
+        warnings.warn(
+            f"System prompt blocks {dropped} are dropped by Agent.structured_output_async and never reach the"
+            " model, because model providers accept only the flattened system prompt string on this path."
+            " Pass `structured_output_model` into the agent invocation instead to keep them.",
+            category=UserWarning,
+            stacklevel=2,
+        )
 
     async def _convert_prompt_to_messages(self, prompt: AgentInput) -> Messages:
         if self._interrupt_state.activated:

--- a/strands-py/tests/strands/agent/test_agent.py
+++ b/strands-py/tests/strands/agent/test_agent.py
@@ -1177,6 +1177,48 @@ async def test_agent_structured_output_async(agent, system_prompt, user, agenera
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "system_prompt",
+    [[{"text": "You are a helpful assistant."}, {"cachePoint": {"type": "default"}}]],
+    indirect=True,
+)
+async def test_agent_structured_output_async_warns_on_dropped_system_prompt_blocks(agent, user, agenerator):
+    """Non-text system prompt blocks are dropped on this path, so the caller is told instead of failing silently."""
+    agent.model.structured_output = unittest.mock.Mock(return_value=agenerator([{"output": user}]))
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        await agent.structured_output_async(type(user), "Jane Doe is 30 years old")
+
+    dropped_warnings = [
+        warning
+        for warning in caught
+        if issubclass(warning.category, UserWarning) and "cachePoint" in str(warning.message)
+    ]
+    assert len(dropped_warnings) == 1
+
+    # The provider still only receives the flattened string; this path is deprecated and is not being widened.
+    agent.model.structured_output.assert_called_once_with(
+        type(user),
+        [{"role": "user", "content": [{"text": "Jane Doe is 30 years old"}]}],
+        system_prompt="You are a helpful assistant.",
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("system_prompt", ["You are a helpful assistant."], indirect=True)
+async def test_agent_structured_output_async_does_not_warn_for_plain_system_prompt(agent, user, agenerator):
+    """A plain string system prompt loses nothing, so it must stay quiet."""
+    agent.model.structured_output = unittest.mock.Mock(return_value=agenerator([{"output": user}]))
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        await agent.structured_output_async(type(user), "Jane Doe is 30 years old")
+
+    assert [warning for warning in caught if issubclass(warning.category, UserWarning)] == []
+
+
+@pytest.mark.asyncio
 async def test_stream_async_returns_all_events(mock_event_loop_cycle, alist):
     agent = Agent()
 


### PR DESCRIPTION
## Description

`Agent.structured_output_async()` forwards `self.system_prompt` — the flattened string — to `Model.structured_output()`. Anything the caller expressed as a non-text `SystemContentBlock`, `cachePoint` in particular, simply does not exist by the time the request is built. Nothing errors and nothing is logged, so the only symptom is `CacheReadInputTokens`/`CacheWriteInputTokens` sitting at zero while real traffic flows. That silence is the expensive part: the reporter spent real time chasing missing cache metrics, and @ebarkhordar's investigation on the issue landed on the same conclusion from the other direction.

This PR makes the loss audible and nothing more. When an agent whose system prompt carries non-text blocks calls the deprecated structured-output entry point, it now gets a `UserWarning` naming the dropped block types and pointing at `structured_output_model`, which is both the recommended path and the one where those blocks already survive.

**Before**

```python
agent = Agent(model=..., system_prompt=[{"text": "..."}, {"cachePoint": {"type": "default"}}])
await agent.structured_output_async(Output, "...")
# provider receives: system_prompt='...'   cachePoint: gone, silently
```

**After**

```
UserWarning: System prompt blocks ['cachePoint'] are dropped by Agent.structured_output_async
and never reach the model, because model providers accept only the flattened system prompt
string on this path. Pass `structured_output_model` into the agent invocation instead to keep them.
```

### On scope — please confirm the direction before I go further

The issue leaves two defensible fixes open, and I deliberately took the smaller one:

**(a) Actually forward the block list.** This does not stop at `Agent`. `structured_output` declares `system_prompt_content` in 0 of 13 provider signatures, and `BedrockModel.structured_output` does not pass it into its own `self.stream(...)` call either — so a faithful fix widens a public interface across every provider, to repair an entry point that is already deprecated in favour of `structured_output_model`. That reads to me like the opposite of "simple at any scale", and it is not a change I would want to make without a maintainer explicitly asking for it.

**(b) Make the drop loud.** What is here. No signature changes, no behaviour change for anyone not already losing data, and it steers callers to the path that works today.

I opened this as a draft because (b) only makes sense if you agree (a) is not wanted here. If you would rather have (a), or would rather deprecate the entry point harder and warn nothing, say so and I will redo it — I would rather spend the effort in the direction you want than defend this one.

One placement note worth surfacing: the issue thread suggested warning inside `split_system_prompt`. I did not, because that function is also on the healthy path (`Agent.__init__` and `event_loop.py`), where the block list is preserved and `cachePoint` reaches the provider intact. Warning there would fire loudest at exactly the users who have nothing wrong. The warning belongs at the point of loss.

## Related Issues

Resolves #3496

## Documentation PR

No documentation change. This surfaces an existing limitation of a deprecated method rather than altering documented behaviour.

## Type of Change

Bug fix

## Testing

Two unit tests in `tests/strands/agent/test_agent.py`: one asserting the warning fires for a system prompt carrying `cachePoint`, one asserting a plain string prompt stays quiet. The first fails on `main` (`assert 0 == 1`) and passes here.

I also reproduced the underlying drop offline before writing anything, using a recording `Model` subclass in the shape @ebarkhordar used on the issue — no Bedrock account involved. On `e4d57c1c`, `cachePoint reached provider` is `False` through `structured_output_async` and `True` through the ordinary event-loop path, which is what makes the "use `structured_output_model`" pointer in the warning text accurate rather than aspirational.

- [ ] I ran `hatch run prepare`

Not run in full: `hatch`'s `features = ["all"]` env fails to build `litellm` 1.95.0 locally (maturin/cargo build of its Rust bridge). I ran the equivalent pieces against the repo's own configuration in a venv — `ruff format --check` and `ruff check` clean on both changed files, `mypy ./src` reporting nothing for `agent.py`, and the `tests/strands/{agent,types,event_loop}` suites green (990 passed; `test_a2a_agent.py` deselected, its optional `a2a` dependency is part of the same env problem). Happy to have CI be the real gate here.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings — deliberately false: emitting a new warning is the entire point of this change. No new *build* or *lint* warnings.
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
