### PR TITLE
feat(catalog): add band

### DIFF
--- a/site/src/content/catalog/band.yaml
+++ b/site/src/content/catalog/band.yaml
@@ -1,0 +1,10 @@
+name: band
+description: Chat rooms on Band where your Strands agent collaborates with humans and other agents with routing, durable room history, and peer discovery.
+integrationType: integration
+maintainedBy: partner
+languages:
+  python:
+    package: band-sdk[strands]
+github: https://github.com/band-ai/band-sdk-python
+docsUrl: https://github.com/band-ai/band-sdk-python/blob/main/examples/strands/README.md
+addedDate: 2026-08-16


### PR DESCRIPTION
## Integration submission

**Package name:** band-sdk[strands]
**Integration type:** integration
**Languages published:** Python
**GitHub repo:** https://github.com/band-ai/band-sdk-python
**What it does:** Onboards a Strands agent as a participant in the Band platform and chat rooms, where it collaborates with humans and other agents. The SDK owns the WebSocket subscription and per-room history, wakes the agent when it is @mentioned, and exposes Band's chat tools (send, peer lookup, participant management) to the model alongside the agent's own tools.
**Relationship to service:** official vendor integration, Band maintains band-sdk, hence `maintainedBy: partner`.
**Docs link included:** docsUrl -> https://github.com/band-ai/band-sdk-python/blob/main/examples/strands/README.md

Not an example app: `band-sdk[strands]` is a library you add to your own agent. It contributes
`StrandsAdapter`, which takes your model and tools and runs your agent against Band's transport —
the same shape as the other front-end/venue integrations in this lane (welt, ag-ui, strands-acp).
The linked page documents that adapter; the numbered scripts below it are illustrations of it.

### Submitter checklist

#### Package
- [x] This is a reusable integration (library/plugin/provider), not an example agent or application built with Strands
- [x] Published to PyPI and/or npm under the exact `package` name in my entry (registry links are derived from it) — or this is a guide-only entry (no `package` in any language block) with a `docsUrl` pointing at the vendor's Strands guide
- [x] GitHub repository is public and includes a license

#### Entry
- [x] Description accurately states what the package does in one sentence
- [x] `integrationType` matches what the package actually is
- [x] All URLs are working (`github`, and `docsUrl` if set)
- [x] `addedDate` is set to today (the date I opened this PR)
- [x] `featured` and `badges` are left unset — those are granted by the Strands team

#### Docs (only if setting a `docsUrl`)
- [x] The linked page documents using this integration with Strands Agents

#### Conduct
- [x] I am the package maintainer, or I have the maintainer's explicit consent to list it
- [x] Entry uses the package's real name with no trademark misuse