### PR TITLE
feat(vended-tools): add governed use_agent delegation

### DIFF
--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools-imports.ts
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools-imports.ts
@@ -24,6 +24,12 @@ import { Agent } from '@strands-agents/sdk'
 import { notebook } from '@strands-agents/sdk/vended-tools/notebook'
 // --8<-- [end:notebook_import]
 
+// --8<-- [start:use_agent_import]
+import { Agent } from '@strands-agents/sdk'
+import { makeUseAgent } from '@strands-agents/sdk/experimental/vended-tools/use-agent'
+import { httpRequest } from '@strands-agents/sdk/vended-tools/http-request'
+// --8<-- [end:use_agent_import]
+
 // --8<-- [start:notebook_persistence_import]
 import { Agent, SessionManager, FileStorage } from '@strands-agents/sdk'
 import { notebook } from '@strands-agents/sdk/vended-tools/notebook'

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -10,10 +10,12 @@ sourceLinks:
   - path: strands-ts/src/vended-tools/http-request/http-request.ts
   - path: strands-ts/src/vended-tools/notebook/notebook.ts
   - path: strands-ts/src/vended-tools/sleep/sleep.ts
+  - path: strands-ts/src/experimental/vended-tools/use-agent/use-agent.ts
   - path: strands-ts/src/experimental/vended-tools/stop/stop.ts
   - path: strands-py/src/strands/vended_tools/http_request/http_request.py
   - path: strands-py/src/strands/vended_tools/shell/shell.py
   - path: strands-py/src/strands/vended_tools/sleep/sleep.py
+  - path: strands-py/src/strands/experimental/tools/use_agent/use_agent.py
   - path: strands-py/src/strands/experimental/tools/stop/stop.py
 ---
 
@@ -40,7 +42,52 @@ Each tool is imported from its own subpath under `@strands-agents/sdk/vended-too
 | [Notebook](#notebook) | Manage persistent text notebooks | TypeScript (Node.js, browsers) |
 | [Bash](#bash) | Execute shell commands with persistent sessions | Python, TypeScript (Node.js, Unix/Linux/macOS) |
 | [Sleep](#sleep) | Pause execution for a bounded, cancellable duration | Python, TypeScript (Node.js, browsers) |
+| [Use Agent](#use-agent-experimental) | Create a child agent | Python, TypeScript |
 | [Stop](#stop-experimental) | Gracefully end the agent loop when the task is complete | Python, TypeScript (Node.js, browsers) |
+
+### Use Agent (Experimental)
+
+Each call creates a fresh child agent with the parent's model and sandbox. The model must
+name every parent tool the child can use; omitting `tools` grants none. Parent and ancestor
+pre-tool hooks still govern delegated calls.
+
+Built-in caps bound turns, cumulative tokens, nesting depth, and execution time. Factory
+limits can only lower them. Models with provider-native tools are rejected. Timeout and
+cancellation are cooperative, and interrupted children can resume only while the original
+parent and `use_agent` instances remain in memory.
+
+<Tabs>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/tools/vended-tools-imports.ts:use_agent_import"
+
+--8<-- "user-guide/concepts/tools/vended-tools.ts:use_agent_example"
+```
+
+</Tab>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.experimental.tools import make_use_agent
+from strands.vended_tools import http_request
+
+delegate = make_use_agent(
+    limits={
+        "turns": 20,
+        "total_tokens": 40_000,
+        "timeout_seconds": 120,
+    }
+)
+agent = Agent(tools=[http_request, delegate])
+agent("Delegate web research to use_agent, granting only http_request.")
+```
+
+</Tab>
+</Tabs>
+
+---
 
 ### File Editor
 

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.ts
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.ts
@@ -5,6 +5,7 @@ import { fileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
 import { httpRequest } from '@strands-agents/sdk/vended-tools/http-request'
 import { notebook } from '@strands-agents/sdk/vended-tools/notebook'
 // --8<-- [end:basic_import]
+import { makeUseAgent } from '@strands-agents/sdk/experimental/vended-tools/use-agent'
 import { SessionManager, FileStorage } from '@strands-agents/sdk'
 import { sleep, makeSleep } from '@strands-agents/sdk/vended-tools/sleep'
 import { stop } from '@strands-agents/sdk/experimental/vended-tools/stop'
@@ -16,6 +17,23 @@ async function agentWithVendedToolsExample() {
     tools: [bash, fileEditor, httpRequest, notebook],
   })
   // --8<-- [end:agent_with_vended_tools]
+}
+
+async function useAgentExample() {
+  // --8<-- [start:use_agent_example]
+  const delegate = makeUseAgent({
+    limits: {
+      turns: 20,
+      totalTokens: 40_000,
+      timeoutSeconds: 120,
+    },
+  })
+  const agent = new Agent({
+    tools: [httpRequest, delegate],
+  })
+
+  await agent.invoke('Delegate web research to use_agent, granting only http_request.')
+  // --8<-- [end:use_agent_example]
 }
 
 // Bash tool example - file operations

--- a/strands-py/src/strands/experimental/tools/__init__.py
+++ b/strands-py/src/strands/experimental/tools/__init__.py
@@ -4,6 +4,7 @@ import warnings
 from typing import Any
 
 from .stop import make_stop, stop
+from .use_agent import make_use_agent, use_agent
 
 _DEPRECATED_NAMES = {"ToolProvider"}
 
@@ -23,5 +24,7 @@ def __getattr__(name: str) -> Any:
 
 __all__ = [
     "make_stop",
+    "make_use_agent",
     "stop",
+    "use_agent",
 ]

--- a/strands-py/src/strands/experimental/tools/use_agent/__init__.py
+++ b/strands-py/src/strands/experimental/tools/use_agent/__init__.py
@@ -1,0 +1,9 @@
+"""Experimental governed child-agent tool."""
+
+from .use_agent import UseAgentLimits, make_use_agent, use_agent
+
+__all__ = [
+    "UseAgentLimits",
+    "make_use_agent",
+    "use_agent",
+]

--- a/strands-py/src/strands/experimental/tools/use_agent/use_agent.py
+++ b/strands-py/src/strands/experimental/tools/use_agent/use_agent.py
@@ -1,0 +1,436 @@
+"""Experimental governed child-agent tool."""
+
+from __future__ import annotations
+
+import asyncio
+import weakref
+from dataclasses import dataclass
+from time import monotonic
+from typing import TYPE_CHECKING, Any, cast
+
+from typing_extensions import NotRequired, TypedDict, override
+
+from ....hooks import BeforeToolCallEvent, BeforeToolsEvent
+from ....interrupt import Interrupt
+from ....types._events import ToolInterruptEvent, ToolResultEvent
+from ....types.interrupt import InterruptResponseContent
+from ....types.tools import AgentTool, ToolGenerator, ToolResult, ToolSpec, ToolUse
+
+if TYPE_CHECKING:
+    from ....agent import Agent
+    from ....agent.agent_result import AgentResult
+
+_USE_AGENT_TOOL_NAME = "use_agent"
+_INTERNAL_INVOCATION_STATE_KEYS = (
+    "agent",
+    "event_loop_cycle_id",
+    "event_loop_cycle_span",
+    "event_loop_cycle_trace",
+    "event_loop_parent_cycle_id",
+    "messages",
+    "model",
+    "request_state",
+    "system_prompt",
+    "tool_config",
+)
+
+
+class _UseAgentInput(TypedDict):
+    task: str
+    instructions: NotRequired[str]
+    tools: NotRequired[list[str]]
+
+
+class UseAgentLimits(TypedDict, total=False):
+    """Developer-controlled child execution limits."""
+
+    turns: int
+    total_tokens: int
+    depth: int
+    timeout_seconds: int
+
+
+_DEFAULT_LIMITS: dict[str, int] = {
+    "turns": 50,
+    "total_tokens": 100_000,
+    "depth": 3,
+    "timeout_seconds": 300,
+}
+
+
+@dataclass
+class _PendingChild:
+    child: Agent
+    task: str
+    parent_interrupt_state: object
+    remaining_seconds: float
+    remaining_turns: int
+    remaining_total_tokens: int
+    child_invocation_state: dict[str, Any]
+    interrupt_generation: int = 0
+    interrupts: tuple[tuple[str, str], ...] = ()
+
+
+class _UseAgentTool(AgentTool):
+    """Runs bounded tasks in fresh child agents."""
+
+    def __init__(
+        self,
+        *,
+        limits: UseAgentLimits | None,
+    ) -> None:
+        super().__init__()
+        self._limits = _resolve_limits(limits)
+        self._pending: weakref.WeakKeyDictionary[Agent, dict[str, _PendingChild]] = weakref.WeakKeyDictionary()
+        self._depths: weakref.WeakKeyDictionary[Agent, int] = weakref.WeakKeyDictionary()
+
+    @property
+    @override
+    def tool_name(self) -> str:
+        """Get the tool name."""
+        return _USE_AGENT_TOOL_NAME
+
+    @property
+    @override
+    def tool_spec(self) -> ToolSpec:
+        """Get the model-facing tool specification."""
+        return {
+            "name": self.tool_name,
+            "description": (
+                "Runs a task in a fresh child agent. The child receives only the exact parent tools named in tools; "
+                "omit tools for no child tools."
+            ),
+            "inputSchema": {
+                "json": {
+                    "type": "object",
+                    "properties": {
+                        "task": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "Task for the child agent.",
+                        },
+                        "instructions": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "Optional child-specific instructions.",
+                        },
+                        "tools": {
+                            "type": "array",
+                            "items": {"type": "string", "minLength": 1},
+                            "description": "Exact parent tool names to grant. Omit for no tools.",
+                        },
+                    },
+                    "required": ["task"],
+                    "additionalProperties": False,
+                }
+            },
+        }
+
+    @property
+    @override
+    def tool_type(self) -> str:
+        """Get the tool type."""
+        return "function"
+
+    @override
+    async def stream(self, tool_use: ToolUse, invocation_state: dict[str, Any], **kwargs: Any) -> ToolGenerator:
+        """Run or resume a child agent."""
+        from ....agent import Agent
+
+        tool_use_id = tool_use["toolUseId"]
+        parent = invocation_state.get("agent")
+        if not isinstance(parent, Agent):
+            yield _result_event(tool_use_id, {"status": "failed", "error": "use_agent requires a local Agent context"})
+            return
+
+        pending = self._pending.get(parent, {}).get(tool_use_id)
+        try:
+            interrupt_state = parent._interrupt_state
+            restored = (
+                pending is not None
+                and pending.parent_interrupt_state is not interrupt_state
+                or pending is None
+                and any(interrupt_id.startswith(f"{tool_use_id}:") for interrupt_id in interrupt_state.interrupts)
+            )
+            if restored:
+                raise RuntimeError(
+                    "use_agent cannot resume an interrupted child after the parent or tool instance was restored"
+                )
+            deadline = monotonic() + (
+                pending.remaining_seconds if pending is not None else self._limits["timeout_seconds"]
+            )
+            child_state = pending or self._create_child(
+                parent,
+                tool_use["input"],
+                {key: value for key, value in invocation_state.items() if key not in _INTERNAL_INVOCATION_STATE_KEYS},
+            )
+            stop_reason = None
+            if pending is not None:
+                if child_state.remaining_turns <= 0:
+                    stop_reason = "limit_turns"
+                elif child_state.remaining_total_tokens <= 0:
+                    stop_reason = "limit_total_tokens"
+            if stop_reason is not None:
+                self._pending.get(parent, {}).pop(tool_use_id, None)
+                yield _result_event(tool_use_id, _stopped_result(stop_reason))
+                return
+
+            if pending is None:
+                prompt: str | list[InterruptResponseContent] = child_state.task
+            else:
+                prompt = _interrupt_responses(parent, child_state.interrupts)
+
+            result = await self._run_child(
+                parent,
+                child_state,
+                prompt,
+                deadline,
+            )
+            if result.stop_reason == "interrupt" and result.interrupts:
+                invocation = result.metrics.latest_agent_invocation
+                if invocation is not None:
+                    child_state.remaining_turns -= len(invocation.cycles)
+                    child_state.remaining_total_tokens -= invocation.usage.get("totalTokens", 0)
+                child_state.remaining_seconds = max(0, deadline - monotonic())
+                child_state.interrupt_generation += 1
+                child_state.interrupts = tuple(
+                    (
+                        interrupt.id,
+                        f"{tool_use_id}:{child_state.interrupt_generation}:{interrupt.id}",
+                    )
+                    for interrupt in result.interrupts
+                )
+                self._pending.setdefault(parent, {})[tool_use_id] = child_state
+                yield ToolInterruptEvent(
+                    tool_use,
+                    [
+                        Interrupt(
+                            id=outward_id,
+                            name=interrupt.name,
+                            reason=interrupt.reason,
+                        )
+                        for interrupt, (_, outward_id) in zip(result.interrupts, child_state.interrupts, strict=True)
+                    ],
+                )
+                return
+
+            self._pending.get(parent, {}).pop(tool_use_id, None)
+            yield _result_event(tool_use_id, _terminal_result(result))
+        except Exception as error:
+            self._pending.get(parent, {}).pop(tool_use_id, None)
+            status = "cancelled" if parent._cancel_signal.is_set() else "failed"
+            yield _result_event(tool_use_id, {"status": status, "error": str(error)})
+
+    async def _run_child(
+        self,
+        parent: Agent,
+        child_state: _PendingChild,
+        prompt: str | list[InterruptResponseContent],
+        deadline: float,
+    ) -> AgentResult:
+        invocation = asyncio.create_task(
+            child_state.child.invoke_async(
+                prompt,
+                invocation_state=child_state.child_invocation_state,
+                limits={
+                    "turns": child_state.remaining_turns,
+                    "total_tokens": child_state.remaining_total_tokens,
+                },
+            )
+        )
+        cancellation = asyncio.create_task(_wait_for_parent_cancellation(parent))
+        try:
+            done, _ = await asyncio.wait(
+                {invocation, cancellation},
+                timeout=max(0, deadline - monotonic()),
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if invocation in done:
+                return invocation.result()
+            if cancellation in done:
+                raise RuntimeError("use_agent child was cancelled")
+            raise TimeoutError("use_agent child exceeded its execution timeout")
+        finally:
+            cancellation.cancel()
+            await asyncio.gather(cancellation, return_exceptions=True)
+            if not invocation.done():
+                child_state.child.cancel()
+                invocation.cancel()
+                invocation.add_done_callback(lambda task: task.exception() if not task.cancelled() else None)
+
+    def _create_child(
+        self,
+        parent: Agent,
+        raw_input: Any,
+        parent_state: dict[str, Any],
+    ) -> _PendingChild:
+        from ....agent import Agent
+
+        input_data = _parse_input(raw_input)
+        depth = self._depths.get(parent, 0)
+        if depth >= self._limits["depth"]:
+            raise ValueError(f"use_agent recursion depth limit of {self._limits['depth']} reached")
+        if _has_provider_native_tools(parent):
+            raise ValueError(
+                "use_agent is not supported with provider-native model tools; "
+                "register governed SDK tools on the parent agent instead"
+            )
+
+        tools = _resolve_tools(parent, input_data.get("tools", []), self)
+        child = Agent(
+            model=parent.model,
+            system_prompt=input_data.get("instructions"),
+            sandbox=parent.sandbox,
+            callback_handler=None,
+        )
+        self._depths[child] = depth + 1
+        child.hooks._inherit_callbacks_from(parent.hooks, [BeforeToolsEvent, BeforeToolCallEvent])
+        child.tool_registry.registry.clear()
+        child.tool_registry.dynamic_tools.clear()
+        for selected_tool in tools:
+            child.tool_registry.register_tool(selected_tool)
+        allowed_tool_ids = {id(tool) for tool in tools}
+        child.add_hook(
+            lambda event: _enforce_tool_grants(event, allowed_tool_ids),
+            BeforeToolCallEvent,
+            order=float("inf"),
+        )
+        return _PendingChild(
+            child=child,
+            task=input_data["task"],
+            parent_interrupt_state=parent._interrupt_state,
+            remaining_seconds=self._limits["timeout_seconds"],
+            remaining_turns=self._limits["turns"],
+            remaining_total_tokens=self._limits["total_tokens"],
+            child_invocation_state=parent_state,
+        )
+
+
+def make_use_agent(
+    *,
+    limits: UseAgentLimits | None = None,
+) -> AgentTool:
+    """Create an experimental governed ``use_agent`` tool.
+
+    Args:
+        limits: Child execution limits.
+
+    Returns:
+        A streaming tool that creates bounded child agents.
+
+    Raises:
+        TypeError: If a child execution limit is outside its supported range.
+    """
+    return _UseAgentTool(limits=limits)
+
+
+def _stopped_result(stop_reason: str) -> dict[str, Any]:
+    return {
+        "status": "failed",
+        "error": f"use_agent child stopped before completion: {stop_reason}",
+    }
+
+
+def _terminal_result(result: AgentResult) -> dict[str, Any]:
+    if result.stop_reason == "cancelled":
+        return {"status": "cancelled", "error": "use_agent child was cancelled"}
+    if result.stop_reason not in ("end_turn", "stop_sequence"):
+        return _stopped_result(result.stop_reason)
+    return {
+        "status": "completed",
+        "output": str(result),
+    }
+
+
+def _parse_input(raw_input: Any) -> _UseAgentInput:
+    if not isinstance(raw_input, dict):
+        raise TypeError("use_agent input must be an object")
+    unknown_fields = raw_input.keys() - _UseAgentInput.__annotations__.keys()
+    if unknown_fields:
+        raise ValueError(f"use_agent input contains unknown fields: {', '.join(sorted(unknown_fields))}")
+    task = raw_input.get("task")
+    instructions = raw_input.get("instructions")
+    tools = raw_input.get("tools")
+    if not isinstance(task, str) or not task:
+        raise ValueError("use_agent task must be a non-empty string")
+    if instructions is not None and (not isinstance(instructions, str) or not instructions):
+        raise ValueError("use_agent instructions must be a non-empty string")
+    if tools is not None:
+        if not isinstance(tools, list) or any(not isinstance(name, str) or not name for name in tools):
+            raise ValueError("use_agent tools must be a list of non-empty strings")
+    return cast(_UseAgentInput, raw_input)
+
+
+def _resolve_tools(
+    parent: Agent,
+    requested_names: list[str],
+    executing_tool: AgentTool,
+) -> list[AgentTool]:
+    selected: list[AgentTool] = []
+    for name in dict.fromkeys(requested_names):
+        tool = parent.tool_registry.dynamic_tools.get(name) or parent.tool_registry.registry.get(name)
+        if tool is None:
+            raise ValueError(f"Tool '{name}' was not found on the parent agent")
+        if name == _USE_AGENT_TOOL_NAME and tool is not executing_tool:
+            raise ValueError("A child can receive only the currently executing use_agent tool")
+        selected.append(tool)
+    return selected
+
+
+def _enforce_tool_grants(event: BeforeToolCallEvent, allowed_tool_ids: set[int]) -> None:
+    if event.cancel_tool or event.selected_tool is None:
+        return
+    if id(event.selected_tool) not in allowed_tool_ids:
+        event.cancel_tool = "use_agent blocked a tool outside the child grant set"
+
+
+def _resolve_limits(limits: UseAgentLimits | None) -> dict[str, int]:
+    resolved = _DEFAULT_LIMITS.copy()
+    if limits is not None:
+        resolved.update(cast(dict[str, int], limits))
+    for name, maximum in _DEFAULT_LIMITS.items():
+        value = resolved[name]
+        if isinstance(value, bool) or not isinstance(value, int) or not 1 <= value <= maximum:
+            raise TypeError(f"limits.{name} must be an integer between 1 and {maximum}, got {value!r}")
+    return resolved
+
+
+def _interrupt_responses(
+    parent: Agent,
+    interrupts: tuple[tuple[str, str], ...],
+) -> list[InterruptResponseContent]:
+    responses: list[InterruptResponseContent] = []
+    parent_interrupts = parent._interrupt_state.interrupts
+    for child_id, outward_id in interrupts:
+        interrupt = parent_interrupts.get(outward_id)
+        if interrupt is None or interrupt.response is None:
+            raise ValueError(f"use_agent interrupt '{outward_id}' has no response")
+        responses.append({"interruptResponse": {"interruptId": child_id, "response": interrupt.response}})
+    return responses
+
+
+def _has_provider_native_tools(parent: Agent) -> bool:
+    config = parent.model.get_config()
+    if not isinstance(config, dict):
+        return False
+    if config.get("gemini_tools"):
+        return True
+    params = config.get("params")
+    return isinstance(params, dict) and bool(params.get("tools"))
+
+
+async def _wait_for_parent_cancellation(parent: Agent) -> None:
+    while not parent._cancel_signal.is_set():
+        await asyncio.sleep(0.05)
+
+
+def _result_event(tool_use_id: str, result: dict[str, Any]) -> ToolResultEvent:
+    tool_result: ToolResult = {
+        "toolUseId": tool_use_id,
+        "status": "success" if result["status"] == "completed" else "error",
+        "content": [{"json": cast(Any, result)}],
+    }
+    return ToolResultEvent(tool_result)
+
+
+use_agent = make_use_agent()

--- a/strands-py/src/strands/hooks/registry.py
+++ b/strands-py/src/strands/hooks/registry.py
@@ -182,6 +182,17 @@ class HookRegistry:
         """Initialize an empty hook registry."""
         self._registered_callbacks: dict[type, list[_CallbackEntry]] = {}
 
+    def _inherit_callbacks_from(
+        self,
+        registry: "HookRegistry",
+        event_types: list[type[BaseHookEvent]],
+    ) -> None:
+        """Inherit selected callback types from another registry."""
+        for event_type in event_types:
+            entries = self._registered_callbacks.setdefault(event_type, [])
+            entries.extend(registry._registered_callbacks.get(event_type, []))
+            entries.sort(key=lambda entry: entry.order)
+
     def add_callback(
         self,
         event_type: type[TEvent] | list[type[TEvent]] | None,

--- a/strands-py/tests/strands/experimental/tools/use_agent/test_use_agent.py
+++ b/strands-py/tests/strands/experimental/tools/use_agent/test_use_agent.py
@@ -1,0 +1,294 @@
+import asyncio
+import importlib
+from typing import Any, cast
+
+import pytest
+
+from strands import Agent, tool
+from strands.experimental.tools import make_use_agent, use_agent
+from strands.hooks import BeforeToolCallEvent, BeforeToolsEvent
+from strands.interventions import Confirm, InterventionHandler, Proceed
+from strands.types._events import ToolResultEvent
+from strands.types.content import Message
+from tests.fixtures.mocked_model_provider import MockedModelProvider
+
+
+def _text_turn(text: str) -> Message:
+    return {"role": "assistant", "content": [{"text": text}]}
+
+
+def _tool_turn(name: str, tool_use_id: str, tool_input: dict[str, Any] | None = None) -> Message:
+    return {
+        "role": "assistant",
+        "content": [{"toolUse": {"name": name, "toolUseId": tool_use_id, "input": tool_input or {}}}],
+    }
+
+
+async def _run_tool(
+    agent: Agent,
+    use_agent_tool: Any,
+    tool_input: Any,
+) -> ToolResultEvent:
+    return await anext(
+        use_agent_tool.stream(
+            {"name": "use_agent", "toolUseId": "use-agent-call", "input": tool_input},
+            {"agent": agent},
+        )
+    )
+
+
+def _result_json(event: ToolResultEvent) -> dict[str, Any]:
+    return cast(dict[str, Any], event.tool_result["content"][0].get("json"))
+
+
+class _ConfirmDangerous(InterventionHandler):
+    @property
+    def name(self) -> str:
+        return "confirm-dangerous"
+
+    def before_tool_call(self, event: BeforeToolCallEvent, **kwargs: Any) -> Proceed | Confirm:
+        if event.tool_use["name"].startswith("dangerous"):
+            return Confirm(prompt="approve?")
+        return Proceed()
+
+
+def test_tool_spec_exposes_narrow_input_and_bounded_options():
+    spec = make_use_agent().tool_spec
+    schema = spec["inputSchema"]["json"]
+
+    assert use_agent.tool_name == spec["name"] == "use_agent"
+    assert set(schema["properties"]) == {"task", "instructions", "tools"}
+    assert schema["required"] == ["task"]
+    assert schema["additionalProperties"] is False
+    with pytest.raises(TypeError, match="limits.turns must be an integer between 1 and 50"):
+        make_use_agent(limits={"turns": 51})
+
+
+@pytest.mark.asyncio
+async def test_grants_only_named_parent_tools_and_preserves_inherited_pre_tool_policy():
+    calls: list[str] = []
+
+    @tool
+    def extra() -> str:
+        calls.append("extra")
+        return "extra"
+
+    @tool
+    def blocked() -> str:
+        calls.append("blocked")
+        return "blocked"
+
+    omitted_tool = make_use_agent()
+    omitted_parent = Agent(
+        model=MockedModelProvider([_tool_turn("extra", "extra-call"), _text_turn("handled")]),
+        tools=[extra, omitted_tool],
+        callback_handler=None,
+    )
+    omitted = await _run_tool(omitted_parent, omitted_tool, {"task": "work"})
+
+    before_tools = 0
+    policy_order: list[str] = []
+
+    def record_tools(event: BeforeToolsEvent) -> None:
+        nonlocal before_tools
+        before_tools += 1
+        assert event.agent.system_prompt == "Research carefully."
+
+    def record_ancestor(event: BeforeToolCallEvent) -> None:
+        policy_order.append("ancestor")
+
+    ancestor = Agent(model=MockedModelProvider([_text_turn("unused")]), callback_handler=None)
+    ancestor.add_hook(record_ancestor, BeforeToolCallEvent, order=100)
+    governed_tool = make_use_agent()
+    governed_parent = Agent(
+        model=MockedModelProvider([_tool_turn("extra", "extra-call"), _text_turn("handled")]),
+        tools=[extra, blocked, governed_tool],
+        callback_handler=None,
+    )
+    governed_parent.hooks._inherit_callbacks_from(ancestor.hooks, [BeforeToolsEvent, BeforeToolCallEvent])
+    governed_parent.add_hook(record_tools, BeforeToolsEvent)
+
+    def replace_tool(event: BeforeToolCallEvent) -> None:
+        policy_order.append("parent")
+        event.selected_tool = blocked
+
+    governed_parent.add_hook(replace_tool, BeforeToolCallEvent)
+    governed = await _run_tool(
+        governed_parent,
+        governed_tool,
+        {"task": "work", "instructions": "Research carefully.", "tools": ["extra"]},
+    )
+
+    assert calls == []
+    assert before_tools == 1
+    assert policy_order == ["parent", "ancestor"]
+    assert _result_json(omitted)["output"] == "handled\n"
+    assert governed.tool_result["status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_rejects_grants_or_models_that_bypass_the_governed_tool_registry(monkeypatch: pytest.MonkeyPatch):
+    registered = make_use_agent()
+    parent = Agent(
+        model=MockedModelProvider([_text_turn("unused")]),
+        tools=[registered],
+        callback_handler=None,
+    )
+
+    missing = await _run_tool(parent, registered, {"task": "work", "tools": ["missing"]})
+    different_tool = make_use_agent()
+    different = await _run_tool(parent, different_tool, {"task": "work", "tools": ["use_agent"]})
+
+    monkeypatch.setattr(parent.model, "get_config", lambda: {"params": {"tools": [{"type": "web_search"}]}})
+    native = await _run_tool(parent, registered, {"task": "work"})
+
+    recursive_tool = make_use_agent(limits={"depth": 1})
+    recursive_parent = Agent(
+        model=MockedModelProvider(
+            [
+                _tool_turn("use_agent", "nested-call", {"task": "nested"}),
+                _text_turn("done"),
+            ]
+        ),
+        tools=[recursive_tool],
+        callback_handler=None,
+    )
+    recursive = await _run_tool(recursive_parent, recursive_tool, {"task": "work", "tools": ["use_agent"]})
+
+    assert _result_json(missing)["error"] == "Tool 'missing' was not found on the parent agent"
+    assert _result_json(different)["error"] == "A child can receive only the currently executing use_agent tool"
+    assert "provider-native model tools" in _result_json(native)["error"]
+    assert _result_json(recursive)["output"] == "done\n"
+
+
+@pytest.mark.asyncio
+async def test_scopes_repeated_interrupts_and_resumes_the_same_child_state():
+    calls = 0
+
+    @tool
+    def dangerous() -> str:
+        nonlocal calls
+        calls += 1
+        return "deleted"
+
+    model = MockedModelProvider(
+        [
+            _tool_turn("use_agent", "use-agent-call", {"task": "delete", "tools": ["dangerous"]}),
+            _tool_turn("dangerous", "dangerous-call"),
+            _tool_turn("dangerous", "dangerous-call"),
+            _text_turn("child done"),
+            _text_turn("outer done"),
+        ]
+    )
+    use_agent_tool = make_use_agent()
+    parent = Agent(
+        model=model,
+        tools=[dangerous, use_agent_tool],
+        interventions=[_ConfirmDangerous()],
+        callback_handler=None,
+    )
+
+    first = await parent.invoke_async("go")
+    assert first.interrupts
+    first_interrupt = first.interrupts[0]
+
+    restored_tool = make_use_agent()
+    restored_parent = Agent(
+        model=MockedModelProvider([_text_turn("unused")]),
+        tools=[dangerous, restored_tool],
+        interventions=[_ConfirmDangerous()],
+        callback_handler=None,
+    )
+    restored_parent.load_snapshot(parent.take_snapshot(preset="session"))
+    restored = await _run_tool(restored_parent, restored_tool, {"task": "delete", "tools": ["dangerous"]})
+
+    second = await parent.invoke_async([{"interruptResponse": {"interruptId": first_interrupt.id, "response": "yes"}}])
+    assert second.interrupts
+    second_interrupt = second.interrupts[0]
+    completed = await parent.invoke_async(
+        [{"interruptResponse": {"interruptId": second_interrupt.id, "response": "yes"}}]
+    )
+
+    assert second_interrupt.id != first_interrupt.id
+    assert str(completed).rstrip() == "outer done"
+    assert calls == 2
+    assert _result_json(restored)["error"] == (
+        "use_agent cannot resume an interrupted child after the parent or tool instance was restored"
+    )
+
+
+@pytest.mark.asyncio
+async def test_preserves_turn_and_token_budgets_across_an_interrupt():
+    for limits, usages, stop_reason in [
+        ({"turns": 1}, None, "limit_turns"),
+        (
+            {"total_tokens": 1},
+            [
+                {"inputTokens": 0, "outputTokens": 0, "totalTokens": 0},
+                {"inputTokens": 5, "outputTokens": 5, "totalTokens": 10},
+                {"inputTokens": 0, "outputTokens": 0, "totalTokens": 0},
+            ],
+            "limit_total_tokens",
+        ),
+    ]:
+        calls = 0
+
+        @tool
+        def dangerous() -> str:
+            nonlocal calls
+            calls += 1
+            return "deleted"
+
+        model = MockedModelProvider(
+            [
+                _tool_turn("use_agent", "use-agent-call", {"task": "delete", "tools": ["dangerous"]}),
+                _tool_turn("dangerous", "dangerous-call"),
+                _text_turn("budget exhausted"),
+            ],
+            usages=usages,
+        )
+        use_agent_tool = make_use_agent(limits=limits)
+        parent = Agent(
+            model=model,
+            tools=[dangerous, use_agent_tool],
+            interventions=[_ConfirmDangerous()],
+            callback_handler=None,
+        )
+
+        interrupted = await parent.invoke_async("go")
+        assert interrupted.interrupts
+        await parent.invoke_async(
+            [{"interruptResponse": {"interruptId": interrupted.interrupts[0].id, "response": "yes"}}]
+        )
+        tool_result = next(
+            content["toolResult"]
+            for message in parent.messages
+            for content in message["content"]
+            if "toolResult" in content and content["toolResult"]["toolUseId"] == "use-agent-call"
+        )
+
+        assert calls == 0
+        result_json = cast(dict[str, Any], tool_result["content"][0].get("json"))
+        assert result_json == {"status": "failed", "error": f"use_agent child stopped before completion: {stop_reason}"}
+
+
+@pytest.mark.asyncio
+async def test_returns_promptly_on_parent_cancellation_and_timeout(monkeypatch: pytest.MonkeyPatch):
+    async def wait_forever(*args: Any, **kwargs: Any) -> Any:
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(Agent, "invoke_async", wait_forever)
+    cancelled_parent = Agent(model=MockedModelProvider([_text_turn("unused")]), callback_handler=None)
+    task = asyncio.create_task(_run_tool(cancelled_parent, make_use_agent(), {"task": "work"}))
+    await asyncio.sleep(0)
+    cancelled_parent.cancel()
+    cancelled = await asyncio.wait_for(task, timeout=1)
+
+    ticks = iter([0.0, 2.0])
+    use_agent_module = importlib.import_module("strands.experimental.tools.use_agent.use_agent")
+    monkeypatch.setattr(use_agent_module, "monotonic", lambda: next(ticks))
+    timed_parent = Agent(model=MockedModelProvider([_text_turn("unused")]), callback_handler=None)
+    timed = await _run_tool(timed_parent, make_use_agent(limits={"timeout_seconds": 1}), {"task": "work"})
+
+    assert _result_json(cancelled)["status"] == "cancelled"
+    assert _result_json(timed)["error"] == "use_agent child exceeded its execution timeout"

--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -76,6 +76,10 @@
       "types": "./dist/src/vended-tools/sleep/index.d.ts",
       "default": "./dist/src/vended-tools/sleep/index.js"
     },
+    "./experimental/vended-tools/use-agent": {
+      "types": "./dist/src/experimental/vended-tools/use-agent/index.d.ts",
+      "default": "./dist/src/experimental/vended-tools/use-agent/index.js"
+    },
     "./experimental/vended-tools/stop": {
       "types": "./dist/src/experimental/vended-tools/stop/index.d.ts",
       "default": "./dist/src/experimental/vended-tools/stop/index.js"

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -76,6 +76,7 @@ import {
   AfterToolsEvent,
   BeforeInvocationEvent,
   BeforeModelCallEvent,
+  BeforeToolCallEvent,
   BeforeToolsEvent,
   HookableEvent,
   MessageAddedEvent,
@@ -422,6 +423,9 @@ const DEFAULT_AGENT_ID = 'agent'
 /** Result returned by tool-execution generators, threading the AfterToolsEvent back to the main loop. */
 type ToolsExecutionResult = { message: Message; afterToolsEvent: AfterToolsEvent; toolsSkipped: boolean }
 
+/** @internal */
+export const inheritPreToolHooksSymbol = Symbol('Agent.inheritPreToolHooks')
+
 /**
  * Orchestrates the interaction between a model, a set of tools, and MCP clients.
  * The Agent is responsible for managing the lifecycle of tools and clients
@@ -696,6 +700,11 @@ export class Agent implements LocalAgent, InvokableAgent {
     options?: HookCallbackOptions
   ): HookCleanup {
     return this._hooksRegistry.addCallback(eventType, callback, options)
+  }
+
+  /** @internal */
+  [inheritPreToolHooksSymbol](parent: Agent): void {
+    this._hooksRegistry._inheritCallbacksFrom(parent._hooksRegistry, [BeforeToolsEvent, BeforeToolCallEvent])
   }
 
   /**

--- a/strands-ts/src/experimental/vended-tools/use-agent/__tests__/use-agent.test.ts
+++ b/strands-ts/src/experimental/vended-tools/use-agent/__tests__/use-agent.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { Agent, inheritPreToolHooksSymbol } from '../../../../agent/agent.js'
+import { MockMessageModel } from '../../../../__fixtures__/mock-message-model.js'
+import { collectGenerator, TestModelProvider } from '../../../../__fixtures__/model-test-helpers.js'
+import { createMockContext, createMockTool } from '../../../../__fixtures__/tool-helpers.js'
+import { BeforeToolCallEvent, BeforeToolsEvent } from '../../../../hooks/events.js'
+import { InterventionActions, InterventionHandler } from '../../../../interventions/index.js'
+import type { Tool, ToolContext } from '../../../../tools/tool.js'
+import { InterruptResponseContent } from '../../../../types/interrupt.js'
+import { JsonBlock, type ToolResultBlock } from '../../../../types/messages.js'
+import type { JSONValue } from '../../../../types/json.js'
+import { makeUseAgent } from '../index.js'
+
+function context(
+  parent: Agent,
+  useAgent: Tool,
+  input: Record<string, JSONValue>,
+  cancelSignal = new AbortController().signal
+): ToolContext {
+  return {
+    ...createMockContext({ name: useAgent.name, toolUseId: 'use-agent-call', input }),
+    agent: parent,
+    invocationState: {},
+    cancelSignal,
+  }
+}
+
+function textModel(text: string): MockMessageModel {
+  return new MockMessageModel().addTurn({ type: 'textBlock', text })
+}
+
+function resultJson(result: ToolResultBlock): Record<string, JSONValue> {
+  return (result.content[0] as JsonBlock).json as Record<string, JSONValue>
+}
+
+function gatedModel(): { model: TestModelProvider; release: () => void } {
+  let release!: () => void
+  const gate = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  const model = new TestModelProvider(async function* () {
+    await gate
+    yield { type: 'modelMessageStartEvent', role: 'assistant' }
+    yield { type: 'modelMessageStopEvent', stopReason: 'endTurn' }
+  })
+  return { model, release }
+}
+
+class ConfirmDangerous extends InterventionHandler {
+  readonly name = 'confirm-dangerous'
+
+  override beforeToolCall(event: Parameters<InterventionHandler['beforeToolCall']>[0]) {
+    return event.toolUse.name.startsWith('dangerous')
+      ? InterventionActions.confirm('approve?')
+      : InterventionActions.proceed()
+  }
+}
+
+describe('makeUseAgent', () => {
+  it('exposes the narrow input and bounded execution options', () => {
+    const spec = makeUseAgent().toolSpec
+
+    expect(spec.name).toBe('use_agent')
+    expect(Object.keys(spec.inputSchema?.properties ?? {})).toEqual(['task', 'instructions', 'tools'])
+    expect(spec.inputSchema?.required).toEqual(['task'])
+    expect(spec.inputSchema?.additionalProperties).toBe(false)
+    expect(() => makeUseAgent({ limits: { turns: 51 } })).toThrow(
+      'limits.turns must be a safe integer between 1 and 50'
+    )
+  })
+
+  it('grants only named parent tools and preserves inherited pre-tool policy', async () => {
+    const extra = vi.fn(() => 'extra')
+    const blocked = vi.fn(() => 'blocked')
+    const extraTool = createMockTool('extra', extra)
+    const blockedTool = createMockTool('blocked', blocked)
+
+    const omittedUseAgent = makeUseAgent()
+    const omittedParent = new Agent({
+      model: new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'extra', toolUseId: 'extra-call', input: {} })
+        .addTurn({ type: 'textBlock', text: 'handled' }),
+      tools: [extraTool, omittedUseAgent],
+    })
+    const omitted = await collectGenerator(
+      omittedUseAgent.stream(context(omittedParent, omittedUseAgent, { task: 'work' }))
+    )
+
+    const beforeTools = vi.fn()
+    const policyOrder: string[] = []
+    const governedUseAgent = makeUseAgent()
+    const ancestor = new Agent({ model: textModel('unused') })
+    ancestor.addHook(
+      BeforeToolCallEvent,
+      () => {
+        policyOrder.push('ancestor')
+      },
+      { order: 100 }
+    )
+    const governedParent = new Agent({
+      model: new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'extra', toolUseId: 'extra-call', input: {} })
+        .addTurn({ type: 'textBlock', text: 'handled' }),
+      tools: [extraTool, blockedTool, governedUseAgent],
+    })
+    governedParent[inheritPreToolHooksSymbol](ancestor)
+    governedParent.addHook(BeforeToolsEvent, beforeTools)
+    governedParent.addHook(BeforeToolCallEvent, (event) => {
+      policyOrder.push('parent')
+      event.selectedTool = blockedTool
+    })
+    const governed = await collectGenerator(
+      governedUseAgent.stream(
+        context(governedParent, governedUseAgent, {
+          task: 'work',
+          tools: ['extra'],
+        })
+      )
+    )
+
+    expect(extra).not.toHaveBeenCalled()
+    expect(blocked).not.toHaveBeenCalled()
+    expect(beforeTools).toHaveBeenCalledTimes(1)
+    expect(policyOrder).toEqual(['parent', 'ancestor'])
+    expect(resultJson(omitted.result)).toMatchObject({ status: 'completed', output: 'handled' })
+    expect(governed.result.status).toBe('success')
+  })
+
+  it('rejects grants or models that bypass the governed tool registry', async () => {
+    const registered = makeUseAgent()
+    const parent = new Agent({ model: textModel('unused'), tools: [registered] })
+
+    const missing = await collectGenerator(
+      registered.stream(context(parent, registered, { task: 'work', tools: ['missing'] }))
+    )
+    const different = await collectGenerator(
+      makeUseAgent().stream(context(parent, makeUseAgent(), { task: 'work', tools: ['use_agent'] }))
+    )
+
+    const nativeModel = textModel('unused')
+    Object.assign(nativeModel.getConfig(), { params: { tools: [{ type: 'web_search' }] } })
+    const nativeTool = makeUseAgent()
+    const native = await collectGenerator(
+      nativeTool.stream(context(new Agent({ model: nativeModel }), nativeTool, { task: 'work' }))
+    )
+
+    const recursiveTool = makeUseAgent({ limits: { depth: 1 } })
+    const recursiveParent = new Agent({
+      model: new MockMessageModel()
+        .addTurn({
+          type: 'toolUseBlock',
+          name: 'use_agent',
+          toolUseId: 'nested-call',
+          input: { task: 'nested' },
+        })
+        .addTurn({ type: 'textBlock', text: 'done' }),
+      tools: [recursiveTool],
+    })
+    const recursive = await collectGenerator(
+      recursiveTool.stream(context(recursiveParent, recursiveTool, { task: 'work', tools: ['use_agent'] }))
+    )
+
+    expect(resultJson(missing.result).error).toBe("Tool 'missing' was not found on the parent agent")
+    expect(resultJson(different.result).error).toBe('A child can receive only the currently executing use_agent tool')
+    expect(resultJson(native.result).error).toContain('provider-native model tools')
+    expect(resultJson(recursive.result)).toMatchObject({ status: 'completed', output: 'done' })
+  })
+
+  it('scopes repeated interrupts and resumes the same child state', async () => {
+    const dangerous = vi.fn(() => 'deleted')
+    const dangerousTool = createMockTool('dangerous', dangerous)
+    const model = new MockMessageModel()
+      .addTurn({
+        type: 'toolUseBlock',
+        name: 'use_agent',
+        toolUseId: 'use-agent-call',
+        input: { task: 'delete', tools: ['dangerous'] },
+      })
+      .addTurn({ type: 'toolUseBlock', name: 'dangerous', toolUseId: 'dangerous-call', input: {} })
+      .addTurn({ type: 'toolUseBlock', name: 'dangerous', toolUseId: 'dangerous-call', input: {} })
+      .addTurn({ type: 'textBlock', text: 'child done' })
+      .addTurn({ type: 'textBlock', text: 'outer done' })
+    const useAgent = makeUseAgent()
+    const parent = new Agent({
+      model,
+      tools: [dangerousTool, useAgent],
+      interventions: [new ConfirmDangerous()],
+      printer: false,
+    })
+
+    const first = await parent.invoke('go')
+    const firstInterrupt = first.interrupts![0]!
+
+    const restoredTool = makeUseAgent()
+    const restoredParent = new Agent({
+      model: textModel('unused'),
+      tools: [dangerousTool, restoredTool],
+      interventions: [new ConfirmDangerous()],
+      printer: false,
+    })
+    restoredParent.loadSnapshot(parent.takeSnapshot({ preset: 'session' }))
+    const { result: restored } = await collectGenerator(
+      restoredTool.stream(context(restoredParent, restoredTool, { task: 'delete', tools: ['dangerous'] }))
+    )
+
+    const second = await parent.invoke([
+      new InterruptResponseContent({ interruptId: firstInterrupt.id, response: 'yes' }),
+    ])
+    const secondInterrupt = second.interrupts![0]!
+    const completed = await parent.invoke([
+      new InterruptResponseContent({ interruptId: secondInterrupt.id, response: 'yes' }),
+    ])
+
+    expect(secondInterrupt.id).not.toBe(firstInterrupt.id)
+    expect(completed.toString()).toBe('outer done')
+    expect(dangerous).toHaveBeenCalledTimes(2)
+    expect(resultJson(restored).error).toBe(
+      'use_agent cannot resume an interrupted child after the parent or tool instance was restored'
+    )
+  })
+
+  it('preserves turn and token budgets across an interrupt', async () => {
+    for (const { limits, usage, stopReason } of [
+      { limits: { turns: 1 }, usage: undefined, stopReason: 'limitTurns' },
+      {
+        limits: { totalTokens: 1 },
+        usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 },
+        stopReason: 'limitTotalTokens',
+      },
+    ]) {
+      const dangerous = vi.fn(() => 'deleted')
+      const model = new MockMessageModel()
+        .addTurn({
+          type: 'toolUseBlock',
+          name: 'use_agent',
+          toolUseId: 'use-agent-call',
+          input: { task: 'delete', tools: ['dangerous'] },
+        })
+        .addTurn(
+          { type: 'toolUseBlock', name: 'dangerous', toolUseId: 'dangerous-call', input: {} },
+          usage ? { usage } : undefined
+        )
+        .addTurn({ type: 'textBlock', text: 'budget exhausted' })
+      const useAgent = makeUseAgent({ limits })
+      const parent = new Agent({
+        model,
+        tools: [createMockTool('dangerous', dangerous), useAgent],
+        interventions: [new ConfirmDangerous()],
+        printer: false,
+      })
+
+      const interrupted = await parent.invoke('go')
+      await parent.invoke([
+        new InterruptResponseContent({ interruptId: interrupted.interrupts![0]!.id, response: 'yes' }),
+      ])
+      const toolResult = parent.messages
+        .flatMap((message) => message.content)
+        .find((block) => block.type === 'toolResultBlock' && block.toolUseId === 'use-agent-call')
+
+      expect(dangerous).not.toHaveBeenCalled()
+      expect(toolResult?.toJSON()).toMatchObject({
+        toolResult: {
+          content: [{ json: { status: 'failed', error: `use_agent child stopped before completion: ${stopReason}` } }],
+        },
+      })
+    }
+  })
+
+  it('returns promptly on parent cancellation and timeout', async () => {
+    const cancelledRun = gatedModel()
+    const cancelledTool = makeUseAgent()
+    const cancelledParent = new Agent({ model: cancelledRun.model, tools: [cancelledTool] })
+    const controller = new AbortController()
+    const cancelledPromise = collectGenerator(
+      cancelledTool.stream(context(cancelledParent, cancelledTool, { task: 'work' }, controller.signal))
+    )
+    await Promise.resolve()
+    controller.abort(new DOMException('use_agent child was cancelled', 'AbortError'))
+    const cancelled = await cancelledPromise
+    cancelledRun.release()
+
+    const timedRun = gatedModel()
+    const timedTool = makeUseAgent({ limits: { timeoutSeconds: 1 } })
+    const timedParent = new Agent({ model: timedRun.model, tools: [timedTool] })
+    const timed = await collectGenerator(timedTool.stream(context(timedParent, timedTool, { task: 'work' })))
+    timedRun.release()
+
+    expect(resultJson(cancelled.result).status).toBe('cancelled')
+    expect(resultJson(timed.result).error).toBe('use_agent child exceeded its execution timeout')
+  })
+})

--- a/strands-ts/src/experimental/vended-tools/use-agent/index.ts
+++ b/strands-ts/src/experimental/vended-tools/use-agent/index.ts
@@ -1,0 +1,2 @@
+export { makeUseAgent, useAgent } from './use-agent.js'
+export type { MakeUseAgentOptions, UseAgentLimits } from './use-agent.js'

--- a/strands-ts/src/experimental/vended-tools/use-agent/use-agent.ts
+++ b/strands-ts/src/experimental/vended-tools/use-agent/use-agent.ts
@@ -1,0 +1,363 @@
+import { z } from 'zod'
+
+import { Agent, inheritPreToolHooksSymbol } from '../../../agent/agent.js'
+import { DefaultNotConfiguredError, normalizeError } from '../../../errors.js'
+import { BeforeToolCallEvent } from '../../../hooks/events.js'
+import { Interrupt, InterruptError } from '../../../interrupt.js'
+import { JsonBlock, ToolResultBlock } from '../../../types/messages.js'
+import { InterruptResponseContent } from '../../../types/interrupt.js'
+import { Tool } from '../../../tools/tool.js'
+import type { ToolContext, ToolStreamGenerator } from '../../../tools/tool.js'
+import type { ToolSpec } from '../../../tools/types.js'
+import { zodSchemaToJsonSchema } from '../../../tools/zod-utils.js'
+import type { JSONValue } from '../../../types/json.js'
+import type { AgentResult, InvocationState } from '../../../types/agent.js'
+
+const USE_AGENT_TOOL_NAME = 'use_agent'
+const DEFAULT_LIMITS = {
+  turns: 50,
+  totalTokens: 100_000,
+  depth: 3,
+  timeoutSeconds: 300,
+} as const satisfies Required<UseAgentLimits>
+
+/**
+ * Developer-controlled limits for the experimental `use_agent` tool.
+ */
+export interface UseAgentLimits {
+  /** Maximum child turns. Defaults to and cannot exceed 50. */
+  turns?: number
+  /** Soft cumulative child-token threshold. A model turn can overshoot it. Defaults to and cannot exceed 100000. */
+  totalTokens?: number
+  /** Maximum nested `use_agent` depth. Defaults to and cannot exceed 3. */
+  depth?: number
+  /** Maximum child execution time in seconds. Defaults to and cannot exceed 300. */
+  timeoutSeconds?: number
+}
+
+/**
+ * Options for {@link makeUseAgent}.
+ */
+export interface MakeUseAgentOptions {
+  /** Child execution limits. */
+  limits?: UseAgentLimits
+}
+
+const useAgentInputSchema = z
+  .object({
+    task: z.string().min(1).describe('Task for the child agent.'),
+    instructions: z.string().min(1).optional().describe('Optional child-specific instructions.'),
+    tools: z.array(z.string().min(1)).optional().describe('Exact parent tool names to grant. Omit for no tools.'),
+  })
+  .strict()
+
+interface UseAgentResult {
+  status: 'completed' | 'failed' | 'cancelled'
+  error?: string
+  output?: string
+}
+
+interface PendingChild {
+  child: Agent
+  task: string
+  parentInterruptState: object
+  remainingMs: number
+  remainingTurns: number
+  remainingTotalTokens: number
+  invocationState: InvocationState
+  interruptGeneration: number
+  interrupts: { childId: string; outwardId: string }[]
+}
+
+class UseAgentTool extends Tool {
+  readonly name = USE_AGENT_TOOL_NAME
+  readonly description =
+    'Runs a task in a fresh child agent. The child receives only the exact parent tools named in tools; omit tools for no child tools.'
+  readonly toolSpec: ToolSpec
+
+  private readonly _limits: Required<UseAgentLimits>
+  private readonly _pending = new WeakMap<Agent, Map<string, PendingChild>>()
+  private readonly _depths = new WeakMap<Agent, number>()
+
+  constructor(options: MakeUseAgentOptions) {
+    super()
+    this._limits = resolveLimits(options.limits)
+    this.toolSpec = {
+      name: this.name,
+      description: this.description,
+      inputSchema: zodSchemaToJsonSchema(useAgentInputSchema),
+    }
+  }
+
+  // eslint-disable-next-line require-yield
+  async *stream(context: ToolContext): ToolStreamGenerator {
+    const parent = context.agent
+    if (!(parent instanceof Agent)) {
+      return resultBlock(context.toolUse.toolUseId, {
+        status: 'failed',
+        error: 'use_agent requires a local Agent context',
+      })
+    }
+
+    const pending = this._pending.get(parent)?.get(context.toolUse.toolUseId)
+    const timeoutMs = pending?.remainingMs ?? this._limits.timeoutSeconds * 1000
+    const deadline = Date.now() + timeoutMs
+    const cancelSignal = AbortSignal.any([context.cancelSignal, AbortSignal.timeout(timeoutMs)])
+    try {
+      const interruptState = parent._interruptState
+      const restored =
+        (pending && pending.parentInterruptState !== interruptState) ||
+        (!pending &&
+          Object.keys(interruptState.interrupts).some((id) => id.startsWith(`${context.toolUse.toolUseId}:`)))
+      if (restored) {
+        throw new Error('use_agent cannot resume an interrupted child after the parent or tool instance was restored')
+      }
+      const childState =
+        pending ?? (await this._createChild(parent, context.toolUse.input, context.invocationState, cancelSignal))
+      const stopReason =
+        pending && childState.remainingTurns <= 0
+          ? 'limitTurns'
+          : pending && childState.remainingTotalTokens <= 0
+            ? 'limitTotalTokens'
+            : undefined
+      if (stopReason) {
+        this._pending.get(parent)?.delete(context.toolUse.toolUseId)
+        return resultBlock(context.toolUse.toolUseId, stoppedResult(stopReason))
+      }
+
+      const prompt = pending ? this._interruptResponses(parent, pending) : childState.task
+      const result = await waitForCancellation(
+        childState.child.invoke(prompt, {
+          invocationState: childState.invocationState,
+          cancelSignal,
+          limits: {
+            turns: childState.remainingTurns,
+            totalTokens: childState.remainingTotalTokens,
+          },
+        }),
+        cancelSignal
+      )
+      if (result.stopReason === 'interrupt' && result.interrupts?.length) {
+        const invocation = result.metrics?.latestAgentInvocation
+        if (invocation) {
+          childState.remainingTurns -= invocation.cycles.length
+          childState.remainingTotalTokens -= invocation.usage.totalTokens
+        }
+        childState.remainingMs = Math.max(0, deadline - Date.now())
+        childState.interruptGeneration += 1
+        childState.interrupts = result.interrupts.map((interrupt) => ({
+          childId: interrupt.id,
+          outwardId: `${context.toolUse.toolUseId}:${childState.interruptGeneration}:${interrupt.id}`,
+        }))
+        const pendingChildren = this._pending.get(parent) ?? new Map()
+        pendingChildren.set(context.toolUse.toolUseId, childState)
+        this._pending.set(parent, pendingChildren)
+        throw new InterruptError(
+          result.interrupts.map(
+            (interrupt, index) =>
+              new Interrupt({
+                ...interrupt.toJSON(),
+                id: childState.interrupts[index]!.outwardId,
+              })
+          )
+        )
+      }
+
+      this._pending.get(parent)?.delete(context.toolUse.toolUseId)
+      return resultBlock(context.toolUse.toolUseId, terminalResult(result))
+    } catch (error) {
+      if (error instanceof InterruptError) {
+        throw error
+      }
+      this._pending.get(parent)?.delete(context.toolUse.toolUseId)
+      const normalized = normalizeError(error)
+      const cancelled =
+        context.cancelSignal.aborted || (normalized instanceof DOMException && normalized.name === 'AbortError')
+      const message =
+        normalized instanceof DOMException && normalized.name === 'TimeoutError'
+          ? 'use_agent child exceeded its execution timeout'
+          : normalized.message
+      return resultBlock(context.toolUse.toolUseId, {
+        status: cancelled ? 'cancelled' : 'failed',
+        error: message,
+      })
+    }
+  }
+
+  private async _createChild(
+    parent: Agent,
+    rawInput: unknown,
+    parentState: InvocationState,
+    cancelSignal: AbortSignal
+  ): Promise<PendingChild> {
+    const input = useAgentInputSchema.parse(rawInput)
+    const depth = this._depths.get(parent) ?? 0
+    if (depth >= this._limits.depth) {
+      throw new Error(`use_agent recursion depth limit of ${this._limits.depth} reached`)
+    }
+    if (hasProviderNativeTools(parent)) {
+      throw new Error(
+        'use_agent is not supported with provider-native model tools; ' +
+          'register governed SDK tools on the parent agent instead'
+      )
+    }
+
+    const selectedTools = resolveTools(parent, input.tools ?? [], this)
+    const sandbox = resolveParentSandbox(parent)
+    const child = new Agent({
+      model: parent.model,
+      ...(input.instructions !== undefined && { systemPrompt: input.instructions }),
+      ...(sandbox !== undefined && { sandbox }),
+      printer: false,
+    })
+    this._depths.set(child, depth + 1)
+    child[inheritPreToolHooksSymbol](parent)
+    await waitForCancellation(child.initialize(), cancelSignal)
+    // Agent initialization may vend sandbox tools; exact grants must replace them.
+    child.toolRegistry.clear()
+    child.toolRegistry.add(selectedTools)
+    const allowedTools = new Set(selectedTools)
+    child.addHook(
+      BeforeToolCallEvent,
+      (event) => {
+        const selectedTool = event.selectedTool ?? child.toolRegistry.get(event.toolUse.name)
+        if (!event.cancel && selectedTool && !allowedTools.has(selectedTool)) {
+          event.cancel = 'use_agent blocked a tool outside the child grant set'
+        }
+      },
+      { order: Number.POSITIVE_INFINITY }
+    )
+    return {
+      child,
+      task: input.task,
+      parentInterruptState: parent._interruptState,
+      remainingMs: this._limits.timeoutSeconds * 1000,
+      remainingTurns: this._limits.turns,
+      remainingTotalTokens: this._limits.totalTokens,
+      invocationState: { ...parentState },
+      interruptGeneration: 0,
+      interrupts: [],
+    }
+  }
+
+  private _interruptResponses(parent: Agent, pending: PendingChild): InterruptResponseContent[] {
+    const parentInterrupts = parent._interruptState.interrupts
+    return pending.interrupts.map(({ childId, outwardId }) => {
+      const interrupt = parentInterrupts[outwardId]
+      if (!interrupt || interrupt.response === undefined) {
+        throw new Error(`use_agent interrupt '${outwardId}' has no response`)
+      }
+      return new InterruptResponseContent({ interruptId: childId, response: interrupt.response })
+    })
+  }
+}
+
+/**
+ * Creates an experimental governed `use_agent` tool.
+ *
+ * This tool is subject to change in future revisions without notice.
+ * @param options - Developer-controlled child execution limits
+ * @returns A streaming tool that creates bounded child agents
+ * @throws TypeError if a child execution limit is outside its supported range
+ */
+export function makeUseAgent(options: MakeUseAgentOptions = {}): Tool {
+  return new UseAgentTool(options)
+}
+
+/**
+ * Default experimental `use_agent` tool.
+ */
+export const useAgent = makeUseAgent()
+
+function stoppedResult(stopReason: AgentResult['stopReason']): UseAgentResult {
+  return {
+    status: 'failed',
+    error: `use_agent child stopped before completion: ${stopReason}`,
+  }
+}
+
+function terminalResult(result: AgentResult): UseAgentResult {
+  if (result.stopReason === 'cancelled') {
+    return { status: 'cancelled', error: 'use_agent child was cancelled' }
+  }
+  if (result.stopReason !== 'endTurn' && result.stopReason !== 'stopSequence') {
+    return stoppedResult(result.stopReason)
+  }
+  return {
+    status: 'completed',
+    output: result.toString(),
+  }
+}
+
+function resolveParentSandbox(parent: Agent): Agent['sandbox'] | undefined {
+  try {
+    return parent.sandbox
+  } catch (error) {
+    if (error instanceof DefaultNotConfiguredError) return undefined
+    throw error
+  }
+}
+
+function resolveTools(parent: Agent, requestedNames: string[], executingTool: Tool): Tool[] {
+  return [...new Set(requestedNames)].map((name) => {
+    const selectedTool = parent.toolRegistry.get(name)
+    if (!selectedTool) {
+      throw new Error(`Tool '${name}' was not found on the parent agent`)
+    }
+    if (name === USE_AGENT_TOOL_NAME && selectedTool !== executingTool) {
+      throw new Error('A child can receive only the currently executing use_agent tool')
+    }
+    return selectedTool
+  })
+}
+
+function resolveLimits(limits: UseAgentLimits | undefined): Required<UseAgentLimits> {
+  const resolved = { ...DEFAULT_LIMITS, ...limits }
+  for (const name of Object.keys(DEFAULT_LIMITS) as (keyof UseAgentLimits)[]) {
+    const value = resolved[name]
+    const maximum = DEFAULT_LIMITS[name]
+    if (!Number.isSafeInteger(value) || value < 1 || value > maximum) {
+      throw new TypeError(`limits.${name} must be a safe integer between 1 and ${maximum}, got ${value}`)
+    }
+  }
+  return resolved
+}
+
+function hasProviderNativeTools(parent: Agent): boolean {
+  const config = parent.model.getConfig()
+  if ('builtInTools' in config && Array.isArray(config.builtInTools) && config.builtInTools.length > 0) {
+    return true
+  }
+  if (!('params' in config) || !config.params || typeof config.params !== 'object') {
+    return false
+  }
+  const params = config.params
+  return 'tools' in params && Array.isArray(params.tools) && params.tools.length > 0
+}
+
+function resultBlock(toolUseId: string, result: UseAgentResult): ToolResultBlock {
+  return new ToolResultBlock({
+    toolUseId,
+    status: result.status === 'completed' ? 'success' : 'error',
+    content: [new JsonBlock({ json: result as unknown as JSONValue })],
+  })
+}
+
+async function waitForCancellation<T>(operation: Promise<T>, cancelSignal: AbortSignal): Promise<T> {
+  let onAbort!: () => void
+  const cancellation = new Promise<never>((_, reject) => {
+    onAbort = (): void => {
+      reject(cancelSignal.reason ?? new DOMException('use_agent child was cancelled', 'AbortError'))
+    }
+    if (cancelSignal.aborted) {
+      onAbort()
+    } else {
+      cancelSignal.addEventListener('abort', onAbort, { once: true })
+    }
+  })
+  try {
+    return await Promise.race([operation, cancellation])
+  } finally {
+    cancelSignal.removeEventListener('abort', onAbort)
+  }
+}

--- a/strands-ts/src/hooks/registry.ts
+++ b/strands-ts/src/hooks/registry.ts
@@ -42,6 +42,16 @@ export class HookRegistryImplementation implements HookRegistry {
     this._callbacks = new Map()
   }
 
+  /** @internal */
+  _inheritCallbacksFrom(registry: HookRegistryImplementation, eventTypes: readonly HookableEventConstructor[]): void {
+    for (const eventType of eventTypes) {
+      const callbacks = this._callbacks.get(eventType) ?? []
+      callbacks.push(...(registry._callbacks.get(eventType) ?? []))
+      callbacks.sort((a, b) => a.order - b.order)
+      this._callbacks.set(eventType, callbacks)
+    }
+  }
+
   /** {@inheritDoc HookRegistry.addCallback} */
   addCallback<T extends HookableEvent>(
     eventType: HookableEventConstructor<T>,

--- a/strands-ts/test/packages/npm-pack/verify.ts
+++ b/strands-ts/test/packages/npm-pack/verify.ts
@@ -26,6 +26,7 @@ import { notebook } from '@strands-agents/sdk/vended-tools/notebook'
 import { fileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
 import { httpRequest } from '@strands-agents/sdk/vended-tools/http-request'
 import { bash } from '@strands-agents/sdk/vended-tools/bash'
+import { useAgent } from '@strands-agents/sdk/experimental/vended-tools/use-agent'
 
 import {
   bash as barrelBash,
@@ -78,7 +79,7 @@ if (agent.tools.length === 0) {
 }
 console.log('[pack-test] Agent constructed with tool')
 
-const vendedTools: Record<string, Tool> = { notebook, fileEditor, httpRequest, bash }
+const vendedTools: Record<string, Tool> = { notebook, fileEditor, httpRequest, bash, useAgent }
 for (const [name, t] of Object.entries(vendedTools)) {
   if (!(t instanceof Tool)) {
     throw new Error(`Vended tool '${name}' is not a Tool instance`)


### PR DESCRIPTION
## Description

Agent-authored delegation needs to remain inside the parent agent's governance boundary. The earlier draft in #3392 established a narrow delegation shim, but delegated tool calls did not inherit parent pre-tool policy hooks or configurable invocation budgets.

This adds a cross-SDK `use_agent` vended tool with a deliberately small model-facing contract: `task`, optional `instructions`, and an exact-name list of parent tools. Omitted tools grant the child no tools. Each call creates a fresh child agent, bounds its input, recursion, turns, tokens, and wall-clock time, and resumes the same child after an interrupt. Parent and ancestor `BeforeTools` and `BeforeToolCall` hooks execute before delegated tool calls, keeping authorization and intervention policies in force.

### Public API Changes

Python:

```python
from strands import Agent
from strands.vended_tools import make_use_agent

agent = Agent(
    tools=[
        search,
        make_use_agent(
            limits={
                "turns": 20,
                "total_tokens": 40_000,
                "timeout_seconds": 120,
            }
        ),
    ]
)
```

TypeScript:

```typescript
import { Agent } from '@strands-agents/sdk'
import { makeUseAgent } from '@strands-agents/sdk/vended-tools/use-agent'

const agent = new Agent({
  tools: [
    search,
    makeUseAgent({
      limits: {
        turns: 20,
        totalTokens: 40_000,
        timeoutMs: 120_000,
      },
    }),
  ],
})
```

The default `use_agent` / `useAgent` instances use the built-in limits. This is additive and does not change existing agent behavior.

## Related Issues

Resolves #3244

Supersedes #3392

## Documentation PR

No separate documentation change is included in this draft.

## Type of Change

New feature

## Testing

- Python Ruff formatting/lint and mypy checks
- Python focused tests: 6 passed
- Python full test suite: 5,281 passed
- TypeScript focused tests: 8 passed
- TypeScript full `npm run check`
- Python non-cooperative timeout smoke returned after 1.002 seconds

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
