### PR TITLE
catalog: add strands-dynamodb-storage (AWS DynamoDB Storage backend, Python + TypeScript)

### DIFF
--- a/site/src/content/catalog/strands-dynamodb-storage.yaml
+++ b/site/src/content/catalog/strands-dynamodb-storage.yaml
@@ -1,0 +1,11 @@
+name: strands-dynamodb-storage
+description: Amazon DynamoDB Storage backend for Strands Agents (TypeScript and Python) — sessions, agent memory, and transcripts behind one Storage interface, with S3 offload for large values, TTL, multi-tenant key-space isolation, and semantic search over DynamoDB vector indexes.
+integrationType: storage
+maintainedBy: aws
+languages:
+  python:
+    package: strands-dynamodb-storage
+  typescript:
+    package: strands-dynamodb-storage
+github: https://github.com/aws/strands-dynamodb-storage
+addedDate: 2026-08-16


### PR DESCRIPTION
## Integration submission

**Package name:** `strands-dynamodb-storage`
**Integration type:** storage
**Languages published:** Python ([PyPI](https://pypi.org/project/strands-dynamodb-storage/)) and TypeScript ([npm](https://www.npmjs.com/package/strands-dynamodb-storage))
**GitHub repo:** https://github.com/aws/strands-dynamodb-storage
**What it does:** Amazon DynamoDB implementation of the `strands.storage.Storage` interface (`write`/`read`/`delete`/`list`), shipped for both languages from one repository. One DynamoDB-backed instance serves session snapshots, agent memory, context offloading, and transcripts. Beyond the byte contract: transparent Amazon S3 offload for values above the item-size limit, optional gzip compression and TTL, multi-tenant key-space isolation via a constructor-bound prefix, and semantic search over DynamoDB vector indexes (native `SearchVectors`).
**Relationship to service:** maintained by AWS (DynamoDB team)
**Docs:** README carries quick start, provisioning walkthrough, and a least-privilege IAM policy.

Both packages publish via OIDC trusted publishing with provenance attestations. Verified against `strands-agents` 1.48.0+ / `@strands-agents/sdk` 1.10.0+ (floors proven at the exact versions the `Storage` interface landed), with unit suites and live integration tests against real DynamoDB and S3.