### PR TITLE
fix(anthropic): throw on undeliverable document blocks instead of silently dropping them

### DIFF
--- a/strands-ts/src/models/__tests__/anthropic.test.ts
+++ b/strands-ts/src/models/__tests__/anthropic.test.ts
@@ -644,6 +644,50 @@ describe('AnthropicModel', () => {
         expect(content.title).toBe('doc.pdf')
       })
 
+      // Guards against https://github.com/strands-agents/harness-sdk/issues/3785: documents the
+      // provider cannot deliver must fail loudly, not be silently omitted from the request.
+      it('throws for a document format with no Anthropic mapping', async () => {
+        const { mockClient } = setupCapture()
+        const provider = new AnthropicModel({ client: mockClient })
+        const messages = [
+          new Message({
+            role: 'user',
+            content: [
+              new DocumentBlock({
+                name: 'report',
+                format: 'docx',
+                source: { bytes: new Uint8Array([1, 2, 3]) },
+              }),
+            ],
+          }),
+        ]
+
+        await expect(collectIterator(provider.stream(messages))).rejects.toThrow(
+          'Unsupported document format or source for Anthropic: format=docx, source=documentSourceBytes'
+        )
+      })
+
+      it('throws for a supported document format with an unsupported source', async () => {
+        const { mockClient } = setupCapture()
+        const provider = new AnthropicModel({ client: mockClient })
+        const messages = [
+          new Message({
+            role: 'user',
+            content: [
+              new DocumentBlock({
+                name: 'doc.pdf',
+                format: 'pdf',
+                source: { text: 'not deliverable as a pdf' },
+              }),
+            ],
+          }),
+        ]
+
+        await expect(collectIterator(provider.stream(messages))).rejects.toThrow(
+          'Unsupported document format or source for Anthropic: format=pdf, source=documentSourceText'
+        )
+      })
+
       it('logs warning for unsupported GuardContentBlock in user message', async () => {
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {}) // Spy on console.warn (via logger)
         const { captured, mockClient } = setupCapture()

--- a/strands-ts/src/models/__tests__/anthropic.test.ts
+++ b/strands-ts/src/models/__tests__/anthropic.test.ts
@@ -688,6 +688,54 @@ describe('AnthropicModel', () => {
         )
       })
 
+      it('throws for a document with a content block source', async () => {
+        const { mockClient } = setupCapture()
+        const provider = new AnthropicModel({ client: mockClient })
+        const messages = [
+          new Message({
+            role: 'user',
+            content: [
+              new DocumentBlock({
+                name: 'notes',
+                format: 'txt',
+                source: { content: [{ text: 'inline content' }] },
+              }),
+            ],
+          }),
+        ]
+
+        await expect(collectIterator(provider.stream(messages))).rejects.toThrow(
+          'Unsupported document format or source for Anthropic: format=txt, source=documentSourceContentBlock'
+        )
+      })
+
+      it('throws for an undeliverable document nested in a tool result', async () => {
+        const { mockClient } = setupCapture()
+        const provider = new AnthropicModel({ client: mockClient })
+        const messages = [
+          new Message({
+            role: 'user',
+            content: [
+              new ToolResultBlock({
+                toolUseId: 't1',
+                status: 'success',
+                content: [
+                  new DocumentBlock({
+                    name: 'report',
+                    format: 'docx',
+                    source: { bytes: new Uint8Array([1, 2, 3]) },
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ]
+
+        await expect(collectIterator(provider.stream(messages))).rejects.toThrow(
+          'Unsupported document format or source for Anthropic: format=docx, source=documentSourceBytes'
+        )
+      })
+
       it('logs warning for unsupported GuardContentBlock in user message', async () => {
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {}) // Spy on console.warn (via logger)
         const { captured, mockClient } = setupCapture()

--- a/strands-ts/src/models/anthropic.ts
+++ b/strands-ts/src/models/anthropic.ts
@@ -610,8 +610,9 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
           }
         }
 
-        logger.warn(`format=<${docBlock.format}> | unsupported document format or source for anthropic`)
-        return undefined
+        throw new Error(
+          `Unsupported document format or source for Anthropic: format=${docBlock.format}, source=${docBlock.source.type}`
+        )
       }
 
       case 'toolUseBlock':


### PR DESCRIPTION
## Description

`AnthropicModel` silently drops any `DocumentBlock` it cannot deliver: non-PDF binary formats (`doc`, `docx`, `xls`, `xlsx`), `pdf` with a text source, and content-block or S3 sources. The block is omitted from the request with only a log-level warning, so the model answers as if no file was attached and the caller has no programmatic way to detect the loss. The same application code works on the OpenAI provider, which sends any byte-source document through, so switching providers turns a working attachment into a silent no-op.

This replaces the silent drop with a thrown `Error`, matching the unsupported-image-format behavior a few lines up in the same provider and aligning with the Python SDK, where an undeliverable document fails loudly (as an API 400). The allowlist itself is unchanged and correct: Anthropic's Messages API only accepts PDF base64 and plain-text document sources.

Callers now get:

```typescript
// Before: request succeeds, attachment silently missing
await agent.invoke([textBlock, docxDocumentBlock]) // model never sees the file

// After: catchable error before any API call
// Error: Unsupported document format or source for Anthropic: format=docx, source=documentSourceBytes
```

**Alternatives considered:**

- **Pass the document through with its MIME type and let the API reject it** (what the Python provider does). Same fail-loud outcome, but the failure is an opaque provider 400 after a network round trip instead of a clear client-side message, and Anthropic's API would reject the request shape anyway. The Python provider's error surface could instead be improved to match this one in a follow-up.
- **Extend format support** so docx/xlsx work like they do on OpenAI. Not possible at the provider layer: the Messages API has no generic byte-document support, and converting Office formats to text is content extraction, out of scope for a model provider.
- **A typed error class** (e.g. `UnsupportedContentError`) instead of a plain `Error`. The provider's existing unsupported-image path throws a plain `Error`, so this stays consistent; introducing a typed error for unsupported content across all providers is a larger, separate change.

**Callout:** this is intentionally a behavior change. Code that today passes unsupported documents and silently loses them will start throwing. That failure mode is the bug being fixed, but reviewers should confirm they agree the loud failure is preferable to a deprecation-style warning period.

## Related Issues

Resolves #3785

## Documentation PR

No documentation changes needed: the supported document formats are unchanged, only the failure mode for unsupported ones.

## Type of Change

Bug fix

## Testing

Ran the TypeScript SDK gates: `npm test` (4092 unit tests, including two new regression tests covering the unsupported-format and unsupported-source paths), `npm run lint`, `npm run format:check`, `npm run type-check`, and `npm run build`. Also exercised the change end to end with a script that formats a docx `DocumentBlock` through the provider: before the change the block vanished from the request; after, the call throws the new error.

- [ ] I ran `hatch run prepare` (Python-only gate; this change is TypeScript-only, TS equivalents above)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
