### PR TITLE
style(python): apply ruff formatting

### DIFF
--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -106,7 +106,7 @@ class BedrockModel(Model):
             cache_prompt: Cache point type for the system prompt (deprecated, use cache_config)
             cache_config: Configuration for prompt caching. Use CacheConfig(strategy="auto") for automatic caching.
             cache_tools: Cache point type for tools. Pass a string (e.g. "default") to cache the tools with
-                no explicit TTL, or a CacheToolsConfig instance to set both type and TTL (e.g. "1h"). Inherits 
+                no explicit TTL, or a CacheToolsConfig instance to set both type and TTL (e.g. "1h"). Inherits
                 cache_config.ttl if specified, otherwise it takes the Bedrock default.
             guardrail_id: ID of the guardrail to apply
             guardrail_trace: Guardrail trace mode. Defaults to enabled.

--- a/strands-py/src/strands/models/writer.py
+++ b/strands-py/src/strands/models/writer.py
@@ -150,8 +150,9 @@ class WriterModel(Model):
 
         content_blocks = list(
             filter(
-                lambda content: content.get("text")
-                and not any(block_type in content for block_type in ["toolResult", "toolUse"]),
+                lambda content: (
+                    content.get("text") and not any(block_type in content for block_type in ["toolResult", "toolUse"])
+                ),
                 contents,
             )
         )

--- a/strands-py/src/strands/session/file_session_manager.py
+++ b/strands-py/src/strands/session/file_session_manager.py
@@ -121,8 +121,7 @@ class FileSessionManager(RepositorySessionManager, SessionRepository):
         # Refuse to read through symlinks (prevents session data injection)
         if os.path.islink(path):
             raise SessionException(
-                f"Refusing to read symlink at {path}. "
-                "This may indicate a symlink attack or session tampering."
+                f"Refusing to read symlink at {path}. This may indicate a symlink attack or session tampering."
             )
         try:
             with open(path, encoding="utf-8") as f:
@@ -141,10 +140,7 @@ class FileSessionManager(RepositorySessionManager, SessionRepository):
 
         # Refuse to write if the target path is a symlink (prevents symlink attacks)
         if os.path.islink(path):
-            raise SessionException(
-                f"Refusing to write to symlink at {path}. "
-                "This may indicate a symlink attack."
-            )
+            raise SessionException(f"Refusing to write to symlink at {path}. This may indicate a symlink attack.")
 
         # Use mkstemp for unpredictable temp file name in the same directory
         fd, tmp_path = tempfile.mkstemp(dir=dir_path, prefix=".strands_", suffix=".tmp")
@@ -159,7 +155,6 @@ class FileSessionManager(RepositorySessionManager, SessionRepository):
             except OSError:
                 pass
             raise
-
 
     def create_session(self, session: Session, **kwargs: Any) -> Session:
         """Create a new session."""

--- a/strands-py/src/strands/session/repository_session_manager.py
+++ b/strands-py/src/strands/session/repository_session_manager.py
@@ -295,9 +295,7 @@ class RepositorySessionManager(SessionManager):
 
         for index in reversed(tool_use_indices):
             message = messages[index]
-            tool_use_ids = [
-                content["toolUse"]["toolUseId"] for content in message["content"] if "toolUse" in content
-            ]
+            tool_use_ids = [content["toolUse"]["toolUseId"] for content in message["content"] if "toolUse" in content]
 
             next_message = messages[index + 1]
             next_content = next_message["content"]

--- a/strands-py/src/strands/storage/local_file_storage.py
+++ b/strands-py/src/strands/storage/local_file_storage.py
@@ -250,5 +250,3 @@ class LocalFileStorage:
             else:
                 rel = os.path.relpath(str(full_path), self._base_dir)
                 keys.append(rel.replace(os.sep, "/"))
-
-

--- a/strands-py/src/strands/vended_interventions/hitl/classifier.py
+++ b/strands-py/src/strands/vended_interventions/hitl/classifier.py
@@ -124,9 +124,7 @@ def _create_llm_risk_classifier(config: LLMClassifierConfig | None = None) -> Hu
         result = await inner.invoke_async(prompt, structured_output_model=_RiskDecision)
         decision = result.structured_output
         if not isinstance(decision, _RiskDecision):
-            raise ValueError(
-                f"LLM risk classifier produced no structured output (stop_reason={result.stop_reason!r})"
-            )
+            raise ValueError(f"LLM risk classifier produced no structured output (stop_reason={result.stop_reason!r})")
 
         return ClassifierResult(
             requires_human_in_the_loop=decision.requires_approval,

--- a/strands-py/src/strands/vended_interventions/hitl/hitl.py
+++ b/strands-py/src/strands/vended_interventions/hitl/hitl.py
@@ -180,9 +180,7 @@ class HumanInTheLoop(InterventionHandler):
         self._allowed_tools = set(allowed_tools or [])
         self._classifier = self._resolve_classifier(classifier)
         if self._classifier and "*" in self._allowed_tools:
-            logger.warning(
-                "classifier has no effect when allowed_tools contains '*' — all tools are already allowed"
-            )
+            logger.warning("classifier has no effect when allowed_tools contains '*' — all tools are already allowed")
         self._classified_tool_use_ids: set[str] = set()
         self._enable_trust = enable_trust
         self._evaluate_trust = evaluate_trust if evaluate_trust is not None else self._is_trust_response

--- a/strands-py/src/strands/vended_plugins/context_offloader/search.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/search.py
@@ -146,9 +146,7 @@ def _search_by_pattern(
     return f"{header}\n\n{truncated_body}"
 
 
-def _search_by_line_range(
-    lines: list[str], start: int, end: int, total_lines: int, max_chars: int
-) -> str:
+def _search_by_line_range(lines: list[str], start: int, end: int, total_lines: int, max_chars: int) -> str:
     """Format a contiguous range of lines with truncation."""
     indices = list(range(start, end + 1))
     header = f"[Lines {start + 1}-{end + 1} of {total_lines}]"

--- a/strands-py/src/strands/vended_tools/http_request/http_request.py
+++ b/strands-py/src/strands/vended_tools/http_request/http_request.py
@@ -101,6 +101,7 @@ http_request = make_http_request()
 
 # ---- Internals ----
 
+
 def _resolve_timeout(
     model_timeout: float | None,
     client: httpx.AsyncClient | None,
@@ -188,9 +189,7 @@ async def _perform_request(
 
             if response.status_code >= 400:
                 await response.aclose()
-                raise HttpRequestError(
-                    f"HTTP {response.status_code} {response.reason_phrase}: {method} {url}"
-                )
+                raise HttpRequestError(f"HTTP {response.status_code} {response.reason_phrase}: {method} {url}")
 
             body_text = await _read_body(response, cancel_signal)
         finally:

--- a/strands-py/tests/strands/models/test_anthropic.py
+++ b/strands-py/tests/strands/models/test_anthropic.py
@@ -2087,9 +2087,7 @@ class TestPromptCaching:
 
     def test_dynamic_trailing_blocks_covers_every_block_of_a_multi_block_tail(self, model):
         model.update_config(cache_config=CacheConfig(strategy="auto"))
-        messages = [
-            {"role": "user", "content": [{"text": "durable ask"}, {"text": "injected"}, {"text": "status"}]}
-        ]
+        messages = [{"role": "user", "content": [{"text": "durable ask"}, {"text": "injected"}, {"text": "status"}]}]
 
         request = model.format_request(messages, dynamic_trailing_blocks=2)
 

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -3344,9 +3344,7 @@ def test_cache_strategy_auto_maps_claude_to_anthropic(bedrock_client):
     )
     assert model._cache_strategy == "anthropic"
 
-    model2 = BedrockModel(
-        model_id="anthropic.claude-3-haiku-20240307-v1:0", cache_config=CacheConfig(strategy="auto")
-    )
+    model2 = BedrockModel(model_id="anthropic.claude-3-haiku-20240307-v1:0", cache_config=CacheConfig(strategy="auto"))
     assert model2._cache_strategy == "anthropic"
 
 

--- a/strands-py/tests/strands/storage/test_s3_storage.py
+++ b/strands-py/tests/strands/storage/test_s3_storage.py
@@ -89,7 +89,6 @@ class TestS3Storage:
         with pytest.raises(StorageError, match="Cannot specify both"):
             S3Storage("bucket", region_name="us-east-1", boto_session=boto3.Session())
 
-
     @pytest.mark.asyncio
     async def test_write_error_raises_storage_error(self, s3_bucket):
         storage = S3Storage("nonexistent-bucket-xyz", boto_session=s3_bucket)

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_plugin.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_plugin.py
@@ -634,9 +634,7 @@ class TestRetrievalToolSearch:
     @pytest.mark.asyncio
     async def test_raises_for_missing_reference(self, plugin, tool_context):
         with pytest.raises(ValueError, match="reference not found: nonexistent"):
-            await plugin.retrieve_offloaded_content(
-                reference="nonexistent", pattern="test", tool_context=tool_context
-            )
+            await plugin.retrieve_offloaded_content(reference="nonexistent", pattern="test", tool_context=tool_context)
 
     @pytest.mark.asyncio
     async def test_searches_json_content(self, plugin, storage, tool_context):
@@ -722,9 +720,7 @@ class TestRetrievalToolSearch:
         content = "\n".join(f"line {i + 1}" for i in range(20))
         ref = await storage.store("k1", content.encode("utf-8"), "text/plain")
 
-        result = await plugin.retrieve_offloaded_content(
-            reference=ref, context_lines=10, tool_context=tool_context
-        )
+        result = await plugin.retrieve_offloaded_content(reference=ref, context_lines=10, tool_context=tool_context)
 
         assert "[Lines 1-10 of 20]" in result
         assert "line 1" in result
@@ -1112,9 +1108,7 @@ class TestUnifiedStorage:
             "actively-retrieved entry must survive eviction for unified Storage backends"
         )
         # And remains retrievable
-        content_again = await plugin.retrieve_offloaded_content(
-            reference=ref, tool_context=tool_context
-        )
+        content_again = await plugin.retrieve_offloaded_content(reference=ref, tool_context=tool_context)
         assert "hello world" in content_again
 
     @pytest.mark.asyncio

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_search.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_search.py
@@ -110,18 +110,14 @@ class TestSearchContentPatternWithLineRange:
     text = "\n".join(f"item {i + 1}" for i in range(30))
 
     def test_searches_only_within_range(self):
-        result = _search_content(
-            self.text, pattern="item 1", line_range=(10, 20), context_lines=0, max_chars=10_000
-        )
+        result = _search_content(self.text, pattern="item 1", line_range=(10, 20), context_lines=0, max_chars=10_000)
         assert "in lines 10-20" in result
         assert "> 10| item 10" in result
         assert "> 11| item 11" in result
         assert "> 1|" not in result
 
     def test_no_matches_within_range(self):
-        result = _search_content(
-            self.text, pattern="item 5", line_range=(10, 20), context_lines=0, max_chars=10_000
-        )
+        result = _search_content(self.text, pattern="item 5", line_range=(10, 20), context_lines=0, max_chars=10_000)
         assert "No matches found" in result
         assert "in lines 10-20" in result
 

--- a/strands-py/tests/strands/vended_tools/test_sleep.py
+++ b/strands-py/tests/strands/vended_tools/test_sleep.py
@@ -165,5 +165,3 @@ class TestHappyPath:
 
         fake_sleep.assert_awaited_once_with(2.0)
         assert result == "Slept for 2 seconds"
-
-

--- a/strands-py/tests_integ/models/test_model_bedrock.py
+++ b/strands-py/tests_integ/models/test_model_bedrock.py
@@ -392,8 +392,7 @@ def test_prompt_caching_with_5m_ttl(quiet_strands_logging):
 
 
 def test_prompt_caching_with_1h_ttl(quiet_strands_logging):
-    """Test prompt caching with 1 hour TTL and verify cache metrics.
-    """
+    """Test prompt caching with 1 hour TTL and verify cache metrics."""
     model = BedrockModel(
         model_id="us.anthropic.claude-haiku-4-5-20251001-v1:0",
         streaming=False,


### PR DESCRIPTION
## Description

Applies the repository's configured Ruff formatter to Python files that had drifted from the current formatting rules.

This PR contains formatting-only changes and does not alter runtime behavior.

## Related Issues

None.

## Documentation PR

No documentation changes are required for formatting-only changes.

## Type of Change

Other: code formatting

## Testing

- [x] I ran `hatch run prepare`
- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
