### PR TITLE
test(site): compare content collections against files on disk

### DIFF
--- a/site/test/catalog-collection.test.ts
+++ b/site/test/catalog-collection.test.ts
@@ -1,9 +1,10 @@
-import { existsSync } from 'node:fs'
+import { existsSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, it, expect } from 'vitest'
 import { getCollection } from 'astro:content'
 import { catalogEntrySchema } from '../src/content.config'
 import { CATALOG_TYPES } from '../src/components/catalog/types'
+import stats from '../src/data/catalog-stats.json'
 
 describe('catalog content collection', () => {
   it('loads catalog entries with validated data', async () => {
@@ -171,11 +172,18 @@ describe('catalog content collection', () => {
     expect(anthropic!.data.maintainedBy).toBe('strands')
     expect(anthropic!.data.docsPage).toBe('docs/user-guide/concepts/model-providers/anthropic')
     // The content layer silently drops entries whose YAML fails to parse;
-    // pinned counts catch that. Update them when granting or removing tiers.
+    // matching loaded ids against the on-disk files catches that and names
+    // the dropped entry, without pinning counts.
+    const fileIds = readdirSync('src/content/catalog', { recursive: true })
+      .map((f) => String(f).replaceAll('\\', '/'))
+      .filter((f) => f.endsWith('.yaml'))
+      .map((f) => f.slice(0, -'.yaml'.length))
+      .sort()
+    expect(entries.map((e) => e.id).sort()).toEqual(fileIds)
     const byTier = Map.groupBy(entries, (e) => e.data.maintainedBy)
-    expect(byTier.get('strands')?.length).toBe(33)
-    expect(byTier.get('aws')?.length).toBe(8)
-    expect(byTier.get('partner')?.length).toBe(21)
+    expect(byTier.get('strands')?.length).toBeGreaterThan(0)
+    expect(byTier.get('aws')?.length).toBeGreaterThan(0)
+    expect(byTier.get('partner')?.length).toBeGreaterThan(0)
     // Built-ins point at their source path in the SDK monorepo and always
     // have on-site docs.
     for (const e of byTier.get('strands') ?? []) {
@@ -194,6 +202,14 @@ describe('catalog content collection', () => {
       expect(m, `${e.id}: ${e.data.github}`).not.toBeNull()
       expect(existsSync(join('..', m![1])), `${e.id}: ${m![1]} missing from the repo`).toBe(true)
     }
+  })
+
+  it('has no catalog-stats keys for removed integrations', async () => {
+    // The refresh-stats workflow prunes removed entries only on its weekly
+    // run; a key left behind by a removed integration otherwise lingers.
+    const entries = await getCollection('catalog')
+    const ids = new Set(entries.map((e) => e.id))
+    expect(Object.keys(stats).filter((k) => !ids.has(k))).toEqual([])
   })
 
   it('every docsPage points at a real docs collection entry', async () => {

--- a/site/test/content-collection.test.ts
+++ b/site/test/content-collection.test.ts
@@ -1,7 +1,18 @@
 import { describe, it, expect } from 'vitest'
 import { getCollection } from 'astro:content'
+import { readFileSync } from 'node:fs'
 import path from 'node:path'
+import fg from 'fast-glob'
+import yaml from 'js-yaml'
 import { loadSidebarFromConfig, type StarlightSidebarItem } from '../src/sidebar'
+import { pathToDocsSlug } from '../src/util/links'
+
+// Same first-fence frontmatter read as redirect.static.ts; only `slug` matters here.
+function frontmatterSlug(filePath: string): unknown {
+  const match = readFileSync(filePath, 'utf-8').match(/^---\r?\n([\s\S]*?)\r?\n---/)
+  const parsed = match ? yaml.load(match[1] ?? '') : undefined
+  return typeof parsed === 'object' && parsed !== null ? (parsed as Record<string, unknown>).slug : undefined
+}
 
 describe('Content Collections', () => {
   it('should list all doc contents', async () => {
@@ -19,6 +30,24 @@ describe('Content Collections', () => {
     }
 
     expect(docs.length).toBeGreaterThan(0)
+  })
+
+  it('loads every hand-authored content file on disk', async () => {
+    // The collection's glob patterns match .mdx only and carve out filenames
+    // with a [!index] character class; a file they miss never renders and
+    // nothing reports it. Generated API docs are owned by their generator.
+    const docs = await getCollection('docs')
+    const ids = new Set(docs.map((doc) => doc.id))
+    const files = fg.sync(['404.mdx', 'docs/{user-guide,integrations,contribute,examples,labs}/**/*.{md,mdx}'], {
+      cwd: 'src/content',
+      followSymbolicLinks: false,
+    })
+    const dropped = files.filter((file) => {
+      // examples index pages are excluded by design (see content.config.ts)
+      if (file.startsWith('docs/examples/') && /^index\.mdx?$/.test(path.basename(file))) return false
+      return !ids.has(pathToDocsSlug(file, frontmatterSlug(path.join('src/content', file))))
+    })
+    expect(dropped).toEqual([])
   })
 
   it('should have valid slugs for all sidebar items', async () => {

--- a/site/test/global-setup.ts
+++ b/site/test/global-setup.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process'
-import { readdirSync, realpathSync, statSync } from 'node:fs'
+import { readdirSync, realpathSync, statSync, utimesSync } from 'node:fs'
 import { join } from 'node:path'
 
 const DATA_STORE_PATH = '.astro/data-store.json'
@@ -33,18 +33,21 @@ function newestMtime(path: string, visited: Set<string>): number {
   return newest
 }
 
-// getCollection() reads the snapshot in DATA_STORE_PATH, not the content
-// files, so a stale snapshot silently tests against outdated entries.
-function isDataStoreFresh(): boolean {
-  let storeStat
+function storeHoldsCollections(): boolean {
   try {
-    storeStat = statSync(DATA_STORE_PATH)
+    // A store this small cannot hold real collections; treat it as absent.
+    return statSync(DATA_STORE_PATH).size > 100
   } catch {
     return false
   }
-  // A store this small cannot hold real collections; treat it as absent.
-  if (storeStat.size <= 100) return false
-  return CONTENT_SOURCES.every((source) => newestMtime(source, new Set()) <= storeStat.mtimeMs)
+}
+
+// getCollection() reads the snapshot in DATA_STORE_PATH, not the content
+// files, so a stale snapshot silently tests against outdated entries.
+function isDataStoreFresh(): boolean {
+  if (!storeHoldsCollections()) return false
+  const storeMtime = statSync(DATA_STORE_PATH).mtimeMs
+  return CONTENT_SOURCES.every((source) => newestMtime(source, new Set()) <= storeMtime)
 }
 
 export function setup() {
@@ -53,7 +56,11 @@ export function setup() {
   console.log('[global-setup] Data store missing or stale — running astro sync...')
 
   execFileSync('node', ['--input-type=module', '-e', SYNC_SCRIPT], { stdio: 'inherit', timeout: TIMEOUT_MS })
-  if (!isDataStoreFresh()) throw new Error(`astro sync did not refresh ${DATA_STORE_PATH}`)
+  if (!storeHoldsCollections()) throw new Error(`astro sync did not produce a usable ${DATA_STORE_PATH}`)
+  // sync rewrites the store only when matched content changed, so mtime can't
+  // confirm freshness here; a sync that exits 0 means the store is current.
+  const now = new Date()
+  utimesSync(DATA_STORE_PATH, now, now)
 
   console.log('[global-setup] Data store ready.')
 }


### PR DESCRIPTION
## Description

Adding an integration to the catalog currently breaks the site test suite, because it pins exact per-tier entry counts, so every catalog PR carries an unrelated test edit. The pins existed to catch the Astro content layer silently dropping an entry whose YAML fails to parse, so loosening them to lower bounds would trade that protection away.

The tests now derive their expectations from the repository instead: loaded catalog ids must match the YAML files on disk, so a dropped entry fails the test by name and an added one changes both sides equally. The same on-disk coverage check now guards hand-authored docs pages, where the risk is larger than it looks: the docs glob patterns match only `.mdx`, and the examples pattern's `[!index]` character class excludes any filename starting with i, n, d, e, or x, so a missed file silently never renders. A third check flags `catalog-stats.json` keys for removed integrations, which the weekly refresh would otherwise leave behind until its next run.

Exercising the docs check surfaced a latent wedge in the test global setup: `astro sync` rewrites the data store only when matched content changed, so a content-tree change invisible to the collections (exactly what these tests detect) left the store's mtime permanently stale and setup threw on every run. Since a sync that exits 0 means the store is current, setup now bumps the store's mtime after a successful sync instead of re-running the mtime comparison.

## Related Issues

None.

## Documentation PR

Not needed, test-only change.

## Type of Change

Other (please describe): test maintainability, plus a fix to the site test global setup.

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- Full site suite (36 files, 551 tests), `tsc --noEmit`, Prettier, and `.agents/skills/pre-push/run-checks.sh` all pass locally.
- Verified the docs coverage check fails and names the file when a `.md` the globs miss is planted under `user-guide/`, and that the two global-setup scenarios that previously wedged (adding and deleting an unmatched file) now run the suite.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
