### PR TITLE
fix(build): include strandly workspace in root build and type-check

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "dev": "strandly",
     "prepare": "husky",
-    "build": "npm run build -w strands-ts",
+    "build": "npm run build -w strands-ts -w strandly",
     "test": "npm run test -w strands-ts",
     "test:coverage": "npm run test:coverage -w strands-ts",
     "test:all": "npm run test:all -w strands-ts",
@@ -26,7 +26,7 @@
     "lint": "npm run lint -w strands-ts",
     "format": "npm run format -w strands-ts",
     "format:check": "npm run format:check -w strands-ts",
-    "type-check": "npm run type-check -w strands-ts",
+    "type-check": "npm run type-check -w strands-ts -w strandly",
     "check": "npm run check -w strands-ts",
     "check:browser-bundle": "npm run check:browser-bundle -w strands-ts",
     "complexity": "node .github/scripts/pr-metrics/run-analysis.mjs",


### PR DESCRIPTION
Closes #3768

## What

`strandly` is declared in the root `package.json` `workspaces` array, but every
root script targets `-w strands-ts` only. So `npm run build` and
`npm run type-check` — the exact commands CI's TypeScript code-quality job runs —
never compiled the workspace. This adds `-w strandly` to those two scripts.

## A correction to the issue's diagnosis

The issue reads as "CI is never triggered for `strandly`". That isn't quite what
happens, and the real story is a bit worse:

- `.github/workflows/ci.yml` **does** list `strandly/**` in the `typescript`
  paths-filter, and `typescript-pr-and-push.yml` **does** list it in its `push`
  paths.
- So a change under `strandly/` **does** trigger the TypeScript workflows.
- `typescript-ts-check.yml` then runs `npm run build`, `npm run lint`,
  `npm run format:check`, `npm run type-check`, `npm run check:browser-bundle` —
  **all of which resolve to `-w strands-ts`**.

In other words the jobs run, go green, and report nothing — the path filter
actively creates the impression that the workspace is guarded when the commands
behind it never touch it. A silent green is harder to notice than no run at all.

## Verification

`strandly` already ships its own `build` / `type-check` scripts and a strict
`tsconfig.json`; nothing there needed changing, and it type-checks cleanly today
(so this PR turns the check on without dragging in a backlog of pre-existing
errors).

To prove the checks now actually cover the workspace, I appended a deliberate
type error to `strandly/src/cli.ts` and ran the root scripts with the old and
new `package.json` against identical sources:

**Before (current `main` scripts) — silently passes:**

```
$ npm run type-check ; echo exit=$?
> tsc --noEmit --project src/tsconfig.json && tsc --noEmit --project test/integ/tsconfig.json
exit=0

$ npm run build ; echo exit=$?
> tsc --project src/tsconfig.json
exit=0
```

**After (this PR) — caught by both:**

```
$ npm run type-check ; echo exit=$?
src/cli.ts(123,7): error TS2322: Type 'string' is not assignable to type 'number'.
npm error workspace @strands-agents/strandly@0.0.1
exit=2

$ npm run build ; echo exit=$?
src/cli.ts(123,7): error TS2322: Type 'string' is not assignable to type 'number'.
npm error workspace @strands-agents/strandly@0.0.1
exit=2
```

The deliberate error was reverted; it is not part of this diff.

Full local run of the CI code-quality sequence on the final tree, all green:
`build`, `lint`, `format:check`, `type-check`, `check:browser-bundle`, plus
`npm test` (145 files / 4102 tests passed).

## Scope

Deliberately limited to `build` and `type-check`:

- `lint` / `format` / `format:check` stay `-w strands-ts` — `strandly` has no
  eslint config and no `format` script, so wiring those up means introducing new
  tooling config, which belongs in its own change.
- `check` stays `-w strands-ts` — `strandly` has no `check` script, and CI runs
  `build` / `type-check` as separate steps anyway.
- Kept explicit `-w` names rather than switching to `--workspaces`, so behaviour
  for `strands-ts` is bit-for-bit unchanged.

Happy to fold any of the above in if maintainers would prefer a broader change.
