### PR TITLE
feat(anthropic): route AnthropicModel through the Bedrock Mantle endpoint

### DIFF
--- a/site/src/content/docs/user-guide/concepts/model-providers/anthropic.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/anthropic.mdx
@@ -5,6 +5,7 @@ tags: [structured-output, caching]
 integrationType: model-provider
 sourceLinks:
   - path: strands-py/src/strands/models/anthropic.py
+  - path: strands-py/src/strands/models/_anthropic_bedrock.py
   - path: strands-ts/src/models/anthropic.ts
 ---
 
@@ -67,6 +68,44 @@ print(response)
 ```
 </Tab>
 </Tabs>
+
+### Amazon Bedrock (Mantle)
+
+Claude models also run on
+[Amazon Bedrock's Anthropic-compatible endpoint](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-messages-api.html)
+powered by Mantle, which bills through your AWS account instead of an Anthropic API key.
+Give the provider a region and it signs every request with SigV4 from the standard AWS
+credential chain.
+
+Model IDs on Mantle differ from the direct API. The endpoint serves
+`anthropic.claude-sonnet-5`, `anthropic.claude-opus-4-8`, and `anthropic.claude-haiku-4-5`,
+among others.
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.models.anthropic import AnthropicModel
+
+model = AnthropicModel(
+    model_id="anthropic.claude-sonnet-5",
+    max_tokens=1028,
+    bedrock_mantle_config={"region": "us-east-1"},
+)
+
+agent = Agent(model=model)
+response = agent("What is 2+2?")
+print(response)
+```
+</Tab>
+</Tabs>
+
+Omit the region to resolve it from the `AWS_REGION` environment variable. To authenticate
+with a named profile or a
+[Bedrock API key](https://docs.aws.amazon.com/bedrock/latest/userguide/api-key-management.html)
+instead of the default credential chain, add `profile` or
+<Syntax py="api_key" ts="apiKey" /> to the same config.
 
 ## Configuration
 

--- a/strands-py/pyproject.toml
+++ b/strands-py/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
 
 
 [project.optional-dependencies]
-anthropic = ["anthropic>=0.21.0,<1.0.0"]
+anthropic = ["anthropic>=0.91.0,<1.0.0"]
 gemini = ["google-genai>=1.67.0,<3.0.0"]
 # The latest litellm v1.92.0 do not support python 3.14, for the short term we will keep 
 # the version lower than 1.92.0 until litellm has the python 3.14 supported version.

--- a/strands-py/src/strands/models/_anthropic_bedrock.py
+++ b/strands-py/src/strands/models/_anthropic_bedrock.py
@@ -1,0 +1,107 @@
+"""Internal helpers for routing the Anthropic client to Bedrock Mantle.
+
+Converts a ``bedrock_mantle_config`` dict into the keyword arguments that
+``anthropic.AsyncAnthropicBedrockMantle`` consumes. That client derives the Mantle base URL
+from the region, sends the required ``anthropic-version`` header, and signs every request
+with SigV4 on its own, so nothing here mints or caches a credential.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+import boto3
+
+from ._validation import validate_region
+
+_MANTLE_DOCS_URL = "https://docs.aws.amazon.com/bedrock/latest/userguide/inference-messages-api.html"
+
+# Client kwargs this module derives from the config. A caller that also accepts raw client
+# args must reject these, or the two sources would silently disagree.
+MANTLE_DERIVED_CLIENT_ARGS = ("aws_region", "aws_profile", "api_key")
+
+
+class BedrockMantleConfig(TypedDict, total=False):
+    """Config for routing the Anthropic client through Bedrock Mantle.
+
+    Attributes:
+        region: AWS region hosting the Bedrock Mantle endpoint. If omitted, resolved from
+            ``profile`` (if provided) or the standard boto3 chain (``AWS_REGION`` /
+            ``AWS_DEFAULT_REGION`` / active profile / EC2 metadata). A :class:`ValueError`
+            is raised if none resolve.
+        profile: Optional AWS profile to authenticate with. Selects SigV4 authentication.
+        api_key: Optional Amazon Bedrock API key. When set, requests carry it as a bearer
+            token instead of being signed with SigV4. Omit to use the standard AWS
+            credential chain.
+    """
+
+    region: str
+    profile: str
+    api_key: str
+
+
+def _resolve_region(config: BedrockMantleConfig) -> str:
+    """Resolve the AWS region, preferring explicit config then falling back to boto3.
+
+    The resolved region is validated before it is returned, since
+    ``AsyncAnthropicBedrockMantle`` interpolates it into the Mantle endpoint URL.
+
+    Args:
+        config: The Bedrock Mantle config to resolve the region from.
+
+    Returns:
+        The resolved AWS region.
+
+    Raises:
+        ValueError: If no region can be resolved from the config, the named profile, or the
+            standard boto3 credential chain, or if the resolved region is not a well-formed
+            AWS region identifier.
+    """
+    region = config.get("region")
+    if region:
+        return validate_region(region)
+
+    # ``boto3.Session()`` reads ``AWS_REGION`` / ``AWS_DEFAULT_REGION``, the active profile,
+    # and EC2 instance metadata. The Anthropic client's own fallback reads only the two env
+    # vars, so a profile-configured region would otherwise go unseen.
+    profile = config.get("profile")
+    session = boto3.Session(profile_name=profile) if profile else boto3.Session()
+    if session.region_name:
+        return validate_region(str(session.region_name))
+
+    raise ValueError(
+        "Could not resolve an AWS region for Bedrock Mantle. Pass 'region' in "
+        "bedrock_mantle_config, configure a region on the named profile, or set AWS_REGION "
+        f"in the environment. See {_MANTLE_DOCS_URL} for supported regions."
+    )
+
+
+def resolve_bedrock_client_args(
+    config: BedrockMantleConfig, client_args: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    """Resolve a ``BedrockMantleConfig`` (plus optional ``client_args``) into Mantle client kwargs.
+
+    Callers are expected to validate that ``client_args`` carries none of
+    :data:`MANTLE_DERIVED_CLIENT_ARGS` before calling this function (typically at
+    ``__init__`` time for fail-fast behavior).
+
+    Args:
+        config: Config for routing the Anthropic client through Bedrock Mantle.
+        client_args: Additional arguments for the underlying Anthropic client.
+
+    Returns:
+        Keyword arguments for ``anthropic.AsyncAnthropicBedrockMantle``.
+
+    Raises:
+        ValueError: If no region can be resolved.
+    """
+    resolved: dict[str, Any] = dict(client_args or {})
+    resolved["aws_region"] = _resolve_region(config)
+
+    # Only forward keys the user set; the Anthropic client reads auth precedence off which
+    # arguments are not None, so passing an explicit None would change the selected mode.
+    if "profile" in config:
+        resolved["aws_profile"] = config["profile"]
+    if "api_key" in config:
+        resolved["api_key"] = config["api_key"]
+    return resolved

--- a/strands-py/src/strands/models/anthropic.py
+++ b/strands-py/src/strands/models/anthropic.py
@@ -21,6 +21,7 @@ from ..types.event_loop import Usage
 from ..types.exceptions import ContextWindowOverflowException, ModelThrottledException
 from ..types.streaming import StreamEvent
 from ..types.tools import ToolChoice, ToolChoiceToolDict, ToolSpec
+from ._anthropic_bedrock import MANTLE_DERIVED_CLIENT_ARGS, BedrockMantleConfig, resolve_bedrock_client_args
 from ._defaults import resolve_config_metadata
 from ._validation import _has_location_source, validate_config_keys
 from .model import BaseModelConfig, CacheConfig, CacheToolsConfig, Model
@@ -88,13 +89,29 @@ class AnthropicModel(Model):
         params: dict[str, Any] | None
         use_native_token_count: bool
 
-    def __init__(self, *, client_args: dict[str, Any] | None = None, **model_config: Unpack[AnthropicConfig]):
+    def __init__(
+        self,
+        *,
+        client_args: dict[str, Any] | None = None,
+        bedrock_mantle_config: BedrockMantleConfig | None = None,
+        **model_config: Unpack[AnthropicConfig],
+    ):
         """Initialize provider instance.
 
         Args:
             client_args: Arguments for the underlying Anthropic client (e.g., api_key).
                 For a complete list of supported arguments, see https://docs.anthropic.com/en/api/client-sdks.
+                May be combined with ``bedrock_mantle_config``; when both are set, the config
+                derives the AWS arguments, which must not appear in ``client_args``.
+            bedrock_mantle_config: Route requests through Amazon Bedrock's Mantle
+                (Anthropic-compatible) endpoint. See :class:`BedrockMantleConfig` for accepted
+                keys. Requests are signed with SigV4 unless the config supplies an API key,
+                using the profile it names or the standard AWS credential chain.
             **model_config: Configuration options for the Anthropic model.
+
+        Raises:
+            ValueError: If ``client_args`` carries an argument that ``bedrock_mantle_config``
+                derives, or if no AWS region can be resolved.
         """
         validate_config_keys(model_config, self.AnthropicConfig)
         self.config = AnthropicModel.AnthropicConfig(**model_config)
@@ -102,7 +119,21 @@ class AnthropicModel(Model):
         logger.debug("config=<%s> | initializing", self.config)
 
         client_args = client_args or {}
-        self.client = anthropic.AsyncAnthropic(**client_args)
+        self.client: anthropic.AsyncAnthropic | anthropic.AsyncAnthropicBedrockMantle
+        if bedrock_mantle_config is None:
+            self.client = anthropic.AsyncAnthropic(**client_args)
+            return
+
+        conflicting = [argument for argument in MANTLE_DERIVED_CLIENT_ARGS if argument in client_args]
+        if conflicting:
+            raise ValueError(
+                f"client_args must not contain {conflicting} when bedrock_mantle_config is set; "
+                "these are derived from the Mantle config automatically."
+            )
+
+        self.client = anthropic.AsyncAnthropicBedrockMantle(
+            **resolve_bedrock_client_args(bedrock_mantle_config, client_args)
+        )
 
     @override
     def update_config(self, **model_config: Unpack[AnthropicConfig]) -> None:  # type: ignore[override]

--- a/strands-py/tests/strands/models/test_anthropic.py
+++ b/strands-py/tests/strands/models/test_anthropic.py
@@ -2023,9 +2023,7 @@ class TestPromptCaching:
 
     def test_dynamic_trailing_blocks_covers_every_block_of_a_multi_block_tail(self, model):
         model.update_config(cache_config=CacheConfig(strategy="auto"))
-        messages = [
-            {"role": "user", "content": [{"text": "durable ask"}, {"text": "injected"}, {"text": "status"}]}
-        ]
+        messages = [{"role": "user", "content": [{"text": "durable ask"}, {"text": "injected"}, {"text": "status"}]}]
 
         request = model.format_request(messages, dynamic_trailing_blocks=2)
 
@@ -2072,3 +2070,155 @@ class TestPromptCaching:
         request = model.format_request(messages, dynamic_trailing_blocks=1)
 
         assert self._breakpoints(request) == []
+
+
+# =============================================================================
+# Bedrock Mantle (bedrock_mantle_config) integration with AnthropicModel
+# =============================================================================
+
+
+class TestAnthropicModelBedrockMantleConfig:
+    @pytest.fixture
+    def mantle_client_cls(self):
+        with unittest.mock.patch.object(
+            strands.models.anthropic.anthropic, "AsyncAnthropicBedrockMantle"
+        ) as mock_client_cls:
+            yield mock_client_cls
+
+    def test_bedrock_mantle_config_builds_mantle_client(self, mantle_client_cls, max_tokens):
+        """bedrock_mantle_config swaps in the Mantle client and passes only the resolved region.
+
+        Keys the config leaves unset stay absent rather than being passed as None, which would
+        change the auth mode the client selects.
+        """
+        model = AnthropicModel(
+            model_id="anthropic.claude-sonnet-5",
+            max_tokens=max_tokens,
+            bedrock_mantle_config={"region": "us-east-1"},
+        )
+
+        assert model.client is mantle_client_cls.return_value
+
+        tru_client_args = mantle_client_cls.call_args.kwargs
+        exp_client_args = {"aws_region": "us-east-1"}
+
+        assert tru_client_args == exp_client_args
+
+    def test_bedrock_mantle_config_omitted_builds_plain_client(self, anthropic_client, max_tokens):
+        """Without bedrock_mantle_config the provider still builds the direct Anthropic client."""
+        model = AnthropicModel(model_id="claude-sonnet-4-20250514", max_tokens=max_tokens)
+
+        assert model.client is anthropic_client
+
+    def test_bedrock_mantle_config_forwards_profile_and_api_key(self, mantle_client_cls, max_tokens):
+        """Optional profile and api_key map onto the Anthropic client's AWS arguments."""
+        AnthropicModel(
+            model_id="anthropic.claude-sonnet-5",
+            max_tokens=max_tokens,
+            bedrock_mantle_config={"region": "us-east-1", "profile": "p1", "api_key": "k1"},
+        )
+
+        tru_client_args = mantle_client_cls.call_args.kwargs
+        exp_client_args = {"aws_region": "us-east-1", "aws_profile": "p1", "api_key": "k1"}
+
+        assert tru_client_args == exp_client_args
+
+    def test_bedrock_mantle_config_merges_with_client_args(self, mantle_client_cls, max_tokens):
+        """bedrock_mantle_config composes with client_args; transport options are preserved."""
+        sentinel_http_client = unittest.mock.Mock()
+        AnthropicModel(
+            model_id="anthropic.claude-sonnet-5",
+            max_tokens=max_tokens,
+            client_args={
+                "timeout": 42,
+                "http_client": sentinel_http_client,
+                "default_headers": {"X-Trace-Id": "abc"},
+            },
+            bedrock_mantle_config={"region": "us-east-1"},
+        )
+
+        tru_client_args = mantle_client_cls.call_args.kwargs
+        exp_client_args = {
+            "aws_region": "us-east-1",
+            "timeout": 42,
+            "http_client": sentinel_http_client,
+            "default_headers": {"X-Trace-Id": "abc"},
+        }
+
+        assert tru_client_args == exp_client_args
+
+    @pytest.mark.parametrize("argument", ["aws_region", "aws_profile", "api_key"])
+    def test_bedrock_mantle_config_rejects_derived_client_args(self, argument, mantle_client_cls, max_tokens):
+        """client_args must not carry an argument the Mantle config derives."""
+        _ = mantle_client_cls
+
+        with pytest.raises(ValueError, match="client_args must not contain"):
+            AnthropicModel(
+                model_id="anthropic.claude-sonnet-5",
+                max_tokens=max_tokens,
+                client_args={argument: "x"},
+                bedrock_mantle_config={"region": "us-east-1"},
+            )
+
+    def test_bedrock_mantle_config_region_resolved_from_boto3_default(self, mantle_client_cls, max_tokens):
+        """When region is omitted, the default boto3 session chain resolves it."""
+        with unittest.mock.patch("boto3.Session") as mock_session_cls:
+            mock_session_cls.return_value.region_name = "eu-west-1"
+
+            AnthropicModel(model_id="anthropic.claude-sonnet-5", max_tokens=max_tokens, bedrock_mantle_config={})
+
+        mock_session_cls.assert_called_once_with()
+
+        tru_client_args = mantle_client_cls.call_args.kwargs
+        exp_client_args = {"aws_region": "eu-west-1"}
+
+        assert tru_client_args == exp_client_args
+
+    def test_bedrock_mantle_config_region_resolved_from_named_profile(self, mantle_client_cls, max_tokens):
+        """A named profile supplies the region the Anthropic client's own fallback would miss."""
+        with unittest.mock.patch("boto3.Session") as mock_session_cls:
+            mock_session_cls.return_value.region_name = "ap-northeast-1"
+
+            AnthropicModel(
+                model_id="anthropic.claude-sonnet-5",
+                max_tokens=max_tokens,
+                bedrock_mantle_config={"profile": "p1"},
+            )
+
+        mock_session_cls.assert_called_once_with(profile_name="p1")
+
+        tru_client_args = mantle_client_cls.call_args.kwargs
+        exp_client_args = {"aws_region": "ap-northeast-1", "aws_profile": "p1"}
+
+        assert tru_client_args == exp_client_args
+
+    def test_bedrock_mantle_config_unresolvable_region_raises(self, mantle_client_cls, max_tokens):
+        """A region that resolves from nowhere fails at construction with actionable guidance."""
+        _ = mantle_client_cls
+
+        with unittest.mock.patch("boto3.Session") as mock_session_cls:
+            mock_session_cls.return_value.region_name = None
+
+            with pytest.raises(ValueError, match="Could not resolve an AWS region"):
+                AnthropicModel(model_id="anthropic.claude-sonnet-5", max_tokens=max_tokens, bedrock_mantle_config={})
+
+    def test_bedrock_mantle_config_rejects_malformed_region(self, mantle_client_cls, max_tokens):
+        """A region carrying URL control characters is rejected before it reaches the endpoint URL."""
+        _ = mantle_client_cls
+
+        with pytest.raises(ValueError, match="invalid AWS region"):
+            AnthropicModel(
+                model_id="anthropic.claude-sonnet-5",
+                max_tokens=max_tokens,
+                bedrock_mantle_config={"region": "x@attacker.com:443/#"},
+            )
+
+    def test_bedrock_mantle_config_rejects_malformed_region_from_boto3_default(self, mantle_client_cls, max_tokens):
+        """A malformed region resolved from the boto3 default chain is also rejected."""
+        _ = mantle_client_cls
+
+        with unittest.mock.patch("boto3.Session") as mock_session_cls:
+            mock_session_cls.return_value.region_name = "x@attacker.com:443/#"
+
+            with pytest.raises(ValueError, match="invalid AWS region"):
+                AnthropicModel(model_id="anthropic.claude-sonnet-5", max_tokens=max_tokens, bedrock_mantle_config={})

--- a/strands-py/tests_integ/models/test_model_mantle.py
+++ b/strands-py/tests_integ/models/test_model_mantle.py
@@ -1,19 +1,23 @@
-"""Integration tests for OpenAI-compatible APIs on Bedrock Mantle.
+"""Integration tests for the OpenAI- and Anthropic-compatible APIs on Bedrock Mantle.
 
-Exercises the ``bedrock_mantle_config`` pathway on ``OpenAIModel`` (Chat Completions) and
-``OpenAIResponsesModel`` (Responses API) against the live
-``bedrock-mantle.<region>.api.aws/v1`` endpoint. Credentials come from the
-ambient AWS credential chain; no explicit API key is passed by the user.
+Exercises the ``bedrock_mantle_config`` pathway on ``OpenAIModel`` (Chat Completions),
+``OpenAIResponsesModel`` (Responses API), and ``AnthropicModel`` (Messages API) against the
+live ``bedrock-mantle.<region>.api.aws`` endpoint. Credentials come from the ambient AWS
+credential chain; no explicit API key is passed by the user.
 """
 
+import pydantic
 import pytest
 
 from strands import Agent
+from strands.models.anthropic import AnthropicModel
 from strands.models.openai import OpenAIModel
 from strands.models.openai_responses import OpenAIResponsesModel
 
 _REGION = "us-east-1"
 _MODEL_ID = "openai.gpt-oss-120b"
+_ANTHROPIC_MODEL_ID = "anthropic.claude-sonnet-5"
+_ANTHROPIC_MAX_TOKENS = 512
 
 
 @pytest.fixture
@@ -103,3 +107,53 @@ def test_reasoning_content_multi_turn(bedrock_mantle_config):
 
     # Second turn should not raise despite reasoningContent in message history
     agent("What about 3+3?")
+
+
+@pytest.fixture
+def anthropic_model(bedrock_mantle_config):
+    return AnthropicModel(
+        model_id=_ANTHROPIC_MODEL_ID,
+        max_tokens=_ANTHROPIC_MAX_TOKENS,
+        bedrock_mantle_config=bedrock_mantle_config,
+    )
+
+
+def test_anthropic_agent_invoke(anthropic_model):
+    """AnthropicModel reaches the Mantle Messages API via bedrock_mantle_config."""
+    agent = Agent(model=anthropic_model, system_prompt="Reply in one short sentence.", callback_handler=None)
+
+    result = agent("What is 2+2?")
+
+    assert "4" in str(result) or "four" in str(result).lower()
+
+
+def test_anthropic_structured_output(anthropic_model):
+    """Tool-based structured output works over Mantle, which rejects output_config.format."""
+
+    class Weather(pydantic.BaseModel):
+        time: str
+        weather: str
+
+    agent = Agent(model=anthropic_model, callback_handler=None)
+
+    result = agent("The time is 12:00 and the weather is sunny", structured_output_model=Weather)
+
+    assert result.structured_output == Weather(time="12:00", weather="sunny")
+
+
+@pytest.mark.asyncio
+async def test_anthropic_native_token_count(bedrock_mantle_config, caplog):
+    """The native count_tokens path answers from Mantle rather than falling back to estimation."""
+    model = AnthropicModel(
+        model_id=_ANTHROPIC_MODEL_ID,
+        max_tokens=_ANTHROPIC_MAX_TOKENS,
+        use_native_token_count=True,
+        bedrock_mantle_config=bedrock_mantle_config,
+    )
+
+    with caplog.at_level("DEBUG"):
+        count = await model.count_tokens([{"role": "user", "content": [{"text": "What is 2+2?"}]}])
+
+    assert count > 0
+    assert "native token count" in caplog.text
+    assert "falling back" not in caplog.text


### PR DESCRIPTION
## Description

Amazon Bedrock serves Claude models through the Anthropic Messages API on the `bedrock-mantle` endpoint, billing through the caller's AWS account rather than an Anthropic API key. Reaching it from `AnthropicModel` today means assembling the region-specific base URL by hand in `client_args` and authenticating with a static API key string; the SigV4 path that makes instance roles, SSO sessions, and assumed roles usable is unreachable, because `client_args` is forwarded to `anthropic.AsyncAnthropic` and the SigV4-capable client is a different class.

This adds `bedrock_mantle_config` to `AnthropicModel`, matching the option `OpenAIModel` and `OpenAIResponsesModel` already expose for the OpenAI-compatible side of the same endpoint.

```python
from strands import Agent
from strands.models.anthropic import AnthropicModel

model = AnthropicModel(
    model_id="anthropic.claude-sonnet-5",
    max_tokens=1028,
    bedrock_mantle_config={"region": "us-east-1"},
)

agent = Agent(model=model)
print(agent("What is 2+2?"))
```

`BedrockMantleConfig` accepts `region`, `profile`, and `api_key`, all optional. Requests are signed with SigV4 unless `api_key` is supplied, using the named profile or the standard AWS credential chain. Omitting `region` resolves it through boto3, so a profile-configured region is picked up. Anything else — `timeout`, `max_retries`, `default_headers`, `http_client`, explicit static credentials — passes through `client_args` unchanged; the three arguments this config derives (`aws_region`, `aws_profile`, `api_key`) are rejected there so the two sources cannot disagree.

Two implementation notes worth a reviewer's attention:

**This deliberately does not share code with `_openai_bedrock.py`.** The OpenAI pathway mints and refreshes a bearer token because the `openai` package knows nothing about AWS. The `anthropic` package ships `AsyncAnthropicBedrockMantle`, which derives the base URL, sends the required `anthropic-version` header, and signs each request itself, so there is no token to mint and the client is still built once in `__init__`. The only genuinely common piece is `validate_region()`, which is already shared from `_validation.py`. The two `_resolve_region` helpers look similar but resolve different config shapes (`boto_session` versus a profile name).

**Region validation is a security guard, not a convenience.** The region is interpolated into the endpoint URL, so a malformed value containing `@`, `:`, `/`, or `#` could re-point a signed request at a non-AWS host. It goes through the same `validate_region()` the OpenAI path uses, on both the explicit and the boto3-resolved value.

The `anthropic` extra floor moves from `>=0.21.0` to `>=0.91.0`, the release that introduced the Mantle client. Users pinned below that will be upgraded by `strands-agents[anthropic]`.

## Related Issues

Resolves #3832

## Documentation PR

The provider page gains an "Amazon Bedrock (Mantle)" section under `site/`, documenting
this option, the model IDs the endpoint serves, and how to pick an authentication mode.

The sibling PR adds the same section for the other SDK. Both introduce the section
independently so either can merge first; whichever merges second resolves the overlap by
keeping both language tabs in the one section.

## Type of Change

New feature

## Testing

Unit tests cover the client swap, the argument mapping, `client_args` composition, the rejection of derived arguments, region resolution from an explicit value / the boto3 chain / a named profile, and rejection of a malformed region from either source.

Integration tests in `tests_integ/models/test_model_mantle.py` exercise the live `bedrock-mantle.us-east-1.api.aws/anthropic` endpoint: an agent invocation, tool-based structured output, and the native `count_tokens` path. All three pass against `anthropic.claude-sonnet-5`.

I also ran the documented example verbatim against the live endpoint, and confirmed the request reaches `POST /anthropic/v1/messages` with `anthropic-version: 2023-06-01`.

- [ ] I ran `hatch run prepare`

Not exactly: `hatch run prepare` starts with `hatch run format`, which reformats the whole package and dirties 13 files unrelated to this change. I ran the stages individually instead — `hatch run lint`, `hatch run test-lint`, and `hatch test` (5261 passed) — plus `.agents/skills/pre-push/run-checks.sh`, which reports all local checks passing. `hatch test --all` could not complete locally: the Python 3.14 environment fails to import `charset_normalizer`, which is unrelated to this change.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
