### PR TITLE
fix: count Gemini tool-use tokens as input and thinking tokens as output

### DIFF
--- a/strands-py/src/strands/models/gemini.py
+++ b/strands-py/src/strands/models/gemini.py
@@ -477,15 +477,28 @@ class GeminiModel(Model):
                         return {"messageStop": {"stopReason": "end_turn"}}
 
             case "metadata":
-                input_tokens = event["data"].prompt_token_count or 0
-                total_tokens = event["data"].total_token_count or 0
+                usage_metadata = event["data"]
+                prompt_tokens = usage_metadata.prompt_token_count or 0
+                tool_use_prompt_tokens = usage_metadata.tool_use_prompt_token_count or 0
+                input_tokens = prompt_tokens + tool_use_prompt_tokens
+                total_tokens = usage_metadata.total_token_count or 0
+                candidates_tokens = usage_metadata.candidates_token_count
+                thoughts_tokens = usage_metadata.thoughts_token_count or 0
+                # Gemini's total_token_count folds four disjoint buckets (prompt + candidates +
+                # tool_use_prompt + thoughts). tool_use_prompt is input and thoughts are billed as output,
+                # so deriving output by subtraction miscounts tool_use_prompt as output; sum each side from
+                # its own fields, falling back to subtraction only when candidates is absent.
                 usage_data: Usage = {
                     "inputTokens": input_tokens,
-                    "outputTokens": max(0, total_tokens - input_tokens),
+                    "outputTokens": (
+                        candidates_tokens + thoughts_tokens
+                        if candidates_tokens is not None
+                        else max(0, total_tokens - input_tokens)
+                    ),
                     "totalTokens": total_tokens,
                 }
 
-                if cached := event["data"].cached_content_token_count:
+                if cached := usage_metadata.cached_content_token_count:
                     usage_data["cacheReadInputTokens"] = cached
 
                 return {

--- a/strands-py/tests/strands/models/test_gemini.py
+++ b/strands-py/tests/strands/models/test_gemini.py
@@ -623,6 +623,65 @@ def test_format_chunk_metadata_with_missing_token_counts(model):
     }
 
 
+def test_format_chunk_metadata_counts_tool_use_as_input_and_thoughts_as_output(model):
+    """Tool-use tokens count as input and thinking tokens as output, not folded into output by subtraction.
+
+    Regression for the token miscount catalogued in #3546: total_token_count sums four disjoint buckets
+    (prompt + candidates + tool_use_prompt + thoughts), so subtracting only prompt miscounts the input-side
+    tool_use_prompt tokens as output.
+    """
+    event = {
+        "chunk_type": "metadata",
+        "data": genai.types.GenerateContentResponseUsageMetadata(
+            prompt_token_count=100,
+            candidates_token_count=20,
+            tool_use_prompt_token_count=5,
+            thoughts_token_count=30,
+            total_token_count=155,
+        ),
+    }
+
+    result = model._format_chunk(event)
+
+    assert result == {
+        "metadata": {
+            "usage": {
+                "inputTokens": 105,
+                "outputTokens": 50,
+                "totalTokens": 155,
+            },
+            "metrics": {"latencyMs": 0},
+        },
+    }
+
+
+def test_format_chunk_metadata_with_candidates_and_cache_tokens(model):
+    """Test _format_chunk uses candidates for output while still surfacing cache-read tokens."""
+    event = {
+        "chunk_type": "metadata",
+        "data": genai.types.GenerateContentResponseUsageMetadata(
+            prompt_token_count=100,
+            candidates_token_count=20,
+            cached_content_token_count=25,
+            total_token_count=120,
+        ),
+    }
+
+    result = model._format_chunk(event)
+
+    assert result == {
+        "metadata": {
+            "usage": {
+                "inputTokens": 100,
+                "outputTokens": 20,
+                "totalTokens": 120,
+                "cacheReadInputTokens": 25,
+            },
+            "metrics": {"latencyMs": 0},
+        },
+    }
+
+
 @pytest.mark.asyncio
 async def test_stream_response_tool_use(gemini_client, model, messages, agenerator, alist):
     gemini_client.aio.models.generate_content_stream.return_value = agenerator(

--- a/strands-py/tests_integ/models/test_model_gemini.py
+++ b/strands-py/tests_integ/models/test_model_gemini.py
@@ -266,6 +266,15 @@ def test_agent_with_reasoning_content(model, assistant_agent):
     assert result.message["content"][0]["reasoningContent"]["reasoningText"]["text"]
 
 
+def test_agent_usage_tokens_hold_total_invariant(tool_agent):
+    result = tool_agent("What is the current time and weather in New York?")
+
+    usage = result.metrics.accumulated_usage
+    assert usage["inputTokens"] > 0
+    assert usage["outputTokens"] > 0
+    assert usage["totalTokens"] == usage["inputTokens"] + usage["outputTokens"]
+
+
 class TestCountTokens:
     @pytest.fixture
     def model(self):

--- a/strands-ts/src/models/__tests__/google.test.ts
+++ b/strands-ts/src/models/__tests__/google.test.ts
@@ -319,6 +319,117 @@ describe('GoogleModel', () => {
       })
     })
 
+    // Regression for the token miscount catalogued in #3546: totalTokenCount sums four disjoint buckets
+    // (prompt + candidates + toolUsePrompt + thoughts), so subtracting only prompt miscounts the
+    // input-side toolUsePrompt tokens as output.
+    it('counts tool-use tokens as input and thinking tokens as output', async () => {
+      const { provider, messages } = setupStreamTest(async function* () {
+        yield {
+          candidates: [{ content: { parts: [{ text: 'Hi' }] } }],
+          usageMetadata: {
+            promptTokenCount: 100,
+            candidatesTokenCount: 20,
+            toolUsePromptTokenCount: 5,
+            thoughtsTokenCount: 30,
+            totalTokenCount: 155,
+          },
+        }
+        yield { candidates: [{ finishReason: 'STOP' }] }
+      })
+
+      const events = await collectIterator(provider.stream(messages))
+
+      const metadataEvent = events.find((e) => e.type === 'modelMetadataEvent')
+      expect(metadataEvent).toEqual({
+        type: 'modelMetadataEvent',
+        usage: {
+          inputTokens: 105,
+          outputTokens: 50,
+          totalTokens: 155,
+        },
+      })
+    })
+
+    it('surfaces cache-read tokens when present', async () => {
+      const { provider, messages } = setupStreamTest(async function* () {
+        yield {
+          candidates: [{ content: { parts: [{ text: 'Hi' }] } }],
+          usageMetadata: {
+            promptTokenCount: 100,
+            candidatesTokenCount: 20,
+            cachedContentTokenCount: 25,
+            totalTokenCount: 120,
+          },
+        }
+        yield { candidates: [{ finishReason: 'STOP' }] }
+      })
+
+      const events = await collectIterator(provider.stream(messages))
+
+      const metadataEvent = events.find((e) => e.type === 'modelMetadataEvent')
+      expect(metadataEvent).toEqual({
+        type: 'modelMetadataEvent',
+        usage: {
+          inputTokens: 100,
+          outputTokens: 20,
+          totalTokens: 120,
+          cacheReadInputTokens: 25,
+        },
+      })
+    })
+
+    it('omits cache-read tokens when cachedContentTokenCount is 0', async () => {
+      const { provider, messages } = setupStreamTest(async function* () {
+        yield {
+          candidates: [{ content: { parts: [{ text: 'Hi' }] } }],
+          usageMetadata: {
+            promptTokenCount: 100,
+            candidatesTokenCount: 20,
+            cachedContentTokenCount: 0,
+            totalTokenCount: 120,
+          },
+        }
+        yield { candidates: [{ finishReason: 'STOP' }] }
+      })
+
+      const events = await collectIterator(provider.stream(messages))
+
+      const metadataEvent = events.find((e) => e.type === 'modelMetadataEvent')
+      expect(metadataEvent).toEqual({
+        type: 'modelMetadataEvent',
+        usage: {
+          inputTokens: 100,
+          outputTokens: 20,
+          totalTokens: 120,
+        },
+      })
+    })
+
+    it('clamps output to zero when totalTokenCount is below promptTokenCount', async () => {
+      const { provider, messages } = setupStreamTest(async function* () {
+        yield {
+          candidates: [{ content: { parts: [{ text: 'Hi' }] } }],
+          usageMetadata: {
+            promptTokenCount: 10,
+            totalTokenCount: 5,
+          },
+        }
+        yield { candidates: [{ finishReason: 'STOP' }] }
+      })
+
+      const events = await collectIterator(provider.stream(messages))
+
+      const metadataEvent = events.find((e) => e.type === 'modelMetadataEvent')
+      expect(metadataEvent).toEqual({
+        type: 'modelMetadataEvent',
+        usage: {
+          inputTokens: 10,
+          outputTokens: 0,
+          totalTokens: 5,
+        },
+      })
+    })
+
     it('handles MAX_TOKENS finish reason', async () => {
       const { provider, messages } = setupStreamTest(async function* () {
         yield {
@@ -1118,6 +1229,7 @@ describe('GoogleModel', () => {
         hasToolCalls: false,
         inputTokens: 0,
         outputTokens: 0,
+        totalTokens: 0,
       }
     }
 

--- a/strands-ts/src/models/__tests__/google.test.ts
+++ b/strands-ts/src/models/__tests__/google.test.ts
@@ -405,6 +405,40 @@ describe('GoogleModel', () => {
       })
     })
 
+    it('clears cache-read tokens when a later usage chunk reports none', async () => {
+      const { provider, messages } = setupStreamTest(async function* () {
+        yield {
+          candidates: [{ content: { parts: [{ text: 'Hi' }] } }],
+          usageMetadata: {
+            promptTokenCount: 100,
+            candidatesTokenCount: 20,
+            cachedContentTokenCount: 25,
+            totalTokenCount: 120,
+          },
+        }
+        yield {
+          candidates: [{ finishReason: 'STOP' }],
+          usageMetadata: {
+            promptTokenCount: 100,
+            candidatesTokenCount: 20,
+            totalTokenCount: 120,
+          },
+        }
+      })
+
+      const events = await collectIterator(provider.stream(messages))
+
+      const metadataEvent = events.find((e) => e.type === 'modelMetadataEvent')
+      expect(metadataEvent).toEqual({
+        type: 'modelMetadataEvent',
+        usage: {
+          inputTokens: 100,
+          outputTokens: 20,
+          totalTokens: 120,
+        },
+      })
+    })
+
     it('clamps output to zero when totalTokenCount is below promptTokenCount', async () => {
       const { provider, messages } = setupStreamTest(async function* () {
         yield {

--- a/strands-ts/src/models/google/adapters.ts
+++ b/strands-ts/src/models/google/adapters.ts
@@ -381,6 +381,8 @@ export function mapChunkToEvents(chunk: GenerateContentResponse, streamState: Go
     const cachedTokens = usageMetadata.cachedContentTokenCount
     if (typeof cachedTokens === 'number' && cachedTokens > 0) {
       streamState.cacheReadInputTokens = cachedTokens
+    } else {
+      delete streamState.cacheReadInputTokens
     }
   }
 

--- a/strands-ts/src/models/google/adapters.ts
+++ b/strands-ts/src/models/google/adapters.ts
@@ -366,10 +366,22 @@ export function mapChunkToEvents(chunk: GenerateContentResponse, streamState: Go
 
   // Extract usage metadata if available
   if (chunk.usageMetadata) {
-    const promptTokens = chunk.usageMetadata.promptTokenCount || 0
-    const totalTokens = chunk.usageMetadata.totalTokenCount || 0
-    streamState.inputTokens = promptTokens
-    streamState.outputTokens = totalTokens - promptTokens
+    const usageMetadata = chunk.usageMetadata
+    const promptTokens = usageMetadata.promptTokenCount || 0
+    const toolUsePromptTokens = usageMetadata.toolUsePromptTokenCount || 0
+    const totalTokens = usageMetadata.totalTokenCount || 0
+    const candidatesTokens = usageMetadata.candidatesTokenCount
+    const thoughtsTokens = usageMetadata.thoughtsTokenCount || 0
+    const inputTokens = promptTokens + toolUsePromptTokens
+
+    streamState.inputTokens = inputTokens
+    streamState.outputTokens =
+      candidatesTokens === undefined ? Math.max(0, totalTokens - inputTokens) : candidatesTokens + thoughtsTokens
+    streamState.totalTokens = totalTokens
+    const cachedTokens = usageMetadata.cachedContentTokenCount
+    if (typeof cachedTokens === 'number' && cachedTokens > 0) {
+      streamState.cacheReadInputTokens = cachedTokens
+    }
   }
 
   const candidates = chunk.candidates

--- a/strands-ts/src/models/google/model.ts
+++ b/strands-ts/src/models/google/model.ts
@@ -16,7 +16,7 @@ import {
 import { Model, resolveConfigMetadata } from '../model.js'
 import type { CountTokensOptions, StreamOptions } from '../model.js'
 import type { Message } from '../../types/messages.js'
-import type { ModelStreamEvent } from '../streaming.js'
+import type { ModelStreamEvent, Usage } from '../streaming.js'
 import { ContextWindowOverflowError, ModelThrottledError, ProviderTokenCountError } from '../../errors.js'
 import type { GoogleModelConfig, GoogleModelOptions, GoogleStreamState } from './types.js'
 export type { GoogleModelConfig, GoogleModelOptions }
@@ -236,6 +236,7 @@ export class GoogleModel extends Model<GoogleModelConfig> {
         hasToolCalls: false,
         inputTokens: 0,
         outputTokens: 0,
+        totalTokens: 0,
       }
 
       for await (const chunk of stream) {
@@ -243,14 +244,15 @@ export class GoogleModel extends Model<GoogleModelConfig> {
       }
 
       if (streamState.inputTokens > 0 || streamState.outputTokens > 0) {
-        yield {
-          type: 'modelMetadataEvent',
-          usage: {
-            inputTokens: streamState.inputTokens,
-            outputTokens: streamState.outputTokens,
-            totalTokens: streamState.inputTokens + streamState.outputTokens,
-          },
+        const usage: Usage = {
+          inputTokens: streamState.inputTokens,
+          outputTokens: streamState.outputTokens,
+          totalTokens: streamState.totalTokens,
         }
+        if (streamState.cacheReadInputTokens !== undefined && streamState.cacheReadInputTokens > 0) {
+          usage.cacheReadInputTokens = streamState.cacheReadInputTokens
+        }
+        yield { type: 'modelMetadataEvent', usage }
       }
     } catch (error) {
       if (!(error instanceof Error)) {

--- a/strands-ts/src/models/google/model.ts
+++ b/strands-ts/src/models/google/model.ts
@@ -249,7 +249,7 @@ export class GoogleModel extends Model<GoogleModelConfig> {
           outputTokens: streamState.outputTokens,
           totalTokens: streamState.totalTokens,
         }
-        if (streamState.cacheReadInputTokens !== undefined && streamState.cacheReadInputTokens > 0) {
+        if (streamState.cacheReadInputTokens !== undefined) {
           usage.cacheReadInputTokens = streamState.cacheReadInputTokens
         }
         yield { type: 'modelMetadataEvent', usage }

--- a/strands-ts/src/models/google/types.ts
+++ b/strands-ts/src/models/google/types.ts
@@ -86,4 +86,6 @@ export interface GoogleStreamState {
   hasToolCalls: boolean
   inputTokens: number
   outputTokens: number
+  totalTokens: number
+  cacheReadInputTokens?: number
 }

--- a/strands-ts/test/integ/models/google.test.ts
+++ b/strands-ts/test/integ/models/google.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { Message, TextBlock } from '@strands-agents/sdk'
+import { Message, TextBlock, ToolResultBlock, ToolUseBlock } from '@strands-agents/sdk'
 import type { ModelStreamEvent } from '$/sdk/models/streaming.js'
 
 import { collectIterator } from '$/sdk/__fixtures__/model-test-helpers.js'
@@ -124,6 +124,42 @@ describe.skipIf(gemini.skip)('GoogleModel Integration Tests', () => {
         const messageStopEvent = events.find((e) => e.type === 'modelMessageStopEvent')
         expect(messageStopEvent).toBeDefined()
         expect(messageStopEvent?.stopReason).toBe('endTurn')
+      })
+    })
+
+    describe('Usage Metadata', () => {
+      it.concurrent('reports usage that satisfies the total invariant on a tool-using turn', async () => {
+        const provider = gemini.createModel({ params: { maxOutputTokens: 100 } })
+
+        const toolSpecs = [
+          {
+            name: 'get_weather',
+            description: 'Get the current weather for a city',
+            inputSchema: { type: 'object' as const, properties: { city: { type: 'string' as const } } },
+          },
+        ]
+        const messages: Message[] = [
+          new Message({ role: 'user', content: [new TextBlock('What is the weather in New York?')] }),
+          new Message({
+            role: 'assistant',
+            content: [new ToolUseBlock({ name: 'get_weather', toolUseId: 'weather-1', input: { city: 'New York' } })],
+          }),
+          new Message({
+            role: 'user',
+            content: [
+              new ToolResultBlock({ toolUseId: 'weather-1', status: 'success', content: [new TextBlock('sunny')] }),
+            ],
+          }),
+        ]
+
+        const events = await collectIterator<ModelStreamEvent>(provider.stream(messages, { toolSpecs }))
+
+        const metadataEvent = events.find((e) => e.type === 'modelMetadataEvent')
+        const usage = metadataEvent?.usage
+        expect(usage).toBeDefined()
+        expect(usage!.inputTokens).toBeGreaterThan(0)
+        expect(usage!.outputTokens).toBeGreaterThan(0)
+        expect(usage!.totalTokens).toBe(usage!.inputTokens + usage!.outputTokens)
       })
     })
   })


### PR DESCRIPTION
## Description

Gemini providers derive `outputTokens` by subtracting `promptTokenCount` from `totalTokenCount`. But Gemini's `totalTokenCount` is the sum of four *disjoint* buckets:

`prompt + candidates + tool_use_prompt + thoughts` 

So the existing setup sweeps `tool_use_prompt_token_count` (tool results fed back to the model, an **input** quantity) into output. On any tool-using turn, `outputTokens` over-reports and, because output is the priced side, inflates cost.

This computes each side from its own fields: `inputTokens = prompt + tool_use_prompt`, `outputTokens = candidates + thoughts`.

`totalTokens` remains Gemini's reported total, so the `total = input + output` invariant holds. 

No API surface changes. The `Usage` shape is unchanged; only the token *values* the Gemini/Google providers report are corrected. For a turn with `prompt=100, candidates=20, tool_use_prompt=5, thoughts=30, total=155`:

```
# Before: tool_use_prompt miscounted as output
{ inputTokens: 100, outputTokens: 55, totalTokens: 155 }

# After: tool_use_prompt is input, thoughts are output
{ inputTokens: 105, outputTokens: 50, totalTokens: 155 }
```

## Related Issues

#3546

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

Ran the Gemini/Google unit suites in both SDKs (`hatch run test tests/strands/models/test_gemini.py`; `npx vitest run src/models/__tests__/google.test.ts`), plus `hatch fmt --linter`, `hatch run complexity`, and the TS `src` `type-check` and `lint`. Added regression coverage for the corrected accounting (input/output split, thinking-in-output, cache-read surfacing, and the zero-clamp fallback); the fixtures set `tool_use_prompt > 0` because that is the only shape under which the old and new formulas diverge. Also exercised the mapping end to end against a real `google.genai` `GenerateContentResponseUsageMetadata` object, confirming the pre-fix value was 55 and the post-fix value is 50.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
