### PR TITLE
refactor(site): consolidate src/utils into src/util

### DIFF
--- a/site/SITE-ARCHITECTURE.md
+++ b/site/SITE-ARCHITECTURE.md
@@ -724,7 +724,7 @@ Edit `SLUG_RULES` in `src/util/redirect.ts` for structural renames affecting man
 { match: startsWith('docs/old-prefix'), to: (m) => `docs/new-prefix/${m[1]}` },
 ```
 
-Helper builders from `src/utils/regex.ts`:
+Helper builders from `src/util/regex.ts`:
 - `startsWith(prefix)` — matches slugs starting with `prefix/`, captures the rest in `m[1]`
 - `exactly(s)` — matches the slug exactly
 

--- a/site/src/util/redirect.ts
+++ b/site/src/util/redirect.ts
@@ -8,7 +8,7 @@
  * The path-normalization fallback never returns an external URL (prevents open redirects).
  */
 
-import { exactly, startsWith } from '../utils/regex'
+import { exactly, startsWith } from './regex'
 
 // ── Slug-level rename rules ───────────────────────────────────────────────────
 
@@ -113,9 +113,7 @@ export const STATIC_SLUG_REDIRECTS: Record<string, string> = {
     'https://github.com/strands-agents/harness-sdk/blob/main/site/docs/examples/typescript/deploy_to_bedrock_agentcore/README.md',
 }
 
-type SlugRule =
-  | { match: RegExp; to: string }
-  | { match: RegExp; to: (m: RegExpMatchArray) => string }
+type SlugRule = { match: RegExp; to: string } | { match: RegExp; to: (m: RegExpMatchArray) => string }
 
 // Exact-match rules generated from STATIC_SLUG_REDIRECTS, plus any dynamic
 // (regex-based) rules. Dynamic rules can't be enumerated into static stubs,
@@ -173,10 +171,7 @@ export function resolveRedirect(slug: string, redirectFromMap?: Record<string, s
  * @param path - The URL path to resolve (e.g. "/docs/user-guide/...")
  * @param redirectFromMap - Optional map of source slugs to target slugs (from frontmatter redirectFrom)
  */
-export function resolveRedirectFromUrl(
-  path: string,
-  redirectFromMap?: Record<string, string>
-): string | null {
+export function resolveRedirectFromUrl(path: string, redirectFromMap?: Record<string, string>): string | null {
   // Strip leading version segment: /latest/, /1.x/, /1.5.x/, etc.
   path = path.replace(/^\/?(latest|[\d]+(?:\.[\dx]+)*)\//, '/')
 

--- a/site/src/util/regex.ts
+++ b/site/src/util/regex.ts
@@ -1,9 +1,12 @@
 // Source - https://stackoverflow.com/a/3561711
 // Posted by bobince, modified by community. See post 'Timeline' for change history
 // Retrieved 2026-03-06, License - CC BY-SA 4.0
-declare global { interface RegExpConstructor { escape?: (s: string) => string } }
-export const escapeRegex: (s: string) => string =
-  RegExp.escape ?? ((s) => s.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&'))
+declare global {
+  interface RegExpConstructor {
+    escape?: (s: string) => string
+  }
+}
+export const escapeRegex: (s: string) => string = RegExp.escape ?? ((s) => s.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&'))
 
 /** Build a regex that matches strings starting with a literal prefix, capturing the rest. */
 export function startsWith(prefix: string): RegExp {


### PR DESCRIPTION
## Description

`site/src/` has two helper directories: `util/` (the established one, 20+ modules) and `utils/`, which holds a single `regex.ts` introduced in #603 and imported only by `util/redirect.ts`. There is no semantic distinction between them; this moves `regex.ts` into `util/` so the site has one helpers directory. No behavior change.

## Related Issues

N/A

## Documentation PR

Updated the `src/utils/regex.ts` reference in `site/SITE-ARCHITECTURE.md`; no doc site pages are affected.

## Type of Change

Other (please describe): code organization refactor

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [ ] I ran `hatch run prepare` (site-only change; ran the site checks via `.agents/skills/pre-push/run-checks.sh` instead: unit tests, typecheck, snippet typecheck, format check, all passing)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
