### PR TITLE
feat(site): add strands-dynamodb-storage to the catalog and tier compat-layer providers

### DIFF
--- a/site/src/content/catalog/agentcore-tool-search.yaml
+++ b/site/src/content/catalog/agentcore-tool-search.yaml
@@ -7,5 +7,4 @@ languages:
     package: bedrock-agentcore[strands-agents]
 github: https://github.com/aws/bedrock-agentcore-sdk-python
 docsPage: docs/integrations/plugins/agentcore-tool-search
-featured: true
 addedDate: 2026-01-01

--- a/site/src/content/catalog/cohere.yaml
+++ b/site/src/content/catalog/cohere.yaml
@@ -1,8 +1,9 @@
 name: cohere
 description: Cohere language models accessed through the Strands Agents OpenAI-compatibility layer, requiring only the strands-agents[openai] extra.
 integrationType: model-provider
+maintainedBy: strands
 languages:
   python: {}
-github: https://github.com/strands-agents/harness-sdk
+github: https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/models/openai.py
 docsPage: docs/integrations/model-providers/cohere
 addedDate: 2026-01-01

--- a/site/src/content/catalog/crusoe.yaml
+++ b/site/src/content/catalog/crusoe.yaml
@@ -1,8 +1,9 @@
 name: crusoe
 description: Crusoe Managed Inference models on renewable-powered GPUs, accessed through the Strands Agents OpenAI-compatibility layer.
 integrationType: model-provider
+maintainedBy: strands
 languages:
   python: {}
-github: https://github.com/strands-agents/harness-sdk
+github: https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/models/openai.py
 docsPage: docs/integrations/model-providers/crusoe
 addedDate: 2026-07-31

--- a/site/src/content/catalog/datadog-ai-guard.yaml
+++ b/site/src/content/catalog/datadog-ai-guard.yaml
@@ -7,5 +7,4 @@ languages:
     package: ddtrace
 github: https://github.com/DataDog/dd-trace-py
 docsPage: docs/integrations/plugins/datadog-ai-guard
-featured: true
 addedDate: 2026-01-01

--- a/site/src/content/catalog/fireworksai.yaml
+++ b/site/src/content/catalog/fireworksai.yaml
@@ -1,8 +1,9 @@
 name: fireworksai
 description: Fireworks AI open-source model inference accessed through the Strands Agents OpenAI-compatibility layer, requiring only the strands-agents[openai] extra.
 integrationType: model-provider
+maintainedBy: strands
 languages:
   python: {}
-github: https://github.com/strands-agents/harness-sdk
+github: https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/models/openai.py
 docsPage: docs/integrations/model-providers/fireworksai
 addedDate: 2026-01-01

--- a/site/src/content/catalog/nebius-token-factory.yaml
+++ b/site/src/content/catalog/nebius-token-factory.yaml
@@ -1,8 +1,9 @@
 name: nebius-token-factory
 description: Nebius Token Factory fast open-source model inference, accessed through the Strands Agents OpenAI-compatibility layer.
 integrationType: model-provider
+maintainedBy: strands
 languages:
   python: {}
-github: https://github.com/strands-agents/harness-sdk
+github: https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/models/openai.py
 docsPage: docs/integrations/model-providers/nebius-token-factory
 addedDate: 2026-01-01

--- a/site/src/content/catalog/ovhcloud-ai-endpoints.yaml
+++ b/site/src/content/catalog/ovhcloud-ai-endpoints.yaml
@@ -1,8 +1,9 @@
 name: ovhcloud-ai-endpoints
 description: OVHcloud AI Endpoints, a European OpenAI-compatible inference service for Strands Agents with GDPR-compliant data sovereignty.
 integrationType: model-provider
+maintainedBy: strands
 languages:
   python: {}
-github: https://github.com/strands-agents/harness-sdk
+github: https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/models/openai.py
 docsPage: docs/integrations/model-providers/ovhcloud-ai-endpoints
 addedDate: 2026-01-01

--- a/site/src/content/catalog/strands-dynamodb-storage.yaml
+++ b/site/src/content/catalog/strands-dynamodb-storage.yaml
@@ -8,4 +8,5 @@ languages:
   typescript:
     package: strands-dynamodb-storage
 github: https://github.com/aws/strands-dynamodb-storage
+featured: true
 addedDate: 2026-08-14

--- a/site/src/content/catalog/strands-dynamodb-storage.yaml
+++ b/site/src/content/catalog/strands-dynamodb-storage.yaml
@@ -1,0 +1,11 @@
+name: strands-dynamodb-storage
+description: Amazon DynamoDB Storage backend for Strands agents, covering sessions, agent memory, and semantic search over DynamoDB vector indexes, with optional S3 offload for large values.
+integrationType: storage
+maintainedBy: aws
+languages:
+  python:
+    package: strands-dynamodb-storage
+  typescript:
+    package: strands-dynamodb-storage
+github: https://github.com/aws/strands-dynamodb-storage
+addedDate: 2026-08-14

--- a/site/test/catalog-collection.test.ts
+++ b/site/test/catalog-collection.test.ts
@@ -173,8 +173,8 @@ describe('catalog content collection', () => {
     // The content layer silently drops entries whose YAML fails to parse;
     // pinned counts catch that. Update them when granting or removing tiers.
     const byTier = Map.groupBy(entries, (e) => e.data.maintainedBy)
-    expect(byTier.get('strands')?.length).toBe(28)
-    expect(byTier.get('aws')?.length).toBe(7)
+    expect(byTier.get('strands')?.length).toBe(33)
+    expect(byTier.get('aws')?.length).toBe(8)
     expect(byTier.get('partner')?.length).toBe(21)
     // Built-ins point at their source path in the SDK monorepo and always
     // have on-site docs.


### PR DESCRIPTION
## Description

Adds [aws/strands-dynamodb-storage](https://github.com/aws/strands-dynamodb-storage) to the integrations catalog as a featured entry: an AWS-vended DynamoDB Storage backend covering sessions, agent memory, and vector search, published as `strands-dynamodb-storage` on both PyPI and npm (registry metadata points back at the repo, so the provenance check passes).

While auditing the catalog against the maintainer-tier schema from #3766, five OpenAI-compatibility model-provider entries (`cohere`, `crusoe`, `fireworksai`, `nebius-token-factory`, `ovhcloud-ai-endpoints`) turned out to predate that PR and were defaulting to the `community` tier despite pointing at the SDK monorepo itself. This PR grants them `maintainedBy: strands` and deep-links their `github` to the compat-layer source (`strands-py/src/strands/models/openai.py`), which the built-in invariant tests require. Pinned tier counts in the collection test move to 33 strands / 8 aws.

Also drops the `featured` flag from `agentcore-tool-search` and `datadog-ai-guard` to rotate the featured set.

The `strands`/`aws` tier grants and the `featured` changes are team-granted fields, so the editorial-review workflow will flag this PR for maintainer confirmation as intended.

## Related Issues

N/A

## Documentation PR

N/A (catalog data only; the new entry links out to its GitHub repo, no docs page added)

## Type of Change

Documentation update

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `bash .agents/skills/pre-push/run-checks.sh` (site vitest suite, typecheck, format check, snippet typecheck all pass; `hatch run prepare` not applicable, no Python SDK changes)

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
