### PR TITLE
fix(anthropic): raise on unsupported document and image formats instead of sending undeliverable requests

### DIFF
--- a/strands-py/src/strands/models/anthropic.py
+++ b/strands-py/src/strands/models/anthropic.py
@@ -6,7 +6,6 @@
 import base64
 import json
 import logging
-import mimetypes
 from collections.abc import AsyncGenerator
 from typing import Any, TypeVar, cast
 
@@ -164,13 +163,13 @@ class AnthropicModel(Model):
 
         if "image" in content:
             image_format = content["image"]["format"]
+            if image_format not in _IMAGE_MEDIA_TYPES:
+                raise TypeError(f"content_type=<image>, format=<{image_format}> | unsupported format")
+
             return {
                 "source": {
                     "data": base64.b64encode(content["image"]["source"]["bytes"]).decode("utf-8"),
-                    "media_type": _IMAGE_MEDIA_TYPES.get(
-                        image_format,
-                        mimetypes.types_map.get(f".{image_format}", "application/octet-stream"),
-                    ),
+                    "media_type": _IMAGE_MEDIA_TYPES[image_format],
                     "type": "base64",
                 },
                 "type": "image",

--- a/strands-py/src/strands/models/anthropic.py
+++ b/strands-py/src/strands/models/anthropic.py
@@ -37,6 +37,9 @@ _IMAGE_MEDIA_TYPES = {
     "webp": "image/webp",
 }
 
+# Anthropic document sources accept only pdf (base64) and plain text; these formats are delivered as text.
+_TEXT_FILE_FORMATS = frozenset({"csv", "html", "md", "txt"})
+
 # Anthropic accepts ``cache_control`` on these block types only; any other block is rejected.
 # https://docs.claude.com/en/docs/build-with-claude/prompt-caching
 _CACHEABLE_BLOCK_TYPES = frozenset({"document", "image", "text", "tool_result", "tool_use"})
@@ -133,20 +136,28 @@ class AnthropicModel(Model):
             Anthropic formatted content block.
 
         Raises:
-            TypeError: If the content block type cannot be converted to an Anthropic-compatible format.
+            TypeError: If the content block type or document format cannot be converted to an
+                Anthropic-compatible format.
         """
         if "document" in content:
-            mime_type = mimetypes.types_map.get(f".{content['document']['format']}", "application/octet-stream")
+            document_format = content["document"]["format"]
+            if document_format != "pdf" and document_format not in _TEXT_FILE_FORMATS:
+                raise TypeError(f"content_type=<document>, format=<{document_format}> | unsupported format")
+
             return {
-                "source": {
-                    "data": (
-                        content["document"]["source"]["bytes"].decode("utf-8")
-                        if mime_type == "text/plain"
-                        else base64.b64encode(content["document"]["source"]["bytes"]).decode("utf-8")
-                    ),
-                    "media_type": mime_type,
-                    "type": "text" if mime_type == "text/plain" else "base64",
-                },
+                "source": (
+                    {
+                        "data": base64.b64encode(content["document"]["source"]["bytes"]).decode("utf-8"),
+                        "media_type": "application/pdf",
+                        "type": "base64",
+                    }
+                    if document_format == "pdf"
+                    else {
+                        "data": content["document"]["source"]["bytes"].decode("utf-8"),
+                        "media_type": "text/plain",
+                        "type": "text",
+                    }
+                ),
                 "title": content["document"]["name"],
                 "type": "document",
             }

--- a/strands-py/src/strands/models/anthropic.py
+++ b/strands-py/src/strands/models/anthropic.py
@@ -140,23 +140,29 @@ class AnthropicModel(Model):
         """
         if "document" in content:
             document_format = content["document"]["format"]
-            if document_format != "pdf" and document_format not in _TEXT_FILE_FORMATS:
+            if document_format == "pdf":
+                source: dict[str, Any] = {
+                    "data": base64.b64encode(content["document"]["source"]["bytes"]).decode("utf-8"),
+                    "media_type": "application/pdf",
+                    "type": "base64",
+                }
+            elif document_format in _TEXT_FILE_FORMATS:
+                try:
+                    text_data = content["document"]["source"]["bytes"].decode("utf-8")
+                except UnicodeDecodeError as decode_error:
+                    raise TypeError(
+                        f"content_type=<document>, format=<{document_format}> | document is not valid utf-8 text"
+                    ) from decode_error
+                source = {
+                    "data": text_data,
+                    "media_type": "text/plain",
+                    "type": "text",
+                }
+            else:
                 raise TypeError(f"content_type=<document>, format=<{document_format}> | unsupported format")
 
             return {
-                "source": (
-                    {
-                        "data": base64.b64encode(content["document"]["source"]["bytes"]).decode("utf-8"),
-                        "media_type": "application/pdf",
-                        "type": "base64",
-                    }
-                    if document_format == "pdf"
-                    else {
-                        "data": content["document"]["source"]["bytes"].decode("utf-8"),
-                        "media_type": "text/plain",
-                        "type": "text",
-                    }
-                ),
+                "source": source,
                 "title": content["document"]["name"],
                 "type": "document",
             }

--- a/strands-py/tests/strands/models/test_anthropic.py
+++ b/strands-py/tests/strands/models/test_anthropic.py
@@ -251,6 +251,21 @@ def test_format_request_with_unsupported_document_format(document_format, model)
         model.format_request(messages)
 
 
+def test_format_request_with_non_utf8_text_document(model):
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"document": {"format": "csv", "name": "test doc", "source": {"bytes": b"caf\xe9"}}},
+            ],
+        },
+    ]
+
+    expected_message = "content_type=<document>, format=<csv> | document is not valid utf-8 text"
+    with pytest.raises(TypeError, match=re.escape(expected_message)):
+        model.format_request(messages)
+
+
 def test_format_request_with_image(model, model_id, max_tokens):
     messages = [
         {

--- a/strands-py/tests/strands/models/test_anthropic.py
+++ b/strands-py/tests/strands/models/test_anthropic.py
@@ -1,6 +1,7 @@
 import copy
 import logging
 import mimetypes
+import re
 import unittest.mock
 import warnings
 
@@ -191,6 +192,21 @@ def test_format_request_with_system_prompt(model, messages, model_id, max_tokens
                 "type": "document",
             },
         ),
+        # Text-file format delivered as plain text
+        (
+            {
+                "document": {"format": "csv", "name": "test doc", "source": {"bytes": b"a,b\n1,2"}},
+            },
+            {
+                "source": {
+                    "data": "a,b\n1,2",
+                    "media_type": "text/plain",
+                    "type": "text",
+                },
+                "title": "test doc",
+                "type": "document",
+            },
+        ),
     ],
 )
 def test_format_request_with_document(content, formatted_content, model, model_id, max_tokens):
@@ -215,6 +231,24 @@ def test_format_request_with_document(content, formatted_content, model, model_i
     }
 
     assert tru_request == exp_request
+
+
+# Guards against https://github.com/strands-agents/harness-sdk/issues/3789: formats Anthropic cannot
+# accept must raise client-side instead of being sent in a request shape the API rejects.
+@pytest.mark.parametrize("document_format", ["doc", "docx", "xls", "xlsx"])
+def test_format_request_with_unsupported_document_format(document_format, model):
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"document": {"format": document_format, "name": "test doc", "source": {"bytes": b"content"}}},
+            ],
+        },
+    ]
+
+    expected_message = f"content_type=<document>, format=<{document_format}> | unsupported format"
+    with pytest.raises(TypeError, match=re.escape(expected_message)):
+        model.format_request(messages)
 
 
 def test_format_request_with_image(model, model_id, max_tokens):

--- a/strands-py/tests/strands/models/test_anthropic.py
+++ b/strands-py/tests/strands/models/test_anthropic.py
@@ -306,6 +306,21 @@ def test_format_request_with_webp_image_does_not_depend_on_mimetypes(model, mode
     assert tru_request["messages"][0]["content"][0]["source"]["media_type"] == "image/webp"
 
 
+# Guards against https://github.com/strands-agents/harness-sdk/issues/3789: formats Anthropic cannot
+# accept must raise client-side instead of being sent with a media type the API rejects.
+def test_format_request_with_unsupported_image_format(model):
+    messages = [
+        {
+            "role": "user",
+            "content": [{"image": {"format": "bmp", "source": {"bytes": b"bmpimage"}}}],
+        },
+    ]
+
+    expected_message = "content_type=<image>, format=<bmp> | unsupported format"
+    with pytest.raises(TypeError, match=re.escape(expected_message)):
+        model.format_request(messages)
+
+
 def test_format_request_with_reasoning(model, model_id, max_tokens):
     messages = [
         {


### PR DESCRIPTION
## Description

The Python Anthropic provider guessed media types with `mimetypes` and forwarded content to the API even when the resulting request shape was one Anthropic always rejects, so undeliverable content failed as an opaque `anthropic.BadRequestError` after a network round trip instead of a clear client-side error.

**Documents.** Anthropic's Messages API only accepts `application/pdf` base64 sources and `text/plain` text sources for document blocks, so only `pdf` and `txt` ever survived: `csv` and `html` were sent base64 with `text/csv`/`text/html`, `md` as `application/octet-stream` on Python < 3.13, and `doc`/`docx`/`xls`/`xlsx` in shapes the API always rejects. Document handling now matches the TypeScript provider: `pdf` is delivered as a base64 document source (unchanged), the text formats in the `DocumentContent` literal (`csv`, `html`, `md`, `txt`) are delivered as `text/plain` text sources so they actually work, and the binary Office formats raise a `TypeError` client-side.

**Images.** Formats outside `_IMAGE_MEDIA_TYPES` fell back to a `mimetypes` lookup defaulting to `application/octet-stream`, another doomed request. They now raise the same client-side `TypeError`, matching the TypeScript provider's unsupported-image-format behavior. Supported formats are unchanged.

`TypeError` is already the documented error contract of `_format_request_message_content` and matches the Mistral provider's unsupported-format precedent.

A note on the parity claim, since the failure modes only align once both PRs land: TypeScript on `main` still warns-and-skips undeliverable documents; #3786 changes it to throw, and this PR gives Python the matching raise. One divergence is intentional and remains: TypeScript's delivered text-format list is wider (`json`, `xml`, `yaml`, ...) than Python's, because those formats are not in Python's `DocumentContent` literal; that gap is #2204's scope. Non-UTF-8 bytes in a text-format document also raise the documented `TypeError` (rather than an undocumented `UnicodeDecodeError`).

```python
# Before: docx forwarded as base64 application/octet-stream, API returns an opaque 400
# Before: csv forwarded as base64 text/csv, API returns an opaque 400
# Before: bmp image forwarded as base64 image/bmp, API returns an opaque 400

# After: csv delivered as a text/plain text source (works)
# After: docx and bmp raise client-side before any API call
# TypeError: content_type=<document>, format=<docx> | unsupported format
# TypeError: content_type=<image>, format=<bmp> | unsupported format
```

**Alternatives considered:**

- **Raise for everything except `pdf` and `txt`** (pure error-surface fix). Rejected: `csv`/`html`/`md` are plain text Anthropic can accept, and the TypeScript provider already delivers them, so raising would open a parity gap in the opposite direction.
- **Keep forwarding and let the API reject.** Rejected in #3786 for TypeScript for the same reason it fails here: the error is an opaque provider 400 after a network round trip instead of a clear client-side message.
- **Widen the delivered text formats to TypeScript's full list** (`json`, `xml`, `yaml`, ...). Deferred: those formats are not in Python's `DocumentContent` format literal; widening the literal is tracked in #2204.

**Callout:** intentional behavior change on a public provider. Requests that previously failed with a provider 400 for undeliverable documents and images now raise `TypeError` client-side, and `csv`/`html`/`md` documents that previously failed now succeed.

## Related Issues

Resolves #3789

Related: #3785, #3786 (TypeScript counterpart), #2204 (format literal gaps)

## Documentation PR

No documentation changes needed: the set of formats a user can pass is unchanged, only delivery and the failure mode.

## Type of Change

Bug fix

## Testing

Ran `hatch run format`, `hatch run lint`, `hatch run test-lint` (mypy), and the full unit suite on Python 3.11 (5166 tests passing, including new regression tests for the raising document and image formats and a csv delivery case).

- [x] I ran `hatch run prepare` (format, lint, test-lint, and the unit suite on 3.11; the full version matrix runs in CI)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
