### PR TITLE
fix(a2a): forward tool_stream events to A2A clients

### DIFF
--- a/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
@@ -455,6 +455,105 @@ A task with a pending interrupt also rejects an ordinary conversational message 
 
 A `DataPart` without an `interruptResponse` key is unaffected and continues to reach the agent as structured data.
 
+### Streaming Tool Progress
+
+:::note[Python only]
+This feature is currently available in the Python SDK only.
+:::
+
+A [streaming tool](../tools/custom-tools.md#tool-streaming) yields values while it runs. The
+server forwards each yield to the client as a `working` status update, so a client watching
+`message/stream` sees progress while a long running tool executes. This needs no configuration.
+
+The server forwards every yield, including the last one. A tool's last yield is also its return
+value, so the client receives the tool's result as a chunk as well.
+
+The update carries a single `DataPart` and no `TextPart`:
+
+```json
+{
+  "kind": "data",
+  "data": {
+    "toolStream": {
+      "toolUseId": "tu-1",
+      "name": "fetch_report",
+      "data": {"progress": 25}
+    }
+  }
+}
+```
+
+Tool progress is progress, not output, so it never enters the `agent_response` artifact.
+A client that concatenates artifacts, or one that reads the text of every status update,
+still sees the agent's answer alone. Only a client that reads the `toolStream` key sees
+the tool progress.
+
+`A2AAgent` reads these chunks, unlike an interrupt. `stream_async` yields every protocol
+event, so the chunks arrive as `working` status updates while the tool runs:
+
+```python
+from a2a.types import DataPart, TaskStatusUpdateEvent
+
+async for event in a2a_agent.stream_async("Generate the report"):
+    if event.get("type") != "a2a_stream" or not isinstance(event["event"], tuple):
+        continue
+
+    _task, update = event["event"]
+    if not isinstance(update, TaskStatusUpdateEvent) or update.status.message is None:
+        continue
+
+    for part in update.status.message.parts:
+        if isinstance(part.root, DataPart) and "toolStream" in part.root.data:
+            chunk = part.root.data["toolStream"]
+            print(f"{chunk['name']}: {chunk['data']}")
+```
+
+`invoke` and `invoke_async` return the final result alone, so they never carry progress.
+
+`data` holds whatever the tool yielded. A yield the transport cannot encode as JSON
+degrades to its string form, so one bad yield never fails the task.
+
+The whole yield degrades together, not the one field at fault. A dict that holds a single
+unencodable value arrives as one string, not as a dict with one string field. Read `data`
+defensively, and expect a string wherever you expect an object.
+
+#### Agents Used as Tools
+
+An [agent used as a tool](agents-as-tools.md) does not choose what it yields — the SDK forwards
+the sub-agent's whole stream: a per-token delta for every token generated, the lifecycle events
+around each cycle, and one completed message at the end of each turn.
+
+The server reduces those to tool activity: which tool the sub-agent ran and how it ended, one
+update per completed message and none for a sub-agent that runs no tools. `data` holds a
+`subAgent` list of blocks stripped of their payloads:
+
+```json
+{
+  "toolStream": {
+    "toolUseId": "a4b2...",
+    "name": "researcher",
+    "data": {"subAgent": [{"toolUse": {"toolUseId": "t1", "name": "customer_lookup"}}]}
+  }
+}
+```
+
+A `toolResult` block reports `toolUseId` and `status` the same way. The `toolUseId` is the
+sub-agent's own, forwarded so a client can pair a tool starting with the update that reports how
+it ended, which matters when a sub-agent runs several tools at once.
+
+Nothing else about the message travels: tool inputs and results, the sub-agent's text and
+reasoning, token usage and message tracking ids all stay server-side. The parent agent's own
+answer is what discloses a sub-agent's work to the client, and it is free to summarize or
+withhold. A client gets enough to show "the researcher is running customer_lookup" and no content
+it was not meant to see.
+
+:::caution[A tool that relays a sub-agent's stream itself]
+A tool that runs `agent.stream_async` and yields the raw events is choosing those yields, so the
+server forwards every one and `data` holds a raw Strands event rather than the shape above. Yield
+a curated progress value instead of the raw event, or a long sub-agent answer becomes thousands
+of status updates.
+:::
+
 ### Server Configuration Options
 
 <Tabs>

--- a/site/src/content/docs/user-guide/concepts/streaming/index.mdx
+++ b/site/src/content/docs/user-guide/concepts/streaming/index.mdx
@@ -93,6 +93,7 @@ Each event emitted from the TypeScript agent is a class with a `type` attribute 
 - **`tool_stream_event`**: Information about [an event streamed from a tool](../tools/custom-tools.md#tool-streaming), including:
     - **`tool_use`**: The [`ToolUse`](@api/python/strands.types.tools#ToolUse) for the tool that streamed the event
     - **`data`**: The data streamed from the tool
+    - **`sub_agent`**: `True` when the event came from an [agent used as a tool](../multi-agent/agents-as-tools.md), absent otherwise
 </Tab>
 <Tab label="TypeScript">
 - **`BeforeToolCallEvent`**: Before a tool is executed

--- a/strands-py/src/strands/multiagent/a2a/executor.py
+++ b/strands-py/src/strands/multiagent/a2a/executor.py
@@ -64,6 +64,11 @@ INTERRUPT_RESPONSE_KEY = "interruptResponse"
 # Each entry carries the `interruptId` that the matching interrupt response must echo back.
 INTERRUPTS_KEY = "interrupts"
 
+# Key under which a `working` status message carries one chunk yielded by a streaming tool. The
+# chunk travels in a DataPart alone: clients that concatenate the text of every status update read
+# the agent's answer, and only a client that reads this key sees the tool progress.
+TOOL_STREAM_KEY = "toolStream"
+
 # What this executor invokes the agent with: fresh conversational content, or interrupt responses
 # resuming a task parked in `input_required`. Deliberately narrower than the public `AgentInput`,
 # which also admits `str`, `Messages`, and `None` — an A2A message only ever converts to these two.
@@ -80,14 +85,39 @@ def _is_interrupt_resume(prompt: _AgentPrompt) -> bool:
 def _jsonable(value: Any) -> Any:
     """Return a value unchanged when it can cross the JSON-RPC boundary, else its string form.
 
-    An interrupt reason is arbitrary user data. A value the transport cannot encode would otherwise
-    surface only while serializing the response, long after the interrupt details are assembled.
+    An interrupt reason and a tool yield are both arbitrary user data. A value the transport cannot
+    encode would otherwise surface only while serializing the response, long after it is assembled.
     """
     try:
         json.dumps(value)
     except (TypeError, ValueError):
         return str(value)
     return value
+
+
+def _sub_agent_progress(data: Any) -> list[dict[str, Any]] | None:
+    """A sub-agent's tool activity for one completed message, with every payload removed.
+
+    Returns None when the message carries no tool activity to report.
+
+    A sub-agent's messages are the SDK's to forward rather than the tool author's, so they are
+    reduced to which tool ran and how it ended. Tool inputs and results, text, reasoning, usage
+    metrics and tracking ids stay server-side: the parent agent decides what of a sub-agent's work
+    reaches the client, and its own answer is the vehicle for that.
+    """
+    message = data.get("message") if isinstance(data, dict) else None
+    if not isinstance(message, dict):
+        return None
+
+    activity: list[dict[str, Any]] = []
+    for block in message.get("content", []):
+        if tool_use := block.get("toolUse"):
+            activity.append({"toolUse": {"toolUseId": tool_use.get("toolUseId"), "name": tool_use.get("name")}})
+        elif tool_result := block.get("toolResult"):
+            activity.append(
+                {"toolResult": {"toolUseId": tool_result.get("toolUseId"), "status": tool_result.get("status")}}
+            )
+    return activity or None
 
 
 @dataclass
@@ -474,14 +504,17 @@ class StrandsA2AExecutor(AgentExecutor):
         task updates and handling the final result when streaming is complete.
 
         Args:
-            event: The streaming event from the agent, containing either 'data' for
-                incremental content or 'result' for the final response.
+            event: The streaming event from the agent, containing 'data' for incremental content,
+                'tool_stream_event' for a chunk yielded by a streaming tool, or 'result' for the
+                final response.
             updater: The task updater for managing task state and sending updates.
             stream_state: Per-invocation streaming state when A2A-compliant streaming is enabled,
                 else None.
         """
         logger.debug("Streaming event: %s", event)
-        if "data" in event:
+        if tool_stream_event := event.get("tool_stream_event"):
+            await self._handle_tool_stream_event(tool_stream_event, updater)
+        elif "data" in event:
             if text_content := event["data"]:
                 if stream_state is not None:
                     await updater.add_artifact(
@@ -501,6 +534,41 @@ class StrandsA2AExecutor(AgentExecutor):
                             updater.task_id,
                         ),
                     )
+
+    async def _handle_tool_stream_event(self, tool_stream_event: dict[str, Any], updater: TaskUpdater) -> None:
+        """Forward one chunk yielded by a streaming tool as a `working` status update.
+
+        Tool progress is progress, not output, so it travels as a status update and leaves the
+        `agent_response` artifact holding the answer alone. The update carries a DataPart and no
+        TextPart, which keeps clients that read only prose unaffected. Both streaming modes share
+        this path, since a status update needs no artifact bookkeeping.
+
+        A tool's own yields are forwarded whole, since the tool chose them. An ``Agent.as_tool()``
+        sub-agent yields nothing deliberately — the SDK forwards its entire stream, a delta per
+        generated token plus one completed message per turn — so those are reduced to the tool
+        activity of each completed message: which tool ran and how it ended, and no payload.
+
+        Args:
+            tool_stream_event: The agent's `tool_stream_event` payload, holding the `tool_use` that
+                produced the chunk and the `data` it yielded.
+            updater: The task updater for managing task state and sending updates.
+        """
+        data = tool_stream_event["data"]
+        if tool_stream_event.get("sub_agent"):
+            if (activity := _sub_agent_progress(data)) is None:
+                return
+            data = {"subAgent": activity}
+
+        tool_use = tool_stream_event["tool_use"]
+        payload = {
+            "toolUseId": tool_use["toolUseId"],
+            "name": tool_use["name"],
+            "data": _jsonable(data),
+        }
+        await updater.update_status(
+            TaskState.working,
+            updater.new_agent_message(parts=[Part(root=DataPart(data={TOOL_STREAM_KEY: payload}))]),
+        )
 
     async def _handle_agent_result(
         self, result: SAAgentResult | None, updater: TaskUpdater, stream_state: _StreamState | None

--- a/strands-py/src/strands/types/_events.py
+++ b/strands-py/src/strands/types/_events.py
@@ -334,7 +334,8 @@ class AgentAsToolStreamEvent(ToolStreamEvent):
 
     Extends ToolStreamEvent with a reference to the originating _AgentAsTool so callers
     can distinguish sub-agent stream events from regular tool stream events and access
-    the wrapped agent, tool name, description, etc.
+    the wrapped agent, tool name, description, etc. The payload additionally carries
+    ``sub_agent``, for a consumer that sees only the emitted dict.
     """
 
     def __init__(self, tool_use: ToolUse, tool_stream_data: Any, agent_as_tool: "_AgentAsTool") -> None:
@@ -346,6 +347,9 @@ class AgentAsToolStreamEvent(ToolStreamEvent):
             agent_as_tool: The _AgentAsTool instance that produced this event.
         """
         super().__init__(tool_use, tool_stream_data)
+        # A consumer of the emitted dict has no other way to tell a sub-agent's forwarded event
+        # from a chunk the tool yielded itself: without this key the two payloads are identical.
+        self["tool_stream_event"]["sub_agent"] = True
         self._agent_as_tool = agent_as_tool
 
     @property

--- a/strands-py/tests/strands/multiagent/a2a/test_executor.py
+++ b/strands-py/tests/strands/multiagent/a2a/test_executor.py
@@ -10,6 +10,7 @@ from a2a.utils.errors import ServerError
 
 from strands.agent.agent_result import AgentResult as SAAgentResult
 from strands.multiagent.a2a.executor import StrandsA2AExecutor, _StreamState
+from strands.types._events import AgentAsToolStreamEvent
 from strands.types.content import ContentBlock
 
 # Suppress A2A compliance warnings for legacy streaming mode tests, and the single-agent
@@ -2729,3 +2730,215 @@ async def test_interrupt_without_details_sends_no_data_part(mock_strands_agent, 
     parts = _input_required_message(mock_event_queue).parts
     assert not [p for p in parts if isinstance(p.root, DataPart)]
     assert isinstance(parts[0].root, TextPart)
+
+
+# --- streaming-tool progress ---------------------------------------------------------------------
+# Guards https://github.com/strands-agents/harness-sdk/issues/3749. Every yield of a streaming tool
+# reaches the client as a working status update, in both streaming modes, and the agent_response
+# artifact still holds the answer alone.
+
+
+def _working_status_messages(mock_event_queue):
+    """The status messages from every working event on the queue."""
+    from a2a.types import TaskState, TaskStatusUpdateEvent
+
+    events = [call[0][0] for call in mock_event_queue.enqueue_event.call_args_list]
+    return [
+        event.status.message
+        for event in events
+        if isinstance(event, TaskStatusUpdateEvent) and event.status.state == TaskState.working
+    ]
+
+
+def _working_status_data(mock_event_queue):
+    """The data of every working status part, grouped per message so the part count is pinned."""
+    return [[part.root.data for part in message.parts] for message in _working_status_messages(mock_event_queue)]
+
+
+def _tool_stream_chunk(data, tool_use_id="tu-1", name="fetch_report"):
+    """The event dict the agent emits when a streaming tool yields a chunk."""
+    from strands.types._events import ToolStreamEvent
+
+    return ToolStreamEvent({"toolUseId": tool_use_id, "name": name, "input": {}}, data).as_dict()
+
+
+def _sub_agent_chunk(data, tool_use_id="tu-2", name="researcher"):
+    """The event dict an agent used as a tool emits while its sub-agent streams."""
+    return AgentAsToolStreamEvent({"toolUseId": tool_use_id, "name": name, "input": {}}, data, MagicMock()).as_dict()
+
+
+def _tool_stream_payloads(mock_event_queue):
+    """The toolStream payload of every working status part that carries one."""
+    return [
+        data["toolStream"] for parts in _working_status_data(mock_event_queue) for data in parts if "toolStream" in data
+    ]
+
+
+async def _run_with_stream_events(executor, mock_strands_agent, mock_request_context, mock_event_queue, events):
+    """Drive one execution whose agent emits the given stream events before completing."""
+    mock_result = MagicMock(spec=SAAgentResult)
+    mock_result.stop_reason = "end_turn"
+    mock_result.__str__ = MagicMock(return_value="done")
+
+    async def mock_stream(agent_input, **kwargs):
+        for event in events:
+            yield event
+        yield {"result": mock_result}
+
+    mock_strands_agent.stream_async = MagicMock(side_effect=mock_stream)
+    _request_with_parts(mock_request_context, [_text_part("do the thing")], task_id="task-tool-stream")
+    await executor.execute(mock_request_context, mock_event_queue)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("compliant", [True, False], ids=["a2a_compliant", "legacy"])
+async def test_tool_stream_chunk_forwarded(compliant, mock_strands_agent, mock_request_context, mock_event_queue):
+    """A streaming tool's yield reaches the client in both modes, and the artifact stays clean."""
+    executor = StrandsA2AExecutor(mock_strands_agent, enable_a2a_compliant_streaming=compliant)
+    await _run_with_stream_events(
+        executor,
+        mock_strands_agent,
+        mock_request_context,
+        mock_event_queue,
+        [_tool_stream_chunk({"progress": 0.5})],
+    )
+
+    tru_messages = _working_status_data(mock_event_queue)
+    exp_messages = [[{"toolStream": {"toolUseId": "tu-1", "name": "fetch_report", "data": {"progress": 0.5}}}]]
+    assert tru_messages == exp_messages
+
+    # The chunk is progress, not output, so the artifact carries the answer alone.
+    tru_texts = _artifact_texts(mock_event_queue)
+    exp_texts = ["done"]
+    assert tru_texts == exp_texts
+
+
+@pytest.mark.asyncio
+async def test_tool_stream_forwards_every_chunk_in_order(mock_strands_agent, mock_request_context, mock_event_queue):
+    """Each yield is its own update, in order, and two tools stay separable by toolUseId."""
+    executor = StrandsA2AExecutor(mock_strands_agent)
+    await _run_with_stream_events(
+        executor,
+        mock_strands_agent,
+        mock_request_context,
+        mock_event_queue,
+        [
+            _tool_stream_chunk({"progress": 0.25}),
+            _tool_stream_chunk({"step": "fetch"}, tool_use_id="tu-2", name="lookup"),
+            _tool_stream_chunk({"progress": 0.75}),
+        ],
+    )
+
+    tru_messages = _working_status_data(mock_event_queue)
+    exp_messages = [
+        [{"toolStream": {"toolUseId": "tu-1", "name": "fetch_report", "data": {"progress": 0.25}}}],
+        [{"toolStream": {"toolUseId": "tu-2", "name": "lookup", "data": {"step": "fetch"}}}],
+        [{"toolStream": {"toolUseId": "tu-1", "name": "fetch_report", "data": {"progress": 0.75}}}],
+    ]
+    assert tru_messages == exp_messages
+
+
+@pytest.mark.asyncio
+async def test_tool_stream_status_update_carries_no_text_part(
+    mock_strands_agent, mock_request_context, mock_event_queue
+):
+    """A legacy client that concatenates working-update text must not pick up tool narration."""
+    executor = StrandsA2AExecutor(mock_strands_agent)
+    await _run_with_stream_events(
+        executor,
+        mock_strands_agent,
+        mock_request_context,
+        mock_event_queue,
+        [_tool_stream_chunk("searching"), {"data": "Here is "}],
+    )
+
+    messages = _working_status_messages(mock_event_queue)
+    tru_texts = [part.root.text for message in messages for part in message.parts if isinstance(part.root, TextPart)]
+    exp_texts = ["Here is "]
+    assert tru_texts == exp_texts
+
+
+class _Unserializable:
+    """A yield no JSON encoder accepts."""
+
+    def __str__(self):
+        return "<custom chunk>"
+
+
+@pytest.mark.asyncio
+async def test_tool_stream_chunk_that_is_not_json_falls_back_to_text(
+    mock_strands_agent, mock_request_context, mock_event_queue
+):
+    """A yield the transport cannot encode degrades to its string form rather than failing the task."""
+    executor = StrandsA2AExecutor(mock_strands_agent)
+    await _run_with_stream_events(
+        executor,
+        mock_strands_agent,
+        mock_request_context,
+        mock_event_queue,
+        [_tool_stream_chunk(_Unserializable())],
+    )
+
+    tru_messages = _working_status_data(mock_event_queue)
+    exp_messages = [[{"toolStream": {"toolUseId": "tu-1", "name": "fetch_report", "data": "<custom chunk>"}}]]
+    assert tru_messages == exp_messages
+
+
+@pytest.mark.asyncio
+async def test_sub_agent_stream_is_reduced_to_tool_activity(mock_strands_agent, mock_request_context, mock_event_queue):
+    """An agent used as a tool reports which tool ran and how it ended, and nothing else.
+
+    Its per-token events would each become a status update the task history retains, and its
+    completed messages carry the sub-agent's text, tool inputs and tool results — which the parent
+    agent's own answer, not a progress update, is responsible for disclosing.
+    """
+    executor = StrandsA2AExecutor(mock_strands_agent)
+    await _run_with_stream_events(
+        executor,
+        mock_strands_agent,
+        mock_request_context,
+        mock_event_queue,
+        [
+            _sub_agent_chunk({"init_event_loop": True}),
+            _sub_agent_chunk({"data": "Paris"}),
+            _sub_agent_chunk({"event": {"contentBlockDelta": {}}}),
+            _sub_agent_chunk(
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"toolUse": {"toolUseId": "t1", "name": "lookup", "input": {"q": "secret"}}}],
+                        "metadata": {"usage": {"inputTokens": 7}},
+                        "tracking_id": "trk-1",
+                    }
+                }
+            ),
+            _sub_agent_chunk(
+                {
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {"toolResult": {"toolUseId": "t1", "status": "success", "content": [{"text": "secret"}]}}
+                        ],
+                    }
+                }
+            ),
+            _sub_agent_chunk({"message": {"role": "assistant", "content": [{"text": "Paris is sunny."}]}}),
+            _tool_stream_chunk({"progress": 0.5}),
+        ],
+    )
+
+    tru_payloads = _tool_stream_payloads(mock_event_queue)
+    exp_payloads = [
+        {
+            "toolUseId": "tu-2",
+            "name": "researcher",
+            "data": {"subAgent": [{"toolUse": {"toolUseId": "t1", "name": "lookup"}}]},
+        },
+        {
+            "toolUseId": "tu-2",
+            "name": "researcher",
+            "data": {"subAgent": [{"toolResult": {"toolUseId": "t1", "status": "success"}}]},
+        },
+        {"toolUseId": "tu-1", "name": "fetch_report", "data": {"progress": 0.5}},
+    ]
+    assert tru_payloads == exp_payloads

--- a/strands-py/tests/strands/types/test__events.py
+++ b/strands-py/tests/strands/types/test__events.py
@@ -490,6 +490,20 @@ class TestAgentAsToolStreamEvent:
         assert event.agent_as_tool is mock_agent_as_tool
         assert event.tool_use_id == "agent_tool_123"
 
+    def test_payload_marks_the_chunk_as_a_sub_agent_event(self):
+        """The emitted dict carries the marker a consumer without the class needs.
+
+        Guards https://github.com/strands-agents/harness-sdk/issues/3749: the A2A executor sees
+        only the dict, and forwards a chunk a tool yielded itself but not a sub-agent's events.
+        """
+        tool_use: ToolUse = {"toolUseId": "id_123", "name": "researcher", "input": {}}
+
+        sub_agent_event = AgentAsToolStreamEvent(tool_use, {"data": "token"}, MagicMock()).as_dict()
+        tool_event = ToolStreamEvent(tool_use, {"progress": 1}).as_dict()
+
+        assert sub_agent_event["tool_stream_event"]["sub_agent"] is True
+        assert "sub_agent" not in tool_event["tool_stream_event"]
+
     def test_is_tool_stream_event_subclass(self):
         """Test that AgentAsToolStreamEvent is a ToolStreamEvent subclass."""
         tool_use: ToolUse = {


### PR DESCRIPTION
## Description

`StrandsA2AExecutor` converted only text chunks from `agent.stream_async`, so a streaming tool's yields stopped at the executor. A client watching `message/stream` saw nothing while a long-running tool ran.

Each yield now reaches the client as a `working` status update carrying a DataPart under the key `toolStream`:

```json
{
  "kind": "data",
  "data": {
    "toolStream": {"toolUseId": "tu-1", "name": "fetch_report", "data": {"progress": 25}}
  }
}
```

@yonib05 settled the mapping in [this comment](https://github.com/strands-agents/harness-sdk/issues/3749#issuecomment-5288978300), and this follows it: tool progress is progress rather than output, so it travels as a status update and leaves the `agent_response` artifact holding the answer alone. The update carries no `TextPart`, so a legacy client that concatenates the text of every status update is unaffected — only a client that reads the `toolStream` key sees the progress. Because a status update needs no artifact bookkeeping, one branch serves both streaming modes.

`data` passes through the existing `_jsonable` helper, since a tool yields arbitrary values. The `NaN`/`Infinity` hardening of that helper is split into its own PR, #3826, so this one carries no interrupt-path behavior change.

Forwarding is **on by default** and has no configuration. An opt-in flag was considered and rejected: a fix nobody discovers leaves the reported bug open for exactly the users who hit it.

## An agent used as a tool

A plain tool chooses what it yields, so its yields are forwarded whole. An agent used as a tool chooses nothing — `_AgentAsTool` forwards the sub-agent's entire stream, a delta per generated token plus a whole message per turn. Measured against a mocked model, a two-turn sub-agent with one tool call emits **21 events**:

| kind | count |
|---|---|
| `event` (raw model chunk) | 10 |
| `start` | 3 |
| `message` | 3 |
| `start_event_loop` | 2 |
| `init_event_loop` | 1 |
| callback dicts carrying `agent`, spans, `tool_config` | 2 |

Forwarding those whole has two costs. Every token becomes a status update that `a2a-sdk` persists into task history. And the messages carry the sub-agent's raw tool inputs and results, text, reasoning, usage metrics and `tracking_id` — handing a remote client more than the parent agent's own answer would. A sub-agent whose tool returns customer records would ship those records to the client while the parent answered "2 customers match."

So the SDK curates what the SDK synthesized, and leaves alone what a tool author wrote. `AgentAsToolStreamEvent` now marks its payload `sub_agent`, and those events are reduced to tool activity — which tool ran and how it ended, and nothing else:

```json
{"subAgent": [{"toolUse": {"toolUseId": "t1", "name": "customer_lookup"}}]}
{"subAgent": [{"toolResult": {"toolUseId": "t1", "status": "success"}}]}
```

The `toolUseId` is kept so a client can pair a tool starting with its completion when a sub-agent runs several at once. Inputs, results, text, reasoning, usage metrics and tracking ids never leave the server. The 21 events become 2 updates, and a sub-agent that runs no tools produces none — its answer arrives as the tool result, as it always did.

A tool that relays a sub-agent's stream itself *is* choosing those yields, so they are forwarded verbatim. That is deliberate: the [original report](https://github.com/strands-agents/harness-sdk/discussions/1145) is a swarm wrapped as a generator tool yielding curated progress strings, and filtering relay tools would re-break the case this issue exists to fix. The docs tell such a tool to yield a curated value rather than the raw event.

## Public API Changes

No Python API surface changes and no new constructor parameters.

Two wire-level additions, both documented:

- `toolStream` — the status-update key. `TOOL_STREAM_KEY` is a module-level constant beside `INTERRUPT_RESPONSE_KEY` and stays out of the package's `__all__`, matching that precedent.
- `sub_agent` — a new key on the `tool_stream_event` payload that `agent.stream_async` emits for an agent used as a tool. It is additive; a consumer that does not read it sees the payload it saw before. Added to the streaming reference page.

`A2AAgent.stream_async` surfaces the progress; `invoke` and `invoke_async` return the final result alone and never carry it.

Not addressed here: `strands-ts` has `toolStreamEvent` but its A2A executor does not forward it. Cross-SDK parity is worth a follow-up issue rather than widening this PR.

## Related Issues

Closes #3749

## Documentation PR

Included in this PR under `site/` — a "Streaming Tool Progress" section on the A2A page with the wire shape, a client-side read snippet, degradation semantics, an "Agents Used as Tools" subsection covering the redacted shape and what is withheld, and a caution for tools that relay a raw sub-agent stream. The `tool_stream_event` key list on the streaming page gains `sub_agent`.

## Type of Change

Bug fix

## Testing

Unit tests cover both streaming modes, multiple ordered chunks across two tool uses, the DataPart-only guarantee against a legacy text client, values the transport cannot encode, and the sub-agent reduction — asserting that lifecycle and per-token events are dropped while tool activity travels stripped of its payloads.

Beyond the suite, I exercised the change end to end against a real `Agent` driven by a mocked model, through the real `_AgentAsTool` and tool-decorator paths into the executor:

| tool shape | raw events | status updates |
|---|---|---|
| `Agent.as_tool()` | 21 | 2 |
| plain streaming tool | 4 | 4 |
| relay tool yielding curated strings | 2 | 2 |

I also ran a disclosure probe: a sub-agent whose tool returns a sentinel string containing fake customer records, asserting the sentinel, `tracking_id`, and usage-metric keys are all absent from every DataPart the executor emits. That probe is what caught the over-forwarding, and it now reports `LEAKED: none`.

- [x] I ran `hatch run prepare`

`4983 passed, 5 skipped` — format, lint, mypy, and the full suite.

Rebased onto current `main` afterwards and re-verified: 1051 tests in the affected suites, ruff clean, mypy reporting 5 errors that are **identical on a clean `main` checkout** (missing `numpy`/`pywebrtc_audio` stubs in `bidi/_audio.py`, and an `arg-type` in `a2a/_converters.py` — a file this PR does not touch).

The `site/` build passes locally and renders the new section. Its only failures are pre-existing broken links into `/docs/api/typescript/*`, caused by `.build/api-docs/typescript` being empty on a local checkout rather than by anything here.

Unrelated to this PR, but worth flagging: `hatch run prepare` on a clean checkout also reformats files nobody touched, so the committed tree disagrees with the ruff that `hatch` resolves (0.16.3 today, from the `>=0.13.0,<0.17.0` range). I reverted that churn rather than carry it here.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
