### PR TITLE
ci(python): scope portaudio install to a gated bidi job

### DIFF
--- a/.github/workflows/python-test-lint.yml
+++ b/.github/workflows/python-test-lint.yml
@@ -57,8 +57,7 @@ jobs:
       fail-fast: true
     runs-on: ${{ matrix.os }}
     # Successful unit-test legs run in ~3-4 min (slowest observed ~16 min);
-    # 25 min caps a hung step (e.g. apt) instead of letting it run to the
-    # 6-hour default.
+    # 25 min caps a hung step instead of letting it run to the 6-hour default.
     timeout-minutes: 25
     env:
       LOG_LEVEL: DEBUG
@@ -75,47 +74,6 @@ jobs:
         uses: actions/setup-python@v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install system audio dependencies (Linux)
-        if: matrix.os-name == 'linux'
-        working-directory: .
-        timeout-minutes: 5
-        env:
-          DEBIAN_FRONTEND: noninteractive
-        run: |
-          for attempt in 1 2 3; do
-            if sudo apt-get -o Acquire::Retries=3 update \
-              && sudo apt-get -o Acquire::Retries=3 install -y portaudio19-dev libasound2-dev; then
-              exit 0
-            fi
-            if [ "$attempt" -lt 3 ]; then
-              echo "apt-get attempt $attempt failed; retrying in 15s..."
-              sleep 15
-            fi
-          done
-          echo "apt-get failed after 3 attempts" >&2
-          exit 1
-      - name: Install system audio dependencies (macOS)
-        if: matrix.os-name == 'macOS'
-        working-directory: .
-        timeout-minutes: 5
-        run: |
-          for attempt in 1 2 3; do
-            if brew install portaudio; then
-              exit 0
-            fi
-            if [ "$attempt" -lt 3 ]; then
-              echo "brew install attempt $attempt failed; retrying in 15s..."
-              sleep 15
-            fi
-          done
-          echo "brew install failed after 3 attempts" >&2
-          exit 1
-      - name: Install system audio dependencies (Windows)
-        if: matrix.os-name == 'windows'
-        working-directory: .
-        run: |
-          # Windows typically has audio libraries available by default
-          echo "Windows audio dependencies handled by PyAudio wheels"
       - name: Install dependencies
         run: |
           pip install --no-cache-dir hatch
@@ -154,7 +112,63 @@ jobs:
           python-version: '3.10'
           cache: 'pip'
 
-      - name: Install system audio dependencies (Linux)
+      - name: Install dependencies
+        run: |
+          pip install --no-cache-dir hatch
+
+      - name: Run lint
+        id: lint
+        run: hatch fmt --linter --check
+        continue-on-error: false
+
+  # Bidi has its own extras (pyaudio, pywebrtc-audio) and system dependencies
+  # (portaudio) that the general unit-test/lint jobs neither install nor need.
+  # Run the bidi suite — and install portaudio — only when bidi sources change.
+  bidi-test:
+    name: Bidi Tests - Python ${{ matrix.python-version }}
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    # 25 min caps a hung step (portaudio apt install / pyaudio build) instead of
+    # the 6-hour default.
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        # bidi requires Python >= 3.12 (see the bidi extra markers in pyproject.toml).
+        python-version: ["3.12", "3.13"]
+    defaults:
+      run:
+        working-directory: strands-py
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      # Only build pyaudio / run the bidi suite when bidi sources or tests changed.
+      # This keeps the portaudio system-dependency install off every other PR.
+      - name: Detect bidi changes
+        id: changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          filters: |
+            bidi:
+              - 'strands-py/src/strands/experimental/bidi/**'
+              - 'strands-py/tests/strands/experimental/bidi/**'
+
+      - name: Set up Python
+        if: steps.changes.outputs.bidi == 'true'
+        uses: actions/setup-python@v7.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # portaudio19-dev / libasound2-dev are the C headers pyaudio (bidi-io extra)
+      # builds against; only this job installs them.
+      - name: Install system audio dependencies
+        if: steps.changes.outputs.bidi == 'true'
         working-directory: .
         timeout-minutes: 5
         env:
@@ -174,10 +188,12 @@ jobs:
           exit 1
 
       - name: Install dependencies
-        run: |
-          pip install --no-cache-dir hatch
+        if: steps.changes.outputs.bidi == 'true'
+        run: pip install --no-cache-dir hatch
 
-      - name: Run lint
-        id: lint
-        run: hatch fmt --linter --check
-        continue-on-error: false
+      - name: Run bidi tests
+        if: steps.changes.outputs.bidi == 'true'
+        # The bidi-test hatch env installs bidi-all (pyaudio, pywebrtc-audio, ...) and
+        # its pytest target runs tests/strands/experimental/bidi, which the default
+        # unit-test run ignores.
+        run: hatch run bidi-test:test


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

The unit-test and lint jobs ran an unconditional "Install system audio dependencies" step (apt-get portaudio19-dev/libasound2-dev on Linux, brew portaudio on macOS) on every PR, regardless of whether it's a bidi related PR or not. This PR removes the audio-install steps from the unit-test and lint jobs and adds a dedicated bidi-test job that installs portaudio and runs the bidi suite (hatch run bidi-test:test) only when bidi sources/tests change.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix


## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [ ] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
