### PR TITLE
fix(a2a): reject NaN and Infinity at the JSON-RPC boundary

### DIFF
--- a/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
+++ b/site/src/content/docs/user-guide/concepts/multi-agent/agent-to-agent.mdx
@@ -406,6 +406,10 @@ Each interrupt has a server-generated id, and an answer is bound to the id of th
 }
 ```
 
+The `reason` is whatever the tool passed to `interrupt()`. A reason that is not
+JSON-encodable — a custom object, or a non-finite number like `NaN` — arrives as its
+string form instead.
+
 To answer, send a new message on the same `taskId` containing a `DataPart` that echoes the `interruptId` back with the response:
 
 ```json

--- a/strands-py/src/strands/multiagent/a2a/executor.py
+++ b/strands-py/src/strands/multiagent/a2a/executor.py
@@ -84,7 +84,9 @@ def _jsonable(value: Any) -> Any:
     surface only while serializing the response, long after the interrupt details are assembled.
     """
     try:
-        json.dumps(value)
+        # allow_nan=False rejects NaN and Infinity, which json.dumps otherwise emits as bare
+        # literals that a strict JSON-RPC client refuses to parse.
+        json.dumps(value, allow_nan=False)
     except (TypeError, ValueError):
         return str(value)
     return value

--- a/strands-py/src/strands/multiagent/a2a/executor.py
+++ b/strands-py/src/strands/multiagent/a2a/executor.py
@@ -12,6 +12,7 @@ import asyncio
 import base64
 import json
 import logging
+import math
 import mimetypes
 import uuid
 import warnings
@@ -83,10 +84,13 @@ def _jsonable(value: Any) -> Any:
     An interrupt reason is arbitrary user data. A value the transport cannot encode would otherwise
     surface only while serializing the response, long after the interrupt details are assembled.
     """
+    if isinstance(value, float) and not math.isfinite(value):
+        # A non-finite float is not valid JSON. pydantic's response serialization silently turns it
+        # into null, so the reason vanishes with no error; degrade just this scalar to a string and
+        # leave a structured reason's shape intact.
+        return str(value)
     try:
-        # allow_nan=False rejects NaN and Infinity, which json.dumps otherwise emits as bare
-        # literals that a strict JSON-RPC client refuses to parse.
-        json.dumps(value, allow_nan=False)
+        json.dumps(value)
     except (TypeError, ValueError):
         return str(value)
     return value

--- a/strands-py/tests/strands/multiagent/a2a/test_executor.py
+++ b/strands-py/tests/strands/multiagent/a2a/test_executor.py
@@ -2694,16 +2694,30 @@ async def test_interrupt_advertises_every_pending_id(mock_strands_agent, mock_re
     assert tru_ids == exp_ids
 
 
+class _UnserializableReason:
+    """A reason no JSON encoder accepts."""
+
+    def __str__(self):
+        return "<custom reason>"
+
+
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("reason", "exp_reason"),
+    [
+        (_UnserializableReason(), "<custom reason>"),
+        # json.dumps emits NaN and Infinity as bare literals that a strict JSON-RPC client refuses.
+        (float("nan"), "nan"),
+        (float("inf"), "inf"),
+        # The whole reason degrades together, so one bad leaf collapses the dict around it.
+        ({"limit": float("inf"), "note": "cap"}, "{'limit': inf, 'note': 'cap'}"),
+    ],
+)
 async def test_interrupt_reason_that_is_not_json_falls_back_to_text(
-    mock_strands_agent, mock_request_context, mock_event_queue
+    reason, exp_reason, mock_strands_agent, mock_request_context, mock_event_queue
 ):
     """A reason the transport cannot encode degrades to its string form rather than failing late."""
     from strands.interrupt import Interrupt
-
-    class Unserializable:
-        def __str__(self):
-            return "<custom reason>"
 
     executor = StrandsA2AExecutor(mock_strands_agent)
     await _run_until_interrupt(
@@ -2711,12 +2725,11 @@ async def test_interrupt_reason_that_is_not_json_falls_back_to_text(
         mock_strands_agent,
         mock_request_context,
         mock_event_queue,
-        [Interrupt(id="int-1", name="approval", reason=Unserializable())],
+        [Interrupt(id="int-1", name="approval", reason=reason)],
     )
 
     data_parts = [p.root.data for p in _input_required_message(mock_event_queue).parts if isinstance(p.root, DataPart)]
     tru_reason = data_parts[0]["interrupts"][0]["reason"]
-    exp_reason = "<custom reason>"
     assert tru_reason == exp_reason
 
 

--- a/strands-py/tests/strands/multiagent/a2a/test_executor.py
+++ b/strands-py/tests/strands/multiagent/a2a/test_executor.py
@@ -1,6 +1,7 @@
 """Tests for the StrandsA2AExecutor class."""
 
 import base64
+import json
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -2639,7 +2640,7 @@ async def test_interrupt_advertises_ids_in_data_part(mock_strands_agent, mock_re
         mock_strands_agent,
         mock_request_context,
         mock_event_queue,
-        [Interrupt(id="v1:tool_call:tu-1:abc", name="approve_campaign", reason={"name": "spring"})],
+        [Interrupt(id="v1:tool_call:tu-1:abc", name="approve_campaign", reason={"name": "spring", "limit": 1.5})],
     )
 
     data_parts = [p.root.data for p in _input_required_message(mock_event_queue).parts if isinstance(p.root, DataPart)]
@@ -2647,7 +2648,11 @@ async def test_interrupt_advertises_ids_in_data_part(mock_strands_agent, mock_re
     exp_data = [
         {
             "interrupts": [
-                {"interruptId": "v1:tool_call:tu-1:abc", "name": "approve_campaign", "reason": {"name": "spring"}}
+                {
+                    "interruptId": "v1:tool_call:tu-1:abc",
+                    "name": "approve_campaign",
+                    "reason": {"name": "spring", "limit": 1.5},
+                }
             ]
         }
     ]
@@ -2706,17 +2711,17 @@ class _UnserializableReason:
     ("reason", "exp_reason"),
     [
         (_UnserializableReason(), "<custom reason>"),
-        # json.dumps emits NaN and Infinity as bare literals that a strict JSON-RPC client refuses.
+        # pydantic serializes a non-finite float to null, so the reason would vanish with no error.
         (float("nan"), "nan"),
         (float("inf"), "inf"),
-        # The whole reason degrades together, so one bad leaf collapses the dict around it.
-        ({"limit": float("inf"), "note": "cap"}, "{'limit': inf, 'note': 'cap'}"),
+        # Only the non-finite scalar degrades; a structured reason keeps its shape.
+        ({"limit": float("inf"), "note": "cap"}, {"limit": float("inf"), "note": "cap"}),
     ],
 )
 async def test_interrupt_reason_that_is_not_json_falls_back_to_text(
     reason, exp_reason, mock_strands_agent, mock_request_context, mock_event_queue
 ):
-    """A reason the transport cannot encode degrades to its string form rather than failing late."""
+    """A reason the wire would drop or reject degrades to its string form rather than vanishing."""
     from strands.interrupt import Interrupt
 
     executor = StrandsA2AExecutor(mock_strands_agent)
@@ -2730,6 +2735,27 @@ async def test_interrupt_reason_that_is_not_json_falls_back_to_text(
 
     data_parts = [p.root.data for p in _input_required_message(mock_event_queue).parts if isinstance(p.root, DataPart)]
     tru_reason = data_parts[0]["interrupts"][0]["reason"]
+    assert tru_reason == exp_reason
+
+
+@pytest.mark.asyncio
+async def test_interrupt_reason_survives_wire_serialization(mock_strands_agent, mock_request_context, mock_event_queue):
+    """The reason a client actually receives is the degraded text, not a silent null."""
+    from strands.interrupt import Interrupt
+
+    executor = StrandsA2AExecutor(mock_strands_agent)
+    await _run_until_interrupt(
+        executor,
+        mock_strands_agent,
+        mock_request_context,
+        mock_event_queue,
+        [Interrupt(id="int-1", name="approval", reason=float("nan"))],
+    )
+
+    wire = json.loads(_input_required_message(mock_event_queue).model_dump_json(exclude_none=True))
+    data_parts = [part for part in wire["parts"] if part["kind"] == "data"]
+    tru_reason = data_parts[0]["data"]["interrupts"][0]["reason"]
+    exp_reason = "nan"
     assert tru_reason == exp_reason
 
 


### PR DESCRIPTION
## Description

`_jsonable` guards the A2A executor's JSON-RPC boundary, but a non-finite float (`NaN`, `Infinity`) passes its `json.dumps` probe while pydantic's response serialization silently turns it into `null` (`ser_json_inf_nan` default) — the reason vanishes with no error, far from the interrupt that produced it. Guard non-finite float scalars explicitly and degrade them to their string form (`"nan"`, `"inf"`).

The guard is scalar-only on purpose: a structured reason keeps its JSON shape, so a dict with one non-finite leaf still arrives as a dict (the leaf becomes a `null` leaf on the wire, unchanged from today) rather than collapsing to an unparseable repr string.

Also adds a wire-level test pinning what a client actually receives (`model_dump_json` output, not the in-memory dict), finite-float coverage proving ordinary numbers pass unchanged, and a docs line on the degradation behavior.

Split out of #3817, which routes streaming-tool yields through the same helper and should not carry an interrupt-path behavior change.

## Related Issues

Split out of #3817.

## Documentation PR

None. One sentence on the degradation behavior added to `agent-to-agent.mdx` in this PR.

## Type of Change

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
