### PR TITLE
docs(community): document the Neo4j Agent Memory session manager

### DIFF
--- a/site/src/config/navigation.yml
+++ b/site/src/config/navigation.yml
@@ -357,6 +357,7 @@ sidebar:
       - label: Session Managers
         items:
           - docs/integrations/session-managers/agentcore-memory
+          - docs/integrations/session-managers/neo4j-agent-memory
           - docs/integrations/session-managers/strands-valkey-session-manager
       - label: Tool Protocols
         items:

--- a/site/src/content/catalog/neo4j-agent-memory.yaml
+++ b/site/src/content/catalog/neo4j-agent-memory.yaml
@@ -1,11 +1,13 @@
 name: neo4j-agent-memory
 description: Neo4j graph memory for Strands agents — session persistence, entity and relationship extraction, and reasoning traces, on hosted NAMS or self-hosted Neo4j.
 integrationType: session-manager
+maintainedBy: partner
 languages:
   python:
     package: neo4j-agent-memory[strands]
   typescript:
     package: "@neo4j-labs/agent-memory"
 github: https://github.com/neo4j-labs/agent-memory
+docsPage: docs/integrations/session-managers/neo4j-agent-memory
 docsUrl: https://neo4j.com/labs/agent-memory/how-to/integrations/aws-strands/
 addedDate: 2026-08-11

--- a/site/src/content/docs/integrations/session-managers/neo4j-agent-memory.mdx
+++ b/site/src/content/docs/integrations/session-managers/neo4j-agent-memory.mdx
@@ -1,0 +1,117 @@
+---
+title: Neo4j Agent Memory Session Manager
+community: true
+description: 'Persist Strands sessions in a Neo4j knowledge graph, extract entities from every turn, and recall long-term memory on hosted NAMS or self-hosted Neo4j.'
+integrationType: session-manager
+sidebar:
+  label: "Neo4j Agent Memory"
+---
+
+
+[Neo4j Agent Memory](https://github.com/neo4j-labs/agent-memory) persists a Strands
+session as a conversation in a Neo4j knowledge graph. Every turn becomes a `Message`
+node, and the entities and relationships extracted from those turns accumulate as
+long-term memory the agent can recall in later sessions.
+
+Two backends serve it: the hosted Neo4j Agent Memory Service (NAMS), or a Neo4j
+instance you run yourself. The Python SDK supports both. The TypeScript SDK targets
+NAMS.
+
+## Installation
+
+<Tabs>
+  <Tab label="Python">
+    ```bash
+    pip install 'neo4j-agent-memory[strands]'
+    ```
+  </Tab>
+  <Tab label="TypeScript">
+    ```bash
+    npm install @neo4j-labs/agent-memory @strands-agents/sdk
+    ```
+  </Tab>
+</Tabs>
+
+## Persisting a session
+
+Pass the session manager when you construct the agent. Strands restores the stored
+turns on the first invocation and persists each new turn as it happens.
+
+<Tabs>
+  <Tab label="Python">
+    ```python
+    from strands import Agent
+    from neo4j_agent_memory.integrations.strands import (
+        Neo4jRetrievalConfig,
+        Neo4jSessionManager,
+    )
+
+    # Connection comes from MEMORY_ENDPOINT and MEMORY_API_KEY. The retrieval
+    # config is optional: it searches long-term memory before each model call and
+    # prepends what it finds to the turn.
+    with Neo4jSessionManager.for_nams(
+        "support-session-42",
+        user_id="user-123",
+        retrieval_config=Neo4jRetrievalConfig(top_k=5),
+    ) as session_manager:
+        agent = Agent(session_manager=session_manager)
+        agent("I'm migrating our billing service from Postgres to Neo4j.")
+    ```
+
+    To reach a self-hosted instance, pass `settings=MemorySettings(...)` to the
+    constructor instead of using the factory.
+  </Tab>
+  <Tab label="TypeScript">
+    ```typescript
+    import { Agent } from '@strands-agents/sdk'
+    import { MemoryClient } from '@neo4j-labs/agent-memory'
+    import { connectMemoryToAgent } from '@neo4j-labs/agent-memory/integrations/strands'
+
+    // Reads MEMORY_API_KEY from the environment.
+    const memory = new MemoryClient()
+    const conversation = await memory.shortTerm.createConversation({
+      userId: 'user-123',
+    })
+
+    const agent = new Agent({
+      ...(await connectMemoryToAgent(memory, { conversationId: conversation.id })),
+    })
+
+    await agent.invoke("I'm migrating our billing service from Postgres to Neo4j.")
+    ```
+
+    `connectMemoryToAgent` also injects the reflections and observations NAMS derives
+    from the conversation into every model call.
+  </Tab>
+</Tabs>
+
+Reuse the same identifier on a later run and the stored turns come back. Persistence is
+memory-grade, not a byte-exact snapshot: the Python manager stores text turns and skips
+tool-use blocks and agent state, while the TypeScript storage carries the rest of the
+snapshot alongside the messages and restores it in full.
+
+## Backends
+
+Only the Python SDK has a choice to make here.
+
+| | Hosted NAMS | Self-hosted Neo4j |
+|---|---|---|
+| Setup | API key | Neo4j 5.20 or later that you operate |
+| Entity extraction | Server-side | Runs in your process |
+| Long-term recall | Entities | Entities, preferences, facts, relationships |
+
+Start on NAMS: an API key is the only setup. Move to a self-hosted instance when you
+need preference or fact recall, arbitrary Cypher, or a graph that never leaves your
+network.
+
+## References
+
+Both guides carry the full parameter reference for their SDK.
+
+- **Guides**:
+  [Python](https://neo4j.com/labs/agent-memory/how-to/integrations/aws-strands/),
+  [TypeScript](https://neo4j.com/labs/agent-memory/how-to/typescript/strands/)
+- **GitHub**: [neo4j-labs/agent-memory](https://github.com/neo4j-labs/agent-memory)
+- **PyPI**: [neo4j-agent-memory](https://pypi.org/project/neo4j-agent-memory/)
+- **npm**:
+  [@neo4j-labs/agent-memory](https://www.npmjs.com/package/@neo4j-labs/agent-memory)


### PR DESCRIPTION
## Description

On-site page for the Neo4j Agent Memory session manager, plus catalog-entry edits.
Follow-up to #3757, which listed the integration but pointed readers at neo4j.com.
The Strands team asked for a page that explains the setup without sending readers
off-site; the neo4j.com guides stay linked for the full parameter reference.

The page covers install, one runnable example per SDK, what persistence does and
does not restore, and the choice between hosted NAMS and self-hosted Neo4j. The
catalog entry gains `docsPage`, so the card's primary link becomes the on-site
page, and `maintainedBy: partner`.

`maintainedBy: partner` needs maintainer verification: `github` points at
`neo4j-labs`, Neo4j's official org.

TypeScript is inlined in the MDX rather than extracted to `--8<--` snippet files.
`@neo4j-labs/agent-memory` is not in `test-snippets/package.json`, so extracted
snippets would need `// @ts-nocheck` and gain no type-checking. This matches
`memory-stores/agentcore-memory-store.mdx`; no `.ts` snippet files exist under
`integrations/`.

A second entry with `integrationType: memory-store` follows once
neo4j-agent-memory implements the `MemoryStore` interface.

## Related Issues

Follow-up to #3757

## Documentation PR

This is the documentation change.

## Type of Change

Documentation update

## Testing

Run from `site/`:

- `npm run build` — 890 pages, no broken links
- `npm test` — 551 passed, 2 skipped
- `npm run typecheck` — clean

Every code example verified against `neo4j-labs/agent-memory@main` (`231d60e`):
`Neo4jSessionManager.for_nams`, the constructor's `settings` alternative,
context-manager support, `Neo4jRetrievalConfig` defaults, `connectMemoryToAgent`'s
return shape and options, `MEMORY_ENDPOINT` / `MEMORY_API_KEY`, and the NAMS
entity-only limits in `nams/long_term.py`.

- [ ] I ran `hatch run prepare` — not applicable, no Python changed

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works — docs only; site build and tests cover the page
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
