### PR TITLE
ci(anthropic): re-enable anthropic integration tests

### DIFF
--- a/strands-py/tests_integ/models/test_model_anthropic.py
+++ b/strands-py/tests_integ/models/test_model_anthropic.py
@@ -9,17 +9,12 @@ from strands.agent import NullConversationManager
 from strands.models.anthropic import AnthropicModel
 from strands.types.content import ContentBlock, Message
 from strands.types.exceptions import ContextWindowOverflowException
+from tests_integ.models import providers
 
-"""
-These tests only run if we have the anthropic api key
+# these tests only run if we have the anthropic api key
+pytestmark = providers.anthropic.mark
 
-Because of infrequent burst usage, Anthropic tests are unreliable, failing tests with 529s.
-{'type': 'error', 'error': {'details': None, 'type': 'overloaded_error', 'message': 'Overloaded'}}
-https://docs.anthropic.com/en/api/errors#http-errors
-"""
-pytestmark = pytest.skip(
-    "Because of infrequent burst usage, Anthropic tests are unreliable, failing with 529s", allow_module_level=True
-)
+MODEL_ID = "claude-sonnet-4-6"
 
 
 @pytest.fixture
@@ -28,7 +23,7 @@ def model():
         client_args={
             "api_key": os.getenv("ANTHROPIC_API_KEY"),
         },
-        model_id="claude-sonnet-4-6",
+        model_id=MODEL_ID,
         max_tokens=512,
     )
 
@@ -165,11 +160,11 @@ def test_input_and_max_tokens_exceed_context_limit(quiet_strands_logging):
     # verify behavior
 
     model = AnthropicModel(
-        model_id="claude-sonnet-4-20250514",
+        model_id=MODEL_ID,
         max_tokens=64000,
     )
 
-    large_message = "This is a very long text. " * 10000
+    large_message = "This is a very long text. " * 60000
 
     messages = [
         Message(role="user", content=[ContentBlock(text=large_message)]),
@@ -188,8 +183,9 @@ class TestCountTokens:
     @pytest.fixture
     def model(self):
         return AnthropicModel(
-            model_id="claude-sonnet-4-20250514",
+            model_id=MODEL_ID,
             max_tokens=1024,
+            use_native_token_count=True,
             client_args={"api_key": os.environ["ANTHROPIC_API_KEY"]},
         )
 


### PR DESCRIPTION
## Description

The Python Anthropic integration tests have been disabled for over a year. This restores the tests to the standard API-key gate every other cloud provider uses (`providers.anthropic.mark`), so they skip locally without a key and run in CI where the key is provisioned.

While the suite was disabled, three tests rotted: two pinned `claude-sonnet-4-20250514`, which the API now 404s, and `TestCountTokens` never actually hit the native count-tokens path because its fixture omitted `use_native_token_count=True`. All model IDs now flow from a single `MODEL_ID` constant, and the context-overflow test's payload is sized to `claude-sonnet-4-6`'s larger context window.

Verified against a live `ANTHROPIC_API_KEY`: all 10 tests pass; with no key set, all 10 skip via the mark rather than a module-level skip.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

CI

## Testing

- [x] I ran `hatch run prepare`


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
