### PR TITLE
fix(anthropic): deliver url-source images instead of silently dropping them

### DIFF
--- a/strands-ts/src/models/__tests__/anthropic.test.ts
+++ b/strands-ts/src/models/__tests__/anthropic.test.ts
@@ -619,6 +619,31 @@ describe('AnthropicModel', () => {
         expect(content.source.data).toBe('SGVsbG8=')
       })
 
+      // Guards against https://github.com/strands-agents/harness-sdk/issues/3791: anthropic accepts
+      // url image sources natively, so url-source images must be delivered rather than dropped.
+      it('formats url-source images as anthropic url sources', async () => {
+        const { captured, mockClient } = setupCapture()
+        const provider = new AnthropicModel({ client: mockClient })
+        const messages = [
+          new Message({
+            role: 'user',
+            content: [
+              new ImageBlock({
+                format: 'png',
+                source: { url: 'https://example.com/image.png' },
+              }),
+            ],
+          }),
+        ]
+
+        await collectIterator(provider.stream(messages))
+
+        expect(captured.request.messages[0].content[0]).toEqual({
+          type: 'image',
+          source: { type: 'url', url: 'https://example.com/image.png' },
+        })
+      })
+
       it('formats PDFs correctly', async () => {
         const { captured, mockClient } = setupCapture()
         const provider = new AnthropicModel({ client: mockClient })
@@ -1322,7 +1347,7 @@ describe('AnthropicModel', () => {
           role: 'user',
           content: [
             new TextBlock('long prefix'),
-            new ImageBlock({ format: 'png', source: { url: 'https://example.com/a.png' } as never }),
+            new ImageBlock({ format: 'png', source: { location: { type: 's3', uri: 's3://bucket/a.png' } } }),
           ],
         }),
       ]
@@ -1346,7 +1371,7 @@ describe('AnthropicModel', () => {
           role: 'user',
           content: [
             new ReasoningBlock({ text: 'thinking', signature: 'sig' }),
-            new ImageBlock({ format: 'png', source: { url: 'https://example.com/a.png' } as never }),
+            new ImageBlock({ format: 'png', source: { location: { type: 's3', uri: 's3://bucket/a.png' } } }),
           ],
         }),
       ]
@@ -1627,7 +1652,7 @@ describe('AnthropicModel', () => {
         new Message({
           role: 'user',
           content: [
-            new ImageBlock({ format: 'png', source: { url: 'https://example.com/a.png' } as never }),
+            new ImageBlock({ format: 'png', source: { location: { type: 's3', uri: 's3://bucket/a.png' } } }),
             new CachePointBlock({ cacheType: 'default' }),
             new TextBlock('volatile'),
           ],
@@ -1779,7 +1804,7 @@ describe('AnthropicModel', () => {
             new TextBlock('prefix'),
             new ImageBlock({ format: 'png', source: { bytes: new Uint8Array([1, 2, 3]) } }),
             // Dropped in translation: the breakpoint must fall back to the image above, not vanish.
-            new ImageBlock({ format: 'png', source: { url: 'https://example.com/a.png' } as never }),
+            new ImageBlock({ format: 'png', source: { location: { type: 's3', uri: 's3://bucket/a.png' } } }),
           ],
         }),
       ]

--- a/strands-ts/src/models/anthropic.ts
+++ b/strands-ts/src/models/anthropic.ts
@@ -560,29 +560,32 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
             throw new Error(`Unsupported image format for Anthropic: ${imgBlock.format}`)
         }
 
-        if (imgBlock.source.type === 'imageSourceBytes') {
-          return {
-            type: 'image',
-            source: {
-              type: 'base64',
-              media_type: mediaType,
-              data: encodeBase64(imgBlock.source.bytes),
-            },
-          }
+        switch (imgBlock.source.type) {
+          case 'imageSourceBytes':
+            return {
+              type: 'image',
+              source: {
+                type: 'base64',
+                media_type: mediaType,
+                data: encodeBase64(imgBlock.source.bytes),
+              },
+            }
+          case 'imageSourceUrl':
+            return {
+              type: 'image',
+              source: {
+                type: 'url',
+                url: imgBlock.source.url,
+              },
+            }
+          case 'imageSourceS3Location':
+            logger.warn(
+              'source_type=<imageSourceS3Location> | s3 location sources are not supported by anthropic | skipping'
+            )
+            return undefined
+          default:
+            throw new Error(`Unsupported image source for Anthropic: ${(imgBlock.source as { type: string }).type}`)
         }
-        if (imgBlock.source.type === 'imageSourceUrl') {
-          return {
-            type: 'image',
-            source: {
-              type: 'url',
-              url: imgBlock.source.url,
-            },
-          }
-        }
-        logger.warn(
-          'source_type=<imageSourceS3Location> | s3 location sources are not supported by anthropic, skipping'
-        )
-        return undefined
       }
 
       case 'documentBlock': {

--- a/strands-ts/src/models/anthropic.ts
+++ b/strands-ts/src/models/anthropic.ts
@@ -570,7 +570,18 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
             },
           }
         }
-        logger.warn('source_type=<imageSourceUrl> | anthropic requires image bytes | url sources not fully supported')
+        if (imgBlock.source.type === 'imageSourceUrl') {
+          return {
+            type: 'image',
+            source: {
+              type: 'url',
+              url: imgBlock.source.url,
+            },
+          }
+        }
+        logger.warn(
+          'source_type=<imageSourceS3Location> | s3 location sources are not supported by anthropic, skipping'
+        )
         return undefined
       }
 


### PR DESCRIPTION
## Description

The Anthropic provider only delivered images with byte sources; an `ImageBlock` with a URL source was silently omitted from the request with a log-level warning, so the model answered as if no image was attached. This is the silent-drop class fixed for documents in #3786, and it surfaced during that PR's review. It is worse here than it was for documents: Anthropic's Messages API accepts URL image sources natively (`{"type": "image", "source": {"type": "url", "url": ...}}`), so the SDK was dropping content the API could have taken.

`imageSourceUrl` now maps to the API's native URL source. S3 location sources keep the established cross-provider warn-and-skip behavior (Python filters them centrally for all providers, and Bedrock/TS does the same), but the warning previously hardcoded `source_type=<imageSourceUrl>` and now names the actual source type.

```typescript
// Before: request sent without the image, warn in logs only
// After: delivered
{ type: 'image', source: { type: 'url', url: 'https://example.com/image.png' } }
```

**Alternatives considered:**

- **Throw for URL sources**, extending the fail-loud invariant from #3786. Rejected: unlike docx documents, the API supports this source type, so the correct fix is delivery, not a louder failure.
- **Also throw for S3 location sources.** Rejected for now: location sources are a deliberate warn-and-skip pattern shared across providers and SDKs (Python's `_has_location_source` filter), and several cache-placement tests encode that dropped-in-translation behavior. Changing that convention would be a cross-provider, cross-SDK decision, not part of this fix.

**Callout:** four prompt-caching tests used a URL-source image as their "block dropped in translation" fixture; they now use an S3 location source, which keeps the dropped behavior those tests exercise (and matches their comments, which already said "location source"). This includes the cross-SDK parity test, whose formatted request is unchanged, so the strands-py mirror needs no update.

## Related Issues

Resolves #3791

Related: #3785, #3786 (same silent-drop class, documents)

## Documentation PR

No documentation changes needed.

## Type of Change

Bug fix

## Testing

Ran the TypeScript SDK gates: full unit suite (4091 tests including the new URL-delivery regression test), `npm run lint`, `npm run format:check`, `npm run type-check`, `npm run build`. Also exercised the change end to end: formatting a message with a URL-source image previously produced a request without the image; it now contains the URL source block.

- [ ] I ran `hatch run prepare` (Python-only gate; this change is TypeScript-only, TS equivalents above)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
