### PR TITLE
docs(team): record decision on null vs undefined input handling

### DIFF
--- a/team/DECISIONS.md
+++ b/team/DECISIONS.md
@@ -210,10 +210,10 @@ When handling input, the SDK distinguishes two "no value" states:
 - **`null` means explicit removal.** The user is deliberately opting a field out. When plumbing information through to a downstream service, a `null` field SHOULD be removed from the request — not sent as `null`, and not replaced with an SDK default.
 - **`undefined` (or an absent field) means the default case.** The SDK is free to apply its own logic for sensible defaults — which may itself be to omit the field.
 
-In Python, which has no `undefined`, an absent key plays the `undefined` role and, for inputs plumbed through to a downstream service, an explicit `None` plays `null`. This does not reinterpret parameters where `None` already means "unspecified" — `Agent(model=None)` still applies the default model.
+In Python, which has no `undefined`, an absent key plays the `undefined` role and, for inputs plumbed through to a downstream service, an explicit `None` SHOULD be treated as `null`. This does not reinterpret parameters where `None` already means "unspecified" — `Agent(model=None)` still applies the default model.
 
 ### Rationale
 
 Users need a way to say "don't send this field at all" that is distinct from "I didn't specify this field." Collapsing the two either makes SDK-managed defaults impossible to opt out of, or forces the SDK to treat every unspecified field as a deliberate removal.
 
-For example, the TypeScript `OpenAIModel` manages `stream_options: { include_usage: true }` on streaming requests, but Cohere's OpenAI-compatibility endpoint rejects the field entirely. [#3872](https://github.com/strands-agents/harness-sdk/pull/3872) applies this decision: an explicit `params.stream_options: null` omits the field from the wire request, while leaving it undefined keeps the managed default.
+For example, the TypeScript `OpenAIModel` manages `stream_options: { include_usage: true }` on streaming requests, but some OpenAI-compatible endpoints — e.g. Cohere's Compatibility API — reject the field entirely. [#3872](https://github.com/strands-agents/harness-sdk/pull/3872) applies this decision: an explicit `params.stream_options: null` omits the field from the wire request, while leaving it undefined keeps the managed default.

--- a/team/DECISIONS.md
+++ b/team/DECISIONS.md
@@ -207,13 +207,13 @@ But the principle extends beyond size — wherever there is an LLM-native concep
 
 When handling input, the SDK distinguishes two "no value" states:
 
-- **`null` means explicit removal.** The user is deliberately opting a field out. When plumbing information through to a downstream service, a `null` field should be removed from the request — not sent as `null`, and not replaced with an SDK default.
+- **`null` means explicit removal.** The user is deliberately opting a field out. When plumbing information through to a downstream service, a `null` field SHOULD be removed from the request — not sent as `null`, and not replaced with an SDK default.
 - **`undefined` (or an absent field) means the default case.** The SDK is free to apply its own logic for sensible defaults — which may itself be to omit the field.
 
-In Python, which has no `undefined`, a missing key plays the `undefined` role and `None` plays `null`.
+In Python, which has no `undefined`, an absent key plays the `undefined` role and, for inputs plumbed through to a downstream service, an explicit `None` plays `null`. This does not reinterpret parameters where `None` already means "unspecified" — `Agent(model=None)` still applies the default model.
 
 ### Rationale
 
 Users need a way to say "don't send this field at all" that is distinct from "I didn't specify this field." Collapsing the two either makes SDK-managed defaults impossible to opt out of, or forces the SDK to treat every unspecified field as a deliberate removal.
 
-For example, the TypeScript `OpenAIModel` manages `stream_options: { include_usage: true }` on streaming requests, but some OpenAI-compatible endpoints reject the field entirely. An explicit `params.stream_options: null` removes it from the wire request, while leaving it undefined gets the managed default ([#3872](https://github.com/strands-agents/harness-sdk/pull/3872)). The Python SDK behaves the same way: `params={"stream_options": None}` removes the field.
+For example, the TypeScript `OpenAIModel` manages `stream_options: { include_usage: true }` on streaming requests, but Cohere's OpenAI-compatibility endpoint rejects the field entirely. [#3872](https://github.com/strands-agents/harness-sdk/pull/3872) applies this decision: an explicit `params.stream_options: null` omits the field from the wire request, while leaving it undefined keeps the managed default.

--- a/team/DECISIONS.md
+++ b/team/DECISIONS.md
@@ -205,12 +205,14 @@ But the principle extends beyond size — wherever there is an LLM-native concep
 
 ### Decision
 
-When handling input, the SDK distinguishes two "no value" states:
+This decision governs **pass-through values**: fields the caller supplies for the SDK to forward to a downstream service, such as a provider's `params` bag or `additional_request_fields`. For those, the SDK distinguishes two "no value" states:
 
 - **`null` means explicit removal.** The user is deliberately opting a field out. When plumbing information through to a downstream service, a `null` field SHOULD be removed from the request — not sent as `null`, and not replaced with an SDK default.
 - **`undefined` (or an absent field) means the default case.** The SDK is free to apply its own logic for sensible defaults — which may itself be to omit the field.
 
-In Python, which has no `undefined`, an absent key plays the `undefined` role and, for inputs plumbed through to a downstream service, an explicit `None` SHOULD be treated as `null`. This does not reinterpret parameters where `None` already means "unspecified" — `Agent(model=None)` still applies the default model.
+In Python, which has no `undefined`, an absent key plays the `undefined` role and an explicit `None` SHOULD be treated as `null`. This does not reinterpret parameters where `None` already means "unspecified" — `Agent(model=None)` still applies the default model.
+
+It does **not** govern **feature enablement**. Parameters that switch an SDK-managed feature on or off keep `false`/`False` as the explicit off-switch (e.g. `MemoryManager(injection=False)`, `sandbox: false`). The two kinds cannot share a sentinel: a pass-through field may legitimately carry the value `false` (`store: false`, `parallel_tool_calls: false`), so `false` cannot mean "remove this field" — while a toggle's value is never forwarded, so `false` is unambiguous there.
 
 ### Rationale
 

--- a/team/DECISIONS.md
+++ b/team/DECISIONS.md
@@ -197,3 +197,23 @@ LLMs think in tokens — they consume tokens, produce tokens, and their context 
 Tokens are also a unified unit across modalities — text, images, JSON, video, and other content types all tokenize into the same currency. Characters only apply to text, forcing different heuristics for different content types. Token-based parameters provide a single, consistent metric regardless of what the model is processing.
 
 But the principle extends beyond size — wherever there is an LLM-native concept, our APIs should prefer it over a traditional developer abstraction.
+
+
+## Null Means Explicit Removal; Undefined Means Apply the Default
+
+**Date**: Aug 19, 2026
+
+### Decision
+
+When handling input, the SDK distinguishes two "no value" states:
+
+- **`null` means explicit removal.** The user is deliberately opting a field out. When plumbing information through to a downstream service, a `null` field should be removed from the request — not sent as `null`, and not replaced with an SDK default.
+- **`undefined` (or an absent field) means the default case.** The SDK is free to apply its own logic for sensible defaults — which may itself be to omit the field.
+
+In Python, which has no `undefined`, a missing key plays the `undefined` role and `None` plays `null`.
+
+### Rationale
+
+Users need a way to say "don't send this field at all" that is distinct from "I didn't specify this field." Collapsing the two either makes SDK-managed defaults impossible to opt out of, or forces the SDK to treat every unspecified field as a deliberate removal.
+
+For example, the TypeScript `OpenAIModel` manages `stream_options: { include_usage: true }` on streaming requests, but some OpenAI-compatible endpoints reject the field entirely. An explicit `params.stream_options: null` removes it from the wire request, while leaving it undefined gets the managed default ([#3872](https://github.com/strands-agents/harness-sdk/pull/3872)). The Python SDK behaves the same way: `params={"stream_options": None}` removes the field.


### PR DESCRIPTION
## Description

Adds a decision record to `team/DECISIONS.md` capturing the null/undefined input-handling decision from #3888, as requested by `Unshure`:

- **`null` = explicit removal** — when plumbing input through to a downstream service, a `null` field SHOULD be removed from the request (not sent as `null`, not replaced with an SDK default).
- **`undefined` / absent = default case** — the SDK applies its own sensible default, which may itself be to omit the field.
- Python mapping is scoped to pass-through inputs (absent key ↔ `undefined`, explicit `None` ↔ `null`), with an explicit carve-out for parameters where `None` already means "unspecified" (e.g. `Agent(model=None)`).

The example cites #3872 as *applying* this decision (it is still open, so the entry attributes the behavior to the PR rather than stating it as shipped).

<details>
<summary>Review loop ledger + known follow-up</summary>

Two independent fresh-context review rounds before opening:

- **Round 1 (CHANGES REQUESTED):** (1) unscoped "`None` plays `null`" claim contradicted `Agent(model=None)`-style defaults → scoped with a carve-out; (2) false claim that Python's `OpenAIModel` already omits `params={"stream_options": None}` from the wire → deleted (it actually sends `stream_options: null`; `strands-py/src/strands/models/openai.py:501` pops the value and `:524` puts it back verbatim); (3) unmerged #3872 described in present tense → re-attributed.
- **Round 2 (APPROVE):** fixes verified against source; two non-blocking wording tweaks applied (RFC-style SHOULD in the Python sentence; "some OpenAI-compatible endpoints — e.g. Cohere's Compatibility API").

**Known follow-up (not in this PR):** Python's `OpenAIModel` currently deviates from this decision — `params={"stream_options": None}` sends `stream_options: null` on the wire instead of omitting the field. #3872 fixes the TS side; the Python side would need an equivalent change. Happy to file an issue for it if wanted.

</details>

## Related Issues

Closes #3888

## Documentation PR

Governance doc only (`team/DECISIONS.md`); no `site/` changes needed.

## Type of Change

Documentation update

## Testing

Docs-only change to `team/` — not covered by CI gates or formatters. Verified the entry matches the file's existing format (`## Title` / `**Date**` / `### Decision` / `### Rationale`, chronological order) and that the cited code behavior is accurate (`strands-ts/src/models/openai/chat-adapter.ts:22,68`; `strands-py/src/strands/agent/agent.py:328-329`).

- [ ] I ran `hatch run prepare` (N/A — no Python code changed)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works (N/A — docs)
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
