### PR TITLE
feat(mcp): added server/discover for SEP-2575

### DIFF
--- a/.github/workflows/python-test-lint.yml
+++ b/.github/workflows/python-test-lint.yml
@@ -88,7 +88,7 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-  mcp-v2-compat:
+  unit-test-mcp-v2:
     name: MCP 2.x Compat
     # The dependency pin is `mcp<2`, so the unit-test matrix only ever
     # exercises the 1.x line and the 2.x branches of `_compat` run against

--- a/strands-py/src/strands/tools/mcp/_compat.py
+++ b/strands-py/src/strands/tools/mcp/_compat.py
@@ -21,7 +21,7 @@ import httpx
 from mcp import ClientSession
 from mcp.types import ServerCapabilities
 
-__all__ = ["MCP_V2", "GetSessionIdCallback", "MCPError", "initialize_session", "streamable_http_transport"]
+__all__ = ["MCP_V2", "GetSessionIdCallback", "MCPError", "negotiate_session", "streamable_http_transport"]
 
 # Feature-probed rather than version-parsed so pre-releases and backports
 # resolve by capability: `ClientSession.discover` is the 2.x replacement for
@@ -44,14 +44,17 @@ except ImportError:
     GetSessionIdCallback = Callable[[], str | None]  # type: ignore[misc, assignment]
 
 
-async def initialize_session(session: ClientSession) -> tuple[str | None, ServerCapabilities | None]:
+async def negotiate_session(session: ClientSession) -> tuple[str | None, ServerCapabilities | None]:
     """Negotiate the connection on an entered session, on either `mcp` major line.
 
-    The 2026-07-28 spec replaced the mandatory `initialize` handshake with a
-    stateless `server/discover` probe (SEP-2575). `negotiate_auto` is the
-    official 2.x client's connect-time policy: it probes `server/discover`
-    first and falls back to the legacy handshake for pre-2026 servers, so
-    either server era works. It lives in a private module, so the forced-2.x
+    The 2026-07-28 spec (SEP-2575) removed the `initialize` handshake and
+    moved negotiation into a per-request `_meta` envelope that the 2.x client
+    stamps itself. `server/discover` is the optional up-front probe for the
+    server's supported versions and capabilities. `negotiate_auto` is the
+    official 2.x client's connect-time policy over it: it probes
+    `server/discover` first and falls back to the legacy handshake for
+    pre-2026 servers, so either server era works. It is importable from
+    `mcp.client.client` but not exported in an `__all__`, so the forced-2.x
     CI job is what catches a relocation.
 
     Args:
@@ -61,13 +64,13 @@ async def initialize_session(session: ClientSession) -> tuple[str | None, Server
         The server's instructions (if any) and advertised capabilities.
     """
     if MCP_V2:
-        from mcp.client._probe import negotiate_auto  # type: ignore[import-not-found]
+        from mcp.client.client import negotiate_auto  # type: ignore[import-not-found]
 
         await negotiate_auto(session)
         return session.instructions, session.server_capabilities  # type: ignore[attr-defined]
 
     init_result = await session.initialize()
-    return init_result.instructions, session.get_server_capabilities()
+    return init_result.instructions, session.get_server_capabilities()  # type: ignore[attr-defined]
 
 
 def streamable_http_transport(

--- a/strands-py/src/strands/tools/mcp/_compat.py
+++ b/strands-py/src/strands/tools/mcp/_compat.py
@@ -19,8 +19,9 @@ from typing import Any
 
 import httpx
 from mcp import ClientSession
+from mcp.types import ServerCapabilities
 
-__all__ = ["MCP_V2", "GetSessionIdCallback", "MCPError", "streamable_http_transport"]
+__all__ = ["MCP_V2", "GetSessionIdCallback", "MCPError", "initialize_session", "streamable_http_transport"]
 
 # Feature-probed rather than version-parsed so pre-releases and backports
 # resolve by capability: `ClientSession.discover` is the 2.x replacement for
@@ -41,6 +42,32 @@ except ImportError:
     from collections.abc import Callable
 
     GetSessionIdCallback = Callable[[], str | None]  # type: ignore[misc, assignment]
+
+
+async def initialize_session(session: ClientSession) -> tuple[str | None, ServerCapabilities | None]:
+    """Negotiate the connection on an entered session, on either `mcp` major line.
+
+    The 2026-07-28 spec replaced the mandatory `initialize` handshake with a
+    stateless `server/discover` probe (SEP-2575). `negotiate_auto` is the
+    official 2.x client's connect-time policy: it probes `server/discover`
+    first and falls back to the legacy handshake for pre-2026 servers, so
+    either server era works. It lives in a private module, so the forced-2.x
+    CI job is what catches a relocation.
+
+    Args:
+        session: An entered `ClientSession` that has not yet negotiated.
+
+    Returns:
+        The server's instructions (if any) and advertised capabilities.
+    """
+    if MCP_V2:
+        from mcp.client._probe import negotiate_auto  # type: ignore[import-not-found]
+
+        await negotiate_auto(session)
+        return session.instructions, session.server_capabilities  # type: ignore[attr-defined]
+
+    init_result = await session.initialize()
+    return init_result.instructions, session.get_server_capabilities()
 
 
 def streamable_http_transport(

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -61,7 +61,7 @@ from ...types.exceptions import MCPClientInitializationError, ToolProviderExcept
 from ...types.media import ImageFormat
 from ...types.tools import AgentTool, ToolResultContent, ToolResultStatus
 from ..tool_provider import ToolProvider
-from ._compat import MCPError, initialize_session, streamable_http_transport
+from ._compat import MCPError, negotiate_session, streamable_http_transport
 from .mcp_agent_tool import MCPAgentTool
 from .mcp_instrumentation import inject_trace_context, mcp_instrumentation
 from .mcp_tasks import DEFAULT_TASK_CONFIG, DEFAULT_TASK_POLL_TIMEOUT, DEFAULT_TASK_TTL, TasksConfig
@@ -1078,7 +1078,7 @@ class MCPClient(ToolProvider):
                     ),
                 ) as session:
                     self._log_debug_with_thread("initializing MCP session")
-                    instructions, caps = await initialize_session(session)
+                    instructions, caps = await negotiate_session(session)
 
                     self._log_debug_with_thread("session initialized successfully")
                     # Store server instructions from the handshake for Host applications

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -61,7 +61,7 @@ from ...types.exceptions import MCPClientInitializationError, ToolProviderExcept
 from ...types.media import ImageFormat
 from ...types.tools import AgentTool, ToolResultContent, ToolResultStatus
 from ..tool_provider import ToolProvider
-from ._compat import MCPError, streamable_http_transport
+from ._compat import MCPError, initialize_session, streamable_http_transport
 from .mcp_agent_tool import MCPAgentTool
 from .mcp_instrumentation import inject_trace_context, mcp_instrumentation
 from .mcp_tasks import DEFAULT_TASK_CONFIG, DEFAULT_TASK_POLL_TIMEOUT, DEFAULT_TASK_TTL, TasksConfig
@@ -1078,17 +1078,15 @@ class MCPClient(ToolProvider):
                     ),
                 ) as session:
                     self._log_debug_with_thread("initializing MCP session")
-                    init_result = await session.initialize()
+                    instructions, caps = await initialize_session(session)
 
                     self._log_debug_with_thread("session initialized successfully")
-                    # Store server instructions from InitializeResult for Host applications
-                    self.server_instructions = init_result.instructions
+                    # Store server instructions from the handshake for Host applications
+                    self.server_instructions = instructions
                     # Store the session for use while we await the close event
                     self._background_thread_session = session
 
-                    # Cache server task capability immediately after initialization
-                    # Capabilities are exchanged during session.initialize(), so this is available now
-                    caps = session.get_server_capabilities()
+                    # Capabilities are exchanged during the handshake, so this is available now
                     self._server_task_capable = (
                         caps is not None
                         and caps.tasks is not None

--- a/strands-py/tests/strands/tools/mcp/test__compat.py
+++ b/strands-py/tests/strands/tools/mcp/test__compat.py
@@ -19,7 +19,7 @@ import mcp.client.streamable_http as streamable_http_module
 import pytest
 
 from strands.tools.mcp import _compat
-from strands.tools.mcp._compat import MCPError, initialize_session, streamable_http_transport
+from strands.tools.mcp._compat import MCPError, negotiate_session, streamable_http_transport
 
 requires_mcp_v1 = pytest.mark.skipif(_compat.MCP_V2, reason="exercises the mcp 1.x branch")
 requires_mcp_v2 = pytest.mark.skipif(not _compat.MCP_V2, reason="exercises the mcp 2.x line")
@@ -71,14 +71,14 @@ def test_get_session_id_callback_falls_back_to_plain_callable(monkeypatch):
 
 @requires_mcp_v2
 def test_installed_v2_line_exposes_negotiate_auto():
-    """Test that the private negotiation policy `initialize_session` imports exists on the 2.x line."""
-    from mcp.client._probe import negotiate_auto
+    """Test that the negotiation policy `negotiate_session` imports exists on the 2.x line."""
+    from mcp.client.client import negotiate_auto
 
     assert callable(negotiate_auto)
 
 
 @pytest.mark.asyncio
-async def test_initialize_session_v1_runs_the_initialize_handshake(monkeypatch):
+async def test_negotiate_session_v1_runs_the_initialize_handshake(monkeypatch):
     """Test that the 1.x handshake is initialize(), with instructions read from its result."""
     monkeypatch.setattr(_compat, "MCP_V2", False)
     server_capabilities = MagicMock()
@@ -86,7 +86,7 @@ async def test_initialize_session_v1_runs_the_initialize_handshake(monkeypatch):
     session.initialize = AsyncMock(return_value=MagicMock(instructions="use the tools"))
     session.get_server_capabilities = MagicMock(return_value=server_capabilities)
 
-    instructions, capabilities = await initialize_session(session)
+    instructions, capabilities = await negotiate_session(session)
 
     session.initialize.assert_awaited_once_with()
     assert instructions == "use the tools"
@@ -94,25 +94,26 @@ async def test_initialize_session_v1_runs_the_initialize_handshake(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_initialize_session_v2_negotiates_and_reads_session_properties(monkeypatch):
+async def test_negotiate_session_v2_negotiates_and_reads_session_properties(monkeypatch):
     """Test that the 2.x handshake delegates to negotiate_auto and reads the session properties.
 
-    The `mcp.client._probe` module exists only on the 2.x line, so a stub
+    The `mcp.client.client` module exists only on the 2.x line, so a stub
     module stands in for it to exercise this branch under the 1.x pin.
     """
     monkeypatch.setattr(_compat, "MCP_V2", True)
     negotiate_auto = AsyncMock()
-    probe_module = ModuleType("mcp.client._probe")
-    probe_module.negotiate_auto = negotiate_auto  # type: ignore[attr-defined]
-    monkeypatch.setitem(sys.modules, "mcp.client._probe", probe_module)
+    client_module = ModuleType("mcp.client.client")
+    client_module.negotiate_auto = negotiate_auto  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "mcp.client.client", client_module)
     server_capabilities = MagicMock()
     session = MagicMock()
     session.instructions = "use the tools"
     session.server_capabilities = server_capabilities
 
-    instructions, capabilities = await initialize_session(session)
+    instructions, capabilities = await negotiate_session(session)
 
     negotiate_auto.assert_awaited_once_with(session)
+    session.initialize.assert_not_called()
     assert instructions == "use the tools"
     assert capabilities is server_capabilities
 

--- a/strands-py/tests/strands/tools/mcp/test__compat.py
+++ b/strands-py/tests/strands/tools/mcp/test__compat.py
@@ -9,17 +9,20 @@ the `MCP_V2` flag forced.
 """
 
 import importlib
+import sys
 from collections.abc import Callable
 from contextlib import asynccontextmanager
-from unittest.mock import MagicMock, patch
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import mcp.client.streamable_http as streamable_http_module
 import pytest
 
 from strands.tools.mcp import _compat
-from strands.tools.mcp._compat import MCPError, streamable_http_transport
+from strands.tools.mcp._compat import MCPError, initialize_session, streamable_http_transport
 
 requires_mcp_v1 = pytest.mark.skipif(_compat.MCP_V2, reason="exercises the mcp 1.x branch")
+requires_mcp_v2 = pytest.mark.skipif(not _compat.MCP_V2, reason="exercises the mcp 2.x line")
 requires_v2_transport_names = pytest.mark.skipif(
     not hasattr(streamable_http_module, "streamable_http_client"),
     reason="installed mcp line lacks the 2.x transport names",
@@ -64,6 +67,54 @@ def test_get_session_id_callback_falls_back_to_plain_callable(monkeypatch):
     finally:
         monkeypatch.undo()
         importlib.reload(_compat)
+
+
+@requires_mcp_v2
+def test_installed_v2_line_exposes_negotiate_auto():
+    """Test that the private negotiation policy `initialize_session` imports exists on the 2.x line."""
+    from mcp.client._probe import negotiate_auto
+
+    assert callable(negotiate_auto)
+
+
+@pytest.mark.asyncio
+async def test_initialize_session_v1_runs_the_initialize_handshake(monkeypatch):
+    """Test that the 1.x handshake is initialize(), with instructions read from its result."""
+    monkeypatch.setattr(_compat, "MCP_V2", False)
+    server_capabilities = MagicMock()
+    session = MagicMock()
+    session.initialize = AsyncMock(return_value=MagicMock(instructions="use the tools"))
+    session.get_server_capabilities = MagicMock(return_value=server_capabilities)
+
+    instructions, capabilities = await initialize_session(session)
+
+    session.initialize.assert_awaited_once_with()
+    assert instructions == "use the tools"
+    assert capabilities is server_capabilities
+
+
+@pytest.mark.asyncio
+async def test_initialize_session_v2_negotiates_and_reads_session_properties(monkeypatch):
+    """Test that the 2.x handshake delegates to negotiate_auto and reads the session properties.
+
+    The `mcp.client._probe` module exists only on the 2.x line, so a stub
+    module stands in for it to exercise this branch under the 1.x pin.
+    """
+    monkeypatch.setattr(_compat, "MCP_V2", True)
+    negotiate_auto = AsyncMock()
+    probe_module = ModuleType("mcp.client._probe")
+    probe_module.negotiate_auto = negotiate_auto  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "mcp.client._probe", probe_module)
+    server_capabilities = MagicMock()
+    session = MagicMock()
+    session.instructions = "use the tools"
+    session.server_capabilities = server_capabilities
+
+    instructions, capabilities = await initialize_session(session)
+
+    negotiate_auto.assert_awaited_once_with(session)
+    assert instructions == "use the tools"
+    assert capabilities is server_capabilities
 
 
 @requires_mcp_v1


### PR DESCRIPTION
## Description

Another work for `mcp` 2.x in the Python SDK. 

`mcp` 2.0 renamed and moved several things we import, and the new spec (SEP-2575) replaced the `initialize` handshake with `server/discover`. Instead of scattering version checks around the codebase, this PR adds one module, `strands.tools.mcp._compat`, that handles the differences. Everything else imports from it and doesn't care which version is installed.

What's in `_compat`:

- `MCP_V2` tells you which major version is installed. It checks `hasattr(ClientSession, "discover")` instead of parsing the package version, so pre-releases and backports still work.
- `initialize_session()` sets up the connection on either version. On 2.x it uses the client's own `negotiate_auto`, which tries `server/discover` first and falls back to the old handshake for older servers. On 1.x it calls `session.initialize()` like before.
- `streamable_http_transport()` keeps the old `(url, headers, auth)` signature on both versions. The 2.x replacement takes a pre-built HTTPX client and only closes clients it created itself, so the wrapper builds the client and closes it when the transport closes. Otherwise we'd leak connections. Follow-up to #3708.
- Plain renames: `MCPError` (1.x spells it `McpError`) and `GetSessionIdCallback` (gone in 2.x, so it becomes a plain callable type there).

`mcp_instrumentation.py` now uses the shared `MCP_V2` flag instead of its own version check (`_is_mcp_v1`). The server-side OTEL patches still only apply on 1.x.

## Related Issues

Part of #1659.

## Type of Change

New feature

## Testing

- New `tests/strands/tools/mcp/test__compat.py` covers both versions. The version-specific tests patch real attributes on the installed package (no `create=True`) and skip when the installed version doesn't have them.
- New `mcp-v2-compat` CI job installs `mcp==2.0.*` over the pin and checks against the real package: `import strands` works, `MCP_V2` is true, and the compat tests pass. It pins `2.0.*` so new `mcp` releases can't break unrelated PRs.
- New `make_mcp_error` helper in conftest builds the error type for whichever version is installed, since 2.x changed the constructor. The elicitation tests use it.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [ ] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
