### PR TITLE
fix(mcp): deliver document attachments instead of silently dropping them

### DIFF
--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from re import Pattern
 from types import TracebackType
 from typing import Any, TypeVar, cast
+from urllib.parse import unquote
 
 import anyio
 from mcp import ClientSession, ListToolsResult, StdioServerParameters, stdio_client
@@ -57,7 +58,7 @@ from typing_extensions import Protocol, TypedDict
 
 from ...types import PaginatedList
 from ...types.exceptions import MCPClientInitializationError, ToolProviderException
-from ...types.media import ImageFormat
+from ...types.media import DocumentFormat, ImageFormat
 from ...types.tools import AgentTool, ToolResultContent, ToolResultStatus
 from ..tool_provider import ToolProvider
 from .mcp_agent_tool import MCPAgentTool
@@ -136,6 +137,23 @@ MIME_TO_FORMAT: dict[str, ImageFormat] = {
     "image/gif": "gif",
     "image/webp": "webp",
 }
+
+MIME_TO_DOCUMENT_FORMAT: dict[str, DocumentFormat] = {
+    "application/pdf": "pdf",
+    "application/msword": "doc",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",
+    "application/vnd.ms-excel": "xls",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xlsx",
+}
+"""Binary document MIME types, mapped to their DocumentFormat.
+
+Textual document formats (csv, html, txt, md) are deliberately absent: their MIME
+types are already decoded to text content by the textual branch below, which loses
+nothing and keeps existing behavior unchanged.
+"""
+
+_DOCUMENT_NAME_DISALLOWED = re.compile(r"[^a-zA-Z0-9\s\-()\[\]]")
+_DOCUMENT_NAME_WHITESPACE = re.compile(r"\s+")
 
 CLIENT_SESSION_NOT_RUNNING_ERROR_MESSAGE = (
     "the client session is not running. Ensure the agent is used within "
@@ -1203,6 +1221,22 @@ class MCPClient(ToolProvider):
                         }
                     }
 
+                if resource.mimeType in MIME_TO_DOCUMENT_FORMAT:
+                    if not raw_bytes:
+                        self._log_debug_with_thread("embedded resource document blob is empty - dropping")
+                        return None
+
+                    self._log_debug_with_thread(
+                        "mapping MCP embedded resource document with mime type: %s", resource.mimeType
+                    )
+                    return {
+                        "document": {
+                            "format": MIME_TO_DOCUMENT_FORMAT[resource.mimeType],
+                            "name": _document_name_from_uri(str(resource.uri)),
+                            "source": {"bytes": raw_bytes},
+                        }
+                    }
+
                 self._log_debug_with_thread("embedded resource blob with non-textual/unknown mimeType - dropping")
                 return None
 
@@ -1788,3 +1822,28 @@ def _interpolate_env_vars(value: Any) -> Any:
     if isinstance(value, dict):
         return {key: _interpolate_env_vars(item) for key, item in value.items()}
     return value
+
+
+def _document_name_from_uri(uri: str) -> str:
+    """Derives a document name from a resource URI.
+
+    DocumentContent leaves name optional, but the providers that consume it do not:
+    Bedrock's DocumentBlock requires a non-empty name, so omitting it produces a
+    request the API rejects. MCP resources carry only a URI, so a name is derived
+    from it here.
+
+    The URI's last segment is sanitized rather than passed through, because Bedrock
+    also constrains the name's contents - alphanumerics, whitespace, hyphens,
+    parentheses, and square brackets only, no consecutive whitespace, and no dots.
+    The extension is dropped for that reason; the format is carried separately.
+
+    Args:
+        uri: The resource URI, e.g. "mcp://resource/uat%20results.pdf"
+
+    Returns:
+        str: A sanitized document name, never empty.
+    """
+    last_segment = unquote(uri).rstrip("/").rsplit("/", 1)[-1]
+    stem = last_segment.rsplit(".", 1)[0] if "." in last_segment else last_segment
+    sanitized = _DOCUMENT_NAME_WHITESPACE.sub(" ", _DOCUMENT_NAME_DISALLOWED.sub("-", stem)).strip()
+    return sanitized or "document"

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client.py
@@ -24,6 +24,7 @@ from mcp.types import Tool as MCPTool
 from pydantic import AnyUrl
 
 from strands.tools.mcp import MCPClient
+from strands.tools.mcp.mcp_client import _document_name_from_uri
 from strands.tools.mcp.mcp_types import MCPToolResult
 from strands.types.exceptions import MCPClientInitializationError
 
@@ -1135,6 +1136,102 @@ def test_call_tool_sync_embedded_non_textual_blob_dropped(mock_transport, mock_s
         mock_session.call_tool.assert_called_once_with("get_file_contents", {}, None, progress_callback=None, meta=None)
         assert result["status"] == "success"
         assert len(result["content"]) == 0  # Content should be dropped
+
+
+def test_call_tool_sync_embedded_document_blob(mock_transport, mock_session):
+    """EmbeddedResource.resource (blob with document MIME) should map to document content."""
+    pdf_bytes = b"%PDF-1.4 fake document bytes"
+    payload = base64.b64encode(pdf_bytes).decode()
+
+    embedded_resource = {
+        "type": "resource",
+        "resource": {
+            "uri": "mcp://resource/uat-results.pdf",
+            "blob": payload,
+            "mimeType": "application/pdf",
+        },
+    }
+    mock_session.call_tool.return_value = MCPCallToolResult(isError=False, content=[embedded_resource])
+
+    with MCPClient(mock_transport["transport_callable"]) as client:
+        result = client.call_tool_sync(tool_use_id="er-document", name="get_file_contents", arguments={})
+
+        mock_session.call_tool.assert_called_once_with("get_file_contents", {}, None, progress_callback=None, meta=None)
+        assert result["status"] == "success"
+        assert len(result["content"]) == 1
+        assert result["content"][0]["document"]["format"] == "pdf"
+        assert result["content"][0]["document"]["name"] == "uat-results"
+        assert result["content"][0]["document"]["source"]["bytes"] == pdf_bytes
+
+
+@pytest.mark.parametrize(
+    ("mime_type", "expected_format"),
+    [
+        ("application/pdf", "pdf"),
+        ("application/msword", "doc"),
+        ("application/vnd.openxmlformats-officedocument.wordprocessingml.document", "docx"),
+        ("application/vnd.ms-excel", "xls"),
+        ("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "xlsx"),
+    ],
+)
+def test_call_tool_sync_embedded_document_mime_types(mock_transport, mock_session, mime_type, expected_format):
+    """Every document MIME type should map to its DocumentFormat."""
+    embedded_resource = {
+        "type": "resource",
+        "resource": {
+            "uri": "mcp://resource/attachment",
+            "blob": base64.b64encode(b"document bytes").decode(),
+            "mimeType": mime_type,
+        },
+    }
+    mock_session.call_tool.return_value = MCPCallToolResult(isError=False, content=[embedded_resource])
+
+    with MCPClient(mock_transport["transport_callable"]) as client:
+        result = client.call_tool_sync(tool_use_id="er-doc-mime", name="get_file_contents", arguments={})
+
+        assert result["status"] == "success"
+        assert result["content"][0]["document"]["format"] == expected_format
+
+
+def test_call_tool_sync_embedded_empty_document_blob_dropped(mock_transport, mock_session):
+    """A document blob that decodes to zero bytes should be dropped.
+
+    base64.b64decode discards non-alphabet characters, so a corrupt blob can decode
+    without raising and still yield nothing. An empty document source is rejected by
+    providers, so it must not be forwarded.
+    """
+    embedded_resource = {
+        "type": "resource",
+        "resource": {
+            "uri": "mcp://resource/empty.pdf",
+            "blob": "!!!!",
+            "mimeType": "application/pdf",
+        },
+    }
+    mock_session.call_tool.return_value = MCPCallToolResult(isError=False, content=[embedded_resource])
+
+    with MCPClient(mock_transport["transport_callable"]) as client:
+        result = client.call_tool_sync(tool_use_id="er-empty-doc", name="get_file_contents", arguments={})
+
+        assert result["status"] == "success"
+        assert len(result["content"]) == 0
+
+
+@pytest.mark.parametrize(
+    ("uri", "expected_name"),
+    [
+        ("mcp://resource/uat-results.pdf", "uat-results"),
+        ("mcp://resource/uat%20results%20v2.pdf", "uat results v2"),
+        ("mcp://resource/report.final.pdf", "report-final"),
+        ("servicenow://attachment/abc123/Change (CHG0012345).pdf", "Change (CHG0012345)"),
+        ("mcp://resource/no-extension", "no-extension"),
+        ("mcp://resource/", "resource"),
+        ("mcp://resource/.pdf", "document"),
+    ],
+)
+def test_document_name_from_uri(uri, expected_name):
+    """Document names should be derived from the URI and sanitized for providers."""
+    assert _document_name_from_uri(uri) == expected_name
 
 
 def test_call_tool_sync_embedded_multiple_textual_mimes(mock_transport, mock_session):


### PR DESCRIPTION
An MCP tool returning a document as an EmbeddedResource with BlobResourceContents had its content discarded: the blob branch of map_mcp_content_to_tool_result_content decodes textual MIME types to text and maps MIME_TO_FORMAT image types to image content, but any other MIME type fell through to a debug log and `return None`.

Because the tool result status is derived only from `isError`, the call was still reported as successful. A tool returning nothing but a PDF therefore produced a successful result with an empty content list, which providers render as empty text, and the model concludes the attachment does not exist.

Document blobs are now mapped to DocumentContent, which the Bedrock, Anthropic, and OpenAI providers already format. Only the binary Office MIME types and application/pdf are mapped; the textual document formats (csv, html, txt, md) are left to the existing textual branch, which already decodes them without loss. DocumentContent leaves `name` optional but Bedrock requires it, so a sanitized name is derived from the resource URI.

Existing behavior is unchanged for text, images, text resources, and blobs whose MIME type remains unrecognized.

## Description
<!-- Provide a detailed description of the changes in this PR -->

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [ ] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
