### PR TITLE
Feature/litellm provider typescript

### DIFF
--- a/site/src/content/docs/user-guide/concepts/model-providers/litellm.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/litellm.mdx
@@ -1,54 +1,83 @@
 ---
 title: LiteLLM
-description: 'Use LiteLLM with Strands agents to access models from OpenAI, Anthropic, Amazon, and more through one API. Install and configure LiteLLMModel.'
-tags: [structured-output]
-languages: Python
+description: >-
+  Use LiteLLM with Strands agents in Python or TypeScript to access models from
+  OpenAI, Anthropic, Amazon, and more through one OpenAI-compatible gateway.
+tags: [structured-output, caching]
 integrationType: model-provider
 sourceLinks:
   - path: strands-py/src/strands/models/litellm.py
+  - path: strands-ts/src/models/litellm.ts
 ---
 
-[LiteLLM](https://docs.litellm.ai/docs/) is a unified interface for various LLM providers that allows you to interact with models from Amazon, Anthropic, OpenAI, and many others through a single API. The Strands Agents SDK implements a LiteLLM provider, allowing you to run agents against any model LiteLLM supports.
+[LiteLLM](https://docs.litellm.ai/docs/) provides one API for models from Amazon,
+Anthropic, OpenAI, and many other providers. Strands Agents supports LiteLLM in
+both SDKs, with a language-specific connection model.
 
 ## Installation
 
-LiteLLM is configured as an optional dependency in Strands Agents. To install, run:
+Install the provider dependencies for the SDK you use.
+
+<Tabs>
+<Tab label="Python">
 
 ```bash
 pip install 'strands-agents[litellm]' strands-agents-tools
 ```
+</Tab>
+<Tab label="TypeScript">
+
+The TypeScript provider connects to the gateway through the OpenAI client:
+
+```bash
+npm install @strands-agents/sdk openai zod
+```
+
+Set `LITELLM_BASE_URL` and `LITELLM_API_KEY` before running the examples.
+</Tab>
+</Tabs>
 
 ## Usage
 
-After installing `litellm`, you can import and initialize Strands Agents' LiteLLM provider as follows:
+Initialize `LiteLLMModel` with the model alias configured in LiteLLM.
+
+<Tabs>
+<Tab label="Python">
 
 ```python
 from strands import Agent
 from strands.models.litellm import LiteLLMModel
-from strands_tools import calculator
 
 model = LiteLLMModel(
-    client_args={
-        "api_key": "<KEY>",
-    },
-    # **model_config
-    model_id="anthropic/claude-3-7-sonnet-20250219",
-    params={
-        "max_tokens": 1000,
-        "temperature": 0.7,
-    }
+    client_args={"api_key": "<KEY>"},
+    model_id="anthropic/claude-sonnet-4-20250514",
+    params={"temperature": 0.7},
 )
 
-agent = Agent(model=model, tools=[calculator])
-response = agent("What is 2+2")
+agent = Agent(model=model)
+response = agent("What is 2+2?")
 print(response)
 ```
+</Tab>
+<Tab label="TypeScript">
 
-## Using LiteLLM Proxy
+```typescript
+--8<-- "user-guide/concepts/model-providers/litellm_imports.ts:basic_usage_imports"
 
-To use a [LiteLLM Proxy Server](https://docs.litellm.ai/docs/simple_proxy), you have two options:
+--8<-- "user-guide/concepts/model-providers/litellm.ts:basic_usage"
+```
+</Tab>
+</Tabs>
 
-### Option 1: Use `use_litellm_proxy` parameter
+## Using a LiteLLM gateway
+
+Connect the provider to a LiteLLM gateway by setting its URL and virtual key.
+
+<Tabs>
+<Tab label="Python">
+
+Python routes calls through the [proxy](https://docs.litellm.ai/docs/simple_proxy)
+with `use_litellm_proxy` or a `litellm_proxy/` model prefix:
 
 ```python
 from strands import Agent
@@ -58,94 +87,157 @@ model = LiteLLMModel(
     client_args={
         "api_key": "<PROXY_KEY>",
         "api_base": "<PROXY_URL>",
-        "use_litellm_proxy": True
+        "use_litellm_proxy": True,
     },
-    model_id="amazon.nova-lite-v1:0"
+    model_id="amazon.nova-lite-v1:0",
 )
 
 agent = Agent(model=model)
 response = agent("Tell me a story")
 ```
+</Tab>
+<Tab label="TypeScript">
 
-### Option 2: Use `litellm_proxy/` prefix in model ID
+TypeScript uses the gateway URL directly. The URL must expose the OpenAI-compatible
+`/chat/completions` endpoint:
 
-```python
-model = LiteLLMModel(
-    client_args={
-        "api_key": "<PROXY_KEY>",
-        "api_base": "<PROXY_URL>"
-    },
-    model_id="litellm_proxy/amazon.nova-lite-v1:0"
-)
+```typescript
+--8<-- "user-guide/concepts/model-providers/litellm_imports.ts:proxy_imports"
+
+--8<-- "user-guide/concepts/model-providers/litellm.ts:proxy_usage"
 ```
+
+The TypeScript provider does not use Python's `use_litellm_proxy` option or the
+`litellm_proxy/` model prefix.
+</Tab>
+</Tabs>
 
 ## Configuration
 
-### Client Configuration
+### Client configuration
 
-The `client_args` configure the underlying LiteLLM `completion` API. For a complete list of available arguments, please refer to the LiteLLM [docs](https://docs.litellm.ai/docs/completion/input).
+Configure the client connection separately from model inference parameters.
 
-### Model Configuration
+<Tabs>
+<Tab label="Python">
 
-The `model_config` configures the underlying model selected for inference. The supported configurations are:
+`client_args` accepts the arguments passed to LiteLLM. See the LiteLLM [completion
+input documentation](https://docs.litellm.ai/docs/completion/input) for the
+available options.
+</Tab>
+<Tab label="TypeScript">
 
-|  Parameter | Description | Example | Options |
-|------------|-------------|---------|---------|
-| `model_id` | ID of a model to use | `anthropic/claude-3-7-sonnet-20250219` | [reference](https://docs.litellm.ai/docs/providers)
-| `params` | Model specific parameters | `{"max_tokens": 1000, "temperature": 0.7}` | [reference](https://docs.litellm.ai/docs/completion/input)
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `baseURL` | LiteLLM gateway URL | `process.env.LITELLM_BASE_URL` |
+| `apiKey` | LiteLLM virtual key | `process.env.LITELLM_API_KEY` |
+| `clientConfig` | Additional OpenAI client settings | `{ timeout: 30_000 }` |
+| `client` | Pre-configured OpenAI client | `new OpenAI({ ... })` |
+
+The examples require both environment variables and throw an error when either is
+missing. Use an HTTPS URL for a remote gateway.
+</Tab>
+</Tabs>
+
+### Model configuration
+
+Set the model alias and inference parameters on `LiteLLMModel`.
+
+<Tabs>
+<Tab label="Python">
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `model_id` | Model alias or provider/model identifier | `"anthropic/claude-sonnet-4"` |
+| `params` | Model-specific parameters | `{"max_tokens": 1000, "temperature": 0.7}` |
+</Tab>
+<Tab label="TypeScript">
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `modelId` | Model alias or provider/model identifier | `'anthropic/claude-sonnet-4'` |
+| `stream` | Select streaming or non-streaming responses | `false` |
+| `maxTokens` | Maximum output tokens | `1000` |
+| `temperature` | Controls randomness | `0.7` |
+| `topP` | Nucleus sampling | `0.9` |
+| `frequencyPenalty` | Reduces repetition | `0.5` |
+| `presencePenalty` | Encourages new topics | `0.5` |
+| `params` | Additional LiteLLM parameters | `{ seed: 42 }` |
+</Tab>
+</Tabs>
 
 ## Troubleshooting
 
-### Module Not Found
+Install the provider dependency when the SDK cannot resolve the LiteLLM integration.
 
-If you encounter the error `ModuleNotFoundError: No module named 'litellm'`, this means you haven't installed the `litellm` dependency in your environment. To fix, run `pip install 'strands-agents[litellm]'`.
+<Tabs>
+<Tab label="Python">
 
-## Advanced Features
+If you see `ModuleNotFoundError: No module named 'litellm'`, install the Python extra:
+
+```bash
+pip install 'strands-agents[litellm]'
+```
+</Tab>
+<Tab label="TypeScript">
+
+If `@strands-agents/sdk/models/litellm` or `openai` cannot be resolved, install
+both packages:
+
+```bash
+npm install @strands-agents/sdk openai
+```
+</Tab>
+</Tabs>
+
+## Advanced features
 
 ### Caching
 
-LiteLLM supports provider-agnostic caching through SystemContentBlock arrays, allowing you to define cache points that work across all supported model providers. This enables you to reuse parts of previous requests, which can significantly reduce token usage and latency.
+Add a cache point to the system prompt when the provider and model support prompt
+caching. Cache availability and minimum token requirements depend on the upstream
+provider.
 
-#### System Prompt Caching
-
-Use SystemContentBlock arrays to define cache points in your system prompts:
+<Tabs>
+<Tab label="Python">
 
 ```python
 from strands import Agent
 from strands.models.litellm import LiteLLMModel
 from strands.types.content import SystemContentBlock
 
-# Define system content with cache points
 system_content = [
-    SystemContentBlock(
-        text="You are a helpful assistant that provides concise answers. "
-             "This is a long system prompt with detailed instructions..."
-             "..." * 1000  # needs to be at least 1,024 tokens
-    ),
-    SystemContentBlock(cachePoint={"type": "default"})
+    SystemContentBlock(text="Reusable instructions and context."),
+    SystemContentBlock(cachePoint={"type": "default", "ttl": "1h"}),
 ]
 
-# Create an agent with SystemContentBlock array
-model = LiteLLMModel(
-    model_id="bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0"
+agent = Agent(
+    model=LiteLLMModel(model_id="anthropic/claude-sonnet-4-20250514"),
+    system_prompt=system_content,
 )
-
-agent = Agent(model=model, system_prompt=system_content)
-
-# First request will cache the system prompt
-response1 = agent("Tell me about Python")
-# Cache metrics like cacheWriteInputTokens will be present in response1.metrics.accumulated_usage
-
-# Second request will reuse the cached system prompt
-response2 = agent("Tell me about JavaScript")
-# Cache metrics like cacheReadInputTokens will be present in response2.metrics.accumulated_usage
+response = agent("Summarize this report.")
+print(response.metrics.accumulated_usage)
 ```
+</Tab>
+<Tab label="TypeScript">
 
-> **Note**: Caching availability and behavior depends on the underlying model provider accessed through LiteLLM. Some providers may have minimum token requirements or other limitations for cache creation.
+```typescript
+--8<-- "user-guide/concepts/model-providers/litellm_imports.ts:caching_imports"
 
-### Structured Output
+--8<-- "user-guide/concepts/model-providers/litellm.ts:caching_usage"
+```
+</Tab>
+</Tabs>
 
-LiteLLM supports structured output by proxying requests to underlying model providers that support tool calling. The availability of structured output depends on the specific model and provider you're using through LiteLLM.
+Cache usage appears in model metadata and agent accumulated usage when the upstream
+provider reports cache reads or writes.
+
+### Structured output
+
+Use structured output when the agent must return data that conforms to a schema.
+
+<Tabs>
+<Tab label="Python">
 
 ```python
 from pydantic import BaseModel, Field
@@ -153,33 +245,32 @@ from strands import Agent
 from strands.models.litellm import LiteLLMModel
 
 class BookAnalysis(BaseModel):
-    """Analyze a book's key information."""
     title: str = Field(description="The book's title")
     author: str = Field(description="The book's author")
-    genre: str = Field(description="Primary genre or category")
-    summary: str = Field(description="Brief summary of the book")
+    genre: str = Field(description="Primary genre")
+    summary: str = Field(description="Brief summary")
     rating: int = Field(description="Rating from 1-10", ge=1, le=10)
 
-model = LiteLLMModel(
-    model_id="bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0"
-)
-
-agent = Agent(model=model)
-
+agent = Agent(model=LiteLLMModel(model_id="anthropic/claude-sonnet-4-20250514"))
 result = agent.structured_output(
     BookAnalysis,
-    """
-    Analyze this book: "The Hitchhiker's Guide to the Galaxy" by Douglas Adams.
-    It's a science fiction comedy about Arthur Dent's adventures through space
-    after Earth is destroyed. It's widely considered a classic of humorous sci-fi.
-    """
+    "Analyze The Hitchhiker's Guide to the Galaxy by Douglas Adams.",
 )
-
-print(f"Title: {result.title}")
-print(f"Author: {result.author}")
-print(f"Genre: {result.genre}")
-print(f"Rating: {result.rating}")
+print(result.title, result.rating)
 ```
+</Tab>
+<Tab label="TypeScript">
+
+TypeScript uses the Agent structured-output workflow, which validates the tool result
+against a Zod schema:
+
+```typescript
+--8<-- "user-guide/concepts/model-providers/litellm_imports.ts:structured_output_imports"
+
+--8<-- "user-guide/concepts/model-providers/litellm.ts:structured_output"
+```
+</Tab>
+</Tabs>
 
 ## References
 

--- a/site/src/content/docs/user-guide/concepts/model-providers/litellm.ts
+++ b/site/src/content/docs/user-guide/concepts/model-providers/litellm.ts
@@ -1,0 +1,107 @@
+import { Agent, CachePointBlock, TextBlock } from '@strands-agents/sdk'
+import { LiteLLMModel } from '@strands-agents/sdk/models/litellm'
+import { z } from 'zod'
+
+async function basicUsage() {
+  // --8<-- [start:basic_usage]
+  const baseURL = process.env.LITELLM_BASE_URL
+  if (!baseURL) throw new Error('LITELLM_BASE_URL is required')
+  const apiKey = process.env.LITELLM_API_KEY
+  if (!apiKey) throw new Error('LITELLM_API_KEY is required')
+
+  const model = new LiteLLMModel({
+    modelId: 'anthropic/claude-sonnet-4-20250514',
+    baseURL,
+    apiKey,
+    temperature: 0.7,
+  })
+
+  const agent = new Agent({ model })
+  const response = await agent.invoke('What is 2+2?')
+  console.log(response)
+  // Typical output: an AgentResult containing the model response.
+  // --8<-- [end:basic_usage]
+}
+
+async function proxyUsage() {
+  // --8<-- [start:proxy_usage]
+  const baseURL = process.env.LITELLM_BASE_URL
+  if (!baseURL) throw new Error('LITELLM_BASE_URL is required')
+  const apiKey = process.env.LITELLM_API_KEY
+  if (!apiKey) throw new Error('LITELLM_API_KEY is required')
+
+  const model = new LiteLLMModel({
+    modelId: 'amazon.nova-lite-v1:0',
+    baseURL,
+    apiKey,
+  })
+
+  const agent = new Agent({ model })
+  const response = await agent.invoke('Tell me a story.')
+  console.log(response)
+  // Typical output: an AgentResult containing the model response.
+  // --8<-- [end:proxy_usage]
+}
+
+async function cachingUsage() {
+  // --8<-- [start:caching_usage]
+  const baseURL = process.env.LITELLM_BASE_URL
+  if (!baseURL) throw new Error('LITELLM_BASE_URL is required')
+  const apiKey = process.env.LITELLM_API_KEY
+  if (!apiKey) throw new Error('LITELLM_API_KEY is required')
+
+  const model = new LiteLLMModel({
+    modelId: 'anthropic/claude-sonnet-4-20250514',
+    baseURL,
+    apiKey,
+  })
+
+  const systemPrompt = [
+    new TextBlock('Use concise answers. This context is reused across requests.'),
+    new CachePointBlock({ cacheType: 'default', ttl: '1h' }),
+  ]
+  const agent = new Agent({ model, systemPrompt })
+
+  const firstResponse = await agent.invoke('Tell me about Python.')
+  const secondResponse = await agent.invoke('Tell me about JavaScript.')
+  console.log(firstResponse.metrics?.accumulatedUsage)
+  console.log(secondResponse.metrics?.accumulatedUsage)
+  // Typical output: usage fields reported by the upstream provider.
+  // --8<-- [end:caching_usage]
+}
+
+async function structuredOutputUsage() {
+  // --8<-- [start:structured_output]
+  const baseURL = process.env.LITELLM_BASE_URL
+  if (!baseURL) throw new Error('LITELLM_BASE_URL is required')
+  const apiKey = process.env.LITELLM_API_KEY
+  if (!apiKey) throw new Error('LITELLM_API_KEY is required')
+
+  const BookAnalysis = z.object({
+    title: z.string(),
+    author: z.string(),
+    genre: z.string(),
+    summary: z.string(),
+    rating: z.number().min(1).max(10),
+  })
+
+  const model = new LiteLLMModel({
+    modelId: 'anthropic/claude-sonnet-4-20250514',
+    baseURL,
+    apiKey,
+  })
+  const agent = new Agent({ model, structuredOutputSchema: BookAnalysis })
+
+  const result = await agent.invoke(
+    "Analyze The Hitchhiker's Guide to the Galaxy by Douglas Adams. " +
+      'Return its title, author, genre, summary, and rating.'
+  )
+  const analysis = BookAnalysis.parse(result.structuredOutput)
+  console.log(analysis.title, analysis.rating)
+  // --8<-- [end:structured_output]
+}
+
+void basicUsage
+void proxyUsage
+void cachingUsage
+void structuredOutputUsage

--- a/site/src/content/docs/user-guide/concepts/model-providers/litellm_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/model-providers/litellm_imports.ts
@@ -1,0 +1,22 @@
+// @ts-nocheck
+
+// --8<-- [start:basic_usage_imports]
+import { Agent } from '@strands-agents/sdk'
+import { LiteLLMModel } from '@strands-agents/sdk/models/litellm'
+// --8<-- [end:basic_usage_imports]
+
+// --8<-- [start:proxy_imports]
+import { Agent } from '@strands-agents/sdk'
+import { LiteLLMModel } from '@strands-agents/sdk/models/litellm'
+// --8<-- [end:proxy_imports]
+
+// --8<-- [start:caching_imports]
+import { Agent, CachePointBlock, TextBlock } from '@strands-agents/sdk'
+import { LiteLLMModel } from '@strands-agents/sdk/models/litellm'
+// --8<-- [end:caching_imports]
+
+// --8<-- [start:structured_output_imports]
+import { Agent } from '@strands-agents/sdk'
+import { LiteLLMModel } from '@strands-agents/sdk/models/litellm'
+import { z } from 'zod'
+// --8<-- [end:structured_output_imports]

--- a/site/src/content/docs/user-guide/quickstart/overview.mdx
+++ b/site/src/content/docs/user-guide/quickstart/overview.mdx
@@ -46,7 +46,7 @@ The table below compares feature availability between the Python and TypeScript 
 | | [Anthropic](../concepts/model-providers/anthropic/) | ✅ | ✅ |
 | | [Google](../concepts/model-providers/google/) | ✅ | ✅ |
 | | [Ollama](../concepts/model-providers/ollama/) | ✅ | ❌ |
-| | [LiteLLM](../concepts/model-providers/litellm/) | ✅ | ❌ |
+| | [LiteLLM](../concepts/model-providers/litellm/) | ✅ | ✅ |
 | | [Custom providers](../concepts/model-providers/custom_model_provider/) | ✅ | ✅ |
 | | [Additional providers](../concepts/model-providers/) | 5+ | 1+ |
 | **Tools** | [Custom function tools](../concepts/tools/custom-tools/) | ✅ | ✅ |

--- a/strands-ts/examples/README.md
+++ b/strands-ts/examples/README.md
@@ -18,12 +18,13 @@ npm start
 
 ## Available Examples
 
-| Example | Description |
-|---------|-------------|
-| [first-agent](./first-agent/) | Basic agent usage with tools, invoke, and streaming patterns |
-| [graph](./graph/) | Graph multi-agent orchestration (linear, fan-out, streaming) |
-| [swarm](./swarm/) | Swarm multi-agent orchestration (agent-driven handoffs) |
-| [mcp](./mcp/) | Model Context Protocol integration with external tool servers |
-| [agents-as-tools](./agents-as-tools/) | Agents as tools pattern (orchestrator delegates to specialized tool agents) |
-| [browser-agent](./browser-agent/) | Browser-based agent with DOM manipulation canvas (OpenAI, Anthropic, Bedrock) |
-| [telemetry](./telemetry/) | OpenTelemetry tracing with Jaeger (requires Docker, see its [README](./telemetry/README.md)) |
+| Example                               | Description                                                                                  |
+| ------------------------------------- | -------------------------------------------------------------------------------------------- |
+| [first-agent](./first-agent/)         | Basic agent usage with tools, invoke, and streaming patterns                                 |
+| [graph](./graph/)                     | Graph multi-agent orchestration (linear, fan-out, streaming)                                 |
+| [swarm](./swarm/)                     | Swarm multi-agent orchestration (agent-driven handoffs)                                      |
+| [mcp](./mcp/)                         | Model Context Protocol integration with external tool servers                                |
+| [agents-as-tools](./agents-as-tools/) | Agents as tools pattern (orchestrator delegates to specialized tool agents)                  |
+| [browser-agent](./browser-agent/)     | Browser-based agent with DOM manipulation canvas (OpenAI, Anthropic, Bedrock)                |
+| [litellm-docker](./litellm-docker/)   | LiteLLM Docker gateway with streamed TypeScript SDK output                        |
+| [telemetry](./telemetry/)             | OpenTelemetry tracing with Jaeger (requires Docker, see its [README](./telemetry/README.md)) |

--- a/strands-ts/examples/litellm-docker/README.md
+++ b/strands-ts/examples/litellm-docker/README.md
@@ -1,0 +1,19 @@
+# LiteLLM Docker smoke test
+
+This script starts the official LiteLLM proxy image, routes it to a local
+OpenAI-compatible streaming fixture, and consumes the response through the
+TypeScript `LiteLLMModel`.
+
+Run it from the repository root after building the SDK:
+
+```bash
+npm run build -w strands-ts
+node --experimental-strip-types strands-ts/examples/litellm-docker/index.ts
+```
+
+The fixture keeps the check deterministic and does not require a paid provider
+API key. It verifies the Docker gateway, proxy authentication, OpenAI-compatible
+routing, SSE streaming, and the SDK's streamed text mapping.
+
+The script uses Docker host networking so the container can reach the local
+fixture; this is intended for Linux development environments.

--- a/strands-ts/examples/litellm-docker/index.ts
+++ b/strands-ts/examples/litellm-docker/index.ts
@@ -1,0 +1,182 @@
+import { createServer, request as httpRequest } from 'node:http'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawn } from 'node:child_process'
+import type { ChildProcessWithoutNullStreams } from 'node:child_process'
+import { LiteLLMModel } from '@strands-agents/sdk/models/litellm'
+import { Message, TextBlock } from '@strands-agents/sdk'
+import type { ModelStreamEvent } from '@strands-agents/sdk'
+
+const LITELLM_IMAGE = 'docker.litellm.ai/berriai/litellm:main-latest'
+const PROXY_API_KEY = 'strands-litellm-smoke-key'
+const EXPECTED_TEXT = 'Hello from the LiteLLM Docker gateway.'
+
+const streamedChunks = [
+  {
+    id: 'chatcmpl-strands-smoke',
+    object: 'chat.completion.chunk',
+    created: 1,
+    model: 'fake',
+    choices: [{ index: 0, delta: { role: 'assistant' }, finish_reason: null }],
+  },
+  {
+    id: 'chatcmpl-strands-smoke',
+    object: 'chat.completion.chunk',
+    created: 1,
+    model: 'fake',
+    choices: [{ index: 0, delta: { content: EXPECTED_TEXT }, finish_reason: null }],
+  },
+  {
+    id: 'chatcmpl-strands-smoke',
+    object: 'chat.completion.chunk',
+    created: 1,
+    model: 'fake',
+    choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+    usage: { prompt_tokens: 8, completion_tokens: 8, total_tokens: 16 },
+  },
+] as const
+
+function listen(server: ReturnType<typeof createServer>): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '0.0.0.0', () => {
+      const address = server.address()
+      if (address === null || typeof address === 'string') {
+        reject(new Error('Unable to determine upstream server port'))
+        return
+      }
+      resolve(address.port)
+    })
+  })
+}
+
+function wait(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds))
+}
+
+function requestStatus(url: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const request = httpRequest(url, (response) => {
+      response.resume()
+      response.once('end', () => resolve(response.statusCode ?? 0))
+    })
+    request.setTimeout(3_000, () => request.destroy(new Error('Health request timed out')))
+    request.once('error', reject)
+    request.end()
+  })
+}
+
+async function waitForProxy(proxyProcess: ChildProcessWithoutNullStreams, proxyUrl: string): Promise<void> {
+  const deadline = Date.now() + 60_000
+  while (Date.now() < deadline) {
+    if (proxyProcess.exitCode !== null) {
+      throw new Error(`LiteLLM exited before becoming ready (code ${proxyProcess.exitCode})`)
+    }
+    try {
+      const status = await requestStatus(`${proxyUrl}/health/readiness`)
+      if (status === 200) return
+    } catch (error) {
+      if (!(error instanceof Error)) throw error
+    }
+    await wait(500)
+  }
+  throw new Error('Timed out waiting for LiteLLM readiness')
+}
+
+function createUpstreamServer() {
+  return createServer((request, response) => {
+    if (request.method !== 'POST' || request.url !== '/v1/chat/completions') {
+      response.writeHead(404).end()
+      return
+    }
+
+    response.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    })
+    for (const chunk of streamedChunks) {
+      response.write(`data: ${JSON.stringify(chunk)}\n\n`)
+    }
+    response.end('data: [DONE]\n\n')
+  })
+}
+
+function textDelta(event: ModelStreamEvent): string {
+  if (event.type !== 'modelContentBlockDeltaEvent' || event.delta.type !== 'textDelta') return ''
+  return event.delta.text
+}
+
+async function main(): Promise<void> {
+  const upstream = createUpstreamServer()
+  const upstreamPort = await listen(upstream)
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), 'strands-litellm-smoke-'))
+  const configPath = join(temporaryDirectory, 'config.yaml')
+  const proxyPort = 40_000 + Math.floor(Math.random() * 1_000)
+  const proxyUrl = `http://127.0.0.1:${proxyPort}/v1`
+  const containerName = `strands-litellm-smoke-${process.pid}`
+  let proxyProcess: ChildProcessWithoutNullStreams | undefined
+
+  try {
+    await writeFile(
+      configPath,
+      `model_list:\n  - model_name: strands-smoke\n    litellm_params:\n      model: openai/fake\n      api_base: http://127.0.0.1:${upstreamPort}/v1\n      api_key: smoke-upstream-key\ngeneral_settings:\n  master_key: ${PROXY_API_KEY}\n`,
+      'utf8'
+    )
+
+    proxyProcess = spawn(
+      'docker',
+      [
+        'run',
+        '--rm',
+        '--name',
+        containerName,
+        '--network',
+        'host',
+        '--volume',
+        `${configPath}:/app/config.yaml:ro`,
+        LITELLM_IMAGE,
+        '--config',
+        '/app/config.yaml',
+        '--port',
+        String(proxyPort),
+      ],
+      { stdio: 'pipe' }
+    )
+    proxyProcess.stderr.on('data', (chunk: Buffer) => process.stderr.write(`[LiteLLM] ${chunk}`))
+
+    console.log(`Waiting for LiteLLM on ${proxyUrl}`)
+    await waitForProxy(proxyProcess, proxyUrl.replace('/v1', ''))
+    console.log('LiteLLM is ready; sending a streamed completion')
+
+    const model = new LiteLLMModel({
+      modelId: 'strands-smoke',
+      baseURL: proxyUrl,
+      apiKey: PROXY_API_KEY,
+      stream: true,
+    })
+    const messages = [new Message({ role: 'user', content: [new TextBlock('Say hello.')] })]
+    let responseText = ''
+
+    for await (const event of model.stream(messages)) {
+      const delta = textDelta(event)
+      responseText += delta
+      if (delta) process.stdout.write(delta)
+    }
+    process.stdout.write('\n')
+
+    if (responseText !== EXPECTED_TEXT) {
+      throw new Error(`Unexpected streamed response: ${JSON.stringify(responseText)}`)
+    }
+    console.log('LiteLLM Docker smoke test passed')
+  } finally {
+    if (proxyProcess?.exitCode === null) {
+      proxyProcess.kill('SIGTERM')
+    }
+    upstream.close()
+    await rm(temporaryDirectory, { recursive: true, force: true })
+  }
+}
+
+await main()

--- a/strands-ts/package.json
+++ b/strands-ts/package.json
@@ -32,6 +32,10 @@
       "types": "./dist/src/models/openai/index.d.ts",
       "default": "./dist/src/models/openai/index.js"
     },
+    "./models/litellm": {
+      "types": "./dist/src/models/litellm.d.ts",
+      "default": "./dist/src/models/litellm.js"
+    },
     "./models/bedrock": {
       "types": "./dist/src/models/bedrock.d.ts",
       "default": "./dist/src/models/bedrock.js"

--- a/strands-ts/src/errors.ts
+++ b/strands-ts/src/errors.ts
@@ -41,9 +41,10 @@ export class ContextWindowOverflowError extends ModelError {
    * Creates a new ContextWindowOverflowError.
    *
    * @param message - Error message describing the context overflow
+   * @param options - Optional error options including the provider error cause
    */
-  constructor(message: string) {
-    super(message)
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options)
     this.name = 'ContextWindowOverflowError'
   }
 }

--- a/strands-ts/src/models/__tests__/litellm-http.test.node.ts
+++ b/strands-ts/src/models/__tests__/litellm-http.test.node.ts
@@ -1,0 +1,70 @@
+import { Buffer } from 'node:buffer'
+import { createServer, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { afterEach, describe, expect, it } from 'vitest'
+import { collectIterator } from '../../__fixtures__/model-test-helpers.js'
+import { Message, TextBlock } from '../../types/messages.js'
+import { LiteLLMModel } from '../litellm.js'
+
+describe('LiteLLMModel HTTP gateway', () => {
+  let server: Server | undefined
+
+  afterEach(async () => {
+    if (!server) return
+    server.closeAllConnections()
+    await new Promise<void>((resolve, reject) => server?.close((error) => (error ? reject(error) : resolve())))
+  })
+
+  it('sends and consumes a real OpenAI-compatible SSE exchange', async () => {
+    let requestPath: string | undefined
+    let authorization: string | undefined
+    let requestBody: unknown
+    server = createServer((request, response) => {
+      const chunks: Buffer[] = []
+      requestPath = request.url
+      authorization = request.headers.authorization
+      request.on('data', (chunk: Buffer) => chunks.push(chunk))
+      request.on('end', () => {
+        requestBody = JSON.parse(Buffer.concat(chunks).toString('utf8')) as unknown
+        response.writeHead(200, { 'content-type': 'text/event-stream' })
+        response.write('data: {"choices":[{"delta":{"role":"assistant"},"index":0}]}\n\n')
+        response.write('data: {"choices":[{"delta":{"content":"gateway ok"},"index":0}]}\n\n')
+        response.write('data: {"choices":[{"delta":{},"finish_reason":"stop","index":0}]}\n\n')
+        response.write('data: {"choices":[],"usage":{"prompt_tokens":2,"completion_tokens":2,"total_tokens":4}}\n\n')
+        response.end('data: [DONE]\n\n')
+      })
+    })
+    await new Promise<void>((resolve, reject) => {
+      server?.once('error', reject)
+      server?.listen(0, '127.0.0.1', resolve)
+    })
+    const address = server.address() as AddressInfo
+    const model = new LiteLLMModel({
+      modelId: 'gateway-alias',
+      baseURL: `http://127.0.0.1:${address.port}`,
+      apiKey: 'sk-local-test',
+    })
+
+    const events = await collectIterator(
+      model.stream([new Message({ role: 'user', content: [new TextBlock('hello gateway')] })])
+    )
+
+    expect(requestPath).toBe('/chat/completions')
+    expect(authorization).toBe('Bearer sk-local-test')
+    expect(requestBody).toEqual({
+      model: 'gateway-alias',
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'hello gateway' }] }],
+      stream: true,
+      stream_options: { include_usage: true },
+      tools: [],
+    })
+    expect(events).toEqual([
+      { type: 'modelMessageStartEvent', role: 'assistant' },
+      { type: 'modelContentBlockStartEvent' },
+      { type: 'modelContentBlockDeltaEvent', delta: { type: 'textDelta', text: 'gateway ok' } },
+      { type: 'modelContentBlockStopEvent' },
+      { type: 'modelMessageStopEvent', stopReason: 'endTurn' },
+      { type: 'modelMetadataEvent', usage: { inputTokens: 2, outputTokens: 2, totalTokens: 4 } },
+    ])
+  })
+})

--- a/strands-ts/src/models/__tests__/litellm.test.ts
+++ b/strands-ts/src/models/__tests__/litellm.test.ts
@@ -1,0 +1,535 @@
+import OpenAI from 'openai'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+import { collectIterator } from '../../__fixtures__/model-test-helpers.js'
+import { Agent } from '../../agent/agent.js'
+import { DocumentBlock, ImageBlock, VideoBlock } from '../../types/media.js'
+import {
+  CachePointBlock,
+  JsonBlock,
+  Message,
+  ReasoningBlock,
+  TextBlock,
+  ToolResultBlock,
+  ToolUseBlock,
+} from '../../types/messages.js'
+import { ContextWindowOverflowError, ModelThrottledError } from '../../errors.js'
+import { LiteLLMModel } from '../litellm.js'
+
+const openAIMocks = vi.hoisted(() => ({
+  create: vi.fn(),
+  post: vi.fn(),
+}))
+
+vi.mock('openai', () => ({
+  default: vi.fn(function () {
+    return {
+      post: openAIMocks.post,
+      chat: {
+        completions: {
+          create: openAIMocks.create,
+        },
+      },
+    }
+  }),
+}))
+
+describe('LiteLLMModel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('configuration', () => {
+    it('returns and updates LiteLLM model parameters', () => {
+      const model = new LiteLLMModel({
+        modelId: 'anthropic/claude-3-7-sonnet',
+        temperature: 0.5,
+      })
+
+      model.updateConfig({ temperature: 0.8, maxTokens: 2_048 })
+
+      expect(model.getConfig()).toStrictEqual({
+        modelId: 'anthropic/claude-3-7-sonnet',
+        temperature: 0.8,
+        maxTokens: 2_048,
+      })
+    })
+  })
+
+  describe('Agent integration', () => {
+    it('returns structured output through the TypeScript agent tool workflow', async () => {
+      openAIMocks.post.mockResolvedValue(
+        (async function* () {
+          yield { choices: [{ delta: { role: 'assistant' }, index: 0 }] }
+          yield {
+            choices: [
+              {
+                delta: {
+                  tool_calls: [
+                    {
+                      index: 0,
+                      id: 'structured-output-1',
+                      function: {
+                        name: 'strands_structured_output',
+                        arguments: '{"name":"Ada","age":37}',
+                      },
+                    },
+                  ],
+                },
+                index: 0,
+              },
+            ],
+          }
+          yield { choices: [{ delta: {}, finish_reason: 'tool_calls', index: 0 }] }
+        })()
+      )
+      const model = new LiteLLMModel({ modelId: 'openai/gpt-4o' })
+      const agent = new Agent({
+        model,
+        structuredOutputSchema: z.object({ name: z.string(), age: z.number() }),
+        printer: false,
+        retryStrategy: null,
+      })
+
+      const result = await agent.invoke('Describe Ada')
+
+      expect(result.structuredOutput).toEqual({ name: 'Ada', age: 37 })
+      expect(openAIMocks.post).toHaveBeenCalledOnce()
+      expect(openAIMocks.post.mock.calls[0]?.[1]).toMatchObject({
+        body: {
+          tools: [
+            {
+              type: 'function',
+              function: { name: 'strands_structured_output' },
+            },
+          ],
+        },
+      })
+    })
+  })
+
+  describe('stream', () => {
+    it('formats LiteLLM-specific content, caching, tools, and thought signatures', async () => {
+      openAIMocks.post.mockResolvedValue(
+        (async function* () {
+          yield { choices: [{ delta: { role: 'assistant' }, finish_reason: 'stop', index: 0 }] }
+        })()
+      )
+      const model = new LiteLLMModel({
+        modelId: 'gemini/gemini-2.5-pro',
+        temperature: 0.2,
+        maxTokens: 1_024,
+        topP: 0.8,
+        frequencyPenalty: 0.1,
+        presencePenalty: 0.3,
+      })
+      const messages = [
+        new Message({
+          role: 'user',
+          content: [
+            new TextBlock('Inspect these files'),
+            new ImageBlock({ format: 'png', source: { url: 'https://example.com/image.png' } }),
+            new VideoBlock({ format: 'mp4', source: { bytes: new Uint8Array([1, 2, 3]) } }),
+            new DocumentBlock({ name: 'guide.pdf', format: 'pdf', source: { bytes: new Uint8Array([4, 5]) } }),
+          ],
+        }),
+        new Message({
+          role: 'assistant',
+          content: [
+            new ReasoningBlock({ text: 'I should inspect them.', signature: 'reasoning-signature' }),
+            new ToolUseBlock({
+              name: 'inspect',
+              toolUseId: 'call-1',
+              input: { path: '/tmp/input' },
+              reasoningSignature: 'thought-signature',
+            }),
+          ],
+        }),
+      ]
+
+      await collectIterator(
+        model.stream(messages, {
+          systemPrompt: [new TextBlock('Follow policy.'), new CachePointBlock({ cacheType: 'default', ttl: '1h' })],
+          toolSpecs: [
+            {
+              name: 'inspect',
+              description: 'Inspect a path',
+              inputSchema: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] },
+            },
+          ],
+          toolChoice: { tool: { name: 'inspect' } },
+        })
+      )
+
+      expect(openAIMocks.post).toHaveBeenCalledWith('/chat/completions', {
+        body: {
+          model: 'gemini/gemini-2.5-pro',
+          messages: [
+            {
+              role: 'system',
+              content: [
+                {
+                  type: 'text',
+                  text: 'Follow policy.',
+                  cache_control: { type: 'ephemeral', ttl: '1h' },
+                },
+              ],
+            },
+            {
+              role: 'user',
+              content: [
+                { type: 'text', text: 'Inspect these files' },
+                { type: 'image_url', image_url: { detail: 'auto', url: 'https://example.com/image.png' } },
+                { type: 'video_url', video_url: { detail: 'auto', url: 'data:video/mp4;base64,AQID' } },
+                {
+                  type: 'file',
+                  file: { file_data: 'data:application/pdf;base64,BAU=', filename: 'guide.pdf' },
+                },
+              ],
+            },
+            {
+              role: 'assistant',
+              content: [{ type: 'thinking', thinking: 'I should inspect them.', signature: 'reasoning-signature' }],
+              tool_calls: [
+                {
+                  id: 'call-1__thought__thought-signature',
+                  type: 'function',
+                  function: { name: 'inspect', arguments: '{"path":"/tmp/input"}' },
+                },
+              ],
+            },
+          ],
+          stream: true,
+          stream_options: { include_usage: true },
+          temperature: 0.2,
+          max_tokens: 1_024,
+          top_p: 0.8,
+          frequency_penalty: 0.1,
+          presence_penalty: 0.3,
+          tools: [
+            {
+              type: 'function',
+              function: {
+                name: 'inspect',
+                description: 'Inspect a path',
+                parameters: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] },
+              },
+            },
+          ],
+          tool_choice: { type: 'function', function: { name: 'inspect' } },
+        },
+        stream: true,
+      })
+    })
+
+    it('preserves encoded tool IDs across assistant calls and tool results', async () => {
+      openAIMocks.post.mockResolvedValue(
+        (async function* () {
+          yield { choices: [{ delta: {}, finish_reason: 'stop', index: 0 }] }
+        })()
+      )
+      const model = new LiteLLMModel({ modelId: 'gemini/gemini-2.5-pro' })
+      const encodedId = 'call-3__thought__signature'
+      const messages = [
+        new Message({
+          role: 'assistant',
+          content: [
+            new ToolUseBlock({
+              name: 'inspect',
+              toolUseId: encodedId,
+              input: { path: '/tmp' },
+              reasoningSignature: 'signature',
+            }),
+          ],
+        }),
+        new Message({
+          role: 'user',
+          content: [
+            new ToolResultBlock({
+              toolUseId: encodedId,
+              status: 'success',
+              content: [new TextBlock('found'), new JsonBlock({ json: { count: 1 } })],
+            }),
+          ],
+        }),
+      ]
+
+      await collectIterator(model.stream(messages))
+
+      expect(openAIMocks.post).toHaveBeenCalledWith('/chat/completions', {
+        body: {
+          model: 'gemini/gemini-2.5-pro',
+          messages: [
+            {
+              role: 'assistant',
+              tool_calls: [
+                {
+                  id: encodedId,
+                  type: 'function',
+                  function: { name: 'inspect', arguments: '{"path":"/tmp"}' },
+                },
+              ],
+            },
+            { role: 'tool', tool_call_id: encodedId, content: 'found\n{"count":1}' },
+          ],
+          stream: true,
+          stream_options: { include_usage: true },
+          tools: [],
+        },
+        stream: true,
+      })
+    })
+
+    it('handles a non-streaming LiteLLM response when streaming is disabled', async () => {
+      openAIMocks.post.mockResolvedValue({
+        choices: [
+          {
+            message: { role: 'assistant', content: 'Hello without streaming' },
+            finish_reason: 'stop',
+            index: 0,
+          },
+        ],
+        usage: { prompt_tokens: 4, completion_tokens: 5, total_tokens: 9 },
+      })
+      const model = new LiteLLMModel({ modelId: 'openai/gpt-4o', params: { stream: false } })
+      const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
+
+      const events = await collectIterator(model.stream(messages))
+
+      expect(openAIMocks.post).toHaveBeenCalledWith('/chat/completions', {
+        body: {
+          model: 'openai/gpt-4o',
+          messages: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
+          stream: false,
+          tools: [],
+        },
+      })
+      expect(events).toEqual([
+        { type: 'modelMessageStartEvent', role: 'assistant' },
+        { type: 'modelContentBlockStartEvent' },
+        { type: 'modelContentBlockDeltaEvent', delta: { type: 'textDelta', text: 'Hello without streaming' } },
+        { type: 'modelContentBlockStopEvent' },
+        { type: 'modelMessageStopEvent', stopReason: 'endTurn' },
+        { type: 'modelMetadataEvent', usage: { inputTokens: 4, outputTokens: 5, totalTokens: 9 } },
+      ])
+    })
+
+    it('streams an agent message through the configured LiteLLM model', async () => {
+      openAIMocks.post.mockResolvedValue(
+        (async function* () {
+          yield { choices: [{ delta: { role: 'assistant' }, index: 0 }] }
+          yield { choices: [{ delta: { content: 'Hello from LiteLLM' }, index: 0 }] }
+          yield { choices: [{ delta: {}, finish_reason: 'stop', index: 0 }] }
+          yield {
+            choices: [],
+            usage: { prompt_tokens: 4, completion_tokens: 5, total_tokens: 9 },
+          }
+        })()
+      )
+      const model = new LiteLLMModel({
+        modelId: 'openai/gpt-4o',
+        baseURL: 'https://litellm.example.com/v1',
+        apiKey: 'sk-proxy',
+        params: { seed: 42 },
+      })
+      const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
+
+      const events = await collectIterator(model.stream(messages))
+
+      expect(openAIMocks.post).toHaveBeenCalledWith('/chat/completions', {
+        body: {
+          seed: 42,
+          model: 'openai/gpt-4o',
+          messages: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
+          stream: true,
+          stream_options: { include_usage: true },
+          tools: [],
+        },
+        stream: true,
+      })
+      expect(events).toEqual([
+        { type: 'modelMessageStartEvent', role: 'assistant' },
+        { type: 'modelContentBlockStartEvent' },
+        { type: 'modelContentBlockDeltaEvent', delta: { type: 'textDelta', text: 'Hello from LiteLLM' } },
+        { type: 'modelContentBlockStopEvent' },
+        { type: 'modelMessageStopEvent', stopReason: 'endTurn' },
+        { type: 'modelMetadataEvent', usage: { inputTokens: 4, outputTokens: 5, totalTokens: 9 } },
+      ])
+    })
+
+    it('streams reasoning, text, Gemini tool signatures, and cache metrics', async () => {
+      openAIMocks.post.mockResolvedValue(
+        (async function* () {
+          yield { choices: [{ delta: { role: 'assistant' }, index: 0 }] }
+          yield { choices: [{ delta: { reasoning_content: 'Inspect first. ' }, index: 0 }] }
+          yield { choices: [{ delta: { content: 'Using the tool.' }, index: 0 }] }
+          yield {
+            choices: [
+              {
+                delta: {
+                  tool_calls: [
+                    {
+                      index: 0,
+                      id: 'call-2__thought__encoded-signature',
+                      provider_specific_fields: { thought_signature: 'structured-signature' },
+                      function: { name: 'inspect', arguments: '{"path":' },
+                    },
+                  ],
+                },
+                index: 0,
+              },
+            ],
+          }
+          yield {
+            choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: '"/tmp/input"}' } }] }, index: 0 }],
+          }
+          yield { choices: [{ delta: {}, finish_reason: 'tool_calls', index: 0 }] }
+          yield {
+            choices: [],
+            usage: {
+              prompt_tokens: 20,
+              completion_tokens: 7,
+              total_tokens: 27,
+              prompt_tokens_details: { cached_tokens: 12 },
+              cache_creation_input_tokens: 4,
+            },
+          }
+        })()
+      )
+      const model = new LiteLLMModel({ modelId: 'gemini/gemini-2.5-pro' })
+      const messages = [new Message({ role: 'user', content: [new TextBlock('Inspect')] })]
+
+      const events = await collectIterator(model.stream(messages))
+
+      expect(events).toEqual([
+        { type: 'modelMessageStartEvent', role: 'assistant' },
+        { type: 'modelContentBlockStartEvent' },
+        {
+          type: 'modelContentBlockDeltaEvent',
+          delta: { type: 'reasoningContentDelta', text: 'Inspect first. ' },
+        },
+        { type: 'modelContentBlockStopEvent' },
+        { type: 'modelContentBlockStartEvent' },
+        { type: 'modelContentBlockDeltaEvent', delta: { type: 'textDelta', text: 'Using the tool.' } },
+        { type: 'modelContentBlockStopEvent' },
+        {
+          type: 'modelContentBlockStartEvent',
+          start: {
+            type: 'toolUseStart',
+            name: 'inspect',
+            toolUseId: 'call-2__thought__encoded-signature',
+            reasoningSignature: 'structured-signature',
+          },
+        },
+        { type: 'modelContentBlockDeltaEvent', delta: { type: 'toolUseInputDelta', input: '{"path":' } },
+        { type: 'modelContentBlockDeltaEvent', delta: { type: 'toolUseInputDelta', input: '"/tmp/input"}' } },
+        { type: 'modelContentBlockStopEvent' },
+        { type: 'modelMessageStopEvent', stopReason: 'toolUse' },
+        {
+          type: 'modelMetadataEvent',
+          usage: {
+            inputTokens: 20,
+            outputTokens: 7,
+            totalTokens: 27,
+            cacheReadInputTokens: 12,
+            cacheWriteInputTokens: 4,
+          },
+        },
+      ])
+    })
+
+    it('maps non-streaming reasoning and synthesizes missing tool call IDs', async () => {
+      openAIMocks.post.mockResolvedValue({
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              reasoning_content: 'I need a tool.',
+              tool_calls: [{ type: 'function', function: { name: 'inspect', arguments: '{"path":"/tmp"}' } }],
+            },
+            finish_reason: 'tool_calls',
+            index: 0,
+          },
+        ],
+      })
+      const model = new LiteLLMModel({ modelId: 'openai/gpt-4o', stream: false })
+      const messages = [new Message({ role: 'user', content: [new TextBlock('Inspect')] })]
+
+      const events = await collectIterator(model.stream(messages))
+      const toolStart = events[4]
+
+      expect(toolStart).toMatchObject({
+        type: 'modelContentBlockStartEvent',
+        start: { type: 'toolUseStart', name: 'inspect', toolUseId: expect.stringMatching(/^call_[0-9a-f-]+$/) },
+      })
+      if (toolStart?.type !== 'modelContentBlockStartEvent' || !toolStart.start) {
+        throw new Error('Expected a tool use start event')
+      }
+      expect(events).toEqual([
+        { type: 'modelMessageStartEvent', role: 'assistant' },
+        { type: 'modelContentBlockStartEvent' },
+        { type: 'modelContentBlockDeltaEvent', delta: { type: 'reasoningContentDelta', text: 'I need a tool.' } },
+        { type: 'modelContentBlockStopEvent' },
+        {
+          type: 'modelContentBlockStartEvent',
+          start: { type: 'toolUseStart', name: 'inspect', toolUseId: toolStart.start.toolUseId },
+        },
+        {
+          type: 'modelContentBlockDeltaEvent',
+          delta: { type: 'toolUseInputDelta', input: '{"path":"/tmp"}' },
+        },
+        { type: 'modelContentBlockStopEvent' },
+        { type: 'modelMessageStopEvent', stopReason: 'toolUse' },
+      ])
+    })
+
+    it('honors top-level stream configuration over legacy params', async () => {
+      openAIMocks.post.mockResolvedValue(
+        (async function* () {
+          yield { choices: [{ delta: {}, finish_reason: 'stop', index: 0 }] }
+        })()
+      )
+      const model = new LiteLLMModel({
+        modelId: 'openai/gpt-4o',
+        stream: true,
+        params: { stream: false, stream_options: { include_usage: false } },
+      })
+      const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
+
+      await collectIterator(model.stream(messages))
+
+      expect(openAIMocks.post).toHaveBeenCalledWith('/chat/completions', {
+        body: {
+          model: 'openai/gpt-4o',
+          messages: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
+          stream: true,
+          stream_options: { include_usage: false },
+          tools: [],
+        },
+        stream: true,
+      })
+    })
+
+    it.each([
+      {
+        name: 'context overflow',
+        vendorError: Object.assign(new Error('maximum context length exceeded'), { status: 400 }),
+        expectedError: ContextWindowOverflowError,
+      },
+      {
+        name: 'throttling',
+        vendorError: Object.assign(new Error('rate limit exceeded'), { status: 429 }),
+        expectedError: ModelThrottledError,
+      },
+    ])('maps $name errors and preserves their cause', async ({ vendorError, expectedError }) => {
+      openAIMocks.post.mockRejectedValue(vendorError)
+      const model = new LiteLLMModel({ modelId: 'openai/gpt-4o' })
+      const messages = [new Message({ role: 'user', content: [new TextBlock('Hello')] })]
+
+      const invocation = collectIterator(model.stream(messages))
+
+      await expect(invocation).rejects.toBeInstanceOf(expectedError)
+      await expect(invocation).rejects.toMatchObject({ cause: vendorError })
+    })
+  })
+})

--- a/strands-ts/src/models/__tests__/litellm.test.ts
+++ b/strands-ts/src/models/__tests__/litellm.test.ts
@@ -1,4 +1,3 @@
-import OpenAI from 'openai'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
 import { collectIterator } from '../../__fixtures__/model-test-helpers.js'

--- a/strands-ts/src/models/litellm.ts
+++ b/strands-ts/src/models/litellm.ts
@@ -1,0 +1,132 @@
+/**
+ * LiteLLM AI Gateway model provider implementation.
+ *
+ * @see https://docs.litellm.ai/docs/proxy/quick_start
+ */
+
+import OpenAI from 'openai'
+import type { ApiKeySetter } from 'openai/client'
+import type { ClientOptions } from 'openai'
+import type { Stream } from 'openai/core/streaming'
+import { Model, resolveConfigMetadata } from './model.js'
+import type { StreamOptions } from './model.js'
+import type { Message } from '../types/messages.js'
+import type { ModelStreamEvent } from './streaming.js'
+import type { OpenAIChatConfig } from './openai/types.js'
+import { ContextWindowOverflowError, ModelError, ModelThrottledError } from '../errors.js'
+import { classifyOpenAIError } from './openai/errors.js'
+import { formatLiteLLMRequest } from './litellm/request.js'
+import { mapNonStreamingResponse, mapStreamingResponse } from './litellm/response.js'
+
+const DEFAULT_BASE_URL = 'http://localhost:4000'
+const DEFAULT_API_KEY = 'sk-no-key-required'
+
+/** Configuration fields passed to a model served by LiteLLM. */
+export interface LiteLLMModelConfig extends OpenAIChatConfig {
+  /** LiteLLM model identifier or configured model alias. */
+  modelId?: string
+  /** Whether the gateway response should use server-sent event streaming. Defaults to `true`. */
+  stream?: boolean
+}
+
+/** Options for constructing a {@link LiteLLMModel}. */
+export interface LiteLLMModelOptions extends LiteLLMModelConfig {
+  /** LiteLLM model identifier or configured model alias. */
+  modelId: string
+  /** LiteLLM gateway URL. Defaults to the local gateway at `http://localhost:4000`. */
+  baseURL?: string
+  /** LiteLLM virtual key. Unauthenticated local gateways do not require one. */
+  apiKey?: string | ApiKeySetter
+  /** Pre-configured OpenAI-compatible client instance. */
+  client?: OpenAI
+  /** OpenAI client settings other than `apiKey` and `baseURL`. */
+  clientConfig?: Omit<ClientOptions, 'apiKey' | 'baseURL'>
+}
+
+/**
+ * Model provider for the OpenAI-compatible LiteLLM AI Gateway.
+ *
+ * LiteLLM's in-process SDK is Python-only. TypeScript applications connect to
+ * the LiteLLM gateway through its Chat Completions-compatible API.
+ *
+ * @example
+ * ```typescript
+ * import { LiteLLMModel } from '@strands-agents/sdk/models/litellm'
+ *
+ * const model = new LiteLLMModel({
+ *   modelId: 'anthropic/claude-sonnet-4-20250514',
+ *   baseURL: 'http://localhost:4000',
+ *   apiKey: process.env.LITELLM_API_KEY,
+ * })
+ * ```
+ */
+export class LiteLLMModel extends Model<LiteLLMModelConfig> {
+  private _config: LiteLLMModelOptions
+  private readonly _client: OpenAI
+
+  constructor(options: LiteLLMModelOptions) {
+    super()
+    const { baseURL = DEFAULT_BASE_URL, apiKey = DEFAULT_API_KEY, client, clientConfig, ...modelConfig } = options
+    this._config = modelConfig
+    this._client =
+      client ??
+      new OpenAI({
+        apiKey,
+        ...clientConfig,
+        baseURL,
+      })
+  }
+
+  /** The OpenAI-compatible API mode used by LiteLLM gateways. */
+  get api(): 'chat' {
+    return 'chat'
+  }
+
+  updateConfig(modelConfig: LiteLLMModelConfig): void {
+    this._config = { ...this._config, ...modelConfig }
+  }
+
+  getConfig(): LiteLLMModelConfig {
+    return resolveConfigMetadata(this._config, this._config.modelId ?? '')
+  }
+
+  async *stream(messages: Message[], options?: StreamOptions): AsyncIterable<ModelStreamEvent> {
+    if (messages.length === 0) {
+      throw new Error('At least one message is required')
+    }
+
+    try {
+      const request = formatLiteLLMRequest(this._config, messages, options)
+      const requestOptions = {
+        body: request,
+        ...(options?.cancelSignal !== undefined && { signal: options.cancelSignal }),
+      }
+
+      if (request.stream) {
+        const response = await this._client.post<Stream<unknown>>('/chat/completions', {
+          ...requestOptions,
+          stream: true,
+        })
+        yield* mapStreamingResponse(response)
+        return
+      }
+
+      const response = await this._client.post<unknown>('/chat/completions', requestOptions)
+      yield* mapNonStreamingResponse(response)
+    } catch (error) {
+      throw this._wrapError(error)
+    }
+  }
+
+  private _wrapError(error: unknown): ModelError {
+    const providerError = error instanceof Error ? error : new Error(String(error))
+    const errorKind = classifyOpenAIError(providerError)
+    if (errorKind === 'contextOverflow') {
+      return new ContextWindowOverflowError(providerError.message, { cause: providerError })
+    }
+    if (errorKind === 'throttling') {
+      return new ModelThrottledError(providerError.message, { cause: providerError })
+    }
+    return new ModelError(providerError.message, { cause: providerError })
+  }
+}

--- a/strands-ts/src/models/litellm/request.ts
+++ b/strands-ts/src/models/litellm/request.ts
@@ -1,0 +1,250 @@
+import { toMimeType } from '../../mime.js'
+import { encodeBase64 } from '../../types/media.js'
+import type { DocumentBlock, ImageBlock, VideoBlock } from '../../types/media.js'
+import type { ContentBlock, Message, SystemPrompt, ToolResultBlock } from '../../types/messages.js'
+import type { ToolChoice, ToolSpec } from '../../tools/types.js'
+import type { StreamOptions } from '../model.js'
+import type { LiteLLMModelOptions } from '../litellm.js'
+
+const THOUGHT_SIGNATURE_SEPARATOR = '__thought__'
+
+interface LiteLLMRequest {
+  model: string
+  messages: LiteLLMMessage[]
+  stream: boolean
+  stream_options?: unknown
+  [key: string]: unknown
+}
+
+interface LiteLLMMessage {
+  role: 'system' | 'user' | 'assistant' | 'tool'
+  content?: unknown
+  tool_call_id?: string
+  tool_calls?: LiteLLMToolCall[]
+}
+
+interface LiteLLMToolCall {
+  id: string
+  type: 'function'
+  function: {
+    name: string
+    arguments: string
+  }
+}
+
+/**
+ * Formats an SDK invocation as a LiteLLM Chat Completions request.
+ *
+ * @internal
+ * @param config - Current model configuration.
+ * @param messages - Conversation messages to send.
+ * @param options - Invocation-specific system prompt and tool settings.
+ * @returns The LiteLLM gateway request body.
+ */
+export function formatLiteLLMRequest(
+  config: LiteLLMModelOptions,
+  messages: Message[],
+  options?: StreamOptions
+): LiteLLMRequest {
+  const { stream: legacyStream, stream_options: legacyStreamOptions, ...params } = config.params ?? {}
+  const stream = config.stream ?? (typeof legacyStream === 'boolean' ? legacyStream : true)
+  const request: LiteLLMRequest = {
+    ...params,
+    model: config.modelId,
+    messages: [...formatSystemPrompt(options?.systemPrompt), ...formatMessages(messages)],
+    stream,
+  }
+
+  if (stream) request.stream_options = legacyStreamOptions ?? { include_usage: true }
+  if (config.temperature !== undefined) request.temperature = config.temperature
+  if (config.maxTokens !== undefined) request.max_tokens = config.maxTokens
+  if (config.topP !== undefined) request.top_p = config.topP
+  if (config.frequencyPenalty !== undefined) request.frequency_penalty = config.frequencyPenalty
+  if (config.presencePenalty !== undefined) request.presence_penalty = config.presencePenalty
+
+  request.tools = formatTools(options?.toolSpecs) ?? []
+  const toolChoice = formatToolChoice(options?.toolChoice)
+  if (toolChoice) request.tool_choice = toolChoice
+
+  return request
+}
+
+function formatSystemPrompt(systemPrompt: SystemPrompt | undefined): LiteLLMMessage[] {
+  if (typeof systemPrompt === 'string') {
+    return systemPrompt.trim().length > 0 ? [{ role: 'system', content: [{ type: 'text', text: systemPrompt }] }] : []
+  }
+  if (!systemPrompt || systemPrompt.length === 0) return []
+
+  const content: Array<Record<string, unknown>> = []
+  for (const block of systemPrompt) {
+    if (block.type === 'textBlock') {
+      content.push({ type: 'text', text: block.text })
+    } else if (block.type === 'cachePointBlock' && content.length > 0) {
+      content[content.length - 1]!.cache_control = {
+        type: 'ephemeral',
+        ...(block.ttl !== undefined && { ttl: block.ttl }),
+      }
+    }
+  }
+  return content.length > 0 ? [{ role: 'system', content }] : []
+}
+
+function formatMessages(messages: Message[]): LiteLLMMessage[] {
+  return messages.flatMap((message) =>
+    message.role === 'assistant' ? formatAssistantMessage(message.content) : formatUserMessage(message.content)
+  )
+}
+
+function formatAssistantMessage(contentBlocks: ContentBlock[]): LiteLLMMessage[] {
+  const content: unknown[] = []
+  const toolCalls: LiteLLMToolCall[] = []
+
+  for (const block of contentBlocks) {
+    if (block.type === 'textBlock') {
+      content.push({ type: 'text', text: block.text })
+    } else if (block.type === 'reasoningBlock') {
+      content.push({
+        type: 'thinking',
+        ...(block.text !== undefined && { thinking: block.text }),
+        ...(block.signature !== undefined && { signature: block.signature }),
+      })
+    } else if (block.type === 'toolUseBlock') {
+      const signatureSuffix = block.reasoningSignature
+        ? `${THOUGHT_SIGNATURE_SEPARATOR}${block.reasoningSignature}`
+        : ''
+      const encodedId = block.toolUseId.includes(THOUGHT_SIGNATURE_SEPARATOR)
+        ? block.toolUseId
+        : `${block.toolUseId}${signatureSuffix}`
+      toolCalls.push({
+        id: encodedId,
+        type: 'function',
+        function: { name: block.name, arguments: JSON.stringify(block.input) },
+      })
+    }
+  }
+
+  if (content.length === 0 && toolCalls.length === 0) return []
+  return [
+    {
+      role: 'assistant',
+      ...(content.length > 0 && { content }),
+      ...(toolCalls.length > 0 && { tool_calls: toolCalls }),
+    },
+  ]
+}
+
+function formatUserMessage(contentBlocks: ContentBlock[]): LiteLLMMessage[] {
+  const regularContent: unknown[] = []
+  const toolResults: ToolResultBlock[] = []
+
+  for (const block of contentBlocks) {
+    if (block.type === 'toolResultBlock') {
+      toolResults.push(block)
+    } else {
+      const formatted = formatUserContent(block)
+      if (formatted !== undefined) regularContent.push(formatted)
+    }
+  }
+
+  const result: LiteLLMMessage[] = []
+  if (regularContent.length > 0) result.push({ role: 'user', content: regularContent })
+  for (const toolResult of toolResults) result.push(...formatToolResult(toolResult))
+  return result
+}
+
+function formatUserContent(block: ContentBlock): unknown | undefined {
+  switch (block.type) {
+    case 'textBlock':
+      return { type: 'text', text: block.text }
+    case 'imageBlock':
+      return formatImage(block)
+    case 'videoBlock':
+      return formatVideo(block)
+    case 'documentBlock':
+      return formatDocument(block)
+    default:
+      return undefined
+  }
+}
+
+function formatImage(block: ImageBlock): unknown | undefined {
+  let url: string
+  if (block.source.type === 'imageSourceBytes') {
+    const mimeType = toMimeType(block.format) ?? `image/${block.format}`
+    url = `data:${mimeType};base64,${encodeBase64(block.source.bytes)}`
+  } else if (block.source.type === 'imageSourceUrl') {
+    url = block.source.url
+  } else {
+    url = block.source.location.uri
+  }
+  return { type: 'image_url', image_url: { detail: 'auto', url } }
+}
+
+function formatVideo(block: VideoBlock): unknown {
+  const url =
+    block.source.type === 'videoSourceBytes'
+      ? `data:${toMimeType(block.format) ?? `video/${block.format}`};base64,${encodeBase64(block.source.bytes)}`
+      : block.source.location.uri
+  return { type: 'video_url', video_url: { detail: 'auto', url } }
+}
+
+function formatDocument(block: DocumentBlock): unknown {
+  if (block.source.type === 'documentSourceText') return { type: 'text', text: block.source.text }
+  if (block.source.type === 'documentSourceContentBlock') {
+    return { type: 'text', text: block.source.content.map((content) => content.text).join('\n') }
+  }
+  if (block.source.type === 'documentSourceS3Location') {
+    return { type: 'file', file: { file_data: block.source.location.uri, filename: block.name } }
+  }
+  const mimeType = toMimeType(block.format) ?? `application/${block.format}`
+  return {
+    type: 'file',
+    file: {
+      file_data: `data:${mimeType};base64,${encodeBase64(block.source.bytes)}`,
+      filename: block.name,
+    },
+  }
+}
+
+function formatToolResult(toolResult: ToolResultBlock): LiteLLMMessage[] {
+  const text: string[] = []
+  const media: unknown[] = []
+  for (const block of toolResult.content) {
+    if (block.type === 'textBlock') text.push(block.text)
+    else if (block.type === 'jsonBlock') text.push(JSON.stringify(block.json))
+    else {
+      const formatted = formatUserContent(block)
+      if (formatted !== undefined) media.push(formatted)
+    }
+  }
+
+  const statusPrefix = toolResult.status === 'error' ? '[ERROR] ' : ''
+  const toolContent = `${statusPrefix}${text.join('\n')}`
+  const messages: LiteLLMMessage[] = [
+    {
+      role: 'tool',
+      tool_call_id: toolResult.toolUseId,
+      content: toolContent || 'Tool successfully returned media.',
+    },
+  ]
+  if (media.length > 0) messages.push({ role: 'user', content: media })
+  return messages
+}
+
+function formatTools(toolSpecs: ToolSpec[] | undefined): unknown[] | undefined {
+  if (!toolSpecs || toolSpecs.length === 0) return undefined
+  return toolSpecs.map((toolSpec) => ({
+    type: 'function',
+    function: {
+      name: toolSpec.name,
+      description: toolSpec.description,
+      parameters: toolSpec.inputSchema ?? { type: 'object', properties: {} },
+    },
+  }))
+}
+
+function formatToolChoice(toolChoice: ToolChoice | undefined): unknown | undefined {
+  if (!toolChoice || 'auto' in toolChoice) return toolChoice ? 'auto' : undefined
+  if ('any' in toolChoice) return 'required'
+  return { type: 'function', function: { name: toolChoice.tool.name } }
+}

--- a/strands-ts/src/models/litellm/response.ts
+++ b/strands-ts/src/models/litellm/response.ts
@@ -1,0 +1,211 @@
+import type { StopReason } from '../../types/messages.js'
+import type { ModelStreamEvent, Usage } from '../streaming.js'
+
+const THOUGHT_SIGNATURE_SEPARATOR = '__thought__'
+
+interface LiteLLMUsage {
+  prompt_tokens?: number
+  completion_tokens?: number
+  total_tokens?: number
+  prompt_tokens_details?: { cached_tokens?: number }
+  cache_creation_input_tokens?: number
+}
+
+interface LiteLLMToolCall {
+  index?: number
+  id?: string
+  provider_specific_fields?: { thought_signature?: unknown }
+  function?: {
+    name?: string
+    arguments?: string
+  }
+}
+
+interface LiteLLMMessagePayload {
+  role?: string
+  content?: string | null
+  reasoning_content?: string | null
+  tool_calls?: LiteLLMToolCall[]
+}
+
+interface LiteLLMChoice {
+  delta?: LiteLLMMessagePayload
+  message?: LiteLLMMessagePayload
+  finish_reason?: string | null
+}
+
+interface LiteLLMCompletion {
+  choices?: LiteLLMChoice[]
+  usage?: LiteLLMUsage
+}
+
+interface ContentState {
+  active?: 'reasoning' | 'text'
+}
+
+/**
+ * Maps a non-streaming LiteLLM completion to SDK stream events.
+ *
+ * @internal
+ * @param response - Raw LiteLLM gateway completion payload.
+ * @returns SDK events representing the completed response.
+ */
+export function* mapNonStreamingResponse(response: unknown): Generator<ModelStreamEvent> {
+  const completion = asCompletion(response)
+  const choice = completion.choices?.[0]
+  const contentState: ContentState = {}
+  const toolCalls = new Map<number, LiteLLMToolCall[]>()
+
+  yield { type: 'modelMessageStartEvent', role: 'assistant' }
+  if (choice?.message) {
+    yield* mapPayloadContent(choice.message, contentState)
+    collectToolCalls(choice.message.tool_calls, toolCalls, false)
+  }
+  yield* closeContent(contentState)
+  yield* mapToolCalls(toolCalls)
+  yield { type: 'modelMessageStopEvent', stopReason: mapStopReason(choice?.finish_reason) }
+  if (completion.usage) yield { type: 'modelMetadataEvent', usage: mapUsage(completion.usage) }
+}
+
+/**
+ * Maps a streaming LiteLLM completion sequence to SDK stream events.
+ *
+ * @internal
+ * @param response - Raw LiteLLM gateway completion stream.
+ * @returns SDK events emitted as gateway chunks arrive.
+ */
+export async function* mapStreamingResponse(response: AsyncIterable<unknown>): AsyncIterable<ModelStreamEvent> {
+  const contentState: ContentState = {}
+  const toolCalls = new Map<number, LiteLLMToolCall[]>()
+  let stopReason: StopReason = 'endTurn'
+  let usage: Usage | undefined
+
+  yield { type: 'modelMessageStartEvent', role: 'assistant' }
+  for await (const rawChunk of response) {
+    const chunk = asCompletion(rawChunk)
+    if (chunk.usage) usage = mapUsage(chunk.usage)
+    const choice = chunk.choices?.[0]
+    if (!choice) continue
+    if (choice.delta) {
+      yield* mapPayloadContent(choice.delta, contentState)
+      collectToolCalls(choice.delta.tool_calls, toolCalls, true)
+    }
+    if (choice.finish_reason) stopReason = mapStopReason(choice.finish_reason)
+  }
+
+  yield* closeContent(contentState)
+  yield* mapToolCalls(toolCalls)
+  yield { type: 'modelMessageStopEvent', stopReason }
+  if (usage) yield { type: 'modelMetadataEvent', usage }
+}
+
+function asCompletion(value: unknown): LiteLLMCompletion {
+  if (!value || typeof value !== 'object') return {}
+  return value as LiteLLMCompletion
+}
+
+function* mapPayloadContent(payload: LiteLLMMessagePayload, state: ContentState): Generator<ModelStreamEvent> {
+  if (payload.reasoning_content) {
+    yield* switchContent(state, 'reasoning')
+    yield {
+      type: 'modelContentBlockDeltaEvent',
+      delta: { type: 'reasoningContentDelta', text: payload.reasoning_content },
+    }
+  }
+  if (payload.content) {
+    yield* switchContent(state, 'text')
+    yield { type: 'modelContentBlockDeltaEvent', delta: { type: 'textDelta', text: payload.content } }
+  }
+}
+
+function* switchContent(state: ContentState, next: 'reasoning' | 'text'): Generator<ModelStreamEvent> {
+  if (state.active === next) return
+  if (state.active !== undefined) yield { type: 'modelContentBlockStopEvent' }
+  state.active = next
+  yield { type: 'modelContentBlockStartEvent' }
+}
+
+function* closeContent(state: ContentState): Generator<ModelStreamEvent> {
+  if (state.active === undefined) return
+  delete state.active
+  yield { type: 'modelContentBlockStopEvent' }
+}
+
+function collectToolCalls(
+  deltas: LiteLLMToolCall[] | undefined,
+  toolCalls: Map<number, LiteLLMToolCall[]>,
+  useWireIndex: boolean
+): void {
+  for (const [position, delta] of (deltas ?? []).entries()) {
+    const index = useWireIndex ? (delta.index ?? position) : position
+    const collected = toolCalls.get(index) ?? []
+    collected.push(delta)
+    toolCalls.set(index, collected)
+  }
+}
+
+function* mapToolCalls(toolCalls: Map<number, LiteLLMToolCall[]>): Generator<ModelStreamEvent> {
+  for (const deltas of toolCalls.values()) {
+    const first = deltas[0]
+    if (!first) continue
+    const toolUseId = deltas.find((delta) => delta.id)?.id ?? `call_${globalThis.crypto.randomUUID()}`
+    const name = deltas.find((delta) => delta.function?.name)?.function?.name ?? ''
+    const reasoningSignature = extractThoughtSignature(first, toolUseId)
+    yield {
+      type: 'modelContentBlockStartEvent',
+      start: {
+        type: 'toolUseStart',
+        name,
+        toolUseId,
+        ...(reasoningSignature !== undefined && { reasoningSignature }),
+      },
+    }
+    for (const delta of deltas) {
+      if (delta.function?.arguments) {
+        yield {
+          type: 'modelContentBlockDeltaEvent',
+          delta: { type: 'toolUseInputDelta', input: delta.function.arguments },
+        }
+      }
+    }
+    yield { type: 'modelContentBlockStopEvent' }
+  }
+}
+
+function extractThoughtSignature(first: LiteLLMToolCall, toolUseId: string): string | undefined {
+  const structured = first.provider_specific_fields?.thought_signature
+  if (typeof structured === 'string' && structured.length > 0) return structured
+  const separatorIndex = toolUseId.indexOf(THOUGHT_SIGNATURE_SEPARATOR)
+  return separatorIndex >= 0 ? toolUseId.slice(separatorIndex + THOUGHT_SIGNATURE_SEPARATOR.length) : undefined
+}
+
+function mapStopReason(reason: string | null | undefined): StopReason {
+  switch (reason) {
+    case 'tool_calls':
+      return 'toolUse'
+    case 'length':
+      return 'maxTokens'
+    case 'content_filter':
+      return 'contentFiltered'
+    case 'stop':
+    case null:
+    case undefined:
+      return 'endTurn'
+    default:
+      return reason.replace(/_([a-z])/g, (_match, letter: string) => letter.toUpperCase())
+  }
+}
+
+function mapUsage(usage: LiteLLMUsage): Usage {
+  return {
+    inputTokens: usage.prompt_tokens ?? 0,
+    outputTokens: usage.completion_tokens ?? 0,
+    totalTokens: usage.total_tokens ?? 0,
+    ...(usage.prompt_tokens_details?.cached_tokens !== undefined && {
+      cacheReadInputTokens: usage.prompt_tokens_details.cached_tokens,
+    }),
+    ...(usage.cache_creation_input_tokens !== undefined && {
+      cacheWriteInputTokens: usage.cache_creation_input_tokens,
+    }),
+  }
+}

--- a/strands-ts/test/packages/cjs-module/cjs.js
+++ b/strands-ts/test/packages/cjs-module/cjs.js
@@ -26,6 +26,7 @@ async function main() {
 
   const { BedrockModel: BedrockFromSubpath } = await import('@strands-agents/sdk/models/bedrock')
   const { OpenAIModel } = await import('@strands-agents/sdk/models/openai')
+  const { LiteLLMModel } = await import('@strands-agents/sdk/models/litellm')
   const { AnthropicModel } = await import('@strands-agents/sdk/models/anthropic')
   const { GoogleModel } = await import('@strands-agents/sdk/models/google')
 
@@ -112,6 +113,11 @@ async function main() {
     throw new Error('GoalLoop from subpath should match barrel export')
   }
   console.log('✓ GoalLoop subpath export verified')
+
+  if (typeof LiteLLMModel !== 'function') {
+    throw new Error('LiteLLMModel subpath export is not constructible')
+  }
+  console.log('✓ LiteLLMModel subpath export verified')
 
   // Reference remaining imports so static analysis doesn't flag them unused.
   void OpenAIModel

--- a/strands-ts/test/packages/esm-module/esm.js
+++ b/strands-ts/test/packages/esm-module/esm.js
@@ -24,6 +24,7 @@ import { GoalLoop as GoalLoopFromSubpath } from '@strands-agents/sdk/vended-plug
 // Verify model subpath exports
 import { BedrockModel as BedrockFromSubpath } from '@strands-agents/sdk/models/bedrock'
 import { OpenAIModel } from '@strands-agents/sdk/models/openai'
+import { LiteLLMModel } from '@strands-agents/sdk/models/litellm'
 import { AnthropicModel } from '@strands-agents/sdk/models/anthropic'
 import { GoogleModel } from '@strands-agents/sdk/models/google'
 
@@ -126,6 +127,11 @@ if (BedrockFromSubpath !== BedrockModel) {
   throw new Error('BedrockModel from subpath should match main export')
 }
 console.log('✓ Model subpath exports verified')
+
+if (typeof LiteLLMModel !== 'function') {
+  throw new Error('LiteLLMModel subpath export is not constructible')
+}
+console.log('✓ LiteLLMModel subpath export verified')
 
 // Verify barrel exports match individual subpath exports
 if (

--- a/strands-ts/test/packages/npm-pack/verify.ts
+++ b/strands-ts/test/packages/npm-pack/verify.ts
@@ -4,7 +4,7 @@
  * that transitively pulls an optional peer fails at module load.
  *
  * Subpaths deliberately NOT imported because they require optional peers:
- *   models/{anthropic,openai,google,vercel}, a2a, a2a/express,
+ *   models/{anthropic,openai,litellm,google,vercel}, a2a, a2a/express,
  *   session/s3-storage, telemetry. Those are covered by the sibling
  *   `../esm-module` and `../cjs-module` suites.
  */
@@ -135,7 +135,12 @@ if (!(ctxErr instanceof Error)) {
 void AgentResult
 console.log('[pack-test] Error + result types importable')
 
-if (barrelBash !== bash || barrelFileEditor !== fileEditor || barrelHttpRequest !== httpRequest || barrelNotebook !== notebook) {
+if (
+  barrelBash !== bash ||
+  barrelFileEditor !== fileEditor ||
+  barrelHttpRequest !== httpRequest ||
+  barrelNotebook !== notebook
+) {
   throw new Error('Barrel vended-tools exports do not match individual subpath exports')
 }
 if (


### PR DESCRIPTION
 ## Description

LiteLLM is available as a model provider in the Python SDK, but TypeScript users could not connect Strands agents to a LiteLLM gateway. This PR adds a TypeScript `LiteLLMModel` backed by the gateway's OpenAI-compatible Chat Completions API, including streaming and non-streaming responses, provider-specific request/response mapping, reasoning and thought signatures, media, cache metadata, error translation, and model subpath exports.

The TypeScript integration intentionally uses the LiteLLM proxy rather than the Python-only in-process LiteLLM SDK. This keeps the provider compatible with the existing TypeScript OpenAI client boundary while allowing configured LiteLLM model aliases and gateway authentication.

  ### Public API Changes

  ```typescript
  import { LiteLLMModel } from '@strands-agents/sdk/models/litellm'

  const model = new LiteLLMModel({
    modelId: 'anthropic/claude-sonnet-4-20250514',
    baseURL: process.env.LITELLM_BASE_URL,
    apiKey: process.env.LITELLM_API_KEY,
  })
 ```
  The new provider is exported through the @strands-agents/sdk/models/litellm subpath. It accepts LiteLLM model IDs, gateway URL and virtual-key settings, OpenAI client configuration,
  streaming selection, model parameters, and a pre-configured OpenAI-compatible client.
  

  ## Related Issues

  I haven't checked, I just found this in docs and realised I may need this myself in the TS SDK

  ## Documentation PR

  Documentation is included in this PR under site/

  ## Type of Change

  New feature

  ## Testing

  - [x] npm run build -w strands-ts
  - [x] npm run type-check -w strands-ts
  - [x] npm run test:all:coverage -w strands-ts (273 test files, 7,571 tests passed, 5 skipped)
  - [x] npm run test:package -w strands-ts
  - [x] npm run check:browser-bundle -w strands-ts
  - [x] npm run typecheck:snippets --prefix site
  - [x] Docker example with the official LiteLLM image and streamed output through LiteLLMModel
  - [x] TypeScript type-checking, Prettier validation, and git diff --check

  ## Checklist

  - [x] I have read the CONTRIBUTING document
  - [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
  - [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
  - [x] I have added any necessary tests that prove my fix is effective or my feature works
  - [x] I have updated the documentation accordingly
  - [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
  - [x] My changes generate no new warnings
  - [x] Any dependent changes have been merged and published

  ———

  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.