### PR TITLE
fix(site): set catalog addedDate values from actual git history

### DIFF
--- a/site/src/content/catalog/ag-ui.yaml
+++ b/site/src/content/catalog/ag-ui.yaml
@@ -7,4 +7,4 @@ languages:
     package: ag-ui-strands
 github: https://github.com/ag-ui-protocol/ag-ui
 docsPage: docs/integrations/integrations/ag-ui
-addedDate: 2026-01-01
+addedDate: 2025-12-03

--- a/site/src/content/catalog/agent-control.yaml
+++ b/site/src/content/catalog/agent-control.yaml
@@ -7,4 +7,4 @@ languages:
     package: agent-control-sdk[strands-agents]
 github: https://github.com/agentcontrol/agent-control
 docsPage: docs/integrations/plugins/agent-control
-addedDate: 2026-01-01
+addedDate: 2026-03-11

--- a/site/src/content/catalog/agent-skills.yaml
+++ b/site/src/content/catalog/agent-skills.yaml
@@ -7,4 +7,4 @@ languages:
   typescript: {}
 github: https://github.com/strands-agents/harness-sdk/tree/main/strands-py/src/strands/vended_plugins/skills
 docsPage: docs/user-guide/concepts/plugins/skills
-addedDate: 2025-12-01
+addedDate: 2026-03-10

--- a/site/src/content/catalog/agent402.yaml
+++ b/site/src/content/catalog/agent402.yaml
@@ -5,4 +5,4 @@ languages:
   typescript:
     package: "agent402-strands"
 github: https://github.com/MikeyPetrillo/Agent402
-addedDate: 2026-08-04
+addedDate: 2026-06-16

--- a/site/src/content/catalog/agent402.yaml
+++ b/site/src/content/catalog/agent402.yaml
@@ -5,4 +5,4 @@ languages:
   typescript:
     package: "agent402-strands"
 github: https://github.com/MikeyPetrillo/Agent402
-addedDate: 2026-07-18
+addedDate: 2026-08-04

--- a/site/src/content/catalog/agentcore-memory-store.yaml
+++ b/site/src/content/catalog/agentcore-memory-store.yaml
@@ -8,4 +8,4 @@ languages:
 github: https://github.com/aws/bedrock-agentcore-sdk-typescript
 docsPage: docs/integrations/memory-stores/agentcore-memory-store
 featured: true
-addedDate: 2026-07-23
+addedDate: 2026-07-20

--- a/site/src/content/catalog/agentcore-memory.yaml
+++ b/site/src/content/catalog/agentcore-memory.yaml
@@ -7,4 +7,4 @@ languages:
     package: bedrock-agentcore[strands-agents]
 github: https://github.com/aws/bedrock-agentcore-sdk-python
 docsPage: docs/integrations/session-managers/agentcore-memory
-addedDate: 2026-01-01
+addedDate: 2025-10-16

--- a/site/src/content/catalog/agentcore-payments.yaml
+++ b/site/src/content/catalog/agentcore-payments.yaml
@@ -7,4 +7,4 @@ languages:
     package: bedrock-agentcore[strands-agents]
 github: https://github.com/aws/bedrock-agentcore-sdk-python
 docsPage: docs/integrations/plugins/agentcore-payments
-addedDate: 2026-01-01
+addedDate: 2026-05-07

--- a/site/src/content/catalog/agentcore-push.yaml
+++ b/site/src/content/catalog/agentcore-push.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: agentcore-push
 github: https://github.com/minorun365/agentcore-push
-addedDate: 2026-07-19
+addedDate: 2026-08-04

--- a/site/src/content/catalog/agentcore-push.yaml
+++ b/site/src/content/catalog/agentcore-push.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: agentcore-push
 github: https://github.com/minorun365/agentcore-push
-addedDate: 2026-08-04
+addedDate: 2026-05-14

--- a/site/src/content/catalog/agentcore-rl-toolkit.yaml
+++ b/site/src/content/catalog/agentcore-rl-toolkit.yaml
@@ -6,4 +6,4 @@ languages:
   python:
     package: agentcore-rl-toolkit
 github: https://github.com/awslabs/agentcore-rl-toolkit
-addedDate: 2026-08-04
+addedDate: 2026-01-08

--- a/site/src/content/catalog/agentcore-rl-toolkit.yaml
+++ b/site/src/content/catalog/agentcore-rl-toolkit.yaml
@@ -6,4 +6,4 @@ languages:
   python:
     package: agentcore-rl-toolkit
 github: https://github.com/awslabs/agentcore-rl-toolkit
-addedDate: 2026-07-19
+addedDate: 2026-08-04

--- a/site/src/content/catalog/agentcore-tool-search.yaml
+++ b/site/src/content/catalog/agentcore-tool-search.yaml
@@ -7,4 +7,4 @@ languages:
     package: bedrock-agentcore[strands-agents]
 github: https://github.com/aws/bedrock-agentcore-sdk-python
 docsPage: docs/integrations/plugins/agentcore-tool-search
-addedDate: 2026-01-01
+addedDate: 2026-06-05

--- a/site/src/content/catalog/amazon-bedrock.yaml
+++ b/site/src/content/catalog/amazon-bedrock.yaml
@@ -7,4 +7,4 @@ languages:
   typescript: {}
 github: https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/models/bedrock.py
 docsPage: docs/user-guide/concepts/model-providers/amazon-bedrock
-addedDate: 2025-12-01
+addedDate: 2025-05-16

--- a/site/src/content/catalog/amazon-sagemaker.yaml
+++ b/site/src/content/catalog/amazon-sagemaker.yaml
@@ -6,4 +6,4 @@ languages:
   python: {}
 github: https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/models/sagemaker.py
 docsPage: docs/user-guide/concepts/model-providers/sagemaker
-addedDate: 2025-12-01
+addedDate: 2025-07-28

--- a/site/src/content/catalog/anthropic.yaml
+++ b/site/src/content/catalog/anthropic.yaml
@@ -7,4 +7,4 @@ languages:
   typescript: {}
 github: https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/models/anthropic.py
 docsPage: docs/user-guide/concepts/model-providers/anthropic
-addedDate: 2025-12-01
+addedDate: 2025-05-16

--- a/site/src/content/catalog/bash.yaml
+++ b/site/src/content/catalog/bash.yaml
@@ -7,4 +7,4 @@ languages:
   typescript: {}
 github: https://github.com/strands-agents/harness-sdk/tree/main/strands-py/src/strands/vended_tools/shell
 docsPage: docs/user-guide/concepts/tools/vended-tools
-addedDate: 2025-12-01
+addedDate: 2025-11-12

--- a/site/src/content/catalog/bedrock-knowledge-base.yaml
+++ b/site/src/content/catalog/bedrock-knowledge-base.yaml
@@ -7,4 +7,4 @@ languages:
   typescript: {}
 github: https://github.com/strands-agents/harness-sdk/tree/main/strands-py/src/strands/vended_memory_stores/bedrock_knowledge_base
 docsPage: docs/user-guide/concepts/memory/bedrock-knowledge-base
-addedDate: 2025-12-01
+addedDate: 2026-06-09

--- a/site/src/content/catalog/cedar-authorization.yaml
+++ b/site/src/content/catalog/cedar-authorization.yaml
@@ -7,4 +7,4 @@ languages:
   typescript: {}
 github: https://github.com/strands-agents/harness-sdk/tree/main/strands-py/src/strands/vended_interventions/cedar
 docsPage: docs/user-guide/concepts/agents/interventions/cedar-authorization
-addedDate: 2025-12-01
+addedDate: 2026-06-15

--- a/site/src/content/catalog/clawskills-strands.yaml
+++ b/site/src/content/catalog/clawskills-strands.yaml
@@ -5,4 +5,4 @@ languages:
   typescript:
     package: "clawskills-strands"
 github: https://github.com/Vivek0712/clawskills-strands
-addedDate: 2026-07-18
+addedDate: 2026-08-04

--- a/site/src/content/catalog/clawskills-strands.yaml
+++ b/site/src/content/catalog/clawskills-strands.yaml
@@ -5,4 +5,4 @@ languages:
   typescript:
     package: "clawskills-strands"
 github: https://github.com/Vivek0712/clawskills-strands
-addedDate: 2026-08-04
+addedDate: 2026-02-06

--- a/site/src/content/catalog/clova-studio.yaml
+++ b/site/src/content/catalog/clova-studio.yaml
@@ -6,4 +6,4 @@ languages:
     package: strands-clova
 github: https://github.com/aidendef/strands-clova
 docsPage: docs/integrations/model-providers/clova-studio
-addedDate: 2026-01-01
+addedDate: 2025-09-30

--- a/site/src/content/catalog/cohere.yaml
+++ b/site/src/content/catalog/cohere.yaml
@@ -6,4 +6,4 @@ languages:
   python: {}
 github: https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/models/openai.py
 docsPage: docs/integrations/model-providers/cohere
-addedDate: 2026-01-01
+addedDate: 2025-07-09

--- a/site/src/content/catalog/coinbase-agentkit.yaml
+++ b/site/src/content/catalog/coinbase-agentkit.yaml
@@ -7,4 +7,4 @@ languages:
     package: coinbase-agentkit-strands-agents
 github: https://github.com/coinbase/agentkit
 docsUrl: https://github.com/coinbase/agentkit/tree/main/python/framework-extensions/strands-agents
-addedDate: 2026-08-04
+addedDate: 2025-08-01

--- a/site/src/content/catalog/coinbase-agentkit.yaml
+++ b/site/src/content/catalog/coinbase-agentkit.yaml
@@ -7,4 +7,4 @@ languages:
     package: coinbase-agentkit-strands-agents
 github: https://github.com/coinbase/agentkit
 docsUrl: https://github.com/coinbase/agentkit/tree/main/python/framework-extensions/strands-agents
-addedDate: 2026-07-19
+addedDate: 2026-08-04

--- a/site/src/content/catalog/context-injector.yaml
+++ b/site/src/content/catalog/context-injector.yaml
@@ -7,4 +7,4 @@ languages:
   typescript: {}
 github: https://github.com/strands-agents/harness-sdk/tree/main/strands-py/src/strands/vended_plugins/context_injector
 docsPage: docs/user-guide/concepts/plugins/context-injector
-addedDate: 2025-12-01
+addedDate: 2026-06-12

--- a/site/src/content/catalog/context-offloader.yaml
+++ b/site/src/content/catalog/context-offloader.yaml
@@ -7,4 +7,4 @@ languages:
   typescript: {}
 github: https://github.com/strands-agents/harness-sdk/tree/main/strands-py/src/strands/vended_plugins/context_offloader
 docsPage: docs/user-guide/concepts/plugins/context-offloader
-addedDate: 2025-12-01
+addedDate: 2026-04-24

--- a/site/src/content/catalog/crusoe.yaml
+++ b/site/src/content/catalog/crusoe.yaml
@@ -6,4 +6,4 @@ languages:
   python: {}
 github: https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/models/openai.py
 docsPage: docs/integrations/model-providers/crusoe
-addedDate: 2026-07-31
+addedDate: 2026-07-30

--- a/site/src/content/catalog/datadog-ai-guard.yaml
+++ b/site/src/content/catalog/datadog-ai-guard.yaml
@@ -7,4 +7,4 @@ languages:
     package: ddtrace
 github: https://github.com/DataDog/dd-trace-py
 docsPage: docs/integrations/plugins/datadog-ai-guard
-addedDate: 2026-01-01
+addedDate: 2026-03-11

--- a/site/src/content/catalog/file-editor.yaml
+++ b/site/src/content/catalog/file-editor.yaml
@@ -7,4 +7,4 @@ languages:
   typescript: {}
 github: https://github.com/strands-agents/harness-sdk/tree/main/strands-py/src/strands/vended_tools/file_editor
 docsPage: docs/user-guide/concepts/tools/vended-tools
-addedDate: 2025-12-01
+addedDate: 2025-11-10

--- a/site/src/content/catalog/file-session-manager.yaml
+++ b/site/src/content/catalog/file-session-manager.yaml
@@ -7,4 +7,4 @@ languages:
   typescript: {}
 github: https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/session/file_session_manager.py
 docsPage: docs/user-guide/concepts/agents/session-management
-addedDate: 2025-12-01
+addedDate: 2025-07-13

--- a/site/src/content/catalog/fireworksai.yaml
+++ b/site/src/content/catalog/fireworksai.yaml
@@ -6,4 +6,4 @@ languages:
   python: {}
 github: https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/models/openai.py
 docsPage: docs/integrations/model-providers/fireworksai
-addedDate: 2026-01-01
+addedDate: 2025-10-06

--- a/site/src/content/catalog/goal-loop.yaml
+++ b/site/src/content/catalog/goal-loop.yaml
@@ -7,4 +7,4 @@ languages:
   typescript: {}
 github: https://github.com/strands-agents/harness-sdk/tree/main/strands-py/src/strands/vended_plugins/goal
 docsPage: docs/user-guide/concepts/plugins/goal-loop
-addedDate: 2025-12-01
+addedDate: 2026-06-01

--- a/site/src/content/catalog/google-gemini.yaml
+++ b/site/src/content/catalog/google-gemini.yaml
@@ -7,4 +7,4 @@ languages:
   typescript: {}
 github: https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/models/gemini.py
 docsPage: docs/user-guide/concepts/model-providers/google
-addedDate: 2025-12-01
+addedDate: 2025-09-19

--- a/site/src/content/catalog/grantex.yaml
+++ b/site/src/content/catalog/grantex.yaml
@@ -5,4 +5,4 @@ languages:
   typescript:
     package: "@grantex/strands"
 github: https://github.com/mishrasanjeev/grantex
-addedDate: 2026-07-18
+addedDate: 2026-08-04

--- a/site/src/content/catalog/grantex.yaml
+++ b/site/src/content/catalog/grantex.yaml
@@ -5,4 +5,4 @@ languages:
   typescript:
     package: "@grantex/strands"
 github: https://github.com/mishrasanjeev/grantex
-addedDate: 2026-08-04
+addedDate: 2026-06-20

--- a/site/src/content/catalog/headroom.yaml
+++ b/site/src/content/catalog/headroom.yaml
@@ -7,4 +7,4 @@ languages:
     package: headroom-ai[strands]
 github: https://github.com/chopratejas/headroom
 docsUrl: https://headroom-docs.vercel.app/docs/strands
-addedDate: 2026-07-19
+addedDate: 2026-08-04

--- a/site/src/content/catalog/headroom.yaml
+++ b/site/src/content/catalog/headroom.yaml
@@ -7,4 +7,4 @@ languages:
     package: headroom-ai[strands]
 github: https://github.com/chopratejas/headroom
 docsUrl: https://headroom-docs.vercel.app/docs/strands
-addedDate: 2026-08-04
+addedDate: 2026-02-02

--- a/site/src/content/catalog/hiddenlayer-strands.yaml
+++ b/site/src/content/catalog/hiddenlayer-strands.yaml
@@ -6,4 +6,4 @@ languages:
   python:
     package: hiddenlayer-strands
 github: https://github.com/hiddenlayerai/hiddenlayer-strands
-addedDate: 2026-08-04
+addedDate: 2025-12-01

--- a/site/src/content/catalog/hiddenlayer-strands.yaml
+++ b/site/src/content/catalog/hiddenlayer-strands.yaml
@@ -6,4 +6,4 @@ languages:
   python:
     package: hiddenlayer-strands
 github: https://github.com/hiddenlayerai/hiddenlayer-strands
-addedDate: 2026-07-19
+addedDate: 2026-08-04

--- a/site/src/content/catalog/hindsight-strands.yaml
+++ b/site/src/content/catalog/hindsight-strands.yaml
@@ -7,4 +7,4 @@ languages:
     package: hindsight-strands
 github: https://github.com/vectorize-io/hindsight
 docsUrl: https://github.com/vectorize-io/hindsight/tree/main/hindsight-integrations/strands
-addedDate: 2026-08-04
+addedDate: 2026-03-24

--- a/site/src/content/catalog/hindsight-strands.yaml
+++ b/site/src/content/catalog/hindsight-strands.yaml
@@ -7,4 +7,4 @@ languages:
     package: hindsight-strands
 github: https://github.com/vectorize-io/hindsight
 docsUrl: https://github.com/vectorize-io/hindsight/tree/main/hindsight-integrations/strands
-addedDate: 2026-07-19
+addedDate: 2026-08-04

--- a/site/src/content/catalog/http-request.yaml
+++ b/site/src/content/catalog/http-request.yaml
@@ -7,4 +7,4 @@ languages:
   typescript: {}
 github: https://github.com/strands-agents/harness-sdk/tree/main/strands-py/src/strands/vended_tools/http_request
 docsPage: docs/user-guide/concepts/tools/vended-tools
-addedDate: 2025-12-01
+addedDate: 2025-11-28

--- a/site/src/content/catalog/human-in-the-loop.yaml
+++ b/site/src/content/catalog/human-in-the-loop.yaml
@@ -7,4 +7,4 @@ languages:
   typescript: {}
 github: https://github.com/strands-agents/harness-sdk/tree/main/strands-py/src/strands/vended_interventions/hitl
 docsPage: docs/user-guide/concepts/agents/interventions/human-in-the-loop
-addedDate: 2025-12-01
+addedDate: 2026-05-22

--- a/site/src/content/catalog/langfuse.yaml
+++ b/site/src/content/catalog/langfuse.yaml
@@ -6,4 +6,4 @@ languages:
   python: {}
 github: https://github.com/langfuse/langfuse
 docsUrl: https://langfuse.com/integrations/frameworks/strands-agents
-addedDate: 2026-07-21
+addedDate: 2025-05-16

--- a/site/src/content/catalog/litellm.yaml
+++ b/site/src/content/catalog/litellm.yaml
@@ -6,4 +6,4 @@ languages:
   python: {}
 github: https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/models/litellm.py
 docsPage: docs/user-guide/concepts/model-providers/litellm
-addedDate: 2025-12-01
+addedDate: 2025-05-16

--- a/site/src/content/catalog/llama-api.yaml
+++ b/site/src/content/catalog/llama-api.yaml
@@ -6,4 +6,4 @@ languages:
   python: {}
 github: https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/models/llamaapi.py
 docsPage: docs/user-guide/concepts/model-providers/llamaapi
-addedDate: 2025-12-01
+addedDate: 2025-05-16

--- a/site/src/content/catalog/llama-cpp.yaml
+++ b/site/src/content/catalog/llama-cpp.yaml
@@ -6,4 +6,4 @@ languages:
   python: {}
 github: https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/models/llamacpp.py
 docsPage: docs/user-guide/concepts/model-providers/llamacpp
-addedDate: 2025-12-01
+addedDate: 2025-09-10

--- a/site/src/content/catalog/llm-tracekit-strands.yaml
+++ b/site/src/content/catalog/llm-tracekit-strands.yaml
@@ -7,4 +7,4 @@ languages:
     package: llm-tracekit-strands
 github: https://github.com/coralogix/llm-tracekit
 docsUrl: https://www.coralogix.com/docs/integrations/ai-observability/strands/
-addedDate: 2026-07-19
+addedDate: 2026-08-04

--- a/site/src/content/catalog/llm-tracekit-strands.yaml
+++ b/site/src/content/catalog/llm-tracekit-strands.yaml
@@ -7,4 +7,4 @@ languages:
     package: llm-tracekit-strands
 github: https://github.com/coralogix/llm-tracekit
 docsUrl: https://www.coralogix.com/docs/integrations/ai-observability/strands/
-addedDate: 2026-08-04
+addedDate: 2026-03-19

--- a/site/src/content/catalog/mistral.yaml
+++ b/site/src/content/catalog/mistral.yaml
@@ -6,4 +6,4 @@ languages:
   python: {}
 github: https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/models/mistral.py
 docsPage: docs/user-guide/concepts/model-providers/mistral
-addedDate: 2025-12-01
+addedDate: 2025-06-27

--- a/site/src/content/catalog/mlx.yaml
+++ b/site/src/content/catalog/mlx.yaml
@@ -6,4 +6,4 @@ languages:
     package: strands-mlx
 github: https://github.com/cagataycali/strands-mlx
 docsPage: docs/integrations/model-providers/mlx
-addedDate: 2026-01-01
+addedDate: 2026-01-12

--- a/site/src/content/catalog/nebius-token-factory.yaml
+++ b/site/src/content/catalog/nebius-token-factory.yaml
@@ -6,4 +6,4 @@ languages:
   python: {}
 github: https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/models/openai.py
 docsPage: docs/integrations/model-providers/nebius-token-factory
-addedDate: 2026-01-01
+addedDate: 2026-01-02

--- a/site/src/content/catalog/notebook.yaml
+++ b/site/src/content/catalog/notebook.yaml
@@ -6,4 +6,4 @@ languages:
   typescript: {}
 github: https://github.com/strands-agents/harness-sdk/tree/main/strands-ts/src/vended-tools/notebook
 docsPage: docs/user-guide/concepts/tools/vended-tools
-addedDate: 2025-12-01
+addedDate: 2025-11-07

--- a/site/src/content/catalog/nvidia-nat-strands.yaml
+++ b/site/src/content/catalog/nvidia-nat-strands.yaml
@@ -7,4 +7,4 @@ languages:
     package: nvidia-nat-strands
 github: https://github.com/NVIDIA/NeMo-Agent-Toolkit
 docsUrl: https://docs.nvidia.com/nemo/agent-toolkit/latest/components/integrations/frameworks.html
-addedDate: 2026-07-19
+addedDate: 2026-08-04

--- a/site/src/content/catalog/nvidia-nat-strands.yaml
+++ b/site/src/content/catalog/nvidia-nat-strands.yaml
@@ -7,4 +7,4 @@ languages:
     package: nvidia-nat-strands
 github: https://github.com/NVIDIA/NeMo-Agent-Toolkit
 docsUrl: https://docs.nvidia.com/nemo/agent-toolkit/latest/components/integrations/frameworks.html
-addedDate: 2026-08-04
+addedDate: 2025-11-19

--- a/site/src/content/catalog/nvidia-nim.yaml
+++ b/site/src/content/catalog/nvidia-nim.yaml
@@ -6,4 +6,4 @@ languages:
     package: strands-nvidia-nim
 github: https://github.com/thiago4go/strands-nvidia-nim
 docsPage: docs/integrations/model-providers/nvidia-nim
-addedDate: 2026-01-01
+addedDate: 2026-01-12

--- a/site/src/content/catalog/ollama.yaml
+++ b/site/src/content/catalog/ollama.yaml
@@ -6,4 +6,4 @@ languages:
   python: {}
 github: https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/models/ollama.py
 docsPage: docs/user-guide/concepts/model-providers/ollama
-addedDate: 2025-12-01
+addedDate: 2025-05-16

--- a/site/src/content/catalog/openai-responses.yaml
+++ b/site/src/content/catalog/openai-responses.yaml
@@ -7,4 +7,4 @@ languages:
   typescript: {}
 github: https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/models/openai_responses.py
 docsPage: docs/user-guide/concepts/model-providers/openai-responses
-addedDate: 2025-12-01
+addedDate: 2026-03-04

--- a/site/src/content/catalog/openai.yaml
+++ b/site/src/content/catalog/openai.yaml
@@ -7,4 +7,4 @@ languages:
   typescript: {}
 github: https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/models/openai.py
 docsPage: docs/user-guide/concepts/model-providers/openai
-addedDate: 2025-12-01
+addedDate: 2025-05-22

--- a/site/src/content/catalog/openinference-instrumentation-strands-agents.yaml
+++ b/site/src/content/catalog/openinference-instrumentation-strands-agents.yaml
@@ -7,4 +7,4 @@ languages:
     package: openinference-instrumentation-strands-agents
 github: https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-strands-agents
 docsUrl: https://arize.com/docs/ax/integrations/python-agent-frameworks/aws
-addedDate: 2026-04-29
+addedDate: 2026-01-26

--- a/site/src/content/catalog/openinference-instrumentation-strands-agents.yaml
+++ b/site/src/content/catalog/openinference-instrumentation-strands-agents.yaml
@@ -7,4 +7,4 @@ languages:
     package: openinference-instrumentation-strands-agents
 github: https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-strands-agents
 docsUrl: https://arize.com/docs/ax/integrations/python-agent-frameworks/aws
-addedDate: 2026-07-21
+addedDate: 2026-04-29

--- a/site/src/content/catalog/ovhcloud-ai-endpoints.yaml
+++ b/site/src/content/catalog/ovhcloud-ai-endpoints.yaml
@@ -6,4 +6,4 @@ languages:
   python: {}
 github: https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/models/openai.py
 docsPage: docs/integrations/model-providers/ovhcloud-ai-endpoints
-addedDate: 2026-01-01
+addedDate: 2026-03-20

--- a/site/src/content/catalog/portkey.yaml
+++ b/site/src/content/catalog/portkey.yaml
@@ -6,4 +6,4 @@ languages:
   python: {}
 github: https://github.com/Portkey-AI/gateway
 docsUrl: https://portkey.ai/docs/integrations/agents/strands
-addedDate: 2026-08-04
+addedDate: 2025-05-27

--- a/site/src/content/catalog/portkey.yaml
+++ b/site/src/content/catalog/portkey.yaml
@@ -6,4 +6,4 @@ languages:
   python: {}
 github: https://github.com/Portkey-AI/gateway
 docsUrl: https://portkey.ai/docs/integrations/agents/strands
-addedDate: 2026-07-21
+addedDate: 2026-08-04

--- a/site/src/content/catalog/respan.yaml
+++ b/site/src/content/catalog/respan.yaml
@@ -6,4 +6,4 @@ languages:
   typescript:
     package: "@respan/instrumentation-strands-agents"
 github: https://github.com/respanai/respan
-addedDate: 2026-07-18
+addedDate: 2026-08-04

--- a/site/src/content/catalog/respan.yaml
+++ b/site/src/content/catalog/respan.yaml
@@ -6,4 +6,4 @@ languages:
   typescript:
     package: "@respan/instrumentation-strands-agents"
 github: https://github.com/respanai/respan
-addedDate: 2026-08-04
+addedDate: 2026-06-30

--- a/site/src/content/catalog/s3-session-manager.yaml
+++ b/site/src/content/catalog/s3-session-manager.yaml
@@ -7,4 +7,4 @@ languages:
   typescript: {}
 github: https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/session/s3_session_manager.py
 docsPage: docs/user-guide/concepts/agents/session-management
-addedDate: 2025-12-01
+addedDate: 2025-07-13

--- a/site/src/content/catalog/s3-vectors-memory.yaml
+++ b/site/src/content/catalog/s3-vectors-memory.yaml
@@ -8,4 +8,4 @@ languages:
 github: https://github.com/aws-samples/data-for-saas-patterns/tree/main/samples/multi-tenant-strands-s3-vectors-memory
 docsPage: docs/integrations/plugins/s3-vectors-memory
 featured: true
-addedDate: 2026-01-01
+addedDate: 2026-04-09

--- a/site/src/content/catalog/sglang.yaml
+++ b/site/src/content/catalog/sglang.yaml
@@ -6,4 +6,4 @@ languages:
     package: strands-sglang
 github: https://github.com/horizon-rl/strands-sglang
 docsPage: docs/integrations/model-providers/sglang
-addedDate: 2026-01-01
+addedDate: 2026-01-09

--- a/site/src/content/catalog/sigil-sdk-strands.yaml
+++ b/site/src/content/catalog/sigil-sdk-strands.yaml
@@ -6,4 +6,4 @@ languages:
   python:
     package: sigil-sdk-strands
 github: https://github.com/grafana/agento11y
-addedDate: 2026-08-04
+addedDate: 2026-04-29

--- a/site/src/content/catalog/sigil-sdk-strands.yaml
+++ b/site/src/content/catalog/sigil-sdk-strands.yaml
@@ -6,4 +6,4 @@ languages:
   python:
     package: sigil-sdk-strands
 github: https://github.com/grafana/agento11y
-addedDate: 2026-07-21
+addedDate: 2026-08-04

--- a/site/src/content/catalog/sleep.yaml
+++ b/site/src/content/catalog/sleep.yaml
@@ -7,4 +7,4 @@ languages:
   typescript: {}
 github: https://github.com/strands-agents/harness-sdk/tree/main/strands-py/src/strands/vended_tools/sleep
 docsPage: docs/user-guide/concepts/tools/vended-tools
-addedDate: 2025-12-01
+addedDate: 2026-07-23

--- a/site/src/content/catalog/steering.yaml
+++ b/site/src/content/catalog/steering.yaml
@@ -7,4 +7,4 @@ languages:
   typescript: {}
 github: https://github.com/strands-agents/harness-sdk/tree/main/strands-py/src/strands/vended_plugins/steering
 docsPage: docs/user-guide/concepts/agents/interventions/steering
-addedDate: 2025-12-01
+addedDate: 2025-12-03

--- a/site/src/content/catalog/strands-acp.yaml
+++ b/site/src/content/catalog/strands-acp.yaml
@@ -6,4 +6,4 @@ languages:
     package: "@ryancormack/strands-acp"
 github: https://github.com/ryancormack/strands-acp
 featured: true
-addedDate: 2026-08-04
+addedDate: 2026-05-21

--- a/site/src/content/catalog/strands-acp.yaml
+++ b/site/src/content/catalog/strands-acp.yaml
@@ -6,4 +6,4 @@ languages:
     package: "@ryancormack/strands-acp"
 github: https://github.com/ryancormack/strands-acp
 featured: true
-addedDate: 2026-07-18
+addedDate: 2026-08-04

--- a/site/src/content/catalog/strands-adb.yaml
+++ b/site/src/content/catalog/strands-adb.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-adb
 github: https://github.com/cagataycali/strands-adb
-addedDate: 2026-07-19
+addedDate: 2026-08-04

--- a/site/src/content/catalog/strands-adb.yaml
+++ b/site/src/content/catalog/strands-adb.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-adb
 github: https://github.com/cagataycali/strands-adb
-addedDate: 2026-08-04
+addedDate: 2026-04-27

--- a/site/src/content/catalog/strands-agentcore-tools.yaml
+++ b/site/src/content/catalog/strands-agentcore-tools.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-agentcore-tools
 github: https://github.com/cagataycali/strands-agentcore-tools
-addedDate: 2026-08-04
+addedDate: 2025-10-25

--- a/site/src/content/catalog/strands-agentcore-tools.yaml
+++ b/site/src/content/catalog/strands-agentcore-tools.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-agentcore-tools
 github: https://github.com/cagataycali/strands-agentcore-tools
-addedDate: 2026-07-21
+addedDate: 2026-08-04

--- a/site/src/content/catalog/strands-agt.yaml
+++ b/site/src/content/catalog/strands-agt.yaml
@@ -6,4 +6,4 @@ languages:
     package: strands-agt
 github: https://github.com/lizradway/strands-agt
 docsPage: docs/integrations/interventions/strands-agt
-addedDate: 2026-01-01
+addedDate: 2026-07-15

--- a/site/src/content/catalog/strands-apify.yaml
+++ b/site/src/content/catalog/strands-apify.yaml
@@ -7,4 +7,4 @@ languages:
     package: strands-apify
 github: https://github.com/apify/strands-apify
 docsPage: docs/integrations/tools/strands-apify
-addedDate: 2026-01-01
+addedDate: 2026-07-09

--- a/site/src/content/catalog/strands-arise.yaml
+++ b/site/src/content/catalog/strands-arise.yaml
@@ -6,4 +6,4 @@ languages:
     package: strands-arise
 github: https://github.com/abekek/strands-arise
 docsUrl: https://arise-ai.dev
-addedDate: 2026-08-04
+addedDate: 2026-03-29

--- a/site/src/content/catalog/strands-arise.yaml
+++ b/site/src/content/catalog/strands-arise.yaml
@@ -6,4 +6,4 @@ languages:
     package: strands-arise
 github: https://github.com/abekek/strands-arise
 docsUrl: https://arise-ai.dev
-addedDate: 2026-07-19
+addedDate: 2026-08-04

--- a/site/src/content/catalog/strands-bitchat.yaml
+++ b/site/src/content/catalog/strands-bitchat.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-bitchat
 github: https://github.com/cagataycali/strands-bitchat
-addedDate: 2026-08-04
+addedDate: 2025-08-18

--- a/site/src/content/catalog/strands-bitchat.yaml
+++ b/site/src/content/catalog/strands-bitchat.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-bitchat
 github: https://github.com/cagataycali/strands-bitchat
-addedDate: 2026-07-21
+addedDate: 2026-08-04

--- a/site/src/content/catalog/strands-ccxt.yaml
+++ b/site/src/content/catalog/strands-ccxt.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-ccxt
 github: https://github.com/mertozbas/strands-ccxt
-addedDate: 2026-08-04
+addedDate: 2026-01-18

--- a/site/src/content/catalog/strands-ccxt.yaml
+++ b/site/src/content/catalog/strands-ccxt.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-ccxt
 github: https://github.com/mertozbas/strands-ccxt
-addedDate: 2026-07-21
+addedDate: 2026-08-04

--- a/site/src/content/catalog/strands-cloudflare.yaml
+++ b/site/src/content/catalog/strands-cloudflare.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-cloudflare
 github: https://github.com/mertozbas/strands-cloudflare
-addedDate: 2026-08-04
+addedDate: 2026-01-20

--- a/site/src/content/catalog/strands-cloudflare.yaml
+++ b/site/src/content/catalog/strands-cloudflare.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-cloudflare
 github: https://github.com/mertozbas/strands-cloudflare
-addedDate: 2026-07-21
+addedDate: 2026-08-04

--- a/site/src/content/catalog/strands-code-agent.yaml
+++ b/site/src/content/catalog/strands-code-agent.yaml
@@ -7,4 +7,4 @@ languages:
     package: strands-code-agent
 github: https://github.com/aws-samples/sample-strands-code-agent
 docsPage: docs/integrations/agent-extensions/strands-code-agent
-addedDate: 2026-01-01
+addedDate: 2026-05-15

--- a/site/src/content/catalog/strands-compose-agentcore.yaml
+++ b/site/src/content/catalog/strands-compose-agentcore.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-compose-agentcore
 github: https://github.com/strands-compose/bedrock-agentcore
-addedDate: 2026-07-19
+addedDate: 2026-08-04

--- a/site/src/content/catalog/strands-compose-agentcore.yaml
+++ b/site/src/content/catalog/strands-compose-agentcore.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-compose-agentcore
 github: https://github.com/strands-compose/bedrock-agentcore
-addedDate: 2026-08-04
+addedDate: 2026-04-12

--- a/site/src/content/catalog/strands-cosmos.yaml
+++ b/site/src/content/catalog/strands-cosmos.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-cosmos
 github: https://github.com/cagataycali/strands-cosmos
-addedDate: 2026-08-04
+addedDate: 2026-03-09

--- a/site/src/content/catalog/strands-cosmos.yaml
+++ b/site/src/content/catalog/strands-cosmos.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-cosmos
 github: https://github.com/cagataycali/strands-cosmos
-addedDate: 2026-07-19
+addedDate: 2026-08-04

--- a/site/src/content/catalog/strands-dakera.yaml
+++ b/site/src/content/catalog/strands-dakera.yaml
@@ -7,4 +7,4 @@ languages:
     package: strands-dakera
 github: https://github.com/dakera-ai/strands-dakera
 docsPage: docs/integrations/memory-stores/strands-dakera
-addedDate: 2026-07-23
+addedDate: 2026-07-22

--- a/site/src/content/catalog/strands-deepgram.yaml
+++ b/site/src/content/catalog/strands-deepgram.yaml
@@ -6,4 +6,4 @@ languages:
     package: strands-deepgram
 github: https://github.com/eraykeskinmac/strands-deepgram
 docsPage: docs/integrations/tools/strands-deepgram
-addedDate: 2026-01-01
+addedDate: 2025-12-05

--- a/site/src/content/catalog/strands-erc8004.yaml
+++ b/site/src/content/catalog/strands-erc8004.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-erc8004
 github: https://github.com/cagataycali/strands-erc8004
-addedDate: 2026-07-21
+addedDate: 2026-08-04

--- a/site/src/content/catalog/strands-erc8004.yaml
+++ b/site/src/content/catalog/strands-erc8004.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-erc8004
 github: https://github.com/cagataycali/strands-erc8004
-addedDate: 2026-08-04
+addedDate: 2026-02-10

--- a/site/src/content/catalog/strands-fun-tools.yaml
+++ b/site/src/content/catalog/strands-fun-tools.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-fun-tools
 github: https://github.com/cagataycali/strands-fun-tools
-addedDate: 2026-07-19
+addedDate: 2026-08-04

--- a/site/src/content/catalog/strands-fun-tools.yaml
+++ b/site/src/content/catalog/strands-fun-tools.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-fun-tools
 github: https://github.com/cagataycali/strands-fun-tools
-addedDate: 2026-08-04
+addedDate: 2025-10-26

--- a/site/src/content/catalog/strands-google.yaml
+++ b/site/src/content/catalog/strands-google.yaml
@@ -6,4 +6,4 @@ languages:
     package: strands-google
 github: https://github.com/cagataycali/strands-google
 docsPage: docs/integrations/tools/strands-google
-addedDate: 2026-01-01
+addedDate: 2026-03-26

--- a/site/src/content/catalog/strands-hackerone.yaml
+++ b/site/src/content/catalog/strands-hackerone.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-hackerone
 github: https://github.com/cagataycali/strands-hackerone
-addedDate: 2026-08-04
+addedDate: 2026-01-07

--- a/site/src/content/catalog/strands-hackerone.yaml
+++ b/site/src/content/catalog/strands-hackerone.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-hackerone
 github: https://github.com/cagataycali/strands-hackerone
-addedDate: 2026-07-21
+addedDate: 2026-08-04

--- a/site/src/content/catalog/strands-hubspot.yaml
+++ b/site/src/content/catalog/strands-hubspot.yaml
@@ -6,4 +6,4 @@ languages:
     package: strands-hubspot
 github: https://github.com/eraykeskinmac/strands-hubspot
 docsPage: docs/integrations/tools/strands-hubspot
-addedDate: 2026-01-01
+addedDate: 2025-12-05

--- a/site/src/content/catalog/strands-mcp-server.yaml
+++ b/site/src/content/catalog/strands-mcp-server.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-mcp-server
 github: https://github.com/cagataycali/strands-mcp-server
-addedDate: 2026-07-19
+addedDate: 2026-08-04

--- a/site/src/content/catalog/strands-mcp-server.yaml
+++ b/site/src/content/catalog/strands-mcp-server.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-mcp-server
 github: https://github.com/cagataycali/strands-mcp-server
-addedDate: 2026-08-04
+addedDate: 2025-11-11

--- a/site/src/content/catalog/strands-osmo.yaml
+++ b/site/src/content/catalog/strands-osmo.yaml
@@ -6,4 +6,4 @@ languages:
     package: strands-osmo
 github: https://github.com/cagataycali/strands-osmo
 docsUrl: https://cagataycali.github.io/strands-osmo/
-addedDate: 2026-07-19
+addedDate: 2026-08-04

--- a/site/src/content/catalog/strands-osmo.yaml
+++ b/site/src/content/catalog/strands-osmo.yaml
@@ -6,4 +6,4 @@ languages:
     package: strands-osmo
 github: https://github.com/cagataycali/strands-osmo
 docsUrl: https://cagataycali.github.io/strands-osmo/
-addedDate: 2026-08-04
+addedDate: 2026-05-14

--- a/site/src/content/catalog/strands-pack.yaml
+++ b/site/src/content/catalog/strands-pack.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-pack
 github: https://github.com/labeveryday/strands-pack
-addedDate: 2026-08-04
+addedDate: 2026-02-23

--- a/site/src/content/catalog/strands-pack.yaml
+++ b/site/src/content/catalog/strands-pack.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-pack
 github: https://github.com/labeveryday/strands-pack
-addedDate: 2026-07-19
+addedDate: 2026-08-04

--- a/site/src/content/catalog/strands-perplexity.yaml
+++ b/site/src/content/catalog/strands-perplexity.yaml
@@ -6,4 +6,4 @@ languages:
     package: strands-perplexity
 github: https://github.com/mkmeral/strands-perplexity
 docsPage: docs/integrations/tools/strands-perplexity
-addedDate: 2026-01-01
+addedDate: 2026-03-26

--- a/site/src/content/catalog/strands-postgresql-session-manager.yaml
+++ b/site/src/content/catalog/strands-postgresql-session-manager.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-postgresql-session-manager
 github: https://github.com/macuartin/strands-postgresql-session-manager
-addedDate: 2026-08-04
+addedDate: 2025-12-02

--- a/site/src/content/catalog/strands-postgresql-session-manager.yaml
+++ b/site/src/content/catalog/strands-postgresql-session-manager.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-postgresql-session-manager
 github: https://github.com/macuartin/strands-postgresql-session-manager
-addedDate: 2026-07-19
+addedDate: 2026-08-04

--- a/site/src/content/catalog/strands-redis-session-manager.yaml
+++ b/site/src/content/catalog/strands-redis-session-manager.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-redis-session-manager
 github: https://github.com/lekhnath/strands-redis-session-manager
-addedDate: 2026-07-27
+addedDate: 2026-08-04

--- a/site/src/content/catalog/strands-redis-session-manager.yaml
+++ b/site/src/content/catalog/strands-redis-session-manager.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-redis-session-manager
 github: https://github.com/lekhnath/strands-redis-session-manager
-addedDate: 2026-08-04
+addedDate: 2025-11-16

--- a/site/src/content/catalog/strands-rendercv.yaml
+++ b/site/src/content/catalog/strands-rendercv.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-rendercv
 github: https://github.com/cagataycali/strands-rendercv
-addedDate: 2026-08-04
+addedDate: 2026-01-07

--- a/site/src/content/catalog/strands-rendercv.yaml
+++ b/site/src/content/catalog/strands-rendercv.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-rendercv
 github: https://github.com/cagataycali/strands-rendercv
-addedDate: 2026-07-19
+addedDate: 2026-08-04

--- a/site/src/content/catalog/strands-robots.yaml
+++ b/site/src/content/catalog/strands-robots.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-robots
 github: https://github.com/cagataycali/strands-robots
-addedDate: 2026-07-21
+addedDate: 2026-02-24

--- a/site/src/content/catalog/strands-sapiens.yaml
+++ b/site/src/content/catalog/strands-sapiens.yaml
@@ -6,4 +6,4 @@ languages:
     package: strands-sapiens
 github: https://github.com/cagataycali/strands-sapiens
 docsUrl: https://cagataycali.github.io/strands-sapiens/
-addedDate: 2026-07-19
+addedDate: 2026-08-04

--- a/site/src/content/catalog/strands-sapiens.yaml
+++ b/site/src/content/catalog/strands-sapiens.yaml
@@ -6,4 +6,4 @@ languages:
     package: strands-sapiens
 github: https://github.com/cagataycali/strands-sapiens
 docsUrl: https://cagataycali.github.io/strands-sapiens/
-addedDate: 2026-08-04
+addedDate: 2026-05-04

--- a/site/src/content/catalog/strands-spraay.yaml
+++ b/site/src/content/catalog/strands-spraay.yaml
@@ -6,4 +6,4 @@ languages:
     package: strands-agents-spraay
 github: https://github.com/plagtech/strands-agents-spraay
 docsPage: docs/integrations/tools/strands-spraay
-addedDate: 2026-01-01
+addedDate: 2026-05-14

--- a/site/src/content/catalog/strands-sql.yaml
+++ b/site/src/content/catalog/strands-sql.yaml
@@ -6,4 +6,4 @@ languages:
     package: strands-sql
 github: https://github.com/NithiN-1808/strands-sql
 docsPage: docs/integrations/tools/strands-sql
-addedDate: 2026-01-01
+addedDate: 2026-04-11

--- a/site/src/content/catalog/strands-swarms.yaml
+++ b/site/src/content/catalog/strands-swarms.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-swarms
 github: https://github.com/JackXu0/strands-swarms
-addedDate: 2026-07-19
+addedDate: 2026-08-04

--- a/site/src/content/catalog/strands-swarms.yaml
+++ b/site/src/content/catalog/strands-swarms.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-swarms
 github: https://github.com/JackXu0/strands-swarms
-addedDate: 2026-08-04
+addedDate: 2026-01-29

--- a/site/src/content/catalog/strands-teams.yaml
+++ b/site/src/content/catalog/strands-teams.yaml
@@ -6,4 +6,4 @@ languages:
     package: strands-teams
 github: https://github.com/eraykeskinmac/strands-teams
 docsPage: docs/integrations/tools/strands-teams
-addedDate: 2026-01-01
+addedDate: 2025-12-05

--- a/site/src/content/catalog/strands-telegram-listener.yaml
+++ b/site/src/content/catalog/strands-telegram-listener.yaml
@@ -6,4 +6,4 @@ languages:
     package: strands-telegram-listener
 github: https://github.com/eraykeskinmac/strands-telegram-listener
 docsPage: docs/integrations/tools/strands-telegram-listener
-addedDate: 2026-01-01
+addedDate: 2025-12-05

--- a/site/src/content/catalog/strands-telegram.yaml
+++ b/site/src/content/catalog/strands-telegram.yaml
@@ -6,4 +6,4 @@ languages:
     package: strands-telegram
 github: https://github.com/eraykeskinmac/strands-telegram
 docsPage: docs/integrations/tools/strands-telegram
-addedDate: 2026-01-01
+addedDate: 2025-12-05

--- a/site/src/content/catalog/strands-token-telemetry.yaml
+++ b/site/src/content/catalog/strands-token-telemetry.yaml
@@ -6,4 +6,4 @@ languages:
   python:
     package: strands-token-telemetry
 github: https://github.com/flockcover/strands-token-telemetry
-addedDate: 2026-07-19
+addedDate: 2026-08-04

--- a/site/src/content/catalog/strands-token-telemetry.yaml
+++ b/site/src/content/catalog/strands-token-telemetry.yaml
@@ -6,4 +6,4 @@ languages:
   python:
     package: strands-token-telemetry
 github: https://github.com/flockcover/strands-token-telemetry
-addedDate: 2026-08-04
+addedDate: 2026-02-20

--- a/site/src/content/catalog/strands-transformers.yaml
+++ b/site/src/content/catalog/strands-transformers.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-transformers
 github: https://github.com/cagataycali/strands-transformers
-addedDate: 2026-08-04
+addedDate: 2026-06-14

--- a/site/src/content/catalog/strands-transformers.yaml
+++ b/site/src/content/catalog/strands-transformers.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: strands-transformers
 github: https://github.com/cagataycali/strands-transformers
-addedDate: 2026-07-21
+addedDate: 2026-08-04

--- a/site/src/content/catalog/strands-valkey-session-manager.yaml
+++ b/site/src/content/catalog/strands-valkey-session-manager.yaml
@@ -6,4 +6,4 @@ languages:
     package: strands-valkey-session-manager
 github: https://github.com/jeromevdl/strands-valkey-session-manager
 docsPage: docs/integrations/session-managers/strands-valkey-session-manager
-addedDate: 2026-01-01
+addedDate: 2025-11-17

--- a/site/src/content/catalog/supabase-strands.yaml
+++ b/site/src/content/catalog/supabase-strands.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: supabase-strands
 github: https://github.com/siddharthkrish/strands-supabase-session-manager
-addedDate: 2026-07-19
+addedDate: 2026-08-04

--- a/site/src/content/catalog/supabase-strands.yaml
+++ b/site/src/content/catalog/supabase-strands.yaml
@@ -5,4 +5,4 @@ languages:
   python:
     package: supabase-strands
 github: https://github.com/siddharthkrish/strands-supabase-session-manager
-addedDate: 2026-08-04
+addedDate: 2026-02-25

--- a/site/src/content/catalog/temporal.yaml
+++ b/site/src/content/catalog/temporal.yaml
@@ -7,4 +7,4 @@ languages:
     package: temporalio[strands-agents]
 github: https://github.com/temporalio/sdk-python
 docsUrl: https://docs.temporal.io/develop/python/integrations/strands-agents
-addedDate: 2026-08-04
+addedDate: 2026-06-01

--- a/site/src/content/catalog/temporal.yaml
+++ b/site/src/content/catalog/temporal.yaml
@@ -7,4 +7,4 @@ languages:
     package: temporalio[strands-agents]
 github: https://github.com/temporalio/sdk-python
 docsUrl: https://docs.temporal.io/develop/python/integrations/strands-agents
-addedDate: 2026-07-19
+addedDate: 2026-08-04

--- a/site/src/content/catalog/traceai.yaml
+++ b/site/src/content/catalog/traceai.yaml
@@ -6,4 +6,4 @@ languages:
   typescript:
     package: "@traceai/strands"
 github: https://github.com/future-agi/traceAI
-addedDate: 2026-08-04
+addedDate: 2026-03-10

--- a/site/src/content/catalog/traceai.yaml
+++ b/site/src/content/catalog/traceai.yaml
@@ -6,4 +6,4 @@ languages:
   typescript:
     package: "@traceai/strands"
 github: https://github.com/future-agi/traceAI
-addedDate: 2026-07-18
+addedDate: 2026-08-04

--- a/site/src/content/catalog/utcp.yaml
+++ b/site/src/content/catalog/utcp.yaml
@@ -7,4 +7,4 @@ languages:
     package: strands-utcp
 github: https://github.com/universal-tool-calling-protocol/python-utcp
 docsPage: docs/integrations/tools/utcp
-addedDate: 2026-01-01
+addedDate: 2025-10-08

--- a/site/src/content/catalog/valyu-agentcore.yaml
+++ b/site/src/content/catalog/valyu-agentcore.yaml
@@ -7,4 +7,4 @@ languages:
     package: valyu-agentcore
 github: https://github.com/valyu-network/valyu-agentcore
 docsUrl: https://docs.valyu.ai/integrations/aws-agentcore
-addedDate: 2026-08-04
+addedDate: 2025-12-04

--- a/site/src/content/catalog/valyu-agentcore.yaml
+++ b/site/src/content/catalog/valyu-agentcore.yaml
@@ -7,4 +7,4 @@ languages:
     package: valyu-agentcore
 github: https://github.com/valyu-network/valyu-agentcore
 docsUrl: https://docs.valyu.ai/integrations/aws-agentcore
-addedDate: 2026-07-19
+addedDate: 2026-08-04

--- a/site/src/content/catalog/vercel-ai.yaml
+++ b/site/src/content/catalog/vercel-ai.yaml
@@ -6,4 +6,4 @@ languages:
   typescript: {}
 github: https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/models/vercel.ts
 docsPage: docs/user-guide/concepts/model-providers/vercel
-addedDate: 2025-12-01
+addedDate: 2026-03-27

--- a/site/src/content/catalog/vllm.yaml
+++ b/site/src/content/catalog/vllm.yaml
@@ -6,4 +6,4 @@ languages:
     package: strands-vllm
 github: https://github.com/agents-community/strands-vllm
 docsPage: docs/integrations/model-providers/vllm
-addedDate: 2026-01-01
+addedDate: 2026-01-23

--- a/site/src/content/catalog/writer.yaml
+++ b/site/src/content/catalog/writer.yaml
@@ -6,4 +6,4 @@ languages:
   python: {}
 github: https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/models/writer.py
 docsPage: docs/user-guide/concepts/model-providers/writer
-addedDate: 2025-12-01
+addedDate: 2025-07-09

--- a/site/src/content/catalog/xai.yaml
+++ b/site/src/content/catalog/xai.yaml
@@ -6,4 +6,4 @@ languages:
     package: strands-xai
 github: https://github.com/Cerrix/strands-xai
 docsPage: docs/integrations/model-providers/xai
-addedDate: 2026-01-01
+addedDate: 2026-02-03


### PR DESCRIPTION
## Description

The catalog backfills (#3416, #3766) set `addedDate` on entries to placeholder values: `2025-12-01` and `2026-01-01` for the built-in and pre-existing integrations, and July 2026 drafting dates for the rest. The July dates fall inside the 30-day `NEW_BADGE_DAYS` window, so ~40 integrations that are months or a year old currently render with a "New" badge on the integrations pages, and the catalog's date-based sorting is wrong for everything backfilled.

This corrects `addedDate` on 105 entries to the date the integration actually became available for Strands:

- Built-in SDK integrations: the first commit of the backing source in either SDK, whichever shipped first (several Python entries are ports of earlier TypeScript originals, e.g. the vended tools and interventions).
- Community integrations with a docs page in this repo: the first commit of that page (`git log --follow`), which traces cleanly through the docs conversion and monorepo moves.
- External packages with no docs page: the date the package first shipped Strands support, taken from the first PyPI/npm release of the Strands package or subpackage, or for vendor products (Temporal, Portkey, Coinbase AgentKit, headroom) the earliest commit or release that added Strands support upstream.

With this, the "New" section is left with only the ten entries genuinely added in the last 30 days.

Entries added organically after the catalog shipped (welt, stigmer, zep, neo4j, github-storage, dynamodb-storage) are untouched.

## Related Issues

N/A

## Documentation PR

Site-only change; no doc content changes.

## Type of Change

Bug fix

## Testing

Ran `bash .agents/skills/pre-push/run-checks.sh` (all local checks pass, including `astro sync` content-collection validation and the site test suite, which compares catalog collections against files on disk). Spot-verified a sample of traced dates by hand against `git log` and the PyPI API.

Dates worth a second look:

- `portkey`: dated 2025-05-27 from Portkey's gateway docs adding a Strands page; their dedicated Python SDK integration landed 2025-08-27. Pick the later one if the SDK integration is what the entry represents.
- `headroom`: Strands code merged upstream 2026-01-31, first release carrying the `strands` extra shipped 2026-02-02; dated by the release.
- `strands-robots`: dated 2026-02-24 from the old `docs/labs/robots.md` page, which documents the identical PyPI package `strands-robots` but links `strands-labs/robots` rather than the current `cagataycali/strands-robots` (repo appears to have moved).

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
