### PR TITLE
fix(bedrock): inherit cache_config ttl on an untimed tools cache point

### DIFF
--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -228,10 +228,17 @@ class BedrockModel(Model):
 
     @property
     def _cache_strategy(self) -> str | None:
-        """The cache strategy for this model based on its model ID.
+        """The effective cache strategy for this request, or None when caching is off or unsupported.
 
-        Returns the appropriate cache strategy name, or None if automatic caching is not supported for this model.
+        Resolves ``cache_config.strategy``: an explicit strategy is returned as written, while ``"auto"``
+        maps to ``"anthropic"`` for Claude/Anthropic model IDs and None for models without automatic
+        caching support.
         """
+        cache_config = self.config.get("cache_config")
+        if not cache_config:
+            return None
+        if cache_config.strategy != "auto":
+            return cache_config.strategy
         model_id = self.config.get("model_id", "").lower()
         if "claude" in model_id or "anthropic" in model_id:
             return "anthropic"
@@ -422,13 +429,10 @@ class BedrockModel(Model):
         ttl: str | None = None
         cache_config = self.config.get("cache_config")
         if cache_config and cache_config.ttl:
-            strategy: str | None = cache_config.strategy
-            if strategy == "auto":
-                strategy = self._cache_strategy
             tools_ttl_differs = bool(tools_cache_point) and (
                 tools_cache_point[0]["cachePoint"].get("ttl") != cache_config.ttl
             )
-            if strategy == "anthropic" and not tools_ttl_differs:
+            if self._cache_strategy == "anthropic" and not tools_ttl_differs:
                 ttl = cache_config.ttl
 
         normalized: list[SystemContentBlock] = []
@@ -468,12 +472,8 @@ class BedrockModel(Model):
 
         if not ttl:
             cache_config = self.config.get("cache_config")
-            if cache_config and cache_config.ttl:
-                strategy: str | None = cache_config.strategy
-                if strategy == "auto":
-                    strategy = self._cache_strategy
-                if strategy == "anthropic":
-                    ttl = cache_config.ttl
+            if cache_config and cache_config.ttl and self._cache_strategy == "anthropic":
+                ttl = cache_config.ttl
 
         cache_point: dict[str, Any] = {"type": cache_type}
         if ttl:
@@ -765,15 +765,13 @@ class BedrockModel(Model):
         # Inject cache point into cleaned_messages (not original messages) if cache_config is set
         cache_config = self.config.get("cache_config")
         if cache_config:
-            strategy: str | None = cache_config.strategy
-            if strategy == "auto":
-                strategy = self._cache_strategy
-                if not strategy:
-                    logger.warning(
-                        "model_id=<%s> | cache_config is enabled but this model does not support automatic caching",
-                        self.config.get("model_id"),
-                    )
-            if strategy == "anthropic":
+            cache_strategy = self._cache_strategy
+            if cache_config.strategy == "auto" and not cache_strategy:
+                logger.warning(
+                    "model_id=<%s> | cache_config is enabled but this model does not support automatic caching",
+                    self.config.get("model_id"),
+                )
+            if cache_strategy == "anthropic":
                 self._inject_cache_point(cleaned_messages, dynamic_trailing_blocks)
 
         return cleaned_messages

--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -105,8 +105,9 @@ class BedrockModel(Model):
             additional_response_field_paths: Additional response field paths to extract
             cache_prompt: Cache point type for the system prompt (deprecated, use cache_config)
             cache_config: Configuration for prompt caching. Use CacheConfig(strategy="auto") for automatic caching.
-            cache_tools: Cache point type for tools. Pass a string (e.g. "default") for the default 5m TTL,
-                or a CacheToolsConfig instance to set both type and TTL (e.g. "1h").
+            cache_tools: Cache point type for tools. Pass a string (e.g. "default") to cache the tools with
+                no explicit TTL, or a CacheToolsConfig instance to set both type and TTL (e.g. "1h"). Inherits 
+                cache_config.ttl if specified, otherwise it takes the Bedrock default.
             guardrail_id: ID of the guardrail to apply
             guardrail_trace: Guardrail trace mode. Defaults to enabled.
             guardrail_version: Version of the guardrail to apply
@@ -451,6 +452,8 @@ class BedrockModel(Model):
     def _build_tools_cache_point(self) -> list[dict[str, Any]]:
         """Build the cache point block appended to ``toolConfig.tools`` if ``cache_tools`` is configured.
 
+        A ``cache_tools`` that carries no TTL of its own inherits ``cache_config.ttl``
+
         Returns:
             A single-element list containing the cache point block, or an empty list if no cache_tools is set.
         """
@@ -459,11 +462,22 @@ class BedrockModel(Model):
             return []
 
         if isinstance(cache_tools, CacheToolsConfig):
-            cache_point: dict[str, Any] = {"type": cache_tools.type}
-            if cache_tools.ttl:
-                cache_point["ttl"] = cache_tools.ttl
+            cache_type, ttl = cache_tools.type, cache_tools.ttl
         else:
-            cache_point = {"type": cache_tools}
+            cache_type, ttl = cache_tools, None
+
+        if not ttl:
+            cache_config = self.config.get("cache_config")
+            if cache_config and cache_config.ttl:
+                strategy: str | None = cache_config.strategy
+                if strategy == "auto":
+                    strategy = self._cache_strategy
+                if strategy == "anthropic":
+                    ttl = cache_config.ttl
+
+        cache_point: dict[str, Any] = {"type": cache_type}
+        if ttl:
+            cache_point["ttl"] = ttl
 
         return [{"cachePoint": cache_point}]
 

--- a/strands-py/src/strands/models/model.py
+++ b/strands-py/src/strands/models/model.py
@@ -141,11 +141,8 @@ class CacheConfig:
         ttl: Optional TTL duration for cache entries (e.g. "5m", "1h").
             When specified, auto-injected cache points will include this TTL value. Bedrock requires
             checkpoint TTLs to be non-increasing across toolConfig, system and messages, and rejects a
-            longer TTL that follows a shorter one, so this TTL also fills in for a cache point placed by
-            hand in the system prompt that carries none of its own. A TTL written on such a point is
-            left as written, and a differing ``cache_tools`` TTL leaves the point at the Bedrock default
-            rather than landing a longer TTL behind a shorter checkpoint - either way, two TTLs in
-            tension are the caller's to reconcile.
+            longer TTL that follows a shorter one. This TTL also fills in for a cache point that carries
+            none of its own.
     """
 
     strategy: Literal["auto", "anthropic"] = "auto"

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -4715,17 +4715,88 @@ def test_format_request_leaves_a_system_cache_point_alone_behind_a_shorter_tools
     assert tru_request["system"][1] == {"cachePoint": {"type": "default"}}
 
 
-def test_format_request_leaves_a_system_cache_point_alone_behind_an_untimed_tools_cache_point(
-    bedrock_client, messages, tool_spec
-):
-    """A tools cache point with no TTL takes the provider default, which the configured ttl may exceed."""
+def test_format_request_fills_the_configured_ttl_into_an_untimed_tools_cache_point(bedrock_client, messages, tool_spec):
+    """The tools point is first in Bedrock's order, so an untimed one takes the provider default that a
+    configured ttl on a later checkpoint would exceed. Filling it in keeps every checkpoint in step.
+    """
     _ = bedrock_client
     model = BedrockModel(cache_config=CacheConfig(strategy="anthropic", ttl="1h"), cache_tools="default")
     system_blocks = [{"text": "s"}, {"cachePoint": {"type": "default"}}]
 
     tru_request = model.format_request(messages, tool_specs=[tool_spec], system_prompt_content=system_blocks)
 
-    assert tru_request["system"][1] == {"cachePoint": {"type": "default"}}
+    assert tru_request["toolConfig"]["tools"][-1] == {"cachePoint": {"type": "default", "ttl": "1h"}}
+    assert tru_request["system"][1] == {"cachePoint": {"type": "default", "ttl": "1h"}}
+
+
+def test_format_request_fills_the_configured_ttl_into_an_untimed_cache_tools_config(
+    bedrock_client, messages, tool_spec
+):
+    """A CacheToolsConfig without a TTL is untimed just like the bare string, so it inherits the same fill-in."""
+    _ = bedrock_client
+    model = BedrockModel(cache_config=CacheConfig(strategy="anthropic", ttl="1h"), cache_tools=CacheToolsConfig())
+
+    tru_point = model.format_request(messages, tool_specs=[tool_spec])["toolConfig"]["tools"][-1]
+
+    assert tru_point == {"cachePoint": {"type": "default", "ttl": "1h"}}
+
+
+def test_format_request_fills_an_empty_cache_tools_ttl_rather_than_shipping_it(bedrock_client, messages, tool_spec):
+    """A falsy TTL is not a TTL, so an empty one is filled in rather than sent as "", which Bedrock rejects."""
+    _ = bedrock_client
+    model = BedrockModel(cache_config=CacheConfig(strategy="anthropic", ttl="1h"), cache_tools=CacheToolsConfig(ttl=""))
+
+    tru_point = model.format_request(messages, tool_specs=[tool_spec])["toolConfig"]["tools"][-1]
+
+    assert tru_point == {"cachePoint": {"type": "default", "ttl": "1h"}}
+
+
+def test_format_request_leaves_a_tools_cache_point_ttl_the_caller_wrote(bedrock_client, messages, tool_spec):
+    """A TTL the caller wrote on cache_tools is theirs; only an absent one is filled in."""
+    _ = bedrock_client
+    model = BedrockModel(
+        cache_config=CacheConfig(strategy="anthropic", ttl="1h"), cache_tools=CacheToolsConfig(ttl="5m")
+    )
+
+    tru_point = model.format_request(messages, tool_specs=[tool_spec])["toolConfig"]["tools"][-1]
+
+    assert tru_point == {"cachePoint": {"type": "default", "ttl": "5m"}}
+
+
+def test_format_request_leaves_a_tools_cache_point_alone_for_a_model_without_caching(
+    bedrock_client, messages, tool_spec
+):
+    """A config that never reaches the wire must not reach the tools point either."""
+    _ = bedrock_client
+    model = BedrockModel(
+        model_id="meta.llama3-70b-instruct-v1:0", cache_config=CacheConfig(ttl="1h"), cache_tools="default"
+    )
+
+    tru_point = model.format_request(messages, tool_specs=[tool_spec])["toolConfig"]["tools"][-1]
+
+    assert tru_point == {"cachePoint": {"type": "default"}}
+
+
+def test_format_request_leaves_a_tools_cache_point_alone_for_an_empty_configured_ttl(
+    bedrock_client, messages, tool_spec
+):
+    """An empty configured ttl is unconfigured, so it does not fill the tools point in."""
+    _ = bedrock_client
+    model = BedrockModel(cache_config=CacheConfig(strategy="anthropic", ttl=""), cache_tools="default")
+
+    tru_point = model.format_request(messages, tool_specs=[tool_spec])["toolConfig"]["tools"][-1]
+
+    assert tru_point == {"cachePoint": {"type": "default"}}
+
+
+def test_format_request_leaves_a_tools_cache_point_alone_when_no_ttl_is_configured(bedrock_client, messages, tool_spec):
+    """Without a configured ttl there is nothing to inherit, so a bare cache_tools stays untimed."""
+    _ = bedrock_client
+    model = BedrockModel(cache_config=CacheConfig(strategy="anthropic"), cache_tools="default")
+
+    tru_point = model.format_request(messages, tool_specs=[tool_spec])["toolConfig"]["tools"][-1]
+
+    assert tru_point == {"cachePoint": {"type": "default"}}
 
 
 def test_format_request_applies_the_configured_ttl_behind_a_matching_tools_ttl(bedrock_client, messages, tool_spec):

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -3356,6 +3356,12 @@ def test_cache_strategy_auto_is_none_for_non_claude(bedrock_client):
     assert model._cache_strategy is None
 
 
+def test_cache_strategy_is_none_without_cache_config(bedrock_client):
+    """A caching-capable model still resolves to no strategy until cache_config turns caching on."""
+    model = BedrockModel(model_id="us.anthropic.claude-sonnet-4-20250514-v1:0")
+    assert model._cache_strategy is None
+
+
 def test_inject_cache_point_keeps_only_the_first_of_several_placed_points(bedrock_client):
     """One boundary per message: extras would spend the provider's cache-point budget for nothing."""
     _ = bedrock_client

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -3337,18 +3337,22 @@ async def test_format_request_with_guardrail_multiple_tool_results_same_message(
     assert formatted_messages[0]["content"][0]["guardContent"]["text"]["text"] == "Question requiring multiple tools"
 
 
-def test_cache_strategy_anthropic_for_claude(bedrock_client):
-    """Test that _cache_strategy returns 'anthropic' for Claude models."""
-    model = BedrockModel(model_id="us.anthropic.claude-sonnet-4-20250514-v1:0")
+def test_cache_strategy_auto_maps_claude_to_anthropic(bedrock_client):
+    """Under strategy="auto", a Claude/Anthropic model id resolves to the anthropic strategy."""
+    model = BedrockModel(
+        model_id="us.anthropic.claude-sonnet-4-20250514-v1:0", cache_config=CacheConfig(strategy="auto")
+    )
     assert model._cache_strategy == "anthropic"
 
-    model2 = BedrockModel(model_id="anthropic.claude-3-haiku-20240307-v1:0")
+    model2 = BedrockModel(
+        model_id="anthropic.claude-3-haiku-20240307-v1:0", cache_config=CacheConfig(strategy="auto")
+    )
     assert model2._cache_strategy == "anthropic"
 
 
-def test_cache_strategy_none_for_non_claude(bedrock_client):
-    """Test that _cache_strategy returns None for unsupported models."""
-    model = BedrockModel(model_id="amazon.nova-pro-v1:0")
+def test_cache_strategy_auto_is_none_for_non_claude(bedrock_client):
+    """Under strategy="auto", a model without automatic caching support resolves to None."""
+    model = BedrockModel(model_id="amazon.nova-pro-v1:0", cache_config=CacheConfig(strategy="auto"))
     assert model._cache_strategy is None
 
 

--- a/strands-py/tests_integ/models/test_model_bedrock.py
+++ b/strands-py/tests_integ/models/test_model_bedrock.py
@@ -24,6 +24,12 @@ def _durable_prefix() -> str:
     return f"Dossier {uuid.uuid4()}. " + ("The subject prefers concise written answers. " * 600)
 
 
+@strands.tool
+def echo(value: str) -> str:
+    """Echo the given value back."""
+    return value
+
+
 @pytest.fixture
 def system_prompt():
     return "You are an AI assistant that uses & instead of ."
@@ -659,11 +665,6 @@ def test_prompt_caching_aligned_1h_ttl_across_checkpoints(quiet_strands_logging)
         {"text": "You are a helpful assistant."},
     ]
 
-    @strands.tool
-    def echo(value: str) -> str:
-        """Echo the given value back."""
-        return value
-
     agent = Agent(
         model=model,
         system_prompt=system_prompt_with_cache,
@@ -672,6 +673,32 @@ def test_prompt_caching_aligned_1h_ttl_across_checkpoints(quiet_strands_logging)
     )
 
     # Must succeed without ValidationException on the non-increasing TTL rule
+    result = agent("What is 2+2?")
+    assert len(str(result)) > 0
+
+
+def test_prompt_caching_untimed_cache_tools_inherits_the_configured_ttl(quiet_strands_logging):
+    """An untimed cache_tools takes the Bedrock default, which a configured ttl on the message point exceeds.
+
+    Bedrock processes cache checkpoints in order toolConfig -> system -> messages and requires their TTLs
+    to be non-increasing. A bare-string cache_tools="default" emits no TTL, so the tools point sat at the
+    5m default while the auto-injected message point carried the configured 1h - an increasing sequence
+    Bedrock rejects. The tools point now inherits the configured ttl, keeping the sequence in step.
+    """
+    model = BedrockModel(
+        model_id=_CACHE_TTL_MODEL_ID,
+        streaming=False,
+        cache_tools="default",
+        cache_config=CacheConfig(strategy="auto", ttl="1h"),
+    )
+
+    agent = Agent(
+        model=model,
+        system_prompt=_durable_prefix(),
+        tools=[echo],
+        load_tools_from_directory=False,
+    )
+
     result = agent("What is 2+2?")
     assert len(str(result)) > 0
 


### PR DESCRIPTION
## Description

Bedrock reads prompt-cache checkpoints in the fixed order toolConfig → system → messages and rejects the request when a later checkpoint's TTL exceeds an earlier one's. A bare-string `cache_tools="default"` emits an untimed tools point, which takes the provider default of 5m — so pairing it with a configured longer TTL produced a request Bedrock rejected live:

```python
BedrockModel(cache_config=CacheConfig(strategy="anthropic", ttl="1h"), cache_tools="default")
# tools point → 5m (default), auto-injected message point → 1h
# 5m → 1h is increasing → ValidationException
```

The tools point is *first* in Bedrock's order, so raising its TTL is always safe for the non-increasing rule — nothing precedes it. An untimed `cache_tools` now inherits `cache_config.ttl` under the same anthropic-strategy gate the system cache point already uses (#3571), which lands the tools point at 1h and lets the rest of the sequence hold. A TTL the caller wrote on `cache_tools` is left untouched.

This closes the last unpatched corner of the non-increasing-TTL problem #3571 solved for the system point, and restores parity with the TypeScript SDK, where a shared `ttl` already fans into the tools section. Python's separate `cache_tools` knob was the sole source of the divergence.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

Unit-tested the `format_request` output across the matrix: bare-string and `CacheToolsConfig` inheriting the configured TTL, an empty TTL treated as untimed (filled rather than shipped as `""`), a caller-written TTL left as-is, and the fill-in standing down for a non-caching model and for an absent/empty configured TTL. Ran the Bedrock unit suite and the linter (ruff + mypy strict) — green. Added an end-to-end integ regression that exercises the reported config against a Claude model with a registered tool; it runs in CI against provisioned Bedrock and I have not run it locally.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.