### PR TITLE
docs(bedrock): move Mantle guide to the Bedrock page and document the Mantle config

### DIFF
--- a/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
@@ -996,10 +996,21 @@ const model = new BedrockModel({
 
 ### OpenAI-Compatible Endpoints (Mantle)
 
-Amazon Bedrock exposes
-[OpenAI-compatible endpoints](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html),
-powered by Mantle, for select models. You connect through the SDK's
-[OpenAI Responses provider](./openai-responses) rather than `BedrockModel`.
+Mantle is not a separate service or model catalog: it is Amazon Bedrock's second
+endpoint family,
+[`bedrock-mantle`](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html),
+which serves Bedrock-hosted models through OpenAI-compatible APIs. The two families
+serve different, overlapping model sets: many models are only on the standard
+`bedrock-runtime` endpoint that `BedrockModel` uses, some model lines are only on
+`bedrock-mantle`, and some are on both. AWS lists which endpoint serves each model in
+[endpoint availability by model](https://docs.aws.amazon.com/bedrock/latest/userguide/models-endpoint-availability.html).
+
+Pick your provider by where the model is served. When it is on `bedrock-runtime`, use
+`BedrockModel` as described on the rest of this page (AWS recommends that endpoint
+when a model is on both). When it is served through Mantle, connect with the SDK's
+[OpenAI Responses provider](./openai-responses) instead, in one of the two ways below.
+
+#### Connecting with AWS Credentials
 
 Pass <Syntax py="bedrock_mantle_config" ts="bedrockMantleConfig" /> and the provider
 derives the endpoint from your region, routes the model to the correct Mantle base
@@ -1036,16 +1047,20 @@ Requires the optional dependency: `npm install @aws/bedrock-token-generator`
 </Tab>
 </Tabs>
 
-Omit the region to resolve it from your AWS environment. The config also accepts
-explicit credentials and a token-lifetime override; see the
-<Syntax py="BedrockMantleConfig" ts="BedrockMantleConfig" plain /> API reference for
-the accepted fields.
+Omit the region to resolve it from your AWS environment. The config also accepts AWS
+credentials to forward to the token generator
+(<Syntax py="credentials_provider" ts="credentials" />, a
+<Syntax py="botocore CredentialProvider" ts="static identity or provider function" plain />)
+and a token-lifetime override (<Syntax py="expiry" ts="expiresInSeconds" />). In
+Python, `boto_session` can also supply the region from a configured profile.
 
-Alternatively, authenticate with a
+#### Connecting with a Bedrock API Key
+
+Authenticate with a
 [Bedrock API key](https://docs.aws.amazon.com/bedrock/latest/userguide/api-key-management.html)
 and point the client at your region's Mantle endpoint yourself. Note that some model
-lines are served from `/openai/v1` rather than `/v1`; the config-based approach picks
-the right path for you.
+lines are served from `/openai/v1` rather than `/v1`; the config-based approach above
+picks the right path for you.
 
 <Tabs>
 <Tab label="Python">

--- a/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
@@ -999,10 +999,53 @@ const model = new BedrockModel({
 Amazon Bedrock exposes
 [OpenAI-compatible endpoints](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html),
 powered by Mantle, for select models. You connect through the SDK's
-[OpenAI Responses provider](./openai-responses) rather than `BedrockModel`:
-authenticate with a
+[OpenAI Responses provider](./openai-responses) rather than `BedrockModel`.
+
+Pass <Syntax py="bedrock_mantle_config" ts="bedrockMantleConfig" /> and the provider
+derives the endpoint from your region, routes the model to the correct Mantle base
+path, and mints short-lived bearer tokens from your AWS credentials (via the
+standard credential chain), refreshing them so long-running agents survive token
+expiry:
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.models.openai_responses import OpenAIResponsesModel
+
+model = OpenAIResponsesModel(
+    model_id="openai.gpt-oss-120b",
+    bedrock_mantle_config={"region": "us-east-1"},
+)
+
+agent = Agent(model=model)
+response = agent("What is 2+2?")
+print(response)
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/model-providers/amazon-bedrock_imports.ts:mantle_config_imports"
+
+--8<-- "user-guide/concepts/model-providers/amazon-bedrock.ts:mantle_config"
+```
+
+Requires the optional dependency: `npm install @aws/bedrock-token-generator`
+</Tab>
+</Tabs>
+
+Omit the region to resolve it from your AWS environment. The config also accepts
+explicit credentials and a token-lifetime override; see the
+<Syntax py="BedrockMantleConfig" ts="BedrockMantleConfig" plain /> API reference for
+the accepted fields.
+
+Alternatively, authenticate with a
 [Bedrock API key](https://docs.aws.amazon.com/bedrock/latest/userguide/api-key-management.html)
-and point the client at your region's Mantle endpoint.
+and point the client at your region's Mantle endpoint yourself. Note that some model
+lines are served from `/openai/v1` rather than `/v1`; the config-based approach picks
+the right path for you.
 
 <Tabs>
 <Tab label="Python">

--- a/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.mdx
@@ -994,6 +994,47 @@ const model = new BedrockModel({
 </Tab>
 </Tabs>
 
+### OpenAI-Compatible Endpoints (Mantle)
+
+Amazon Bedrock exposes
+[OpenAI-compatible endpoints](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html),
+powered by Mantle, for select models. You connect through the SDK's
+[OpenAI Responses provider](./openai-responses) rather than `BedrockModel`:
+authenticate with a
+[Bedrock API key](https://docs.aws.amazon.com/bedrock/latest/userguide/api-key-management.html)
+and point the client at your region's Mantle endpoint.
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.models.openai_responses import OpenAIResponsesModel
+
+region = "us-east-1"
+model = OpenAIResponsesModel(
+    model_id="openai.gpt-oss-120b",
+    client_args={
+        "api_key": "<BEDROCK_API_KEY>",
+        "base_url": f"https://bedrock-mantle.{region}.api.aws/v1",
+    },
+)
+
+agent = Agent(model=model)
+response = agent("What is 2+2?")
+print(response)
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/model-providers/amazon-bedrock_imports.ts:bedrock_mantle_imports"
+
+--8<-- "user-guide/concepts/model-providers/amazon-bedrock.ts:bedrock_mantle"
+```
+</Tab>
+</Tabs>
+
 ## Troubleshooting
 
 ### On-demand throughput isn’t supported

--- a/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.ts
+++ b/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.ts
@@ -491,3 +491,17 @@ async function bedrockMantle() {
   console.log(response)
   // --8<-- [end:bedrock_mantle]
 }
+
+// Mantle via bedrockMantleConfig
+async function bedrockMantleConfig() {
+  // --8<-- [start:mantle_config]
+  const model = new OpenAIModel({
+    modelId: 'openai.gpt-oss-120b',
+    bedrockMantleConfig: { region: 'us-east-1' },
+  })
+
+  const agent = new Agent({ model })
+  const response = await agent.invoke('What is 2+2?')
+  console.log(response)
+  // --8<-- [end:mantle_config]
+}

--- a/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.ts
+++ b/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock.ts
@@ -12,6 +12,7 @@ import {
   CachePointBlock,
   Message,
 } from '@strands-agents/sdk'
+import { OpenAIModel } from '@strands-agents/sdk/models/openai'
 import { z } from 'zod'
 
 // Basic usage examples
@@ -472,3 +473,21 @@ async function structuredOutputExample() {
 }
 
 void structuredOutputExample
+
+// OpenAI-compatible endpoints (Mantle)
+async function bedrockMantle() {
+  // --8<-- [start:bedrock_mantle]
+  const region = 'us-east-1'
+  const model = new OpenAIModel({
+    modelId: 'openai.gpt-oss-120b',
+    apiKey: '<BEDROCK_API_KEY>',
+    clientConfig: {
+      baseURL: `https://bedrock-mantle.${region}.api.aws/v1`,
+    },
+  })
+
+  const agent = new Agent({ model })
+  const response = await agent.invoke('What is 2+2?')
+  console.log(response)
+  // --8<-- [end:bedrock_mantle]
+}

--- a/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock_imports.ts
@@ -22,3 +22,8 @@ import { Agent } from '@strands-agents/sdk'
 import { BedrockModel } from '@strands-agents/sdk/models/bedrock'
 import { z } from 'zod'
 // --8<-- [end:structured_output_imports]
+
+// --8<-- [start:bedrock_mantle_imports]
+import { Agent } from '@strands-agents/sdk'
+import { OpenAIModel } from '@strands-agents/sdk/models/openai'
+// --8<-- [end:bedrock_mantle_imports]

--- a/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/model-providers/amazon-bedrock_imports.ts
@@ -27,3 +27,8 @@ import { z } from 'zod'
 import { Agent } from '@strands-agents/sdk'
 import { OpenAIModel } from '@strands-agents/sdk/models/openai'
 // --8<-- [end:bedrock_mantle_imports]
+
+// --8<-- [start:mantle_config_imports]
+import { Agent } from '@strands-agents/sdk'
+import { OpenAIModel } from '@strands-agents/sdk/models/openai'
+// --8<-- [end:mantle_config_imports]

--- a/site/src/content/docs/user-guide/concepts/model-providers/openai-responses.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/openai-responses.mdx
@@ -62,40 +62,9 @@ In TypeScript, both the Responses API and Chat Completions API are available thr
 </Tab>
 </Tabs>
 
-### Amazon Bedrock (Mantle)
-
-The Responses provider can connect to [Amazon Bedrock's OpenAI-compatible endpoints](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html) powered by Mantle. Authenticate with a [Bedrock API key](https://docs.aws.amazon.com/bedrock/latest/userguide/api-key-management.html) and point the client at your region's Mantle endpoint.
-
-<Tabs>
-<Tab label="Python">
-
-```python
-from strands import Agent
-from strands.models.openai_responses import OpenAIResponsesModel
-
-region = "us-east-1"
-model = OpenAIResponsesModel(
-    model_id="openai.gpt-oss-120b",
-    client_args={
-        "api_key": "<BEDROCK_API_KEY>",
-        "base_url": f"https://bedrock-mantle.{region}.api.aws/v1",
-    },
-)
-
-agent = Agent(model=model)
-response = agent("What is 2+2?")
-print(response)
-```
-</Tab>
-<Tab label="TypeScript">
-
-```typescript
---8<-- "user-guide/concepts/model-providers/openai-responses_imports.ts:bedrock_mantle_imports"
-
---8<-- "user-guide/concepts/model-providers/openai-responses.ts:bedrock_mantle"
-```
-</Tab>
-</Tabs>
+To connect to Amazon Bedrock's OpenAI-compatible Mantle endpoints, see
+[OpenAI-compatible endpoints (Mantle)](./amazon-bedrock#openai-compatible-endpoints-mantle)
+on the Amazon Bedrock page.
 
 ## Configuration
 

--- a/site/src/content/docs/user-guide/concepts/model-providers/openai-responses.ts
+++ b/site/src/content/docs/user-guide/concepts/model-providers/openai-responses.ts
@@ -19,24 +19,6 @@ import { OpenAIModel } from '@strands-agents/sdk/models/openai'
   // --8<-- [end:basic_usage]
 }
 
-// Amazon Bedrock (Mantle)
-{
-  // --8<-- [start:bedrock_mantle]
-  const region = 'us-east-1'
-  const model = new OpenAIModel({
-    modelId: 'openai.gpt-oss-120b',
-    apiKey: '<BEDROCK_API_KEY>',
-    clientConfig: {
-      baseURL: `https://bedrock-mantle.${region}.api.aws/v1`,
-    },
-  })
-
-  const agent = new Agent({ model })
-  const response = await agent.invoke('What is 2+2?')
-  console.log(response)
-  // --8<-- [end:bedrock_mantle]
-}
-
 // Web search
 {
   // --8<-- [start:web_search]

--- a/site/src/content/docs/user-guide/concepts/model-providers/openai-responses_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/model-providers/openai-responses_imports.ts
@@ -5,8 +5,3 @@
 import { Agent } from '@strands-agents/sdk'
 import { OpenAIModel } from '@strands-agents/sdk/models/openai'
 // --8<-- [end:basic_usage_imports]
-
-// --8<-- [start:bedrock_mantle_imports]
-import { Agent } from '@strands-agents/sdk'
-import { OpenAIModel } from '@strands-agents/sdk/models/openai'
-// --8<-- [end:bedrock_mantle_imports]


### PR DESCRIPTION
## Description

Bedrock's OpenAI-compatible Mantle endpoints were documented only as a section of the OpenAI Responses provider page, and the docs showed only the manual approach: create a Bedrock API key and hardcode the regional URL. Meanwhile the SDKs ship a dedicated config for this, `bedrock_mantle_config` (Python) / `bedrockMantleConfig` (TypeScript), that derives the endpoint from the region, routes each model to its correct Mantle base path (some model lines are served from `/openai/v1` rather than `/v1`, which the manual approach silently gets wrong), and mints refreshing bearer tokens from the standard AWS credential chain so long-running agents survive token expiry. That option is integration tested in both SDKs (`tests_integ/models/test_model_mantle.py`, `test/integ/models/openai/mantle*.test.node.ts`) but was documented nowhere.

This PR moves the Mantle guide to the Amazon Bedrock page, where developers looking for Bedrock connectivity actually start (the Responses page keeps a pointer), and documents the Mantle config as the primary connection method with the manual API-key approach as the alternative.

Split out of #3829 to keep that PR scoped to the OpenAI-compatible integration pages.

## Related Issues

Related: #3829 (split from it).

## Documentation PR

Documentation-only change under `site/`.

## Type of Change

Documentation update

## Testing

- `npm run typecheck:snippets`, Prettier check, and the site unit suite (549 tests) all pass; pre-commit hooks passed on both commits
- Rendered the Amazon Bedrock and OpenAI Responses pages in the dev server: the new section renders both language tabs with resolved snippets, and the cross-page anchor from the Responses page resolves
- Callout: the config examples mirror the values exercised by the existing Mantle integration tests but were not run against a live Mantle endpoint from this environment

- [ ] I ran `hatch run prepare` (not applicable — documentation-only change)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
