### PR TITLE
feat(ts): add execution-scoped cancellation to ToolContext

### DIFF
--- a/site/src/content/docs/user-guide/concepts/agents/agent-loop.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/agent-loop.mdx
@@ -180,7 +180,7 @@ The `agent.cancel()` method provides a way to stop the loop from outside, such a
 
   #### Cancellation within tool execution
 
-  The SDK automatically checks for cancellation before and between tool invocations (see checkpoints above). However, once a tool callback is running, cancellation is **cooperative** — only the tool itself can respond mid-execution. Tools can participate by forwarding the signal to APIs that accept `AbortSignal`, or by polling `cancelSignal.aborted` between steps. If a tool does neither, it runs to completion and the agent resumes cancellation handling after the tool returns.
+  The SDK automatically checks for cancellation before and between tool calls (see checkpoints above). Once a tool callback is running, cancellation is **cooperative**: only the tool itself can respond mid-execution. Tools can participate by forwarding `context.cancelSignal` to APIs that accept `AbortSignal`, or by polling `context.cancelSignal.aborted` between steps. If a tool does neither, it runs to completion, and the agent resumes cancellation handling after the tool returns.
 
   ```typescript
   --8<-- "user-guide/concepts/agents/agent-loop.ts:cancel_signal"

--- a/site/src/content/docs/user-guide/concepts/agents/agent-loop.ts
+++ b/site/src/content/docs/user-guide/concepts/agents/agent-loop.ts
@@ -22,7 +22,7 @@ const myTool = tool({
   callback: async (input, context) => {
     // Forward the cancel signal to APIs that accept AbortSignal
     const response = await fetch(input.url, {
-      signal: context?.agent.cancelSignal,
+      signal: context?.cancelSignal,
     })
     return response.text()
   },

--- a/site/src/content/docs/user-guide/concepts/tools/executors.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/executors.mdx
@@ -119,7 +119,7 @@ Cancellation works identically in both modes. Call `agent.cancel()` to request c
 <Tab label="TypeScript">
 
 - **Pre-launch cancel**: set `BeforeToolsEvent.cancel` on the batch-level hook, or call `agent.cancel()` before tools start, to produce error results for every tool in the batch.
-- **Mid-flight cancel** in sequential mode short-circuits not-yet-started tools. In concurrent mode, all tools have already launched, so each in-flight tool must cooperatively observe `agent.cancelSignal` to stop early.
+- **Mid-flight cancel** in sequential mode short-circuits not-yet-started tools. In concurrent mode, all tools have already launched, so each in-flight tool must cooperatively observe `context.cancelSignal` to stop early.
 
 </Tab>
 </Tabs>

--- a/strands-ts/AGENTS.md
+++ b/strands-ts/AGENTS.md
@@ -208,7 +208,7 @@ export class XModel extends Model<XModelConfig> {
 - **`stream` is an async generator** typed `async *stream(messages, options?): AsyncIterable<ModelStreamEvent>`, matching the abstract base exactly. Consume async iterables with `for await`.
 - **Providers emit raw `ModelStreamEvent`s and must not buffer the whole response.** The base `Model.streamAggregated` performs event accumulation on top of `stream`.
 - **The SDK is async-only — no sync facade.** `invoke()` returns a `Promise`; there is no blocking equivalent (unlike the Python SDK's `__call__`).
-- **Cancellation uses `AbortSignal`.** `agent.cancelSignal` is exposed, and callers may pass an external `cancelSignal` via `invoke`/`stream` options (merged with `AbortSignal.any`). When merging concurrent async generators, race `.next()` with `Promise.race` and close the rest with `Promise.allSettled(gen.return())` in `finally`; use `Promise.all`/`allSettled` for simple fan-out.
+- **Cancellation uses `AbortSignal`.** Tools receive the execution-scoped signal through `ToolContext.cancelSignal`, and tool middleware through `ExecuteToolContext.cancelSignal`; foreground and direct tool execution use `agent.cancelSignal`. Callers may pass an external `cancelSignal` via `invoke`/`stream` options (merged with `AbortSignal.any`). When merging concurrent async generators, race `.next()` with `Promise.race` and close the rest with `Promise.allSettled(gen.return())` in `finally`; use `Promise.all`/`allSettled` for simple fan-out.
 
 ## Testing
 

--- a/strands-ts/src/__fixtures__/tool-helpers.ts
+++ b/strands-ts/src/__fixtures__/tool-helpers.ts
@@ -24,6 +24,7 @@ export function createMockContext(
   appState?: Record<string, JSONValue>,
   invocationState?: InvocationState
 ): ToolContext {
+  const cancelSignal = new AbortController().signal
   return {
     toolUse,
     agent: {
@@ -31,9 +32,11 @@ export function createMockContext(
       appState: new StateStore(appState),
       messages: [],
       toolRegistry: new ToolRegistry(),
+      cancelSignal,
       addHook: () => () => {},
     } as unknown as LocalAgent,
     invocationState: invocationState ?? {},
+    cancelSignal,
     interrupt: (): never => {
       throw new Error('interrupt not available in mock context')
     },

--- a/strands-ts/src/agent/__tests__/agent-as-tool.test.ts
+++ b/strands-ts/src/agent/__tests__/agent-as-tool.test.ts
@@ -5,10 +5,12 @@ import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
 import { collectGenerator } from '../../__fixtures__/model-test-helpers.js'
 import { createMockContext } from '../../__fixtures__/tool-helpers.js'
 import { ToolValidationError } from '../../errors.js'
-import { Tool, ToolStreamEvent } from '../../tools/tool.js'
+import { BeforeModelCallEvent } from '../../hooks/events.js'
+import { createErrorResult, Tool, ToolStreamEvent } from '../../tools/tool.js'
 import { DELEGATION_DESCRIPTION_SUFFIX } from '../agent-as-tool.js'
 import { ToolResultBlock } from '../../types/messages.js'
 import { SessionManager } from '../../session/session-manager.js'
+import type { Plugin } from '../../plugins/plugin.js'
 import type { SnapshotStorage } from '../../session/storage.js'
 
 describe('AgentAsTool', () => {
@@ -130,6 +132,67 @@ describe('AgentAsTool', () => {
           text: 'Agent response',
         })
       )
+    })
+
+    it('returns an error when the execution signal cancels the wrapped agent', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Agent response' })
+      const agent = new Agent({ model, name: 'test-agent', printer: false })
+      const tool = new AgentAsTool({ agent })
+      const controller = new AbortController()
+      agent.addHook(BeforeModelCallEvent, () => controller.abort())
+
+      const context = createMockContext({
+        name: 'test-agent',
+        toolUseId: 'tool-1',
+        input: { input: 'Hello agent' },
+      })
+      context.cancelSignal = controller.signal
+
+      const { result } = await collectGenerator(tool.stream(context))
+
+      expect(result).toEqual(createErrorResult("Agent 'test-agent' cancelled", 'tool-1'))
+    })
+
+    it('does not persist cancellation when the signal aborts during initialization', async () => {
+      let signalInitializationStarted!: () => void
+      const initializationStarted = new Promise<void>((resolve) => {
+        signalInitializationStarted = resolve
+      })
+      let releaseInitialization!: () => void
+      const initializationReleased = new Promise<void>((resolve) => {
+        releaseInitialization = resolve
+      })
+      const plugin: Plugin = {
+        name: 'delayed-initialization',
+        async initAgent(): Promise<void> {
+          signalInitializationStarted()
+          await initializationReleased
+        },
+      }
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Agent response' })
+      const agent = new Agent({ model, name: 'test-agent', plugins: [plugin], printer: false })
+      const tool = new AgentAsTool({ agent, preserveContext: true })
+      const controller = new AbortController()
+      const context = createMockContext({
+        name: 'test-agent',
+        toolUseId: 'tool-1',
+        input: { input: 'Hello agent' },
+      })
+      context.cancelSignal = controller.signal
+
+      const execution = collectGenerator(tool.stream(context))
+      await initializationStarted
+      controller.abort()
+      releaseInitialization()
+      const { result } = await execution
+
+      expect({
+        result,
+        messages: agent.messages,
+      }).toEqual({
+        result: createErrorResult("Agent 'test-agent' cancelled", 'tool-1'),
+        messages: [],
+      })
     })
 
     it('yields ToolStreamEvents wrapping sub-agent events', async () => {

--- a/strands-ts/src/agent/__tests__/agent.cancel.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.cancel.test.ts
@@ -31,9 +31,7 @@ describe('Agent Cancellation', () => {
 
       expect(result.stopReason).toBe('cancelled')
       expect(result.lastMessage.content[0]).toEqual(new TextBlock('Cancelled by user'))
-      // User message is not appended — cancel fires before message append in the loop
-      expect(agent.messages).toHaveLength(1)
-      expect(agent.messages[0]!.role).toBe('assistant')
+      expect(agent.messages).toEqual([])
     })
 
     it('cancels at top of second cycle when tool calls cancel()', async () => {
@@ -416,14 +414,16 @@ describe('Agent Cancellation', () => {
   })
 
   describe('tool-level cancellation cooperation', () => {
-    it('exposes cancelSignal to tools via context.agent', async () => {
+    it('passes agent.cancelSignal to foreground tools', async () => {
       let signalSeen: AbortSignal | undefined
+      let agentSignalSeen: AbortSignal | undefined
 
       const signalTool = tool({
         name: 'signalTool',
         description: 'Tool that reads the cancellation signal',
         callback: (_input, context) => {
-          signalSeen = context?.agent.cancelSignal
+          signalSeen = context?.cancelSignal
+          agentSignalSeen = context?.agent.cancelSignal
           return 'done'
         },
       })
@@ -437,6 +437,7 @@ describe('Agent Cancellation', () => {
 
       expect(signalSeen).toBeInstanceOf(AbortSignal)
       expect(signalSeen!.aborted).toBe(false)
+      expect(signalSeen).toBe(agentSignalSeen)
     })
 
     it('signal is aborted when tool checks it after cancel()', async () => {
@@ -448,7 +449,7 @@ describe('Agent Cancellation', () => {
         description: 'Tool that cancels then checks the signal',
         callback: (_input, context) => {
           agent.cancel()
-          signalAborted = context?.agent.cancelSignal.aborted
+          signalAborted = context?.cancelSignal.aborted
           return 'done'
         },
       })

--- a/strands-ts/src/agent/__tests__/agent.concurrent.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.concurrent.test.ts
@@ -25,7 +25,7 @@ import type { ToolSpec } from '../../tools/types.js'
  *
  * `started` resolves as soon as the agent enters the tool's `stream()`, so
  * tests can await "both tools in flight" without polling. The tool also
- * honors `ctx.agent.cancelSignal`: aborting the signal resolves the gate and
+ * honors `ctx.cancelSignal`: aborting the signal resolves the gate and
  * marks `observations.cancelled = true`.
  */
 class GatedTool extends Tool {
@@ -60,7 +60,7 @@ class GatedTool extends Tool {
 
     await new Promise<void>((resolve) => {
       void this._releaser.then(resolve)
-      ctx.agent.cancelSignal.addEventListener(
+      ctx.cancelSignal.addEventListener(
         'abort',
         () => {
           this.observations.cancelled = true

--- a/strands-ts/src/agent/__tests__/tool-caller.test.ts
+++ b/strands-ts/src/agent/__tests__/tool-caller.test.ts
@@ -58,6 +58,26 @@ describe('ToolCaller', () => {
       )
     })
 
+    it('passes agent.cancelSignal to direct tool calls', async () => {
+      let receivedSignal: AbortSignal | undefined
+      const tool = createMockTool('probe', (context) => {
+        receivedSignal = context.cancelSignal
+        return new ToolResultBlock({
+          toolUseId: context.toolUse.toolUseId,
+          status: 'success',
+          content: [],
+        })
+      })
+      const agent = new Agent({
+        model: new MockMessageModel().addTurn({ type: 'textBlock', text: 'unused' }),
+        tools: [tool],
+      })
+
+      await agent.tool.probe!.invoke({})
+
+      expect(receivedSignal).toBe(agent.cancelSignal)
+    })
+
     it('throws when tool is not found', async () => {
       const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
       const agent = new Agent({ model, tools: [] })

--- a/strands-ts/src/agent/agent-as-tool.ts
+++ b/strands-ts/src/agent/agent-as-tool.ts
@@ -175,7 +175,7 @@ export class AgentAsTool extends Tool {
   }
 
   async *stream(toolContext: ToolContext): ToolStreamGenerator {
-    const { toolUse } = toolContext
+    const { toolUse, invocationState, cancelSignal } = toolContext
     const toolUseId = toolUse.toolUseId
 
     // Concurrency guard: loadSnapshot + agent.stream() must not overlap.
@@ -195,7 +195,10 @@ export class AgentAsTool extends Tool {
       // Stream the sub-agent, forwarding the outer invocation's state so
       // mutations in the inner agent's hooks/tools are visible to the outer
       // agent's downstream callbacks and final AgentResult.
-      const gen = this._agent.stream(input, { invocationState: toolContext.invocationState })
+      const gen = this._agent.stream(input, {
+        invocationState,
+        cancelSignal,
+      })
       let next = await gen.next()
       while (!next.done) {
         const event = next.value
@@ -208,6 +211,10 @@ export class AgentAsTool extends Tool {
         next = await gen.next()
       }
       const result = next.value
+
+      if (result.stopReason === 'cancelled') {
+        return createErrorResult(`Agent '${this.name}' cancelled`, toolUseId)
+      }
 
       // Build the tool result
       if (result.structuredOutput !== undefined) {

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -141,7 +141,7 @@ export type ToolList = (Tool | McpClient | Agent | ToolList)[]
  * - `'sequential'` — runs tool calls one at a time
  *
  * Cancellation works identically in both modes: {@link Agent.cancel} flips
- * {@link Agent.cancelSignal} and tools must observe it cooperatively to stop early.
+ * {@link Agent.cancelSignal}, which SDK-managed tool contexts expose as `context.cancelSignal`.
  * In concurrent mode, prompt batch-wide cancellation requires every in-flight tool
  * to honor the signal.
  */
@@ -972,7 +972,7 @@ export class Agent implements LocalAgent, InvokableAgent {
   /**
    * The cancellation signal for the current invocation.
    *
-   * Tools can pass this to cancellable operations (e.g., `fetch(url, { signal: agent.cancelSignal })`).
+   * SDK-managed tool contexts receive this as `context.cancelSignal` for cancellable operations.
    * Hooks can check `event.agent.cancelSignal.aborted` to detect cancellation.
    */
   get cancelSignal(): AbortSignal {
@@ -989,7 +989,7 @@ export class Agent implements LocalAgent, InvokableAgent {
    * - At the top of each agent loop cycle
    *
    * If a tool is already executing, it will run to completion unless
-   * the tool checks {@link LocalAgent.cancelSignal | cancelSignal} internally.
+   * the tool checks `context.cancelSignal` internally.
    *
    * Hook callbacks can check `event.agent.cancelSignal.aborted` to detect
    * cancellation and adjust their behavior accordingly.
@@ -1726,7 +1726,9 @@ export class Agent implements LocalAgent, InvokableAgent {
           role: 'assistant',
           content: [new TextBlock('Cancelled by user')],
         })
-        yield this._appendMessage(cancelMessage, invocationState)
+        if (this._hasOpenUserTurn()) {
+          yield this._appendMessage(cancelMessage, invocationState)
+        }
 
         result = new AgentResult({
           stopReason: 'cancelled',
@@ -1756,14 +1758,16 @@ export class Agent implements LocalAgent, InvokableAgent {
       throw error
     } finally {
       // If cancelled but the catch block was bypassed (generator terminated
-      // via .return() when the consumer breaks out of for-await), append an
-      // assistant message so the agent can be reinvoked with a new user prompt.
+      // via .return() when the consumer breaks out of for-await), close an
+      // existing user turn so the agent can be reinvoked.
       if (!caughtError && !result && this.isCancelled) {
         const cancelMessage = new Message({
           role: 'assistant',
           content: [new TextBlock('Cancelled by user')],
         })
-        yield this._appendMessage(cancelMessage, invocationState)
+        if (this._hasOpenUserTurn()) {
+          yield this._appendMessage(cancelMessage, invocationState)
+        }
       }
 
       this._tracer.endAgentSpan(agentSpan, {
@@ -2284,6 +2288,7 @@ export class Agent implements LocalAgent, InvokableAgent {
             middlewareRegistry: this._middlewareRegistry,
             tracer: this._tracer,
             meter: this._meter,
+            cancelSignal: this._abortSignal,
           },
           {
             toolUseBlocks,
@@ -2434,6 +2439,11 @@ export class Agent implements LocalAgent, InvokableAgent {
   private _appendMessage(message: Message, invocationState: InvocationState): MessageAddedEvent {
     this.messages.push(message)
     return new MessageAddedEvent({ agent: this, message, invocationState })
+  }
+
+  private _hasOpenUserTurn(): boolean {
+    const lastMessage = this.messages[this.messages.length - 1]
+    return lastMessage?.role === 'user'
   }
 }
 

--- a/strands-ts/src/agent/tool-caller.ts
+++ b/strands-ts/src/agent/tool-caller.ts
@@ -227,6 +227,7 @@ export class ToolCaller {
       toolUse,
       agent: this._agent,
       invocationState: {},
+      cancelSignal: this._agent.cancelSignal,
       interrupt: (): never => {
         throw new Error('Interrupts are not supported in direct tool calls')
       },

--- a/strands-ts/src/experimental/vended-tools/stop/__tests__/stop.test.ts
+++ b/strands-ts/src/experimental/vended-tools/stop/__tests__/stop.test.ts
@@ -14,6 +14,7 @@ const createFreshContext = (
     toolUse: { name: 'stop', toolUseId: 'test-id', input: {} },
     agent,
     invocationState,
+    cancelSignal: agent.cancelSignal,
     interrupt: () => {
       throw new Error('interrupt not available in mock context')
     },

--- a/strands-ts/src/mcp/__tests__/client.test.ts
+++ b/strands-ts/src/mcp/__tests__/client.test.ts
@@ -911,12 +911,13 @@ describe('MCP Integration', () => {
       toolUse: { toolUseId: 'id-123', name: 'weather', input: { city: 'NYC' } },
       agent: { cancelSignal: new AbortController().signal } as LocalAgent,
       invocationState: {},
+      cancelSignal: new AbortController().signal,
       interrupt: () => {
         throw new Error('interrupt not available in mock context')
       },
     }
 
-    it('forwards agent cancelSignal to callTool', async () => {
+    it('forwards the tool execution cancelSignal to callTool', async () => {
       vi.mocked(mockClientWrapper.callTool).mockResolvedValue({
         content: [{ type: 'text', text: 'ok' }],
       })
@@ -927,7 +928,7 @@ describe('MCP Integration', () => {
         tool,
         { city: 'NYC' },
         {
-          signal: toolContext.agent.cancelSignal,
+          signal: toolContext.cancelSignal,
         }
       )
     })

--- a/strands-ts/src/middleware/stages.ts
+++ b/strands-ts/src/middleware/stages.ts
@@ -119,6 +119,8 @@ export interface ExecuteToolContext extends MiddlewareInterruptible {
   readonly toolUse: ToolUseData
   /** Per-invocation state. Shared by reference — mutations are visible to hooks, tools, and AgentResult. */
   readonly invocationState: InvocationState
+  /** Executor-owned cancellation signal for this tool call; middleware can observe but cannot replace it. */
+  readonly cancelSignal: AbortSignal
 }
 
 /**

--- a/strands-ts/src/tools/executors/__tests__/executor.cancel-signal.test.ts
+++ b/strands-ts/src/tools/executors/__tests__/executor.cancel-signal.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest'
+
+import { Agent } from '../../../agent/agent.js'
+import { MockMessageModel } from '../../../__fixtures__/mock-message-model.js'
+import { createMockTool } from '../../../__fixtures__/tool-helpers.js'
+import { AfterToolCallEvent } from '../../../hooks/events.js'
+import { ExecuteToolStage } from '../../../middleware/stages.js'
+import { MiddlewareRegistry } from '../../../middleware/registry.js'
+import { Meter } from '../../../telemetry/meter.js'
+import { Tracer } from '../../../telemetry/tracer.js'
+import { Message, TextBlock, ToolResultBlock, ToolUseBlock } from '../../../types/messages.js'
+import { SequentialToolExecutor } from '../sequential.js'
+
+import type { ToolExecutorOptions } from '../executor.js'
+import type { AgentStreamEvent } from '../../../types/agent.js'
+
+function createOptions(
+  agent: Agent,
+  cancelSignal: AbortSignal,
+  middlewareRegistry = new MiddlewareRegistry()
+): ToolExecutorOptions {
+  return {
+    agent,
+    middlewareRegistry,
+    tracer: new Tracer(),
+    meter: new Meter(),
+    cancelSignal,
+  }
+}
+
+async function runExecutor(
+  executor: SequentialToolExecutor,
+  options: ToolExecutorOptions,
+  toolUseBlocks: ToolUseBlock[],
+  onEvent?: (event: AgentStreamEvent) => void
+): Promise<ToolResultBlock[]> {
+  const toolResultBlocks: ToolResultBlock[] = []
+  const assistantMessage = new Message({ role: 'assistant', content: toolUseBlocks })
+  const generator = executor.execute(options, {
+    toolUseBlocks,
+    toolResultBlocks,
+    invocationState: {},
+    assistantMessage,
+  })
+
+  let next = await generator.next()
+  while (!next.done) {
+    onEvent?.(next.value)
+    next = await generator.next()
+  }
+
+  return toolResultBlocks
+}
+
+describe('ToolExecutor cancellation signal', () => {
+  it('keeps middleware and tools on the supplied execution signal', async () => {
+    const executionController = new AbortController()
+    const replacementSignal = new AbortController().signal
+    let middlewareSignal: AbortSignal | undefined
+    let toolSignal: AbortSignal | undefined
+    const tool = createMockTool('probe', (context) => {
+      toolSignal = context.cancelSignal
+      return 'ok'
+    })
+    const agent = new Agent({ model: new MockMessageModel(), tools: [tool], printer: false })
+    const middlewareRegistry = new MiddlewareRegistry()
+    middlewareRegistry.add(ExecuteToolStage, async function* (context, next) {
+      middlewareSignal = context.cancelSignal
+      return yield* next({ ...context, cancelSignal: replacementSignal })
+    })
+
+    const results = await runExecutor(
+      new SequentialToolExecutor(),
+      createOptions(agent, executionController.signal, middlewareRegistry),
+      [new ToolUseBlock({ name: 'probe', toolUseId: 'probe-1', input: {} })]
+    )
+
+    expect(executionController.signal).not.toBe(agent.cancelSignal)
+    expect({
+      middlewareSignal,
+      toolSignal,
+      resultStatus: results[0]?.status,
+    }).toEqual({
+      middlewareSignal: executionController.signal,
+      toolSignal: executionController.signal,
+      resultStatus: 'success',
+    })
+  })
+
+  it('uses the supplied signal between sequential tool executions', async () => {
+    const executionController = new AbortController()
+    const executedTools: string[] = []
+    const firstTool = createMockTool('first', () => {
+      executedTools.push('first')
+      executionController.abort()
+      return 'done'
+    })
+    const secondTool = createMockTool('second', () => {
+      executedTools.push('second')
+      return 'unexpected'
+    })
+    const agent = new Agent({
+      model: new MockMessageModel(),
+      tools: [firstTool, secondTool],
+      printer: false,
+    })
+
+    const results = await runExecutor(new SequentialToolExecutor(), createOptions(agent, executionController.signal), [
+      new ToolUseBlock({ name: 'first', toolUseId: 'first-1', input: {} }),
+      new ToolUseBlock({ name: 'second', toolUseId: 'second-1', input: {} }),
+    ])
+
+    expect(agent.cancelSignal.aborted).toBe(false)
+    expect(executedTools).toEqual(['first'])
+    expect(results).toEqual([
+      new ToolResultBlock({
+        toolUseId: 'first-1',
+        status: 'success',
+        content: [new TextBlock('done')],
+      }),
+      new ToolResultBlock({
+        toolUseId: 'second-1',
+        status: 'error',
+        content: [new TextBlock('Tool execution cancelled')],
+      }),
+    ])
+  })
+
+  it('does not retry after the supplied signal is aborted', async () => {
+    const executionController = new AbortController()
+    let toolCallCount = 0
+    const tool = createMockTool('retryable', () => {
+      toolCallCount += 1
+      return 'done'
+    })
+    const agent = new Agent({ model: new MockMessageModel(), tools: [tool], printer: false })
+    let afterToolCallCount = 0
+
+    await runExecutor(
+      new SequentialToolExecutor(),
+      createOptions(agent, executionController.signal),
+      [new ToolUseBlock({ name: 'retryable', toolUseId: 'retry-1', input: {} })],
+      (event) => {
+        if (event instanceof AfterToolCallEvent && afterToolCallCount === 0) {
+          afterToolCallCount += 1
+          executionController.abort()
+          event.retry = true
+        }
+      }
+    )
+
+    expect(agent.cancelSignal.aborted).toBe(false)
+    expect(toolCallCount).toBe(1)
+    expect(afterToolCallCount).toBe(1)
+  })
+})

--- a/strands-ts/src/tools/executors/executor.ts
+++ b/strands-ts/src/tools/executors/executor.ts
@@ -31,6 +31,8 @@ export interface ToolExecutorOptions {
   readonly tracer: Tracer
   /** Meter used to record tool-call metrics. */
   readonly meter: Meter
+  /** Cancellation signal scoped to this executor invocation. */
+  readonly cancelSignal: AbortSignal
 }
 
 /**
@@ -122,7 +124,7 @@ export abstract class ToolExecutor {
           invocationState,
         })
         yield afterToolCallEvent
-        if (this._shouldRetry(options.agent, afterToolCallEvent)) {
+        if (this._shouldRetry(afterToolCallEvent, options.cancelSignal)) {
           continue
         }
         return this._normalizeToolResultId(afterToolCallEvent.result, toolUseBlock.toolUseId)
@@ -143,7 +145,7 @@ export abstract class ToolExecutor {
       })
       yield afterToolCallEvent
 
-      if (this._shouldRetry(options.agent, afterToolCallEvent)) {
+      if (this._shouldRetry(afterToolCallEvent, options.cancelSignal)) {
         continue
       }
 
@@ -153,8 +155,8 @@ export abstract class ToolExecutor {
     }
   }
 
-  private _shouldRetry(agent: Agent, afterToolCallEvent: AfterToolCallEvent): boolean {
-    return afterToolCallEvent.retry === true && !agent.cancelSignal.aborted
+  private _shouldRetry(afterToolCallEvent: AfterToolCallEvent, cancelSignal: AbortSignal): boolean {
+    return afterToolCallEvent.retry === true && !cancelSignal.aborted
   }
 
   private _normalizeToolResultId(result: ToolResultBlock, toolUseId: string): ToolResultBlock {
@@ -198,6 +200,7 @@ export abstract class ToolExecutor {
       tool,
       toolUse: deepCopy(toolUse) as unknown as ToolUseData,
       invocationState,
+      cancelSignal: options.cancelSignal,
       interrupt: createMiddlewareInterrupt(
         options.agent._interruptState,
         `middleware:executeTool:${toolUse.toolUseId}`
@@ -253,6 +256,7 @@ export abstract class ToolExecutor {
           },
           agent: options.agent,
           invocationState,
+          cancelSignal: options.cancelSignal,
           interrupt: <T = JSONValue>(params: InterruptParams): T =>
             interruptFromAgent<T>(options.agent, `tool:${toolUse.toolUseId}:${params.name}`, params, 'tool'),
         }

--- a/strands-ts/src/tools/executors/sequential.ts
+++ b/strands-ts/src/tools/executors/sequential.ts
@@ -22,7 +22,7 @@ import type { ToolExecutionInput, ToolExecutorOptions } from './executor.js'
  */
 export class SequentialToolExecutor extends ToolExecutor {
   /**
-   * Executes tool calls in source order, honoring `agent.cancelSignal` between
+   * Executes tool calls in source order, honoring the execution cancellation signal between
    * calls to short-circuit tools that have not started.
    *
    * @param options - Agent dependencies used to execute tools
@@ -48,7 +48,7 @@ export class SequentialToolExecutor extends ToolExecutor {
         continue
       }
 
-      if (options.agent.cancelSignal.aborted) {
+      if (options.cancelSignal.aborted) {
         const cancelBlock = new ToolResultBlock({
           toolUseId: toolUseBlock.toolUseId,
           status: 'error',

--- a/strands-ts/src/tools/mcp-tool.ts
+++ b/strands-ts/src/tools/mcp-tool.ts
@@ -51,7 +51,7 @@ export class McpTool extends Tool {
 
     try {
       const rawResult: unknown = await this.mcpClient.callTool(this, input as JSONValue, {
-        signal: toolContext.agent.cancelSignal,
+        signal: toolContext.cancelSignal,
       })
 
       if (!this._isMcpToolResult(rawResult)) {

--- a/strands-ts/src/tools/tool.ts
+++ b/strands-ts/src/tools/tool.ts
@@ -33,6 +33,9 @@ export interface ToolContext extends Interruptible {
    * deep-copied on read/write.
    */
   invocationState: InvocationState
+
+  /** Execution-scoped cancellation signal for this tool call. */
+  cancelSignal: AbortSignal
 }
 
 /**

--- a/strands-ts/src/types/agent.ts
+++ b/strands-ts/src/types/agent.ts
@@ -324,7 +324,7 @@ export interface LocalAgent {
    * callback: async ({ items }, context) => {
    *   const results = []
    *   for (const item of items) {
-   *     if (context.agent.cancelSignal.aborted) return results
+   *     if (context?.cancelSignal.aborted) return results
    *     results.push(await process(item))
    *   }
    *   return results
@@ -334,7 +334,7 @@ export interface LocalAgent {
    * **Signal forwarding** — pass to APIs that accept `AbortSignal`:
    * ```ts
    * callback: async ({ url }, context) => {
-   *   const res = await fetch(url, { signal: context.agent.cancelSignal })
+   *   const res = await fetch(url, { signal: context?.cancelSignal })
    *   return res.text()
    * }
    * ```

--- a/strands-ts/src/vended-plugins/context-offloader/__tests__/plugin.test.node.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/__tests__/plugin.test.node.ts
@@ -47,6 +47,7 @@ function makeToolContext(agent: MockAgent, reference: string): ToolContext {
     },
     agent,
     invocationState: {},
+    cancelSignal: agent.cancelSignal,
     interrupt: () => {
       throw new Error('interrupt not available in mock context')
     },

--- a/strands-ts/src/vended-plugins/skills/__tests__/agent-skills.test.node.ts
+++ b/strands-ts/src/vended-plugins/skills/__tests__/agent-skills.test.node.ts
@@ -342,6 +342,7 @@ describe('AgentSkills', () => {
         toolUse: { name: 'skills', toolUseId: 'test-id', input: { skill_name: skillName } },
         agent: agent as any,
         invocationState: {},
+        cancelSignal: agent.cancelSignal,
         interrupt: () => {
           throw new Error('interrupt not available in mock context')
         },
@@ -426,6 +427,7 @@ describe('AgentSkills', () => {
         toolUse: { name: 'skills', toolUseId: 'id', input: { skill_name: 'resource-skill' } },
         agent: agent2 as any,
         invocationState: {},
+        cancelSignal: agent2.cancelSignal,
         interrupt: () => {
           throw new Error('interrupt not available in mock context')
         },
@@ -453,6 +455,7 @@ describe('AgentSkills', () => {
         toolUse: { name: 'skills', toolUseId: 'id', input: { skill_name: 'no-resources' } },
         agent: agent2 as any,
         invocationState: {},
+        cancelSignal: agent2.cancelSignal,
         interrupt: () => {
           throw new Error('interrupt not available in mock context')
         },
@@ -484,6 +487,7 @@ describe('AgentSkills', () => {
         toolUse: { name: 'skills', toolUseId: 'id', input: { skill_name: 'many-files' } },
         agent: agent2 as any,
         invocationState: {},
+        cancelSignal: agent2.cancelSignal,
         interrupt: () => {
           throw new Error('interrupt not available in mock context')
         },

--- a/strands-ts/src/vended-tools/bash/__tests__/bash.test.node.ts
+++ b/strands-ts/src/vended-tools/bash/__tests__/bash.test.node.ts
@@ -18,6 +18,7 @@ describe.skipIf(process.platform === 'win32')('bash tool', () => {
       },
       agent,
       invocationState: {},
+      cancelSignal: agent.cancelSignal,
       interrupt: () => {
         throw new Error('interrupt not available in mock context')
       },

--- a/strands-ts/src/vended-tools/file-editor/__tests__/file-editor.test.node.ts
+++ b/strands-ts/src/vended-tools/file-editor/__tests__/file-editor.test.node.ts
@@ -23,6 +23,7 @@ describe('fileEditor tool', () => {
       },
       agent,
       invocationState: {},
+      cancelSignal: agent.cancelSignal,
       interrupt: () => {
         throw new Error('interrupt not available in mock context')
       },
@@ -523,6 +524,7 @@ describe.skipIf(process.platform === 'win32')('fileEditor tool (sandbox path)', 
       toolUse: { name: 'fileEditor', toolUseId: 'test-id', input: {} },
       agent,
       invocationState: {},
+      cancelSignal: agent.cancelSignal,
       interrupt: () => {
         throw new Error('interrupt not available in mock context')
       },
@@ -576,6 +578,7 @@ describe.skipIf(process.platform === 'win32')('fileEditor tool (sandbox path)', 
       toolUse: { name: 'fileEditor', toolUseId: 'test-id', input: {} },
       agent,
       invocationState: {},
+      cancelSignal: agent.cancelSignal,
       interrupt: () => {
         throw new Error('interrupt not available in mock context')
       },

--- a/strands-ts/src/vended-tools/http-request/__tests__/http-request.test.ts
+++ b/strands-ts/src/vended-tools/http-request/__tests__/http-request.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { ToolContext } from '../../../tools/tool.js'
+import type { LocalAgent } from '../../../types/agent.js'
 import { httpRequest } from '../http-request.js'
 
 describe('httpRequest tool', () => {
@@ -230,6 +232,45 @@ describe('httpRequest tool', () => {
           url: 'https://invalid-domain.com',
         })
       ).rejects.toThrow('Network error: Failed to fetch')
+    })
+
+    it('uses context.cancelSignal when it differs from the agent signal', async () => {
+      let requestSignal: AbortSignal | undefined
+      globalThis.fetch = vi.fn((_url, options) => {
+        const signal = options?.signal as AbortSignal
+        requestSignal = signal
+        return new Promise<Response>((_resolve, reject) => {
+          signal.addEventListener('abort', () => reject(new DOMException('The operation was aborted', 'AbortError')), {
+            once: true,
+          })
+        })
+      })
+      const executionController = new AbortController()
+      const agentController = new AbortController()
+      const context: ToolContext = {
+        toolUse: {
+          name: 'http_request',
+          toolUseId: 'task-http',
+          input: { method: 'GET', url: 'https://slow-api.example.com' },
+        },
+        agent: { cancelSignal: agentController.signal } as LocalAgent,
+        invocationState: {},
+        cancelSignal: executionController.signal,
+        interrupt: vi.fn() as ToolContext['interrupt'],
+      }
+
+      const request = httpRequest.invoke(
+        {
+          method: 'GET',
+          url: 'https://slow-api.example.com',
+        },
+        context
+      )
+      await vi.waitFor(() => expect(requestSignal).toBeDefined())
+      const cancelled = expect(request).rejects.toThrow('Request cancelled: GET https://slow-api.example.com')
+      executionController.abort()
+
+      await cancelled
     })
   })
 })

--- a/strands-ts/src/vended-tools/http-request/http-request.ts
+++ b/strands-ts/src/vended-tools/http-request/http-request.ts
@@ -44,9 +44,9 @@ export const httpRequest = tool({
   callback: async (input, context) => {
     const { method, url, headers, body, timeout = 30 } = input
 
-    // Abort on timeout or agent cancellation, whichever comes first
+    // Abort on timeout or tool-execution cancellation, whichever comes first
     const timeoutSignal = AbortSignal.timeout(timeout * 1000)
-    const signal = context ? AbortSignal.any([timeoutSignal, context.agent.cancelSignal]) : timeoutSignal
+    const signal = context ? AbortSignal.any([timeoutSignal, context.cancelSignal]) : timeoutSignal
 
     try {
       const fetchOptions: RequestInit = { method, signal }

--- a/strands-ts/src/vended-tools/notebook/__tests__/notebook.test.ts
+++ b/strands-ts/src/vended-tools/notebook/__tests__/notebook.test.ts
@@ -17,6 +17,7 @@ describe('notebook tool', () => {
       },
       agent,
       invocationState: {},
+      cancelSignal: agent.cancelSignal,
       interrupt: () => {
         throw new Error('interrupt not available in mock context')
       },

--- a/strands-ts/src/vended-tools/shell/__tests__/shell.test.node.ts
+++ b/strands-ts/src/vended-tools/shell/__tests__/shell.test.node.ts
@@ -18,6 +18,7 @@ describe.skipIf(process.platform === 'win32')('makeShell', () => {
       toolUse: { name: 'shell', toolUseId: 'test-id', input: {} },
       agent,
       invocationState: {},
+      cancelSignal: agent.cancelSignal,
       interrupt: () => {
         throw new Error('interrupt not available in mock context')
       },

--- a/strands-ts/src/vended-tools/sleep/README.md
+++ b/strands-ts/src/vended-tools/sleep/README.md
@@ -2,7 +2,7 @@
 
 Pauses agent execution for a bounded, cooperative duration.
 
-The tool takes a `duration` in seconds. It attaches a one-shot listener to `context.agent.cancelSignal`, so cancelling the agent aborts the sleep immediately rather than waiting for the full duration. A configurable maximum (default: 60 s) rejects oversized requests before the sleep starts, and negative, `NaN`, `Infinity`, and non-numeric inputs are rejected at the tool boundary.
+The tool takes a `duration` in seconds. It listens to `context.cancelSignal`, so cancellation aborts the sleep immediately rather than waiting for the full duration. A configurable maximum (default: 60 s) rejects oversized requests before the sleep starts, and negative, `NaN`, `Infinity`, and non-numeric inputs are rejected at the tool boundary.
 
 ## Usage
 

--- a/strands-ts/src/vended-tools/sleep/__tests__/sleep.test.ts
+++ b/strands-ts/src/vended-tools/sleep/__tests__/sleep.test.ts
@@ -4,19 +4,16 @@ import type { ToolContext } from '../../../index.js'
 import { createMockAgent } from '../../../__fixtures__/agent-helpers.js'
 
 /**
- * Build a fresh ToolContext, optionally wiring an AbortController's signal
- * onto the mock agent for cancellation testing.
+ * Build a fresh ToolContext, optionally using an AbortController's signal
+ * for cancellation testing.
  */
 function createContext(controller?: AbortController): ToolContext {
   const agent = createMockAgent()
-  if (controller) {
-    // Override the mock's default (unaborted) signal with the test's controller.
-    Object.defineProperty(agent, 'cancelSignal', { value: controller.signal, configurable: true })
-  }
   return {
     toolUse: { name: 'sleep', toolUseId: 'test-id', input: {} },
     agent,
     invocationState: {},
+    cancelSignal: controller?.signal ?? agent.cancelSignal,
     interrupt: () => {
       throw new Error('interrupt not available in mock context')
     },
@@ -92,6 +89,7 @@ describe('sleep tool', () => {
     it('aborts immediately when cancelSignal fires mid-sleep', async () => {
       const controller = new AbortController()
       const context = createContext(controller)
+      expect(context.cancelSignal).not.toBe(context.agent.cancelSignal)
 
       const invocation = sleep.invoke({ duration: 5 }, context)
       globalThis.setTimeout(() => controller.abort(), 10)

--- a/strands-ts/src/vended-tools/sleep/make-sleep.ts
+++ b/strands-ts/src/vended-tools/sleep/make-sleep.ts
@@ -1,9 +1,8 @@
 /**
  * Sleep tool factory: pauses execution for a bounded, cooperative duration.
  *
- * The returned tool honors the invocation's `AbortSignal` (from
- * `context.agent.cancelSignal`), so cancelling the agent aborts the sleep
- * immediately rather than waiting for the full duration.
+ * The returned tool honors `context.cancelSignal`, so cancelling the current
+ * tool call aborts the sleep immediately.
  */
 
 import type { InvokableTool } from '../../tools/tool.js'
@@ -36,9 +35,8 @@ export interface MakeSleepOptions {
  * Creates a sleep tool with a configurable maximum duration.
  *
  * The returned tool pauses for the requested number of seconds. It attaches a
- * one-shot listener to `context.agent.cancelSignal` so that cancellation of
- * the enclosing agent invocation immediately aborts the sleep with an
- * `AbortError`.
+ * one-shot listener to `context.cancelSignal` so that cancellation immediately
+ * aborts the sleep with an `AbortError`.
  *
  * @param options - Configuration options.
  * @returns A tool that pauses execution for the requested duration.
@@ -72,7 +70,7 @@ export function makeSleep(options: MakeSleepOptions = {}): InvokableTool<SleepIn
     callback: async (input, context) => {
       const { duration } = input
 
-      const cancelSignal = context?.agent.cancelSignal
+      const cancelSignal = context?.cancelSignal
       if (cancelSignal?.aborted) {
         throw cancelSignal.reason ?? new DOMException('Sleep cancelled before it started', 'AbortError')
       }


### PR DESCRIPTION
## Description

Tool cancellation is currently coupled to the Agent invocation through `context.agent.cancelSignal`. Tool executors need an execution-scoped signal decoupled from the Agent to enable alternate execution lifetimes (i.e. background tasks) without changing existing behavior.

SDK-managed tool and middleware contexts now receive an executor-supplied `context.cancelSignal`. Foreground and direct calls receive `agent.cancelSignal` as their execution signal, while `AgentAsTool`, sequential cancellation, and retry suppression use the same executor-supplied signal. 

### Public API Changes

```diff
export interface ToolContext extends Interruptible {
  toolUse: ToolUse
  agent: LocalAgent
  invocationState: InvocationState
+ cancelSignal: AbortSignal
}
```

## Related Issues

Parent Background Tasks PR (extracted change from it): #3632

## Documentation PR

Documentation updates are included in this PR under `site/`.

## Type of Change

New feature

## Testing

- [x] Focused TypeScript unit tests
- [x] `npm run build -w strands-ts`
- [x] `npm run lint -w strands-ts`
- [x] `npm run format:check -w strands-ts`
- [x] `npm run type-check -w strands-ts`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.