### PR TITLE
fix(graph): fail closed on cancelled results

### DIFF
--- a/strands-py/src/strands/multiagent/graph.py
+++ b/strands-py/src/strands/multiagent/graph.py
@@ -945,6 +945,9 @@ class Graph(MultiAgentBase):
         Only evaluates destination nodes of outbound edges from the completed batch,
         instead of iterating over all nodes in the graph.
         """
+        if any(node.execution_status == Status.FAILED for node in completed_batch):
+            return []
+
         # Collect unique candidate nodes reachable from the completed batch
         candidates = {edge.to_node for edge in self.edges if edge.from_node in completed_batch}
 
@@ -1061,11 +1064,15 @@ class Graph(MultiAgentBase):
                 # Handle stop_reason and interrupts (use getattr for AgentBase compatibility)
                 stop_reason = getattr(agent_response, "stop_reason", "end_turn")
                 interrupts = getattr(agent_response, "interrupts", None) or []
+                agent_status = {
+                    "cancelled": Status.FAILED,
+                    "interrupt": Status.INTERRUPTED,
+                }.get(stop_reason, Status.COMPLETED)
 
                 node_result = NodeResult(
                     result=agent_response,
                     execution_time=round((time.time() - start_time) * 1000),
-                    status=Status.INTERRUPTED if stop_reason == "interrupt" else Status.COMPLETED,
+                    status=agent_status,
                     accumulated_usage=usage,
                     accumulated_metrics=metrics,
                     execution_count=1,

--- a/strands-py/tests/strands/multiagent/test_graph.py
+++ b/strands-py/tests/strands/multiagent/test_graph.py
@@ -1936,6 +1936,31 @@ async def test_graph_nested_multiagent_failed_status_routed_to_failed_nodes(mock
 
 
 @pytest.mark.asyncio
+async def test_graph_cancelled_agent_result_fails_closed(mock_strands_tracer, mock_use_span):
+    """A cancelled child fails the Graph without routing downstream (#3798)."""
+    cancelled_agent = create_mock_agent("cancelled_agent", "Cancelled")
+    cancelled_agent.return_value.stop_reason = "cancelled"
+    downstream_agent = create_mock_agent("downstream_agent", "Should not execute")
+
+    builder = GraphBuilder()
+    builder.add_node(cancelled_agent, "cancelled")
+    builder.add_node(downstream_agent, "downstream")
+    builder.add_edge("cancelled", "downstream")
+    builder.set_entry_point("cancelled")
+    graph = builder.build()
+
+    tru_result = await graph.invoke_async("Test cancelled child result")
+    tru_downstream_calls = downstream_agent.stream_async.call_count
+    exp_result_status = Status.FAILED
+    exp_node_status = Status.FAILED
+    exp_downstream_calls = 0
+
+    assert tru_result.status == exp_result_status
+    assert tru_result.results["cancelled"].status == exp_node_status
+    assert tru_downstream_calls == exp_downstream_calls
+
+
+@pytest.mark.asyncio
 async def test_graph_persisted(mock_strands_tracer, mock_use_span):
     """Test graph persistence functionality with multimodal input containing binary bytes."""
     import base64


### PR DESCRIPTION
## Description

A cancelled child `AgentResult` currently enters the Graph's completed set, which allows dependent nodes to run and the Graph to finish successfully. This change maps `cancelled` to the existing fail-closed `FAILED` status and prevents downstream routing from a failed batch.

This deliberately avoids adding a public cancellation status while the semantics in #2401 remain under discussion. Other stop reasons remain unchanged.

## Related Issues

Resolves #3798

Related: #2401

## Documentation PR

No documentation changes are needed because this corrects internal Graph result handling without changing the public API.

## Type of Change

Bug fix

## Testing

- [x] I ran `hatch run prepare`
- [x] The regression test passes on Python 3.10, 3.11, 3.12, 3.13, and 3.14

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
