### PR TITLE
feat(model-routing): add context-fit strategy

### DIFF
--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -45,7 +45,7 @@ from ..types._snapshot import (
 if TYPE_CHECKING:
     from ..tools import ToolProvider
 from .._middleware import MiddlewareRegistry
-from .._middleware.stages import AgentStreamContext, AgentStreamStage
+from .._middleware.stages import AgentStreamContext, AgentStreamStage, InvokeModelStage
 from ..handlers.callback_handler import PrintingCallbackHandler, null_callback_handler
 from ..hooks import (
     AfterInvocationEvent,
@@ -451,10 +451,14 @@ class Agent(AgentBase):
         if self._model_router is not None:
             self._plugin_registry.add_and_init(self._model_router)
 
+        self._middleware_registry.add_middleware(
+            InvokeModelStage.Input,
+            self.conversation_manager._proactive_compression_middleware(),
+        )
+
         # In agentic mode, surface live token usage to the model so it can decide when to compress.
         if context_manager == "agentic":
             from .._context_manager.modes.agentic.agentic_context import create_token_usage_middleware
-            from .._middleware.stages import InvokeModelStage
 
             self._middleware_registry.add_middleware(InvokeModelStage.Input, create_token_usage_middleware())
 

--- a/strands-py/src/strands/agent/conversation_manager/conversation_manager.py
+++ b/strands-py/src/strands/agent/conversation_manager/conversation_manager.py
@@ -1,19 +1,20 @@
 """Abstract interface for conversation history management."""
 
+import copy
 import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, TypedDict, Union
 
-from ...hooks.events import BeforeModelCallEvent
+from ..._middleware.stages import InvokeModelContext
+from ..._middleware.types import MiddlewareInputHandler
 from ...hooks.registry import HookProvider, HookRegistry
-from ...types.content import Message
+from ...models._defaults import DEFAULT_COMPRESSION_THRESHOLD
+from ...types.content import Message, split_system_prompt
 
 if TYPE_CHECKING:
     from ...agent.agent import Agent
 
 logger = logging.getLogger(__name__)
-
-DEFAULT_COMPRESSION_THRESHOLD = 0.7
 
 
 class ProactiveCompressionConfig(TypedDict, total=False):
@@ -38,19 +39,17 @@ class ConversationManager(ABC, HookProvider):
     - Control context length
     - Maintain relevant conversation state
 
-    ConversationManager implements the HookProvider protocol, allowing derived classes to register hooks for agent
-    lifecycle events. Derived classes that override register_hooks must call the base implementation to ensure proper
-    hook registration chain.
+    ConversationManager implements the HookProvider protocol so derived classes can register hooks for agent
+    lifecycle events when needed.
 
     The primary responsibility of a ConversationManager is overflow recovery: when the model encounters a context
     window overflow, :meth:`reduce_context` is called with ``e`` set and MUST reduce the history enough for the next
     model call to succeed.
 
     Subclasses can enable proactive compression by passing ``proactive_compression`` in the constructor.
-    When enabled, the base class registers a ``BeforeModelCallEvent`` hook that checks projected input tokens
-    against the model's context window limit and calls :meth:`reduce_context` (without ``e``) when the
-    threshold is exceeded. This is a best-effort operation — errors are swallowed so the model call can
-    still proceed.
+    When enabled, invoke-model middleware checks the effective model's projected input tokens against its
+    context window and calls :meth:`reduce_context` (without ``e``) when the threshold is exceeded. This
+    is a best-effort operation: errors are swallowed so the model call can still proceed.
 
     Example:
         ```python
@@ -94,54 +93,67 @@ class ConversationManager(ABC, HookProvider):
         self._compression_threshold = threshold
 
     def register_hooks(self, registry: HookRegistry, **kwargs: Any) -> None:
-        """Register hooks for agent lifecycle events.
+        """Register conversation-manager-specific hooks.
 
-        Always registers a ``BeforeModelCallEvent`` hook for proactive compression.
-        When ``proactive_compression`` is not configured, the handler is a no-op (early return).
-
-        Derived classes that override this method must call the base implementation to ensure proper hook
-        registration chain.
+        The base manager has no hooks. Derived classes may override this method to subscribe to
+        lifecycle events and can call the base implementation without additional requirements.
 
         Args:
             registry: The hook registry to register callbacks with.
             **kwargs: Additional keyword arguments for future extensibility.
         """
-        # Always subscribe — the threshold check happens inside the handler
-        registry.add_callback(BeforeModelCallEvent, self._on_before_model_call_threshold)
 
-    def _on_before_model_call_threshold(self, event: BeforeModelCallEvent) -> None:
-        """Handle BeforeModelCallEvent for proactive compression.
+    def _proactive_compression_middleware(self) -> MiddlewareInputHandler:
+        """Build middleware that compresses against the effective model's context window."""
 
-        When proactive compression is not configured, this is a no-op.
-        When configured, checks projected input tokens against the context window limit
-        and calls reduce_context() without error (best-effort) when threshold is exceeded.
+        async def middleware(context: InvokeModelContext) -> InvokeModelContext:
+            if self._compression_threshold is None:
+                return context
 
-        Args:
-            event: The before model call event.
-        """
-        # Early return if proactive compression is not enabled
-        if self._compression_threshold is None:
-            return
+            try:
+                input_tokens = await self._count_input_tokens(context)
+                context.projected_input_tokens = input_tokens
+                ratio = context.model.estimate_utilization(input_tokens)
+            except Exception:
+                logger.debug("proactive compression measurement failed, proceeding with model call", exc_info=True)
+                return context
 
-        if event.projected_input_tokens is None:
-            logger.debug("projected_input_tokens=<None> | skipping proactive compression")
-            return
+            if ratio < self._compression_threshold:
+                return context
 
-        ratio = event.agent.model.estimate_utilization(event.projected_input_tokens)
-        if ratio >= self._compression_threshold:
             logger.debug(
                 "projected_tokens=<%s>, context_window_limit=<%s>, ratio=<%.2f>, compression_threshold=<%s>"
                 " | compression threshold exceeded, reducing context",
-                event.projected_input_tokens,
-                event.agent.model.context_window_limit,
+                input_tokens,
+                context.model.context_window_limit,
                 ratio,
                 self._compression_threshold,
             )
-            # Proactive compression is best-effort: swallow errors so the model call can still proceed.
             try:
-                self.reduce_context(agent=event.agent)
+                self.reduce_context(agent=context.agent)
             except Exception:
-                logger.debug("proactive compression failed, will proceed with model call", exc_info=True)
+                logger.debug("proactive compression failed, proceeding with model call", exc_info=True)
+
+            try:
+                context.messages = copy.deepcopy(context.agent.messages)
+                context.projected_input_tokens = None
+                context.projected_input_tokens = await self._count_input_tokens(context)
+            except Exception:
+                logger.debug("proactive compression refresh failed, proceeding with model call", exc_info=True)
+            return context
+
+        return middleware
+
+    @staticmethod
+    async def _count_input_tokens(context: InvokeModelContext) -> int:
+        """Count the middleware request with its effective model."""
+        system_prompt, system_prompt_content = split_system_prompt(context.system_prompt)
+        return await context.model.count_tokens(
+            context.messages,
+            tool_specs=list(context.tool_specs),
+            system_prompt=system_prompt,
+            system_prompt_content=system_prompt_content,
+        )
 
     def restore_from_session(self, state: dict[str, Any]) -> list[Message] | None:
         """Restore the Conversation Manager's state from a session.

--- a/strands-py/src/strands/models/__init__.py
+++ b/strands-py/src/strands/models/__init__.py
@@ -10,6 +10,7 @@ from .bedrock import BedrockModel
 from .model import BaseModelConfig, CacheConfig, CacheToolsConfig, Model
 from .routing import (
     CandidateInput,
+    ContextFitStrategy,
     FallbackStrategy,
     ModelRouter,
     RoutingAttempt,
@@ -27,6 +28,7 @@ __all__ = [
     "CacheConfig",
     "CacheToolsConfig",
     "CandidateInput",
+    "ContextFitStrategy",
     "FallbackStrategy",
     "Model",
     "ModelRouter",

--- a/strands-py/src/strands/models/_defaults.py
+++ b/strands-py/src/strands/models/_defaults.py
@@ -22,6 +22,9 @@ _C = TypeVar("_C", bound=Mapping[str, object])
 # Default context window limit (in tokens) when the model does not report one.
 DEFAULT_CONTEXT_WINDOW_LIMIT = 200_000
 
+# Context-window utilization at which proactive compression and context-fit routing act.
+DEFAULT_COMPRESSION_THRESHOLD = 0.7
+
 # Context window limits (in tokens) for known model IDs.
 #
 # Best-effort lookup table — unknown models return None and callers

--- a/strands-py/src/strands/models/routing/__init__.py
+++ b/strands-py/src/strands/models/routing/__init__.py
@@ -8,12 +8,14 @@ candidate with the fewest recorded failures, breaking ties by declaration order,
 once a later call succeeds. The API is provisional and may change before it is finalized.
 """
 
+from .context_fit_strategy import ContextFitStrategy
 from .fallback_strategy import FallbackStrategy
 from .router import CandidateInput, ModelRouter, RoutingCandidate
 from .strategy import RoutingAttempt, RoutingContext, RoutingStrategy
 
 __all__ = [
     "CandidateInput",
+    "ContextFitStrategy",
     "FallbackStrategy",
     "ModelRouter",
     "RoutingAttempt",

--- a/strands-py/src/strands/models/routing/context_fit_strategy.py
+++ b/strands-py/src/strands/models/routing/context_fit_strategy.py
@@ -1,0 +1,138 @@
+"""A local routing strategy that selects a model whose context window fits the request."""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from ...types.content import split_system_prompt
+from .._defaults import DEFAULT_COMPRESSION_THRESHOLD, DEFAULT_CONTEXT_WINDOW_LIMIT
+from ..model import Model
+from .strategy import RoutingContext, RoutingStrategy
+
+if TYPE_CHECKING:
+    from .router import RoutingCandidate
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _CandidateFit:
+    candidate: RoutingCandidate
+    input_tokens: float | None = None
+    context_window_limit: float | None = None
+    fits: bool | None = None
+
+
+class ContextFitStrategy:
+    """Select the smallest direct model whose context window fits the request.
+
+    Candidate models count the request with their own tokenizer. Models without a configured context
+    window use :data:`DEFAULT_CONTEXT_WINDOW_LIMIT`. A nested ``ModelRouter`` or a candidate whose
+    measurement fails has unknown fit: a known fitting model wins, otherwise the first unknown candidate
+    is preserved rather than excluded. When every fit is known and none fits, the largest model wins.
+
+    After a model failure, selection is delegated to ``fallback`` when configured. With no fallback,
+    returning ``None`` ends routing and preserves the model error.
+    """
+
+    def __init__(
+        self,
+        *,
+        threshold: float = DEFAULT_COMPRESSION_THRESHOLD,
+        fallback: RoutingStrategy | None = None,
+    ) -> None:
+        """Initialize the strategy.
+
+        Args:
+            threshold: Maximum context-window utilization considered a fit, in ``(0, 1]``.
+            fallback: Strategy that handles selection after a model failure. Defaults to no failover.
+
+        Raises:
+            ValueError: If ``threshold`` is not finite or is outside ``(0, 1]``.
+        """
+        if not math.isfinite(threshold) or threshold <= 0 or threshold > 1:
+            raise ValueError(f"threshold must be between 0 (exclusive) and 1 (inclusive), got {threshold}")
+        self._threshold = threshold
+        self._fallback = fallback
+
+    async def select(self, context: RoutingContext, **kwargs: Any) -> RoutingCandidate | None:
+        """Return the best-fitting candidate, or delegate selection after a failure."""
+        if context.attempts:
+            if self._fallback is None:
+                return None
+            return await self._fallback.select(context)
+
+        measured = await _measure_candidate_fit(context, self._threshold)
+        fitting = [measurement for measurement in measured if measurement.fits]
+        if fitting:
+            return min(fitting, key=lambda measurement: measurement.context_window_limit or 0).candidate
+
+        unknown = [measurement for measurement in measured if measurement.fits is None]
+        if unknown:
+            return unknown[0].candidate
+
+        if measured:
+            return max(measured, key=lambda measurement: measurement.context_window_limit or 0).candidate
+        return None
+
+
+async def _measure_candidate_fit(context: RoutingContext, threshold: float) -> list[_CandidateFit]:
+    """Measure direct candidates sequentially, preserving unmeasurable candidates as unknown."""
+    system_prompt, system_prompt_content = split_system_prompt(context.system_prompt)
+    measurements: list[_CandidateFit] = []
+
+    for candidate in context.candidates:
+        model = candidate.model
+        if not isinstance(model, Model):
+            measurements.append(_CandidateFit(candidate=candidate))
+            continue
+
+        try:
+            configured_limit = model.context_window_limit
+            limit = DEFAULT_CONTEXT_WINDOW_LIMIT if configured_limit is None else _nonnegative_number(configured_limit)
+            tokens = _nonnegative_number(
+                await model.count_tokens(
+                    context.messages,
+                    tool_specs=list(context.tool_specs),
+                    system_prompt=system_prompt,
+                    system_prompt_content=system_prompt_content,
+                )
+            )
+        except (TypeError, ValueError) as error:
+            logger.debug(
+                "candidate=<%s>, error=<%s> | context fit could not be measured",
+                candidate.name or type(model).__name__,
+                error,
+            )
+            measurements.append(_CandidateFit(candidate=candidate))
+            continue
+        except Exception as error:
+            logger.debug(
+                "candidate=<%s>, error=<%s> | context fit token counting failed",
+                candidate.name or type(model).__name__,
+                error,
+            )
+            measurements.append(_CandidateFit(candidate=candidate))
+            continue
+
+        measurements.append(
+            _CandidateFit(
+                candidate=candidate,
+                input_tokens=tokens,
+                context_window_limit=limit,
+                fits=tokens <= limit * threshold,
+            )
+        )
+
+    return measurements
+
+
+def _nonnegative_number(value: Any) -> float:
+    """Return a finite non-negative number, raising for invalid provider metadata."""
+    number = float(value)
+    if not math.isfinite(number) or number < 0:
+        raise ValueError(f"expected a finite non-negative number, got {value!r}")
+    return number

--- a/strands-py/src/strands/models/routing/router.py
+++ b/strands-py/src/strands/models/routing/router.py
@@ -35,13 +35,11 @@ events, so a streaming consumer sees that partial output followed by the replace
 ``AfterModelCallEvent`` documents this for any hook-requested retry; routing reaches it more often
 because it advances on any failure the retry strategy declines, not only throttling.
 
-Known limitation: routing applies to ``InvokeModelStage``, so ``agent.model`` stays the first declared
-candidate and subsystems reading it reason about that model rather than the one running. Proactive
-compression sizes against ``agent.model``'s context window, so routing among candidates with
-materially different windows can under-compress and overflow the routed model; the agent span reports
-the first candidate's model id; and ``Agent.structured_output()`` calls the model directly, bypassing
-routing entirely. Prefer candidates with comparable context windows and tokenizers until the selected
-model is threaded to those consumers.
+Known limitation: ``agent.model`` stays the first declared candidate, so subsystems reading it reason
+about that model rather than the one running. ``BeforeModelCallEvent.projected_input_tokens`` and the
+agent span still describe the first candidate, and ``Agent.structured_output()`` calls the model
+directly, bypassing routing entirely. Proactive compression is coordinated through invoke-model
+middleware and uses the effective selected model.
 """
 
 from __future__ import annotations

--- a/strands-py/tests/strands/agent/test_conversation_manager.py
+++ b/strands-py/tests/strands/agent/test_conversation_manager.py
@@ -1,8 +1,9 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from strands import tool
+from strands._middleware.stages import InvokeModelContext
 from strands.agent.agent import Agent
 from strands.agent.conversation_manager.conversation_manager import ConversationManager
 from strands.agent.conversation_manager.null_conversation_manager import NullConversationManager
@@ -442,10 +443,9 @@ def test_derived_class_does_not_need_to_implement_register_hooks():
     manager = MinimalConversationManager()
     registry = HookRegistry()
 
-    # Should work without error — the base class always registers the hook
+    # Calling the inherited implementation succeeds and does not add callbacks.
     manager.register_hooks(registry)
-    # Base class always registers the proactive compression hook
-    assert registry.has_callbacks()
+    assert not registry.has_callbacks()
 
 
 def test_per_turn_hooks_registration():
@@ -831,12 +831,22 @@ def _make_mock_agent(messages=None, context_window_limit=1000):
     return agent
 
 
-def _make_threshold_event(agent, projected_input_tokens=None):
-    return BeforeModelCallEvent(
+def _make_invoke_context(agent, input_tokens=0):
+    agent.model.count_tokens = AsyncMock(return_value=input_tokens)
+    return InvokeModelContext(
         agent=agent,
+        messages=list(agent.messages),
+        system_prompt=None,
+        tool_specs=[],
+        tool_choice=None,
         invocation_state={},
-        projected_input_tokens=projected_input_tokens,
+        model=agent.model,
     )
+
+
+async def _run_proactive_compression(manager, agent, input_tokens=0):
+    context = _make_invoke_context(agent, input_tokens)
+    return await manager._proactive_compression_middleware()(context)
 
 
 def test_proactive_compression_rejects_zero():
@@ -876,97 +886,96 @@ def test_proactive_compression_false_disables():
     assert manager._compression_threshold is None
 
 
-def test_proactive_compression_always_registers_hook():
-    """Hook is always registered regardless of proactive_compression setting."""
+def test_proactive_compression_base_register_hooks_is_noop():
     manager = _MinimalManager()
     registry = HookRegistry()
+
     manager.register_hooks(registry)
-    # Always registers the hook
-    assert registry.has_callbacks()
+
+    assert not registry.has_callbacks()
 
 
-def test_proactive_compression_hook_is_noop_when_not_configured():
-    """BeforeModelCallEvent handler is a no-op when proactive_compression is not set."""
+@pytest.mark.asyncio
+async def test_proactive_compression_middleware_is_noop_when_not_configured():
     manager = _MinimalManager()
     agent = _make_mock_agent(context_window_limit=1000)
-    registry = HookRegistry()
-    manager.register_hooks(registry)
+    context = _make_invoke_context(agent, input_tokens=900)
 
-    event = _make_threshold_event(agent, projected_input_tokens=900)
-    registry.invoke_callbacks(event)
+    result = await manager._proactive_compression_middleware()(context)
 
+    assert result is context
     assert manager.reduce_context_call_count == 0
+    agent.model.count_tokens.assert_not_awaited()
 
 
-def test_proactive_compression_calls_reduce_context_when_exceeded():
+@pytest.mark.asyncio
+async def test_proactive_compression_calls_reduce_context_and_refreshes_input_when_exceeded():
     manager = _MinimalManager(proactive_compression={"compression_threshold": 0.7})
-    agent = _make_mock_agent(messages=[{"role": "user", "content": [{"text": "msg"}]}], context_window_limit=1000)
-    registry = HookRegistry()
-    manager.register_hooks(registry)
-
-    event = _make_threshold_event(agent, projected_input_tokens=800)
-    registry.invoke_callbacks(event)
+    agent = _make_mock_agent(
+        messages=[{"role": "user", "content": [{"text": "first"}]}, {"role": "assistant", "content": []}],
+        context_window_limit=1000,
+    )
+    context = await _run_proactive_compression(manager, agent, input_tokens=800)
 
     assert manager.reduce_context_call_count == 1
+    assert context.messages == agent.messages == [{"role": "assistant", "content": []}]
+    assert context.projected_input_tokens == 800
+    agent.model.count_tokens.assert_awaited()
+    assert agent.model.count_tokens.await_count == 2
 
 
-def test_proactive_compression_no_call_when_below():
+@pytest.mark.asyncio
+async def test_proactive_compression_no_call_when_below():
     manager = _MinimalManager(proactive_compression={"compression_threshold": 0.7})
     agent = _make_mock_agent(context_window_limit=1000)
-    registry = HookRegistry()
-    manager.register_hooks(registry)
 
-    event = _make_threshold_event(agent, projected_input_tokens=500)
-    registry.invoke_callbacks(event)
+    context = await _run_proactive_compression(manager, agent, input_tokens=500)
 
     assert manager.reduce_context_call_count == 0
+    assert context.projected_input_tokens == 500
+    assert agent.model.count_tokens.await_count == 1
 
 
-def test_proactive_compression_no_call_when_projected_tokens_none():
+@pytest.mark.asyncio
+async def test_proactive_compression_measurement_failure_is_swallowed():
     manager = _MinimalManager(proactive_compression=True)
     agent = _make_mock_agent(context_window_limit=1000)
-    registry = HookRegistry()
-    manager.register_hooks(registry)
+    context = _make_invoke_context(agent)
+    agent.model.count_tokens.side_effect = RuntimeError("count failed")
 
-    event = _make_threshold_event(agent, projected_input_tokens=None)
-    registry.invoke_callbacks(event)
+    result = await manager._proactive_compression_middleware()(context)
 
+    assert result is context
     assert manager.reduce_context_call_count == 0
 
 
-def test_proactive_compression_uses_default_when_context_window_limit_not_set():
+@pytest.mark.asyncio
+async def test_proactive_compression_uses_default_when_context_window_limit_not_set():
     manager = _MinimalManager(proactive_compression={"compression_threshold": 0.7})
     agent = _make_mock_agent(context_window_limit=None)
-    registry = HookRegistry()
-    manager.register_hooks(registry)
 
-    # projected_input_tokens=150_000 is 75% of the 200k default, exceeding 0.7 threshold
-    event = _make_threshold_event(agent, projected_input_tokens=150_000)
     with patch("strands.models.model.logger") as mock_logger:
-        registry.invoke_callbacks(event)
+        await _run_proactive_compression(manager, agent, input_tokens=150_000)
         mock_logger.warning.assert_called_once()
         assert "using default" in mock_logger.warning.call_args[0][0]
 
     assert manager.reduce_context_call_count == 1
 
 
-def test_proactive_compression_warns_only_once_per_instance():
-    """Second invocation on the same manager instance suppresses the context_window_limit warning."""
+@pytest.mark.asyncio
+async def test_proactive_compression_warns_only_once_per_model_instance():
     manager = _MinimalManager(proactive_compression={"compression_threshold": 0.7})
     agent = _make_mock_agent(context_window_limit=None)
-    registry = HookRegistry()
-    manager.register_hooks(registry)
 
-    event = _make_threshold_event(agent, projected_input_tokens=150_000)
     with patch("strands.models.model.logger") as mock_logger:
-        registry.invoke_callbacks(event)
-        registry.invoke_callbacks(event)
-        assert mock_logger.warning.call_count == 1
+        await _run_proactive_compression(manager, agent, input_tokens=150_000)
+        await _run_proactive_compression(manager, agent, input_tokens=150_000)
+
+    assert mock_logger.warning.call_count == 1
 
 
-def test_proactive_compression_exception_swallowed():
-    """Exceptions in reduce_context during proactive compression should not propagate."""
-
+@pytest.mark.asyncio
+async def test_proactive_compression_exception_swallowed():
     class _FailingManager(ConversationManager):
         def apply_management(self, agent, **kwargs):
             pass
@@ -976,32 +985,42 @@ def test_proactive_compression_exception_swallowed():
 
     manager = _FailingManager(proactive_compression={"compression_threshold": 0.7})
     agent = _make_mock_agent(context_window_limit=1000)
-    registry = HookRegistry()
-    manager.register_hooks(registry)
 
-    event = _make_threshold_event(agent, projected_input_tokens=800)
-    registry.invoke_callbacks(event)
+    context = await _run_proactive_compression(manager, agent, input_tokens=800)
+
+    assert context.messages == agent.messages
 
 
-def test_proactive_compression_true_default_threshold_behavior():
-    """proactive_compression=True uses 0.7 — triggered at 0.7+ but not below."""
+@pytest.mark.asyncio
+async def test_proactive_compression_recount_failure_clears_stale_projection():
+    manager = _MinimalManager(proactive_compression={"compression_threshold": 0.7})
+    agent = _make_mock_agent(
+        messages=[{"role": "user", "content": [{"text": "first"}]}, {"role": "assistant", "content": []}],
+        context_window_limit=1000,
+    )
+    context = _make_invoke_context(agent, input_tokens=800)
+    agent.model.count_tokens.side_effect = [800, RuntimeError("recount failed")]
+
+    result = await manager._proactive_compression_middleware()(context)
+
+    assert result.messages == agent.messages == [{"role": "assistant", "content": []}]
+    assert result.projected_input_tokens is None
+
+
+@pytest.mark.asyncio
+async def test_proactive_compression_true_default_threshold_behavior():
     manager = _MinimalManager(proactive_compression=True)
     agent = _make_mock_agent(messages=[{"role": "user", "content": [{"text": "msg"}]}], context_window_limit=1000)
-    registry = HookRegistry()
-    manager.register_hooks(registry)
 
-    # 650/1000 = 0.65 < 0.7 — should NOT trigger
-    event = _make_threshold_event(agent, projected_input_tokens=650)
-    registry.invoke_callbacks(event)
+    await _run_proactive_compression(manager, agent, input_tokens=650)
     assert manager.reduce_context_call_count == 0
 
-    # 800/1000 = 0.8 >= 0.7 — should trigger
-    event2 = _make_threshold_event(agent, projected_input_tokens=800)
-    registry.invoke_callbacks(event2)
+    await _run_proactive_compression(manager, agent, input_tokens=800)
     assert manager.reduce_context_call_count == 1
 
 
-def test_sliding_window_proactive_compression_trims():
+@pytest.mark.asyncio
+async def test_sliding_window_proactive_compression_trims():
     manager = SlidingWindowConversationManager(
         window_size=4, should_truncate_results=False, proactive_compression={"compression_threshold": 0.7}
     )
@@ -1012,16 +1031,15 @@ def test_sliding_window_proactive_compression_trims():
         for i in range(6)
     ]
     agent = _make_mock_agent(messages=messages, context_window_limit=1000)
-    registry = HookRegistry()
-    manager.register_hooks(registry)
 
-    event = _make_threshold_event(agent, projected_input_tokens=800)
-    registry.invoke_callbacks(event)
+    context = await _run_proactive_compression(manager, agent, input_tokens=800)
 
     assert len(agent.messages) == 4
+    assert context.messages == agent.messages
 
 
-def test_sliding_window_proactive_compression_no_trim_below():
+@pytest.mark.asyncio
+async def test_sliding_window_proactive_compression_no_trim_below():
     manager = SlidingWindowConversationManager(
         window_size=4, should_truncate_results=False, proactive_compression={"compression_threshold": 0.7}
     )
@@ -1030,13 +1048,11 @@ def test_sliding_window_proactive_compression_no_trim_below():
         {"role": "assistant", "content": [{"text": "Hi"}]},
     ]
     agent = _make_mock_agent(messages=messages, context_window_limit=1000)
-    registry = HookRegistry()
-    manager.register_hooks(registry)
 
-    event = _make_threshold_event(agent, projected_input_tokens=500)
-    registry.invoke_callbacks(event)
+    context = await _run_proactive_compression(manager, agent, input_tokens=500)
 
     assert len(agent.messages) == 2
+    assert context.messages == messages
 
 
 # --- pin_first tests ---

--- a/strands-py/tests/strands/agent/test_summarizing_conversation_manager.py
+++ b/strands-py/tests/strands/agent/test_summarizing_conversation_manager.py
@@ -1,15 +1,14 @@
 from typing import cast
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
+from strands._middleware.stages import InvokeModelContext
 from strands.agent.agent import Agent
 from strands.agent.conversation_manager.summarizing_conversation_manager import (
     DEFAULT_SUMMARIZATION_PROMPT,
     SummarizingConversationManager,
 )
-from strands.hooks.events import BeforeModelCallEvent
-from strands.hooks.registry import HookRegistry
 from strands.models.model import Model
 from strands.types.content import Messages
 from strands.types.exceptions import ContextWindowOverflowException
@@ -841,11 +840,26 @@ def _make_summarizing_threshold_agent(messages, summary_response="Summary of con
     agent.model.context_window_limit = context_window_limit
     agent.model._utilization_limit_warned = False
     agent.model.estimate_utilization = lambda input_tokens: Model.estimate_utilization(agent.model, input_tokens)
+    agent.model.count_tokens = AsyncMock()
     agent.model.stream = Mock(side_effect=lambda *a, **kw: _mock_model_stream(summary_response))
     return agent
 
 
-def test_proactive_compression_summarizes_when_exceeded():
+def _make_summarizing_invoke_context(agent, input_tokens):
+    agent.model.count_tokens.return_value = input_tokens
+    return InvokeModelContext(
+        agent=agent,
+        messages=list(agent.messages),
+        system_prompt=None,
+        tool_specs=[],
+        tool_choice=None,
+        invocation_state={},
+        model=agent.model,
+    )
+
+
+@pytest.mark.asyncio
+async def test_proactive_compression_summarizes_when_exceeded():
     manager = SummarizingConversationManager(
         summary_ratio=0.5,
         preserve_recent_messages=2,
@@ -858,18 +872,18 @@ def test_proactive_compression_summarizes_when_exceeded():
         for i in range(20)
     ]
     agent = _make_summarizing_threshold_agent(messages, context_window_limit=1000)
-    registry = HookRegistry()
-    manager.register_hooks(registry)
+    context = _make_summarizing_invoke_context(agent, input_tokens=800)
 
-    event = BeforeModelCallEvent(agent=agent, invocation_state={}, projected_input_tokens=800)
-    registry.invoke_callbacks(event)
+    result = await manager._proactive_compression_middleware()(context)
 
-    # 20 * 0.5 = 10 summarized → 1 summary + 10 remaining = 11
     assert len(agent.messages) == 11
     assert agent.messages[0]["role"] == "user"
+    assert result.messages == agent.messages
+    assert agent.model.count_tokens.await_count == 2
 
 
-def test_proactive_compression_no_summarize_when_below():
+@pytest.mark.asyncio
+async def test_proactive_compression_no_summarize_when_below():
     manager = SummarizingConversationManager(proactive_compression={"compression_threshold": 0.7})
     messages = [
         {"role": "user", "content": [{"text": f"Message {i}"}]}
@@ -878,16 +892,17 @@ def test_proactive_compression_no_summarize_when_below():
         for i in range(20)
     ]
     agent = _make_summarizing_threshold_agent(messages, context_window_limit=1000)
-    registry = HookRegistry()
-    manager.register_hooks(registry)
+    context = _make_summarizing_invoke_context(agent, input_tokens=500)
 
-    event = BeforeModelCallEvent(agent=agent, invocation_state={}, projected_input_tokens=500)
-    registry.invoke_callbacks(event)
+    result = await manager._proactive_compression_middleware()(context)
 
     assert len(agent.messages) == 20
+    assert result.messages == messages
+    assert agent.model.count_tokens.await_count == 1
 
 
-def test_proactive_compression_swallows_errors():
+@pytest.mark.asyncio
+async def test_proactive_compression_swallows_errors():
     manager = SummarizingConversationManager(
         summary_ratio=0.5,
         preserve_recent_messages=2,
@@ -899,18 +914,11 @@ def test_proactive_compression_swallows_errors():
         else {"role": "assistant", "content": [{"text": f"Response {i}"}]}
         for i in range(20)
     ]
-    agent = MagicMock()
-    agent.messages = messages
-    agent.model = MagicMock()
-    agent.model.context_window_limit = 1000
-    agent.model._utilization_limit_warned = False
-    agent.model.estimate_utilization = lambda input_tokens: Model.estimate_utilization(agent.model, input_tokens)
+    agent = _make_summarizing_threshold_agent(messages, context_window_limit=1000)
     agent.model.stream = Mock(side_effect=lambda *a, **kw: _mock_model_stream_error(RuntimeError("model failed")))
+    context = _make_summarizing_invoke_context(agent, input_tokens=800)
 
-    registry = HookRegistry()
-    manager.register_hooks(registry)
+    result = await manager._proactive_compression_middleware()(context)
 
-    event = BeforeModelCallEvent(agent=agent, invocation_state={}, projected_input_tokens=800)
-    # Should not throw — proactive compression is best-effort
-    registry.invoke_callbacks(event)
     assert len(agent.messages) == 20
+    assert result.messages == agent.messages

--- a/strands-py/tests/strands/models/routing/test_context_fit_strategy.py
+++ b/strands-py/tests/strands/models/routing/test_context_fit_strategy.py
@@ -1,0 +1,299 @@
+"""Tests for ContextFitStrategy and route-before-compress coordination."""
+
+import copy
+import math
+
+import pytest
+
+from strands import Agent
+from strands.agent.conversation_manager.conversation_manager import ConversationManager
+from strands.models._defaults import DEFAULT_CONTEXT_WINDOW_LIMIT
+from strands.models.routing import (
+    ContextFitStrategy,
+    FallbackStrategy,
+    ModelRouter,
+    RoutingAttempt,
+    RoutingContext,
+)
+from tests.fixtures.mocked_model_provider import MockedModelProvider
+
+
+class _FitModel(MockedModelProvider):
+    def __init__(self, tokens, limit, text="ok", error=None):
+        super().__init__([{"role": "assistant", "content": [{"text": text}]}])
+        self.tokens = tokens
+        self.limit = limit
+        self.error = error
+        self.count_calls = []
+        self.stream_messages = []
+
+    def get_config(self):
+        return {} if self.limit is None else {"context_window_limit": self.limit}
+
+    async def count_tokens(self, messages, tool_specs=None, system_prompt=None, system_prompt_content=None):
+        self.count_calls.append((copy.deepcopy(messages), tool_specs, system_prompt, system_prompt_content))
+        if self.error is not None:
+            raise self.error
+        return self.tokens
+
+    async def stream(self, messages, *args, **kwargs):
+        self.stream_messages.append(copy.deepcopy(messages))
+        async for event in super().stream(messages, *args, **kwargs):
+            yield event
+
+
+class _FailingFitModel(_FitModel):
+    async def stream(self, *args, **kwargs):
+        raise RuntimeError("model failed")
+        yield  # pragma: no cover
+
+
+class _Pick:
+    def __init__(self, index):
+        self.index = index
+        self.calls = 0
+
+    async def select(self, context, **kwargs):
+        self.calls += 1
+        return context.candidates[self.index]
+
+
+class _RecordingManager(ConversationManager):
+    def __init__(self):
+        super().__init__(proactive_compression=True)
+        self.reductions = 0
+
+    def apply_management(self, agent, **kwargs):
+        pass
+
+    def reduce_context(self, agent, e=None, **kwargs):
+        self.reductions += 1
+        agent.messages[:] = agent.messages[-1:]
+
+
+def _context(router, *, attempts=()):
+    return RoutingContext(
+        messages=[{"role": "user", "content": [{"text": "request"}]}],
+        system_prompt="system",
+        tool_specs=[{"name": "tool", "description": "", "inputSchema": {"json": {}}}],
+        candidates=router.candidates,
+        invocation_state={},
+        attempts=attempts,
+    )
+
+
+@pytest.mark.asyncio
+async def test_selects_smallest_context_window_that_fits():
+    large = _FitModel(50, 1_000)
+    small = _FitModel(50, 100)
+    router = ModelRouter([large, small])
+
+    selected = await ContextFitStrategy().select(_context(router))
+
+    assert selected is router.candidates[1]
+
+
+@pytest.mark.asyncio
+async def test_uses_candidate_specific_token_counts_and_request_fields():
+    too_full = _FitModel(80, 100)
+    fits = _FitModel(60, 100)
+    router = ModelRouter([too_full, fits])
+
+    selected = await ContextFitStrategy().select(_context(router))
+
+    assert selected is router.candidates[1]
+    assert too_full.count_calls == fits.count_calls
+    _, tool_specs, system_prompt, system_prompt_content = fits.count_calls[0]
+    assert tool_specs == [{"name": "tool", "description": "", "inputSchema": {"json": {}}}]
+    assert system_prompt == "system"
+    assert system_prompt_content == [{"text": "system"}]
+
+
+@pytest.mark.asyncio
+async def test_exact_threshold_boundary_fits():
+    model = _FitModel(70, 100)
+    router = ModelRouter([model])
+
+    assert await ContextFitStrategy().select(_context(router)) is router.candidates[0]
+
+
+@pytest.mark.asyncio
+async def test_selects_largest_window_when_every_measurement_is_known_and_none_fits():
+    small = _FitModel(100, 50)
+    large = _FitModel(100, 80)
+    router = ModelRouter([small, large])
+
+    assert await ContextFitStrategy().select(_context(router)) is router.candidates[1]
+
+
+@pytest.mark.asyncio
+async def test_missing_window_uses_shared_default():
+    defaulted = _FitModel(DEFAULT_CONTEXT_WINDOW_LIMIT * 0.7, None)
+    larger = _FitModel(DEFAULT_CONTEXT_WINDOW_LIMIT * 0.7, 300_000)
+    router = ModelRouter([defaulted, larger])
+
+    assert await ContextFitStrategy().select(_context(router)) is router.candidates[0]
+
+
+@pytest.mark.asyncio
+async def test_equal_fitting_windows_preserve_declaration_order():
+    first = _FitModel(10, 100)
+    second = _FitModel(10, 100)
+    router = ModelRouter([first, second])
+
+    assert await ContextFitStrategy().select(_context(router)) is router.candidates[0]
+
+
+@pytest.mark.asyncio
+async def test_zero_context_window_is_measured_instead_of_replaced_by_default():
+    zero = _FitModel(1, 0)
+    positive = _FitModel(1, 2)
+    router = ModelRouter([zero, positive])
+
+    assert await ContextFitStrategy(threshold=1).select(_context(router)) is router.candidates[1]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tokens", [-1, math.nan, math.inf, "invalid"])
+async def test_invalid_token_count_is_unknown(tokens):
+    unknown = _FitModel(tokens, 100)
+    no_fit = _FitModel(100, 100)
+    router = ModelRouter([unknown, no_fit])
+
+    assert await ContextFitStrategy().select(_context(router)) is router.candidates[0]
+
+
+@pytest.mark.asyncio
+async def test_count_failure_is_unknown_but_known_fit_wins():
+    unknown = _FitModel(0, 100, error=RuntimeError("count failed"))
+    fitting = _FitModel(10, 100)
+    router = ModelRouter([unknown, fitting])
+
+    assert await ContextFitStrategy().select(_context(router)) is router.candidates[1]
+
+
+@pytest.mark.asyncio
+async def test_nested_router_is_unknown_and_is_not_resolved_by_strategy():
+    class _RaisesIfAsked:
+        async def select(self, context, **kwargs):
+            raise AssertionError("nested router must not be resolved")
+
+    nested = ModelRouter([_FitModel(1, 100)], strategy=_RaisesIfAsked())
+    no_fit = _FitModel(100, 100)
+    outer = ModelRouter([nested, no_fit])
+
+    assert await ContextFitStrategy().select(_context(outer)) is outer.candidates[0]
+
+
+@pytest.mark.asyncio
+async def test_returns_none_after_failure_without_explicit_fallback():
+    router = ModelRouter([_FitModel(1, 100), _FitModel(1, 200)])
+    attempts = (RoutingAttempt(router.candidates[0], RuntimeError("failed")),)
+
+    assert await ContextFitStrategy().select(_context(router, attempts=attempts)) is None
+
+
+@pytest.mark.asyncio
+async def test_delegates_failure_selection_to_explicit_fallback():
+    router = ModelRouter([_FitModel(1, 100), _FitModel(1, 200)])
+    attempts = (RoutingAttempt(router.candidates[0], RuntimeError("failed")),)
+
+    selected = await ContextFitStrategy(fallback=FallbackStrategy()).select(_context(router, attempts=attempts))
+
+    assert selected is router.candidates[1]
+
+
+@pytest.mark.parametrize("threshold", [0, -0.1, 1.1, math.nan, math.inf])
+def test_rejects_invalid_threshold(threshold):
+    with pytest.raises(ValueError, match="threshold must be between"):
+        ContextFitStrategy(threshold=threshold)
+
+
+def test_is_re_exported_from_models_packages():
+    import strands.models as models
+
+    assert models.ContextFitStrategy is ContextFitStrategy
+    assert models.routing.ContextFitStrategy is ContextFitStrategy
+    assert "ContextFitStrategy" in models.__all__
+    assert "ContextFitStrategy" in models.routing.__all__
+
+
+def test_context_fit_routes_to_larger_model_before_compression():
+    small = _FitModel(80, 100, text="small")
+    large = _FitModel(80, 1_000, text="large")
+    manager = _RecordingManager()
+    agent = Agent(
+        model=ModelRouter([small, large], strategy=ContextFitStrategy()),
+        conversation_manager=manager,
+        callback_handler=None,
+    )
+
+    result = agent("request")
+
+    assert result.message["content"][0]["text"] == "large"
+    assert manager.reductions == 0
+    assert not small.stream_messages
+    assert large.stream_messages
+
+
+def test_compression_uses_selected_model_and_refreshes_terminal_messages():
+    selected = _FitModel(80, 100, text="selected")
+    other = _FitModel(1, 1_000, text="other")
+    strategy = _Pick(0)
+    manager = _RecordingManager()
+    agent = Agent(
+        model=ModelRouter([selected, other], strategy=strategy),
+        messages=[
+            {"role": "user", "content": [{"text": "old"}]},
+            {"role": "assistant", "content": [{"text": "old response"}]},
+        ],
+        conversation_manager=manager,
+        callback_handler=None,
+    )
+
+    agent("current")
+
+    assert strategy.calls == 1
+    assert manager.reductions == 1
+    assert selected.stream_messages == [[{"role": "user", "content": [{"text": "current"}]}]]
+
+
+def test_nested_selection_compresses_against_final_leaf_model():
+    small = _FitModel(1, 100, text="small")
+    large = _FitModel(800, 1_000, text="large")
+    nested_strategy = _Pick(1)
+    nested = ModelRouter([small, large], strategy=nested_strategy)
+    outer_strategy = _Pick(0)
+    manager = _RecordingManager()
+    agent = Agent(
+        model=ModelRouter([nested], strategy=outer_strategy),
+        conversation_manager=manager,
+        callback_handler=None,
+    )
+
+    result = agent("request")
+
+    assert result.message["content"][0]["text"] == "large"
+    assert outer_strategy.calls == nested_strategy.calls == 1
+    assert manager.reductions == 1
+
+
+def test_fallback_retry_compresses_against_newly_selected_model():
+    failing = _FailingFitModel(50, 100)
+    replacement = _FitModel(800, 1_000, text="replacement")
+    manager = _RecordingManager()
+    agent = Agent(
+        model=ModelRouter(
+            [failing, replacement],
+            strategy=ContextFitStrategy(fallback=FallbackStrategy()),
+        ),
+        conversation_manager=manager,
+        callback_handler=None,
+        retry_strategy=None,
+    )
+
+    result = agent("request")
+
+    assert result.message["content"][0]["text"] == "replacement"
+    assert manager.reductions == 1
+    assert replacement.stream_messages


### PR DESCRIPTION
## Description

`ModelRouter` can now select the smallest direct model whose context window fits the request. Proactive compression uses the effective routed model, allowing an invocation to move to a larger candidate before discarding conversation context.

## Related Issues

Resolves #364

## Documentation PR

N/A — the provisional API is documented through its public docstrings.

## Public API Changes

```python
router = ModelRouter(
    models=[small_model, large_model],
    strategy=ContextFitStrategy(fallback=FallbackStrategy()),
)
agent = Agent(model=router)
```

Runtime failure handling remains explicit: omit `fallback` to surface the selected model's error without switching candidates.

## Type of Change

New feature

## Testing

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
