### PR TITLE
fix(python): suppress delegation end_turn placeholder in MessageAdded…

### DIFF
--- a/strands-py/src/strands/agent/_agent_delegation.py
+++ b/strands-py/src/strands/agent/_agent_delegation.py
@@ -6,11 +6,6 @@ When a tool is configured with ``delegate=True``, this plugin ensures:
 2. The agent loop exits immediately after a successful delegation (via end_turn)
 3. The AgentResult is transformed with the delegation tool's content as the last message
 4. Streaming events from the delegate agent are surfaced natively in the parent stream
-
-The delegation plugin sets ``AfterToolsEvent.end_turn`` to ``SUPPRESS_MESSAGE`` so the
-event loop stops without appending or persisting a placeholder. The final delegation
-message is produced in middleware after the core loop exits, and ``MessageAddedEvent``
-fires exactly once with the real delegated content, regardless of session manager presence.
 """
 
 from __future__ import annotations
@@ -355,9 +350,6 @@ class AgentDelegation(Plugin):
         delegation_message: MessageType = {"role": "assistant", "content": delegation_content}
         _ensure_tracking_id(delegation_message)
 
-        # No placeholder was ever appended (end_turn was set to SUPPRESS_MESSAGE),
-        # so append the real delegation message and fire MessageAddedEvent exactly
-        # once, regardless of session manager presence.
         messages.append(delegation_message)
         await context.agent.hooks.invoke_callbacks_async(
             MessageAddedEvent(agent=context.agent, message=delegation_message)

--- a/strands-py/src/strands/agent/_agent_delegation.py
+++ b/strands-py/src/strands/agent/_agent_delegation.py
@@ -7,10 +7,10 @@ When a tool is configured with ``delegate=True``, this plugin ensures:
 3. The AgentResult is transformed with the delegation tool's content as the last message
 4. Streaming events from the delegate agent are surfaced natively in the parent stream
 
-The final delegation message is produced in middleware after the core loop exits.
-``MessageAddedEvent`` subscribers will see the end_turn placeholder followed by a second
-event with the real delegation content (no session manager), or no event for the real
-content at all (session manager attached).
+The delegation plugin sets ``AfterToolsEvent.end_turn`` to ``SUPPRESS_MESSAGE`` so the
+event loop stops without appending or persisting a placeholder. The final delegation
+message is produced in middleware after the core loop exits, and ``MessageAddedEvent``
+fires exactly once with the real delegated content, regardless of session manager presence.
 """
 
 from __future__ import annotations
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING
 from .._middleware.stages import AgentStreamContext, AgentStreamStage, ExecuteToolContext, ExecuteToolStage
 from .._middleware.types import MiddlewareNext
 from ..hooks import (
+    SUPPRESS_MESSAGE,
     AfterToolCallEvent,
     AfterToolsEvent,
     BeforeModelCallEvent,
@@ -240,7 +241,7 @@ class AgentDelegation(Plugin):
             )
             return
 
-        event.end_turn = True
+        event.end_turn = SUPPRESS_MESSAGE
         state.end_turn_via_delegation = True
 
     # --- Middleware ---
@@ -354,21 +355,13 @@ class AgentDelegation(Plugin):
         delegation_message: MessageType = {"role": "assistant", "content": delegation_content}
         _ensure_tracking_id(delegation_message)
 
-        # Replace the placeholder message the event loop persisted.
-        session_manager = getattr(context.agent, "_session_manager", None)
-        if messages and messages[-1].get("role") == "assistant":
-            messages[-1] = delegation_message
-            if session_manager is not None:
-                session_manager.redact_latest_message(delegation_message, context.agent)
-            else:
-                await context.agent.hooks.invoke_callbacks_async(
-                    MessageAddedEvent(agent=context.agent, message=delegation_message)
-                )
-        else:
-            messages.append(delegation_message)
-            await context.agent.hooks.invoke_callbacks_async(
-                MessageAddedEvent(agent=context.agent, message=delegation_message)
-            )
+        # No placeholder was ever appended (end_turn was set to SUPPRESS_MESSAGE),
+        # so append the real delegation message and fire MessageAddedEvent exactly
+        # once, regardless of session manager presence.
+        messages.append(delegation_message)
+        await context.agent.hooks.invoke_callbacks_async(
+            MessageAddedEvent(agent=context.agent, message=delegation_message)
+        )
 
         # Replay tail with stop replaced by delegation terminal.
         for event in tail_buffer:

--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -919,8 +919,6 @@ async def _handle_tool_execution(
             else "Turn ended early by hook after tool execution"
         )
         end_turn_message: Message = {"role": "assistant", "content": [{"text": end_turn_text}]}
-        # SUPPRESS_MESSAGE: halt without appending or persisting any message.
-        # The component that set the sentinel produces the final message itself.
         if after_tools_event.end_turn is not SUPPRESS_MESSAGE:
             await agent._append_messages(end_turn_message)
         yield EventLoopStopEvent(

--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -18,7 +18,13 @@ from opentelemetry import trace as trace_api
 
 from .._middleware.stages import InvokeModelContext, InvokeModelStage
 from ..experimental.checkpoint import Checkpoint, CheckpointPosition
-from ..hooks import AfterModelCallEvent, AfterToolsEvent, BeforeModelCallEvent, BeforeToolsEvent
+from ..hooks import (
+    SUPPRESS_MESSAGE,
+    AfterModelCallEvent,
+    AfterToolsEvent,
+    BeforeModelCallEvent,
+    BeforeToolsEvent,
+)
 from ..telemetry.metrics import Trace
 from ..telemetry.tracer import Tracer, get_tracer
 from ..tools._validator import validate_and_prepare_tools
@@ -913,7 +919,10 @@ async def _handle_tool_execution(
             else "Turn ended early by hook after tool execution"
         )
         end_turn_message: Message = {"role": "assistant", "content": [{"text": end_turn_text}]}
-        await agent._append_messages(end_turn_message)
+        # SUPPRESS_MESSAGE: halt without appending or persisting any message.
+        # The component that set the sentinel produces the final message itself.
+        if after_tools_event.end_turn is not SUPPRESS_MESSAGE:
+            await agent._append_messages(end_turn_message)
         yield EventLoopStopEvent(
             "end_turn",
             end_turn_message,

--- a/strands-py/src/strands/hooks/__init__.py
+++ b/strands-py/src/strands/hooks/__init__.py
@@ -30,6 +30,7 @@ type-safe system that supports multiple subscribers per event type.
 """
 
 from .events import (
+    SUPPRESS_MESSAGE,
     AfterInvocationEvent,
     AfterModelCallEvent,
     # Multiagent hook events
@@ -50,6 +51,7 @@ from .events import (
 from .registry import BaseHookEvent, HookCallback, HookEvent, HookOrder, HookProvider, HookRegistry
 
 __all__ = [
+    "SUPPRESS_MESSAGE",
     "AgentInitializedEvent",
     "BeforeInvocationEvent",
     "BeforeToolCallEvent",

--- a/strands-py/src/strands/hooks/events.py
+++ b/strands-py/src/strands/hooks/events.py
@@ -23,6 +23,34 @@ if TYPE_CHECKING:
     from ..multiagent.base import MultiAgentBase
 
 
+class _SuppressMessage:
+    """Sentinel type for :attr:`AfterToolsEvent.end_turn`.
+
+    Setting ``end_turn`` to :data:`SUPPRESS_MESSAGE` halts the loop without
+    appending or persisting any assistant message, leaving production of the
+    turn's final message entirely to the component that set the sentinel.
+    """
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        """Render the sentinel as its canonical name."""
+        return "SUPPRESS_MESSAGE"
+
+    def __bool__(self) -> bool:
+        """Stay truthy so the event loop's ``end_turn`` branch is entered."""
+        return True
+
+
+SUPPRESS_MESSAGE = _SuppressMessage()
+"""Sentinel value for :attr:`AfterToolsEvent.end_turn`.
+
+Truthy (so the event loop's ``end_turn`` branch is entered) but distinct from
+``bool`` and ``str``. When set, the loop halts without appending or persisting
+any message.
+"""
+
+
 @dataclass
 class AgentInitializedEvent(HookEvent):
     """Event triggered when an agent has finished initialization.
@@ -169,45 +197,6 @@ class BeforeToolsEvent(HookEvent, _Interruptible):
         return f"v1:before_tools:{uuid.uuid5(uuid.NAMESPACE_OID, name)}"
 
 
-class SuppressMessage:
-    """Sentinel type for :attr:`AfterToolsEvent.end_turn`.
-
-    Setting ``end_turn`` to :data:`SUPPRESS_MESSAGE` halts the loop without
-    appending or persisting any assistant message, leaving production of the
-    turn's final message entirely to the component that set the sentinel
-    (e.g. the delegation plugin).
-    """
-
-    _instance: "SuppressMessage | None" = None
-
-    def __new__(cls) -> "SuppressMessage":
-        """Return the process-wide singleton instance."""
-        if cls._instance is None:
-            cls._instance = super().__new__(cls)
-        return cls._instance
-
-    def __repr__(self) -> str:
-        """Render the sentinel as its canonical name."""
-        return "SUPPRESS_MESSAGE"
-
-    def __bool__(self) -> bool:
-        """Stay truthy so the event loop's ``end_turn`` branch is entered."""
-        return True
-
-    def __reduce__(self) -> tuple[type["SuppressMessage"], tuple]:
-        """Keep pickling stable across process boundaries (singleton is re-created)."""
-        return (SuppressMessage, ())
-
-
-SUPPRESS_MESSAGE = SuppressMessage()
-"""Sentinel value for :attr:`AfterToolsEvent.end_turn`.
-
-Truthy (so the event loop's ``end_turn`` branch is entered) but distinct from
-``bool`` and ``str``. When set, the loop halts without appending or persisting
-any message.
-"""
-
-
 @dataclass
 class AfterToolsEvent(HookEvent):
     """Event triggered after all tools complete execution.
@@ -235,7 +224,7 @@ class AfterToolsEvent(HookEvent):
 
     message: Message
     invocation_state: dict[str, Any]
-    end_turn: bool | str | SuppressMessage = False
+    end_turn: bool | str | _SuppressMessage = False
 
     def _can_write(self, name: str) -> bool:
         return name == "end_turn"

--- a/strands-py/src/strands/hooks/events.py
+++ b/strands-py/src/strands/hooks/events.py
@@ -169,6 +169,45 @@ class BeforeToolsEvent(HookEvent, _Interruptible):
         return f"v1:before_tools:{uuid.uuid5(uuid.NAMESPACE_OID, name)}"
 
 
+class SuppressMessage:
+    """Sentinel type for :attr:`AfterToolsEvent.end_turn`.
+
+    Setting ``end_turn`` to :data:`SUPPRESS_MESSAGE` halts the loop without
+    appending or persisting any assistant message, leaving production of the
+    turn's final message entirely to the component that set the sentinel
+    (e.g. the delegation plugin).
+    """
+
+    _instance: "SuppressMessage | None" = None
+
+    def __new__(cls) -> "SuppressMessage":
+        """Return the process-wide singleton instance."""
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:
+        """Render the sentinel as its canonical name."""
+        return "SUPPRESS_MESSAGE"
+
+    def __bool__(self) -> bool:
+        """Stay truthy so the event loop's ``end_turn`` branch is entered."""
+        return True
+
+    def __reduce__(self) -> tuple[type["SuppressMessage"], tuple]:
+        """Keep pickling stable across process boundaries (singleton is re-created)."""
+        return (SuppressMessage, ())
+
+
+SUPPRESS_MESSAGE = SuppressMessage()
+"""Sentinel value for :attr:`AfterToolsEvent.end_turn`.
+
+Truthy (so the event loop's ``end_turn`` branch is entered) but distinct from
+``bool`` and ``str``. When set, the loop halts without appending or persisting
+any message.
+"""
+
+
 @dataclass
 class AfterToolsEvent(HookEvent):
     """Event triggered after all tools complete execution.
@@ -189,11 +228,14 @@ class AfterToolsEvent(HookEvent):
             calling the model again. If a string, that string becomes the content of
             a final assistant text message. If True, a default message is used.
             In both cases stop_reason on the returned result is "end_turn".
+            May also be :data:`SUPPRESS_MESSAGE`, which halts the loop without
+            appending or persisting any message; the component that set it is
+            responsible for producing the final message.
     """
 
     message: Message
     invocation_state: dict[str, Any]
-    end_turn: bool | str = False
+    end_turn: bool | str | SuppressMessage = False
 
     def _can_write(self, name: str) -> bool:
         return name == "end_turn"

--- a/strands-py/tests/strands/agent/hooks/test_events.py
+++ b/strands-py/tests/strands/agent/hooks/test_events.py
@@ -4,6 +4,7 @@ import pytest
 
 from strands.agent.agent_result import AgentResult
 from strands.hooks import (
+    SUPPRESS_MESSAGE,
     AfterInvocationEvent,
     AfterModelCallEvent,
     AfterToolCallEvent,
@@ -185,6 +186,9 @@ def test_after_tools_event_fields_default_and_writability(after_tools_event, age
     assert tru_event.end_turn is True
     tru_event.end_turn = "enough gathered"
     assert tru_event.end_turn == "enough gathered"
+    tru_event.end_turn = SUPPRESS_MESSAGE
+    assert tru_event.end_turn is SUPPRESS_MESSAGE
+    assert bool(tru_event.end_turn)  # truthy — the event loop end_turn branch is entered
 
     with pytest.raises(AttributeError, match="Property agent is not writable"):
         tru_event.agent = Mock()

--- a/strands-py/tests/strands/agent/test_agent_delegation.py
+++ b/strands-py/tests/strands/agent/test_agent_delegation.py
@@ -12,6 +12,7 @@ from strands.agent._agent_delegation import AgentDelegation, _DelegationState, _
 from strands.agent.agent import Agent
 from strands.agent.agent_result import AgentResult
 from strands.hooks import (
+    SUPPRESS_MESSAGE,
     AfterToolCallEvent,
     AfterToolsEvent,
     BeforeToolsEvent,
@@ -246,7 +247,8 @@ def test_on_after_tools_sets_end_turn_on_success():
     plugin._state[parent] = _DelegationState(tool_use_id="t1", tool_use_count=1)
 
     tru_event = _fire_after_tools(parent, plugin)
-    assert tru_event.end_turn is True
+    assert tru_event.end_turn is SUPPRESS_MESSAGE
+    assert bool(tru_event.end_turn)  # truthy — the event loop end_turn branch is entered
 
 
 def test_on_after_tools_skips_when_result_is_error():
@@ -345,8 +347,12 @@ async def test_handle_stream_non_delegation_multiple_stops_preserved():
 
 
 @pytest.mark.asyncio
-async def test_handle_stream_delegation_replaces_stop_with_trailing():
-    """Delegation replaces stop; trailing events keep position; exactly one terminal."""
+async def test_handle_stream_delegation_appends_and_fires_once():
+    """Delegation appends the real message and fires MessageAddedEvent exactly once.
+
+    No placeholder was ever appended (end_turn was set to SUPPRESS_MESSAGE), so
+    the middleware is the sole appender on every path.
+    """
     tool = _make_delegation_tool()
     parent = Agent(name="p", tools=[tool], callback_handler=None)
     plugin = _get_plugin(parent)
@@ -358,13 +364,21 @@ async def test_handle_stream_delegation_replaces_stop_with_trailing():
                 "role": "user",
                 "content": [{"toolResult": {"toolUseId": "t1", "status": "success", "content": [{"text": "answer"}]}}],
             },
-            {"role": "assistant", "content": [{"text": "placeholder"}]},
         ]
     )
 
+    added_events = []
+
+    async def on_added(event):
+        added_events.append(event)
+
+    parent.add_hook(on_added, MessageAddedEvent)
+
     ctx = AgentStreamContext(agent=parent, messages=[], invocation_state={"request_state": {}}, _interrupts={})
     pre = TypedEvent({"pre": 1})
-    stop = EventLoopStopEvent("end_turn", parent.messages[-1], parent.event_loop_metrics, {})
+    stop = EventLoopStopEvent(
+        "end_turn", {"role": "assistant", "content": [{"text": "placeholder"}]}, parent.event_loop_metrics, {}
+    )
     trail = TypedEvent({"trail": 1})
 
     async def inner(c):
@@ -380,6 +394,11 @@ async def test_handle_stream_delegation_replaces_stop_with_trailing():
     assert len(tru_stops) == 1
     assert tru_stops[0]["stop"][1]["content"][0]["text"] == "answer"
     assert tru_events[-1] is trail
+
+    # The real delegation message is appended and fired exactly once.
+    assert len(added_events) == 1
+    assert added_events[0].message["content"][0]["text"] == "answer"
+    assert parent.messages[-1] is added_events[0].message
     assert "tracking_id" in parent.messages[-1]
 
 
@@ -748,8 +767,8 @@ async def test_ordering_guard_late_hook_flipping_result_prevents_end_turn():
 
 
 @pytest.mark.asyncio
-async def test_message_added_event_fires_for_delegation_message():
-    """MessageAddedEvent fires for the placeholder and then the real delegation content."""
+async def test_message_added_event_fires_once_for_delegation_message():
+    """MessageAddedEvent fires exactly once with the real delegation content (no placeholder)."""
     sub = Agent(
         model=MockedModelProvider([{"role": "assistant", "content": [{"text": "Balance: $42"}]}]),
         name="billing",
@@ -778,15 +797,15 @@ async def test_message_added_event_fires_for_delegation_message():
     orch.add_hook(on_message_added, MessageAddedEvent)
     await orch.invoke_async("Check balance")
 
-    # Expected: user prompt, assistant tool_use, tool_result, end_turn placeholder, delegation content
-    assert len(received_messages) == 5
+    # Expected: user prompt, assistant tool_use, tool_result, delegation content
+    assert len(received_messages) == 4
 
     tru_placeholders = [
         m
         for m in received_messages
         if m["role"] == "assistant" and any("Turn ended early" in str(b.get("text", "")) for b in m.get("content", []))
     ]
-    assert len(tru_placeholders) == 1
+    assert len(tru_placeholders) == 0
 
     tru_delegation = [
         m
@@ -794,14 +813,12 @@ async def test_message_added_event_fires_for_delegation_message():
         if m["role"] == "assistant" and any("$42" in str(b.get("text", "")) for b in m.get("content", []))
     ]
     assert len(tru_delegation) == 1
-
-    # Placeholder comes before delegation content
-    assert received_messages.index(tru_placeholders[0]) < received_messages.index(tru_delegation[0])
+    assert tru_delegation[0]["content"][0]["text"] == "Balance: $42"
 
 
 @pytest.mark.asyncio
-async def test_session_manager_suppresses_delegation_message_added_event():
-    """With a session manager, subscribers see the placeholder but not the delegation content event."""
+async def test_session_manager_receives_delegation_message_added_event_once():
+    """With a session manager, subscribers see exactly one real delegation content event."""
     from strands.session.repository_session_manager import RepositorySessionManager
     from tests.fixtures.mock_session_repository import MockedSessionRepository
 
@@ -837,15 +854,31 @@ async def test_session_manager_suppresses_delegation_message_added_event():
     orch.add_hook(on_message_added, MessageAddedEvent)
     await orch.invoke_async("Check balance")
 
+    # Exactly one real delegation event reaches subscribers, no placeholder.
     tru_delegation = [
         m
         for m in received_messages
         if m["role"] == "assistant" and any("$42" in str(b.get("text", "")) for b in m.get("content", []))
     ]
-    assert len(tru_delegation) == 0
+    assert len(tru_delegation) == 1
+    tru_placeholders = [
+        m
+        for m in received_messages
+        if m["role"] == "assistant" and any("Turn ended early" in str(b.get("text", "")) for b in m.get("content", []))
+    ]
+    assert len(tru_placeholders) == 0
 
-    # But agent.messages still reflects the delegation content
+    # agent.messages reflects the delegation content and nothing was persisted twice.
     assert any("$42" in str(b.get("text", "")) for b in orch.messages[-1].get("content", []))
+
+    persisted = repo.list_messages("s1", orch.agent_id)
+    persisted_texts = [
+        b.get("text", "")
+        for m in persisted
+        for b in (m.message.get("content", []) if isinstance(m.message, dict) else [])
+    ]
+    assert sum("$42" in t for t in persisted_texts) == 1
+    assert not any("Turn ended early" in t for t in persisted_texts)
 
 
 # --- Middleware single-call guard ---

--- a/strands-py/tests/strands/event_loop/test_event_loop.py
+++ b/strands-py/tests/strands/event_loop/test_event_loop.py
@@ -16,6 +16,7 @@ from strands import Agent
 from strands.event_loop._retry import ModelRetryStrategy
 from strands.experimental.checkpoint import Checkpoint
 from strands.hooks import (
+    SUPPRESS_MESSAGE,
     AfterModelCallEvent,
     AfterToolCallEvent,
     AfterToolsEvent,
@@ -1192,6 +1193,50 @@ async def test_event_loop_cycle_after_tools_end_turn_halts_loop(
     tru_last_message = agent.messages[-1]
     assert tru_last_message["role"] == "assistant"
     assert tru_last_message["content"] == [{"text": expected_text}]
+
+
+@pytest.mark.asyncio
+async def test_event_loop_cycle_after_tools_suppress_message_does_not_append(
+    agent, model, tool_stream, agenerator, alist
+):
+    """SUPPRESS_MESSAGE halts the loop without appending or persisting any message."""
+    added_events = []
+
+    def on_message_added(event):
+        added_events.append(event.message)
+
+    agent.hooks.add_callback(MessageAddedEvent, on_message_added)
+
+    def set_suppress(event):
+        event.end_turn = SUPPRESS_MESSAGE
+
+    agent.hooks.add_callback(AfterToolsEvent, set_suppress)
+    # Only one model call should happen — the loop must not recurse.
+    model.stream.side_effect = [agenerator(tool_stream)]
+
+    events = await alist(strands.event_loop.event_loop.event_loop_cycle(agent, invocation_state={}))
+
+    tru_stop_reason = events[-1]["stop"][0]
+    assert tru_stop_reason == "end_turn"
+    assert model.stream.call_count == 1
+
+    # The stop event still carries a Message payload (the pre-replacement value
+    # that delegation middleware substitutes with the real content).
+    assert events[-1]["stop"][1]["role"] == "assistant"
+
+    # No placeholder assistant message was appended; the last message is the
+    # tool result (user role), and no placeholder text exists anywhere.
+    tru_last_message = agent.messages[-1]
+    assert tru_last_message["role"] == "user"
+    assert not any(
+        "Turn ended early" in str(b.get("text", ""))
+        for m in agent.messages
+        for b in m.get("content", [])
+        if isinstance(b, dict)
+    )
+
+    # No MessageAddedEvent fired for a placeholder (only the tool result message).
+    assert not any("Turn ended early" in str(b.get("text", "")) for m in added_events for b in m.get("content", []))
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
…Event stream

The event loop unconditionally appended the end_turn placeholder and fired MessageAddedEvent for it before the delegation middleware ran. With a session manager attached, the real delegated content never reached subscribers (only the placeholder did); without one, subscribers saw both the placeholder and the real message (a phantom duplicate assistant turn).

Introduce a SUPPRESS_MESSAGE sentinel on AfterToolsEvent.end_turn: the delegation plugin sets it instead of True, the event loop skips the placeholder append/persist (still halting via EventLoopStopEvent), and the delegation middleware becomes the sole appender, firing MessageAddedEvent exactly once with the real delegated content on both paths.

Fixes #3808

## Description
<!-- Provide a detailed description of the changes in this PR -->

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [ ] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
