### PR TITLE
fix(bedrock): omit falsy cache point TTLs

### DIFF
--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -814,7 +814,7 @@ class BedrockModel(Model):
         if "cachePoint" in content:
             cache_point = content["cachePoint"]
             result: dict[str, Any] = {"type": cache_point["type"]}
-            if "ttl" in cache_point:
+            if cache_point.get("ttl"):
                 result["ttl"] = cache_point["ttl"]
             return {"cachePoint": result}
 

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -2717,6 +2717,30 @@ def test_format_request_preserves_cache_point_ttl(model, model_id):
     assert cache_point_block["ttl"] == "1h"
 
 
+# https://github.com/strands-agents/harness-sdk/issues/3759
+@pytest.mark.parametrize("ttl", [None, ""])
+def test_format_request_omits_falsy_cache_point_ttl(model, ttl):
+    """Falsy caller TTLs are omitted before Bedrock validates the request."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "cachePoint": {
+                        "type": "default",
+                        "ttl": ttl,
+                    }
+                },
+            ],
+        }
+    ]
+
+    tru_cache_point = model.format_request(messages)["messages"][0]["content"][0]["cachePoint"]
+    exp_cache_point = {"type": "default"}
+
+    assert tru_cache_point == exp_cache_point
+
+
 def test_format_request_cache_point_without_ttl(model, model_id):
     """Test that cache points work without ttl field (backward compatibility)."""
     messages = [

--- a/strands-ts/src/models/__tests__/bedrock.test.ts
+++ b/strands-ts/src/models/__tests__/bedrock.test.ts
@@ -823,6 +823,32 @@ describe('BedrockModel', () => {
       })
     })
 
+    // https://github.com/strands-agents/harness-sdk/issues/3759
+    it.each([null, ''])('omits a falsy ttl on user-supplied cache point blocks in messages', async (ttl) => {
+      const provider = new BedrockModel()
+      const messages = [
+        new Message({
+          role: 'user',
+          content: [
+            new TextBlock('Message with cache point'),
+            new CachePointBlock({ cacheType: 'default', ttl: ttl as unknown as string }),
+          ],
+        }),
+      ]
+
+      await collectIterator(provider.stream(messages))
+
+      expect(mockConverseStreamCommand).toHaveBeenLastCalledWith({
+        messages: [
+          {
+            role: 'user',
+            content: [{ text: 'Message with cache point' }, { cachePoint: { type: 'default' } }],
+          },
+        ],
+        modelId: expect.any(String),
+      })
+    })
+
     it('preserves ttl on cache point blocks in system prompt', async () => {
       const provider = new BedrockModel()
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]

--- a/strands-ts/src/models/bedrock.ts
+++ b/strands-ts/src/models/bedrock.ts
@@ -1271,8 +1271,8 @@ export class BedrockModel extends Model<BedrockModelConfig> {
 
       case 'cachePointBlock': {
         const cachePoint: BedrockCachePointBlock = { type: block.cacheType }
-        if (block.ttl !== undefined) {
-          // Bedrock validates TTL values server-side, so accept any string here.
+        if (block.ttl) {
+          // Bedrock validates non-empty TTL values server-side, so do not restrict them to known values here.
           cachePoint.ttl = block.ttl as BedrockSdkCacheTTL
         }
         return { cachePoint }


### PR DESCRIPTION
## Description

Caller-placed message cache points could forward empty or null TTLs when Bedrock caching was disabled, causing botocore or Bedrock to reject an otherwise valid request. Normalize those values at the wire-format boundary in both SDKs while preserving non-empty TTLs.

## Related Issues

Resolves #3759

## Documentation PR

Not required; this corrects internal request normalization without changing public API or documented behavior.

## Type of Change

Bug fix

## Testing

- Python official check: `hatch run prepare` — format, lint, and type checks passed; Python 3.14–3.11 each passed 5167 tests, and Python 3.10 passed 5162 with 5 skipped
- Python coverage suite: `hatch test tests --cover` — 5167 passed
- TypeScript pre-commit suite: build, lint, format, type-check, and `npm run test:coverage` — 4104 passed
- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
