### PR TITLE
test(openai): remove unwinnable rate-limit throttling integ test

### DIFF
--- a/strands-py/tests_integ/models/test_model_openai.py
+++ b/strands-py/tests_integ/models/test_model_openai.py
@@ -9,9 +9,8 @@ import pytest
 
 import strands
 from strands import Agent, tool
-from strands.event_loop._retry import ModelRetryStrategy
 from strands.models.openai import OpenAIModel
-from strands.types.exceptions import ContextWindowOverflowException, ModelThrottledException
+from strands.types.exceptions import ContextWindowOverflowException
 from tests_integ.models import providers
 from tests_integ.models.providers import _openai_responses_available
 
@@ -264,41 +263,6 @@ def test_context_window_overflow_integration(model_class, model_id, quiet_strand
     # The agent should attempt to reduce context and retry
     with pytest.raises(ContextWindowOverflowException):
         agent(long_text)
-
-
-def _rate_limit_params():
-    params = [(OpenAIModel, "gpt-4o")]
-    if _openai_responses_available:
-        params.append((OpenAIResponsesModel, "gpt-4o"))
-    return params
-
-
-def test_rate_limit_throttling_integration_no_retries(quiet_strands_logging):
-    """Integration test for rate limit handling with retries disabled.
-
-    This test verifies that when a request exceeds OpenAI's rate limits,
-    the model properly raises a ModelThrottledException. We disable retries
-    to avoid waiting for the exponential backoff during testing.
-    """
-    model = OpenAIModel(
-        model_id="gpt-4o",
-        client_args={
-            "api_key": os.getenv("OPENAI_API_KEY"),
-        },
-    )
-    agent = Agent(model=model, retry_strategy=ModelRetryStrategy(max_attempts=1))
-
-    # Create a message that's very long to trigger token-per-minute rate limits
-    # This should be large enough to exceed TPM limits immediately
-    very_long_text = "Really long text " * 600000
-
-    # This should raise ModelThrottledException without retries
-    with pytest.raises(ModelThrottledException) as exc_info:
-        agent(very_long_text)
-
-    # Verify it's a rate limit error
-    error_message = str(exc_info.value).lower()
-    assert "rate_limit_exceeded" in error_message
 
 
 def test_content_blocks_handling(model):


### PR DESCRIPTION
## Description

`test_rate_limit_throttling_integration_no_retries` cannot pass on our CI account. It sends a ~2.5M-token prompt to `gpt-4o` expecting a per-minute rate limit (429 → `ModelThrottledException`), but 2.5M tokens far exceed `gpt-4o`'s 128k context window, so OpenAI returns a context-length 400 first — which the SDK correctly maps to `ContextWindowOverflowException`, and the conversation manager then can't trim a single oversized message. A TPM 429 can only arrive *before* context overflow when the account's per-minute token limit sits below the context window (roughly tier 1); on any higher tier no payload triggers the throttle before overflow, so the premise is impossible rather than a value we can tune.

The throttling → `ModelThrottledException` mapping it aimed to prove is fully and deterministically covered by unit tests, so deleting it loses no coverage: the classifier (`test_openai_errors.py`), the provider `stream`/`structured_output` error-translation boundary against real `openai.RateLimitError`/`APIStatusError` objects (`test_openai.py::test_stream_rate_limit_as_throttle`, `test_stream_http_429_as_throttle`, `test_structured_output_rate_limit_as_throttle`), and the retries-disabled path end-to-end (`test_agent_retry.py`). The throttling-precedes-context-overflow precedence — the one thing this integ test could never actually exercise — is proven directly by `test_classify_openai_error_throttling_precedes_context_overflow`.

## Related Issues

N/A 

## Documentation PR

N/A

## Type of Change

CI

## Testing


- [x] I ran `hatch run prepare`

Ran `hatch fmt --linter` on the file (clean — confirms no unused-import lint after the removal) and the unit suites that carry the deleted behavior, `hatch test tests/strands/models/test_openai_errors.py tests/strands/models/test_openai.py` (158 passed). The remaining OpenAI integration tests require `OPENAI_API_KEY` and run in CI.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
