### PR TITLE
test(site): derive catalog drop detection from the file count instead of pinned tier totals

### DIFF
--- a/site/test/catalog-collection.test.ts
+++ b/site/test/catalog-collection.test.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs'
+import { existsSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, it, expect } from 'vitest'
 import { getCollection } from 'astro:content'
@@ -171,11 +171,13 @@ describe('catalog content collection', () => {
     expect(anthropic!.data.maintainedBy).toBe('strands')
     expect(anthropic!.data.docsPage).toBe('docs/user-guide/concepts/model-providers/anthropic')
     // The content layer silently drops entries whose YAML fails to parse;
-    // pinned counts catch that. Update them when granting or removing tiers.
+    // matching the on-disk file count catches that for every entry.
+    const yamlFiles = readdirSync(join('src', 'content', 'catalog')).filter((f) => f.endsWith('.yaml'))
+    expect(entries.length).toBe(yamlFiles.length)
     const byTier = Map.groupBy(entries, (e) => e.data.maintainedBy)
-    expect(byTier.get('strands')?.length).toBe(33)
-    expect(byTier.get('aws')?.length).toBe(8)
-    expect(byTier.get('partner')?.length).toBe(21)
+    expect(byTier.get('strands')?.length ?? 0).toBeGreaterThan(0)
+    expect(byTier.get('aws')?.length ?? 0).toBeGreaterThan(0)
+    expect(byTier.get('partner')?.length ?? 0).toBeGreaterThan(0)
     // Built-ins point at their source path in the SDK monorepo and always
     // have on-site docs.
     for (const e of byTier.get('strands') ?? []) {


### PR DESCRIPTION
## Description

Follow-up to [review feedback on #3830](https://github.com/strands-agents/harness-sdk/pull/3830#discussion_r3796635524): the pinned per-tier counts in `catalog-collection.test.ts` had to be bumped on every tier grant.

The counts existed to catch entries the content layer silently drops on a YAML parse failure. Comparing the loaded entry count against the on-disk `.yaml` file count catches that directly, for every entry regardless of tier, and never needs a manual update. The per-tier assertions become non-empty checks, since exact membership is already covered by schema validation plus the file-count match.

## Related Issues

Follow-up to #3830.

## Documentation PR

N/A

## Type of Change

Other (please describe): test maintenance

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran the site test suite via the pre-commit gate (`catalog-collection.test.ts` 14/14, plus build, format, and type checks); `hatch run prepare` not applicable, no Python SDK changes

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
