### PR TITLE
docs(catalog): add Python language to strands-github-storage

### DIFF
--- a/site/src/content/catalog/strands-github-storage.yaml
+++ b/site/src/content/catalog/strands-github-storage.yaml
@@ -2,6 +2,8 @@ name: strands-github-storage
 description: GitHub-repository Storage backend for Strands — persists keys as versioned, diffable files in a repo you can browse in the GitHub UI.
 integrationType: storage
 languages:
+  python:
+    package: strands-github-storage
   typescript:
     package: strands-github-storage
 github: https://github.com/maisieyanz/strands-github-storage

--- a/site/src/content/docs/integrations/storage/github.mdx
+++ b/site/src/content/docs/integrations/storage/github.mdx
@@ -126,7 +126,7 @@ Pass it wherever a `Storage` is accepted so the agent's persisted data lives in 
 | `repo` | Yes | Repository name. |
 | `branch` | No | Branch to read from and commit to. Defaults to `main`. |
 | `token` | For writes | GitHub token. Needed for any write and for reading private repos. |
-| `github` (Python) / `octokit` (TS) | No | A pre-configured GitHub client, as an alternative to `token` (e.g. to add retry/throttling behavior). |
+| <Syntax py="github" ts="octokit" /> | No | A pre-configured GitHub client, as an alternative to `token` (e.g. to add retry/throttling behavior). |
 
 ## Behavior and limits
 
@@ -134,7 +134,7 @@ Pass it wherever a `Storage` is accepted so the agent's persisted data lives in 
 - **Single writer per branch.** Commits advance the branch ref without a compare-and-swap retry, so a concurrent writer that moves the branch head surfaces GitHub's non-fast-forward rejection as a `StorageError` rather than being retried.
 - **`read` is limited to files under 1 MB** — the ceiling of the GitHub contents API's inline response. Markdown memory is far below this.
 - **`list` fails loud on truncation.** GitHub's git-tree API caps very large trees and does not paginate; rather than return a silent partial listing, `list` throws a `StorageError`.
-- **No built-in rate-limit handling.** To add exponential backoff on `429`/`5xx`, pass a pre-configured client via `github` (Python) / `octokit` (TypeScript).
+- **No built-in rate-limit handling.** To add exponential backoff on `429`/`5xx`, pass a pre-configured client via <Syntax py="github" ts="octokit" />.
 
 ## References
 

--- a/site/src/content/docs/integrations/storage/github.mdx
+++ b/site/src/content/docs/integrations/storage/github.mdx
@@ -93,11 +93,11 @@ Pass it wherever a `Storage` is accepted so the agent's persisted data lives in 
 
     ```python
     from strands import Agent
-    from strands.session import SessionManager
+    from strands.session import SnapshotSessionManager
     from strands_github_storage import GithubStorage
 
-    storage = GithubStorage(owner="myorg", repo="agent-sessions", token=token)
-    agent = Agent(session_manager=SessionManager(storage=storage))
+    storage = GithubStorage(owner="myorg", repo="agent-sessions", token="ghp_...")
+    agent = Agent(session_manager=SnapshotSessionManager("agent-sessions", storage=storage))
     ```
   </Tab>
   <Tab label="TypeScript">

--- a/site/src/content/docs/integrations/storage/github.mdx
+++ b/site/src/content/docs/integrations/storage/github.mdx
@@ -1,5 +1,6 @@
 ---
 project:
+  pypi: https://pypi.org/project/strands-github-storage/
   npm: https://www.npmjs.com/package/strands-github-storage
   github: https://github.com/maisieyanz/strands-github-storage
   maintainer: maisieyanz
@@ -10,59 +11,112 @@ title: GitHub Storage
 community: true
 description: GitHub-repository Storage backend for Strands — persists each entry as a versioned, diffable file in a repo you can browse on GitHub.
 integrationType: storage
-languages: TypeScript
 sidebar:
   label: "GitHub"
 ---
 
 [strands-github-storage](https://github.com/maisieyanz/strands-github-storage) is a `Storage` backend that persists each entry as a file in a GitHub repository, at the entry's key path on a branch. Because the store *is* a git repository, its contents are browsable in the GitHub UI, diffable per change, and versioned in history.
 
-It implements the SDK's four-method `Storage` interface (`write`, `read`, `delete`, `list`), so it plugs in anywhere a `Storage` is accepted — session snapshots, context offloading, and file-backed memory stores such as `FileMemoryStore`.
+It implements the SDK's four-method `Storage` interface (`write`, `read`, `delete`, `list`), so it plugs in anywhere a `Storage` is accepted — session managers, context offloading, and file-backed memory stores. Available for both the Python and TypeScript SDKs.
 
 ## Installation
 
-```bash
-npm install strands-github-storage
-```
+<Tabs>
+  <Tab label="Python">
+    ```bash
+    pip install strands-github-storage
+    ```
 
-`@strands-agents/sdk` is a peer dependency; `@octokit/rest` is bundled.
+    `strands-agents` and `PyGithub` are installed as dependencies.
+  </Tab>
+  <Tab label="TypeScript">
+    ```bash
+    npm install strands-github-storage
+    ```
+
+    `@strands-agents/sdk` is a peer dependency; `@octokit/rest` is bundled.
+  </Tab>
+</Tabs>
 
 ## Usage
 
 ### Basic setup
 
-```typescript
-import { GithubStorage } from 'strands-github-storage'
+<Tabs>
+  <Tab label="Python">
+    ```python
+    import asyncio
+    from strands_github_storage import GithubStorage
 
-const storage = new GithubStorage({
-  owner: 'myorg',
-  repo: 'agent-memory',
-  branch: 'main', // optional, defaults to 'main'
-  token: process.env.GITHUB_TOKEN, // required for writes and private repos
-})
+    storage = GithubStorage(
+        owner="myorg",
+        repo="agent-memory",
+        branch="main",          # optional, defaults to "main"
+        token="ghp_...",        # required for writes and private repos
+    )
 
-await storage.write('facts/note.md', new TextEncoder().encode('remember this'))
-const bytes = await storage.read('facts/note.md') // Uint8Array | null
-const keys = await storage.list('facts/') // ['facts/note.md']
-await storage.delete('facts/note.md')
-```
+    async def main() -> None:
+        await storage.write("facts/note.md", b"remember this")
+        data = await storage.read("facts/note.md")   # bytes | None
+        keys = await storage.list("facts/")          # ["facts/note.md"]
+        await storage.delete("facts/note.md")
 
-### Backing a memory store
+    asyncio.run(main())
+    ```
+  </Tab>
+  <Tab label="TypeScript">
+    ```typescript
+    import { GithubStorage } from 'strands-github-storage'
 
-Pass it as the `storage` for a `FileMemoryStore` so an agent's knowledge lives in a browsable, versioned repo:
+    const storage = new GithubStorage({
+      owner: 'myorg',
+      repo: 'agent-memory',
+      branch: 'main', // optional, defaults to 'main'
+      token: process.env.GITHUB_TOKEN, // required for writes and private repos
+    })
 
-```typescript
-import { Agent, MemoryManager } from '@strands-agents/sdk'
-import { FileMemoryStore } from '@strands-agents/sdk/vended-memory-stores/file-memory-store'
-import { GithubStorage } from 'strands-github-storage'
+    await storage.write('facts/note.md', new TextEncoder().encode('remember this'))
+    const bytes = await storage.read('facts/note.md') // Uint8Array | null
+    const keys = await storage.list('facts/') // ['facts/note.md']
+    await storage.delete('facts/note.md')
+    ```
+  </Tab>
+</Tabs>
 
-const memoryStore = new FileMemoryStore({
-  name: 'agent-memory',
-  storage: new GithubStorage({ owner: 'myorg', repo: 'agent-memory', token }),
-})
+### Wiring into an agent
 
-const agent = new Agent({ model, memoryManager: new MemoryManager({ stores: [memoryStore] }) })
-```
+Pass it wherever a `Storage` is accepted so the agent's persisted data lives in a browsable, versioned repo:
+
+<Tabs>
+  <Tab label="Python">
+    Use it as a session manager's storage, so conversation sessions persist to a GitHub repo:
+
+    ```python
+    from strands import Agent
+    from strands.session import SessionManager
+    from strands_github_storage import GithubStorage
+
+    storage = GithubStorage(owner="myorg", repo="agent-sessions", token=token)
+    agent = Agent(session_manager=SessionManager(storage=storage))
+    ```
+  </Tab>
+  <Tab label="TypeScript">
+    Back a `FileMemoryStore` so an agent's knowledge lives in a browsable, versioned repo:
+
+    ```typescript
+    import { Agent, MemoryManager } from '@strands-agents/sdk'
+    import { FileMemoryStore } from '@strands-agents/sdk/vended-memory-stores/file-memory-store'
+    import { GithubStorage } from 'strands-github-storage'
+
+    const memoryStore = new FileMemoryStore({
+      name: 'agent-memory',
+      storage: new GithubStorage({ owner: 'myorg', repo: 'agent-memory', token }),
+    })
+
+    const agent = new Agent({ model, memoryManager: new MemoryManager({ stores: [memoryStore] }) })
+    ```
+  </Tab>
+</Tabs>
 
 ## Configuration
 
@@ -72,7 +126,7 @@ const agent = new Agent({ model, memoryManager: new MemoryManager({ stores: [mem
 | `repo` | Yes | Repository name. |
 | `branch` | No | Branch to read from and commit to. Defaults to `main`. |
 | `token` | For writes | GitHub token. Needed for any write and for reading private repos. |
-| `octokit` | No | A pre-configured `Octokit` client, as an alternative to `token` (e.g. to add retry/throttling plugins). |
+| `github` (Python) / `octokit` (TS) | No | A pre-configured GitHub client, as an alternative to `token` (e.g. to add retry/throttling behavior). |
 
 ## Behavior and limits
 
@@ -80,10 +134,11 @@ const agent = new Agent({ model, memoryManager: new MemoryManager({ stores: [mem
 - **Single writer per branch.** Commits advance the branch ref without a compare-and-swap retry, so a concurrent writer that moves the branch head surfaces GitHub's non-fast-forward rejection as a `StorageError` rather than being retried.
 - **`read` is limited to files under 1 MB** — the ceiling of the GitHub contents API's inline response. Markdown memory is far below this.
 - **`list` fails loud on truncation.** GitHub's git-tree API caps very large trees and does not paginate; rather than return a silent partial listing, `list` throws a `StorageError`.
-- **No built-in rate-limit handling.** To add exponential backoff on `429`/`5xx`, pass an `octokit` client configured with `@octokit/plugin-throttling` / `@octokit/plugin-retry`.
+- **No built-in rate-limit handling.** To add exponential backoff on `429`/`5xx`, pass a pre-configured client via `github` (Python) / `octokit` (TypeScript).
 
 ## References
 
 - [GitHub](https://github.com/maisieyanz/strands-github-storage)
 - [npm](https://www.npmjs.com/package/strands-github-storage)
+- [PyPI](https://pypi.org/project/strands-github-storage/)
 - [Strands Storage docs](../../user-guide/concepts/storage.mdx)


### PR DESCRIPTION
## Integration submission

<!-- This template is for adding or updating an entry on the integrations page at strandsagents.com/integrations.
     Full submission guide and YAML field reference: https://strandsagents.com/docs/integrations/get-featured/
     The site build validates your YAML against the schema automatically — a CI failure here is a schema error in your entry file. -->

**Package name:** strands-github-storage
  **Integration type:** storage
  **Languages published:** Python and TypeScript (both live: PyPI + npm)
  **GitHub repo:** https://github.com/maisieyanz/strands-github-storage
  **What it does:** A `Storage` backend that persists each key as a file in a GitHub repository, so the store is browsable, diffable, and versioned through GitHub itself. This PR adds the newly-published Python package to the existing entry (previously TypeScript-only).
  **Relationship to service:** Community-built
  **Docs link included:** none — on-site docs page (`docsPage`) already exists from the original submission

### Submitter checklist

#### Package
- [x] This is a reusable integration (library/plugin/provider), not an example agent or application built with Strands
- [x] Published to PyPI and/or npm under the exact `package` name in my entry (registry links are derived from it) — or this is a guide-only entry (no `package` in any language block) with a `docsUrl` pointing at the vendor's Strands guide
- [x] GitHub repository is public and includes a license

#### Entry
- [ ] Description accurately states what the package does in one sentence
- [ ] `integrationType` matches what the package actually is
- [x] All URLs are working (`github`, and `docsUrl` if set)
- [ ] `addedDate` is set to today (the date I opened this PR)
- [x] `featured` and `badges` are left unset — those are granted by the Strands team

#### Docs (only if setting a `docsUrl`)
- [x] The linked page documents using this integration with Strands Agents

#### Conduct
- [x] I am the package maintainer, or I have the maintainer's explicit consent to list it
- [x] Entry uses the package's real name with no trademark misuse

---

### For reviewers

- Package installs cleanly and imports without error against the current SDK release (guide-only entries: the `docsUrl` guide's setup steps work instead)
- Description matches what the package's README says it does
- No existing catalog entry for this package (`site/src/content/catalog/`)
- All URLs are reachable and resolve to the expected destinations
- `addedDate` matches the submission date and `featured`/`badges` are unset (CI labels the PR `catalog: editorial-review` if a non-maintainer sets them)
- The `docsUrl` page (if set) is a real Strands integration guide, not a generic product page
