### PR TITLE
feat(ts): thread per-call model through InvokeModelStage

### DIFF
--- a/strands-ts/src/agent/__tests__/agent.tracer.test.node.ts
+++ b/strands-ts/src/agent/__tests__/agent.tracer.test.node.ts
@@ -326,13 +326,16 @@ describe('Agent tracer integration', () => {
       expect(tracer.endModelInvokeSpan).toHaveBeenCalledTimes(2)
     })
 
-    it('model span records post-middleware messages when InvokeModelStage middleware transforms input', async () => {
-      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+    it('model span records post-middleware context when InvokeModelStage middleware transforms input', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Default response' })
+      const selectedModel = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Selected response' })
+      selectedModel.updateConfig({ modelId: 'selected-model' })
       const agent = new Agent({ model, systemPrompt: 'Original prompt' })
       const tracer = getLatestTracer()
 
       agent.addMiddleware(InvokeModelStage.Input, async (context) => ({
         ...context,
+        model: selectedModel,
         systemPrompt: 'Transformed prompt',
       }))
 
@@ -340,6 +343,7 @@ describe('Agent tracer integration', () => {
 
       expect(tracer.startModelInvokeSpan).toHaveBeenCalledWith(
         expect.objectContaining({
+          modelId: 'selected-model',
           systemPrompt: 'Transformed prompt',
         })
       )

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -558,7 +558,7 @@ export class Agent implements LocalAgent, InvokableAgent {
     this._middlewareRegistry = new MiddlewareRegistry()
 
     if (config?.contextManager === 'agentic') {
-      this._middlewareRegistry.addInput(InvokeModelStage.Input, createTokenUsageMiddleware(this.model))
+      this._middlewareRegistry.addInput(InvokeModelStage.Input, createTokenUsageMiddleware())
     }
 
     // `undefined` (omitted) → install the default; `null`/`[]` → explicit opt-out.
@@ -2098,6 +2098,7 @@ export class Agent implements LocalAgent, InvokableAgent {
   ): AsyncGenerator<AgentStreamEvent, StreamAggregatedResult, undefined> {
     const context: InvokeModelContext = {
       agent: this,
+      model: this.model,
       messages: this.messages.map((msg) => msg.clone()),
       ...(this.systemPrompt !== undefined && { systemPrompt: cloneSystemPrompt(this.systemPrompt) }),
       toolSpecs: deepCopy(this._toolRegistry.list().map((tool) => tool.toolSpec)) as unknown as ToolSpec[],
@@ -2119,7 +2120,7 @@ export class Agent implements LocalAgent, InvokableAgent {
       InvokeModelStage,
       context,
       async function* (ctx: InvokeModelContext): AsyncGenerator<AgentStreamEvent, InvokeModelResult, undefined> {
-        const modelId = self.model.modelId
+        const modelId = ctx.model.modelId
         const modelSpan = self._tracer.startModelInvokeSpan({
           messages: ctx.messages as Message[],
           ...(modelId && { modelId }),
@@ -2139,7 +2140,7 @@ export class Agent implements LocalAgent, InvokableAgent {
             // Omitted when zero, so an ordinary call's options are unchanged.
             ...(ctx.dynamicTrailingBlocks ? { dynamicTrailingBlocks: ctx.dynamicTrailingBlocks } : {}),
           }
-          const gen = self._streamFromModel(ctx.messages as Message[], streamOptions, ctx.invocationState)
+          const gen = self._streamFromModel(ctx.model, ctx.messages as Message[], streamOptions, ctx.invocationState)
           let iterResult = await gen.next()
           while (!iterResult.done) {
             yield iterResult.value
@@ -2185,17 +2186,19 @@ export class Agent implements LocalAgent, InvokableAgent {
    * These are separate event classes because they represent different granularities
    * (partial deltas vs finished blocks). Both are yielded in the stream and hookable.
    *
+   * @param model - Model selected for this call
    * @param messages - Messages to send to the model
    * @param streamOptions - Options for streaming
    * @returns StreamAggregatedResult containing message, stop reason, and optional redaction message
    */
   private async *_streamFromModel(
+    model: Model,
     messages: Message[],
     streamOptions: StreamOptions,
     invocationState: InvocationState
   ): AsyncGenerator<AgentStreamEvent, StreamAggregatedResult, undefined> {
     messages = normalizeToolUseNames(messages)
-    const streamGenerator = this.model.streamAggregated(messages, streamOptions)
+    const streamGenerator = model.streamAggregated(messages, streamOptions)
     try {
       let result = await streamGenerator.next()
 

--- a/strands-ts/src/context-manager/modes/agentic/agentic-context.ts
+++ b/strands-ts/src/context-manager/modes/agentic/agentic-context.ts
@@ -17,7 +17,6 @@ import {
 } from '../../../conversation-manager/compression/context-compression.js'
 import type { InvokeModelContext } from '../../../middleware/stages.js'
 import type { MiddlewareInputHandler } from '../../../middleware/types.js'
-import type { Model } from '../../../models/model.js'
 import { DEFAULT_CONTEXT_WINDOW_LIMIT } from '../../../models/defaults.js'
 
 /** Default number of recent messages to preserve verbatim during summarization or truncation. */
@@ -181,14 +180,14 @@ export const truncateContextTool = tool({
   },
 })
 
-export function createTokenUsageMiddleware(model: Model): MiddlewareInputHandler<InvokeModelContext> {
+export function createTokenUsageMiddleware(): MiddlewareInputHandler<InvokeModelContext> {
   return async (context: InvokeModelContext): Promise<InvokeModelContext> => {
     const projectedInputTokens = context.projectedInputTokens
     if (projectedInputTokens === undefined) {
       return context
     }
 
-    const contextWindowLimit = model.getConfig().contextWindowLimit ?? DEFAULT_CONTEXT_WINDOW_LIMIT
+    const contextWindowLimit = context.model.getConfig().contextWindowLimit ?? DEFAULT_CONTEXT_WINDOW_LIMIT
     const remaining = Math.max(0, contextWindowLimit - projectedInputTokens)
     const percentUsed = ((projectedInputTokens / contextWindowLimit) * 100).toFixed(1)
 

--- a/strands-ts/src/conversation-manager/__tests__/token-usage-middleware.test.ts
+++ b/strands-ts/src/conversation-manager/__tests__/token-usage-middleware.test.ts
@@ -15,6 +15,7 @@ function createMockModel(contextWindowLimit?: number): Model {
 function createContext(overrides: Partial<InvokeModelContext> = {}): InvokeModelContext {
   return {
     agent: {} as InvokeModelContext['agent'],
+    model: createMockModel(200_000),
     messages: [new Message({ role: 'user', content: [new TextBlock('hello')] })],
     toolSpecs: [],
     invocationState: {},
@@ -24,7 +25,7 @@ function createContext(overrides: Partial<InvokeModelContext> = {}): InvokeModel
 
 describe('createTokenUsageMiddleware', () => {
   it('returns context unchanged when projectedInputTokens is not set', async () => {
-    const middleware = createTokenUsageMiddleware(createMockModel(200_000))
+    const middleware = createTokenUsageMiddleware()
     const context = createContext()
 
     const result = await middleware(context)
@@ -33,7 +34,7 @@ describe('createTokenUsageMiddleware', () => {
   })
 
   it('returns context unchanged when messages are empty', async () => {
-    const middleware = createTokenUsageMiddleware(createMockModel(200_000))
+    const middleware = createTokenUsageMiddleware()
     const context = createContext({
       messages: [],
       projectedInputTokens: 50_000,
@@ -45,7 +46,7 @@ describe('createTokenUsageMiddleware', () => {
   })
 
   it('appends context status to last message content', async () => {
-    const middleware = createTokenUsageMiddleware(createMockModel(200_000))
+    const middleware = createTokenUsageMiddleware()
     const context = createContext({
       projectedInputTokens: 50_000,
     })
@@ -62,9 +63,23 @@ describe('createTokenUsageMiddleware', () => {
     expect(statusBlock.text).toContain('</context-status>')
   })
 
+  it('uses the effective context model limit', async () => {
+    const middleware = createTokenUsageMiddleware()
+    const context = createContext({
+      model: createMockModel(10_000),
+      projectedInputTokens: 8_000,
+    })
+
+    const result = await middleware(context)
+
+    const statusBlock = result.messages[0]!.content[1] as TextBlock
+    expect(statusBlock.text).toContain('8,000 / 10,000 tokens (80.0%)')
+    expect(statusBlock.text).toContain('<remaining>~2,000 tokens</remaining>')
+  })
+
   it('reports the status line as one per-call block', async () => {
     // The live token count makes this per-call, so a cache point must stay ahead of it.
-    const middleware = createTokenUsageMiddleware(createMockModel(200_000))
+    const middleware = createTokenUsageMiddleware()
     const context = createContext({ projectedInputTokens: 50_000 })
 
     const result = await middleware(context)
@@ -76,7 +91,7 @@ describe('createTokenUsageMiddleware', () => {
     // The status text lands in whatever message is last. On an assistant-terminated history it is
     // already outside the cached prefix, so reporting it would evict durable content. Reachable via invoke()
     // with no prompt, and restored sessions.
-    const middleware = createTokenUsageMiddleware(createMockModel(200_000))
+    const middleware = createTokenUsageMiddleware()
     const context = createContext({
       messages: [
         new Message({ role: 'user', content: [new TextBlock('durable ask')] }),
@@ -94,7 +109,7 @@ describe('createTokenUsageMiddleware', () => {
   })
 
   it('reports no per-call trailing blocks when no status line is appended', async () => {
-    const middleware = createTokenUsageMiddleware(createMockModel(200_000))
+    const middleware = createTokenUsageMiddleware()
     const context = createContext()
 
     const result = await middleware(context)
@@ -103,7 +118,7 @@ describe('createTokenUsageMiddleware', () => {
   })
 
   it('does not mutate the original messages array', async () => {
-    const middleware = createTokenUsageMiddleware(createMockModel(200_000))
+    const middleware = createTokenUsageMiddleware()
     const originalMessage = new Message({ role: 'user', content: [new TextBlock('hello')] })
     const context = createContext({
       messages: [originalMessage],
@@ -117,8 +132,9 @@ describe('createTokenUsageMiddleware', () => {
   })
 
   it('uses DEFAULT_CONTEXT_WINDOW_LIMIT when model config has no limit', async () => {
-    const middleware = createTokenUsageMiddleware(createMockModel(undefined))
+    const middleware = createTokenUsageMiddleware()
     const context = createContext({
+      model: createMockModel(undefined),
       projectedInputTokens: 100_000,
     })
 
@@ -131,7 +147,7 @@ describe('createTokenUsageMiddleware', () => {
   })
 
   it('preserves message metadata', async () => {
-    const middleware = createTokenUsageMiddleware(createMockModel(200_000))
+    const middleware = createTokenUsageMiddleware()
     const metadata = { usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } }
     const context = createContext({
       messages: [new Message({ role: 'user', content: [new TextBlock('hello')], metadata })],
@@ -144,8 +160,9 @@ describe('createTokenUsageMiddleware', () => {
   })
 
   it('reports correct remaining tokens', async () => {
-    const middleware = createTokenUsageMiddleware(createMockModel(100_000))
+    const middleware = createTokenUsageMiddleware()
     const context = createContext({
+      model: createMockModel(100_000),
       projectedInputTokens: 80_000,
     })
 

--- a/strands-ts/src/middleware/README.md
+++ b/strands-ts/src/middleware/README.md
@@ -62,6 +62,14 @@ Middleware is intended to supersede hooks. The Input/Output phases already cover
 
 We may revisit this later.
 
+## Per-call model
+
+`InvokeModelContext.model` is the model the terminal invokes, initialized from `agent.model`. Middleware can replace it for one call without mutating agent state; the selected model also determines the model ID recorded on the trace span:
+
+```typescript
+const modified = { ...context, model: otherModel }
+```
+
 ## Metadata transport (future)
 
 No metadata fields exist today, but the wrappers are designed to carry them. This section documents the intent so implementations stay consistent when metadata is added.

--- a/strands-ts/src/middleware/__tests__/agent-middleware.test.ts
+++ b/strands-ts/src/middleware/__tests__/agent-middleware.test.ts
@@ -71,12 +71,30 @@ describe('Agent middleware integration — InvokeModelStage', () => {
       await agent.invoke('Test prompt')
 
       expect(receivedContext?.agent).toBe(agent)
+      expect(receivedContext?.model).toBe(model)
       expect(receivedContext).toMatchObject({
         systemPrompt: 'Be helpful',
         messages: expect.arrayContaining([expect.any(Message)]),
         toolSpecs: expect.arrayContaining([expect.objectContaining({ name: 'testTool' })]),
         invocationState: expect.anything(),
       })
+    })
+
+    it('middleware can select the model for one call', async () => {
+      const defaultModel = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Default response' })
+      const selectedModel = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Selected response' })
+      const defaultStreamSpy = vi.spyOn(defaultModel, 'stream')
+      const agent = new Agent({ model: defaultModel, printer: false })
+
+      agent.addMiddleware(InvokeModelStage.Input, async (context) => ({
+        ...context,
+        model: selectedModel,
+      }))
+
+      const result = await agent.invoke('Test prompt')
+
+      expect(result.lastMessage.content).toEqual([new TextBlock('Selected response')])
+      expect(defaultStreamSpy).not.toHaveBeenCalled()
     })
 
     it('middleware result is used as the model call result', async () => {

--- a/strands-ts/src/middleware/__tests__/copy-on-input.test.ts
+++ b/strands-ts/src/middleware/__tests__/copy-on-input.test.ts
@@ -174,7 +174,7 @@ describe('InvokeModelStage copy-on-input isolation', () => {
       await agent.invoke('Hello')
 
       expect(contextKeys.sort()).toEqual(
-        ['agent', 'invocationState', 'messages', 'projectedInputTokens', 'systemPrompt', 'toolSpecs'].sort()
+        ['agent', 'invocationState', 'messages', 'model', 'projectedInputTokens', 'systemPrompt', 'toolSpecs'].sort()
       )
     })
 

--- a/strands-ts/src/middleware/stages.ts
+++ b/strands-ts/src/middleware/stages.ts
@@ -9,7 +9,7 @@ import type {
 } from '../types/agent.js'
 import type { Message, SystemPrompt, ToolResultBlock } from '../types/messages.js'
 import type { ToolSpec, ToolChoice } from '../tools/types.js'
-import type { StreamAggregatedResult } from '../models/model.js'
+import type { Model, StreamAggregatedResult } from '../models/model.js'
 import type { ToolUseData } from '../hooks/events.js'
 import type { Tool } from '../tools/tool.js'
 import type { InterruptParams } from '../types/interrupt.js'
@@ -69,11 +69,14 @@ export function createStage<TContext, TResult, TEvent>(name: string): Middleware
 /**
  * Context passed to model-stage middleware.
  * All inputs to the model call are explicit — middleware can inspect and transform
- * any of them by passing a modified context to next().
+ * any of them by passing a modified context to next(). Collection fields are
+ * defensive copies; invocationState and model are shared references.
  */
 export interface InvokeModelContext {
   /** The agent instance (escape hatch for advanced use cases). */
   readonly agent: LocalAgent
+  /** The model this call invokes. Initialized from agent.model and replaceable per call. */
+  readonly model: Model
   /** The messages to send to the model. */
   readonly messages: readonly Message[]
   /** System prompt to guide the model's behavior. */


### PR DESCRIPTION
## Description

### Motivation

Model-routing middleware needs to select a concrete model for one call without mutating agent state. Python gained this seam in #3434, but the TypeScript terminal still re-read `agent.model`, blocking SDK parity and the TypeScript `ModelRouter` port.

### Public API Changes

`InvokeModelContext` now exposes the effective `model`, initialized from `agent.model` and replaceable per call:

```typescript
agent.addMiddleware(InvokeModelStage.Input, async (context) => ({
  ...context,
  model: selectedModel,
}))
```

The selected model drives invocation, model-aware context guidance, and the model ID recorded in tracing. Existing middleware remains compatible.

## Related Issues

Ports #3434 to TypeScript.

## Documentation PR

No separate documentation PR is needed; the middleware contract is documented here.

## Type of Change

New feature

## Testing

- [x] TypeScript pre-commit checks pass

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.