### PR TITLE
feat(anthropic): route the TypeScript AnthropicModel through the Bedrock Mantle endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -145,10 +145,208 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
+    "node_modules/@anthropic-ai/bedrock-sdk": {
+      "version": "0.32.4",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/bedrock-sdk/-/bedrock-sdk-0.32.4.tgz",
+      "integrity": "sha512-E9NbAyrqJrTuXllTNojR9RWZyPTH6pDzw9bdKPYqtSfPGoyyDL029LJqueu8fiWatUo494IG2zcGjgbqvmM7IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": ">=0.115.1 <1",
+        "@aws-crypto/sha256-js": "^4.0.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.797.0",
+        "@aws-sdk/credential-providers": "^3.796.0",
+        "@smithy/eventstream-serde-node": "^2.0.10",
+        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/signature-v4": "^3.1.1",
+        "@smithy/smithy-client": "^2.1.9",
+        "@smithy/types": "^2.3.4",
+        "@smithy/util-base64": "^2.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@aws-crypto/sha256-js": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-4.0.0.tgz",
+      "integrity": "sha512-MHGJyjE7TX9aaqXj7zk2ppnFUOhaDs5sP+HtNS0evOxn72c+5njUmyJmpGd7TfyoDznZlHMmdo/xGUdu2NIjNQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^4.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@aws-crypto/util": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-4.0.0.tgz",
+      "integrity": "sha512-2EnmPy2gsFZ6m8bwUQN4jq+IyXV3quHAcwPOS6ZA3k+geujiqI8aRokO2kFJe+idJ/P3v4qWI186rVMo0+zLDQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/protocol-http": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.3.0.tgz",
+      "integrity": "sha512-Xy5XK1AFWW2nlY/biWZXu6/krgbaf2dg0q492D8M5qthsnU2H+UgFeZLbM76FnH7s6RO/xhQRkj+T6KBO3JzgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/signature-v4": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-3.1.2.tgz",
+      "integrity": "sha512-3BcPylEsYtD0esM4Hoyml/+s7WP2LFhcM3J2AGdcL2vx9O60TtfpDOL72gjb4lU8NeRPeKAwR77YNyyGvMbuEA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/signature-v4/node_modules/@smithy/types": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.2.tgz",
+      "integrity": "sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/util-middleware": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.11.tgz",
+      "integrity": "sha512-dWpyc1e1R6VoXrwLoLDd57U1z6CwNSdkM69Ie4+6uYh2GC7Vg51Qtan7ITzczuVpqezdDTKJGJB95fFvvjU/ow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/util-middleware/node_modules/@smithy/types": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.2.tgz",
+      "integrity": "sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/bedrock-sdk/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.109.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.109.1.tgz",
-      "integrity": "sha512-q9OnEKLr5H9nxSuXdgDgJhxfYMiE+AaUEBze2Gk91UcaaLnsN+Lx5fbCYywiqurU/APLdwv23x03Wm6WN3EBsg==",
+      "version": "0.117.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.117.1.tgz",
+      "integrity": "sha512-Yn2QlXfyCiKJ5YGCOOay7ZE78ISvII2XY621WMCiflmG8IYgwx59IBwPExxki3Xk9jKUtnD/Sj6UvplWr0rZxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -166,6 +364,37 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "5.2.0",
@@ -856,6 +1085,16 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
@@ -2345,6 +2584,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@smithy/abort-controller": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.2.0.tgz",
+      "integrity": "sha512-wRlta7GuLWpTqtFfGo+nZyOO1vEvewdNR1R4rTxpC8XU6vG/NDyrFBhwLZsqg1NUoR1noVaXJPC/7ZK47QCySw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/abort-controller/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@smithy/config-resolver": {
       "version": "4.5.6",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.5.6.tgz",
@@ -2398,6 +2664,75 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.2.0.tgz",
+      "integrity": "sha512-zpQMtJVqCUMn+pCSFcl9K/RPNtQE0NuMh8sKpCdEHafhwRsjP50Oq/4kMmvxSRy6d8Jslqd8BLvDngrUtmN9iA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-2.2.0.tgz",
+      "integrity": "sha512-pvoe/vvJY0mOpuF84BEtyZoYfbehiFj8KKWk1ds2AT0mTLYFVs+7sBJZmioOFdBXKd48lfrx1vumdPdmGlCLxA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal/node_modules/@smithy/eventstream-codec": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.2.0.tgz",
+      "integrity": "sha512-8janZoJw85nJmQZc4L8TuePp2pk1nxLgkxIR0TUjKJ5Dkj5oelB9WtiSSGXCQvNsJl0VSTvK/2ueMXxvpa9GVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
@@ -2455,6 +2790,108 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.5.1.tgz",
+      "integrity": "sha512-1/8kFp6Fl4OsSIVTWHnNjLnTL8IqpIb/D3sTSczrKFnrE9VMNWxnrRKNvpUHOJ6zpGD5f62TPm7+17ilTJpiCQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint/node_modules/@smithy/node-config-provider": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.3.0.tgz",
+      "integrity": "sha512-0elK5/03a1JPWMDPaS726Iw6LpQg80gFut1tNpPfxFuChEEklo2yL823V94SpTZTxmKlXFtFgsP55uh3dErnIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.3.0.tgz",
+      "integrity": "sha512-sIADe7ojwqTyvEQBe1nc/GXB9wdHhi9UwyX0lTyttmUWDJLP655ZYE1WngnNyXREme8I27KCaUhyhZWRXL0q7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.2.0.tgz",
+      "integrity": "sha512-Qntc3jrtwwrsAC+X8wms8zhrTr0sFXnyEGhZd9sLtsJ/6gGQKFzNB+wWbOcpJd7BR8ThNCoKt76BuQahfMvpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@smithy/node-config-provider": {
       "version": "4.4.6",
       "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.4.6.tgz",
@@ -2483,6 +2920,33 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@smithy/property-provider": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+      "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@smithy/protocol-http": {
       "version": "5.4.6",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.4.6.tgz",
@@ -2495,6 +2959,101 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.2.0.tgz",
+      "integrity": "sha512-L1kSeviUWL+emq3CUVSgdogoM/D9QMFaqxL/dd0X7PCNWmPXqt+ExtrBjqT0V7HLN03Vs9SuiLrG3zy3JGnE5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-uri-escape": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder/node_modules/@smithy/util-uri-escape": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.2.0.tgz",
+      "integrity": "sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.2.0.tgz",
+      "integrity": "sha512-BvHCDrKfbG5Yhbpj4vsbuPV2GgcpHiAkLeIlcA1LtfpMz3jrqizP1+OguSNSj1MwBHEiN+jwNisXLGdajGDQJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.4.0.tgz",
+      "integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/signature-v4": {
@@ -2511,6 +3070,51 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@smithy/smithy-client": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.5.1.tgz",
+      "integrity": "sha512-jrbSQrYCho0yDaaf92qWgd+7nAeap5LtHTI51KXqmpIFCceKU3K9+vIVTUH72bOJngBMqa4kyu1VJhRcSrk/CQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-stream": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client/node_modules/@smithy/protocol-http": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.3.0.tgz",
+      "integrity": "sha512-Xy5XK1AFWW2nlY/biWZXu6/krgbaf2dg0q492D8M5qthsnU2H+UgFeZLbM76FnH7s6RO/xhQRkj+T6KBO3JzgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@smithy/types": {
       "version": "4.16.1",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
@@ -2521,6 +3125,60 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.2.0.tgz",
+      "integrity": "sha512-hoA4zm61q1mNTpksiSWp2nEl1dt3j726HdRhiNgVJQMj7mLp7dprtF57mOB6JvEk/x9d2bsuL5hlqZbBuHQylQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/url-parser/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
+      "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-buffer-from": {
@@ -2535,6 +3193,151 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.2.0.tgz",
+      "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.2.0.tgz",
+      "integrity": "sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.2.0.tgz",
+      "integrity": "sha512-17faEXbYWIRst1aU9SvPZyMdWmqIrduZjVOqCPMIsWFNxs5yQQgFrJL6b2SdiCzyW9mJoDjFtgi53xx7EH+BXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream/node_modules/@smithy/fetch-http-handler": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.5.0.tgz",
+      "integrity": "sha512-BOWEBeppWhLn/no/JxUL/ghTfANTjT7kg3Ww2rPqTUY9R4yHPXxJ9JhMe3Z03LN3aPwiwlpDIUcVw1xDyHqEhw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/querystring-builder": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-base64": "^2.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/util-stream/node_modules/@smithy/node-http-handler": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.5.0.tgz",
+      "integrity": "sha512-mVGyPBzkkGQsPoxQUbxlEfRjrj6FPyA3u3u2VXGr9hT8wilsoQdZdvKpMBFMB8Crfhv5dNkKHIW0Yyuc7eABqA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/querystring-builder": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream/node_modules/@smithy/protocol-http": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.3.0.tgz",
+      "integrity": "sha512-Xy5XK1AFWW2nlY/biWZXu6/krgbaf2dg0q492D8M5qthsnU2H+UgFeZLbM76FnH7s6RO/xhQRkj+T6KBO3JzgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-utf8": {
@@ -6724,7 +7527,8 @@
         "@ai-sdk/amazon-bedrock": "^4.0.129",
         "@ai-sdk/openai": "^3.0.41",
         "@ai-sdk/provider": "^3.0.0",
-        "@anthropic-ai/sdk": "^0.109.1",
+        "@anthropic-ai/bedrock-sdk": "^0.32.4",
+        "@anthropic-ai/sdk": "^0.117.1",
         "@aws-sdk/client-bedrock": "^3.1078.0",
         "@aws-sdk/client-bedrock-agent": "^3.1078.0",
         "@aws-sdk/client-bedrock-agent-runtime": "^3.1078.0",
@@ -6768,7 +7572,8 @@
       "peerDependencies": {
         "@a2a-js/sdk": "^0.3.10",
         "@ai-sdk/provider": "^3.0.0",
-        "@anthropic-ai/sdk": "^0.109.1",
+        "@anthropic-ai/bedrock-sdk": "^0.32.4",
+        "@anthropic-ai/sdk": "^0.117.1",
         "@aws-sdk/client-bedrock-agent": "^3.1078.0",
         "@aws-sdk/client-bedrock-agent-runtime": "^3.1078.0",
         "@aws-sdk/client-s3": "^3.1078.0",
@@ -6794,6 +7599,9 @@
           "optional": true
         },
         "@ai-sdk/provider": {
+          "optional": true
+        },
+        "@anthropic-ai/bedrock-sdk": {
           "optional": true
         },
         "@anthropic-ai/sdk": {

--- a/site/src/content/docs/user-guide/concepts/model-providers/anthropic.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/anthropic.mdx
@@ -6,6 +6,7 @@ integrationType: model-provider
 sourceLinks:
   - path: strands-py/src/strands/models/anthropic.py
   - path: strands-ts/src/models/anthropic.ts
+  - path: strands-ts/src/models/anthropic-bedrock.ts
 ---
 
 [Anthropic](https://docs.anthropic.com/en/home) is an AI safety and research company focused on building reliable, interpretable, and steerable AI systems. Included in their offerings is the Claude AI family of models, which are known for their conversational abilities, careful reasoning, and capacity to follow complex instructions. The Strands Agents SDK implements an Anthropic provider, allowing users to run agents against Claude models directly.
@@ -67,6 +68,41 @@ print(response)
 ```
 </Tab>
 </Tabs>
+
+### Amazon Bedrock (Mantle)
+
+Claude models also run on
+[Amazon Bedrock's Anthropic-compatible endpoint](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-messages-api.html)
+powered by Mantle, which bills through your AWS account instead of an Anthropic API key.
+Give the provider a region and it signs every request with SigV4 from the standard AWS
+credential chain.
+
+Model IDs on Mantle differ from the direct API. The endpoint serves
+`anthropic.claude-sonnet-5`, `anthropic.claude-opus-4-8`, and `anthropic.claude-haiku-4-5`,
+among others.
+
+<Tabs>
+<Tab label="TypeScript">
+
+Mantle needs one more package alongside the provider:
+
+```bash
+npm install @anthropic-ai/bedrock-sdk
+```
+
+```typescript
+--8<-- "user-guide/concepts/model-providers/anthropic_imports.ts:bedrock_mantle_imports"
+
+--8<-- "user-guide/concepts/model-providers/anthropic.ts:bedrock_mantle"
+```
+</Tab>
+</Tabs>
+
+Omit the region to resolve it from the `AWS_REGION` environment variable. To authenticate
+with a named profile or a
+[Bedrock API key](https://docs.aws.amazon.com/bedrock/latest/userguide/api-key-management.html)
+instead of the default credential chain, add `profile` or
+<Syntax py="api_key" ts="apiKey" /> to the same config.
 
 ## Configuration
 

--- a/site/src/content/docs/user-guide/concepts/model-providers/anthropic.ts
+++ b/site/src/content/docs/user-guide/concepts/model-providers/anthropic.ts
@@ -94,3 +94,18 @@ async function promptCaching() {
   // { inputTokens: 12, ..., cacheReadInputTokens: 2505 }
   // --8<-- [end:prompt_caching]
 }
+
+// Amazon Bedrock (Mantle)
+async function bedrockMantle() {
+  // --8<-- [start:bedrock_mantle]
+  const model = new AnthropicModel({
+    modelId: 'anthropic.claude-sonnet-5',
+    maxTokens: 1028,
+    bedrockMantleConfig: { region: 'us-east-1' },
+  })
+
+  const agent = new Agent({ model })
+  const response = await agent.invoke('What is 2+2?')
+  console.log(response)
+  // --8<-- [end:bedrock_mantle]
+}

--- a/site/src/content/docs/user-guide/concepts/model-providers/anthropic_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/model-providers/anthropic_imports.ts
@@ -21,3 +21,8 @@ import { z } from 'zod'
 import { Agent } from '@strands-agents/sdk'
 import { AnthropicModel } from '@strands-agents/sdk/models/anthropic'
 // --8<-- [end:prompt_caching_imports]
+
+// --8<-- [start:bedrock_mantle_imports]
+import { Agent } from '@strands-agents/sdk'
+import { AnthropicModel } from '@strands-agents/sdk/models/anthropic'
+// --8<-- [end:bedrock_mantle_imports]

--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -197,7 +197,8 @@
     "@ai-sdk/amazon-bedrock": "^4.0.129",
     "@ai-sdk/openai": "^3.0.41",
     "@ai-sdk/provider": "^3.0.0",
-    "@anthropic-ai/sdk": "^0.109.1",
+    "@anthropic-ai/bedrock-sdk": "^0.32.4",
+    "@anthropic-ai/sdk": "^0.117.1",
     "@aws-sdk/client-bedrock": "^3.1078.0",
     "@aws-sdk/client-bedrock-agent": "^3.1078.0",
     "@aws-sdk/client-bedrock-agent-runtime": "^3.1078.0",
@@ -256,7 +257,8 @@
   "peerDependencies": {
     "@a2a-js/sdk": "^0.3.10",
     "@ai-sdk/provider": "^3.0.0",
-    "@anthropic-ai/sdk": "^0.109.1",
+    "@anthropic-ai/bedrock-sdk": "^0.32.4",
+    "@anthropic-ai/sdk": "^0.117.1",
     "@aws-sdk/client-bedrock-agent": "^3.1078.0",
     "@aws-sdk/client-bedrock-agent-runtime": "^3.1078.0",
     "@aws-sdk/client-s3": "^3.1078.0",
@@ -282,6 +284,9 @@
       "optional": true
     },
     "@ai-sdk/provider": {
+      "optional": true
+    },
+    "@anthropic-ai/bedrock-sdk": {
       "optional": true
     },
     "@anthropic-ai/sdk": {

--- a/strands-ts/src/models/__tests__/anthropic-bedrock.test.ts
+++ b/strands-ts/src/models/__tests__/anthropic-bedrock.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import Anthropic from '@anthropic-ai/sdk'
+import { isNode } from '../../__fixtures__/environment.js'
+import { AnthropicModel } from '../anthropic.js'
+import { Message, TextBlock } from '../../types/messages.js'
+
+vi.mock('@anthropic-ai/sdk', () => {
+  const mockConstructor = vi.fn(function () {
+    return { messages: { stream: vi.fn(), countTokens: vi.fn() } }
+  })
+  return { default: mockConstructor }
+})
+
+const countTokensMock = vi.fn()
+const mantleConstructorMock = vi.fn((_options: Record<string, unknown>) => ({
+  messages: { stream: vi.fn(), countTokens: countTokensMock },
+}))
+vi.mock('@anthropic-ai/bedrock-sdk', () => ({
+  AnthropicBedrockMantle: function (this: unknown, options: Record<string, unknown>) {
+    return mantleConstructorMock(options)
+  },
+}))
+
+vi.mock('../../logging/warn-once.js', () => ({
+  warnOnce: vi.fn(),
+}))
+
+const TEST_MODEL_ID = 'anthropic.claude-sonnet-5'
+const MESSAGES: Message[] = [new Message({ role: 'user', content: [new TextBlock('hello')] })]
+
+/** Builds a Mantle-routed model; the client itself is only created on first request. */
+function mantleModel(options: Record<string, unknown> = {}): AnthropicModel {
+  return new AnthropicModel({
+    modelId: TEST_MODEL_ID,
+    maxTokens: 64,
+    useNativeTokenCount: true,
+    bedrockMantleConfig: { region: 'us-east-1' },
+    ...options,
+  })
+}
+
+/** Drives the lazily imported client into existence. */
+async function firstRequest(model: AnthropicModel): Promise<void> {
+  await model.countTokens(MESSAGES)
+}
+
+/** Options the Mantle client was last constructed with. */
+function lastMantleOptions(): Record<string, unknown> {
+  expect(mantleConstructorMock).toHaveBeenCalled()
+  return mantleConstructorMock.mock.calls.at(-1)![0]
+}
+
+describe('AnthropicModel bedrockMantleConfig', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    countTokensMock.mockResolvedValue({ input_tokens: 7 })
+    if (isNode) {
+      // The Mantle pathway must not read the direct-API key, and region resolution must
+      // not inherit the runner's environment.
+      vi.stubEnv('ANTHROPIC_API_KEY', '')
+      vi.stubEnv('AWS_REGION', '')
+      vi.stubEnv('AWS_DEFAULT_REGION', '')
+    }
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    if (isNode) {
+      vi.unstubAllEnvs()
+    }
+  })
+
+  describe('client wiring', () => {
+    it('builds the Mantle client rather than the direct Anthropic client', async () => {
+      await firstRequest(mantleModel())
+
+      expect(lastMantleOptions()).toEqual({ awsRegion: 'us-east-1' })
+      expect(Anthropic).not.toHaveBeenCalled()
+    })
+
+    it('builds the direct Anthropic client when the config is absent', () => {
+      new AnthropicModel({ modelId: 'claude-sonnet-4-6', maxTokens: 64, apiKey: 'sk-ant-test' })
+
+      expect(Anthropic).toHaveBeenCalled()
+      expect(mantleConstructorMock).not.toHaveBeenCalled()
+    })
+
+    it('defers building the client until the first request', () => {
+      mantleModel()
+
+      expect(mantleConstructorMock).not.toHaveBeenCalled()
+    })
+
+    it('reuses a single client across requests', async () => {
+      const model = mantleModel()
+
+      await firstRequest(model)
+      await firstRequest(model)
+
+      expect(mantleConstructorMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('model defaults', () => {
+    it('defaults to a model the Mantle catalog serves', () => {
+      // Mantle does not carry Sonnet 4.6, so the direct-API default would 404 there.
+      const model = new AnthropicModel({ maxTokens: 64, bedrockMantleConfig: { region: 'us-east-1' } })
+
+      expect(model.getConfig().modelId).toBe('anthropic.claude-sonnet-5')
+    })
+
+    it('leaves the direct-API default alone', () => {
+      const model = new AnthropicModel({ maxTokens: 64, apiKey: 'sk-ant-test' })
+
+      expect(model.getConfig().modelId).toBe('claude-sonnet-4-6')
+    })
+  })
+
+  describe('option mapping', () => {
+    it('forwards profile and apiKey', async () => {
+      await firstRequest(mantleModel({ bedrockMantleConfig: { region: 'us-east-1', profile: 'p1', apiKey: 'k1' } }))
+
+      expect(lastMantleOptions()).toEqual({ awsRegion: 'us-east-1', awsProfile: 'p1', apiKey: 'k1' })
+    })
+
+    it('merges clientConfig transport options', async () => {
+      await firstRequest(mantleModel({ clientConfig: { timeout: 42, defaultHeaders: { 'X-Trace-Id': 'abc' } } }))
+
+      expect(lastMantleOptions()).toEqual({
+        awsRegion: 'us-east-1',
+        timeout: 42,
+        defaultHeaders: { 'X-Trace-Id': 'abc' },
+      })
+    })
+  })
+
+  describe('validation', () => {
+    // The message names the offending option, so it is asserted here rather than only the
+    // prefix: the check and the message must not be able to disagree about what conflicted.
+    it.each([
+      ['a pre-built client', { client: {} as Anthropic }, 'client'],
+      ['a top-level apiKey', { apiKey: 'sk-ant-test' }, 'apiKey'],
+      ['clientConfig.apiKey', { clientConfig: { apiKey: 'sk-ant-test' } }, 'clientConfig.apiKey'],
+    ])('rejects %s', (_label, options, named) => {
+      expect(() => mantleModel(options)).toThrow(`bedrockMantleConfig cannot be combined with ${named};`)
+    })
+
+    it('rejects a malformed region before it reaches the endpoint URL', () => {
+      expect(() => mantleModel({ bedrockMantleConfig: { region: 'x@attacker.com:443/#' } })).toThrow(
+        'invalid AWS region'
+      )
+    })
+  })
+
+  if (isNode) {
+    describe('region resolution', () => {
+      it('resolves the region from AWS_REGION', async () => {
+        vi.stubEnv('AWS_REGION', 'eu-west-1')
+
+        await firstRequest(mantleModel({ bedrockMantleConfig: {} }))
+
+        expect(lastMantleOptions()).toEqual({ awsRegion: 'eu-west-1' })
+      })
+
+      it('resolves the region from AWS_DEFAULT_REGION', async () => {
+        vi.stubEnv('AWS_DEFAULT_REGION', 'ap-northeast-1')
+
+        await firstRequest(mantleModel({ bedrockMantleConfig: {} }))
+
+        expect(lastMantleOptions()).toEqual({ awsRegion: 'ap-northeast-1' })
+      })
+
+      it('rejects a malformed region resolved from the environment', () => {
+        vi.stubEnv('AWS_REGION', 'x@attacker.com:443/#')
+
+        expect(() => mantleModel({ bedrockMantleConfig: {} })).toThrow('invalid AWS region')
+      })
+
+      it('throws when no region resolves', () => {
+        expect(() => mantleModel({ bedrockMantleConfig: {} })).toThrow('could not resolve an AWS region')
+      })
+    })
+  }
+})

--- a/strands-ts/src/models/anthropic-bedrock.ts
+++ b/strands-ts/src/models/anthropic-bedrock.ts
@@ -1,0 +1,138 @@
+/**
+ * Internal helpers for routing an {@link AnthropicModel} through Amazon Bedrock's
+ * Anthropic-compatible "Mantle" endpoint.
+ *
+ * Converts a {@link BedrockMantleConfig} into the options `AnthropicBedrockMantle`
+ * consumes. That client derives the Mantle base URL, sends the required
+ * `anthropic-version` header, and signs every request with SigV4 on its own, so
+ * unlike the OpenAI-compatible pathway nothing here mints or caches a credential.
+ */
+
+import type { AnthropicBedrockMantle, BedrockMantleClientOptions } from '@anthropic-ai/bedrock-sdk'
+import type { ClientOptions } from '@anthropic-ai/sdk'
+
+const MANTLE_DOCS_URL = 'https://docs.aws.amazon.com/bedrock/latest/userguide/inference-messages-api.html'
+
+// Matches AWS region identifiers such as us-east-1, ap-southeast-1, and us-gov-east-1.
+// Anchored so a malformed region (e.g. one containing '@', ':', '/', '#') cannot re-point
+// the Mantle endpoint URL to a non-AWS host. Mirrors the Python SDK's validate_region
+// (`[0-9]` rather than `\d` keeps the two patterns character-identical).
+const VALID_REGION = /^[a-z]{2}(-[a-z]+)+-[0-9]+$/
+
+/**
+ * Config for routing an Anthropic client through Amazon Bedrock's Mantle endpoint.
+ *
+ * When supplied to `AnthropicModel`, this config builds the Mantle client. It cannot
+ * be combined with a pre-built `client`, a top-level `apiKey`, or `clientConfig.apiKey`,
+ * since authentication is derived from this config.
+ */
+export interface BedrockMantleConfig {
+  /**
+   * AWS region hosting the Bedrock Mantle endpoint. If omitted, resolved from the
+   * `AWS_REGION` or `AWS_DEFAULT_REGION` environment variable. An error is thrown if
+   * none resolve.
+   */
+  region?: string
+
+  /**
+   * AWS named profile to authenticate with. Selects SigV4 authentication.
+   */
+  profile?: string
+
+  /**
+   * Amazon Bedrock API key. When set, requests carry it as a bearer token instead of
+   * being signed with SigV4. Omit to use the standard AWS credential chain.
+   */
+  apiKey?: string
+}
+
+/**
+ * Validates an AWS region before it is interpolated into the Mantle endpoint URL.
+ *
+ * Guards against a malformed region (containing URL control characters such as `@`,
+ * `:`, `/`, `#`) re-pointing a signed request to a non-AWS host.
+ *
+ * @internal
+ */
+function validateRegion(region: string): string {
+  if (!VALID_REGION.test(region)) {
+    throw new Error(`invalid AWS region: '${region}'`)
+  }
+  return region
+}
+
+/**
+ * Resolves the AWS region for Mantle, preferring explicit config and falling back to
+ * the standard AWS env vars. The resolved region is validated before it is returned,
+ * since `AnthropicBedrockMantle` interpolates it into the Mantle endpoint URL.
+ *
+ * @throws Error when no region resolves from the config or the environment, or when the
+ * resolved region is not a well-formed AWS region identifier.
+ * @internal
+ */
+export function resolveMantleRegion(config: BedrockMantleConfig): string {
+  if (config.region) {
+    return validateRegion(config.region)
+  }
+
+  const envRegion = globalThis?.process?.env?.AWS_REGION || globalThis?.process?.env?.AWS_DEFAULT_REGION
+  if (envRegion) {
+    return validateRegion(envRegion)
+  }
+
+  throw new Error(
+    "could not resolve an AWS region for Bedrock Mantle. Pass 'region' in " +
+      'bedrockMantleConfig or set AWS_REGION in the environment. ' +
+      `See ${MANTLE_DOCS_URL} for supported regions.`
+  )
+}
+
+/**
+ * Resolves a Mantle config (plus optional client options) into `AnthropicBedrockMantle`
+ * constructor options.
+ *
+ * Synchronous so a caller can fail fast on an unresolvable or malformed region without
+ * waiting for the lazily imported client package.
+ *
+ * @throws Error when the region cannot be resolved or is malformed.
+ * @internal
+ */
+export function resolveMantleClientOptions(
+  config: BedrockMantleConfig,
+  clientConfig?: Omit<ClientOptions, 'apiKey'>
+): BedrockMantleClientOptions {
+  // Only forward keys the caller set; the Mantle client reads auth precedence off which
+  // options are not undefined, so passing an explicit undefined would change the mode.
+  return {
+    ...clientConfig,
+    awsRegion: resolveMantleRegion(config),
+    ...(config.profile !== undefined ? { awsProfile: config.profile } : {}),
+    ...(config.apiKey !== undefined ? { apiKey: config.apiKey } : {}),
+  }
+}
+
+/**
+ * Builds an `AnthropicBedrockMantle` client from resolved options.
+ *
+ * The `@anthropic-ai/bedrock-sdk` package is loaded lazily on first use so applications
+ * that never touch the Mantle pathway don't need it installed.
+ *
+ * @throws Error when `@anthropic-ai/bedrock-sdk` is not installed.
+ * @internal
+ */
+export async function createMantleClient(options: BedrockMantleClientOptions): Promise<AnthropicBedrockMantle> {
+  const { AnthropicBedrockMantle: MantleClient } = await loadBedrockSdk()
+  return new MantleClient(options)
+}
+
+async function loadBedrockSdk(): Promise<typeof import('@anthropic-ai/bedrock-sdk')> {
+  try {
+    return await import('@anthropic-ai/bedrock-sdk')
+  } catch (cause) {
+    throw new Error(
+      "bedrockMantleConfig requires the '@anthropic-ai/bedrock-sdk' package | " +
+        "install it with: npm install '@anthropic-ai/bedrock-sdk'",
+      { cause }
+    )
+  }
+}

--- a/strands-ts/src/models/anthropic.ts
+++ b/strands-ts/src/models/anthropic.ts
@@ -1,4 +1,6 @@
+import type { AnthropicBedrockMantle, BedrockMantleClientOptions } from '@anthropic-ai/bedrock-sdk'
 import Anthropic, { type ClientOptions } from '@anthropic-ai/sdk'
+import { type BedrockMantleConfig, createMantleClient, resolveMantleClientOptions } from './anthropic-bedrock.js'
 import {
   Model,
   type BaseModelConfig,
@@ -18,6 +20,8 @@ import { encodeBase64 } from '../types/media.js'
 import { logger } from '../logging/logger.js'
 import { warnOnce } from '../logging/warn-once.js'
 import { MODEL_DEFAULTS, defaultMaxTokensWarningMessage, defaultModelWarningMessage } from './defaults.js'
+
+export type { BedrockMantleConfig } from './anthropic-bedrock.js'
 
 // Union of overflow phrases observed across Anthropic responses, matched
 // case-insensitively. Kept in lowercase so the comparison is a single
@@ -82,28 +86,66 @@ export interface AnthropicModelOptions extends AnthropicModelConfig {
   apiKey?: string
   client?: Anthropic
   clientConfig?: ClientOptions
+
+  /**
+   * Route requests through Amazon Bedrock's Mantle (Anthropic-compatible) endpoint.
+   *
+   * Requests are signed with SigV4 unless the config supplies an API key, using the
+   * profile it names or the standard AWS credential chain. Cannot be combined with a
+   * pre-built `client`, a top-level `apiKey`, or `clientConfig.apiKey`.
+   *
+   * @see https://docs.aws.amazon.com/bedrock/latest/userguide/inference-messages-api.html
+   */
+  bedrockMantleConfig?: BedrockMantleConfig
 }
 
 export class AnthropicModel extends Model<AnthropicModelConfig> {
   private _config: AnthropicModelConfig
-  private _client: Anthropic
+  private _client?: Anthropic | AnthropicBedrockMantle
+  private _mantleClientOptions?: BedrockMantleClientOptions
+  private _clientPromise?: Promise<AnthropicBedrockMantle>
+  private readonly _defaultModelId: string
 
   constructor(options?: AnthropicModelOptions) {
     super()
-    const { apiKey, client, clientConfig, ...modelConfig } = options || {}
+    const { apiKey, client, clientConfig, bedrockMantleConfig, ...modelConfig } = options || {}
+
+    this._defaultModelId = bedrockMantleConfig
+      ? MODEL_DEFAULTS.anthropic.mantleModelId
+      : MODEL_DEFAULTS.anthropic.modelId
 
     this._config = {
-      modelId: MODEL_DEFAULTS.anthropic.modelId,
+      modelId: this._defaultModelId,
       maxTokens: MODEL_DEFAULTS.anthropic.maxTokens,
       ...modelConfig,
     }
 
     if (modelConfig.modelId === undefined) {
-      warnOnce(logger, defaultModelWarningMessage(MODEL_DEFAULTS.anthropic.modelId))
+      warnOnce(logger, defaultModelWarningMessage(this._defaultModelId))
     }
 
     if (modelConfig.maxTokens === undefined) {
       warnOnce(logger, defaultMaxTokensWarningMessage(MODEL_DEFAULTS.anthropic.maxTokens))
+    }
+
+    if (bedrockMantleConfig) {
+      const conflicting = [
+        ...(client ? ['client'] : []),
+        ...(apiKey ? ['apiKey'] : []),
+        ...(clientConfig?.apiKey ? ['clientConfig.apiKey'] : []),
+      ]
+      if (conflicting.length > 0) {
+        throw new Error(
+          `bedrockMantleConfig cannot be combined with ${conflicting.join(', ')}; ` +
+            'authentication is derived from the Mantle config automatically.'
+        )
+      }
+
+      // Options resolve eagerly so an unresolvable or malformed region fails here, but the
+      // Mantle client lives in an optional package and is imported on first use, since a
+      // constructor cannot await.
+      this._mantleClientOptions = resolveMantleClientOptions(bedrockMantleConfig, clientConfig)
+      return
     }
 
     if (client) {
@@ -125,12 +167,27 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
     }
   }
 
+  /**
+   * Resolves the client for the current request.
+   *
+   * Returns the client built in the constructor, or awaits the lazily imported Mantle
+   * client when `bedrockMantleConfig` was supplied.
+   */
+  private async _resolveClient(): Promise<Anthropic | AnthropicBedrockMantle> {
+    if (this._client !== undefined) {
+      return this._client
+    }
+    this._clientPromise ??= createMantleClient(this._mantleClientOptions!)
+    this._client = await this._clientPromise
+    return this._client
+  }
+
   updateConfig(modelConfig: AnthropicModelConfig): void {
     this._config = { ...this._config, ...modelConfig }
   }
 
   getConfig(): AnthropicModelConfig {
-    return resolveConfigMetadata(this._config, this._config.modelId ?? MODEL_DEFAULTS.anthropic.modelId)
+    return resolveConfigMetadata(this._config, this._config.modelId ?? this._defaultModelId)
   }
 
   /**
@@ -157,9 +214,10 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
       }
 
       const requestOptions = this._buildRequestOptions()
+      const client = await this._resolveClient()
       const response = requestOptions
-        ? await this._client.messages.countTokens(params, requestOptions)
-        : await this._client.messages.countTokens(params)
+        ? await client.messages.countTokens(params, requestOptions)
+        : await client.messages.countTokens(params)
 
       logger.debug(`total_tokens=<${response.input_tokens}> | native token count`)
       return response.input_tokens
@@ -173,9 +231,8 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
     try {
       const request = this._formatRequest(messages, options)
       const requestOptions = this._buildRequestOptions()
-      const stream = requestOptions
-        ? this._client.messages.stream(request, requestOptions)
-        : this._client.messages.stream(request)
+      const client = await this._resolveClient()
+      const stream = requestOptions ? client.messages.stream(request, requestOptions) : client.messages.stream(request)
 
       const usage = createEmptyUsage()
 

--- a/strands-ts/src/models/defaults.ts
+++ b/strands-ts/src/models/defaults.ts
@@ -8,6 +8,9 @@
 export const MODEL_DEFAULTS = {
   anthropic: {
     modelId: 'claude-sonnet-4-6',
+    // Bedrock Mantle serves a different catalog under `anthropic.`-prefixed ids and does
+    // not carry Sonnet 4.6, so the direct-API default would 404 on that endpoint.
+    mantleModelId: 'anthropic.claude-sonnet-5',
     maxTokens: 64_000,
   },
   bedrock: {

--- a/strands-ts/test/integ/models/anthropic-bedrock.test.node.ts
+++ b/strands-ts/test/integ/models/anthropic-bedrock.test.node.ts
@@ -1,0 +1,70 @@
+/**
+ * Integration tests for the Anthropic-compatible Bedrock Mantle pathway.
+ *
+ * Exercises `AnthropicModel` with `bedrockMantleConfig` against the live
+ * `bedrock-mantle.<region>.api.aws/anthropic` endpoint. Credentials come from the
+ * ambient AWS credential chain (same gate as the other Bedrock integ tests).
+ */
+
+import { describe, expect, it } from 'vitest'
+import { Agent, Message, TextBlock } from '@strands-agents/sdk'
+import { AnthropicModel } from '$/sdk/models/anthropic.js'
+
+import { bedrock } from '../__fixtures__/model-providers.js'
+
+const REGION = 'us-east-1'
+const MODEL_ID = 'anthropic.claude-sonnet-5'
+const MAX_TOKENS = 512
+
+describe.skipIf(bedrock.skip)('AnthropicModel (Bedrock Mantle) Integration Tests', () => {
+  it('reaches Mantle via bedrockMantleConfig', async () => {
+    const model = new AnthropicModel({
+      modelId: MODEL_ID,
+      maxTokens: MAX_TOKENS,
+      bedrockMantleConfig: { region: REGION },
+    })
+    const agent = new Agent({
+      model,
+      systemPrompt: 'Reply in one short sentence.',
+      printer: false,
+    })
+
+    const result = await agent.invoke('What is 2+2?')
+
+    expect(result.stopReason).toBe('endTurn')
+    expect(String(result)).toContain('4')
+  })
+
+  it('defaults to a model the Mantle catalog serves', async () => {
+    // The direct-API default is Sonnet 4.6, which Mantle does not serve; omitting
+    // modelId must still reach a model that exists on the endpoint.
+    const model = new AnthropicModel({
+      maxTokens: MAX_TOKENS,
+      bedrockMantleConfig: { region: REGION },
+    })
+    const agent = new Agent({
+      model,
+      systemPrompt: 'Reply in one short sentence.',
+      printer: false,
+    })
+
+    const result = await agent.invoke('What is 2+2?')
+
+    expect(result.stopReason).toBe('endTurn')
+    expect(String(result)).toContain('4')
+  })
+
+  it('counts tokens natively through Mantle', async () => {
+    const model = new AnthropicModel({
+      modelId: MODEL_ID,
+      maxTokens: MAX_TOKENS,
+      useNativeTokenCount: true,
+      bedrockMantleConfig: { region: REGION },
+    })
+    const messages = [new Message({ role: 'user', content: [new TextBlock('What is 2+2?')] })]
+
+    const count = await model.countTokens(messages)
+
+    expect(count).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Description

Amazon Bedrock serves Claude models through the Anthropic Messages API on the `bedrock-mantle` endpoint, billing through the caller's AWS account rather than an Anthropic API key. Reaching it from the TypeScript `AnthropicModel` today means pointing `clientConfig.baseURL` at the endpoint and authenticating with a static API key string; SigV4 signing, and with it instance roles, SSO sessions, and assumed roles, is unreachable. Handing the model a pre-built Mantle client instead does not compile, because `AnthropicBedrockMantle` and `Anthropic` are siblings rather than subtypes.

This adds `bedrockMantleConfig`, matching the option `OpenAIModel` already exposes for the OpenAI-compatible side of the same endpoint, and mirroring `bedrock_mantle_config` on the Python provider (#3832).

```typescript
import { Agent } from '@strands-agents/sdk'
import { AnthropicModel } from '@strands-agents/sdk/models/anthropic'

const model = new AnthropicModel({
  modelId: 'anthropic.claude-sonnet-5',
  maxTokens: 1028,
  bedrockMantleConfig: { region: 'us-east-1' },
})

console.log(String(await new Agent({ model }).invoke('What is 2+2?')))
```

`BedrockMantleConfig` accepts `region`, `profile`, and `apiKey`, all optional, and is re-exported from the anthropic module so callers can name it. Requests are signed with SigV4 unless `apiKey` is supplied, using the named profile or the standard AWS credential chain. Transport options continue through `clientConfig`; `client`, a top-level `apiKey`, and `clientConfig.apiKey` are rejected when the Mantle config is set, since authentication then comes from the config.

Three decisions worth a reviewer's attention:

**The client is imported on first request, not in the constructor.** `@anthropic-ai/bedrock-sdk` is an optional peer dependency, so applications that only call the direct API should not need it installed. A constructor cannot await, so the option resolution stays synchronous and the dynamic import is deferred. Resolution still fails fast: a malformed or unresolvable region throws from the constructor, before anything is imported.

**The default model ID becomes Mantle-aware.** `MODEL_DEFAULTS.anthropic.modelId` is `claude-sonnet-4-6`, which the Mantle catalog does not carry. Constructing the model with `bedrockMantleConfig` and no `modelId` failed every request with a 404 that the existing default-model warning did not predict. The direct-API default is unchanged.

**This deliberately does not share code with `models/openai/mantle.ts`.** The OpenAI pathway mints and refreshes a bearer token because the `openai` package knows nothing about AWS. `AnthropicBedrockMantle` derives the base URL, sends the `anthropic-version` header, and signs each request itself, so there is no token to mint. Only the region guard is conceptually shared, and it is four lines.

`@anthropic-ai/bedrock-sdk` requires `@anthropic-ai/sdk >=0.115.1`. The current peer range is `^0.109.1`, which for a `0.x` version admits only `0.109.x`, so the two ranges are disjoint and the range moves to `^0.117.1`. Consumers of the anthropic provider pinned to `0.109.x` will be moved.

## Related Issues

Resolves #3835

Python counterpart: #3833

## Documentation PR

The provider page gains an "Amazon Bedrock (Mantle)" section under `site/`, documenting
this option, the model IDs the endpoint serves, and how to pick an authentication mode.

The sibling PR adds the same section for the other SDK. Both introduce the section
independently so either can merge first; whichever merges second resolves the overlap by
keeping both language tabs in the one section.

## Type of Change

New feature

## Testing

Unit tests cover the client swap, deferred construction and reuse, the Mantle-aware and direct-API defaults, option mapping, `clientConfig` composition, rejection of conflicting options including the option each error names, and region resolution and rejection from both explicit config and the environment.

An integration test exercises the live `bedrock-mantle.us-east-1.api.aws/anthropic` endpoint: an agent invocation, the omitted-`modelId` default path, and native token counting. All three pass against `anthropic.claude-sonnet-5`.

`.agents/skills/pre-push/run-checks.sh` reports all local checks passing except `npm audit`, which fails identically on `origin/main` (`brace-expansion`, `nanoid`, `protobufjs`); this branch introduces no new advisory. `npm run lock:refresh` produces no diff against the committed lock file.

On the complexity label: the `complexity/high` score comes from `AnthropicModel::stream`, which scores 42 before this change and 42 after. This PR touches two lines inside it, to await the resolved client. The constructor is the function this change actually grows, and it is 20.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
