### PR TITLE
feat(site): expire New sidebar badges 30 days after addedDate

### DIFF
--- a/site/src/config/navigation.yml
+++ b/site/src/config/navigation.yml
@@ -8,7 +8,9 @@
 #
 # NOTE: Page (leaf) badges come from page frontmatter, not this file. Group labels
 # have no frontmatter, so a group may declare a `badge` here (text + variant) to
-# surface status on a collapsed section.
+# surface status on a collapsed section. Never hand-write a New badge: set
+# `addedDate` on the group (pages set it in frontmatter) and the badge derives
+# from it for 30 days.
 
 navbar:
   - label: Home
@@ -82,9 +84,7 @@ sidebar:
           - docs/user-guide/concepts/context-management
           - label: Memory
             collapsed: true
-            badge:
-              text: New
-              variant: tip
+            addedDate: 2026-06-17
             items:
               - label: "Overview"
                 slug: docs/user-guide/concepts/memory/overview
@@ -92,9 +92,7 @@ sidebar:
               - docs/user-guide/concepts/memory/bedrock-knowledge-base
           - docs/user-guide/concepts/agents/retry-strategies
           - label: Sandbox
-            badge:
-              text: New
-              variant: tip
+            addedDate: 2026-06-17
             items:
               - label: "Overview"
                 slug: docs/user-guide/concepts/sandbox
@@ -116,9 +114,7 @@ sidebar:
               - docs/user-guide/concepts/plugins/context-injector
               - docs/user-guide/concepts/plugins/goal-loop
           - label: Interventions
-            badge:
-              text: New
-              variant: tip
+            addedDate: 2026-06-03
             items:
               - label: "Overview"
                 slug: docs/user-guide/concepts/agents/interventions

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -78,10 +78,18 @@ export const changelogFrontmatterSchema = z
   // and omits the field entirely.
   .superRefine((d, ctx) => {
     if (d.sdk === 'harness' && d.language === undefined) {
-      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['language'], message: 'harness releases require a language (python or typescript)' })
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['language'],
+        message: 'harness releases require a language (python or typescript)',
+      })
     }
     if (d.sdk === 'evals' && d.language !== undefined) {
-      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['language'], message: 'evals releases must not set a language (evals is python-only)' })
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['language'],
+        message: 'evals releases must not set a language (evals is python-only)',
+      })
     }
   })
 export type ChangelogFrontmatter = z.infer<typeof changelogFrontmatterSchema>
@@ -207,31 +215,32 @@ export const collections = {
       base: 'src/content',
       pattern: 'testimonials/**/*.md',
     }),
-    schema: ({ image }: SchemaContext) => z.object({
-      name: z.string(),
-      title: z.string().optional(),
-      logo: image().optional(),
-      dark_logo: image().optional(),
-      link: z.string().url().optional(),
-      order: z.number().default(0),
-    }),
+    schema: ({ image }: SchemaContext) =>
+      z.object({
+        name: z.string(),
+        title: z.string().optional(),
+        logo: image().optional(),
+        dark_logo: image().optional(),
+        link: z.string().url().optional(),
+        order: z.number().default(0),
+      }),
   }),
   docs: defineCollection({
     loader: glob({
-      base: "src/content",
+      base: 'src/content',
       // We explicitly declare the folders we want to include, as otherwise it includes index.md files
       // in examples which are not intended to be rendered on the site.
       // Long-term we'll be moving examples into the sdk-python repository instead, solving this problem.
       pattern: [
-        "404.mdx",
+        '404.mdx',
 
-        "docs/user-guide/**/*.mdx",
-        "docs/integrations/**/*.mdx",
-        "docs/contribute/**/*.mdx",
-        "docs/examples/**/[!index]*.mdx",
-        "docs/labs/**/*.mdx",
-        "docs/api/python/**/*.mdx",
-        "docs/api/typescript/**/*.(md|mdx)",
+        'docs/user-guide/**/*.mdx',
+        'docs/integrations/**/*.mdx',
+        'docs/contribute/**/*.mdx',
+        'docs/examples/**/[!index]*.mdx',
+        'docs/labs/**/*.mdx',
+        'docs/api/python/**/*.mdx',
+        'docs/api/typescript/**/*.(md|mdx)',
       ],
       generateId: generateDocsId,
     }),
@@ -241,10 +250,25 @@ export const collections = {
         languages: docsLanguagesSchema,
         community: z.boolean().default(false),
         experimental: z.boolean().default(false),
+        // Drives the derived "New" sidebar badge for NEW_BADGE_DAYS after this
+        // date (see route-middleware.ts). Never hand-write a literal New badge.
+        addedDate: z.coerce.date().optional(),
         // Category for TypeScript API docs (classes, interfaces, type-aliases, functions)
         category: z.string().optional(),
         // Integration type for filtering (e.g., 'model-provider' for model providers)
-        integrationType: z.enum(['model-provider', 'tool', 'session-manager', 'memory-store', 'storage', 'integration', 'plugin', 'agent-extension', 'intervention']).optional(),
+        integrationType: z
+          .enum([
+            'model-provider',
+            'tool',
+            'session-manager',
+            'memory-store',
+            'storage',
+            'integration',
+            'plugin',
+            'agent-extension',
+            'intervention',
+          ])
+          .optional(),
         // Short description for catalog listings
         description: z.string().optional(),
         // Array of slugs that should redirect to this page (e.g., old URLs)

--- a/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/cedar-authorization.mdx
@@ -5,10 +5,7 @@ tags: [safety, interventions, tool-execution]
 sourceLinks:
   - path: strands-py/src/strands/vended_interventions/cedar/cedar_authorization.py
   - path: strands-ts/src/vended-interventions/cedar/cedar.ts
-sidebar:
-  badge:
-    text: New
-    variant: tip
+addedDate: 2026-06-15
 ---
 
 Cedar Authorization evaluates [Cedar](https://cedarpolicy.com) policies before each tool call, giving you declarative, identity-aware access control over agent behavior. It ships as a vended intervention handler in both the Python and TypeScript SDKs.

--- a/site/src/content/docs/user-guide/concepts/agents/interventions/human-in-the-loop.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/human-in-the-loop.mdx
@@ -7,10 +7,7 @@ sourceLinks:
   - path: strands-py/src/strands/vended_interventions/hitl/classifier.py
   - path: strands-ts/src/vended-interventions/hitl/hitl.ts
   - path: strands-ts/src/vended-interventions/hitl/classifier.ts
-sidebar:
-  badge:
-    text: New
-    variant: tip
+addedDate: 2026-06-03
 ---
 
 The `HumanInTheLoop` intervention handler pauses agent execution before tool calls to request human approval. It provides a configurable, drop-in way to add human oversight without writing custom interrupt logic. Pass it to `interventions` and choose how you want to collect the human's response.

--- a/site/src/content/docs/user-guide/concepts/agents/interventions/index.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/index.mdx
@@ -9,10 +9,7 @@ sourceLinks:
   - path: strands-ts/src/interventions/handler.ts
   - path: strands-ts/src/interventions/actions.ts
   - path: strands-ts/src/interventions/registry.ts
-sidebar:
-  badge:
-    text: New
-    variant: tip
+addedDate: 2026-07-01
 ---
 
 Interventions are a composable control layer for agents. They provide a typed action model for common control concerns — authorization, guardrails, steering, and content transformation — with ordered evaluation and short-circuiting. Unlike raw [hooks](../hooks.mdx) and [plugins](../../plugins/index.mdx) which mutate event objects directly, intervention handlers return typed decisions (`proceed`, `deny`, `guide`, `confirm`, `transform`) that the framework applies with well-defined semantics — enabling automatic short-circuiting, feedback accumulation, and conflict resolution.

--- a/site/src/content/docs/user-guide/concepts/agents/interventions/steering.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/interventions/steering.mdx
@@ -5,11 +5,9 @@ tags: [hooks, event-loop, tool-execution]
 sourceLinks:
   - path: strands-py/src/strands/vended_plugins/steering/core/handler.py
   - path: strands-ts/src/vended-interventions/steering/handlers/llm.ts
+addedDate: 2026-07-01
 sidebar:
   label: Steering
-  badge:
-    text: New
-    variant: tip
 ---
 
 Steering provides modular prompting for complex agent tasks through context-aware guidance that appears when relevant, rather than front-loading all instructions in monolithic prompts. Steering handlers observe agent activity and intervene at key moments — before a tool call or after a model response — with targeted feedback. They are built on the [interventions](./index.mdx) framework and use the same typed action model.

--- a/site/src/content/docs/user-guide/concepts/context-management.mdx
+++ b/site/src/content/docs/user-guide/concepts/context-management.mdx
@@ -7,10 +7,7 @@ sourceLinks:
   - path: strands-py/src/strands/agent/conversation_manager/conversation_manager.py
   - path: strands-ts/src/context-manager/modes/agentic/agentic-context.ts
   - path: strands-ts/src/conversation-manager/conversation-manager.ts
-sidebar:
-  badge:
-    text: New
-    variant: tip
+addedDate: 2026-06-12
 ---
 
 As conversations grow, your agent's context window fills with messages, tool results, and system prompts. Without management, this leads to token limit errors, degraded performance, and loss of relevant information.

--- a/site/src/content/docs/user-guide/concepts/memory/bedrock-knowledge-base.mdx
+++ b/site/src/content/docs/user-guide/concepts/memory/bedrock-knowledge-base.mdx
@@ -5,11 +5,9 @@ tags: [memory, bedrock, aws]
 sourceLinks:
   - path: strands-py/src/strands/vended_memory_stores/bedrock_knowledge_base/store.py
   - path: strands-ts/src/vended-memory-stores/bedrock-knowledge-base/store.ts
+addedDate: 2026-06-17
 sidebar:
   label: "Bedrock Knowledge Base"
-  badge:
-    text: New
-    variant: tip
 ---
 
 `BedrockKnowledgeBaseStore` is a [`MemoryStore`](./overview#stores) backed by [Amazon Bedrock Knowledge Bases](https://docs.aws.amazon.com/bedrock/latest/userguide/knowledge-base.html).

--- a/site/src/content/docs/user-guide/concepts/memory/overview.mdx
+++ b/site/src/content/docs/user-guide/concepts/memory/overview.mdx
@@ -7,10 +7,7 @@ sourceLinks:
   - path: strands-py/src/strands/memory/types.py
   - path: strands-ts/src/memory/memory-manager.ts
   - path: strands-ts/src/memory/types.ts
-sidebar:
-  badge:
-    text: New
-    variant: tip
+addedDate: 2026-06-17
 ---
 
 By default a Strands agent starts every conversation from zero: it cannot recall a user's preferences, past decisions, or anything it learned in an earlier session. The `MemoryManager` gives an agent long-term memory that persists across sessions.

--- a/site/src/content/docs/user-guide/concepts/memory/test-memory-store.mdx
+++ b/site/src/content/docs/user-guide/concepts/memory/test-memory-store.mdx
@@ -5,11 +5,9 @@ tags: [memory]
 sourceLinks:
   - path: strands-py/src/strands/vended_memory_stores/test_memory_store/store.py
   - path: strands-ts/src/vended-memory-stores/test-memory-store/store.ts
+addedDate: 2026-07-23
 sidebar:
   label: "Test Store"
-  badge:
-    text: New
-    variant: tip
 ---
 
 `TestMemoryStore` is a [`MemoryStore`](./overview#stores) backed by a JSON file.

--- a/site/src/content/docs/user-guide/concepts/plugins/context-injector.mdx
+++ b/site/src/content/docs/user-guide/concepts/plugins/context-injector.mdx
@@ -5,10 +5,7 @@ tags: [token-management]
 sourceLinks:
   - path: strands-py/src/strands/vended_plugins/context_injector/plugin.py
   - path: strands-ts/src/vended-plugins/context-injector/plugin.ts
-sidebar:
-  badge:
-    text: New
-    variant: tip
+addedDate: 2026-06-17
 ---
 
 The `ContextInjector` plugin folds real-time text into the model input before each call. The text is added to that single call's input only: it is never written to the conversation history, so it is not persisted or replayed on later turns. Use it for context the agent should always have but that does not belong in the stored history: the current time, a sandbox descriptor, environment facts, or a retrieval lookup.

--- a/site/src/content/docs/user-guide/concepts/plugins/context-offloader.mdx
+++ b/site/src/content/docs/user-guide/concepts/plugins/context-offloader.mdx
@@ -5,10 +5,7 @@ tags: [conversation-management, hooks, token-management]
 sourceLinks:
   - path: strands-py/src/strands/vended_plugins/context_offloader/plugin.py
   - path: strands-ts/src/vended-plugins/context-offloader/plugin.ts
-sidebar:
-  badge:
-    text: New
-    variant: tip
+addedDate: 2026-04-24
 ---
 
 The `ContextOffloader` plugin prevents large tool results from consuming your agent's context window. When a tool returns a result that exceeds a configurable token threshold, the plugin stores each content block individually in an external storage backend and replaces it in the conversation with a truncated preview plus per-block references. Each offloaded result includes inline guidance telling the agent to use its available tools to selectively access the data it needs.

--- a/site/src/content/docs/user-guide/concepts/plugins/goal-loop.mdx
+++ b/site/src/content/docs/user-guide/concepts/plugins/goal-loop.mdx
@@ -7,10 +7,7 @@ sourceLinks:
   - path: strands-py/src/strands/vended_plugins/goal/judge.py
   - path: strands-ts/src/vended-plugins/goal/plugin.ts
   - path: strands-ts/src/vended-plugins/goal/judge.ts
-sidebar:
-  badge:
-    text: New
-    variant: tip
+addedDate: 2026-06-15
 ---
 
 When your agent's response needs to meet a quality bar before returning, `GoalLoop` handles the retry loop. It validates the response after each invocation, feeds feedback back as a user message on failure, and re-invokes the agent. This continues until validation passes, a max attempt count is reached, or a timeout elapses.

--- a/site/src/content/docs/user-guide/concepts/plugins/skills.mdx
+++ b/site/src/content/docs/user-guide/concepts/plugins/skills.mdx
@@ -7,10 +7,7 @@ sourceLinks:
   - path: strands-py/src/strands/vended_plugins/skills/skill.py
   - path: strands-ts/src/vended-plugins/skills/agent-skills.ts
   - path: strands-ts/src/vended-plugins/skills/skill.ts
-sidebar:
-  badge:
-    text: New
-    variant: tip
+addedDate: 2026-03-11
 ---
 
 Skills give your agent on-demand access to specialized instructions without bloating the system prompt. Instead of front-loading every possible instruction into a single prompt, you define modular skill packages that the agent discovers and activates only when relevant.

--- a/site/src/content/docs/user-guide/concepts/sandbox/available-sandboxes.mdx
+++ b/site/src/content/docs/user-guide/concepts/sandbox/available-sandboxes.mdx
@@ -2,10 +2,7 @@
 title: Available Sandboxes
 description: "Use the built-in Docker and SSH sandboxes, drive a sandbox from your own code, and stream output from long-running commands."
 tags: [sandbox, tool-execution]
-sidebar:
-  badge:
-    text: New
-    variant: tip
+addedDate: 2026-06-17
 ---
 
 Strands provides two built-in Sandbox backends: `DockerSandbox` for containers on the local host, and `SshSandbox` for remote machines. Both automatically register `sandbox_shell` and `sandbox_file_editor` tools on the agent. This page covers their configuration, plus how to drive a sandbox directly from your own code.

--- a/site/src/content/docs/user-guide/concepts/sandbox/custom-sandbox.mdx
+++ b/site/src/content/docs/user-guide/concepts/sandbox/custom-sandbox.mdx
@@ -2,10 +2,7 @@
 title: Building a Custom Sandbox
 description: "Target an execution environment the built-in sandboxes do not cover: extend PosixShellSandbox or implement the Sandbox interface directly."
 tags: [sandbox, tool-execution]
-sidebar:
-  badge:
-    text: New
-    variant: tip
+addedDate: 2026-06-17
 ---
 
 Looking for something beyond the built-in implementations? Build a custom sandbox when your execution environment is not a local Docker container or an SSH host: a microVM, a cloud code-execution API, or a managed runtime. The agent loop, model, and vended tools all stay the same; you only implement the methods that run commands and access files in your backend.

--- a/site/src/content/docs/user-guide/concepts/sandbox/index.mdx
+++ b/site/src/content/docs/user-guide/concepts/sandbox/index.mdx
@@ -2,11 +2,9 @@
 title: Sandbox
 description: "Configure where an agent runs shell commands, executes code, and accesses a filesystem. Swap between Docker, SSH, or custom environments."
 tags: [sandbox, tool-execution]
+addedDate: 2026-06-17
 sidebar:
   label: "Overview"
-  badge:
-    text: New
-    variant: tip
 ---
 
 Agents are most effective when they can perform real actions rather than being constrained to text-only reasoning: executing shell commands, running code, and reading and writing files. But giving an agent unrestricted access to your host machine, especially the ability to run model-generated code, is a serious security risk.

--- a/site/src/content/docs/user-guide/concepts/storage.mdx
+++ b/site/src/content/docs/user-guide/concepts/storage.mdx
@@ -13,10 +13,7 @@ sourceLinks:
   - path: strands-ts/src/storage/in-memory-storage.ts
   - path: strands-ts/src/storage/local-file-storage.ts
   - path: strands-ts/src/storage/s3-storage.ts
-sidebar:
-  badge:
-    text: New
-    variant: tip
+addedDate: 2026-07-24
 ---
 
 To persist agent state between restarts, pass a Storage backend

--- a/site/src/route-middleware.ts
+++ b/site/src/route-middleware.ts
@@ -3,6 +3,7 @@ import { getCollection } from 'astro:content'
 import { buildPythonApiSidebar, buildTypeScriptApiSidebar, getPrevNextLinks, type DocInfo } from './dynamic-sidebar'
 import { pathWithBase } from './util/links'
 import { navLinks, type NavLink } from './config/navbar'
+import { isNew } from './util/new-badge'
 
 type SidebarEntry = StarlightRouteData['sidebar'][number]
 type SidebarGroup = Extract<SidebarEntry, { type: 'group' }>
@@ -22,9 +23,7 @@ export function findCurrentNavSection(currentPath: string, links: NavLink[]): Na
 
   for (const link of links) {
     if (link.external) continue
-    const basePaths = link.basePath
-      ? (Array.isArray(link.basePath) ? link.basePath : [link.basePath])
-      : [link.href]
+    const basePaths = link.basePath ? (Array.isArray(link.basePath) ? link.basePath : [link.basePath]) : [link.href]
     for (const bp of basePaths) {
       if (currentPath.startsWith(bp) && bp.length > bestMatchLength) {
         bestMatch = link
@@ -81,6 +80,39 @@ export function applyCollapse(items: SidebarEntry[], depth: number = 0): Sidebar
     }
     return item
   })
+}
+
+/**
+ * Add a "New" badge to sidebar links whose page is within the new-badge window.
+ * An explicit badge from frontmatter (e.g. Experimental) wins over the derived one.
+ */
+export function applyNewBadges(items: SidebarEntry[], newHrefs: Set<string>): SidebarEntry[] {
+  if (newHrefs.size === 0) return items
+  return items.map((item) => {
+    if (item.type === 'group') {
+      return { ...item, entries: applyNewBadges(item.entries, newHrefs) }
+    }
+    if (item.badge === undefined && newHrefs.has(item.href)) {
+      return { ...item, badge: { text: 'New', variant: 'tip' } }
+    }
+    return item
+  })
+}
+
+/**
+ * Collect hrefs of docs pages whose frontmatter addedDate falls within the
+ * new-badge window at build time.
+ */
+async function buildNewPageHrefs(buildDate: Date): Promise<Set<string>> {
+  const docs = await getCollection('docs')
+  const hrefs = new Set<string>()
+  for (const doc of docs) {
+    const addedDate = doc.data.addedDate as Date | undefined
+    if (addedDate && isNew(addedDate, buildDate)) {
+      hrefs.add(pathWithBase(`/${doc.id}/`))
+    }
+  }
+  return hrefs
 }
 
 /**
@@ -162,7 +194,7 @@ export const onRequest = defineRouteMiddleware(async (context) => {
   const currentNav = findCurrentNavSection(currentPath, navLinks)
 
   // If no matching nav section, show empty sidebar
-  if (!currentNav || currentNav.label == "Home") {
+  if (!currentNav || currentNav.label == 'Home') {
     starlightRoute.sidebar = []
     return
   }
@@ -173,7 +205,7 @@ export const onRequest = defineRouteMiddleware(async (context) => {
 
   // Otherwise filter it down to the major section that we're in
   const filteredSidebar = filterSidebarByBasePath(sidebar, allBasePaths)
-  starlightRoute.sidebar = applyCollapse(filteredSidebar)
+  starlightRoute.sidebar = applyNewBadges(applyCollapse(filteredSidebar), await buildNewPageHrefs(new Date()))
 
   // Starlight pre-computes pagination from the full sidebar before our middleware runs.
   // Prune any prev/next links that fall outside the current nav section, then override

--- a/site/src/route-middleware.ts
+++ b/site/src/route-middleware.ts
@@ -3,7 +3,7 @@ import { getCollection } from 'astro:content'
 import { buildPythonApiSidebar, buildTypeScriptApiSidebar, getPrevNextLinks, type DocInfo } from './dynamic-sidebar'
 import { pathWithBase } from './util/links'
 import { navLinks, type NavLink } from './config/navbar'
-import { isNew } from './util/new-badge'
+import { isNew, NEW_BADGE } from './util/new-badge'
 
 type SidebarEntry = StarlightRouteData['sidebar'][number]
 type SidebarGroup = Extract<SidebarEntry, { type: 'group' }>
@@ -93,7 +93,7 @@ export function applyNewBadges(items: SidebarEntry[], newHrefs: Set<string>): Si
       return { ...item, entries: applyNewBadges(item.entries, newHrefs) }
     }
     if (item.badge === undefined && newHrefs.has(item.href)) {
-      return { ...item, badge: { text: 'New', variant: 'tip' } }
+      return { ...item, badge: NEW_BADGE }
     }
     return item
   })

--- a/site/src/sidebar.ts
+++ b/site/src/sidebar.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import yaml from 'js-yaml'
-import { isNew } from './util/new-badge'
+import { isNew, NEW_BADGE } from './util/new-badge'
 
 // A badge rendered next to a sidebar label. A bare string is shorthand for the default variant.
 type SidebarBadge = string | { text: string; variant?: 'note' | 'tip' | 'caution' | 'danger' | 'success' | 'default' }
@@ -57,7 +57,7 @@ interface ConvertContext {
 function deriveGroupBadge(item: NavConfigItem, buildDate: Date): SidebarBadge | undefined {
   if (item.badge !== undefined) return item.badge
   if (item.addedDate && isNew(new Date(item.addedDate), buildDate)) {
-    return { text: 'New', variant: 'tip' }
+    return NEW_BADGE
   }
   return undefined
 }

--- a/site/src/sidebar.ts
+++ b/site/src/sidebar.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import yaml from 'js-yaml'
+import { isNew } from './util/new-badge'
 
 // A badge rendered next to a sidebar label. A bare string is shorthand for the default variant.
 type SidebarBadge = string | { text: string; variant?: 'note' | 'tip' | 'caution' | 'danger' | 'success' | 'default' }
@@ -18,6 +19,7 @@ interface NavConfigItem {
   slug?: string // For labeled leaf items "Adding Tools"
   collapsed?: boolean // Explicit collapse state for groups (overrides auto-collapse)
   badge?: SidebarBadge // Badge on a group label (leaf badges come from page frontmatter)
+  addedDate?: string | Date // Derives a "New" badge on a group for NEW_BADGE_DAYS; never hand-write one
 }
 type NavConfigEntry = string | NavConfigItem
 
@@ -49,6 +51,15 @@ interface NavigationConfig {
 
 interface ConvertContext {
   contentDir: string
+  buildDate: Date
+}
+
+function deriveGroupBadge(item: NavConfigItem, buildDate: Date): SidebarBadge | undefined {
+  if (item.badge !== undefined) return item.badge
+  if (item.addedDate && isNew(new Date(item.addedDate), buildDate)) {
+    return { text: 'New', variant: 'tip' }
+  }
+  return undefined
 }
 
 /**
@@ -86,11 +97,12 @@ function convertConfigItem(item: NavConfigEntry, ctx: ConvertContext): Starlight
 
       if (children.length === 0) return null
 
+      const badge = deriveGroupBadge(item, ctx.buildDate)
       return {
         label: item.label,
         items: children,
         ...(typeof item.collapsed === 'boolean' && { collapsed: item.collapsed }),
-        ...(item.badge !== undefined && { badge: item.badge }),
+        ...(badge !== undefined && { badge }),
       }
     }
 
@@ -115,11 +127,15 @@ export function loadNavigationConfig(configPath: string): NavigationConfig {
 /**
  * Load sidebar from navigation.yml config
  */
-export function loadSidebarFromConfig(configPath: string, docsContentDir?: string): StarlightSidebarItem[] {
+export function loadSidebarFromConfig(
+  configPath: string,
+  docsContentDir?: string,
+  buildDate: Date = new Date()
+): StarlightSidebarItem[] {
   const config = loadNavigationConfig(configPath)
   if (!config.sidebar) return []
 
-  const ctx: ConvertContext = { contentDir: docsContentDir || '' }
+  const ctx: ConvertContext = { contentDir: docsContentDir || '', buildDate }
 
   const items = config.sidebar
     .map((item) => convertConfigItem(item, ctx))

--- a/site/src/util/catalog.ts
+++ b/site/src/util/catalog.ts
@@ -4,6 +4,7 @@
  */
 
 import type { CatalogEntryData } from '../content.config'
+import { isNew } from './new-badge'
 
 export interface CatalogStats {
   stars?: number
@@ -31,9 +32,6 @@ export interface CatalogCardModel {
   stars?: number
   downloads?: number
 }
-
-/** Window (in days) during which an entry carries the derived "new" badge. */
-export const NEW_BADGE_DAYS = 30
 
 export function toCardModel(
   id: string,
@@ -70,8 +68,7 @@ export function toCardModel(
   const maintainer = new URL(data.github).pathname.split('/')[1] ?? ''
 
   const badges: string[] = [...data.badges]
-  const ageDays = (buildDate.getTime() - data.addedDate.getTime()) / 86_400_000
-  if (ageDays >= 0 && ageDays < NEW_BADGE_DAYS) badges.push('new')
+  if (isNew(data.addedDate, buildDate)) badges.push('new')
 
   // Primary link priority: on-site docs page, then the integration's own
   // Strands instructions page, then the bare GitHub repo.

--- a/site/src/util/new-badge.ts
+++ b/site/src/util/new-badge.ts
@@ -1,6 +1,9 @@
 /** Window (in days) during which a dated page, sidebar group, or catalog entry counts as new. */
 export const NEW_BADGE_DAYS = 30
 
+/** The sidebar badge derived for pages and groups within the window. */
+export const NEW_BADGE = { text: 'New', variant: 'tip' } as const
+
 export function isNew(addedDate: Date, buildDate: Date): boolean {
   const ageDays = (buildDate.getTime() - addedDate.getTime()) / 86_400_000
   return ageDays >= 0 && ageDays < NEW_BADGE_DAYS

--- a/site/src/util/new-badge.ts
+++ b/site/src/util/new-badge.ts
@@ -1,0 +1,7 @@
+/** Window (in days) during which a dated page, sidebar group, or catalog entry counts as new. */
+export const NEW_BADGE_DAYS = 30
+
+export function isNew(addedDate: Date, buildDate: Date): boolean {
+  const ageDays = (buildDate.getTime() - addedDate.getTime()) / 86_400_000
+  return ageDays >= 0 && ageDays < NEW_BADGE_DAYS
+}

--- a/site/test/catalog.test.ts
+++ b/site/test/catalog.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { toCardModel, sortEntries, NEW_BADGE_DAYS } from '../src/util/catalog'
+import { toCardModel, sortEntries } from '../src/util/catalog'
+import { NEW_BADGE_DAYS } from '../src/util/new-badge'
 import type { CatalogEntryData } from '../src/content.config'
 
 const BUILD_DATE = new Date('2026-07-17')

--- a/site/test/new-badge.test.ts
+++ b/site/test/new-badge.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { isNew, NEW_BADGE_DAYS } from '../src/util/new-badge'
+import { applyNewBadges } from '../src/route-middleware'
+import { loadSidebarFromConfig } from '../src/sidebar'
+
+const BUILD_DATE = new Date('2026-08-13T00:00:00Z')
+
+function daysBefore(days: number): Date {
+  return new Date(BUILD_DATE.getTime() - days * 86_400_000)
+}
+
+describe('isNew', () => {
+  it('is true within the window and false at its edge', () => {
+    expect(isNew(BUILD_DATE, BUILD_DATE)).toBe(true)
+    expect(isNew(daysBefore(NEW_BADGE_DAYS - 1), BUILD_DATE)).toBe(true)
+    expect(isNew(daysBefore(NEW_BADGE_DAYS), BUILD_DATE)).toBe(false)
+  })
+
+  it('is false for a future date', () => {
+    expect(isNew(daysBefore(-1), BUILD_DATE)).toBe(false)
+  })
+})
+
+describe('applyNewBadges', () => {
+  const link = (href: string, badge?: { text: string; variant: string }) =>
+    ({ type: 'link', label: href, href, isCurrent: false, badge, attrs: {} }) as never
+
+  const group = (entries: never[]) =>
+    ({ type: 'group', label: 'g', entries, collapsed: false, badge: undefined }) as never
+
+  it('adds a New badge to links in the set, including inside groups', () => {
+    const sidebar = applyNewBadges([link('/a/'), group([link('/b/')])], new Set(['/b/']))
+    expect((sidebar[0] as { badge?: unknown }).badge).toBeUndefined()
+    const nested = (sidebar[1] as { entries: { badge?: unknown }[] }).entries[0]
+    expect(nested.badge).toEqual({ text: 'New', variant: 'tip' })
+  })
+
+  it('keeps an explicit badge over the derived one', () => {
+    const explicit = { text: 'Experimental', variant: 'caution' }
+    const sidebar = applyNewBadges([link('/a/', explicit)], new Set(['/a/']))
+    expect((sidebar[0] as { badge?: unknown }).badge).toEqual(explicit)
+  })
+})
+
+describe('sidebar group addedDate', () => {
+  function loadFixtureSidebar(addedDate: string) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nav-'))
+    const configPath = path.join(dir, 'navigation.yml')
+    fs.writeFileSync(
+      configPath,
+      ['sidebar:', '  - label: Fresh', `    addedDate: ${addedDate}`, '    items:', '      - docs/example-page'].join(
+        '\n'
+      )
+    )
+    return loadSidebarFromConfig(configPath, undefined, BUILD_DATE)
+  }
+
+  it('derives a New badge inside the window and none outside it', () => {
+    const fresh = loadFixtureSidebar(daysBefore(1).toISOString().slice(0, 10))
+    expect(fresh[0]).toMatchObject({ badge: { text: 'New', variant: 'tip' } })
+
+    const stale = loadFixtureSidebar(
+      daysBefore(NEW_BADGE_DAYS + 1)
+        .toISOString()
+        .slice(0, 10)
+    )
+    expect(stale[0]).not.toHaveProperty('badge')
+  })
+})
+
+describe('no hand-written New badges', () => {
+  const docsDir = path.resolve('./src/content/docs')
+
+  function walkAuthoredDocs(dir: string): string[] {
+    return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      if (entry.isSymbolicLink()) return []
+      const full = path.join(dir, entry.name)
+      if (entry.isDirectory()) return walkAuthoredDocs(full)
+      return /\.mdx?$/.test(entry.name) ? [full] : []
+    })
+  }
+
+  function frontmatter(file: string): string {
+    const match = fs.readFileSync(file, 'utf-8').match(/^---\n([\s\S]*?)\n---/)
+    return match ? match[1] : ''
+  }
+
+  it('docs frontmatter uses addedDate, never a literal New badge', () => {
+    const offenders = walkAuthoredDocs(docsDir).filter((f) => /text:\s*['"]?New['"]?\s*$/m.test(frontmatter(f)))
+    expect(offenders, 'set addedDate in frontmatter instead of a literal New badge').toEqual([])
+  })
+
+  it('navigation.yml uses addedDate, never a literal New badge', () => {
+    const nav = fs.readFileSync(path.resolve('./src/config/navigation.yml'), 'utf-8')
+    expect(/text:\s*['"]?New['"]?\s*$/m.test(nav), 'set addedDate on the group instead of a literal New badge').toBe(
+      false
+    )
+  })
+})

--- a/site/test/new-badge.test.ts
+++ b/site/test/new-badge.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { isNew, NEW_BADGE_DAYS } from '../src/util/new-badge'
+import { isNew, NEW_BADGE, NEW_BADGE_DAYS } from '../src/util/new-badge'
 import { applyNewBadges } from '../src/route-middleware'
 import { loadSidebarFromConfig } from '../src/sidebar'
 
@@ -35,7 +35,7 @@ describe('applyNewBadges', () => {
     const sidebar = applyNewBadges([link('/a/'), group([link('/b/')])], new Set(['/b/']))
     expect((sidebar[0] as { badge?: unknown }).badge).toBeUndefined()
     const nested = (sidebar[1] as { entries: { badge?: unknown }[] }).entries[0]
-    expect(nested.badge).toEqual({ text: 'New', variant: 'tip' })
+    expect(nested.badge).toEqual(NEW_BADGE)
   })
 
   it('keeps an explicit badge over the derived one', () => {
@@ -46,28 +46,35 @@ describe('applyNewBadges', () => {
 })
 
 describe('sidebar group addedDate', () => {
-  function loadFixtureSidebar(addedDate: string) {
+  function loadFixtureSidebar(...groupFields: string[]) {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nav-'))
     const configPath = path.join(dir, 'navigation.yml')
     fs.writeFileSync(
       configPath,
-      ['sidebar:', '  - label: Fresh', `    addedDate: ${addedDate}`, '    items:', '      - docs/example-page'].join(
-        '\n'
-      )
+      [
+        'sidebar:',
+        '  - label: Fresh',
+        ...groupFields.map((field) => `    ${field}`),
+        '    items:',
+        '      - docs/example-page',
+      ].join('\n')
     )
     return loadSidebarFromConfig(configPath, undefined, BUILD_DATE)
   }
 
-  it('derives a New badge inside the window and none outside it', () => {
-    const fresh = loadFixtureSidebar(daysBefore(1).toISOString().slice(0, 10))
-    expect(fresh[0]).toMatchObject({ badge: { text: 'New', variant: 'tip' } })
+  const added = (days: number) => `addedDate: ${daysBefore(days).toISOString().slice(0, 10)}`
 
-    const stale = loadFixtureSidebar(
-      daysBefore(NEW_BADGE_DAYS + 1)
-        .toISOString()
-        .slice(0, 10)
-    )
-    expect(stale[0]).not.toHaveProperty('badge')
+  it('derives a New badge inside the window and none outside it', () => {
+    expect(loadFixtureSidebar(added(1))[0]).toMatchObject({ badge: NEW_BADGE })
+    expect(loadFixtureSidebar(added(NEW_BADGE_DAYS + 1))[0]).not.toHaveProperty('badge')
+  })
+
+  it('derives no badge for a future addedDate', () => {
+    expect(loadFixtureSidebar(added(-1))[0]).not.toHaveProperty('badge')
+  })
+
+  it('keeps an explicit group badge over the derived one', () => {
+    expect(loadFixtureSidebar('badge: Preview', added(1))[0]).toMatchObject({ badge: 'Preview' })
   })
 })
 


### PR DESCRIPTION
## Description

Docs pages mark newly shipped features with a hand-written `New` sidebar badge, and nothing ever removes them: pages badged in March were still marked New in August. The integrations catalog already solved this by deriving its New badge from an `addedDate` field for 30 days at build time; this PR extends that mechanism to the docs sidebar.

Pages now declare `addedDate` in frontmatter, and sidebar groups declare it in navigation.yml since they have no frontmatter. The badge is derived at build time and disappears at the first deploy after 30 days. An explicit frontmatter badge such as `Experimental` still wins over the derived one, and a unit test rejects literal `text: New` badges so the dated field is the only way to get one. The 30-day window moves to a shared helper that the catalog now imports too.

The 19 existing hand-written badges are migrated with dates taken from the commits that introduced them. Only Storage and Test Memory Store are still within the window; the other 17 badges drop on the next deploy.

One callout: expiry happens at build time, so a badge past day 30 disappears at the next site deploy rather than on the day itself. With the site deploying on every merge to main, that is close enough in practice.

## Related Issues

None.

## Documentation PR

Included: the migrated frontmatter under `site/src/content/docs/` and the navigation.yml comment documenting the mechanism.

## Type of Change

Other (please describe): documentation site build mechanism

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

Ran the site checks locally: `npm test` (all 36 files pass, including new coverage for the badge window, group derivation, badge precedence, and the literal-badge guard), `npm run typecheck`, `npm run typecheck:snippets` against a freshly built TS SDK, and `npm run cms:build`. Also ran a full `npm run build` and inspected the built sidebar HTML: exactly the two pages still within the window carry a New badge, no groups do, and existing Experimental badges are unaffected.

- [ ] I ran `hatch run prepare` (not applicable, site-only change)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
