### PR TITLE
feat(ts): add durable Lambda agent example

### DIFF
--- a/strands-ts/examples/README.md
+++ b/strands-ts/examples/README.md
@@ -27,3 +27,4 @@ npm start
 | [agents-as-tools](./agents-as-tools/) | Agents as tools pattern (orchestrator delegates to specialized tool agents) |
 | [browser-agent](./browser-agent/) | Browser-based agent with DOM manipulation canvas (OpenAI, Anthropic, Bedrock) |
 | [telemetry](./telemetry/) | OpenTelemetry tracing with Jaeger (requires Docker, see its [README](./telemetry/README.md)) |
+| [durable-lambda-agent](./durable-lambda-agent/) | Checkpointed Lambda durable execution with S3-backed sessions |

--- a/strands-ts/examples/durable-lambda-agent/.gitignore
+++ b/strands-ts/examples/durable-lambda-agent/.gitignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+.aws-sam/

--- a/strands-ts/examples/durable-lambda-agent/README.md
+++ b/strands-ts/examples/durable-lambda-agent/README.md
@@ -1,0 +1,116 @@
+# Durable Lambda Agent
+
+This deployable example combines the experimental Strands `Checkpoint` API,
+`SessionManager`, and
+[AWS Lambda durable execution](https://docs.aws.amazon.com/lambda/latest/dg/durable-functions.html).
+The agent pauses at `afterModel` and `afterTools`, persists each `CheckpointData`
+value in the Lambda durable journal, and saves conversation snapshots to S3.
+
+## How persistence works
+
+The handler creates the agent with `checkpointing: true` and invokes it until it
+returns a terminal result. Each `stopReason: 'checkpoint'` result is serialized with
+`Checkpoint.toJSON()`, persisted by `DurableContext.step()`, validated with
+`Checkpoint.fromJSON()`, and passed into the next invocation through
+`checkpointResume`.
+
+`CheckpointData` contains only the boundary position, cycle index, and schema
+version. `SessionManager` saves messages and other session snapshot fields to S3
+after each agent invocation. The S3 storage calls are themselves durable steps, so
+a Lambda replay restores the original session read and does not repeat writes.
+Model and tool middleware steps restore completed calls into the fresh agent.
+
+In the TypeScript SDK, resuming `afterModel` intentionally invokes the model again
+because the pending assistant tool-use message is not part of that checkpoint. The
+middleware records it as a separate durable model call; subsequent Lambda replays
+restore both calls instead of contacting the model again.
+
+## Prerequisites
+
+- Node.js 22+
+- AWS SAM CLI 1.143+
+- AWS CLI v2
+- AWS credentials with permission to deploy the template
+- Bedrock model access in the deployment region
+
+Use least-privilege credentials in a development or sandbox account. Review the IAM
+policies and S3 bucket configuration in `template.yml` before deployment. Bedrock
+and Lambda durable actions use wildcard resources so the example works with model
+IDs and inference profiles across accounts; session access is scoped to the created
+bucket and object prefix.
+
+## Install and validate
+
+From the monorepo root:
+
+```bash
+npm ci
+npm --prefix strands-ts/examples/durable-lambda-agent ci
+npm --prefix strands-ts/examples/durable-lambda-agent run build
+npm --prefix strands-ts/examples/durable-lambda-agent run bundle
+npm --prefix strands-ts/examples/durable-lambda-agent run validate:template
+```
+
+## Deploy
+
+Deployment creates or updates a CloudFormation stack, IAM role, log group, durable
+Lambda function, and encrypted versioned S3 session bucket. SAM displays the change
+set for confirmation before applying it. The bucket has retention policies so stack
+deletion does not remove conversation snapshots.
+
+```bash
+cd strands-ts/examples/durable-lambda-agent
+AWS_REGION=us-west-2 npm run deploy
+```
+
+Optional environment variables:
+
+```bash
+STACK_NAME=my-durable-agent \
+FUNCTION_NAME=my-durable-agent \
+BEDROCK_MODEL_ID=global.anthropic.claude-sonnet-4-6 \
+AWS_REGION=us-west-2 \
+npm run deploy
+```
+
+## Invoke
+
+Each invocation gets a unique durable execution and session ID by default.
+
+```bash
+npm run invoke          # normal execution
+npm run invoke:restart  # wait-driven replay
+npm run invoke:crash    # fail after the first tool, then resume with the second tool
+```
+
+Set `SESSION_ID` to continue a conversation across separate durable executions.
+Session IDs may contain lowercase letters, numbers, hyphens, and underscores.
+
+```bash
+SESSION_ID=seattle_trip PROMPT='Add a hotel to the plan.' npm run invoke
+```
+
+The invocation command follows CloudWatch logs until interrupted with `Ctrl-C`.
+For replay and retry scenarios, each tool and session-storage write should execute
+once across the full durable execution.
+
+## Remove the example stack
+
+Stack deletion removes the function and IAM role and is destructive. The retained
+S3 bucket and its versioned session data remain. Verify the account, region, and
+stack name before running deletion manually:
+
+```bash
+aws sts get-caller-identity
+aws cloudformation delete-stack \
+  --stack-name "${STACK_NAME:-strands-durable-agent}" \
+  --region "${AWS_REGION:-us-west-2}"
+```
+
+## Scope
+
+This example supports synchronous tools and non-streaming durable replay. Stream
+events are emitted during initial execution but are not re-emitted from completed
+steps on replay. Session snapshots and durable step payloads must remain within the
+respective S3 and Lambda service limits. MCP sessions and Strands interrupts require
+separate lifecycle handling and are not covered here.

--- a/strands-ts/examples/durable-lambda-agent/bundle.mjs
+++ b/strands-ts/examples/durable-lambda-agent/bundle.mjs
@@ -1,0 +1,21 @@
+import { rmSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { build } from 'esbuild'
+
+const exampleDirectory = path.dirname(fileURLToPath(import.meta.url))
+const outputDirectory = path.join(exampleDirectory, 'dist')
+
+rmSync(outputDirectory, { recursive: true, force: true })
+
+await build({
+  entryPoints: [path.join(exampleDirectory, 'src/handler.ts')],
+  outfile: path.join(outputDirectory, 'handler.js'),
+  bundle: true,
+  platform: 'node',
+  target: 'node22',
+  format: 'cjs',
+  sourcemap: true,
+  logLevel: 'info',
+})

--- a/strands-ts/examples/durable-lambda-agent/package-lock.json
+++ b/strands-ts/examples/durable-lambda-agent/package-lock.json
@@ -1,0 +1,1122 @@
+{
+  "name": "durable-lambda-agent",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "durable-lambda-agent",
+      "dependencies": {
+        "@aws-sdk/client-s3": "3.1078.0",
+        "@aws/durable-execution-sdk-js": "1.1.6",
+        "@strands-agents/sdk": "file:../..",
+        "zod": "4.4.3"
+      },
+      "devDependencies": {
+        "@types/node": "25.9.4",
+        "esbuild": "0.28.1",
+        "typescript": "6.0.3"
+      }
+    },
+    "../..": {
+      "name": "@strands-agents/sdk",
+      "version": "0.0.1-development",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-bedrock-runtime": "^3.1097.0",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@types/json-schema": "^7.0.15",
+        "uuid": "^14.0.1",
+        "yaml": "^2.8.3"
+      },
+      "devDependencies": {
+        "@a2a-js/sdk": "^0.3.10",
+        "@ai-sdk/amazon-bedrock": "^4.0.129",
+        "@ai-sdk/openai": "^3.0.41",
+        "@ai-sdk/provider": "^3.0.0",
+        "@anthropic-ai/sdk": "^0.109.1",
+        "@aws-sdk/client-bedrock": "^3.1078.0",
+        "@aws-sdk/client-bedrock-agent": "^3.1078.0",
+        "@aws-sdk/client-bedrock-agent-runtime": "^3.1078.0",
+        "@aws-sdk/client-s3": "^3.1078.0",
+        "@aws-sdk/client-secrets-manager": "^3.1078.0",
+        "@aws-sdk/client-ssm": "^3.1078.0",
+        "@aws-sdk/client-sts": "^3.1078.0",
+        "@aws-sdk/credential-providers": "^3.1078.0",
+        "@aws/bedrock-token-generator": "^1.1.0",
+        "@cedar-policy/cedar-wasm": "^4.11.2",
+        "@cedar-policy/mcp-schema-generator-wasm": "^0.6.0",
+        "@eslint/js": "^10.0.1",
+        "@google/genai": "^2.6.0",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "^0.219.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
+        "@opentelemetry/resources": "^2.8.0",
+        "@opentelemetry/sdk-metrics": "^2.6.1",
+        "@opentelemetry/sdk-trace-base": "^2.6.1",
+        "@opentelemetry/sdk-trace-node": "^2.6.1",
+        "@smithy/types": "^4.15.1",
+        "@types/express": "^5.0.6",
+        "@types/node": "^25.9.4",
+        "@typescript-eslint/eslint-plugin": "^8.62.1",
+        "@typescript-eslint/parser": "^8.0.0",
+        "@vitest/browser": "^4.1.10",
+        "@vitest/browser-playwright": "^4.1.10",
+        "@vitest/coverage-v8": "^4.1.10",
+        "eslint": "^10.6.0",
+        "eslint-plugin-tsdoc": "^0.5.0",
+        "express": "^5.2.1",
+        "openai": "^6.45.0",
+        "playwright": "^1.61.0",
+        "tsx": "^4.22.5",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.10"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@a2a-js/sdk": "^0.3.10",
+        "@ai-sdk/provider": "^3.0.0",
+        "@anthropic-ai/sdk": "^0.109.1",
+        "@aws-sdk/client-bedrock-agent": "^3.1078.0",
+        "@aws-sdk/client-bedrock-agent-runtime": "^3.1078.0",
+        "@aws-sdk/client-s3": "^3.1078.0",
+        "@aws/bedrock-token-generator": "^1.1.0",
+        "@cedar-policy/cedar-wasm": "^4.0.0",
+        "@cedar-policy/mcp-schema-generator-wasm": "^0.6.0",
+        "@google/genai": "^2.6.0",
+        "@modelcontextprotocol/sdk": "^1.25.2",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "^0.219.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
+        "@opentelemetry/resources": "^2.8.0",
+        "@opentelemetry/sdk-metrics": "^2.6.1",
+        "@opentelemetry/sdk-trace-base": "^2.6.1",
+        "@opentelemetry/sdk-trace-node": "^2.6.1",
+        "@smithy/types": "^4.15.1",
+        "express": "^5.1.0",
+        "openai": "^6.45.0",
+        "zod": "^4.1.12"
+      },
+      "peerDependenciesMeta": {
+        "@a2a-js/sdk": {
+          "optional": true
+        },
+        "@ai-sdk/provider": {
+          "optional": true
+        },
+        "@anthropic-ai/sdk": {
+          "optional": true
+        },
+        "@aws-sdk/client-bedrock-agent": {
+          "optional": true
+        },
+        "@aws-sdk/client-bedrock-agent-runtime": {
+          "optional": true
+        },
+        "@aws-sdk/client-s3": {
+          "optional": true
+        },
+        "@aws/bedrock-token-generator": {
+          "optional": true
+        },
+        "@cedar-policy/cedar-wasm": {
+          "optional": true
+        },
+        "@cedar-policy/mcp-schema-generator-wasm": {
+          "optional": true
+        },
+        "@google/genai": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-metrics-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/resources": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-metrics": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-node": {
+          "optional": true
+        },
+        "@smithy/types": {
+          "optional": true
+        },
+        "express": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.27.tgz",
+      "integrity": "sha512-insWOqKKNUrbN/dohEG7BJ0U5GkyqhjbMb/NHNaLUtq+7my2M8C4EnZZZoxMmXRqCC+P9dEr+KyJA2JGGzoKLg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda": {
+      "version": "3.1109.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1109.0.tgz",
+      "integrity": "sha512-zcVKl9lKMirUblvLGwiq1nR7BGANI7s4xJhFp0hP5u9lrhPRYOs/9OHQVa6X2TIEBJnkXeRSNqD5p6D33kpSyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/credential-provider-node": "^3.972.79",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1078.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1078.0.tgz",
+      "integrity": "sha512-uQMPma3CzTXPKrRfTkhdKLfXocGoEJwBePcI/ca9iWF+re2gbFSDVV9EIcOrK8ke1OV3Jw4ejNmfmgRVlI5b9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/checksums": "^3.1000.11",
+        "@aws-sdk/core": "^3.974.26",
+        "@aws-sdk/credential-provider-node": "^3.972.61",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.57",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.7.tgz",
+      "integrity": "sha512-I88Iov89NVmjSmJLKSv7Cn9M2J+a2942OkA8nZCbz+sl4ZeY4zEOcoLOrbt1GRfQ8zEQKnjAJdXixA3J/p1fDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/xml-builder": "^3.972.38",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.31.1",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.68",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.68.tgz",
+      "integrity": "sha512-2a20A/IdNOwUvaDq91iqqS7BA0XlNMfW3iLGZGZLJv0EbUqhSxB0PIx4rQQqssvWj1uXImb3/UCCdHz/+1dOiA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.70.tgz",
+      "integrity": "sha512-0yRem2Fs52r/Nn6UAqIlpjexfaYj8ziEozOe9tamtAVT/5bzFLKx8O2r7MaRqgS3hGKHIa1Jij9nKHSsNnb04A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.13.tgz",
+      "integrity": "sha512-2M39DE02XpYYaSWYk/4AsImXYUU/1L2xmTMLUpMMWq7DfLv191/vCRy3baKtdr45AkJQyVgSjmuVOLm15SwrRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/credential-provider-env": "^3.972.68",
+        "@aws-sdk/credential-provider-http": "^3.972.70",
+        "@aws-sdk/credential-provider-login": "^3.972.75",
+        "@aws-sdk/credential-provider-process": "^3.972.68",
+        "@aws-sdk/credential-provider-sso": "^3.973.12",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.74",
+        "@aws-sdk/nested-clients": "^3.997.42",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.75",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.75.tgz",
+      "integrity": "sha512-jaTESuJlQsoUZ44f/i2puyPt8VlF/dMMJ9HM3cStYtk7eKX4N9UWi83OLixUkoOJH3BwWlPLCq9YIK9nfWhVBg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/nested-clients": "^3.997.42",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.79",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.79.tgz",
+      "integrity": "sha512-RIw5dof1EHkWubrZzPC941CDtnFG1iAXsxbFgLkhdYZXHc4icU13c/uxSMI0J5eUx9bxa7LjfpdjfClBB1QsDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.68",
+        "@aws-sdk/credential-provider-http": "^3.972.70",
+        "@aws-sdk/credential-provider-ini": "^3.973.13",
+        "@aws-sdk/credential-provider-process": "^3.972.68",
+        "@aws-sdk/credential-provider-sso": "^3.973.12",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.74",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.68",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.68.tgz",
+      "integrity": "sha512-nLP3Pda2MQTFJ25hKBMmUuB9Uv+bTZQNlufbeCwklP549Vwnkd8bRLJoCKp5k6xjmdyptrPrOfGOhN0mKuca8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.12.tgz",
+      "integrity": "sha512-EmgyyHn+f9WCcelp3L/vci+LGbX8GigWaVphRArjVo5Pktkr9YnLy/mQ6VDkDyBD72dtfRNTgHmD2ts4rTDXKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/nested-clients": "^3.997.42",
+        "@aws-sdk/token-providers": "3.1108.0",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.74.tgz",
+      "integrity": "sha512-0YfczxGXF3RjGj8z7QG/Ho2HnLGKDHfPSHiTs47UU1U/+mmwISDN+rvGKt2zh+3FX8NdT4xd95LGBGyhQw2dgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/nested-clients": "^3.997.42",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.73",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.73.tgz",
+      "integrity": "sha512-oy7sRA5HvHcAvkcKX6F8RI240jcOf3c8y/Gqjs9qemIibdKQqGBIi0uwa+47ZRYqGLpdEO28TQU4G73yUzo06Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.44",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.42.tgz",
+      "integrity": "sha512-XWRyon2MTHXD/zMoo0Mbge6Vwf+iE0qQaM/RyGO6NfZ9WukCFiQL27nQVZjYy2JwSIg+iXZxKOX95OBXqlSM4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.44",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.44.tgz",
+      "integrity": "sha512-ZSfQ35Qn4MhSY+A0Whyr+KBx+wJKZUyBsOrjB2pSHOafRzbFe47T8XcXM8hZqUAC69qnqIy0C9ArxTuud0CC2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1108.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1108.0.tgz",
+      "integrity": "sha512-rI80zxDxGJ6904eC/YbjkdjY6JdaZvQ01kOmrMvw7cFQGIHo27fhnIVbMSVDS4T6foQImjxYSRoOu/uSJscXDw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/nested-clients": "^3.997.42",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.3.tgz",
+      "integrity": "sha512-ECAqfpNsef+7MO8qtR0h9KcFIBAygaE7Cm6UOiQl+ft+uVap+1G7bNEjs4mdJE2OnA4m6k7i8peH8uGIAsOMGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.38.tgz",
+      "integrity": "sha512-grf7mzfVxBS5AlsuTvBN7uDpzqohFww9fRPCO+EBSUdvtsYMcPSKdz54h/7XiscqNcUM1Ae1MF7JLHmiYYuzbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/durable-execution-sdk-js": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@aws/durable-execution-sdk-js/-/durable-execution-sdk-js-1.1.6.tgz",
+      "integrity": "sha512-BinSNwKg9TJVa7VWIVBKzoTZi/2/qKjyPrn6B6ytQvEWxSiKGzbMAe1KIPJaee0Fyp7h+xsi6Qe/KHkzOC9Dfg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-lambda": "^3.943.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.32.0.tgz",
+      "integrity": "sha512-NAiCSC78fzbNIEWoheoF74Ob5ZorLijCHpMY26Fqvqg/+9LuyIqMfHDg2p8Yk1rqOyowtiL3y7WX0AW+teL6zw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.0.tgz",
+      "integrity": "sha512-2jsPi+7Zv2hSzD9IXR9D7DTqSn7mv4XalzRm+bESh53jiaUS3NKEUbpQFTJP0HhQy9qzZvluxQ3yS24zdRrqsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.32.0",
+        "@smithy/types": "^4.17.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.0.tgz",
+      "integrity": "sha512-W/exA8T0LEzCQtJ02w4IzaEQPIspgarqZprb7W8FwnYiDowgCrjl2fTQ6FvuSSUnJORuepBF81abmBJwqh+0XQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.32.0",
+        "@smithy/types": "^4.17.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.10.0.tgz",
+      "integrity": "sha512-nrh7VxqzPQS/ip1hS293aI/OAWDWARQvjUxCfuKhyrfHa2gTdk28066RNeWLI1uuoHXaKAkOF8IcSAHuOp0+SA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.32.0",
+        "@smithy/types": "^4.17.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.0.tgz",
+      "integrity": "sha512-hCynhm22wMJ8wTF9crcwu8mxggtUrSLLJgDcGUvYFBqpofxycYJCGKOMYg4xtPPFtgNiDJSYmhsWLTrcU/g59Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.32.0",
+        "@smithy/types": "^4.17.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.0.tgz",
+      "integrity": "sha512-Aw4joiM0ZdErpo39lCj8phT2lxoiKZV+KZzBxnnQhWVtU2Is/WffQSL04uUWRcXUse9Ln8vXZK6V/FwqRVnQpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@strands-agents/sdk": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
+      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/strands-ts/examples/durable-lambda-agent/package.json
+++ b/strands-ts/examples/durable-lambda-agent/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "durable-lambda-agent",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build:sdk": "npm run build --prefix ../../..",
+    "build": "tsc --noEmit",
+    "bundle": "node bundle.mjs",
+    "deploy": "bash scripts/deploy.sh",
+    "invoke": "bash scripts/invoke.sh",
+    "invoke:restart": "bash scripts/invoke.sh --restart",
+    "invoke:crash": "bash scripts/invoke.sh --crash",
+    "validate:template": "sam validate --lint --template-file template.yml"
+  },
+  "dependencies": {
+    "@aws-sdk/client-s3": "3.1078.0",
+    "@aws/durable-execution-sdk-js": "1.1.6",
+    "@strands-agents/sdk": "file:../..",
+    "zod": "4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "25.9.4",
+    "esbuild": "0.28.1",
+    "typescript": "6.0.3"
+  }
+}

--- a/strands-ts/examples/durable-lambda-agent/scripts/deploy.sh
+++ b/strands-ts/examples/durable-lambda-agent/scripts/deploy.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REGION="${AWS_REGION:-${1:-us-west-2}}"
+STACK_NAME="${STACK_NAME:-strands-durable-agent}"
+FUNCTION_NAME="${FUNCTION_NAME:-strands-durable-agent}"
+MODEL_ID="${BEDROCK_MODEL_ID:-global.anthropic.claude-sonnet-4-6}"
+
+cd "$(dirname "$0")/.."
+
+for command in node npm sam; do
+  if ! command -v "$command" >/dev/null 2>&1; then
+    echo "Required command not found: $command" >&2
+    exit 1
+  fi
+done
+
+npm run build:sdk
+npm run build
+npm run bundle
+npm run validate:template
+
+sam deploy \
+  --template-file template.yml \
+  --stack-name "$STACK_NAME" \
+  --region "$REGION" \
+  --capabilities CAPABILITY_IAM \
+  --resolve-s3 \
+  --confirm-changeset \
+  --no-fail-on-empty-changeset \
+  --parameter-overrides \
+    "BedrockModelId=$MODEL_ID" \
+    "FunctionName=$FUNCTION_NAME"
+
+echo "Deployment complete: stack=$STACK_NAME, function=$FUNCTION_NAME, region=$REGION"

--- a/strands-ts/examples/durable-lambda-agent/scripts/invoke.sh
+++ b/strands-ts/examples/durable-lambda-agent/scripts/invoke.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-west-2}"
+STACK_NAME="${STACK_NAME:-strands-durable-agent}"
+PROMPT="${PROMPT:-Plan my trip to Seattle.}"
+SIMULATE_RESTART=false
+CRASH_AFTER_FIRST_TOOL=false
+SCENARIO=baseline
+
+case "${1:-}" in
+  --restart)
+    SIMULATE_RESTART=true
+    SCENARIO=restart
+    ;;
+  --crash)
+    CRASH_AFTER_FIRST_TOOL=true
+    SCENARIO=crash-after-tool
+    ;;
+  "") ;;
+  *)
+    echo "Usage: $0 [--restart|--crash]" >&2
+    exit 2
+    ;;
+esac
+
+FUNCTION_NAME=$(aws cloudformation describe-stacks \
+  --stack-name "$STACK_NAME" \
+  --region "$REGION" \
+  --query "Stacks[0].Outputs[?OutputKey=='FunctionName'].OutputValue | [0]" \
+  --output text)
+
+if [[ -z "$FUNCTION_NAME" || "$FUNCTION_NAME" == "None" ]]; then
+  echo "FunctionName output not found for stack $STACK_NAME" >&2
+  exit 1
+fi
+
+EXECUTION_NAME="strands-${SCENARIO}-$(date +%s)"
+SESSION_ID="${SESSION_ID:-$EXECUTION_NAME}"
+PAYLOAD=$(printf '{"prompt":"%s","sessionId":"%s","simulateRestart":%s,"crashAfterFirstTool":%s}' \
+  "$PROMPT" "$SESSION_ID" "$SIMULATE_RESTART" "$CRASH_AFTER_FIRST_TOOL")
+
+echo "Invoking function=$FUNCTION_NAME, region=$REGION, scenario=$SCENARIO, session=$SESSION_ID"
+aws lambda invoke \
+  --function-name "${FUNCTION_NAME}:\$LATEST" \
+  --invocation-type Event \
+  --cli-binary-format raw-in-base64-out \
+  --durable-execution-name "$EXECUTION_NAME" \
+  --payload "$PAYLOAD" \
+  --region "$REGION" \
+  /dev/stdout >/dev/null
+
+echo "Invocation queued as $EXECUTION_NAME. Press Ctrl-C to stop following logs."
+LOG_GROUP="/aws/lambda/$FUNCTION_NAME"
+LOG_GROUP_WAIT_SECONDS="${LOG_GROUP_WAIT_SECONDS:-120}"
+POLL_INTERVAL_SECONDS=5
+ELAPSED_SECONDS=0
+RESOLVED_LOG_GROUP=""
+
+while ((ELAPSED_SECONDS < LOG_GROUP_WAIT_SECONDS)); do
+  RESOLVED_LOG_GROUP=$(aws logs describe-log-groups \
+    --log-group-name-prefix "$LOG_GROUP" \
+    --region "$REGION" \
+    --query "logGroups[?logGroupName=='$LOG_GROUP'].logGroupName | [0]" \
+    --output text)
+  if [[ "$RESOLVED_LOG_GROUP" == "$LOG_GROUP" ]]; then
+    break
+  fi
+
+  echo "Waiting for CloudWatch log group $LOG_GROUP..."
+  sleep "$POLL_INTERVAL_SECONDS"
+  ELAPSED_SECONDS=$((ELAPSED_SECONDS + POLL_INTERVAL_SECONDS))
+done
+
+if [[ "$RESOLVED_LOG_GROUP" != "$LOG_GROUP" ]]; then
+  echo "CloudWatch log group was not available after ${LOG_GROUP_WAIT_SECONDS}s." >&2
+  echo "The invocation may still be queued; rerun the command to follow its logs." >&2
+  exit 1
+fi
+
+aws logs tail "$LOG_GROUP" \
+  --region "$REGION" \
+  --since 5m \
+  --follow

--- a/strands-ts/examples/durable-lambda-agent/src/durable-middleware.ts
+++ b/strands-ts/examples/durable-lambda-agent/src/durable-middleware.ts
@@ -1,0 +1,151 @@
+import { ExecuteToolStage, InvokeModelStage, Message, ToolResultBlock } from '@strands-agents/sdk'
+
+import type { DurableContext, DurableLoggingContext } from '@aws/durable-execution-sdk-js'
+import type {
+  Agent,
+  AgentStreamEvent,
+  ExecuteToolContext,
+  ExecuteToolResult,
+  InvokeModelContext,
+  InvokeModelResult,
+  MessageData,
+} from '@strands-agents/sdk'
+
+interface RegisterOptions {
+  crashAfterFirstTool?: boolean
+}
+
+/**
+ * Persists model and tool stage results with Lambda durable execution.
+ *
+ * Strands checkpoint boundaries are handled by the invocation loop in the
+ * Lambda handler. These durable steps restore the state that CheckpointData
+ * intentionally does not contain.
+ *
+ * @param agent - Agent whose model and tool stages should be persisted.
+ * @param context - Durable Lambda invocation context.
+ * @param options - Optional failure injection used by the recovery demo.
+ * @returns A function that removes both middleware handlers.
+ */
+export function registerDurableMiddleware(
+  agent: Agent,
+  context: DurableContext,
+  options: RegisterOptions = {}
+): () => void {
+  let modelCallIndex = 0
+  let toolCallIndex = 0
+  let loggingContext: DurableLoggingContext | undefined
+
+  context.configureLogger({
+    customLogger: {
+      log: (level, ...parameters) => console.log(`[${level}]`, ...parameters),
+      info: (...parameters) => console.info(...parameters),
+      warn: (...parameters) => console.warn(...parameters),
+      error: (...parameters) => console.error(...parameters),
+      debug: (...parameters) => console.debug(...parameters),
+      configureDurableLoggingContext: (nextLoggingContext) => {
+        loggingContext = nextLoggingContext
+      },
+    },
+    modeAware: false,
+  })
+
+  const removeModelMiddleware = agent.addMiddleware(
+    InvokeModelStage,
+    async function* (
+      stageContext: InvokeModelContext,
+      next
+    ): AsyncGenerator<AgentStreamEvent, InvokeModelResult, undefined> {
+      // An afterModel checkpoint resume invokes the model again in the TypeScript
+      // SDK, so this index tracks physical model calls rather than ReAct cycles.
+      const callIndex = modelCallIndex
+      modelCallIndex += 1
+      const stepName = `invoke-model:call-${callIndex}`
+      const events: AgentStreamEvent[] = []
+
+      const persisted = await context.step<{ message: MessageData; stopReason: string }>(stepName, async () => {
+        const result = await drainGenerator(
+          () => next(stageContext),
+          (event) => events.push(event)
+        )
+        return {
+          message: result.result.message.toJSON(),
+          stopReason: result.result.stopReason,
+        }
+      })
+
+      yield* events
+      return {
+        result: {
+          message: Message.fromMessageData(persisted.message),
+          stopReason: persisted.stopReason as InvokeModelResult['result']['stopReason'],
+        },
+      }
+    }
+  )
+
+  const removeToolMiddleware = agent.addMiddleware(
+    ExecuteToolStage,
+    async function* (
+      stageContext: ExecuteToolContext,
+      next
+    ): AsyncGenerator<AgentStreamEvent, ExecuteToolResult, undefined> {
+      const currentToolIndex = toolCallIndex
+      toolCallIndex += 1
+      const stepName = `tool:${stageContext.toolUse.name}:${stageContext.toolUse.toolUseId}`
+      const events: AgentStreamEvent[] = []
+      const persisted = await context.step<ReturnType<ToolResultBlock['toJSON']>>(stepName, async () => {
+        const result = await drainGenerator(
+          () => next(stageContext),
+          (event) => events.push(event)
+        )
+        return result.result.toJSON()
+      })
+
+      yield* events
+
+      if (options.crashAfterFirstTool === true && currentToolIndex === 0) {
+        const failureStepName = `failure-after-tool:${stageContext.toolUse.toolUseId}`
+        await context.step<boolean>(
+          failureStepName,
+          async (stepContext) => {
+            const attempt = loggingContext?.getDurableLogData().attempt ?? 1
+            if (attempt === 1) {
+              stepContext.logger.warn(`step=<${failureStepName}>, attempt=<${attempt}> | injecting failure`)
+              throw new Error('Injected failure after the first tool completed')
+            }
+
+            stepContext.logger.info(`step=<${failureStepName}>, attempt=<${attempt}> | continuing after retry`)
+            return true
+          },
+          {
+            retryStrategy: (_error, attemptCount) => ({
+              shouldRetry: attemptCount < 2,
+              delay: { seconds: 1 },
+            }),
+          }
+        )
+      }
+
+      return { result: ToolResultBlock.fromJSON(persisted) }
+    }
+  )
+
+  return () => {
+    removeToolMiddleware()
+    removeModelMiddleware()
+  }
+}
+
+async function drainGenerator<TEvent, TResult>(
+  generatorFactory: () => AsyncGenerator<TEvent, TResult, undefined>,
+  onEvent: (event: TEvent) => void
+): Promise<TResult> {
+  const generator = generatorFactory()
+  let nextResult = await generator.next()
+  while (!nextResult.done) {
+    onEvent(nextResult.value)
+    nextResult = await generator.next()
+  }
+  return nextResult.value
+}

--- a/strands-ts/examples/durable-lambda-agent/src/durable-storage.ts
+++ b/strands-ts/examples/durable-lambda-agent/src/durable-storage.ts
@@ -1,0 +1,44 @@
+import type { DurableContext } from '@aws/durable-execution-sdk-js'
+import type { Storage } from '@strands-agents/sdk/storage'
+
+/** Journals storage operations so Lambda replay never repeats S3 side effects. */
+export class DurableStorage implements Storage {
+  private operationIndex = 0
+
+  constructor(
+    private readonly context: DurableContext,
+    private readonly delegate: Storage
+  ) {}
+
+  async write(key: string, data: Uint8Array): Promise<void> {
+    await this.context.step<boolean>(this.nextStepName('write'), async () => {
+      await this.delegate.write(key, data)
+      return true
+    })
+  }
+
+  async read(key: string): Promise<Uint8Array | null> {
+    const encoded = await this.context.step<string | null>(this.nextStepName('read'), async () => {
+      const data = await this.delegate.read(key)
+      return data === null ? null : Buffer.from(data).toString('base64')
+    })
+    return encoded === null ? null : new Uint8Array(Buffer.from(encoded, 'base64'))
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.context.step<boolean>(this.nextStepName('delete'), async () => {
+      await this.delegate.delete(key)
+      return true
+    })
+  }
+
+  async list(prefix: string): Promise<string[]> {
+    return this.context.step<string[]>(this.nextStepName('list'), async () => this.delegate.list(prefix))
+  }
+
+  private nextStepName(operation: string): string {
+    const index = this.operationIndex
+    this.operationIndex += 1
+    return `session-storage:${index}:${operation}`
+  }
+}

--- a/strands-ts/examples/durable-lambda-agent/src/handler.ts
+++ b/strands-ts/examples/durable-lambda-agent/src/handler.ts
@@ -1,0 +1,115 @@
+import { createHash } from 'node:crypto'
+
+import { withDurableExecution } from '@aws/durable-execution-sdk-js'
+import { Agent, BedrockModel, SessionManager } from '@strands-agents/sdk'
+import { Checkpoint } from '@strands-agents/sdk/experimental'
+import { S3Storage } from '@strands-agents/sdk/storage'
+
+import { registerDurableMiddleware } from './durable-middleware.js'
+import { DurableStorage } from './durable-storage.js'
+import { buildTools } from './tools.js'
+
+import type { DurableContext } from '@aws/durable-execution-sdk-js'
+import type { InvokeArgs } from '@strands-agents/sdk'
+import type { CheckpointData } from '@strands-agents/sdk/experimental'
+
+interface AgentEvent {
+  prompt?: string
+  sessionId?: string
+  simulateRestart?: boolean
+  crashAfterFirstTool?: boolean
+}
+
+interface AgentOutput {
+  stopReason: string
+  text: string
+}
+
+const DEFAULT_MODEL_ID = 'global.anthropic.claude-sonnet-4-6'
+const DEFAULT_PROMPT = 'Plan my trip to Seattle.'
+const SYSTEM_PROMPT = [
+  'You are a trip planner. The user will name a city.',
+  'Call get_weather with that city, then call book_flight to that city.',
+  'After both tools succeed, respond with one short sentence.',
+].join(' ')
+
+async function invokeToCompletion(agent: Agent, prompt: string, context: DurableContext): Promise<AgentOutput> {
+  let args: InvokeArgs = prompt
+
+  while (true) {
+    const result = await agent.invoke(args)
+    if (result.stopReason !== 'checkpoint') {
+      const text = result.lastMessage.content.map((block) => (block.type === 'textBlock' ? block.text : '')).join('')
+      return { stopReason: result.stopReason, text }
+    }
+
+    if (result.checkpoint === undefined) {
+      throw new Error('Agent returned stopReason=checkpoint without checkpoint data')
+    }
+
+    const checkpointData = result.checkpoint.toJSON()
+    const stepName = `agent-checkpoint:cycle-${checkpointData.cycleIndex}:${checkpointData.position}`
+    const persistedCheckpoint = await context.step<Required<CheckpointData>>(stepName, async (stepContext) => {
+      stepContext.logger.info(`checkpoint=<${JSON.stringify(checkpointData)}> | persisting Strands checkpoint`)
+      return checkpointData
+    })
+    const checkpoint = Checkpoint.fromJSON(persistedCheckpoint)
+
+    args = {
+      checkpointResume: {
+        checkpoint: checkpoint.toJSON(),
+      },
+    }
+  }
+}
+
+function defaultSessionId(context: DurableContext): string {
+  const digest = createHash('sha256').update(context.executionContext.durableExecutionArn).digest('hex')
+  return `execution_${digest}`
+}
+
+async function handler(event: AgentEvent, context: DurableContext): Promise<AgentOutput> {
+  const prompt = event.prompt ?? DEFAULT_PROMPT
+  const sessionId = event.sessionId ?? defaultSessionId(context)
+  const sessionBucketName = process.env.SESSION_BUCKET_NAME
+  if (sessionBucketName === undefined || sessionBucketName.length === 0) {
+    throw new Error('SESSION_BUCKET_NAME is required')
+  }
+
+  context.logger.info('agent invocation started', { prompt, sessionId })
+
+  const sessionManager = new SessionManager({
+    sessionId,
+    storage: new DurableStorage(
+      context,
+      new S3Storage(sessionBucketName, {
+        prefix: 'durable-agent',
+      })
+    ),
+    saveLatestOn: 'invocation',
+  })
+  const agent = new Agent({
+    id: 'durable-agent',
+    model: new BedrockModel({ modelId: process.env.BEDROCK_MODEL_ID ?? DEFAULT_MODEL_ID }),
+    tools: buildTools(),
+    systemPrompt: SYSTEM_PROMPT,
+    printer: false,
+    toolExecutor: 'sequential',
+    checkpointing: true,
+    sessionManager,
+  })
+
+  registerDurableMiddleware(agent, context, {
+    crashAfterFirstTool: event.crashAfterFirstTool === true,
+  })
+
+  const output = await invokeToCompletion(agent, prompt, context)
+  if (event.simulateRestart === true) {
+    await context.wait('replay-trigger', { seconds: 1 })
+  }
+
+  context.logger.info('agent invocation completed', { stopReason: output.stopReason, sessionId })
+  return output
+}
+
+export const lambdaHandler = withDurableExecution(handler)

--- a/strands-ts/examples/durable-lambda-agent/src/tools.ts
+++ b/strands-ts/examples/durable-lambda-agent/src/tools.ts
@@ -1,0 +1,34 @@
+import { tool } from '@strands-agents/sdk'
+import { z } from 'zod'
+
+export const callCounts = { getWeather: 0, bookFlight: 0 }
+
+/**
+ * Creates deterministic tools used by the durable execution example.
+ *
+ * @returns The tools available to the example agent.
+ */
+export function buildTools() {
+  return [
+    tool({
+      name: 'get_weather',
+      description: 'Get the weather for a city.',
+      inputSchema: z.object({ city: z.string() }),
+      callback: (input) => {
+        callCounts.getWeather += 1
+        console.log(`city=<${input.city}>, count=<${callCounts.getWeather}> | get_weather invoked`)
+        return `Weather in ${input.city}: 72°F and sunny.`
+      },
+    }),
+    tool({
+      name: 'book_flight',
+      description: 'Book a flight to a destination.',
+      inputSchema: z.object({ destination: z.string() }),
+      callback: (input) => {
+        callCounts.bookFlight += 1
+        console.log(`destination=<${input.destination}>, count=<${callCounts.bookFlight}> | book_flight invoked`)
+        return `Flight booked to ${input.destination}: confirmation ABC123.`
+      },
+    }),
+  ]
+}

--- a/strands-ts/examples/durable-lambda-agent/template.yml
+++ b/strands-ts/examples/durable-lambda-agent/template.yml
@@ -1,0 +1,110 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Strands agent running with AWS Lambda durable execution
+
+Parameters:
+  BedrockModelId:
+    Type: String
+    Default: global.anthropic.claude-sonnet-4-6
+    Description: Bedrock model or inference profile ID available in the deployment region
+  FunctionName:
+    Type: String
+    Default: strands-durable-agent
+
+Resources:
+  DurableAgentSessionBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      VersioningConfiguration:
+        Status: Enabled
+
+  DurableAgentRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: DurableExecution
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - lambda:CheckpointDurableExecution
+                  - lambda:GetDurableExecutionState
+                Resource: '*'
+        - PolicyName: BedrockInvoke
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - bedrock:InvokeModel
+                  - bedrock:InvokeModelWithResponseStream
+                Resource: '*'
+        - PolicyName: SessionStorage
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                Resource: !Sub '${DurableAgentSessionBucket.Arn}/durable-agent/session/*'
+              - Effect: Allow
+                Action: s3:ListBucket
+                Resource: !GetAtt DurableAgentSessionBucket.Arn
+                Condition:
+                  StringLike:
+                    s3:prefix: durable-agent/session/*
+
+  DurableAgentFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Ref FunctionName
+      CodeUri: ./dist
+      Handler: handler.lambdaHandler
+      Runtime: nodejs22.x
+      Architectures:
+        - arm64
+      MemorySize: 512
+      Timeout: 300
+      Role: !GetAtt DurableAgentRole.Arn
+      DurableConfig:
+        ExecutionTimeout: 300
+        RetentionPeriodInDays: 7
+      Environment:
+        Variables:
+          BEDROCK_MODEL_ID: !Ref BedrockModelId
+          SESSION_BUCKET_NAME: !Ref DurableAgentSessionBucket
+    Metadata:
+      SkipBuild: true
+
+Outputs:
+  FunctionName:
+    Description: Deployed durable Lambda function name
+    Value: !Ref DurableAgentFunction
+  FunctionArn:
+    Description: Deployed durable Lambda function ARN
+    Value: !GetAtt DurableAgentFunction.Arn
+  SessionBucketName:
+    Description: S3 bucket retaining agent session snapshots
+    Value: !Ref DurableAgentSessionBucket

--- a/strands-ts/examples/durable-lambda-agent/tsconfig.json
+++ b/strands-ts/examples/durable-lambda-agent/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Description

### Motivation

The TypeScript SDK exposes experimental checkpointing, but users do not have a deployable reference showing how to combine lightweight `CheckpointData` markers with AWS Lambda Durable Functions and durable conversation state. This example provides that reference for agents that must survive Lambda retries and resume conversations across executions.

Completed model, tool, and session-storage operations are restored during durable replay, while a stable `SESSION_ID` allows a later execution to continue the saved conversation. This adds no SDK public API and does not change existing behavior.

## Related Issues

None.

## Documentation PR

Not required. Usage and deployment guidance are included with the example.

## Type of Change

New feature

## Testing

Validated by deploying the SAM stack and exercising normal execution, retry after the first completed tool, and cross-execution session resume.

- [ ] I ran `hatch run prepare` (not applicable to this TypeScript-only change)

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
