### PR TITLE
docs: add note for disabling conversation managers

### DIFF
--- a/site/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
@@ -45,11 +45,18 @@ or [build your own manager](#creating-a-conversationmanager) that matches your r
 
 ### NullConversationManager
 
-The [`NullConversationManager`](@api/python/strands.agent.conversation_manager.null_conversation_manager#NullConversationManager) is a simple implementation that does not modify the conversation history. It's useful for:
+The [`NullConversationManager`](@api/python/strands.agent.conversation_manager.null_conversation_manager#NullConversationManager) is a simple implementation that does not modify the conversation history. Pass it explicitly to turn off the default [`SlidingWindowConversationManager`](#slidingwindowconversationmanager) and keep the full conversation history. It's useful for:
 
 - Short conversations that won't exceed context limits
 - Debugging purposes
 - Cases where you want to manage context manually
+
+:::note
+Omitting <Syntax py="conversation_manager" ts="conversationManager" /> — or passing
+<Syntax py="conversation_manager=None" ts="conversationManager: undefined" /> — selects
+the default sliding window. It does **not** disable trimming. To keep the full history,
+pass a `NullConversationManager` instance explicitly.
+:::
 
 <Tabs>
 <Tab label="Python">
@@ -75,7 +82,7 @@ agent = Agent(
 
 ### SlidingWindowConversationManager
 
-The [`SlidingWindowConversationManager`](@api/python/strands.agent.conversation_manager.sliding_window_conversation_manager#SlidingWindowConversationManager) implements a sliding window strategy that maintains a fixed number of recent messages. This is the default conversation manager used by the Agent class.
+The [`SlidingWindowConversationManager`](@api/python/strands.agent.conversation_manager.sliding_window_conversation_manager#SlidingWindowConversationManager) implements a sliding window strategy that maintains a fixed number of recent messages. This is the default conversation manager used by the Agent class when no <Syntax py="conversation_manager" ts="conversationManager" /> is specified. To turn it off and keep the full history, pass a [`NullConversationManager`](#nullconversationmanager).
 
 <Tabs>
 <Tab label="Python">


### PR DESCRIPTION
## Description

Add clarifying note on default conversation manager, and that NullConversationManager should be used to disable.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Documentation update

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
