### PR TITLE
fix(bidi): failing tests

### DIFF
--- a/strands-py/tests/strands/experimental/bidi/agent/test_loop.py
+++ b/strands-py/tests/strands/experimental/bidi/agent/test_loop.py
@@ -82,14 +82,17 @@ async def test_bidi_agent_loop_receive_tool_use(loop, agent, agenerator):
     exp_events = [
         tool_use_event,
         tool_result_event,
-        ToolResultMessageEvent({"role": "user", "content": [{"toolResult": tool_result}]}),
+        # The message is assigned a durable tracking_id when appended to history.
+        ToolResultMessageEvent(
+            {"role": "user", "content": [{"toolResult": tool_result}], "tracking_id": unittest.mock.ANY}
+        ),
     ]
     assert tru_events == exp_events
 
     tru_messages = agent.messages
     exp_messages = [
-        {"role": "assistant", "content": [{"toolUse": tool_use}]},
-        {"role": "user", "content": [{"toolResult": tool_result}]},
+        {"role": "assistant", "content": [{"toolUse": tool_use}], "tracking_id": unittest.mock.ANY},
+        {"role": "user", "content": [{"toolResult": tool_result}], "tracking_id": unittest.mock.ANY},
     ]
     assert tru_messages == exp_messages
 
@@ -256,4 +259,8 @@ async def test_bidi_agent_loop_send_respects_event_role(loop, agent):
     agent.model.send = unittest.mock.AsyncMock()
     await loop.start()
     await loop.send(BidiTextInputEvent(text="injected context", role="assistant"))
-    assert agent.messages[-1] == {"role": "assistant", "content": [{"text": "injected context"}]}
+    assert agent.messages[-1] == {
+        "role": "assistant",
+        "content": [{"text": "injected context"}],
+        "tracking_id": unittest.mock.ANY,
+    }


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

This PR fixes two pre-existing test failures in the bidi agent loop:
  - `test_bidi_agent_loop_receive_tool_use`
  - `test_bidi_agent_loop_send_respects_event_role`

What was broken: 

Every message the loop appends to history flows through _append_messages →
  _ensure_tracking_id (types/content.py), which mutates the message dict in place to attach a
  durable tracking_id UUID. Both tests asserted exact-dict equality against literals that omitted
  that key, so they failed. This predates the branch — the mutation and the stale assertions both
  exist on main, so these tests fail there too.

  What this PR fixes it with: 
  
  the expected dicts now match the generated id with
  unittest.mock.ANY, following the existing idiom in tests/strands/tools/test_caller.py. This
  preserves the whole-object equality assertions (per docs/TESTING.md) instead of decomposing into
  field-level checks, while still pinning role/content exactly. No production code changes — the
  tracking_id assignment is intended behavior; only the test expectations were stale.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
