### PR TITLE
feat(ts): support multiple continuation inputs

### DIFF
--- a/strands-ts/src/agent/__tests__/agent.continuation.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.continuation.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
+import { createMockTool } from '../../__fixtures__/tool-helpers.js'
 import { AfterInvocationEvent, BeforeModelCallEvent, MessageAddedEvent } from '../../hooks/events.js'
+import { InterruptResponseContent } from '../../types/interrupt.js'
 import { Message, TextBlock, ToolResultBlock, ToolUseBlock } from '../../types/messages.js'
 import { Agent } from '../agent.js'
 import { continuations } from '../continuation.js'
@@ -59,6 +61,59 @@ describe('Agent continuation input', () => {
     expect(abandoned).toHaveBeenCalledWith(
       expect.objectContaining({ message: 'Continuation input must contain a complete message sequence' })
     )
+  })
+
+  it('retains follow-up input through failed resume attempts', async () => {
+    const model = new MockMessageModel()
+      .addTurn({
+        type: 'toolUseBlock',
+        name: 'confirmTool',
+        toolUseId: 'tool-1',
+        input: {},
+      })
+      .addTurn({ type: 'textBlock', text: 'resumed' })
+      .addTurn({ type: 'textBlock', text: 'continued' })
+    const requests = captureRequests(model)
+    const appended = vi.fn()
+    const abandoned = vi.fn()
+    const tool = createMockTool('confirmTool', (context) => {
+      const response = context.interrupt<string>({ name: 'confirm', reason: 'Confirm?' })
+      return `confirmed:${response}`
+    })
+    const agent = new Agent({ model, tools: [tool], printer: false })
+    let added = false
+
+    agent.addHook(AfterInvocationEvent, (event) => {
+      if (added) return
+      added = true
+      continuations.addInput(event, {
+        args: 'pending',
+        onAppended: appended,
+        onAbandoned: abandoned,
+      })
+    })
+
+    const interruptResult = await agent.invoke('start')
+
+    expect(interruptResult.stopReason).toBe('interrupt')
+    expect(appended).not.toHaveBeenCalled()
+    expect(abandoned).not.toHaveBeenCalled()
+
+    await expect(agent.invoke('invalid resume')).rejects.toThrow('Agent is in an interrupted state')
+    expect(appended).not.toHaveBeenCalled()
+    expect(abandoned).not.toHaveBeenCalled()
+
+    const finalResult = await agent.invoke([
+      new InterruptResponseContent({
+        interruptId: interruptResult.interrupts![0]!.id,
+        response: 'yes',
+      }),
+    ])
+
+    expect(finalResult.stopReason).toBe('endTurn')
+    expect(textOf(requests[2]!.at(-1)!)).toBe('pending')
+    expect(appended).toHaveBeenCalledOnce()
+    expect(abandoned).not.toHaveBeenCalled()
   })
 
   it('preserves an unrecognized stop reason instead of continuing', async () => {

--- a/strands-ts/src/agent/__tests__/agent.continuation.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.continuation.test.ts
@@ -61,6 +61,37 @@ describe('Agent continuation input', () => {
     )
   })
 
+  it('preserves an unrecognized stop reason instead of continuing', async () => {
+    // Unknown provider stop reasons must remain terminal (#3837).
+    const stopReason = 'providerSpecificStop'
+    const model = new MockMessageModel()
+      .addTurn({ type: 'textBlock', text: 'partial' }, { stopReason })
+      .addTurn({ type: 'textBlock', text: 'unreachable' })
+    const abandoned = vi.fn()
+    const agent = new Agent({ model, printer: false })
+    let added = false
+
+    agent.addHook(AfterInvocationEvent, (event) => {
+      if (added) return
+      added = true
+      continuations.addInput(event, { args: 'pending', onAbandoned: abandoned })
+    })
+
+    const result = await agent.invoke('start')
+
+    expect({
+      stopReason: result.stopReason,
+      modelCalls: model.callCount,
+      messages: agent.messages.map(textOf),
+      abandoned: abandoned.mock.calls.length,
+    }).toEqual({
+      stopReason,
+      modelCalls: 1,
+      messages: ['start', 'partial'],
+      abandoned: 1,
+    })
+  })
+
   it('appends a complete tool exchange contributed before the model call', async () => {
     const model = textModel('final')
     const requests = captureRequests(model)

--- a/strands-ts/src/agent/__tests__/agent.continuation.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.continuation.test.ts
@@ -1,23 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
-import { createMockTool } from '../../__fixtures__/tool-helpers.js'
-import {
-  AfterInvocationEvent,
-  BeforeInvocationEvent,
-  BeforeModelCallEvent,
-  MessageAddedEvent,
-} from '../../hooks/events.js'
-import { AgentStreamStage, InvokeModelStage } from '../../middleware/stages.js'
-import { AgentResult } from '../../types/agent.js'
+import { AfterInvocationEvent, BeforeModelCallEvent, MessageAddedEvent } from '../../hooks/events.js'
 import { Message, TextBlock, ToolResultBlock, ToolUseBlock } from '../../types/messages.js'
-import { logger } from '../../logging/logger.js'
 import { Agent } from '../agent.js'
-import { continuations as continuationManager } from '../continuation.js'
-
-import type { InvokeArgs } from '../../types/agent.js'
-import type { AgentStreamContext, AgentStreamResult } from '../../middleware/stages.js'
-import type { StopReason } from '../../types/messages.js'
-import type { ContinuationInput } from '../continuation.js'
+import { continuations } from '../continuation.js'
 
 function textOf(message: Message): string {
   return message.content.flatMap((block) => (block.type === 'textBlock' ? [block.text] : [])).join('')
@@ -37,664 +23,121 @@ function captureRequests(model: MockMessageModel): Message[][] {
   return requests
 }
 
-function toolExchange(toolUseId: string, text: string): [Message, Message] {
-  return [
-    new Message({
-      role: 'assistant',
-      content: [new ToolUseBlock({ name: 'deferred-result', toolUseId, input: {} })],
-    }),
-    new Message({
-      role: 'user',
-      content: [
-        new ToolResultBlock({
-          toolUseId,
-          status: 'success',
-          content: [new TextBlock(text)],
-        }),
-      ],
-    }),
-  ]
-}
-
-function continueAfterInvocation(agent: Agent, ...inputs: ContinuationInput[]): void {
-  let armed = false
-  agent.addHook(AfterInvocationEvent, (event) => {
-    if (armed) return
-    armed = true
-    for (const input of inputs) {
-      continuationManager.add(event, input)
-    }
-  })
-}
-
-function streamResult(
-  context: AgentStreamContext,
-  output: string | Message,
-  stopReason: StopReason = 'endTurn'
-): AgentStreamResult {
-  return {
-    result: new AgentResult({
-      stopReason,
-      lastMessage:
-        typeof output === 'string' ? new Message({ role: 'assistant', content: [new TextBlock(output)] }) : output,
-      invocationState: context.options?.invocationState ?? {},
-    }),
-  }
-}
-
 describe('Agent continuation input', () => {
-  it('combines internal contributions before public resume input', async () => {
-    const model = new MockMessageModel()
-      .addTurn({ type: 'textBlock', text: 'initial' })
-      .addTurn({ type: 'toolUseBlock', name: 'noop', toolUseId: 'tool-1', input: {} })
-      .addTurn({ type: 'textBlock', text: 'final' })
+  it('combines multiple follow-up contributions with public resume input', async () => {
+    const model = textModel('initial', 'final')
     const requests = captureRequests(model)
-    const consumed: string[] = []
-    const projectedInputTokens: number[] = []
-    const agent = new Agent({ model, tools: [createMockTool('noop', () => 'done')], printer: false })
-    let armed = false
-    let streamStageCalls = 0
+    const appended: string[] = []
+    const abandoned = vi.fn()
+    const agent = new Agent({ model, printer: false })
+    let resumed = false
 
-    vi.spyOn(model, 'countTokens').mockImplementation(async (messages) => messages.length)
     agent.addHook(AfterInvocationEvent, (event) => {
-      if (armed) return
-      armed = true
-      for (const args of ['first', 'second', 'third']) {
-        continuationManager.add(event, {
+      if (resumed) return
+      resumed = true
+      for (const args of ['first', 'second']) {
+        continuations.addInput(event, {
           args,
-          onConsumed: () => {
-            consumed.push(args)
+          onAppended: () => {
+            appended.push(args)
           },
         })
       }
+      continuations.addInput(event, {
+        args: [new Message({ role: 'assistant', content: [new TextBlock('invalid')] })],
+        onAbandoned: abandoned,
+      })
       event.resume = 'public'
     })
-    agent.addMiddleware(AgentStreamStage.Input, async (context) => {
-      streamStageCalls += 1
-      return streamStageCalls === 2 ? { ...context, args: 'rewritten public' } : context
-    })
-    agent.addHook(BeforeModelCallEvent, (event) => {
-      projectedInputTokens.push(event.projectedInputTokens ?? 0)
-    })
+
     await agent.invoke('start')
 
     expect(requests[1]?.map((message) => message.role)).toEqual(['user', 'assistant', 'user'])
-    expect(requests[1]?.at(-1)?.content.map((block) => (block.type === 'textBlock' ? block.text : block.type))).toEqual(
-      ['first', 'second', 'third', 'rewritten public']
+    expect(textOf(requests[1]!.at(-1)!)).toBe('firstsecondpublic')
+    expect(agent.messages.map(textOf)).toEqual(['start', 'initial', 'firstsecondpublic', 'final'])
+    expect(appended).toEqual(['first', 'second'])
+    expect(abandoned).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Continuation input must contain a complete message sequence' })
     )
-    expect(requests[2]?.map(textOf)).toEqual(['start', 'initial', 'firstsecondthirdrewritten public', '', ''])
-    expect(agent.messages.map(textOf)).toEqual([
-      'start',
-      'initial',
-      'first',
-      'second',
-      'third',
-      'rewritten public',
-      '',
-      '',
-      'final',
-    ])
-    expect(projectedInputTokens[1]).toBe(3)
-    expect(consumed).toEqual(['first', 'second', 'third'])
   })
 
-  it('consumes complete message input registered before the model call', async () => {
+  it('appends a complete tool exchange contributed before the model call', async () => {
     const model = textModel('final')
     const requests = captureRequests(model)
-    const consumed = vi.fn()
-    const rejected = vi.fn()
-    const [toolUse, toolResult] = toolExchange('delivery-1', 'complete')
-    const agent = new Agent({ model, printer: false })
-    let armed = false
-
-    agent.addHook(BeforeModelCallEvent, (event) => {
-      if (armed) return
-      armed = true
-      continuationManager.add(event, { args: [toolUse, toolResult], onConsumed: consumed, onRejected: rejected })
+    const metadata = { custom: { pinned: true } }
+    const initialInput = new Message({
+      role: 'user',
+      content: [new TextBlock('start')],
+      trackingId: 'durable-1',
+      metadata,
     })
-    agent.addMiddleware(InvokeModelStage.Input, async (context) => ({
-      ...context,
-      messages: context.messages.map((message) => {
-        const clone = message.clone()
-        return new Message({ role: clone.role, content: clone.content })
-      }),
-    }))
-    await agent.invoke('start')
+    const toolUse = new Message({
+      role: 'assistant',
+      content: [new ToolUseBlock({ name: 'background-result', toolUseId: 'delivery-1', input: {} })],
+    })
+    const toolResult = new Message({
+      role: 'user',
+      content: [
+        new ToolResultBlock({
+          toolUseId: 'delivery-1',
+          status: 'success',
+          content: [new TextBlock('complete')],
+        }),
+      ],
+    })
+    const appended = vi.fn()
+    const addedMessages: Message[] = []
+    const agent = new Agent({ model, printer: false })
+
+    agent.addHook(MessageAddedEvent, (event) => {
+      addedMessages.push(event.message)
+    })
+    agent.addHook(BeforeModelCallEvent, (event) => {
+      continuations.addInput(event, { args: 'guidance' })
+      continuations.addInput(event, {
+        args: [toolUse, toolResult],
+        onAppended: () => {
+          expect(agent.messages).toEqual([expect.any(Message), toolUse, toolResult])
+          appended()
+        },
+      })
+    })
+
+    await agent.invoke([initialInput])
 
     expect(requests[0]?.map((message) => message.role)).toEqual(['user', 'assistant', 'user'])
-    expect(agent.messages).toEqual([expect.any(Message), toolUse, toolResult, expect.any(Message)])
-    expect(consumed).toHaveBeenCalledTimes(1)
-    expect(rejected).not.toHaveBeenCalled()
-  })
-
-  it('preserves public resume visibility and history when the provider fails', async () => {
-    const model = new MockMessageModel()
-      .addTurn({ type: 'textBlock', text: 'initial' })
-      .addTurn(new Error('resumed call failed'))
-    const beforeModelMessages: string[][] = []
-    const agent = new Agent({ model, printer: false })
-    let armed = false
-    let streamStageCalls = 0
-
-    agent.addHook(AfterInvocationEvent, (event) => {
-      if (armed) return
-      armed = true
-      event.resume = 'follow-up'
-    })
-    agent.addMiddleware(AgentStreamStage.Input, async (context) => {
-      streamStageCalls += 1
-      return streamStageCalls === 2 ? { ...context, args: 'rewritten follow-up' } : context
-    })
-    agent.addHook(BeforeModelCallEvent, () => {
-      beforeModelMessages.push(agent.messages.map(textOf))
-    })
-
-    await expect(agent.invoke('start')).rejects.toThrow('resumed call failed')
-
-    expect(beforeModelMessages).toEqual([['start'], ['start', 'initial', 'rewritten follow-up']])
-    expect(agent.messages.map(textOf)).toEqual(['start', 'initial', 'rewritten follow-up'])
-  })
-
-  it('leaves history unchanged when a resume-only pass is short-circuited', async () => {
-    const model = textModel('initial')
-    const agent = new Agent({ model, printer: false })
-    let afterCalls = 0
-    let streamStageCalls = 0
-
-    agent.addHook(AfterInvocationEvent, (event) => {
-      afterCalls += 1
-      if (afterCalls === 1) event.resume = 'public'
-    })
-    agent.addMiddleware(AgentStreamStage, async function* (context, next) {
-      streamStageCalls += 1
-      if (streamStageCalls === 1) return yield* next(context)
-      return streamResult(context, 'fabricated')
-    })
-
-    const result = await agent.invoke('start')
-
-    expect(textOf(result.lastMessage)).toBe('fabricated')
-    expect(agent.messages.map(textOf)).toEqual(['start', 'initial'])
-  })
-
-  it('keeps public resume history ordered when the follow-up model call is cancelled', async () => {
-    const model = textModel('initial', 'unreachable')
-    const agent = new Agent({ model, printer: false })
-    let afterCalls = 0
-    let modelCalls = 0
-
-    agent.addHook(AfterInvocationEvent, (event) => {
-      afterCalls += 1
-      if (afterCalls === 1) event.resume = 'public follow-up'
-    })
-    agent.addHook(BeforeModelCallEvent, (event) => {
-      modelCalls += 1
-      if (modelCalls === 2) event.cancel = 'model denied'
-    })
-
-    await agent.invoke('start')
-
-    expect(agent.messages.map(textOf)).toEqual(['start', 'initial', 'public follow-up', 'model denied'])
-  })
-
-  it('rejects input without masking the provider error when its rejection callback fails', async () => {
-    const model = new MockMessageModel()
-      .addTurn({ type: 'textBlock', text: 'initial' })
-      .addTurn(new Error('resumed call failed'))
-    const consumed = vi.fn()
-    const rejected = vi.fn().mockRejectedValue(new Error('rejection callback failed'))
-    const agent = new Agent({ model, printer: false })
-    continueAfterInvocation(agent, { args: 'internal follow-up', onConsumed: consumed, onRejected: rejected })
-
-    await expect(agent.invoke('start')).rejects.toThrow('resumed call failed')
-
-    expect(consumed).not.toHaveBeenCalled()
-    expect(rejected).toHaveBeenCalledTimes(1)
-    expect(agent.messages.map(textOf)).toEqual(['start', 'initial'])
-  })
-
-  it.each(['model', 'agentMiddleware', 'modelMiddleware'] as const)(
-    'keeps a consumed message batch when a later stage fails after %s completion',
-    async (completion) => {
-      const model = textModel('initial', 'unrecorded', 'discarded')
-      const contribution = toolExchange('hook-delivery', 'internal contribution')
-      const beforeModelContribution = new Message({
+    expect(textOf(requests[0]![0]!)).toBe('startguidance')
+    expect(agent.messages).toEqual([
+      new Message({
         role: 'user',
-        content: [new TextBlock('before-model contribution')],
-      })
-      const consumed = vi.fn()
-      const rejected = vi.fn()
-      const added: Message[] = []
-      const agent = new Agent({ model, printer: false })
-      const continuation = {
-        args: contribution,
-        ...(completion !== 'agentMiddleware' && { onConsumed: consumed }),
-        onRejected: rejected,
-      }
+        content: [new TextBlock('start'), new TextBlock('guidance')],
+        trackingId: initialInput.trackingId,
+        metadata,
+      }),
+      toolUse,
+      toolResult,
+      expect.any(Message),
+    ])
+    expect(addedMessages).toContain(agent.messages[0])
+    expect(appended).toHaveBeenCalledOnce()
+  })
 
-      continueAfterInvocation(agent, continuation)
-      let beforeModelCalls = 0
-      agent.addHook(BeforeModelCallEvent, (event) => {
-        beforeModelCalls += 1
-        if (beforeModelCalls === 2) {
-          continuationManager.add(event, { args: [beforeModelContribution] })
-        }
-      })
-      agent.addHook(MessageAddedEvent, (event) => {
-        if (!contribution.includes(event.message) && event.message !== beforeModelContribution) return
-        added.push(event.message)
-        if (event.message === contribution[0] && completion !== 'modelMiddleware') {
-          throw new Error('message hook failed')
-        }
-      })
-      if (completion === 'agentMiddleware') {
-        let calls = 0
-        agent.addMiddleware(AgentStreamStage, async function* (context, next) {
-          calls += 1
-          if (calls === 1) return yield* next(context)
-          return streamResult(context, 'cached')
-        })
-      }
-      if (completion === 'modelMiddleware') {
-        const contributionIds = new Set(contribution.map((message) => message.trackingId))
-        let calls = 0
-        agent.addMiddleware(InvokeModelStage, async function* (context, next) {
-          calls += 1
-          if (calls !== 2) return yield* next(context)
+  it('abandons follow-up input when the stream closes before it is appended', async () => {
+    const abandoned = vi.fn()
+    const agent = new Agent({ model: textModel('initial', 'unreachable'), printer: false })
+    let added = false
 
-          yield* next(context)
-          yield* next({
-            ...context,
-            messages: context.messages.filter((message) => !contributionIds.has(message.trackingId)),
-          })
-          throw new Error('model middleware failed')
-        })
-      }
-
-      await expect(agent.invoke('start')).rejects.toThrow(
-        completion === 'modelMiddleware' ? 'model middleware failed' : 'message hook failed'
-      )
-
-      expect(rejected).not.toHaveBeenCalled()
-      expect(consumed).toHaveBeenCalledTimes(completion === 'agentMiddleware' ? 0 : 1)
-      const expectedMessages =
-        completion === 'agentMiddleware' ? contribution : [...contribution, beforeModelContribution]
-      expect(added).toEqual(expectedMessages)
-      expect(agent.messages).toEqual(expect.arrayContaining(expectedMessages))
-    }
-  )
-
-  it.each(['pendingPass', 'activePass', 'beforeModelCall'] as const)(
-    'rejects unconsumed input when the stream closes with a %s continuation',
-    async (stage) => {
-      const model = textModel('initial', 'unreachable')
-      const rejected = vi.fn()
-      const agent = new Agent({ model, printer: false })
-
-      if (stage === 'beforeModelCall') {
-        agent.addHook(BeforeModelCallEvent, (event) => {
-          continuationManager.add(event, { args: 'pending', onRejected: rejected })
-        })
-      } else {
-        continueAfterInvocation(agent, { args: 'pending', onRejected: rejected })
-      }
-
-      let beforeInvocationCount = 0
-      for await (const event of agent.stream('start')) {
-        if (event instanceof BeforeInvocationEvent) beforeInvocationCount += 1
-        const shouldClose =
-          (stage === 'pendingPass' && event instanceof AfterInvocationEvent) ||
-          (stage === 'activePass' && event instanceof BeforeInvocationEvent && beforeInvocationCount === 2) ||
-          (stage === 'beforeModelCall' && event instanceof BeforeModelCallEvent)
-        if (shouldClose) break
-      }
-
-      expect(rejected).toHaveBeenCalledTimes(1)
-    }
-  )
-
-  it('invokes every committed message hook before yielding the batch', async () => {
-    const model = textModel('initial', 'final')
-    const first = new Message({ role: 'user', content: [new TextBlock('first')] })
-    const second = new Message({ role: 'user', content: [new TextBlock('second')] })
-    const added: Message[] = []
-    const history: string[][] = []
-    const agent = new Agent({ model, printer: false })
-
-    continueAfterInvocation(agent, { args: [first, second] })
-    agent.addHook(MessageAddedEvent, (event) => {
-      if (event.message === first || event.message === second) {
-        added.push(event.message)
-        history.push(agent.messages.map(textOf))
-      }
+    agent.addHook(AfterInvocationEvent, (event) => {
+      if (added) return
+      added = true
+      continuations.addInput(event, { args: 'pending', onAbandoned: abandoned })
     })
 
     for await (const event of agent.stream('start')) {
-      if (event instanceof MessageAddedEvent && event.message === first) break
+      if (event instanceof MessageAddedEvent) break
     }
 
-    expect(added).toEqual([first, second])
-    expect(history).toEqual([
-      ['start', 'initial', 'first'],
-      ['start', 'initial', 'first', 'second'],
-    ])
-    expect(agent.messages).toEqual([expect.any(Message), expect.any(Message), first, second])
-  })
-
-  it('settles continuation input against the model middleware result that wins', async () => {
-    const model = textModel('initial', 'first retry', 'final')
-    const consumed = vi.fn()
-    const rejected = vi.fn()
-    const added: string[] = []
-    const contribution = new Message({ role: 'user', content: [new TextBlock('start')] })
-    const agent = new Agent({ model, printer: false })
-    let modelStageCalls = 0
-
-    continueAfterInvocation(agent, { args: [contribution], onConsumed: consumed, onRejected: rejected })
-    agent.addHook(MessageAddedEvent, (event) => {
-      if (event.message.trackingId === contribution.trackingId) added.push(event.message.trackingId)
-    })
-    agent.addMiddleware(InvokeModelStage, async function* (context, next) {
-      modelStageCalls += 1
-      if (modelStageCalls === 1) return yield* next(context)
-      yield* next(context)
-      const winningMessages = context.messages.filter((message) => message.trackingId !== contribution.trackingId)
-      const winningResult = yield* next({
-        ...context,
-        messages: winningMessages,
-      })
-      winningMessages.push(contribution)
-      return {
-        result: {
-          ...winningResult.result,
-          message: winningResult.result.message.clone(),
-        },
-      }
-    })
-
-    await agent.invoke('start')
-
-    expect(consumed).not.toHaveBeenCalled()
-    expect(rejected).toHaveBeenCalledTimes(1)
-    expect(added).toHaveLength(0)
-    expect(agent.messages.map(textOf)).toEqual(['start', 'initial', 'final'])
-  })
-
-  it('rejects ambiguous model-confirmed input when an identical public resume is retained', async () => {
-    const model = textModel('initial', 'final')
-    const consumed = vi.fn()
-    const rejected = vi.fn()
-    const agent = new Agent({ model, printer: false })
-    let afterInvocationCalls = 0
-    let modelStageCalls = 0
-
-    agent.addHook(AfterInvocationEvent, (event) => {
-      afterInvocationCalls += 1
-      if (afterInvocationCalls !== 1) return
-      continuationManager.add(event, {
-        args: 'duplicate',
-        onConsumed: consumed,
-        onRejected: rejected,
-      })
-      event.resume = 'duplicate'
-    })
-    agent.addMiddleware(InvokeModelStage.Input, async (context) => {
-      modelStageCalls += 1
-      if (modelStageCalls !== 2) return context
-      const messages = context.messages.slice(0, -1)
-      const merged = context.messages.at(-1)!
-      messages.push(new Message({ role: merged.role, content: [merged.content.at(-1)!] }))
-      return { ...context, messages }
-    })
-
-    await agent.invoke('start')
-
-    expect(consumed).not.toHaveBeenCalled()
-    expect(rejected).toHaveBeenCalledTimes(1)
-    expect(agent.messages.map(textOf)).toEqual(['start', 'initial', 'duplicate', 'final'])
-  })
-
-  it('does not turn consumption callback failures into model failures', async () => {
-    const model = textModel('initial', 'unrecorded')
-    const laterConsumed = vi.fn()
-    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
-    const agent = new Agent({ model, printer: false })
-
-    continueAfterInvocation(
-      agent,
-      {
-        args: 'first',
-        onConsumed: () => {
-          throw new Error('consumption callback failed')
-        },
-      },
-      { args: 'second', onConsumed: laterConsumed }
-    )
-
-    const result = await agent.invoke('start')
-
-    expect(result.stopReason).toBe('endTurn')
-    expect(laterConsumed).toHaveBeenCalledTimes(1)
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('continuation consumption callback failed'))
-    warn.mockRestore()
-  })
-
-  it('redacts every history message represented by a continuation request', async () => {
-    const model = textModel('blocked')
-    const originalStream = model.stream.bind(model)
-    vi.spyOn(model, 'stream').mockImplementation(async function* (messages, options) {
-      yield* originalStream(messages, options)
-      yield {
-        type: 'modelRedactionEvent',
-        inputRedaction: { replaceContent: '[redacted]' },
-      }
-    })
-    const agent = new Agent({ model, printer: false })
-    agent.addHook(BeforeModelCallEvent, (event) => {
-      continuationManager.add(event, { args: 'internal secret' })
-    })
-
-    await agent.invoke('original secret')
-
-    expect(agent.messages.map(textOf)).toEqual(['[redacted]', 'blocked'])
-  })
-
-  it.each(['interrupt', 'cancelled', 'checkpoint'] as const)(
-    'rejects pending input instead of following a terminal %s result',
-    async (stopReason) => {
-      const model = textModel('unreachable')
-      const rejected = vi.fn()
-      const agent = new Agent({ model, printer: false })
-
-      // eslint-disable-next-line require-yield
-      agent.addMiddleware(AgentStreamStage, async function* (context) {
-        return streamResult(context, stopReason, stopReason)
-      })
-      agent.addHook(AfterInvocationEvent, (event) => {
-        continuationManager.add(event, { args: 'continue', onRejected: rejected })
-      })
-
-      const result = await agent.invoke('start')
-
-      expect(result.stopReason).toBe(stopReason)
-      expect(rejected).toHaveBeenCalledWith(
-        expect.objectContaining({ message: `Continuation rejected by ${stopReason}` })
-      )
-    }
-  )
-
-  it('rejects an invalid contribution without discarding valid siblings or the completed result', async () => {
-    const model = textModel('initial', 'final')
-    const requests = captureRequests(model)
-    const invalidRejected = vi.fn()
-    const orphanRejected = vi.fn()
-    const validConsumed = vi.fn()
-    const [toolUse, toolResult] = toolExchange('delivery-1', 'complete')
-    const agent = new Agent({ model, printer: false })
-
-    continueAfterInvocation(
-      agent,
-      { args: [], onRejected: invalidRejected },
-      {
-        args: [
-          new Message({
-            role: 'user',
-            content: [
-              new ToolResultBlock({
-                toolUseId: 'missing',
-                status: 'success',
-                content: [new TextBlock('orphan')],
-              }),
-            ],
-          }),
-        ],
-        onRejected: orphanRejected,
-      },
-      { args: [toolUse, toolResult], onConsumed: validConsumed }
-    )
-
-    const result = await agent.invoke('start')
-
-    expect(result.stopReason).toBe('endTurn')
-    expect(invalidRejected).toHaveBeenCalledWith(
-      expect.objectContaining({ message: 'Continuation input must contain a complete message sequence' })
-    )
-    expect(orphanRejected).toHaveBeenCalledTimes(1)
-    expect(validConsumed).toHaveBeenCalledTimes(1)
-    expect(requests[1]?.slice(-2).map((message) => message.trackingId)).toEqual([
-      toolUse.trackingId,
-      toolResult.trackingId,
-    ])
-    expect(agent.messages).toEqual([expect.any(Message), expect.any(Message), toolUse, toolResult, expect.any(Message)])
-  })
-
-  it('rejects prepared contributions when public resume normalization fails', async () => {
-    const model = textModel('initial')
-    const rejected = vi.fn()
-    const agent = new Agent({ model, printer: false })
-    let armed = false
-
-    agent.addHook(AfterInvocationEvent, (event) => {
-      if (armed) return
-      armed = true
-      continuationManager.add(event, { args: 'internal', onRejected: rejected })
-      event.resume = [{ unsupported: true }] as unknown as InvokeArgs
-    })
-
-    await expect(agent.invoke('start')).rejects.toThrow()
-
-    expect(rejected).toHaveBeenCalledTimes(1)
-    expect(agent.messages.map(textOf)).toEqual(['start', 'initial'])
-  })
-
-  it('rejects active and newly registered input when BeforeInvocationEvent cancels the pass', async () => {
-    const model = textModel('initial')
-    const activeRejected = vi.fn()
-    const lateRejected = vi.fn()
-    const agent = new Agent({ model, printer: false })
-    let beforeCalls = 0
-    let afterCalls = 0
-
-    agent.addHook(BeforeInvocationEvent, (event) => {
-      beforeCalls += 1
-      if (beforeCalls === 2) event.cancel = 'invocation denied'
-    })
-    agent.addHook(AfterInvocationEvent, (event) => {
-      afterCalls += 1
-      if (afterCalls === 1) {
-        continuationManager.add(event, { args: 'active', onRejected: activeRejected })
-      } else if (afterCalls === 2) {
-        continuationManager.add(event, { args: 'late', onRejected: lateRejected })
-      }
-    })
-
-    const result = await agent.invoke('start')
-
-    expect(result.stopReason).toBe('endTurn')
-    expect(activeRejected).toHaveBeenCalledWith(
-      expect.objectContaining({ message: 'Continuation invocation cancelled by BeforeInvocationEvent' })
-    )
-    expect(lateRejected).toHaveBeenCalledWith(
-      expect.objectContaining({ message: 'Invocation cancelled by BeforeInvocationEvent' })
-    )
-    expect(agent.messages.map(textOf)).toEqual(['start', 'initial', 'invocation denied'])
-  })
-
-  it.each([
-    [{ turns: 3 }, 'limitTurns'],
-    [{ outputTokens: 3 }, 'limitOutputTokens'],
-  ] as const)('shares %s across middleware and continuation passes', async (limits, stopReason) => {
-    const usage = { inputTokens: 2, outputTokens: 1, totalTokens: 3 }
-    const model = new MockMessageModel()
-      .addTurn({ type: 'textBlock', text: 'initial' }, { usage })
-      .addTurn({ type: 'textBlock', text: 'second' }, { usage })
-      .addTurn({ type: 'textBlock', text: 'third' }, { usage })
-      .addTurn({ type: 'textBlock', text: 'unreachable' }, { usage })
-    const consumed = vi.fn()
-    const rejected = vi.fn()
-    const agent = new Agent({ model, printer: false })
-    let streamCalls = 0
-    agent.addMiddleware(AgentStreamStage, async function* (context, next) {
-      streamCalls += 1
-      if (streamCalls !== 1) return yield* next(context)
-      yield* next(context)
-      return yield* next(context)
-    })
-    agent.addHook(AfterInvocationEvent, (event) => {
-      continuationManager.add(event, { args: 'continue', onConsumed: consumed, onRejected: rejected })
-    })
-
-    const result = await agent.invoke('start', { limits })
-
-    expect(result.stopReason).toBe('endTurn')
-    expect(model.callCount).toBe(3)
-    expect(consumed).toHaveBeenCalledTimes(1)
-    expect(rejected).toHaveBeenCalledWith(
-      expect.objectContaining({ message: `Continuation rejected by ${stopReason}` })
-    )
-    expect(agent.messages.map(textOf)).toEqual(['start', 'initial', 'start', 'second', 'continue', 'third'])
-  })
-
-  it('uses fresh limits and cancellation for a public resume mixed with internal input', async () => {
-    const model = textModel('initial', 'final')
-    const consumed = vi.fn()
-    const rejected = vi.fn()
-    const agent = new Agent({ model, printer: false })
-    let armed = false
-
-    agent.addHook(AfterInvocationEvent, (event) => {
-      if (armed) return
-      armed = true
-      agent.cancel()
-      continuationManager.add(event, { args: 'internal', onConsumed: consumed, onRejected: rejected })
-      event.resume = 'public'
-    })
-
-    const result = await agent.invoke('start', { limits: { turns: 1 } })
-
-    expect(result.stopReason).toBe('endTurn')
-    expect(model.callCount).toBe(2)
-    expect(consumed).toHaveBeenCalledTimes(1)
-    expect(rejected).not.toHaveBeenCalled()
-    expect(agent.messages.map(textOf)).toEqual(['start', 'initial', 'internal', 'public', 'final'])
-  })
-
-  it('preserves cancellation across continuation passes', async () => {
-    const model = textModel('initial', 'unreachable')
-    const consumed = vi.fn()
-    const rejected = vi.fn()
-    const agent = new Agent({ model, printer: false })
-    continueAfterInvocation(agent, { args: 'continue', onConsumed: consumed, onRejected: rejected })
-    agent.addHook(AfterInvocationEvent, () => {
-      agent.cancel()
-    })
-
-    const result = await agent.invoke('start')
-
-    expect(result.stopReason).toBe('cancelled')
-    expect(model.callCount).toBe(1)
-    expect(consumed).not.toHaveBeenCalled()
-    expect(rejected).toHaveBeenCalledTimes(1)
-    expect(agent.messages.map(textOf)).toEqual(['start', 'initial'])
+    expect(abandoned).toHaveBeenCalledOnce()
+    expect(agent.messages.map(textOf)).toEqual(['start'])
   })
 })

--- a/strands-ts/src/agent/__tests__/agent.continuation.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.continuation.test.ts
@@ -1,0 +1,700 @@
+import { describe, expect, it, vi } from 'vitest'
+import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
+import { createMockTool } from '../../__fixtures__/tool-helpers.js'
+import {
+  AfterInvocationEvent,
+  BeforeInvocationEvent,
+  BeforeModelCallEvent,
+  MessageAddedEvent,
+} from '../../hooks/events.js'
+import { AgentStreamStage, InvokeModelStage } from '../../middleware/stages.js'
+import { AgentResult } from '../../types/agent.js'
+import { Message, TextBlock, ToolResultBlock, ToolUseBlock } from '../../types/messages.js'
+import { logger } from '../../logging/logger.js'
+import { Agent } from '../agent.js'
+import { continuations as continuationManager } from '../continuation.js'
+
+import type { InvokeArgs } from '../../types/agent.js'
+import type { AgentStreamContext, AgentStreamResult } from '../../middleware/stages.js'
+import type { StopReason } from '../../types/messages.js'
+import type { ContinuationInput } from '../continuation.js'
+
+function textOf(message: Message): string {
+  return message.content.flatMap((block) => (block.type === 'textBlock' ? [block.text] : [])).join('')
+}
+
+function textModel(...turns: string[]): MockMessageModel {
+  return turns.reduce((model, text) => model.addTurn({ type: 'textBlock', text }), new MockMessageModel())
+}
+
+function captureRequests(model: MockMessageModel): Message[][] {
+  const requests: Message[][] = []
+  const originalStream = model.stream.bind(model)
+  vi.spyOn(model, 'stream').mockImplementation(async function* (messages, options) {
+    requests.push(messages.map((message) => message.clone()))
+    yield* originalStream(messages, options)
+  })
+  return requests
+}
+
+function toolExchange(toolUseId: string, text: string): [Message, Message] {
+  return [
+    new Message({
+      role: 'assistant',
+      content: [new ToolUseBlock({ name: 'deferred-result', toolUseId, input: {} })],
+    }),
+    new Message({
+      role: 'user',
+      content: [
+        new ToolResultBlock({
+          toolUseId,
+          status: 'success',
+          content: [new TextBlock(text)],
+        }),
+      ],
+    }),
+  ]
+}
+
+function continueAfterInvocation(agent: Agent, ...inputs: ContinuationInput[]): void {
+  let armed = false
+  agent.addHook(AfterInvocationEvent, (event) => {
+    if (armed) return
+    armed = true
+    for (const input of inputs) {
+      continuationManager.add(event, input)
+    }
+  })
+}
+
+function streamResult(
+  context: AgentStreamContext,
+  output: string | Message,
+  stopReason: StopReason = 'endTurn'
+): AgentStreamResult {
+  return {
+    result: new AgentResult({
+      stopReason,
+      lastMessage:
+        typeof output === 'string' ? new Message({ role: 'assistant', content: [new TextBlock(output)] }) : output,
+      invocationState: context.options?.invocationState ?? {},
+    }),
+  }
+}
+
+describe('Agent continuation input', () => {
+  it('combines internal contributions before public resume input', async () => {
+    const model = new MockMessageModel()
+      .addTurn({ type: 'textBlock', text: 'initial' })
+      .addTurn({ type: 'toolUseBlock', name: 'noop', toolUseId: 'tool-1', input: {} })
+      .addTurn({ type: 'textBlock', text: 'final' })
+    const requests = captureRequests(model)
+    const consumed: string[] = []
+    const projectedInputTokens: number[] = []
+    const agent = new Agent({ model, tools: [createMockTool('noop', () => 'done')], printer: false })
+    let armed = false
+    let streamStageCalls = 0
+
+    vi.spyOn(model, 'countTokens').mockImplementation(async (messages) => messages.length)
+    agent.addHook(AfterInvocationEvent, (event) => {
+      if (armed) return
+      armed = true
+      for (const args of ['first', 'second', 'third']) {
+        continuationManager.add(event, {
+          args,
+          onConsumed: () => {
+            consumed.push(args)
+          },
+        })
+      }
+      event.resume = 'public'
+    })
+    agent.addMiddleware(AgentStreamStage.Input, async (context) => {
+      streamStageCalls += 1
+      return streamStageCalls === 2 ? { ...context, args: 'rewritten public' } : context
+    })
+    agent.addHook(BeforeModelCallEvent, (event) => {
+      projectedInputTokens.push(event.projectedInputTokens ?? 0)
+    })
+    await agent.invoke('start')
+
+    expect(requests[1]?.map((message) => message.role)).toEqual(['user', 'assistant', 'user'])
+    expect(requests[1]?.at(-1)?.content.map((block) => (block.type === 'textBlock' ? block.text : block.type))).toEqual(
+      ['first', 'second', 'third', 'rewritten public']
+    )
+    expect(requests[2]?.map(textOf)).toEqual(['start', 'initial', 'firstsecondthirdrewritten public', '', ''])
+    expect(agent.messages.map(textOf)).toEqual([
+      'start',
+      'initial',
+      'first',
+      'second',
+      'third',
+      'rewritten public',
+      '',
+      '',
+      'final',
+    ])
+    expect(projectedInputTokens[1]).toBe(3)
+    expect(consumed).toEqual(['first', 'second', 'third'])
+  })
+
+  it('consumes complete message input registered before the model call', async () => {
+    const model = textModel('final')
+    const requests = captureRequests(model)
+    const consumed = vi.fn()
+    const rejected = vi.fn()
+    const [toolUse, toolResult] = toolExchange('delivery-1', 'complete')
+    const agent = new Agent({ model, printer: false })
+    let armed = false
+
+    agent.addHook(BeforeModelCallEvent, (event) => {
+      if (armed) return
+      armed = true
+      continuationManager.add(event, { args: [toolUse, toolResult], onConsumed: consumed, onRejected: rejected })
+    })
+    agent.addMiddleware(InvokeModelStage.Input, async (context) => ({
+      ...context,
+      messages: context.messages.map((message) => {
+        const clone = message.clone()
+        return new Message({ role: clone.role, content: clone.content })
+      }),
+    }))
+    await agent.invoke('start')
+
+    expect(requests[0]?.map((message) => message.role)).toEqual(['user', 'assistant', 'user'])
+    expect(agent.messages).toEqual([expect.any(Message), toolUse, toolResult, expect.any(Message)])
+    expect(consumed).toHaveBeenCalledTimes(1)
+    expect(rejected).not.toHaveBeenCalled()
+  })
+
+  it('preserves public resume visibility and history when the provider fails', async () => {
+    const model = new MockMessageModel()
+      .addTurn({ type: 'textBlock', text: 'initial' })
+      .addTurn(new Error('resumed call failed'))
+    const beforeModelMessages: string[][] = []
+    const agent = new Agent({ model, printer: false })
+    let armed = false
+    let streamStageCalls = 0
+
+    agent.addHook(AfterInvocationEvent, (event) => {
+      if (armed) return
+      armed = true
+      event.resume = 'follow-up'
+    })
+    agent.addMiddleware(AgentStreamStage.Input, async (context) => {
+      streamStageCalls += 1
+      return streamStageCalls === 2 ? { ...context, args: 'rewritten follow-up' } : context
+    })
+    agent.addHook(BeforeModelCallEvent, () => {
+      beforeModelMessages.push(agent.messages.map(textOf))
+    })
+
+    await expect(agent.invoke('start')).rejects.toThrow('resumed call failed')
+
+    expect(beforeModelMessages).toEqual([['start'], ['start', 'initial', 'rewritten follow-up']])
+    expect(agent.messages.map(textOf)).toEqual(['start', 'initial', 'rewritten follow-up'])
+  })
+
+  it('leaves history unchanged when a resume-only pass is short-circuited', async () => {
+    const model = textModel('initial')
+    const agent = new Agent({ model, printer: false })
+    let afterCalls = 0
+    let streamStageCalls = 0
+
+    agent.addHook(AfterInvocationEvent, (event) => {
+      afterCalls += 1
+      if (afterCalls === 1) event.resume = 'public'
+    })
+    agent.addMiddleware(AgentStreamStage, async function* (context, next) {
+      streamStageCalls += 1
+      if (streamStageCalls === 1) return yield* next(context)
+      return streamResult(context, 'fabricated')
+    })
+
+    const result = await agent.invoke('start')
+
+    expect(textOf(result.lastMessage)).toBe('fabricated')
+    expect(agent.messages.map(textOf)).toEqual(['start', 'initial'])
+  })
+
+  it('keeps public resume history ordered when the follow-up model call is cancelled', async () => {
+    const model = textModel('initial', 'unreachable')
+    const agent = new Agent({ model, printer: false })
+    let afterCalls = 0
+    let modelCalls = 0
+
+    agent.addHook(AfterInvocationEvent, (event) => {
+      afterCalls += 1
+      if (afterCalls === 1) event.resume = 'public follow-up'
+    })
+    agent.addHook(BeforeModelCallEvent, (event) => {
+      modelCalls += 1
+      if (modelCalls === 2) event.cancel = 'model denied'
+    })
+
+    await agent.invoke('start')
+
+    expect(agent.messages.map(textOf)).toEqual(['start', 'initial', 'public follow-up', 'model denied'])
+  })
+
+  it('rejects input without masking the provider error when its rejection callback fails', async () => {
+    const model = new MockMessageModel()
+      .addTurn({ type: 'textBlock', text: 'initial' })
+      .addTurn(new Error('resumed call failed'))
+    const consumed = vi.fn()
+    const rejected = vi.fn().mockRejectedValue(new Error('rejection callback failed'))
+    const agent = new Agent({ model, printer: false })
+    continueAfterInvocation(agent, { args: 'internal follow-up', onConsumed: consumed, onRejected: rejected })
+
+    await expect(agent.invoke('start')).rejects.toThrow('resumed call failed')
+
+    expect(consumed).not.toHaveBeenCalled()
+    expect(rejected).toHaveBeenCalledTimes(1)
+    expect(agent.messages.map(textOf)).toEqual(['start', 'initial'])
+  })
+
+  it.each(['model', 'agentMiddleware', 'modelMiddleware'] as const)(
+    'keeps a consumed message batch when a later stage fails after %s completion',
+    async (completion) => {
+      const model = textModel('initial', 'unrecorded', 'discarded')
+      const contribution = toolExchange('hook-delivery', 'internal contribution')
+      const beforeModelContribution = new Message({
+        role: 'user',
+        content: [new TextBlock('before-model contribution')],
+      })
+      const consumed = vi.fn()
+      const rejected = vi.fn()
+      const added: Message[] = []
+      const agent = new Agent({ model, printer: false })
+      const continuation = {
+        args: contribution,
+        ...(completion !== 'agentMiddleware' && { onConsumed: consumed }),
+        onRejected: rejected,
+      }
+
+      continueAfterInvocation(agent, continuation)
+      let beforeModelCalls = 0
+      agent.addHook(BeforeModelCallEvent, (event) => {
+        beforeModelCalls += 1
+        if (beforeModelCalls === 2) {
+          continuationManager.add(event, { args: [beforeModelContribution] })
+        }
+      })
+      agent.addHook(MessageAddedEvent, (event) => {
+        if (!contribution.includes(event.message) && event.message !== beforeModelContribution) return
+        added.push(event.message)
+        if (event.message === contribution[0] && completion !== 'modelMiddleware') {
+          throw new Error('message hook failed')
+        }
+      })
+      if (completion === 'agentMiddleware') {
+        let calls = 0
+        agent.addMiddleware(AgentStreamStage, async function* (context, next) {
+          calls += 1
+          if (calls === 1) return yield* next(context)
+          return streamResult(context, 'cached')
+        })
+      }
+      if (completion === 'modelMiddleware') {
+        const contributionIds = new Set(contribution.map((message) => message.trackingId))
+        let calls = 0
+        agent.addMiddleware(InvokeModelStage, async function* (context, next) {
+          calls += 1
+          if (calls !== 2) return yield* next(context)
+
+          yield* next(context)
+          yield* next({
+            ...context,
+            messages: context.messages.filter((message) => !contributionIds.has(message.trackingId)),
+          })
+          throw new Error('model middleware failed')
+        })
+      }
+
+      await expect(agent.invoke('start')).rejects.toThrow(
+        completion === 'modelMiddleware' ? 'model middleware failed' : 'message hook failed'
+      )
+
+      expect(rejected).not.toHaveBeenCalled()
+      expect(consumed).toHaveBeenCalledTimes(completion === 'agentMiddleware' ? 0 : 1)
+      const expectedMessages =
+        completion === 'agentMiddleware' ? contribution : [...contribution, beforeModelContribution]
+      expect(added).toEqual(expectedMessages)
+      expect(agent.messages).toEqual(expect.arrayContaining(expectedMessages))
+    }
+  )
+
+  it.each(['pendingPass', 'activePass', 'beforeModelCall'] as const)(
+    'rejects unconsumed input when the stream closes with a %s continuation',
+    async (stage) => {
+      const model = textModel('initial', 'unreachable')
+      const rejected = vi.fn()
+      const agent = new Agent({ model, printer: false })
+
+      if (stage === 'beforeModelCall') {
+        agent.addHook(BeforeModelCallEvent, (event) => {
+          continuationManager.add(event, { args: 'pending', onRejected: rejected })
+        })
+      } else {
+        continueAfterInvocation(agent, { args: 'pending', onRejected: rejected })
+      }
+
+      let beforeInvocationCount = 0
+      for await (const event of agent.stream('start')) {
+        if (event instanceof BeforeInvocationEvent) beforeInvocationCount += 1
+        const shouldClose =
+          (stage === 'pendingPass' && event instanceof AfterInvocationEvent) ||
+          (stage === 'activePass' && event instanceof BeforeInvocationEvent && beforeInvocationCount === 2) ||
+          (stage === 'beforeModelCall' && event instanceof BeforeModelCallEvent)
+        if (shouldClose) break
+      }
+
+      expect(rejected).toHaveBeenCalledTimes(1)
+    }
+  )
+
+  it('invokes every committed message hook before yielding the batch', async () => {
+    const model = textModel('initial', 'final')
+    const first = new Message({ role: 'user', content: [new TextBlock('first')] })
+    const second = new Message({ role: 'user', content: [new TextBlock('second')] })
+    const added: Message[] = []
+    const history: string[][] = []
+    const agent = new Agent({ model, printer: false })
+
+    continueAfterInvocation(agent, { args: [first, second] })
+    agent.addHook(MessageAddedEvent, (event) => {
+      if (event.message === first || event.message === second) {
+        added.push(event.message)
+        history.push(agent.messages.map(textOf))
+      }
+    })
+
+    for await (const event of agent.stream('start')) {
+      if (event instanceof MessageAddedEvent && event.message === first) break
+    }
+
+    expect(added).toEqual([first, second])
+    expect(history).toEqual([
+      ['start', 'initial', 'first'],
+      ['start', 'initial', 'first', 'second'],
+    ])
+    expect(agent.messages).toEqual([expect.any(Message), expect.any(Message), first, second])
+  })
+
+  it('settles continuation input against the model middleware result that wins', async () => {
+    const model = textModel('initial', 'first retry', 'final')
+    const consumed = vi.fn()
+    const rejected = vi.fn()
+    const added: string[] = []
+    const contribution = new Message({ role: 'user', content: [new TextBlock('start')] })
+    const agent = new Agent({ model, printer: false })
+    let modelStageCalls = 0
+
+    continueAfterInvocation(agent, { args: [contribution], onConsumed: consumed, onRejected: rejected })
+    agent.addHook(MessageAddedEvent, (event) => {
+      if (event.message.trackingId === contribution.trackingId) added.push(event.message.trackingId)
+    })
+    agent.addMiddleware(InvokeModelStage, async function* (context, next) {
+      modelStageCalls += 1
+      if (modelStageCalls === 1) return yield* next(context)
+      yield* next(context)
+      const winningMessages = context.messages.filter((message) => message.trackingId !== contribution.trackingId)
+      const winningResult = yield* next({
+        ...context,
+        messages: winningMessages,
+      })
+      winningMessages.push(contribution)
+      return {
+        result: {
+          ...winningResult.result,
+          message: winningResult.result.message.clone(),
+        },
+      }
+    })
+
+    await agent.invoke('start')
+
+    expect(consumed).not.toHaveBeenCalled()
+    expect(rejected).toHaveBeenCalledTimes(1)
+    expect(added).toHaveLength(0)
+    expect(agent.messages.map(textOf)).toEqual(['start', 'initial', 'final'])
+  })
+
+  it('rejects ambiguous model-confirmed input when an identical public resume is retained', async () => {
+    const model = textModel('initial', 'final')
+    const consumed = vi.fn()
+    const rejected = vi.fn()
+    const agent = new Agent({ model, printer: false })
+    let afterInvocationCalls = 0
+    let modelStageCalls = 0
+
+    agent.addHook(AfterInvocationEvent, (event) => {
+      afterInvocationCalls += 1
+      if (afterInvocationCalls !== 1) return
+      continuationManager.add(event, {
+        args: 'duplicate',
+        onConsumed: consumed,
+        onRejected: rejected,
+      })
+      event.resume = 'duplicate'
+    })
+    agent.addMiddleware(InvokeModelStage.Input, async (context) => {
+      modelStageCalls += 1
+      if (modelStageCalls !== 2) return context
+      const messages = context.messages.slice(0, -1)
+      const merged = context.messages.at(-1)!
+      messages.push(new Message({ role: merged.role, content: [merged.content.at(-1)!] }))
+      return { ...context, messages }
+    })
+
+    await agent.invoke('start')
+
+    expect(consumed).not.toHaveBeenCalled()
+    expect(rejected).toHaveBeenCalledTimes(1)
+    expect(agent.messages.map(textOf)).toEqual(['start', 'initial', 'duplicate', 'final'])
+  })
+
+  it('does not turn consumption callback failures into model failures', async () => {
+    const model = textModel('initial', 'unrecorded')
+    const laterConsumed = vi.fn()
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+    const agent = new Agent({ model, printer: false })
+
+    continueAfterInvocation(
+      agent,
+      {
+        args: 'first',
+        onConsumed: () => {
+          throw new Error('consumption callback failed')
+        },
+      },
+      { args: 'second', onConsumed: laterConsumed }
+    )
+
+    const result = await agent.invoke('start')
+
+    expect(result.stopReason).toBe('endTurn')
+    expect(laterConsumed).toHaveBeenCalledTimes(1)
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('continuation consumption callback failed'))
+    warn.mockRestore()
+  })
+
+  it('redacts every history message represented by a continuation request', async () => {
+    const model = textModel('blocked')
+    const originalStream = model.stream.bind(model)
+    vi.spyOn(model, 'stream').mockImplementation(async function* (messages, options) {
+      yield* originalStream(messages, options)
+      yield {
+        type: 'modelRedactionEvent',
+        inputRedaction: { replaceContent: '[redacted]' },
+      }
+    })
+    const agent = new Agent({ model, printer: false })
+    agent.addHook(BeforeModelCallEvent, (event) => {
+      continuationManager.add(event, { args: 'internal secret' })
+    })
+
+    await agent.invoke('original secret')
+
+    expect(agent.messages.map(textOf)).toEqual(['[redacted]', 'blocked'])
+  })
+
+  it.each(['interrupt', 'cancelled', 'checkpoint'] as const)(
+    'rejects pending input instead of following a terminal %s result',
+    async (stopReason) => {
+      const model = textModel('unreachable')
+      const rejected = vi.fn()
+      const agent = new Agent({ model, printer: false })
+
+      // eslint-disable-next-line require-yield
+      agent.addMiddleware(AgentStreamStage, async function* (context) {
+        return streamResult(context, stopReason, stopReason)
+      })
+      agent.addHook(AfterInvocationEvent, (event) => {
+        continuationManager.add(event, { args: 'continue', onRejected: rejected })
+      })
+
+      const result = await agent.invoke('start')
+
+      expect(result.stopReason).toBe(stopReason)
+      expect(rejected).toHaveBeenCalledWith(
+        expect.objectContaining({ message: `Continuation rejected by ${stopReason}` })
+      )
+    }
+  )
+
+  it('rejects an invalid contribution without discarding valid siblings or the completed result', async () => {
+    const model = textModel('initial', 'final')
+    const requests = captureRequests(model)
+    const invalidRejected = vi.fn()
+    const orphanRejected = vi.fn()
+    const validConsumed = vi.fn()
+    const [toolUse, toolResult] = toolExchange('delivery-1', 'complete')
+    const agent = new Agent({ model, printer: false })
+
+    continueAfterInvocation(
+      agent,
+      { args: [], onRejected: invalidRejected },
+      {
+        args: [
+          new Message({
+            role: 'user',
+            content: [
+              new ToolResultBlock({
+                toolUseId: 'missing',
+                status: 'success',
+                content: [new TextBlock('orphan')],
+              }),
+            ],
+          }),
+        ],
+        onRejected: orphanRejected,
+      },
+      { args: [toolUse, toolResult], onConsumed: validConsumed }
+    )
+
+    const result = await agent.invoke('start')
+
+    expect(result.stopReason).toBe('endTurn')
+    expect(invalidRejected).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Continuation input must contain a complete message sequence' })
+    )
+    expect(orphanRejected).toHaveBeenCalledTimes(1)
+    expect(validConsumed).toHaveBeenCalledTimes(1)
+    expect(requests[1]?.slice(-2).map((message) => message.trackingId)).toEqual([
+      toolUse.trackingId,
+      toolResult.trackingId,
+    ])
+    expect(agent.messages).toEqual([expect.any(Message), expect.any(Message), toolUse, toolResult, expect.any(Message)])
+  })
+
+  it('rejects prepared contributions when public resume normalization fails', async () => {
+    const model = textModel('initial')
+    const rejected = vi.fn()
+    const agent = new Agent({ model, printer: false })
+    let armed = false
+
+    agent.addHook(AfterInvocationEvent, (event) => {
+      if (armed) return
+      armed = true
+      continuationManager.add(event, { args: 'internal', onRejected: rejected })
+      event.resume = [{ unsupported: true }] as unknown as InvokeArgs
+    })
+
+    await expect(agent.invoke('start')).rejects.toThrow()
+
+    expect(rejected).toHaveBeenCalledTimes(1)
+    expect(agent.messages.map(textOf)).toEqual(['start', 'initial'])
+  })
+
+  it('rejects active and newly registered input when BeforeInvocationEvent cancels the pass', async () => {
+    const model = textModel('initial')
+    const activeRejected = vi.fn()
+    const lateRejected = vi.fn()
+    const agent = new Agent({ model, printer: false })
+    let beforeCalls = 0
+    let afterCalls = 0
+
+    agent.addHook(BeforeInvocationEvent, (event) => {
+      beforeCalls += 1
+      if (beforeCalls === 2) event.cancel = 'invocation denied'
+    })
+    agent.addHook(AfterInvocationEvent, (event) => {
+      afterCalls += 1
+      if (afterCalls === 1) {
+        continuationManager.add(event, { args: 'active', onRejected: activeRejected })
+      } else if (afterCalls === 2) {
+        continuationManager.add(event, { args: 'late', onRejected: lateRejected })
+      }
+    })
+
+    const result = await agent.invoke('start')
+
+    expect(result.stopReason).toBe('endTurn')
+    expect(activeRejected).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Continuation invocation cancelled by BeforeInvocationEvent' })
+    )
+    expect(lateRejected).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Invocation cancelled by BeforeInvocationEvent' })
+    )
+    expect(agent.messages.map(textOf)).toEqual(['start', 'initial', 'invocation denied'])
+  })
+
+  it.each([
+    [{ turns: 3 }, 'limitTurns'],
+    [{ outputTokens: 3 }, 'limitOutputTokens'],
+  ] as const)('shares %s across middleware and continuation passes', async (limits, stopReason) => {
+    const usage = { inputTokens: 2, outputTokens: 1, totalTokens: 3 }
+    const model = new MockMessageModel()
+      .addTurn({ type: 'textBlock', text: 'initial' }, { usage })
+      .addTurn({ type: 'textBlock', text: 'second' }, { usage })
+      .addTurn({ type: 'textBlock', text: 'third' }, { usage })
+      .addTurn({ type: 'textBlock', text: 'unreachable' }, { usage })
+    const consumed = vi.fn()
+    const rejected = vi.fn()
+    const agent = new Agent({ model, printer: false })
+    let streamCalls = 0
+    agent.addMiddleware(AgentStreamStage, async function* (context, next) {
+      streamCalls += 1
+      if (streamCalls !== 1) return yield* next(context)
+      yield* next(context)
+      return yield* next(context)
+    })
+    agent.addHook(AfterInvocationEvent, (event) => {
+      continuationManager.add(event, { args: 'continue', onConsumed: consumed, onRejected: rejected })
+    })
+
+    const result = await agent.invoke('start', { limits })
+
+    expect(result.stopReason).toBe('endTurn')
+    expect(model.callCount).toBe(3)
+    expect(consumed).toHaveBeenCalledTimes(1)
+    expect(rejected).toHaveBeenCalledWith(
+      expect.objectContaining({ message: `Continuation rejected by ${stopReason}` })
+    )
+    expect(agent.messages.map(textOf)).toEqual(['start', 'initial', 'start', 'second', 'continue', 'third'])
+  })
+
+  it('uses fresh limits and cancellation for a public resume mixed with internal input', async () => {
+    const model = textModel('initial', 'final')
+    const consumed = vi.fn()
+    const rejected = vi.fn()
+    const agent = new Agent({ model, printer: false })
+    let armed = false
+
+    agent.addHook(AfterInvocationEvent, (event) => {
+      if (armed) return
+      armed = true
+      agent.cancel()
+      continuationManager.add(event, { args: 'internal', onConsumed: consumed, onRejected: rejected })
+      event.resume = 'public'
+    })
+
+    const result = await agent.invoke('start', { limits: { turns: 1 } })
+
+    expect(result.stopReason).toBe('endTurn')
+    expect(model.callCount).toBe(2)
+    expect(consumed).toHaveBeenCalledTimes(1)
+    expect(rejected).not.toHaveBeenCalled()
+    expect(agent.messages.map(textOf)).toEqual(['start', 'initial', 'internal', 'public', 'final'])
+  })
+
+  it('preserves cancellation across continuation passes', async () => {
+    const model = textModel('initial', 'unreachable')
+    const consumed = vi.fn()
+    const rejected = vi.fn()
+    const agent = new Agent({ model, printer: false })
+    continueAfterInvocation(agent, { args: 'continue', onConsumed: consumed, onRejected: rejected })
+    agent.addHook(AfterInvocationEvent, () => {
+      agent.cancel()
+    })
+
+    const result = await agent.invoke('start')
+
+    expect(result.stopReason).toBe('cancelled')
+    expect(model.callCount).toBe(1)
+    expect(consumed).not.toHaveBeenCalled()
+    expect(rejected).toHaveBeenCalledTimes(1)
+    expect(agent.messages.map(textOf)).toEqual(['start', 'initial'])
+  })
+})

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -94,6 +94,9 @@ import { AgentAsTool } from './agent-as-tool.js'
 import type { AgentAsToolOptions } from './agent-as-tool.js'
 import { ToolCaller } from './tool-caller.js'
 import type { ToolCallerProxy } from './tool-caller.js'
+import { continuations } from './continuation.js'
+
+import type { ContinuationInput, InvocationContinuation } from './continuation.js'
 
 import type { z } from 'zod'
 import { MemoryManager } from '../memory/memory-manager.js'
@@ -400,6 +403,11 @@ const DEFAULT_AGENT_ID = 'agent'
 /** Result returned by tool-execution generators, threading the AfterToolsEvent back to the main loop. */
 type ToolsExecutionResult = { message: Message; afterToolsEvent: AfterToolsEvent; toolsSkipped: boolean }
 
+interface ModelInvocationOutcome {
+  readonly result: StreamAggregatedResult
+  readonly requestMessages: readonly Message[]
+}
+
 /**
  * Orchestrates the interaction between a model, a set of tools, and MCP clients.
  * The Agent is responsible for managing the lifecycle of tools and clients
@@ -487,6 +495,7 @@ export class Agent implements LocalAgent, InvokableAgent {
   private _isInvoking: boolean = false
   private _abortController = new AbortController()
   private _abortSignal: AbortSignal = this._abortController.signal
+  private readonly _dispatchedMessageEvents = new WeakSet<MessageAddedEvent>()
   private _printer?: Printer
   private _structuredOutputSchema?: z.ZodSchema | undefined
   /** Tracer instance for creating and managing OpenTelemetry spans. */
@@ -872,24 +881,26 @@ export class Agent implements LocalAgent, InvokableAgent {
    * against the current invocation's metrics. Called at the top of each
    * agent-loop iteration, after `_throwIfCancelled` and before `startCycle`.
    *
-   * Reads from {@link AgentMetrics.latestAgentInvocation} (scoped to the
-   * current invocation) — not `cycleCount` / `accumulatedUsage`, which are
-   * lifetime accumulators that would cause caps to fire prematurely on the
-   * second `invoke()` call against a reused agent.
+   * Reads from {@link AgentMetrics.latestAgentInvocation} unless explicit
+   * pass usage is supplied by continuation orchestration.
    *
    * Priority on simultaneous trip: turns → totalTokens → outputTokens.
    *
    * Returns the {@link StopReason} the loop should terminate with, or
    * `undefined` if every configured cap is still within budget.
    */
-  private _checkLimits(options: InvokeOptions | undefined): StopReason | undefined {
+  private _checkLimits(
+    options: InvokeOptions | undefined,
+    usage?: { cycles: number; outputTokens: number; totalTokens: number }
+  ): StopReason | undefined {
     const limits = options?.limits
     if (!limits) return undefined
-    const invocation = this._meter.metrics.latestAgentInvocation
-    if (!invocation) return undefined
+    const invocation = usage ? undefined : this._meter.metrics.latestAgentInvocation
+    if (!usage && !invocation) return undefined
 
-    const cycleCount = invocation.cycles.length
-    const { outputTokens, totalTokens } = invocation.usage
+    const cycleCount = usage?.cycles ?? invocation!.cycles.length
+    const outputTokens = usage?.outputTokens ?? invocation!.usage.outputTokens
+    const totalTokens = usage?.totalTokens ?? invocation!.usage.totalTokens
 
     if (limits.turns !== undefined && cycleCount >= limits.turns) {
       return 'limitTurns'
@@ -1083,6 +1094,8 @@ export class Agent implements LocalAgent, InvokableAgent {
     options?: InvokeOptions
   ): AsyncGenerator<AgentStreamEvent, AgentResult, undefined> {
     this.acquireLock()
+    let continuation: InvocationContinuation | undefined
+    let pendingContinuations: readonly ContinuationInput[] = []
     try {
       await this.initialize()
 
@@ -1090,14 +1103,17 @@ export class Agent implements LocalAgent, InvokableAgent {
       const invocationState = options?.invocationState ?? {}
       const resolvedOptions: InvokeOptions = options?.invocationState ? options : { ...options, invocationState }
 
+      let currentOptions = resolvedOptions
       let currentArgs: InvokeArgs = args
 
       while (true) {
-        // Fresh AbortController per iteration, composed with any external signal.
-        this._abortController = new AbortController()
-        this._abortSignal = resolvedOptions?.cancelSignal
-          ? AbortSignal.any([this._abortController.signal, resolvedOptions.cancelSignal])
-          : this._abortController.signal
+        // Internal follow-ups share cancellation; public resume starts a fresh pass.
+        if (!continuation || continuation.publicResume) {
+          this._abortController = new AbortController()
+          this._abortSignal = resolvedOptions?.cancelSignal
+            ? AbortSignal.any([this._abortController.signal, resolvedOptions.cancelSignal])
+            : this._abortController.signal
+        }
 
         // Process interrupt responses before middleware runs so context.interrupt() can find them
         const interruptResponses = this._extractInterruptResponses(currentArgs)
@@ -1110,6 +1126,10 @@ export class Agent implements LocalAgent, InvokableAgent {
         yield await this._invokeCallbacks(beforeInvocationEvent)
 
         if (beforeInvocationEvent.cancel) {
+          await continuations.rejectInvocation(
+            continuation,
+            new Error('Continuation invocation cancelled by BeforeInvocationEvent')
+          )
           const cancelText =
             typeof beforeInvocationEvent.cancel === 'string'
               ? beforeInvocationEvent.cancel
@@ -1117,7 +1137,16 @@ export class Agent implements LocalAgent, InvokableAgent {
           const message = new Message({ role: 'assistant', content: [new TextBlock(cancelText)] })
           yield this._appendMessage(message, invocationState)
           const afterEvent = new AfterInvocationEvent({ agent: this, invocationState })
-          await this._invokeCallbacks(afterEvent)
+          try {
+            await this._invokeCallbacks(afterEvent)
+          } catch (error) {
+            await continuations.rejectInputs(continuations.take(afterEvent), error)
+            throw error
+          }
+          await continuations.rejectInputs(
+            continuations.take(afterEvent),
+            new Error('Invocation cancelled by BeforeInvocationEvent')
+          )
           yield afterEvent
           return new AgentResult({
             stopReason: 'endTurn',
@@ -1130,16 +1159,36 @@ export class Agent implements LocalAgent, InvokableAgent {
 
         let result: AgentResult | undefined
         let caughtError: Error | undefined
+        const metrics = this._meter.metrics
+        const passStart = {
+          cycles: metrics.cycleCount,
+          outputTokens: metrics.accumulatedUsage.outputTokens,
+          totalTokens: metrics.accumulatedUsage.totalTokens,
+        }
         const afterInvocationEvent = new AfterInvocationEvent({ agent: this, invocationState })
         try {
-          result = yield* this._streamWithMiddleware(currentArgs, resolvedOptions, invocationState)
+          result = yield* this._streamWithMiddleware(currentArgs, currentOptions, invocationState, continuation)
+          const passRanAgentLoop = this._meter.metrics.cycleCount > passStart.cycles
+          const continuationEvents = await continuations.settleResult(
+            this,
+            continuation,
+            result,
+            invocationState,
+            passRanAgentLoop
+          )
+          await this._invokeMessageCallbacks(continuationEvents)
+          yield* continuationEvents
         } catch (error) {
           caughtError = error as Error
         } finally {
           // AfterInvocationEvent always fires — even on error or consumer break. Outside middleware.
           // Invoke hooks (so .resume can be set) but don't yield in finally (yields in finally
           // suspend the generator on consumer break instead of completing cleanup).
-          await this._invokeCallbacks(afterInvocationEvent)
+          try {
+            await this._invokeCallbacks(afterInvocationEvent)
+          } finally {
+            pendingContinuations = continuations.take(afterInvocationEvent)
+          }
         }
 
         // Yield outside finally — in JS, a `yield` inside `finally` suspends the generator
@@ -1149,28 +1198,82 @@ export class Agent implements LocalAgent, InvokableAgent {
 
         // Re-throw after hooks have fired
         if (caughtError) {
+          await continuations.rejectInvocation(continuation, caughtError)
+          await continuations.rejectInputs(pendingContinuations, caughtError)
+          pendingContinuations = []
           throw caughtError
         }
+        const completedResult = result!
+        const currentMetrics = this._meter.metrics
+        const passUsage = {
+          cycles: currentMetrics.cycleCount - passStart.cycles,
+          outputTokens: currentMetrics.accumulatedUsage.outputTokens - passStart.outputTokens,
+          totalTokens: currentMetrics.accumulatedUsage.totalTokens - passStart.totalTokens,
+        }
+        const passRanAgentLoop = passUsage.cycles > 0
 
-        // Resume only on a clean invocation — errors propagate above.
-        if (afterInvocationEvent.resume !== undefined) {
-          currentArgs = afterInvocationEvent.resume
-          continue
+        if (continuations.isRejectionStopReason(completedResult.stopReason)) {
+          await continuations.rejectInputs(
+            pendingContinuations,
+            new Error(`Continuation rejected by ${completedResult.stopReason}`)
+          )
+          pendingContinuations = []
         }
 
-        // Only emit AgentResultEvent on the final iteration (not on resumed ones).
-        yield await this._invokeCallbacks(
-          new AgentResultEvent({
-            agent: this,
-            result: result!,
-            invocationState,
-          })
-        )
+        const hasPublicResume = afterInvocationEvent.resume !== undefined
+        const limitStopReason =
+          !hasPublicResume && pendingContinuations.length > 0 && passRanAgentLoop
+            ? this._checkLimits(currentOptions, passUsage)
+            : undefined
+        if (limitStopReason) {
+          await continuations.rejectInputs(
+            pendingContinuations,
+            new Error(`Continuation rejected by ${limitStopReason}`)
+          )
+          pendingContinuations = []
+        }
 
-        return result!
+        const selectedContinuations = pendingContinuations
+        pendingContinuations = []
+        continuation = await continuations.prepareInvocation(
+          selectedContinuations,
+          afterInvocationEvent.resume,
+          (continuationArgs) => this._normalizeInput(continuationArgs)
+        )
+        if (!continuation) {
+          yield await this._invokeCallbacks(
+            new AgentResultEvent({ agent: this, result: completedResult, invocationState })
+          )
+          return completedResult
+        }
+        if (continuation.publicResume) {
+          currentOptions = resolvedOptions
+        } else if (passRanAgentLoop) {
+          currentOptions = this._remainingOptions(currentOptions, passUsage)
+        }
+        currentArgs = continuation.args
       }
     } finally {
+      await continuations.cleanup(continuation, pendingContinuations)
+      this._abortController = new AbortController()
+      this._abortSignal = this._abortController.signal
       this._isInvoking = false
+    }
+  }
+
+  private _remainingOptions(
+    options: InvokeOptions,
+    usage: { cycles: number; outputTokens: number; totalTokens: number }
+  ): InvokeOptions {
+    const limits = options.limits
+    if (!limits) return options
+    return {
+      ...options,
+      limits: {
+        ...(limits.turns !== undefined && { turns: limits.turns - usage.cycles }),
+        ...(limits.outputTokens !== undefined && { outputTokens: limits.outputTokens - usage.outputTokens }),
+        ...(limits.totalTokens !== undefined && { totalTokens: limits.totalTokens - usage.totalTokens }),
+      },
     }
   }
 
@@ -1181,7 +1284,8 @@ export class Agent implements LocalAgent, InvokableAgent {
   private async *_streamWithMiddleware(
     args: InvokeArgs,
     options: InvokeOptions,
-    invocationState: InvocationState
+    invocationState: InvocationState,
+    continuation?: InvocationContinuation
   ): AsyncGenerator<AgentStreamEvent, AgentResult, undefined> {
     // Snapshot so a gate that re-reads its response after next() still resolves even if a tool cycle called deactivate().
     const interruptsSnapshot = { ...this._interruptState.interrupts }
@@ -1200,7 +1304,13 @@ export class Agent implements LocalAgent, InvokableAgent {
         AgentStreamStage,
         context,
         async function* (ctx: AgentStreamContext): AsyncGenerator<AgentStreamEvent, AgentStreamResult, undefined> {
-          const result = yield* self._streamCore(ctx.args, ctx.options)
+          let streamArgs = ctx.args
+          if (continuation) {
+            streamArgs = await continuations.updateArgs(continuation, ctx.args, (continuationArgs) =>
+              self._normalizeInput(continuationArgs)
+            )
+          }
+          const result = yield* self._streamCore(streamArgs, ctx.options, continuation)
           return { result }
         }
       )
@@ -1243,9 +1353,10 @@ export class Agent implements LocalAgent, InvokableAgent {
    */
   private async *_streamCore(
     args: InvokeArgs,
-    options?: InvokeOptions
+    options?: InvokeOptions,
+    continuation?: InvocationContinuation
   ): AsyncGenerator<AgentStreamEvent, AgentResult, undefined> {
-    const streamGenerator = this._stream(args, options)
+    const streamGenerator = this._stream(args, options, continuation)
     let caughtError: Error | undefined
     let iterationResult: IteratorResult<AgentStreamEvent, AgentResult>
     try {
@@ -1253,8 +1364,11 @@ export class Agent implements LocalAgent, InvokableAgent {
 
       while (!iterationResult.done) {
         try {
-          const processed = await this._invokeCallbacks(iterationResult.value)
-          yield processed
+          const event = iterationResult.value
+          if (!(event instanceof MessageAddedEvent && this._dispatchedMessageEvents.delete(event))) {
+            await this._invokeCallbacks(event)
+          }
+          yield event
           iterationResult = await streamGenerator.next()
         } catch (error) {
           // Throw interrupt errors back into _stream so executeTools can store the
@@ -1288,10 +1402,6 @@ export class Agent implements LocalAgent, InvokableAgent {
         }
         drainResult = await streamGenerator.next()
       }
-
-      // Reset controller and signal for next iteration / invocation
-      this._abortController = new AbortController()
-      this._abortSignal = this._abortController.signal
     }
 
     return iterationResult.value
@@ -1390,6 +1500,41 @@ export class Agent implements LocalAgent, InvokableAgent {
   }
 
   /**
+   * Invokes callbacks for a committed continuation message batch.
+   *
+   * @param events - Message events to dispatch
+   */
+  private async _invokeMessageCallbacks(events: readonly MessageAddedEvent[]): Promise<void> {
+    const finalMessages = [...this.messages]
+    const eventIds = new Set(events.map((event) => event.message.trackingId))
+    this.messages.splice(
+      0,
+      this.messages.length,
+      ...this.messages.filter((message) => !eventIds.has(message.trackingId))
+    )
+
+    const errors: unknown[] = []
+    for (const event of events) {
+      const finalIndex = finalMessages.findIndex((message) => message.trackingId === event.message.trackingId)
+      const nextMessage = finalMessages.slice(finalIndex + 1).find((message) => !eventIds.has(message.trackingId))
+      const nextIndex = nextMessage
+        ? this.messages.findIndex((message) => message.trackingId === nextMessage.trackingId)
+        : this.messages.length
+      const insertionIndex = nextIndex >= 0 ? nextIndex : this.messages.length
+      this.messages.splice(insertionIndex, 0, event.message)
+      try {
+        await this._invokeCallbacks(event)
+      } catch (error) {
+        errors.push(error)
+      }
+    }
+    for (const error of errors.slice(1)) {
+      logger.warn(`error=<${error}> | continuation message callback failed after earlier callback error`)
+    }
+    if (errors.length > 0) throw errors[0]
+  }
+
+  /**
    * Invokes hook callbacks and printer for a stream event.
    *
    * @param event - The event to process
@@ -1413,7 +1558,8 @@ export class Agent implements LocalAgent, InvokableAgent {
    */
   private async *_stream(
     args: InvokeArgs,
-    options?: InvokeOptions
+    options?: InvokeOptions,
+    continuation?: InvocationContinuation
   ): AsyncGenerator<AgentStreamEvent, AgentResult, undefined> {
     let currentArgs: InvokeArgs | undefined = args
     let result: AgentResult | undefined
@@ -1525,7 +1671,7 @@ export class Agent implements LocalAgent, InvokableAgent {
             assistantMessage = pendingExecution.assistantMessage
             completedToolResults = pendingExecution.completedToolResults
           } else {
-            const modelResult = yield* this._invokeModel(invocationState, structuredOutputChoice)
+            const modelResult = yield* this._invokeModel(invocationState, structuredOutputChoice, continuation)
 
             if (modelResult.stopReason !== 'toolUse') {
               // Schema set, we already forced, and the model still refused.
@@ -1956,7 +2102,8 @@ export class Agent implements LocalAgent, InvokableAgent {
    */
   private async *_invokeModel(
     invocationState: InvocationState,
-    toolChoice?: ToolChoice
+    toolChoice?: ToolChoice,
+    invocationContinuation?: InvocationContinuation
   ): AsyncGenerator<AgentStreamEvent, StreamAggregatedResult, undefined> {
     const toolSpecs = this._toolRegistry.list().map((tool) => tool.toolSpec)
     const streamOptions: StreamOptions = { toolSpecs, modelState: this.modelState }
@@ -1974,7 +2121,10 @@ export class Agent implements LocalAgent, InvokableAgent {
       // Estimate input tokens for the upcoming model call (non-fatal if estimation fails)
       let projectedInputTokens: number | undefined
       try {
-        projectedInputTokens = await this._estimateInputTokens(streamOptions)
+        projectedInputTokens = await this._estimateInputTokens(
+          streamOptions,
+          continuations.buildRequest(this.messages, invocationContinuation)
+        )
       } catch (e) {
         logger.debug(`error=<${e}> | token estimation failed, proceeding without estimate`)
       }
@@ -1985,9 +2135,22 @@ export class Agent implements LocalAgent, InvokableAgent {
         invocationState,
         ...(projectedInputTokens !== undefined && { projectedInputTokens }),
       })
-      yield beforeModelCallEvent
+      let modelInputs: readonly ContinuationInput[]
+      try {
+        yield beforeModelCallEvent
+        modelInputs = continuations.take(beforeModelCallEvent)
+      } finally {
+        await continuations.cleanup(undefined, continuations.take(beforeModelCallEvent))
+      }
 
+      const modelContinuation = await continuations.prepareInvocation(modelInputs, undefined, (continuationArgs) =>
+        this._normalizeInput(continuationArgs)
+      )
       if (beforeModelCallEvent.cancel) {
+        await continuations.rejectInvocation(
+          modelContinuation,
+          new Error('Continuation model call cancelled by BeforeModelCallEvent')
+        )
         const cancelText =
           typeof beforeModelCallEvent.cancel === 'string' ? beforeModelCallEvent.cancel : 'model call denied by hook'
         const message = new Message({ role: 'assistant', content: [new TextBlock(cancelText)] })
@@ -2010,7 +2173,22 @@ export class Agent implements LocalAgent, InvokableAgent {
       }
 
       try {
-        const result = yield* this._invokeModelWithMiddleware(invocationState, toolChoice, projectedInputTokens)
+        let outcome: ModelInvocationOutcome
+        try {
+          outcome = yield* this._invokeModelWithMiddleware(
+            invocationState,
+            toolChoice,
+            projectedInputTokens,
+            invocationContinuation,
+            modelContinuation
+          )
+        } catch (error) {
+          await continuations.rejectInvocation(modelContinuation, error)
+          throw error
+        } finally {
+          await continuations.cleanup(modelContinuation)
+        }
+        const { result, requestMessages } = outcome
 
         // Accumulate token usage and model latency metrics
         this._meter.updateCycle(result.metadata)
@@ -2024,7 +2202,17 @@ export class Agent implements LocalAgent, InvokableAgent {
 
         // Handle user content redaction if guardrails blocked input
         if (result.redaction?.userMessage) {
-          this._redactLastMessage(result.redaction.userMessage)
+          let requestMessage: Message | undefined
+          for (let index = requestMessages.length - 1; index >= 0; index--) {
+            if (requestMessages[index]!.role === 'user') {
+              requestMessage = requestMessages[index]
+              break
+            }
+          }
+          const sourceIds = requestMessage
+            ? continuations.requestSourceIds(requestMessage, requestMessages, invocationContinuation, modelContinuation)
+            : undefined
+          this._redactLastMessage(result.redaction.userMessage, sourceIds)
         }
 
         const stopData: ModelStopData = {
@@ -2094,11 +2282,14 @@ export class Agent implements LocalAgent, InvokableAgent {
   private async *_invokeModelWithMiddleware(
     invocationState: InvocationState,
     toolChoice?: ToolChoice,
-    projectedInputTokens?: number
-  ): AsyncGenerator<AgentStreamEvent, StreamAggregatedResult, undefined> {
+    projectedInputTokens?: number,
+    invocationContinuation?: InvocationContinuation,
+    modelContinuation?: InvocationContinuation
+  ): AsyncGenerator<AgentStreamEvent, ModelInvocationOutcome, undefined> {
+    const requestMessages = continuations.buildRequest(this.messages, invocationContinuation, modelContinuation)
     const context: InvokeModelContext = {
       agent: this,
-      messages: this.messages.map((msg) => msg.clone()),
+      messages: requestMessages.map((message) => message.clone()),
       ...(this.systemPrompt !== undefined && { systemPrompt: cloneSystemPrompt(this.systemPrompt) }),
       toolSpecs: deepCopy(this._toolRegistry.list().map((tool) => tool.toolSpec)) as unknown as ToolSpec[],
       ...(toolChoice !== undefined && { toolChoice: deepCopy(toolChoice) as unknown as ToolChoice }),
@@ -2111,57 +2302,79 @@ export class Agent implements LocalAgent, InvokableAgent {
     // cannot affect modelState at any point (before or after next()).
     const modelStateSnapshot = this.modelState.getAll()
     let tempModelState: StateStore | undefined
+    const completedModelCalls: ModelInvocationOutcome[] = []
 
     // async function* doesn't bind lexical `this`; capture for the terminal callback.
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this
-    const middlewareResult = yield* this._middlewareRegistry.invoke(
-      InvokeModelStage,
-      context,
-      async function* (ctx: InvokeModelContext): AsyncGenerator<AgentStreamEvent, InvokeModelResult, undefined> {
-        const modelId = self.model.modelId
-        const modelSpan = self._tracer.startModelInvokeSpan({
-          messages: ctx.messages as Message[],
-          ...(modelId && { modelId }),
-          ...(ctx.systemPrompt !== undefined && { systemPrompt: ctx.systemPrompt }),
-        })
-
-        try {
-          // Wrap the snapshot into a StateStore for the model provider, which expects
-          // get/set methods.
-          tempModelState = new StateStore(modelStateSnapshot)
-          const streamOptions: StreamOptions = {
-            cancelSignal: self._abortSignal,
-            toolSpecs: ctx.toolSpecs as ToolSpec[],
-            modelState: tempModelState,
+    let middlewareResult: InvokeModelResult
+    try {
+      middlewareResult = yield* this._middlewareRegistry.invoke(
+        InvokeModelStage,
+        context,
+        async function* (ctx: InvokeModelContext): AsyncGenerator<AgentStreamEvent, InvokeModelResult, undefined> {
+          const modelId = self.model.modelId
+          const modelSpan = self._tracer.startModelInvokeSpan({
+            messages: ctx.messages as Message[],
+            ...(modelId && { modelId }),
             ...(ctx.systemPrompt !== undefined && { systemPrompt: ctx.systemPrompt }),
-            ...(ctx.toolChoice && { toolChoice: ctx.toolChoice }),
-            // Omitted when zero, so an ordinary call's options are unchanged.
-            ...(ctx.dynamicTrailingBlocks ? { dynamicTrailingBlocks: ctx.dynamicTrailingBlocks } : {}),
-          }
-          const gen = self._streamFromModel(ctx.messages as Message[], streamOptions, ctx.invocationState)
-          let iterResult = await gen.next()
-          while (!iterResult.done) {
-            yield iterResult.value
-            iterResult = await gen.next()
-          }
-
-          const usage = iterResult.value.metadata?.usage
-          const metrics = iterResult.value.metadata?.metrics
-          self._tracer.endModelInvokeSpan(modelSpan, {
-            output: iterResult.value.message,
-            stopReason: iterResult.value.stopReason,
-            ...(usage && { usage }),
-            ...(metrics && { metrics }),
           })
+          let modelResult: StreamAggregatedResult
 
-          return { result: iterResult.value }
-        } catch (error) {
-          self._tracer.endModelInvokeSpan(modelSpan, { error: normalizeError(error) })
-          throw error
+          try {
+            // Wrap the snapshot into a StateStore for the model provider, which expects
+            // get/set methods.
+            tempModelState = new StateStore(modelStateSnapshot)
+            const streamOptions: StreamOptions = {
+              cancelSignal: self._abortSignal,
+              toolSpecs: ctx.toolSpecs as ToolSpec[],
+              modelState: tempModelState,
+              ...(ctx.systemPrompt !== undefined && { systemPrompt: ctx.systemPrompt }),
+              ...(ctx.toolChoice && { toolChoice: ctx.toolChoice }),
+              // Omitted when zero, so an ordinary call's options are unchanged.
+              ...(ctx.dynamicTrailingBlocks ? { dynamicTrailingBlocks: ctx.dynamicTrailingBlocks } : {}),
+            }
+            const gen = self._streamFromModel(ctx.messages as Message[], streamOptions, ctx.invocationState)
+            let iterResult = await gen.next()
+            while (!iterResult.done) {
+              yield iterResult.value
+              iterResult = await gen.next()
+            }
+
+            modelResult = iterResult.value
+            const modelRequestMessages = ctx.messages.map((message) => message.clone())
+            completedModelCalls.push({ result: modelResult, requestMessages: modelRequestMessages })
+            const usage = modelResult.metadata?.usage
+            const metrics = modelResult.metadata?.metrics
+            self._tracer.endModelInvokeSpan(modelSpan, {
+              output: modelResult.message,
+              stopReason: modelResult.stopReason,
+              ...(usage && { usage }),
+              ...(metrics && { metrics }),
+            })
+          } catch (error) {
+            self._tracer.endModelInvokeSpan(modelSpan, { error: normalizeError(error) })
+            throw error
+          }
+
+          return { result: modelResult }
+        }
+      )
+    } catch (error) {
+      if (completedModelCalls.length > 0) {
+        const completedRequests = completedModelCalls.map((call) => call.requestMessages)
+        const events = [
+          ...(await continuations.publish(this, invocationContinuation, completedRequests, invocationState)),
+          ...(await continuations.publish(this, modelContinuation, completedRequests, invocationState)),
+        ]
+        await this._invokeMessageCallbacks(events)
+        for (const event of events) this._dispatchedMessageEvents.add(event)
+        for (const event of events) {
+          yield event
         }
       }
-    )
+      throw error
+    }
 
     // Sync model state after the entire middleware chain has completed, so no
     // middleware mutation to agent.modelState (before or after next()) takes effect.
@@ -2170,7 +2383,21 @@ export class Agent implements LocalAgent, InvokableAgent {
       loadStateSerializable(this.modelState, serializeStateSerializable(tempModelState))
     }
 
-    return middlewareResult.result
+    const completedCall =
+      completedModelCalls.find((call) => call.result === middlewareResult.result) ??
+      completedModelCalls.find((call) => call.result.message.trackingId === middlewareResult.result.message.trackingId)
+    const matchedRequestMessages = completedCall?.requestMessages
+    const modelRequests = matchedRequestMessages ? [matchedRequestMessages] : undefined
+    const events = [
+      ...(await continuations.publish(this, invocationContinuation, modelRequests, invocationState)),
+      ...(await continuations.publish(this, modelContinuation, modelRequests, invocationState)),
+    ]
+    await this._invokeMessageCallbacks(events)
+    for (const event of events) this._dispatchedMessageEvents.add(event)
+    for (const event of events) {
+      yield event
+    }
+    return { result: middlewareResult.result, requestMessages: matchedRequestMessages ?? [] }
   }
 
   /**
@@ -2335,15 +2562,17 @@ export class Agent implements LocalAgent, InvokableAgent {
    *
    * @param redactMessage - The redaction message to replace the content with
    */
-  private _redactLastMessage(redactMessage: string): void {
-    // Find and redact the last message
-    const lastIndex = this.messages.length - 1
-    if (lastIndex >= 0) {
-      const lastMessage = this.messages[lastIndex]
-      if (lastMessage && lastMessage.role === 'user') {
+  private _redactLastMessage(redactMessage: string, sourceIds?: ReadonlySet<string>): void {
+    const indexes = sourceIds
+      ? this.messages.flatMap((message, index) => (sourceIds.has(message.trackingId) ? [index] : []))
+      : [this.messages.length - 1]
+    const messages = indexes.map((index) => this.messages[index]).filter((message) => message !== undefined)
+    const lastMessage = messages.at(-1)
+    if (lastMessage) {
+      if (messages.every((message) => message.role === 'user')) {
         // Collect only tool result blocks with redacted content
         const redactedContent: ContentBlock[] = []
-        for (const block of lastMessage.content) {
+        for (const block of messages.flatMap((message) => message.content)) {
           if (block.type === 'toolResultBlock') {
             // Preserve tool result block structure, only redact its content
             redactedContent.push(
@@ -2361,13 +2590,18 @@ export class Agent implements LocalAgent, InvokableAgent {
           redactedContent.push(new TextBlock(redactMessage))
         }
 
-        this.messages[lastIndex] = new Message({
+        const replacement = new Message({
           role: 'user',
           content: redactedContent,
           // Redaction rewrites content but it's the same logical message, so keep its tracking id.
           trackingId: lastMessage.trackingId,
         })
-      } else if (lastMessage) {
+        const ids = new Set(messages.map((message) => message.trackingId))
+        const insertionIndex = indexes[0]!
+        const retained = this.messages.filter((message) => !ids.has(message.trackingId))
+        retained.splice(insertionIndex, 0, replacement)
+        this.messages.splice(0, this.messages.length, ...retained)
+      } else {
         // Unexpected state: redaction requested but last message is not from user
         logger.warn(
           `role=<${lastMessage.role}> | received input redaction but last message is not from user | redaction skipped`
@@ -2385,13 +2619,14 @@ export class Agent implements LocalAgent, InvokableAgent {
    * is available (cold start or first call).
    *
    * @param streamOptions - The stream options containing system prompt and tool specs
+   * @param messages - Messages expected in the next model request
    * @returns Estimated input token count
    */
-  private async _estimateInputTokens(streamOptions: StreamOptions): Promise<number> {
+  private async _estimateInputTokens(streamOptions: StreamOptions, messages: readonly Message[]): Promise<number> {
     // Find the last assistant message with usage metadata
     let lastAssistantIdx = -1
-    for (let i = this.messages.length - 1; i >= 0; i--) {
-      if (this.messages[i]!.role === 'assistant' && this.messages[i]!.metadata?.usage) {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i]!.role === 'assistant' && messages[i]!.metadata?.usage) {
         lastAssistantIdx = i
         break
       }
@@ -2399,9 +2634,9 @@ export class Agent implements LocalAgent, InvokableAgent {
 
     let estimate: number
     if (lastAssistantIdx >= 0) {
-      const usage = this.messages[lastAssistantIdx]!.metadata!.usage!
+      const usage = messages[lastAssistantIdx]!.metadata!.usage!
       const knownBaseline = usage.inputTokens + usage.outputTokens
-      const newMessages = this.messages.slice(lastAssistantIdx + 1)
+      const newMessages = messages.slice(lastAssistantIdx + 1)
       if (newMessages.length === 0) {
         estimate = knownBaseline
       } else {
@@ -2409,7 +2644,7 @@ export class Agent implements LocalAgent, InvokableAgent {
         estimate = knownBaseline + (await this.model.countTokens(newMessages))
       }
     } else {
-      estimate = await this.model.countTokens(this.messages, {
+      estimate = await this.model.countTokens([...messages], {
         ...(streamOptions.systemPrompt !== undefined && { systemPrompt: streamOptions.systemPrompt }),
         ...(streamOptions.toolSpecs !== undefined && { toolSpecs: streamOptions.toolSpecs }),
       })

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -96,8 +96,6 @@ import { ToolCaller } from './tool-caller.js'
 import type { ToolCallerProxy } from './tool-caller.js'
 import { continuations } from './continuation.js'
 
-import type { ContinuationInput, InvocationContinuation } from './continuation.js'
-
 import type { z } from 'zod'
 import { MemoryManager } from '../memory/memory-manager.js'
 import type { MemoryManagerConfig } from '../memory/index.js'
@@ -403,11 +401,6 @@ const DEFAULT_AGENT_ID = 'agent'
 /** Result returned by tool-execution generators, threading the AfterToolsEvent back to the main loop. */
 type ToolsExecutionResult = { message: Message; afterToolsEvent: AfterToolsEvent; toolsSkipped: boolean }
 
-interface ModelInvocationOutcome {
-  readonly result: StreamAggregatedResult
-  readonly requestMessages: readonly Message[]
-}
-
 /**
  * Orchestrates the interaction between a model, a set of tools, and MCP clients.
  * The Agent is responsible for managing the lifecycle of tools and clients
@@ -495,7 +488,6 @@ export class Agent implements LocalAgent, InvokableAgent {
   private _isInvoking: boolean = false
   private _abortController = new AbortController()
   private _abortSignal: AbortSignal = this._abortController.signal
-  private readonly _dispatchedMessageEvents = new WeakSet<MessageAddedEvent>()
   private _printer?: Printer
   private _structuredOutputSchema?: z.ZodSchema | undefined
   /** Tracer instance for creating and managing OpenTelemetry spans. */
@@ -881,26 +873,24 @@ export class Agent implements LocalAgent, InvokableAgent {
    * against the current invocation's metrics. Called at the top of each
    * agent-loop iteration, after `_throwIfCancelled` and before `startCycle`.
    *
-   * Reads from {@link AgentMetrics.latestAgentInvocation} unless explicit
-   * pass usage is supplied by continuation orchestration.
+   * Reads from {@link AgentMetrics.latestAgentInvocation} (scoped to the
+   * current invocation) — not `cycleCount` / `accumulatedUsage`, which are
+   * lifetime accumulators that would cause caps to fire prematurely on the
+   * second `invoke()` call against a reused agent.
    *
    * Priority on simultaneous trip: turns → totalTokens → outputTokens.
    *
    * Returns the {@link StopReason} the loop should terminate with, or
    * `undefined` if every configured cap is still within budget.
    */
-  private _checkLimits(
-    options: InvokeOptions | undefined,
-    usage?: { cycles: number; outputTokens: number; totalTokens: number }
-  ): StopReason | undefined {
+  private _checkLimits(options: InvokeOptions | undefined): StopReason | undefined {
     const limits = options?.limits
     if (!limits) return undefined
-    const invocation = usage ? undefined : this._meter.metrics.latestAgentInvocation
-    if (!usage && !invocation) return undefined
+    const invocation = this._meter.metrics.latestAgentInvocation
+    if (!invocation) return undefined
 
-    const cycleCount = usage?.cycles ?? invocation!.cycles.length
-    const outputTokens = usage?.outputTokens ?? invocation!.usage.outputTokens
-    const totalTokens = usage?.totalTokens ?? invocation!.usage.totalTokens
+    const cycleCount = invocation.cycles.length
+    const { outputTokens, totalTokens } = invocation.usage
 
     if (limits.turns !== undefined && cycleCount >= limits.turns) {
       return 'limitTurns'
@@ -1094,8 +1084,7 @@ export class Agent implements LocalAgent, InvokableAgent {
     options?: InvokeOptions
   ): AsyncGenerator<AgentStreamEvent, AgentResult, undefined> {
     this.acquireLock()
-    let continuation: InvocationContinuation | undefined
-    let pendingContinuations: readonly ContinuationInput[] = []
+    let continuationEvent: AfterInvocationEvent | undefined
     try {
       await this.initialize()
 
@@ -1103,17 +1092,14 @@ export class Agent implements LocalAgent, InvokableAgent {
       const invocationState = options?.invocationState ?? {}
       const resolvedOptions: InvokeOptions = options?.invocationState ? options : { ...options, invocationState }
 
-      let currentOptions = resolvedOptions
       let currentArgs: InvokeArgs = args
 
       while (true) {
-        // Internal follow-ups share cancellation; public resume starts a fresh pass.
-        if (!continuation || continuation.publicResume) {
-          this._abortController = new AbortController()
-          this._abortSignal = resolvedOptions?.cancelSignal
-            ? AbortSignal.any([this._abortController.signal, resolvedOptions.cancelSignal])
-            : this._abortController.signal
-        }
+        // Fresh AbortController per iteration, composed with any external signal.
+        this._abortController = new AbortController()
+        this._abortSignal = resolvedOptions?.cancelSignal
+          ? AbortSignal.any([this._abortController.signal, resolvedOptions.cancelSignal])
+          : this._abortController.signal
 
         // Process interrupt responses before middleware runs so context.interrupt() can find them
         const interruptResponses = this._extractInterruptResponses(currentArgs)
@@ -1126,10 +1112,6 @@ export class Agent implements LocalAgent, InvokableAgent {
         yield await this._invokeCallbacks(beforeInvocationEvent)
 
         if (beforeInvocationEvent.cancel) {
-          await continuations.rejectInvocation(
-            continuation,
-            new Error('Continuation invocation cancelled by BeforeInvocationEvent')
-          )
           const cancelText =
             typeof beforeInvocationEvent.cancel === 'string'
               ? beforeInvocationEvent.cancel
@@ -1137,16 +1119,12 @@ export class Agent implements LocalAgent, InvokableAgent {
           const message = new Message({ role: 'assistant', content: [new TextBlock(cancelText)] })
           yield this._appendMessage(message, invocationState)
           const afterEvent = new AfterInvocationEvent({ agent: this, invocationState })
-          try {
-            await this._invokeCallbacks(afterEvent)
-          } catch (error) {
-            await continuations.rejectInputs(continuations.take(afterEvent), error)
-            throw error
-          }
-          await continuations.rejectInputs(
-            continuations.take(afterEvent),
-            new Error('Invocation cancelled by BeforeInvocationEvent')
+          await continuations.abandon(
+            continuationEvent,
+            new Error('Continuation was not incorporated into agent history')
           )
+          continuationEvent = afterEvent
+          await this._invokeCallbacks(afterEvent)
           yield afterEvent
           return new AgentResult({
             stopReason: 'endTurn',
@@ -1159,36 +1137,21 @@ export class Agent implements LocalAgent, InvokableAgent {
 
         let result: AgentResult | undefined
         let caughtError: Error | undefined
-        const metrics = this._meter.metrics
-        const passStart = {
-          cycles: metrics.cycleCount,
-          outputTokens: metrics.accumulatedUsage.outputTokens,
-          totalTokens: metrics.accumulatedUsage.totalTokens,
-        }
         const afterInvocationEvent = new AfterInvocationEvent({ agent: this, invocationState })
         try {
-          result = yield* this._streamWithMiddleware(currentArgs, currentOptions, invocationState, continuation)
-          const passRanAgentLoop = this._meter.metrics.cycleCount > passStart.cycles
-          const continuationEvents = await continuations.settleResult(
-            this,
-            continuation,
-            result,
-            invocationState,
-            passRanAgentLoop
-          )
-          await this._invokeMessageCallbacks(continuationEvents)
-          yield* continuationEvents
+          result = yield* this._streamWithMiddleware(currentArgs, resolvedOptions, invocationState, continuationEvent)
         } catch (error) {
           caughtError = error as Error
         } finally {
           // AfterInvocationEvent always fires — even on error or consumer break. Outside middleware.
           // Invoke hooks (so .resume can be set) but don't yield in finally (yields in finally
           // suspend the generator on consumer break instead of completing cleanup).
-          try {
-            await this._invokeCallbacks(afterInvocationEvent)
-          } finally {
-            pendingContinuations = continuations.take(afterInvocationEvent)
-          }
+          await continuations.abandon(
+            continuationEvent,
+            new Error('Continuation was not incorporated into agent history')
+          )
+          continuationEvent = afterInvocationEvent
+          await this._invokeCallbacks(afterInvocationEvent)
         }
 
         // Yield outside finally — in JS, a `yield` inside `finally` suspends the generator
@@ -1198,82 +1161,36 @@ export class Agent implements LocalAgent, InvokableAgent {
 
         // Re-throw after hooks have fired
         if (caughtError) {
-          await continuations.rejectInvocation(continuation, caughtError)
-          await continuations.rejectInputs(pendingContinuations, caughtError)
-          pendingContinuations = []
           throw caughtError
         }
-        const completedResult = result!
-        const currentMetrics = this._meter.metrics
-        const passUsage = {
-          cycles: currentMetrics.cycleCount - passStart.cycles,
-          outputTokens: currentMetrics.accumulatedUsage.outputTokens - passStart.outputTokens,
-          totalTokens: currentMetrics.accumulatedUsage.totalTokens - passStart.totalTokens,
-        }
-        const passRanAgentLoop = passUsage.cycles > 0
 
-        if (continuations.isRejectionStopReason(completedResult.stopReason)) {
-          await continuations.rejectInputs(
-            pendingContinuations,
-            new Error(`Continuation rejected by ${completedResult.stopReason}`)
-          )
-          pendingContinuations = []
+        const hasContinuation =
+          (await continuations.prepare(afterInvocationEvent, (continuationArgs) =>
+            this._normalizeInput(continuationArgs)
+          )) !== undefined
+        continuationEvent = hasContinuation ? afterInvocationEvent : undefined
+
+        if (hasContinuation || afterInvocationEvent.resume !== undefined) {
+          currentArgs = afterInvocationEvent.resume ?? []
+          continue
         }
 
-        const hasPublicResume = afterInvocationEvent.resume !== undefined
-        const limitStopReason =
-          !hasPublicResume && pendingContinuations.length > 0 && passRanAgentLoop
-            ? this._checkLimits(currentOptions, passUsage)
-            : undefined
-        if (limitStopReason) {
-          await continuations.rejectInputs(
-            pendingContinuations,
-            new Error(`Continuation rejected by ${limitStopReason}`)
-          )
-          pendingContinuations = []
-        }
-
-        const selectedContinuations = pendingContinuations
-        pendingContinuations = []
-        continuation = await continuations.prepareInvocation(
-          selectedContinuations,
-          afterInvocationEvent.resume,
-          (continuationArgs) => this._normalizeInput(continuationArgs)
+        // Only emit AgentResultEvent on the final iteration (not on resumed ones).
+        yield await this._invokeCallbacks(
+          new AgentResultEvent({
+            agent: this,
+            result: result!,
+            invocationState,
+          })
         )
-        if (!continuation) {
-          yield await this._invokeCallbacks(
-            new AgentResultEvent({ agent: this, result: completedResult, invocationState })
-          )
-          return completedResult
-        }
-        if (continuation.publicResume) {
-          currentOptions = resolvedOptions
-        } else if (passRanAgentLoop) {
-          currentOptions = this._remainingOptions(currentOptions, passUsage)
-        }
-        currentArgs = continuation.args
+        return result!
       }
     } finally {
-      await continuations.cleanup(continuation, pendingContinuations)
-      this._abortController = new AbortController()
-      this._abortSignal = this._abortController.signal
+      await continuations.abandon(
+        continuationEvent,
+        new Error('Agent stream closed before continuation input was incorporated into agent history')
+      )
       this._isInvoking = false
-    }
-  }
-
-  private _remainingOptions(
-    options: InvokeOptions,
-    usage: { cycles: number; outputTokens: number; totalTokens: number }
-  ): InvokeOptions {
-    const limits = options.limits
-    if (!limits) return options
-    return {
-      ...options,
-      limits: {
-        ...(limits.turns !== undefined && { turns: limits.turns - usage.cycles }),
-        ...(limits.outputTokens !== undefined && { outputTokens: limits.outputTokens - usage.outputTokens }),
-        ...(limits.totalTokens !== undefined && { totalTokens: limits.totalTokens - usage.totalTokens }),
-      },
     }
   }
 
@@ -1285,7 +1202,7 @@ export class Agent implements LocalAgent, InvokableAgent {
     args: InvokeArgs,
     options: InvokeOptions,
     invocationState: InvocationState,
-    continuation?: InvocationContinuation
+    continuationEvent?: AfterInvocationEvent
   ): AsyncGenerator<AgentStreamEvent, AgentResult, undefined> {
     // Snapshot so a gate that re-reads its response after next() still resolves even if a tool cycle called deactivate().
     const interruptsSnapshot = { ...this._interruptState.interrupts }
@@ -1304,13 +1221,14 @@ export class Agent implements LocalAgent, InvokableAgent {
         AgentStreamStage,
         context,
         async function* (ctx: AgentStreamContext): AsyncGenerator<AgentStreamEvent, AgentStreamResult, undefined> {
-          let streamArgs = ctx.args
-          if (continuation) {
-            streamArgs = await continuations.updateArgs(continuation, ctx.args, (continuationArgs) =>
-              self._normalizeInput(continuationArgs)
-            )
-          }
-          const result = yield* self._streamCore(streamArgs, ctx.options, continuation)
+          const streamArgs = continuations.combine(continuationEvent, ctx.args, (continuationArgs) =>
+            self._normalizeInput(continuationArgs)
+          )
+          const result = yield* self._streamCore(
+            streamArgs,
+            ctx.options,
+            streamArgs === ctx.args ? undefined : continuationEvent
+          )
           return { result }
         }
       )
@@ -1354,9 +1272,9 @@ export class Agent implements LocalAgent, InvokableAgent {
   private async *_streamCore(
     args: InvokeArgs,
     options?: InvokeOptions,
-    continuation?: InvocationContinuation
+    continuationEvent?: AfterInvocationEvent
   ): AsyncGenerator<AgentStreamEvent, AgentResult, undefined> {
-    const streamGenerator = this._stream(args, options, continuation)
+    const streamGenerator = this._stream(args, options, continuationEvent)
     let caughtError: Error | undefined
     let iterationResult: IteratorResult<AgentStreamEvent, AgentResult>
     try {
@@ -1364,11 +1282,8 @@ export class Agent implements LocalAgent, InvokableAgent {
 
       while (!iterationResult.done) {
         try {
-          const event = iterationResult.value
-          if (!(event instanceof MessageAddedEvent && this._dispatchedMessageEvents.delete(event))) {
-            await this._invokeCallbacks(event)
-          }
-          yield event
+          const processed = await this._invokeCallbacks(iterationResult.value)
+          yield processed
           iterationResult = await streamGenerator.next()
         } catch (error) {
           // Throw interrupt errors back into _stream so executeTools can store the
@@ -1402,6 +1317,10 @@ export class Agent implements LocalAgent, InvokableAgent {
         }
         drainResult = await streamGenerator.next()
       }
+
+      // Reset controller and signal for next iteration / invocation
+      this._abortController = new AbortController()
+      this._abortSignal = this._abortController.signal
     }
 
     return iterationResult.value
@@ -1500,41 +1419,6 @@ export class Agent implements LocalAgent, InvokableAgent {
   }
 
   /**
-   * Invokes callbacks for a committed continuation message batch.
-   *
-   * @param events - Message events to dispatch
-   */
-  private async _invokeMessageCallbacks(events: readonly MessageAddedEvent[]): Promise<void> {
-    const finalMessages = [...this.messages]
-    const eventIds = new Set(events.map((event) => event.message.trackingId))
-    this.messages.splice(
-      0,
-      this.messages.length,
-      ...this.messages.filter((message) => !eventIds.has(message.trackingId))
-    )
-
-    const errors: unknown[] = []
-    for (const event of events) {
-      const finalIndex = finalMessages.findIndex((message) => message.trackingId === event.message.trackingId)
-      const nextMessage = finalMessages.slice(finalIndex + 1).find((message) => !eventIds.has(message.trackingId))
-      const nextIndex = nextMessage
-        ? this.messages.findIndex((message) => message.trackingId === nextMessage.trackingId)
-        : this.messages.length
-      const insertionIndex = nextIndex >= 0 ? nextIndex : this.messages.length
-      this.messages.splice(insertionIndex, 0, event.message)
-      try {
-        await this._invokeCallbacks(event)
-      } catch (error) {
-        errors.push(error)
-      }
-    }
-    for (const error of errors.slice(1)) {
-      logger.warn(`error=<${error}> | continuation message callback failed after earlier callback error`)
-    }
-    if (errors.length > 0) throw errors[0]
-  }
-
-  /**
    * Invokes hook callbacks and printer for a stream event.
    *
    * @param event - The event to process
@@ -1559,7 +1443,7 @@ export class Agent implements LocalAgent, InvokableAgent {
   private async *_stream(
     args: InvokeArgs,
     options?: InvokeOptions,
-    continuation?: InvocationContinuation
+    continuationEvent?: AfterInvocationEvent
   ): AsyncGenerator<AgentStreamEvent, AgentResult, undefined> {
     let currentArgs: InvokeArgs | undefined = args
     let result: AgentResult | undefined
@@ -1655,8 +1539,12 @@ export class Agent implements LocalAgent, InvokableAgent {
           // Normalize input and append user messages on first invocation only
           if (currentArgs !== undefined) {
             const messagesToAppend = this._normalizeInput(currentArgs)
-            for (const message of messagesToAppend) {
-              yield this._appendMessage(message, invocationState)
+            if (continuationEvent) {
+              yield* await this._appendContinuationMessages(messagesToAppend, continuationEvent, invocationState)
+            } else {
+              for (const message of messagesToAppend) {
+                yield this._appendMessage(message, invocationState)
+              }
             }
             currentArgs = undefined
           }
@@ -1671,7 +1559,7 @@ export class Agent implements LocalAgent, InvokableAgent {
             assistantMessage = pendingExecution.assistantMessage
             completedToolResults = pendingExecution.completedToolResults
           } else {
-            const modelResult = yield* this._invokeModel(invocationState, structuredOutputChoice, continuation)
+            const modelResult = yield* this._invokeModel(invocationState, structuredOutputChoice)
 
             if (modelResult.stopReason !== 'toolUse') {
               // Schema set, we already forced, and the model still refused.
@@ -2102,8 +1990,7 @@ export class Agent implements LocalAgent, InvokableAgent {
    */
   private async *_invokeModel(
     invocationState: InvocationState,
-    toolChoice?: ToolChoice,
-    invocationContinuation?: InvocationContinuation
+    toolChoice?: ToolChoice
   ): AsyncGenerator<AgentStreamEvent, StreamAggregatedResult, undefined> {
     const toolSpecs = this._toolRegistry.list().map((tool) => tool.toolSpec)
     const streamOptions: StreamOptions = { toolSpecs, modelState: this.modelState }
@@ -2121,10 +2008,7 @@ export class Agent implements LocalAgent, InvokableAgent {
       // Estimate input tokens for the upcoming model call (non-fatal if estimation fails)
       let projectedInputTokens: number | undefined
       try {
-        projectedInputTokens = await this._estimateInputTokens(
-          streamOptions,
-          continuations.buildRequest(this.messages, invocationContinuation)
-        )
+        projectedInputTokens = await this._estimateInputTokens(streamOptions)
       } catch (e) {
         logger.debug(`error=<${e}> | token estimation failed, proceeding without estimate`)
       }
@@ -2135,22 +2019,23 @@ export class Agent implements LocalAgent, InvokableAgent {
         invocationState,
         ...(projectedInputTokens !== undefined && { projectedInputTokens }),
       })
-      let modelInputs: readonly ContinuationInput[]
+      let modelContinuation: readonly Message[] | undefined
       try {
         yield beforeModelCallEvent
-        modelInputs = continuations.take(beforeModelCallEvent)
+        modelContinuation = await continuations.prepare(beforeModelCallEvent, (continuationArgs) =>
+          this._normalizeInput(continuationArgs)
+        )
       } finally {
-        await continuations.cleanup(undefined, continuations.take(beforeModelCallEvent))
+        if (modelContinuation === undefined) {
+          await continuations.abandon(
+            beforeModelCallEvent,
+            new Error('Agent stream closed before continuation input was incorporated into agent history')
+          )
+        }
       }
 
-      const modelContinuation = await continuations.prepareInvocation(modelInputs, undefined, (continuationArgs) =>
-        this._normalizeInput(continuationArgs)
-      )
       if (beforeModelCallEvent.cancel) {
-        await continuations.rejectInvocation(
-          modelContinuation,
-          new Error('Continuation model call cancelled by BeforeModelCallEvent')
-        )
+        await continuations.abandon(beforeModelCallEvent, new Error('Continuation abandoned by BeforeModelCallEvent'))
         const cancelText =
           typeof beforeModelCallEvent.cancel === 'string' ? beforeModelCallEvent.cancel : 'model call denied by hook'
         const message = new Message({ role: 'assistant', content: [new TextBlock(cancelText)] })
@@ -2172,23 +2057,21 @@ export class Agent implements LocalAgent, InvokableAgent {
         return { message, stopReason: 'endTurn' }
       }
 
-      try {
-        let outcome: ModelInvocationOutcome
+      yield* await this._appendContinuationMessages(modelContinuation ?? [], beforeModelCallEvent, invocationState)
+
+      if (modelContinuation !== undefined) {
         try {
-          outcome = yield* this._invokeModelWithMiddleware(
-            invocationState,
-            toolChoice,
-            projectedInputTokens,
-            invocationContinuation,
-            modelContinuation
-          )
+          projectedInputTokens = await this._estimateInputTokens(streamOptions)
         } catch (error) {
-          await continuations.rejectInvocation(modelContinuation, error)
-          throw error
-        } finally {
-          await continuations.cleanup(modelContinuation)
+          projectedInputTokens = undefined
+          logger.debug(
+            `error=<${error}> | token estimation failed after continuation input, proceeding without estimate`
+          )
         }
-        const { result, requestMessages } = outcome
+      }
+
+      try {
+        const result = yield* this._invokeModelWithMiddleware(invocationState, toolChoice, projectedInputTokens)
 
         // Accumulate token usage and model latency metrics
         this._meter.updateCycle(result.metadata)
@@ -2202,17 +2085,7 @@ export class Agent implements LocalAgent, InvokableAgent {
 
         // Handle user content redaction if guardrails blocked input
         if (result.redaction?.userMessage) {
-          let requestMessage: Message | undefined
-          for (let index = requestMessages.length - 1; index >= 0; index--) {
-            if (requestMessages[index]!.role === 'user') {
-              requestMessage = requestMessages[index]
-              break
-            }
-          }
-          const sourceIds = requestMessage
-            ? continuations.requestSourceIds(requestMessage, requestMessages, invocationContinuation, modelContinuation)
-            : undefined
-          this._redactLastMessage(result.redaction.userMessage, sourceIds)
+          this._redactLastMessage(result.redaction.userMessage)
         }
 
         const stopData: ModelStopData = {
@@ -2282,14 +2155,11 @@ export class Agent implements LocalAgent, InvokableAgent {
   private async *_invokeModelWithMiddleware(
     invocationState: InvocationState,
     toolChoice?: ToolChoice,
-    projectedInputTokens?: number,
-    invocationContinuation?: InvocationContinuation,
-    modelContinuation?: InvocationContinuation
-  ): AsyncGenerator<AgentStreamEvent, ModelInvocationOutcome, undefined> {
-    const requestMessages = continuations.buildRequest(this.messages, invocationContinuation, modelContinuation)
+    projectedInputTokens?: number
+  ): AsyncGenerator<AgentStreamEvent, StreamAggregatedResult, undefined> {
     const context: InvokeModelContext = {
       agent: this,
-      messages: requestMessages.map((message) => message.clone()),
+      messages: this.messages.map((msg) => msg.clone()),
       ...(this.systemPrompt !== undefined && { systemPrompt: cloneSystemPrompt(this.systemPrompt) }),
       toolSpecs: deepCopy(this._toolRegistry.list().map((tool) => tool.toolSpec)) as unknown as ToolSpec[],
       ...(toolChoice !== undefined && { toolChoice: deepCopy(toolChoice) as unknown as ToolChoice }),
@@ -2302,79 +2172,57 @@ export class Agent implements LocalAgent, InvokableAgent {
     // cannot affect modelState at any point (before or after next()).
     const modelStateSnapshot = this.modelState.getAll()
     let tempModelState: StateStore | undefined
-    const completedModelCalls: ModelInvocationOutcome[] = []
 
     // async function* doesn't bind lexical `this`; capture for the terminal callback.
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this
-    let middlewareResult: InvokeModelResult
-    try {
-      middlewareResult = yield* this._middlewareRegistry.invoke(
-        InvokeModelStage,
-        context,
-        async function* (ctx: InvokeModelContext): AsyncGenerator<AgentStreamEvent, InvokeModelResult, undefined> {
-          const modelId = self.model.modelId
-          const modelSpan = self._tracer.startModelInvokeSpan({
-            messages: ctx.messages as Message[],
-            ...(modelId && { modelId }),
+    const middlewareResult = yield* this._middlewareRegistry.invoke(
+      InvokeModelStage,
+      context,
+      async function* (ctx: InvokeModelContext): AsyncGenerator<AgentStreamEvent, InvokeModelResult, undefined> {
+        const modelId = self.model.modelId
+        const modelSpan = self._tracer.startModelInvokeSpan({
+          messages: ctx.messages as Message[],
+          ...(modelId && { modelId }),
+          ...(ctx.systemPrompt !== undefined && { systemPrompt: ctx.systemPrompt }),
+        })
+
+        try {
+          // Wrap the snapshot into a StateStore for the model provider, which expects
+          // get/set methods.
+          tempModelState = new StateStore(modelStateSnapshot)
+          const streamOptions: StreamOptions = {
+            cancelSignal: self._abortSignal,
+            toolSpecs: ctx.toolSpecs as ToolSpec[],
+            modelState: tempModelState,
             ...(ctx.systemPrompt !== undefined && { systemPrompt: ctx.systemPrompt }),
-          })
-          let modelResult: StreamAggregatedResult
-
-          try {
-            // Wrap the snapshot into a StateStore for the model provider, which expects
-            // get/set methods.
-            tempModelState = new StateStore(modelStateSnapshot)
-            const streamOptions: StreamOptions = {
-              cancelSignal: self._abortSignal,
-              toolSpecs: ctx.toolSpecs as ToolSpec[],
-              modelState: tempModelState,
-              ...(ctx.systemPrompt !== undefined && { systemPrompt: ctx.systemPrompt }),
-              ...(ctx.toolChoice && { toolChoice: ctx.toolChoice }),
-              // Omitted when zero, so an ordinary call's options are unchanged.
-              ...(ctx.dynamicTrailingBlocks ? { dynamicTrailingBlocks: ctx.dynamicTrailingBlocks } : {}),
-            }
-            const gen = self._streamFromModel(ctx.messages as Message[], streamOptions, ctx.invocationState)
-            let iterResult = await gen.next()
-            while (!iterResult.done) {
-              yield iterResult.value
-              iterResult = await gen.next()
-            }
-
-            modelResult = iterResult.value
-            const modelRequestMessages = ctx.messages.map((message) => message.clone())
-            completedModelCalls.push({ result: modelResult, requestMessages: modelRequestMessages })
-            const usage = modelResult.metadata?.usage
-            const metrics = modelResult.metadata?.metrics
-            self._tracer.endModelInvokeSpan(modelSpan, {
-              output: modelResult.message,
-              stopReason: modelResult.stopReason,
-              ...(usage && { usage }),
-              ...(metrics && { metrics }),
-            })
-          } catch (error) {
-            self._tracer.endModelInvokeSpan(modelSpan, { error: normalizeError(error) })
-            throw error
+            ...(ctx.toolChoice && { toolChoice: ctx.toolChoice }),
+            // Omitted when zero, so an ordinary call's options are unchanged.
+            ...(ctx.dynamicTrailingBlocks ? { dynamicTrailingBlocks: ctx.dynamicTrailingBlocks } : {}),
+          }
+          const gen = self._streamFromModel(ctx.messages as Message[], streamOptions, ctx.invocationState)
+          let iterResult = await gen.next()
+          while (!iterResult.done) {
+            yield iterResult.value
+            iterResult = await gen.next()
           }
 
-          return { result: modelResult }
-        }
-      )
-    } catch (error) {
-      if (completedModelCalls.length > 0) {
-        const completedRequests = completedModelCalls.map((call) => call.requestMessages)
-        const events = [
-          ...(await continuations.publish(this, invocationContinuation, completedRequests, invocationState)),
-          ...(await continuations.publish(this, modelContinuation, completedRequests, invocationState)),
-        ]
-        await this._invokeMessageCallbacks(events)
-        for (const event of events) this._dispatchedMessageEvents.add(event)
-        for (const event of events) {
-          yield event
+          const usage = iterResult.value.metadata?.usage
+          const metrics = iterResult.value.metadata?.metrics
+          self._tracer.endModelInvokeSpan(modelSpan, {
+            output: iterResult.value.message,
+            stopReason: iterResult.value.stopReason,
+            ...(usage && { usage }),
+            ...(metrics && { metrics }),
+          })
+
+          return { result: iterResult.value }
+        } catch (error) {
+          self._tracer.endModelInvokeSpan(modelSpan, { error: normalizeError(error) })
+          throw error
         }
       }
-      throw error
-    }
+    )
 
     // Sync model state after the entire middleware chain has completed, so no
     // middleware mutation to agent.modelState (before or after next()) takes effect.
@@ -2383,21 +2231,7 @@ export class Agent implements LocalAgent, InvokableAgent {
       loadStateSerializable(this.modelState, serializeStateSerializable(tempModelState))
     }
 
-    const completedCall =
-      completedModelCalls.find((call) => call.result === middlewareResult.result) ??
-      completedModelCalls.find((call) => call.result.message.trackingId === middlewareResult.result.message.trackingId)
-    const matchedRequestMessages = completedCall?.requestMessages
-    const modelRequests = matchedRequestMessages ? [matchedRequestMessages] : undefined
-    const events = [
-      ...(await continuations.publish(this, invocationContinuation, modelRequests, invocationState)),
-      ...(await continuations.publish(this, modelContinuation, modelRequests, invocationState)),
-    ]
-    await this._invokeMessageCallbacks(events)
-    for (const event of events) this._dispatchedMessageEvents.add(event)
-    for (const event of events) {
-      yield event
-    }
-    return { result: middlewareResult.result, requestMessages: matchedRequestMessages ?? [] }
+    return middlewareResult.result
   }
 
   /**
@@ -2562,17 +2396,15 @@ export class Agent implements LocalAgent, InvokableAgent {
    *
    * @param redactMessage - The redaction message to replace the content with
    */
-  private _redactLastMessage(redactMessage: string, sourceIds?: ReadonlySet<string>): void {
-    const indexes = sourceIds
-      ? this.messages.flatMap((message, index) => (sourceIds.has(message.trackingId) ? [index] : []))
-      : [this.messages.length - 1]
-    const messages = indexes.map((index) => this.messages[index]).filter((message) => message !== undefined)
-    const lastMessage = messages.at(-1)
-    if (lastMessage) {
-      if (messages.every((message) => message.role === 'user')) {
+  private _redactLastMessage(redactMessage: string): void {
+    // Find and redact the last message
+    const lastIndex = this.messages.length - 1
+    if (lastIndex >= 0) {
+      const lastMessage = this.messages[lastIndex]
+      if (lastMessage && lastMessage.role === 'user') {
         // Collect only tool result blocks with redacted content
         const redactedContent: ContentBlock[] = []
-        for (const block of messages.flatMap((message) => message.content)) {
+        for (const block of lastMessage.content) {
           if (block.type === 'toolResultBlock') {
             // Preserve tool result block structure, only redact its content
             redactedContent.push(
@@ -2590,18 +2422,13 @@ export class Agent implements LocalAgent, InvokableAgent {
           redactedContent.push(new TextBlock(redactMessage))
         }
 
-        const replacement = new Message({
+        this.messages[lastIndex] = new Message({
           role: 'user',
           content: redactedContent,
           // Redaction rewrites content but it's the same logical message, so keep its tracking id.
           trackingId: lastMessage.trackingId,
         })
-        const ids = new Set(messages.map((message) => message.trackingId))
-        const insertionIndex = indexes[0]!
-        const retained = this.messages.filter((message) => !ids.has(message.trackingId))
-        retained.splice(insertionIndex, 0, replacement)
-        this.messages.splice(0, this.messages.length, ...retained)
-      } else {
+      } else if (lastMessage) {
         // Unexpected state: redaction requested but last message is not from user
         logger.warn(
           `role=<${lastMessage.role}> | received input redaction but last message is not from user | redaction skipped`
@@ -2619,14 +2446,13 @@ export class Agent implements LocalAgent, InvokableAgent {
    * is available (cold start or first call).
    *
    * @param streamOptions - The stream options containing system prompt and tool specs
-   * @param messages - Messages expected in the next model request
    * @returns Estimated input token count
    */
-  private async _estimateInputTokens(streamOptions: StreamOptions, messages: readonly Message[]): Promise<number> {
+  private async _estimateInputTokens(streamOptions: StreamOptions): Promise<number> {
     // Find the last assistant message with usage metadata
     let lastAssistantIdx = -1
-    for (let i = messages.length - 1; i >= 0; i--) {
-      if (messages[i]!.role === 'assistant' && messages[i]!.metadata?.usage) {
+    for (let i = this.messages.length - 1; i >= 0; i--) {
+      if (this.messages[i]!.role === 'assistant' && this.messages[i]!.metadata?.usage) {
         lastAssistantIdx = i
         break
       }
@@ -2634,9 +2460,9 @@ export class Agent implements LocalAgent, InvokableAgent {
 
     let estimate: number
     if (lastAssistantIdx >= 0) {
-      const usage = messages[lastAssistantIdx]!.metadata!.usage!
+      const usage = this.messages[lastAssistantIdx]!.metadata!.usage!
       const knownBaseline = usage.inputTokens + usage.outputTokens
-      const newMessages = messages.slice(lastAssistantIdx + 1)
+      const newMessages = this.messages.slice(lastAssistantIdx + 1)
       if (newMessages.length === 0) {
         estimate = knownBaseline
       } else {
@@ -2644,7 +2470,7 @@ export class Agent implements LocalAgent, InvokableAgent {
         estimate = knownBaseline + (await this.model.countTokens(newMessages))
       }
     } else {
-      estimate = await this.model.countTokens([...messages], {
+      estimate = await this.model.countTokens(this.messages, {
         ...(streamOptions.systemPrompt !== undefined && { systemPrompt: streamOptions.systemPrompt }),
         ...(streamOptions.toolSpecs !== undefined && { toolSpecs: streamOptions.toolSpecs }),
       })
@@ -2674,6 +2500,38 @@ export class Agent implements LocalAgent, InvokableAgent {
   private _appendMessage(message: Message, invocationState: InvocationState): MessageAddedEvent {
     this.messages.push(message)
     return new MessageAddedEvent({ agent: this, message, invocationState })
+  }
+
+  private async _appendContinuationMessages(
+    messages: readonly Message[],
+    continuationEvent: AfterInvocationEvent | BeforeModelCallEvent,
+    invocationState: InvocationState
+  ): Promise<MessageAddedEvent[]> {
+    const events: MessageAddedEvent[] = []
+    for (const message of messages) {
+      const lastMessage = this.messages.at(-1)
+      if (lastMessage?.role !== message.role) {
+        events.push(this._appendMessage(message, invocationState))
+        continue
+      }
+
+      const appendedMessage = new Message({
+        role: message.role,
+        content: [...lastMessage.content, ...message.content],
+        trackingId: lastMessage.trackingId,
+        ...(lastMessage.metadata !== undefined && { metadata: lastMessage.metadata }),
+      })
+      this.messages[this.messages.length - 1] = appendedMessage
+
+      const messageEvent = new MessageAddedEvent({ agent: this, message: appendedMessage, invocationState })
+      if (events.at(-1)?.message === lastMessage) {
+        events[events.length - 1] = messageEvent
+      } else {
+        events.push(messageEvent)
+      }
+    }
+    await continuations.markAppended(continuationEvent)
+    return events
   }
 
   private _hasOpenUserTurn(): boolean {

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -1164,7 +1164,14 @@ export class Agent implements LocalAgent, InvokableAgent {
           throw caughtError
         }
 
+        const stopReason = result!.stopReason
+        const allowsContinuation = stopReason === 'endTurn' || stopReason === 'stopSequence'
+        if (!allowsContinuation) {
+          await continuations.abandon(afterInvocationEvent, new Error(`Continuation abandoned after ${stopReason}`))
+        }
+
         const hasContinuation =
+          allowsContinuation &&
           (await continuations.prepare(afterInvocationEvent, (continuationArgs) =>
             this._normalizeInput(continuationArgs)
           )) !== undefined

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -1166,14 +1166,15 @@ export class Agent implements LocalAgent, InvokableAgent {
 
         const stopReason = result!.stopReason
         const allowsContinuation = stopReason === 'endTurn' || stopReason === 'stopSequence'
-        if (!allowsContinuation) {
+        if (!allowsContinuation && stopReason !== 'interrupt') {
           await continuations.abandon(afterInvocationEvent, new Error(`Continuation abandoned after ${stopReason}`))
         }
 
         const hasContinuation =
-          allowsContinuation &&
-          (await continuations.prepare(afterInvocationEvent, (continuationArgs) =>
-            this._normalizeInput(continuationArgs)
+          (await continuations.prepare(
+            afterInvocationEvent,
+            (continuationArgs) => this._normalizeInput(continuationArgs),
+            stopReason
           )) !== undefined
         continuationEvent = hasContinuation ? afterInvocationEvent : undefined
 

--- a/strands-ts/src/agent/continuation.ts
+++ b/strands-ts/src/agent/continuation.ts
@@ -1,53 +1,30 @@
-import { AfterInvocationEvent, BeforeModelCallEvent, MessageAddedEvent } from '../hooks/events.js'
+import { AfterInvocationEvent, BeforeModelCallEvent } from '../hooks/events.js'
 import { logger } from '../logging/logger.js'
-import { Message } from '../types/messages.js'
 
-import type { AgentResult, InvokeArgs, InvocationState, LocalAgent } from '../types/agent.js'
-import type { StopReason } from '../types/messages.js'
+import type { InvokeArgs } from '../types/agent.js'
+import type { Message } from '../types/messages.js'
 
 /**
  * One internal input contribution to an agent or model invocation.
  *
- * When both settlement callbacks are supplied, exactly one runs once. Callback
- * failures are logged and do not change the agent result.
- *
- * @internal
+ * When both callbacks are supplied, exactly one runs once. Callback failures
+ * are logged and do not change the agent result.
  */
-export interface ContinuationInput {
+interface ContinuationInput {
   /** Input that normalizes to one or more complete messages. */
   readonly args: InvokeArgs
-  /** Runs after the input is committed. */
-  readonly onConsumed?: () => void | Promise<void>
-  /** Runs when the input cannot be included in a successful model-stage result. */
-  readonly onRejected?: (reason: unknown) => void | Promise<void>
+  /** Runs after the input is incorporated into agent history. */
+  readonly onAppended?: () => void | Promise<void>
+  /** Runs when the input cannot be incorporated into agent history. */
+  readonly onAbandoned?: (reason: unknown) => void | Promise<void>
 }
 
-/**
- * Prepared internal input for one agent or model invocation.
- *
- * @internal
- */
-export interface InvocationContinuation {
-  args: InvokeArgs
-  internal: readonly {
-    readonly input: ContinuationInput
-    readonly messages: readonly Message[]
-  }[]
-  readonly publicResume: boolean
-  publicMessages: readonly Message[]
-  requestGroups: readonly (readonly Message[])[]
-  settled: boolean
+interface ContinuationState {
+  readonly inputs: ContinuationInput[]
+  readonly messages?: readonly Message[]
 }
 
-const pendingInputs = new WeakMap<AfterInvocationEvent | BeforeModelCallEvent, ContinuationInput[]>()
-const REJECTION_STOP_REASONS: ReadonlySet<StopReason> = new Set([
-  'cancelled',
-  'checkpoint',
-  'interrupt',
-  'limitTurns',
-  'limitTotalTokens',
-  'limitOutputTokens',
-])
+const stateByEvent = new WeakMap<AfterInvocationEvent | BeforeModelCallEvent, ContinuationState>()
 
 /**
  * Internal continuation operations used by the agent loop.
@@ -55,252 +32,92 @@ const REJECTION_STOP_REASONS: ReadonlySet<StopReason> = new Set([
  * @internal
  */
 export const continuations = {
-  add,
-  buildRequest,
-  cleanup,
-  isRejectionStopReason,
-  prepareInvocation,
-  publish,
-  rejectInputs,
-  rejectInvocation,
-  requestSourceIds,
-  settleResult,
-  take,
-  updateArgs,
+  abandon,
+  addInput,
+  combine,
+  markAppended,
+  prepare,
 }
 
-function add(event: AfterInvocationEvent | BeforeModelCallEvent, input: ContinuationInput): void {
-  const inputs = pendingInputs.get(event) ?? []
-  inputs.push(input)
-  pendingInputs.set(event, inputs)
+function addInput(event: AfterInvocationEvent | BeforeModelCallEvent, input: ContinuationInput): void {
+  const state = stateByEvent.get(event) ?? { inputs: [] }
+  state.inputs.push(input)
+  stateByEvent.set(event, state)
 }
 
-function take(event: AfterInvocationEvent | BeforeModelCallEvent): readonly ContinuationInput[] {
-  const inputs = pendingInputs.get(event) ?? []
-  pendingInputs.delete(event)
-  return inputs
-}
-
-function isRejectionStopReason(stopReason: StopReason): boolean {
-  return REJECTION_STOP_REASONS.has(stopReason)
-}
-
-async function prepareInvocation(
-  inputs: readonly ContinuationInput[],
-  resume: InvokeArgs | undefined,
+async function prepare(
+  event: AfterInvocationEvent | BeforeModelCallEvent,
   normalizeInput: (args: InvokeArgs) => Message[]
-): Promise<InvocationContinuation | undefined> {
-  const internal = await prepareInputs(inputs, normalizeInput)
-  if (internal.length === 0 && resume === undefined) return undefined
+): Promise<readonly Message[] | undefined> {
+  const inputs = stateByEvent.get(event)?.inputs ?? []
+  const acceptedInputs: ContinuationInput[] = []
+  const messages: Message[] = []
 
-  const invocation: InvocationContinuation = {
-    args: resume ?? [],
-    internal,
-    publicResume: resume !== undefined,
-    publicMessages: [],
-    requestGroups: [],
-    settled: false,
-  }
-  if (resume !== undefined) {
-    await updateArgs(invocation, resume, normalizeInput)
-  }
-  return invocation
-}
-
-async function updateArgs(
-  invocation: InvocationContinuation,
-  args: InvokeArgs,
-  normalizeInput: (args: InvokeArgs) => Message[]
-): Promise<InvokeArgs> {
-  try {
-    invocation.publicMessages = normalizeInput(args)
-  } catch (error) {
-    await rejectInvocation(invocation, error)
-    throw error
+  for (const input of inputs) {
+    try {
+      const normalized = normalizeInput(input.args)
+      if (!isCompleteMessageInput(normalized)) {
+        throw new TypeError('Continuation input must contain a complete message sequence')
+      }
+      messages.push(...normalized)
+      acceptedInputs.push(input)
+    } catch (error) {
+      await notifyAbandoned(input, error)
+    }
   }
 
-  const emptyInput = Array.isArray(args) && args.length === 0
-  if (invocation.internal.length > 0 && !emptyInput && !isComposableUserInput(invocation.publicMessages)) {
-    await rejectPrepared(
-      invocation.internal,
-      new TypeError('Continuation input cannot be combined with this public resume')
-    )
-    invocation.internal = []
+  if (acceptedInputs.length === 0) {
+    stateByEvent.delete(event)
+    return undefined
   }
 
-  invocation.args = invocation.publicMessages.length > 0 ? [...invocation.publicMessages] : args
-  return invocation.args
-}
-
-function buildRequest(
-  history: readonly Message[],
-  ...invocations: readonly (InvocationContinuation | undefined)[]
-): Message[] {
-  const activeInvocations = invocations.filter(
-    (invocation): invocation is InvocationContinuation =>
-      invocation !== undefined && invocation.internal.length > 0 && !invocation.settled
-  )
-
-  let sourceMessages = [...history]
-  for (const invocation of activeInvocations) {
-    const publicIds = new Set(invocation.publicMessages.map((message) => message.trackingId))
-    sourceMessages = [
-      ...sourceMessages.filter((message) => !publicIds.has(message.trackingId)),
-      ...invocation.internal.flatMap((input) => input.messages),
-      ...invocation.publicMessages,
-    ]
-  }
-
-  const requestGroups = groupMessages(sourceMessages)
-  const messages = requestGroups.map((group) => {
-    const last = group.at(-1)!
-    return group.length === 1
-      ? last
-      : new Message({
-          role: last.role,
-          content: group.flatMap((message) => message.content),
-          trackingId: last.trackingId,
-        })
-  })
-  for (const invocation of activeInvocations) {
-    invocation.requestGroups = requestGroups.map((group) => group.map((message) => message.clone()))
-  }
+  stateByEvent.set(event, { inputs: acceptedInputs, messages })
   return messages
 }
 
-function requestSourceIds(
-  requestMessage: Message,
-  request: readonly Message[],
-  ...invocations: readonly (InvocationContinuation | undefined)[]
-): ReadonlySet<string> | undefined {
-  const sourceIds = new Set<string>()
-  for (const invocation of invocations) {
-    if (!invocation) continue
-    const group = matchRequestGroups(invocation, request).get(requestMessage.trackingId)
-    if (!group) continue
-    for (const sourceId of matchedSourceIds(group, serializedContent(requestMessage), true)) sourceIds.add(sourceId)
-  }
-  return sourceIds.size > 0 ? sourceIds : undefined
-}
-
-async function publish(
-  agent: LocalAgent,
-  invocation: InvocationContinuation | undefined,
-  modelRequests: readonly (readonly Message[])[] | undefined,
-  invocationState: InvocationState,
-  insertBeforeTrackingId?: string,
-  includePublic = true
-): Promise<readonly MessageAddedEvent[]> {
-  if (!invocation || invocation.settled) return []
-
-  const prepared = invocation.internal
-  const acceptedInputs = findAcceptedInputs(invocation, modelRequests ?? [])
-  const accepted = prepared.filter((entry) => acceptedInputs.has(entry))
-  invocation.settled = true
-  const inserted = integrateMessages(agent, invocation, accepted, insertBeforeTrackingId, includePublic)
-
-  await rejectPrepared(
-    prepared.filter((entry) => !acceptedInputs.has(entry)),
-    new Error('Continuation was not retained in the successful model request')
-  )
-  await notifyConsumed(accepted)
-
-  return inserted.map((message) => new MessageAddedEvent({ agent, message, invocationState }))
-}
-
-async function settleResult(
-  agent: LocalAgent,
-  invocation: InvocationContinuation | undefined,
-  result: AgentResult,
-  invocationState: InvocationState,
-  passRanAgentLoop: boolean
-): Promise<readonly MessageAddedEvent[]> {
-  if (!invocation || invocation.settled) return []
-  if (isRejectionStopReason(result.stopReason)) {
-    await rejectInvocation(invocation, new Error(`Continuation stopped by ${result.stopReason}`))
-    return []
-  }
-  if (!passRanAgentLoop && invocation.internal.length === 0) {
-    invocation.settled = true
-    return []
-  }
-
-  const events = [
-    ...(await publish(
-      agent,
-      invocation,
-      undefined,
-      invocationState,
-      passRanAgentLoop ? result.lastMessage.trackingId : undefined,
-      passRanAgentLoop
-    )),
-  ]
-  if (!agent.messages.some((message) => message.trackingId === result.lastMessage.trackingId)) {
-    agent.messages.push(result.lastMessage)
-    events.push(new MessageAddedEvent({ agent, message: result.lastMessage, invocationState }))
-  }
-
-  return events
-}
-
-async function rejectInvocation(invocation: InvocationContinuation | undefined, reason: unknown): Promise<void> {
-  if (!invocation || invocation.settled) return
-  invocation.settled = true
-  await rejectPrepared(invocation.internal, reason)
-}
-
-async function rejectInputs(inputs: readonly ContinuationInput[], reason: unknown): Promise<void> {
-  for (const input of inputs) {
-    try {
-      await input.onRejected?.(reason)
-    } catch (error) {
-      logger.warn(`error=<${error}> | continuation rejection callback failed`)
-    }
-  }
-}
-
-async function cleanup(
-  invocation: InvocationContinuation | undefined,
-  inputs: readonly ContinuationInput[] = []
-): Promise<void> {
-  const reason = new Error('Agent stream closed before continuation consumption')
-  await rejectInvocation(invocation, reason)
-  await rejectInputs(inputs, reason)
-}
-
-async function prepareInputs(
-  inputs: readonly ContinuationInput[],
+function combine(
+  event: AfterInvocationEvent | BeforeModelCallEvent | undefined,
+  args: InvokeArgs,
   normalizeInput: (args: InvokeArgs) => Message[]
-): Promise<InvocationContinuation['internal']> {
-  const prepared: Array<InvocationContinuation['internal'][number]> = []
+): InvokeArgs {
+  const messages = event ? stateByEvent.get(event)?.messages : undefined
+  if (!messages) return args
 
-  for (const input of inputs) {
-    try {
-      const messages = normalizeInput(input.args)
-      if (!isCompleteMessageInput(messages)) {
-        throw new TypeError('Continuation input must contain a complete message sequence')
-      }
-      prepared.push({ input, messages })
-    } catch (error) {
-      await rejectInputs([input], error)
-    }
+  const publicMessages = normalizeInput(args)
+  const emptyInput = Array.isArray(args) && args.length === 0
+  if (publicMessages.length === 0 && !emptyInput) {
+    return args
   }
-  return prepared
+
+  return [...messages, ...publicMessages]
 }
 
-function isComposableUserInput(messages: readonly Message[]): boolean {
-  return (
-    messages.length > 0 &&
-    messages.every(
-      (message) =>
-        message.role === 'user' &&
-        message.content.every((block) => block.type !== 'toolUseBlock' && block.type !== 'toolResultBlock')
-    )
-  )
+async function markAppended(event: AfterInvocationEvent | BeforeModelCallEvent | undefined): Promise<void> {
+  if (!event || !stateByEvent.get(event)?.messages) return
+  for (const input of consumeInputs(event)) {
+    try {
+      await input.onAppended?.()
+    } catch (error) {
+      logger.warn(`error=<${error}> | continuation append callback failed`)
+    }
+  }
+}
+
+async function abandon(event: AfterInvocationEvent | BeforeModelCallEvent | undefined, reason: unknown): Promise<void> {
+  if (!event) return
+  for (const input of consumeInputs(event)) {
+    await notifyAbandoned(input, reason)
+  }
+}
+
+function consumeInputs(event: AfterInvocationEvent | BeforeModelCallEvent): readonly ContinuationInput[] {
+  const state = stateByEvent.get(event)
+  stateByEvent.delete(event)
+  return state?.inputs ?? []
 }
 
 function isCompleteMessageInput(messages: readonly Message[]): boolean {
-  if (messages.length === 0) return false
+  if (messages.length === 0 || messages.at(-1)?.role !== 'user') return false
 
   let pendingToolUseIds = new Set<string>()
   for (const message of messages) {
@@ -322,181 +139,10 @@ function isCompleteMessageInput(messages: readonly Message[]): boolean {
   return pendingToolUseIds.size === 0
 }
 
-function findAcceptedInputs(
-  invocation: InvocationContinuation,
-  modelRequests: readonly (readonly Message[])[]
-): ReadonlySet<InvocationContinuation['internal'][number]> {
-  const accepted = new Set<InvocationContinuation['internal'][number]>()
-  if (modelRequests.length === 0) {
-    for (const entry of invocation.internal) accepted.add(entry)
-    return accepted
-  }
-  for (const request of modelRequests) {
-    const sourceIds = retainedSourceIds(invocation, request)
-    for (const entry of invocation.internal) {
-      if (!accepted.has(entry) && entry.messages.every((message) => sourceIds.has(message.trackingId))) {
-        accepted.add(entry)
-      }
-    }
-  }
-  return accepted
-}
-
-function retainedSourceIds(invocation: InvocationContinuation, request: readonly Message[]): ReadonlySet<string> {
-  const retained = new Set<string>()
-  const groups = matchRequestGroups(invocation, request)
-  for (const message of request) {
-    const group = groups.get(message.trackingId)
-    if (!group) continue
-    for (const sourceId of matchedSourceIds(group, serializedContent(message), false)) retained.add(sourceId)
-  }
-  return retained
-}
-
-function matchRequestGroups(
-  invocation: InvocationContinuation,
-  request: readonly Message[]
-): ReadonlyMap<string, readonly Message[]> {
-  const matched = new Map<string, readonly Message[]>()
-  const used = new Set<number>()
-  let nextIndex = 0
-
-  for (const message of request) {
-    let index = invocation.requestGroups.findIndex(
-      (group, groupIndex) => !used.has(groupIndex) && group.at(-1)?.trackingId === message.trackingId
-    )
-    if (index < 0) {
-      const content = serializedContent(message)
-      index = invocation.requestGroups.findIndex(
-        (group, groupIndex) =>
-          groupIndex >= nextIndex &&
-          group[0]?.role === message.role &&
-          group.some((source) => findSequence(content, serializedContent(source), 0) >= 0)
-      )
-    }
-    if (index < 0) continue
-    used.add(index)
-    nextIndex = Math.max(nextIndex, index + 1)
-    matched.set(message.trackingId, invocation.requestGroups[index]!)
-  }
-  return matched
-}
-
-function serializedContent(message: Message): string[] {
-  return message.content.map((block) => JSON.stringify(block.toJSON()))
-}
-
-function matchedSourceIds(
-  group: readonly Message[],
-  content: readonly string[],
-  includeAmbiguous: boolean
-): ReadonlySet<string> {
-  const sourceGroups = new Map<string, { content: readonly string[]; count: number }>()
-  for (const source of group) {
-    const sourceContent = serializedContent(source)
-    const key = JSON.stringify(sourceContent)
-    const existing = sourceGroups.get(key)
-    sourceGroups.set(key, { content: sourceContent, count: (existing?.count ?? 0) + 1 })
-  }
-  const ambiguous = new Set(
-    [...sourceGroups].flatMap(([key, sourceGroup]) => {
-      const occurrences = countSequence(content, sourceGroup.content)
-      return sourceGroup.count > 1 && occurrences > 0 && occurrences < sourceGroup.count ? [key] : []
-    })
-  )
-
-  const matched = new Set<string>()
-  let contentIndex = 0
-  for (const source of group) {
-    const sourceContent = serializedContent(source)
-    const key = JSON.stringify(sourceContent)
-    if (ambiguous.has(key)) {
-      if (includeAmbiguous) matched.add(source.trackingId)
-      continue
-    }
-    const sourceIndex = findSequence(content, sourceContent, contentIndex)
-    if (sourceIndex < 0) continue
-    matched.add(source.trackingId)
-    contentIndex = sourceIndex + sourceContent.length
-  }
-  return matched
-}
-
-function countSequence(haystack: readonly string[], needle: readonly string[]): number {
-  let count = 0
-  let index = 0
-  while ((index = findSequence(haystack, needle, index)) >= 0) {
-    count += 1
-    index += needle.length
-  }
-  return count
-}
-
-function findSequence(haystack: readonly string[], needle: readonly string[], start: number): number {
-  if (needle.length === 0) return -1
-  for (let index = start; index <= haystack.length - needle.length; index++) {
-    if (needle.every((value, offset) => haystack[index + offset] === value)) return index
-  }
-  return -1
-}
-
-function integrateMessages(
-  agent: LocalAgent,
-  invocation: InvocationContinuation,
-  accepted: InvocationContinuation['internal'],
-  insertBeforeTrackingId?: string,
-  includePublic = true
-): readonly Message[] {
-  const publicMessages = includePublic ? invocation.publicMessages : []
-  const publicIds = new Set(publicMessages.map((message) => message.trackingId))
-  const existingPublicIds = new Set(
-    agent.messages.filter((message) => publicIds.has(message.trackingId)).map((message) => message.trackingId)
-  )
-  const publicIndex = agent.messages.findIndex((message) => publicIds.has(message.trackingId))
-  if (accepted.length === 0 && (publicMessages.length === 0 || publicIndex >= 0)) return []
-
-  const baseMessages = agent.messages.filter((message) => !publicIds.has(message.trackingId))
-  let insertionIndex = baseMessages.length
-  if (publicIndex >= 0) {
-    insertionIndex = agent.messages.slice(0, publicIndex).filter((message) => !publicIds.has(message.trackingId)).length
-  } else if (insertBeforeTrackingId !== undefined) {
-    const resultIndex = baseMessages.findIndex((message) => message.trackingId === insertBeforeTrackingId)
-    if (resultIndex >= 0) insertionIndex = resultIndex
-  }
-
-  const internalMessages = accepted.flatMap((entry) => entry.messages)
-  const messages = [...internalMessages, ...publicMessages]
-  baseMessages.splice(insertionIndex, 0, ...messages)
-  agent.messages.splice(0, agent.messages.length, ...baseMessages)
-  return [...internalMessages, ...publicMessages.filter((message) => !existingPublicIds.has(message.trackingId))]
-}
-
-function groupMessages(messages: readonly Message[]): Message[][] {
-  const groups: Message[][] = []
-  for (const message of messages) {
-    const group = groups.at(-1)
-    if (group?.[0]?.role === message.role) {
-      group.push(message)
-    } else {
-      groups.push([message])
-    }
-  }
-  return groups
-}
-
-async function rejectPrepared(inputs: InvocationContinuation['internal'], reason: unknown): Promise<void> {
-  await rejectInputs(
-    inputs.map((entry) => entry.input),
-    reason
-  )
-}
-
-async function notifyConsumed(entries: InvocationContinuation['internal']): Promise<void> {
-  for (const entry of entries) {
-    try {
-      await entry.input.onConsumed?.()
-    } catch (error) {
-      logger.warn(`error=<${error}> | continuation consumption callback failed`)
-    }
+async function notifyAbandoned(input: ContinuationInput, reason: unknown): Promise<void> {
+  try {
+    await input.onAbandoned?.(reason)
+  } catch (error) {
+    logger.warn(`error=<${error}> | continuation abandon callback failed`)
   }
 }

--- a/strands-ts/src/agent/continuation.ts
+++ b/strands-ts/src/agent/continuation.ts
@@ -1,0 +1,502 @@
+import { AfterInvocationEvent, BeforeModelCallEvent, MessageAddedEvent } from '../hooks/events.js'
+import { logger } from '../logging/logger.js'
+import { Message } from '../types/messages.js'
+
+import type { AgentResult, InvokeArgs, InvocationState, LocalAgent } from '../types/agent.js'
+import type { StopReason } from '../types/messages.js'
+
+/**
+ * One internal input contribution to an agent or model invocation.
+ *
+ * When both settlement callbacks are supplied, exactly one runs once. Callback
+ * failures are logged and do not change the agent result.
+ *
+ * @internal
+ */
+export interface ContinuationInput {
+  /** Input that normalizes to one or more complete messages. */
+  readonly args: InvokeArgs
+  /** Runs after the input is committed. */
+  readonly onConsumed?: () => void | Promise<void>
+  /** Runs when the input cannot be included in a successful model-stage result. */
+  readonly onRejected?: (reason: unknown) => void | Promise<void>
+}
+
+/**
+ * Prepared internal input for one agent or model invocation.
+ *
+ * @internal
+ */
+export interface InvocationContinuation {
+  args: InvokeArgs
+  internal: readonly {
+    readonly input: ContinuationInput
+    readonly messages: readonly Message[]
+  }[]
+  readonly publicResume: boolean
+  publicMessages: readonly Message[]
+  requestGroups: readonly (readonly Message[])[]
+  settled: boolean
+}
+
+const pendingInputs = new WeakMap<AfterInvocationEvent | BeforeModelCallEvent, ContinuationInput[]>()
+const REJECTION_STOP_REASONS: ReadonlySet<StopReason> = new Set([
+  'cancelled',
+  'checkpoint',
+  'interrupt',
+  'limitTurns',
+  'limitTotalTokens',
+  'limitOutputTokens',
+])
+
+/**
+ * Internal continuation operations used by the agent loop.
+ *
+ * @internal
+ */
+export const continuations = {
+  add,
+  buildRequest,
+  cleanup,
+  isRejectionStopReason,
+  prepareInvocation,
+  publish,
+  rejectInputs,
+  rejectInvocation,
+  requestSourceIds,
+  settleResult,
+  take,
+  updateArgs,
+}
+
+function add(event: AfterInvocationEvent | BeforeModelCallEvent, input: ContinuationInput): void {
+  const inputs = pendingInputs.get(event) ?? []
+  inputs.push(input)
+  pendingInputs.set(event, inputs)
+}
+
+function take(event: AfterInvocationEvent | BeforeModelCallEvent): readonly ContinuationInput[] {
+  const inputs = pendingInputs.get(event) ?? []
+  pendingInputs.delete(event)
+  return inputs
+}
+
+function isRejectionStopReason(stopReason: StopReason): boolean {
+  return REJECTION_STOP_REASONS.has(stopReason)
+}
+
+async function prepareInvocation(
+  inputs: readonly ContinuationInput[],
+  resume: InvokeArgs | undefined,
+  normalizeInput: (args: InvokeArgs) => Message[]
+): Promise<InvocationContinuation | undefined> {
+  const internal = await prepareInputs(inputs, normalizeInput)
+  if (internal.length === 0 && resume === undefined) return undefined
+
+  const invocation: InvocationContinuation = {
+    args: resume ?? [],
+    internal,
+    publicResume: resume !== undefined,
+    publicMessages: [],
+    requestGroups: [],
+    settled: false,
+  }
+  if (resume !== undefined) {
+    await updateArgs(invocation, resume, normalizeInput)
+  }
+  return invocation
+}
+
+async function updateArgs(
+  invocation: InvocationContinuation,
+  args: InvokeArgs,
+  normalizeInput: (args: InvokeArgs) => Message[]
+): Promise<InvokeArgs> {
+  try {
+    invocation.publicMessages = normalizeInput(args)
+  } catch (error) {
+    await rejectInvocation(invocation, error)
+    throw error
+  }
+
+  const emptyInput = Array.isArray(args) && args.length === 0
+  if (invocation.internal.length > 0 && !emptyInput && !isComposableUserInput(invocation.publicMessages)) {
+    await rejectPrepared(
+      invocation.internal,
+      new TypeError('Continuation input cannot be combined with this public resume')
+    )
+    invocation.internal = []
+  }
+
+  invocation.args = invocation.publicMessages.length > 0 ? [...invocation.publicMessages] : args
+  return invocation.args
+}
+
+function buildRequest(
+  history: readonly Message[],
+  ...invocations: readonly (InvocationContinuation | undefined)[]
+): Message[] {
+  const activeInvocations = invocations.filter(
+    (invocation): invocation is InvocationContinuation =>
+      invocation !== undefined && invocation.internal.length > 0 && !invocation.settled
+  )
+
+  let sourceMessages = [...history]
+  for (const invocation of activeInvocations) {
+    const publicIds = new Set(invocation.publicMessages.map((message) => message.trackingId))
+    sourceMessages = [
+      ...sourceMessages.filter((message) => !publicIds.has(message.trackingId)),
+      ...invocation.internal.flatMap((input) => input.messages),
+      ...invocation.publicMessages,
+    ]
+  }
+
+  const requestGroups = groupMessages(sourceMessages)
+  const messages = requestGroups.map((group) => {
+    const last = group.at(-1)!
+    return group.length === 1
+      ? last
+      : new Message({
+          role: last.role,
+          content: group.flatMap((message) => message.content),
+          trackingId: last.trackingId,
+        })
+  })
+  for (const invocation of activeInvocations) {
+    invocation.requestGroups = requestGroups.map((group) => group.map((message) => message.clone()))
+  }
+  return messages
+}
+
+function requestSourceIds(
+  requestMessage: Message,
+  request: readonly Message[],
+  ...invocations: readonly (InvocationContinuation | undefined)[]
+): ReadonlySet<string> | undefined {
+  const sourceIds = new Set<string>()
+  for (const invocation of invocations) {
+    if (!invocation) continue
+    const group = matchRequestGroups(invocation, request).get(requestMessage.trackingId)
+    if (!group) continue
+    for (const sourceId of matchedSourceIds(group, serializedContent(requestMessage), true)) sourceIds.add(sourceId)
+  }
+  return sourceIds.size > 0 ? sourceIds : undefined
+}
+
+async function publish(
+  agent: LocalAgent,
+  invocation: InvocationContinuation | undefined,
+  modelRequests: readonly (readonly Message[])[] | undefined,
+  invocationState: InvocationState,
+  insertBeforeTrackingId?: string,
+  includePublic = true
+): Promise<readonly MessageAddedEvent[]> {
+  if (!invocation || invocation.settled) return []
+
+  const prepared = invocation.internal
+  const acceptedInputs = findAcceptedInputs(invocation, modelRequests ?? [])
+  const accepted = prepared.filter((entry) => acceptedInputs.has(entry))
+  invocation.settled = true
+  const inserted = integrateMessages(agent, invocation, accepted, insertBeforeTrackingId, includePublic)
+
+  await rejectPrepared(
+    prepared.filter((entry) => !acceptedInputs.has(entry)),
+    new Error('Continuation was not retained in the successful model request')
+  )
+  await notifyConsumed(accepted)
+
+  return inserted.map((message) => new MessageAddedEvent({ agent, message, invocationState }))
+}
+
+async function settleResult(
+  agent: LocalAgent,
+  invocation: InvocationContinuation | undefined,
+  result: AgentResult,
+  invocationState: InvocationState,
+  passRanAgentLoop: boolean
+): Promise<readonly MessageAddedEvent[]> {
+  if (!invocation || invocation.settled) return []
+  if (isRejectionStopReason(result.stopReason)) {
+    await rejectInvocation(invocation, new Error(`Continuation stopped by ${result.stopReason}`))
+    return []
+  }
+  if (!passRanAgentLoop && invocation.internal.length === 0) {
+    invocation.settled = true
+    return []
+  }
+
+  const events = [
+    ...(await publish(
+      agent,
+      invocation,
+      undefined,
+      invocationState,
+      passRanAgentLoop ? result.lastMessage.trackingId : undefined,
+      passRanAgentLoop
+    )),
+  ]
+  if (!agent.messages.some((message) => message.trackingId === result.lastMessage.trackingId)) {
+    agent.messages.push(result.lastMessage)
+    events.push(new MessageAddedEvent({ agent, message: result.lastMessage, invocationState }))
+  }
+
+  return events
+}
+
+async function rejectInvocation(invocation: InvocationContinuation | undefined, reason: unknown): Promise<void> {
+  if (!invocation || invocation.settled) return
+  invocation.settled = true
+  await rejectPrepared(invocation.internal, reason)
+}
+
+async function rejectInputs(inputs: readonly ContinuationInput[], reason: unknown): Promise<void> {
+  for (const input of inputs) {
+    try {
+      await input.onRejected?.(reason)
+    } catch (error) {
+      logger.warn(`error=<${error}> | continuation rejection callback failed`)
+    }
+  }
+}
+
+async function cleanup(
+  invocation: InvocationContinuation | undefined,
+  inputs: readonly ContinuationInput[] = []
+): Promise<void> {
+  const reason = new Error('Agent stream closed before continuation consumption')
+  await rejectInvocation(invocation, reason)
+  await rejectInputs(inputs, reason)
+}
+
+async function prepareInputs(
+  inputs: readonly ContinuationInput[],
+  normalizeInput: (args: InvokeArgs) => Message[]
+): Promise<InvocationContinuation['internal']> {
+  const prepared: Array<InvocationContinuation['internal'][number]> = []
+
+  for (const input of inputs) {
+    try {
+      const messages = normalizeInput(input.args)
+      if (!isCompleteMessageInput(messages)) {
+        throw new TypeError('Continuation input must contain a complete message sequence')
+      }
+      prepared.push({ input, messages })
+    } catch (error) {
+      await rejectInputs([input], error)
+    }
+  }
+  return prepared
+}
+
+function isComposableUserInput(messages: readonly Message[]): boolean {
+  return (
+    messages.length > 0 &&
+    messages.every(
+      (message) =>
+        message.role === 'user' &&
+        message.content.every((block) => block.type !== 'toolUseBlock' && block.type !== 'toolResultBlock')
+    )
+  )
+}
+
+function isCompleteMessageInput(messages: readonly Message[]): boolean {
+  if (messages.length === 0) return false
+
+  let pendingToolUseIds = new Set<string>()
+  for (const message of messages) {
+    if (pendingToolUseIds.size > 0 && message.role !== 'user') return false
+
+    const nextToolUseIds = new Set<string>()
+    for (const block of message.content) {
+      if (block.type === 'toolUseBlock') {
+        if (message.role !== 'assistant' || nextToolUseIds.has(block.toolUseId)) return false
+        nextToolUseIds.add(block.toolUseId)
+      } else if (block.type === 'toolResultBlock') {
+        if (message.role !== 'user' || !pendingToolUseIds.delete(block.toolUseId)) return false
+      }
+    }
+
+    if (message.role === 'user' && pendingToolUseIds.size > 0) return false
+    pendingToolUseIds = nextToolUseIds
+  }
+  return pendingToolUseIds.size === 0
+}
+
+function findAcceptedInputs(
+  invocation: InvocationContinuation,
+  modelRequests: readonly (readonly Message[])[]
+): ReadonlySet<InvocationContinuation['internal'][number]> {
+  const accepted = new Set<InvocationContinuation['internal'][number]>()
+  if (modelRequests.length === 0) {
+    for (const entry of invocation.internal) accepted.add(entry)
+    return accepted
+  }
+  for (const request of modelRequests) {
+    const sourceIds = retainedSourceIds(invocation, request)
+    for (const entry of invocation.internal) {
+      if (!accepted.has(entry) && entry.messages.every((message) => sourceIds.has(message.trackingId))) {
+        accepted.add(entry)
+      }
+    }
+  }
+  return accepted
+}
+
+function retainedSourceIds(invocation: InvocationContinuation, request: readonly Message[]): ReadonlySet<string> {
+  const retained = new Set<string>()
+  const groups = matchRequestGroups(invocation, request)
+  for (const message of request) {
+    const group = groups.get(message.trackingId)
+    if (!group) continue
+    for (const sourceId of matchedSourceIds(group, serializedContent(message), false)) retained.add(sourceId)
+  }
+  return retained
+}
+
+function matchRequestGroups(
+  invocation: InvocationContinuation,
+  request: readonly Message[]
+): ReadonlyMap<string, readonly Message[]> {
+  const matched = new Map<string, readonly Message[]>()
+  const used = new Set<number>()
+  let nextIndex = 0
+
+  for (const message of request) {
+    let index = invocation.requestGroups.findIndex(
+      (group, groupIndex) => !used.has(groupIndex) && group.at(-1)?.trackingId === message.trackingId
+    )
+    if (index < 0) {
+      const content = serializedContent(message)
+      index = invocation.requestGroups.findIndex(
+        (group, groupIndex) =>
+          groupIndex >= nextIndex &&
+          group[0]?.role === message.role &&
+          group.some((source) => findSequence(content, serializedContent(source), 0) >= 0)
+      )
+    }
+    if (index < 0) continue
+    used.add(index)
+    nextIndex = Math.max(nextIndex, index + 1)
+    matched.set(message.trackingId, invocation.requestGroups[index]!)
+  }
+  return matched
+}
+
+function serializedContent(message: Message): string[] {
+  return message.content.map((block) => JSON.stringify(block.toJSON()))
+}
+
+function matchedSourceIds(
+  group: readonly Message[],
+  content: readonly string[],
+  includeAmbiguous: boolean
+): ReadonlySet<string> {
+  const sourceGroups = new Map<string, { content: readonly string[]; count: number }>()
+  for (const source of group) {
+    const sourceContent = serializedContent(source)
+    const key = JSON.stringify(sourceContent)
+    const existing = sourceGroups.get(key)
+    sourceGroups.set(key, { content: sourceContent, count: (existing?.count ?? 0) + 1 })
+  }
+  const ambiguous = new Set(
+    [...sourceGroups].flatMap(([key, sourceGroup]) => {
+      const occurrences = countSequence(content, sourceGroup.content)
+      return sourceGroup.count > 1 && occurrences > 0 && occurrences < sourceGroup.count ? [key] : []
+    })
+  )
+
+  const matched = new Set<string>()
+  let contentIndex = 0
+  for (const source of group) {
+    const sourceContent = serializedContent(source)
+    const key = JSON.stringify(sourceContent)
+    if (ambiguous.has(key)) {
+      if (includeAmbiguous) matched.add(source.trackingId)
+      continue
+    }
+    const sourceIndex = findSequence(content, sourceContent, contentIndex)
+    if (sourceIndex < 0) continue
+    matched.add(source.trackingId)
+    contentIndex = sourceIndex + sourceContent.length
+  }
+  return matched
+}
+
+function countSequence(haystack: readonly string[], needle: readonly string[]): number {
+  let count = 0
+  let index = 0
+  while ((index = findSequence(haystack, needle, index)) >= 0) {
+    count += 1
+    index += needle.length
+  }
+  return count
+}
+
+function findSequence(haystack: readonly string[], needle: readonly string[], start: number): number {
+  if (needle.length === 0) return -1
+  for (let index = start; index <= haystack.length - needle.length; index++) {
+    if (needle.every((value, offset) => haystack[index + offset] === value)) return index
+  }
+  return -1
+}
+
+function integrateMessages(
+  agent: LocalAgent,
+  invocation: InvocationContinuation,
+  accepted: InvocationContinuation['internal'],
+  insertBeforeTrackingId?: string,
+  includePublic = true
+): readonly Message[] {
+  const publicMessages = includePublic ? invocation.publicMessages : []
+  const publicIds = new Set(publicMessages.map((message) => message.trackingId))
+  const existingPublicIds = new Set(
+    agent.messages.filter((message) => publicIds.has(message.trackingId)).map((message) => message.trackingId)
+  )
+  const publicIndex = agent.messages.findIndex((message) => publicIds.has(message.trackingId))
+  if (accepted.length === 0 && (publicMessages.length === 0 || publicIndex >= 0)) return []
+
+  const baseMessages = agent.messages.filter((message) => !publicIds.has(message.trackingId))
+  let insertionIndex = baseMessages.length
+  if (publicIndex >= 0) {
+    insertionIndex = agent.messages.slice(0, publicIndex).filter((message) => !publicIds.has(message.trackingId)).length
+  } else if (insertBeforeTrackingId !== undefined) {
+    const resultIndex = baseMessages.findIndex((message) => message.trackingId === insertBeforeTrackingId)
+    if (resultIndex >= 0) insertionIndex = resultIndex
+  }
+
+  const internalMessages = accepted.flatMap((entry) => entry.messages)
+  const messages = [...internalMessages, ...publicMessages]
+  baseMessages.splice(insertionIndex, 0, ...messages)
+  agent.messages.splice(0, agent.messages.length, ...baseMessages)
+  return [...internalMessages, ...publicMessages.filter((message) => !existingPublicIds.has(message.trackingId))]
+}
+
+function groupMessages(messages: readonly Message[]): Message[][] {
+  const groups: Message[][] = []
+  for (const message of messages) {
+    const group = groups.at(-1)
+    if (group?.[0]?.role === message.role) {
+      group.push(message)
+    } else {
+      groups.push([message])
+    }
+  }
+  return groups
+}
+
+async function rejectPrepared(inputs: InvocationContinuation['internal'], reason: unknown): Promise<void> {
+  await rejectInputs(
+    inputs.map((entry) => entry.input),
+    reason
+  )
+}
+
+async function notifyConsumed(entries: InvocationContinuation['internal']): Promise<void> {
+  for (const entry of entries) {
+    try {
+      await entry.input.onConsumed?.()
+    } catch (error) {
+      logger.warn(`error=<${error}> | continuation consumption callback failed`)
+    }
+  }
+}

--- a/strands-ts/src/agent/continuation.ts
+++ b/strands-ts/src/agent/continuation.ts
@@ -1,8 +1,8 @@
 import { AfterInvocationEvent, BeforeModelCallEvent } from '../hooks/events.js'
 import { logger } from '../logging/logger.js'
 
-import type { InvokeArgs } from '../types/agent.js'
-import type { Message } from '../types/messages.js'
+import type { InvokeArgs, LocalAgent } from '../types/agent.js'
+import type { Message, StopReason } from '../types/messages.js'
 
 /**
  * One internal input contribution to an agent or model invocation.
@@ -25,6 +25,7 @@ interface ContinuationState {
 }
 
 const stateByEvent = new WeakMap<AfterInvocationEvent | BeforeModelCallEvent, ContinuationState>()
+const deferredInputsByAgent = new WeakMap<LocalAgent, ContinuationInput[]>()
 
 /**
  * Internal continuation operations used by the agent loop.
@@ -47,9 +48,21 @@ function addInput(event: AfterInvocationEvent | BeforeModelCallEvent, input: Con
 
 async function prepare(
   event: AfterInvocationEvent | BeforeModelCallEvent,
-  normalizeInput: (args: InvokeArgs) => Message[]
+  normalizeInput: (args: InvokeArgs) => Message[],
+  stopReason?: StopReason
 ): Promise<readonly Message[] | undefined> {
-  const inputs = stateByEvent.get(event)?.inputs ?? []
+  if (stopReason === 'interrupt') {
+    const inputs = consumeInputs(event)
+    if (inputs.length > 0) {
+      deferredInputsByAgent.set(event.agent, [...(deferredInputsByAgent.get(event.agent) ?? []), ...inputs])
+    }
+    return undefined
+  }
+  if (stopReason !== undefined && stopReason !== 'endTurn' && stopReason !== 'stopSequence') return undefined
+
+  const deferredInputs = event instanceof AfterInvocationEvent ? deferredInputsByAgent.get(event.agent) : undefined
+  if (deferredInputs) deferredInputsByAgent.delete(event.agent)
+  const inputs = [...(deferredInputs ?? []), ...(stateByEvent.get(event)?.inputs ?? [])]
   const acceptedInputs: ContinuationInput[] = []
   const messages: Message[] = []
 

--- a/strands-ts/src/vended-plugins/goal/__tests__/plugin.test.ts
+++ b/strands-ts/src/vended-plugins/goal/__tests__/plugin.test.ts
@@ -487,18 +487,11 @@ describe('GoalLoop', () => {
         ],
       })
 
-      // Each attempt's transcript: clean input + accumulated feedback only.
-      // The model must never see prior `attempt-N` assistant turns.
+      // Each attempt contains only the clean input and current feedback.
       expect(messageSnapshots).toEqual([
         [{ role: 'user', text: 'do the thing' }],
-        [
-          { role: 'user', text: 'do the thing' },
-          { role: 'user', text: expect.stringContaining('fb1') },
-        ],
-        [
-          { role: 'user', text: 'do the thing' },
-          { role: 'user', text: expect.stringContaining('fb2') },
-        ],
+        [{ role: 'user', text: expect.stringMatching(/^do the thing[\s\S]*fb1/) }],
+        [{ role: 'user', text: expect.stringMatching(/^do the thing[\s\S]*fb2/) }],
       ])
     })
 

--- a/strands-ts/src/vended-plugins/goal/__tests__/plugin.test.ts
+++ b/strands-ts/src/vended-plugins/goal/__tests__/plugin.test.ts
@@ -487,11 +487,18 @@ describe('GoalLoop', () => {
         ],
       })
 
-      // Each attempt contains only the clean input and current feedback.
+      // Each attempt's transcript: clean input + accumulated feedback only.
+      // The model must never see prior `attempt-N` assistant turns.
       expect(messageSnapshots).toEqual([
         [{ role: 'user', text: 'do the thing' }],
-        [{ role: 'user', text: expect.stringMatching(/^do the thing[\s\S]*fb1/) }],
-        [{ role: 'user', text: expect.stringMatching(/^do the thing[\s\S]*fb2/) }],
+        [
+          { role: 'user', text: 'do the thing' },
+          { role: 'user', text: expect.stringContaining('fb1') },
+        ],
+        [
+          { role: 'user', text: 'do the thing' },
+          { role: 'user', text: expect.stringContaining('fb2') },
+        ],
       ])
     })
 


### PR DESCRIPTION
## Description

Adds an internal continuation mechanism that lets multiple hooks contribute ordered input without competing for `AfterInvocationEvent.resume`.

Contributions can be added after an invocation for the next agent pass or before a model call for the current request. Each contribution is incorporated into agent history or abandoned independently, while existing public `resume` behavior remains unchanged.

## Related Issues

None.

## Documentation PR

Not applicable. This change is internal.

## Type of Change

New feature

## Testing

- [x] TypeScript unit tests and repository validation checks

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
