### PR TITLE
docs(openai): document the Bedrock Mantle config for the Responses API

### DIFF
--- a/site/src/content/docs/user-guide/concepts/model-providers/openai-responses.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/openai-responses.mdx
@@ -5,7 +5,9 @@ tags: [mcp, state]
 integrationType: model-provider
 sourceLinks:
   - path: strands-py/src/strands/models/openai_responses.py
+  - path: strands-py/src/strands/models/_openai_bedrock.py
   - path: strands-ts/src/models/openai/responses-adapter.ts
+  - path: strands-ts/src/models/openai/mantle.ts
 ---
 
 The [Responses API](https://platform.openai.com/docs/api-reference/responses) is OpenAI's interface for generating model responses and building agents. It is a superset of the [Chat Completions](./openai) API, with additional support for [built-in tools](#built-in-tools), server-side conversation state management, and multi-modal inputs.
@@ -64,7 +66,73 @@ In TypeScript, both the Responses API and Chat Completions API are available thr
 
 ### Amazon Bedrock (Mantle)
 
-The Responses provider can connect to [Amazon Bedrock's OpenAI-compatible endpoints](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html) powered by Mantle. Authenticate with a [Bedrock API key](https://docs.aws.amazon.com/bedrock/latest/userguide/api-key-management.html) and point the client at your region's Mantle endpoint.
+The Responses provider also runs against
+[Amazon Bedrock's OpenAI-compatible endpoint](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html)
+powered by Mantle, which bills through your AWS account instead of an OpenAI API key.
+Model IDs on Mantle differ from the direct API: the endpoint serves
+`openai.gpt-5.6-terra` and `openai.gpt-oss-120b`, among others.
+
+Two ways in. Pass <Syntax py="bedrock_mantle_config" ts="bedrockMantleConfig" /> to
+authenticate from your AWS credentials, or configure the client yourself with a
+[Bedrock API key](https://docs.aws.amazon.com/bedrock/latest/userguide/api-key-management.html).
+Start with the config: it resolves the endpoint URL for you, and it reaches credentials a
+static key cannot, including instance roles, SSO sessions, and assumed roles.
+
+#### AWS credentials
+
+Give the provider a region and it derives the Mantle endpoint from your model ID, then
+mints a fresh bearer token from the standard AWS credential chain on every request.
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.models.openai_responses import OpenAIResponsesModel
+
+model = OpenAIResponsesModel(
+    model_id="openai.gpt-5.6-terra",
+    bedrock_mantle_config={"region": "us-east-1"},
+)
+
+agent = Agent(model=model)
+response = agent("What is 2+2?")
+print(response)
+```
+
+Omit `region` and it resolves through boto3: the `AWS_REGION` and `AWS_DEFAULT_REGION`
+environment variables, the active profile, then EC2 instance metadata. Pass `boto_session`
+to resolve it from a session you already built, `credentials_provider` to hand the token
+generator a specific botocore credential provider, and `expiry` to set the token
+lifetime.
+</Tab>
+<Tab label="TypeScript">
+
+Mantle needs one more package alongside the provider:
+
+```bash
+npm install @aws/bedrock-token-generator
+```
+
+```typescript
+--8<-- "user-guide/concepts/model-providers/openai-responses_imports.ts:bedrock_mantle_imports"
+
+--8<-- "user-guide/concepts/model-providers/openai-responses.ts:bedrock_mantle"
+```
+
+Omit `region` and it resolves from the `AWS_REGION` or `AWS_DEFAULT_REGION` environment
+variable. Pass `credentials` to hand the token generator a credential identity or provider
+(for example the result of `fromNodeProviderChain()`), and `expiresInSeconds` to set the
+token lifetime.
+</Tab>
+</Tabs>
+
+#### Bedrock API key
+
+To authenticate with a [Bedrock API key](https://docs.aws.amazon.com/bedrock/latest/userguide/api-key-management.html)
+instead, point the client at the endpoint directly. You pick the base path yourself here:
+most Mantle models are served from `/v1`, while the `openai.gpt-5.` line is served from
+`/openai/v1`, and the wrong path fails with HTTP 400.
 
 <Tabs>
 <Tab label="Python">
@@ -90,9 +158,9 @@ print(response)
 <Tab label="TypeScript">
 
 ```typescript
---8<-- "user-guide/concepts/model-providers/openai-responses_imports.ts:bedrock_mantle_imports"
+--8<-- "user-guide/concepts/model-providers/openai-responses_imports.ts:bedrock_mantle_api_key_imports"
 
---8<-- "user-guide/concepts/model-providers/openai-responses.ts:bedrock_mantle"
+--8<-- "user-guide/concepts/model-providers/openai-responses.ts:bedrock_mantle_api_key"
 ```
 </Tab>
 </Tabs>

--- a/site/src/content/docs/user-guide/concepts/model-providers/openai-responses.ts
+++ b/site/src/content/docs/user-guide/concepts/model-providers/openai-responses.ts
@@ -19,9 +19,23 @@ import { OpenAIModel } from '@strands-agents/sdk/models/openai'
   // --8<-- [end:basic_usage]
 }
 
-// Amazon Bedrock (Mantle)
+// Amazon Bedrock (Mantle) with AWS credentials
 {
   // --8<-- [start:bedrock_mantle]
+  const model = new OpenAIModel({
+    modelId: 'openai.gpt-5.6-terra',
+    bedrockMantleConfig: { region: 'us-east-1' },
+  })
+
+  const agent = new Agent({ model })
+  const response = await agent.invoke('What is 2+2?')
+  console.log(response)
+  // --8<-- [end:bedrock_mantle]
+}
+
+// Amazon Bedrock (Mantle) with a Bedrock API key
+{
+  // --8<-- [start:bedrock_mantle_api_key]
   const region = 'us-east-1'
   const model = new OpenAIModel({
     modelId: 'openai.gpt-oss-120b',
@@ -34,7 +48,7 @@ import { OpenAIModel } from '@strands-agents/sdk/models/openai'
   const agent = new Agent({ model })
   const response = await agent.invoke('What is 2+2?')
   console.log(response)
-  // --8<-- [end:bedrock_mantle]
+  // --8<-- [end:bedrock_mantle_api_key]
 }
 
 // Web search

--- a/site/src/content/docs/user-guide/concepts/model-providers/openai-responses_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/model-providers/openai-responses_imports.ts
@@ -10,3 +10,8 @@ import { OpenAIModel } from '@strands-agents/sdk/models/openai'
 import { Agent } from '@strands-agents/sdk'
 import { OpenAIModel } from '@strands-agents/sdk/models/openai'
 // --8<-- [end:bedrock_mantle_imports]
+
+// --8<-- [start:bedrock_mantle_api_key_imports]
+import { Agent } from '@strands-agents/sdk'
+import { OpenAIModel } from '@strands-agents/sdk/models/openai'
+// --8<-- [end:bedrock_mantle_api_key_imports]


### PR DESCRIPTION
## Description

The "Amazon Bedrock (Mantle)" section on the Responses provider page documents one way to reach the endpoint: a static Bedrock API key plus a hand-written `base_url`. Both SDKs have accepted a Mantle config for a while (`bedrock_mantle_config` on `OpenAIResponsesModel`, `bedrockMantleConfig` on `OpenAIModel`), and `git grep` for either name under `site/` returned nothing before this change. The option that unlocks the AWS credential chain, and with it instance roles, SSO sessions, and assumed roles, was invisible to anyone reading the docs.

Hand-writing the endpoint is also the part most likely to go wrong. Mantle splits models across `/v1` and `/openai/v1` with no API that reports which, and the wrong path fails with an opaque HTTP 400: see #2629 and #3654, both filed against that split. The config derives the path from the model id.

So the section now presents the two authentication modes, config first. The API key example stays as the second option, unchanged, because a static key is still the right answer when there is no AWS credential chain to draw on: it just no longer reads as the only way in. The two examples deliberately use models on either side of the base-path split, so the API key example keeps the `/v1` model it always had while the config example uses `openai.gpt-5.6-terra` and never spells out a URL.

Docs only. No SDK change. #3833 proposes the equivalent section for the Anthropic provider page.

## Related Issues

Resolves #3839

## Documentation PR

This is the documentation change.

## Type of Change

Documentation update

## Testing

Ran the `pre-push` skill (`bash .agents/skills/pre-push/run-checks.sh`), which detected the docs area and passed: `cms:build`, `typecheck`, `typecheck:snippets`, and the site suite (549 tests). Prettier reports the two snippet files clean.

I also built the site and read the section in `npm run dev`: both `####` headings appear in the table of contents on either language tab, the `<Syntax>` reference in the shared prose follows the tab selection, and every `--8<--` include resolves (no unexpanded markers in the built HTML).

Every claim in the new prose was checked against the SDK source at the base commit rather than from memory: the config keys (`_openai_bedrock.py:44`, `openai/mantle.ts:51`), region resolution order, per-request token minting (`openai_responses.py:269`, `321`, `513`), the base-path prefixes, and `@aws/bedrock-token-generator` being an optional peer dependency, which is why the TypeScript tab carries its own install line and the Python tab does not.

- [ ] I ran `hatch run prepare`

Not applicable: nothing under `strands-py/` changed. The docs area of the merge gate is what covers this PR, and it is green above.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works — docs-only; the site suite and snippet type-check cover the change
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
