### PR TITLE
docs(changelog): sync strands-agents/harness-sdk typescript/v1.13.0

### DIFF
--- a/site/src/content/changelog/harness/typescript-v1.13.0.md
+++ b/site/src/content/changelog/harness/typescript-v1.13.0.md
@@ -1,0 +1,21 @@
+---
+sdk: harness
+language: typescript
+version: "1.13.0"
+tag: typescript/v1.13.0
+date: 2026-08-12
+releaseUrl: https://github.com/strands-agents/harness-sdk/releases/tag/typescript/v1.13.0
+packageUrl: https://www.npmjs.com/package/@strands-agents/sdk/v/1.13.0
+entries:
+  - { type: feat, breaking: false, scope: ts, areas: [tool], title: "support appending to notebooks", pr: 3459, prUrl: "https://github.com/strands-agents/harness-sdk/pull/3459", commit: "1a06dff", commitUrl: "https://github.com/strands-agents/harness-sdk/commit/1a06dff", author: March-77 }
+  - { type: other, breaking: false, scope: null, areas: [community], title: "bump dorny/paths-filter from 4.0.2 to 4.0.3", pr: 3729, prUrl: "https://github.com/strands-agents/harness-sdk/pull/3729", commit: "f2a8cb4", commitUrl: "https://github.com/strands-agents/harness-sdk/commit/f2a8cb4", author: "dependabot[bot]" }
+  - { type: fix, breaking: false, scope: bedrock, areas: [model], title: "honor a cache point placed in the last user message", pr: 3677, prUrl: "https://github.com/strands-agents/harness-sdk/pull/3677", commit: "d69941a", commitUrl: "https://github.com/strands-agents/harness-sdk/commit/d69941a", author: strandly-the-agent }
+  - { type: test, breaking: false, scope: models, areas: [model, community], title: "retry inconclusive Mantle routing probes", pr: 3747, prUrl: "https://github.com/strands-agents/harness-sdk/pull/3747", commit: "9eaaff4", commitUrl: "https://github.com/strands-agents/harness-sdk/commit/9eaaff4", author: yonib05 }
+  - { type: fix, breaking: false, scope: vended-tools, areas: [devx, tool], title: "keep the pre-rename name on the deprecated bash aliases", pr: 3751, prUrl: "https://github.com/strands-agents/harness-sdk/pull/3751", commit: "679665f", commitUrl: "https://github.com/strands-agents/harness-sdk/commit/679665f", author: yonib05 }
+  - { type: docs, breaking: false, scope: null, areas: [community], title: "add prescriptive guidance for keeping cognitive complexity low", pr: 3741, prUrl: "https://github.com/strands-agents/harness-sdk/pull/3741", commit: "cc7597c", commitUrl: "https://github.com/strands-agents/harness-sdk/commit/cc7597c", author: yonib05 }
+  - { type: other, breaking: false, scope: release, areas: [community], title: "post release notes to the announcements discussion board", pr: 3707, prUrl: "https://github.com/strands-agents/harness-sdk/pull/3707", commit: "cf4a68a", commitUrl: "https://github.com/strands-agents/harness-sdk/commit/cf4a68a", author: yonib05 }
+  - { type: fix, breaking: false, scope: conversation, areas: [context], title: "trim at complete tool pairs", pr: 3447, prUrl: "https://github.com/strands-agents/harness-sdk/pull/3447", commit: "13990f0", commitUrl: "https://github.com/strands-agents/harness-sdk/commit/13990f0", author: March-77 }
+  - { type: refactor, breaking: false, scope: vended-tools, areas: [tool], title: "treat bash as its own deprecated tool", pr: 3756, prUrl: "https://github.com/strands-agents/harness-sdk/pull/3756", commit: "e4d57c1", commitUrl: "https://github.com/strands-agents/harness-sdk/commit/e4d57c1", author: yonib05 }
+  - { type: fix, breaking: false, scope: ts, areas: [model, agent], title: "abort in-flight Bedrock requests on cancellation", pr: 3337, prUrl: "https://github.com/strands-agents/harness-sdk/pull/3337", commit: "2c6c531", commitUrl: "https://github.com/strands-agents/harness-sdk/commit/2c6c531", author: jstar0 }
+  - { type: other, breaking: false, scope: docs-preview, areas: [community], title: "link catalog and standalone page changes in the preview comment", pr: 3774, prUrl: "https://github.com/strands-agents/harness-sdk/pull/3774", commit: "c2df950", commitUrl: "https://github.com/strands-agents/harness-sdk/commit/c2df950", author: yonib05 }
+---


### PR DESCRIPTION
Automated changelog sync.
Add a curated `highlights:` block to any release file before merging if desired.