### PR TITLE
docs(changelog): sync strands-agents/evals backfill

### DIFF
--- a/site/src/content/changelog/evals/v1.1.1.md
+++ b/site/src/content/changelog/evals/v1.1.1.md
@@ -1,0 +1,13 @@
+---
+sdk: evals
+version: "1.1.1"
+tag: v1.1.1
+date: 2026-08-12
+releaseUrl: https://github.com/strands-agents/evals/releases/tag/v1.1.1
+packageUrl: https://pypi.org/project/strands-agents-evals/1.1.1/
+entries:
+  - { type: fix, breaking: false, scope: null, areas: [tracing], title: "add GenericGenAISessionMapper for dict spans with unrecognized scope", pr: 309, prUrl: "https://github.com/strands-agents/evals/pull/309", commit: "86bdeca", commitUrl: "https://github.com/strands-agents/evals/commit/86bdeca", author: ybdarrenwang }
+  - { type: feat, breaking: false, scope: null, areas: [tracing], title: "add support for Claude agents to OpenInference mapper", pr: 340, prUrl: "https://github.com/strands-agents/evals/pull/340", commit: "e82933c", commitUrl: "https://github.com/strands-agents/evals/commit/e82933c", author: liramon2 }
+  - { type: other, breaking: false, scope: null, areas: [community], title: "update pre-commit requirement from <4.6.0,>=3.2.0 to >=3.2.0,<4.7.0", pr: 321, prUrl: "https://github.com/strands-agents/evals/pull/321", commit: "b153212", commitUrl: "https://github.com/strands-agents/evals/commit/b153212", author: "dependabot[bot]" }
+  - { type: other, breaking: false, scope: null, areas: [community], title: "bump pypa/gh-action-pypi-publish from 1.14.0 to 1.14.2", pr: 333, prUrl: "https://github.com/strands-agents/evals/pull/333", commit: "ed7b6a5", commitUrl: "https://github.com/strands-agents/evals/commit/ed7b6a5", author: "dependabot[bot]" }
+---


### PR DESCRIPTION
Automated evals changelog backstop.