### PR TITLE
fix: read prompt_tokens_details cache reads in TS OpenAI Chat

### DIFF
--- a/strands-ts/src/models/openai/__tests__/chat.test.ts
+++ b/strands-ts/src/models/openai/__tests__/chat.test.ts
@@ -618,6 +618,79 @@ describe('OpenAIModel', () => {
       })
     })
 
+    // Regression: the TS Chat path dropped prompt_tokens_details.cached_tokens, so cache reads were
+    // invisible in TS Chat usage while Python OpenAI and the TS Responses path already surfaced them.
+    it('surfaces cacheReadInputTokens from prompt_tokens_details', async () => {
+      const mockClient = createMockClient(async function* () {
+        yield {
+          choices: [{ delta: { role: 'assistant' }, index: 0 }],
+        }
+        yield {
+          choices: [{ finish_reason: 'stop', delta: {}, index: 0 }],
+        }
+        yield {
+          choices: [],
+          usage: {
+            prompt_tokens: 100,
+            completion_tokens: 20,
+            total_tokens: 120,
+            prompt_tokens_details: { cached_tokens: 64 },
+          },
+        }
+      })
+
+      const provider = new OpenAIModel({ api: 'chat', client: mockClient })
+      const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
+
+      const events = await collectIterator(provider.stream(messages))
+
+      const metadataEvent = events.find((e) => e.type === 'modelMetadataEvent')
+      expect(metadataEvent).toEqual({
+        type: 'modelMetadataEvent',
+        usage: {
+          inputTokens: 100,
+          outputTokens: 20,
+          totalTokens: 120,
+          cacheReadInputTokens: 64,
+        },
+      })
+    })
+
+    it('omits cacheReadInputTokens when cached_tokens is zero or absent', async () => {
+      const mockClient = createMockClient(async function* () {
+        yield {
+          choices: [{ delta: { role: 'assistant' }, index: 0 }],
+        }
+        yield {
+          choices: [{ finish_reason: 'stop', delta: {}, index: 0 }],
+        }
+        yield {
+          choices: [],
+          usage: {
+            prompt_tokens: 100,
+            completion_tokens: 20,
+            total_tokens: 120,
+            prompt_tokens_details: { cached_tokens: 0 },
+          },
+        }
+      })
+
+      const provider = new OpenAIModel({ api: 'chat', client: mockClient })
+      const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
+
+      const events = await collectIterator(provider.stream(messages))
+
+      const metadataEvent = events.find((e) => e.type === 'modelMetadataEvent')
+      expect(metadataEvent).toEqual({
+        type: 'modelMetadataEvent',
+        usage: {
+          inputTokens: 100,
+          outputTokens: 20,
+          totalTokens: 120,
+        },
+      })
+    })
+
     it('handles usage with undefined properties', async () => {
       const mockClient = createMockClient(async function* () {
         yield {

--- a/strands-ts/src/models/openai/__tests__/chat.test.ts
+++ b/strands-ts/src/models/openai/__tests__/chat.test.ts
@@ -618,8 +618,6 @@ describe('OpenAIModel', () => {
       })
     })
 
-    // Regression: the TS Chat path dropped prompt_tokens_details.cached_tokens, so cache reads were
-    // invisible in TS Chat usage while Python OpenAI and the TS Responses path already surfaced them.
     it('surfaces cacheReadInputTokens from prompt_tokens_details', async () => {
       const mockClient = createMockClient(async function* () {
         yield {

--- a/strands-ts/src/models/openai/model.ts
+++ b/strands-ts/src/models/openai/model.ts
@@ -13,7 +13,7 @@ import type { ResponseStreamEvent } from 'openai/resources/responses/responses'
 import { Model, resolveConfigMetadata } from '../model.js'
 import type { StreamOptions } from '../model.js'
 import type { Message } from '../../types/messages.js'
-import type { ModelStreamEvent } from '../streaming.js'
+import type { ModelStreamEvent, Usage } from '../streaming.js'
 import { ContextWindowOverflowError, ModelThrottledError } from '../../errors.js'
 import { logger } from '../../logging/logger.js'
 import { warnOnce } from '../../logging/warn-once.js'
@@ -192,7 +192,7 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
 
       let bufferedUsage: {
         type: 'modelMetadataEvent'
-        usage: { inputTokens: number; outputTokens: number; totalTokens: number }
+        usage: Usage
       } | null = null
 
       for await (const chunk of stream) {
@@ -205,6 +205,11 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
                 outputTokens: chunk.usage.completion_tokens ?? 0,
                 totalTokens: chunk.usage.total_tokens ?? 0,
               },
+            }
+            // Match the Responses path's present-and-positive guard so the two OpenAI paths agree.
+            const cached = chunk.usage.prompt_tokens_details?.cached_tokens
+            if (typeof cached === 'number' && cached > 0) {
+              bufferedUsage.usage.cacheReadInputTokens = cached
             }
           }
           continue


### PR DESCRIPTION
## Description

The TypeScript OpenAI Chat Completions path doesn't read `prompt_tokens_details.cached_tokens`, so prompt-cache reads were invisible in its usage 

## Related Issues

Part of the #3546 usage-accounting work (the py/ts Chat parity gap).

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

Ran the TS OpenAI Chat unit suite (`src/models/openai/__tests__/chat.test.ts`), covering a cached-read payload surfacing `cacheReadInputTokens` and a zero/absent case that must not introduce the field.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.