### PR TITLE
refactor(python): port pending tool execution state

### DIFF
--- a/strands-py/src/strands/_middleware/README.md
+++ b/strands-py/src/strands/_middleware/README.md
@@ -197,30 +197,28 @@ short-circuit), at the cost of `replace(messages=...)` not being honored. Both S
 ## AgentStreamStage interrupt resume
 
 Python interrupts were tool-only: the event loop keyed resume behavior on interrupt state being
-`activated` alone — priming a resume by replaying the stored `tool_use_message`, and merging the
-stored `tool_results`. An `AgentStreamStage` interrupt activates interrupt state **without** a
-pending tool execution (empty context), so both reads are gated on the presence of their tool
-context key (`"tool_use_message" in context` / `"tool_results" in context`). An agent-stream
-resume therefore falls through to a normal model call — and if that call then invokes a tool, the
-tool path no longer trips over the empty context — while the middleware resolves its own interrupt
-(returning the response) before calling `next()`.
+`activated` alone. Tool replay state now lives in the typed `PendingToolExecution` field. An
+`AgentStreamStage` interrupt activates interrupt state **without** a pending tool execution, so an
+agent-stream resume falls through to a normal model call while the middleware resolves its own
+interrupt (returning the response) before calling `next()`.
 
 Because an agent-stream interrupt has no tool cycle to deactivate the state afterward, the run
 loop deactivates interrupt state when the pass completes without one. The guard is narrow — it
 fires only when the state is activated, the pass did not stop on an interrupt, **and** no tool
-context is present (`"tool_use_message" not in context`). That last condition is essential: a
+execution is pending (`pending_tool_execution is None`). That last condition is essential: a
 pending *tool* interrupt also leaves the state activated, and some non-interrupt endings keep it
 that way on purpose — e.g. cancelling a resumed tool interrupt ends the pass `"cancelled"` while
-the interrupt is still owed a resume. Without the tool-context check the run loop would wipe that
+the interrupt is still owed a resume. Without the pending-execution check the run loop would wipe that
 pending tool interrupt. Scoped this way, the run-loop deactivation only ever clears agent-stream
-interrupts (which never store tool context); the event loop remains the sole owner of
+interrupts (which never store pending tool execution); the event loop remains the sole owner of
 tool-interrupt state.
 
 A cancelled pass keeps that tool interrupt because the event loop only completes the tool resume
 when the tools actually ran: cancellation (`agent.cancel()` or a `BeforeToolsEvent` cancel) produces
-cancel tool results without executing anything, so the stored `tool_use_message` and the human's
-answer are left in place for a later resume. Clearing them would strand the caller holding
-interrupt responses for state that no longer exists.
+cancel tool results without executing anything, so the stored tool-use message and the human's
+answer are left in place for a later resume (a cancel mid-execution refreshes the stored results so
+completed tools aren't re-run). Clearing them would strand the caller holding interrupt responses
+for state that no longer exists.
 
 (TypeScript mirrors this: its AgentStreamStage wrapper deactivates on a non-interrupt completion
 when no pending tool execution is stored, so an agent-stream interrupt that resumes to a plain
@@ -269,7 +267,7 @@ run loop refuses the part of this it can detect precisely — an interrupt raise
 produced its EventLoopStopEvent — by clearing interrupt state and raising RuntimeError naming the
 interrupt. Interrupts in the window between the model turn and the stop event are not caught.
 
-A *tool* interrupt is exempt: its stored `tool_use_message` is replayed on resume, so no second
+A *tool* interrupt is exempt: its pending tool execution is replayed on resume, so no second
 model call happens, and gating on top of a tool interrupt keeps working.
 
 This makes the Output phase unsuitable for gating. The Output adapter drains the whole inner chain

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -1524,7 +1524,7 @@ class Agent(AgentBase):
                     if (
                         self._interrupt_state.activated
                         and (agent_result is None or agent_result.stop_reason != "interrupt")
-                        and not self._interrupt_state.has_pending_tool_execution
+                        and self._interrupt_state.pending_tool_execution is None
                     ):
                         self._interrupt_state.deactivate()
                 except InterruptException as interrupt_exception:
@@ -1532,7 +1532,7 @@ class Agent(AgentBase):
                     # and corrupt history.
                     if (
                         pass_progress.event_loop_produced_result
-                        and not self._interrupt_state.has_pending_tool_execution
+                        and self._interrupt_state.pending_tool_execution is None
                     ):
                         self._interrupt_state.deactivate()
                         raise RuntimeError(

--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -19,6 +19,7 @@ from opentelemetry import trace as trace_api
 from .._middleware.stages import InvokeModelContext, InvokeModelStage
 from ..experimental.checkpoint import Checkpoint, CheckpointPosition
 from ..hooks import AfterModelCallEvent, AfterToolsEvent, BeforeModelCallEvent, BeforeToolsEvent
+from ..interrupt import PendingToolExecution
 from ..telemetry.metrics import Trace, _total_prompt_tokens
 from ..telemetry.tracer import Tracer, get_tracer
 from ..tools._validator import validate_and_prepare_tools
@@ -285,9 +286,10 @@ async def event_loop_cycle(
     with trace_api.use_span(cycle_span, end_on_exit=False):
         try:
             # Resume a tool interrupt by replaying its stored message instead of calling the model.
-            if agent._interrupt_state.activated and "tool_use_message" in agent._interrupt_state.context:
+            pending_tool_execution = agent._interrupt_state.pending_tool_execution
+            if agent._interrupt_state.activated and pending_tool_execution is not None:
                 stop_reason: StopReason = "tool_use"
-                message = agent._interrupt_state.context["tool_use_message"]
+                message = pending_tool_execution.assistant_message
             # Skip model invocation if the latest message contains ToolUse
             elif _has_tool_use_in_latest_message(agent.messages):
                 stop_reason = "tool_use"
@@ -323,7 +325,7 @@ async def event_loop_cycle(
                 if (
                     agent._checkpointing
                     and not agent._observe_cancellation()
-                    and not agent._interrupt_state.has_pending_tool_execution
+                    and agent._interrupt_state.pending_tool_execution is None
                 ):
                     resume_position = agent._checkpoint_resume_position
                     agent._checkpoint_resume_position = None
@@ -729,7 +731,10 @@ async def _stop_for_interrupts(
     so interrupt persistence logic lives in one place.
     """
     # Session state stored on AfterInvocationEvent.
-    agent._interrupt_state.context = {"tool_use_message": message, "tool_results": tool_results}
+    agent._interrupt_state.pending_tool_execution = PendingToolExecution(
+        assistant_message=message,
+        completed_tool_results=tool_results,
+    )
     agent._interrupt_state.activate()
 
     agent.event_loop_metrics.end_cycle(cycle_start_time, cycle_trace)
@@ -784,8 +789,9 @@ async def _handle_tool_execution(
     tool_results: list[ToolResult] = []
 
     # Merge tool results from a resumed tool interrupt.
-    if agent._interrupt_state.activated and "tool_results" in agent._interrupt_state.context:
-        tool_results.extend(agent._interrupt_state.context["tool_results"])
+    pending_tool_execution = agent._interrupt_state.pending_tool_execution
+    if agent._interrupt_state.activated and pending_tool_execution is not None:
+        tool_results.extend(pending_tool_execution.completed_tool_results)
 
         # Filter to only the interrupted tools when resuming from interrupt (tool uses without results)
         tool_use_ids = {tool_result["toolUseId"] for tool_result in tool_results}
@@ -871,7 +877,10 @@ async def _handle_tool_execution(
         except Exception:
             # Persist pending interrupts before re-raising so they aren't lost.
             if interrupts:
-                agent._interrupt_state.context = {"tool_use_message": message, "tool_results": tool_results}
+                agent._interrupt_state.pending_tool_execution = PendingToolExecution(
+                    assistant_message=message,
+                    completed_tool_results=tool_results,
+                )
                 agent._interrupt_state.activate()
             raise
 
@@ -897,8 +906,8 @@ async def _handle_tool_execution(
     if not agent._observe_cancellation():
         agent._interrupt_state.end_tool_cycle()
     # Update stored results so replay filter skips already-executed tools on next resume.
-    elif cancel_message is None and agent._interrupt_state.has_pending_tool_execution:
-        agent._interrupt_state.context["tool_results"] = tool_results
+    elif cancel_message is None:
+        agent._interrupt_state.set_pending_tool_results(tool_results)
 
     await agent._append_messages(tool_result_message)
 

--- a/strands-py/src/strands/interrupt.py
+++ b/strands-py/src/strands/interrupt.py
@@ -5,7 +5,9 @@ from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from .types.agent import AgentInput
+    from .types.content import Message
     from .types.interrupt import InterruptResponseContent
+    from .types.tools import ToolResult
 
 _AGENT_STREAM_INTERRUPT_ID_PREFIX = "v1:middleware_agent_stream:"
 """Id prefix for interrupts scoped to a whole invocation pass rather than a single tool call."""
@@ -41,6 +43,19 @@ class InterruptException(Exception):
 
 
 @dataclass
+class PendingToolExecution:
+    """State required to resume tool execution without calling the model again.
+
+    Attributes:
+        assistant_message: Assistant message containing the pending tool uses.
+        completed_tool_results: Results completed or synthesized during the interrupted execution.
+    """
+
+    assistant_message: "Message"
+    completed_tool_results: list["ToolResult"]
+
+
+@dataclass
 class _InterruptState:
     """Track the state of interrupt events raised by the user.
 
@@ -52,17 +67,14 @@ class _InterruptState:
             False because retained responses persist until their cycle ends.
         context: Additional context associated with an interrupt event.
         activated: True if agent is in an interrupt state, False otherwise.
+        pending_tool_execution: State required to resume an interrupted tool execution.
     """
 
     interrupts: dict[str, Interrupt] = field(default_factory=dict)
     context: dict[str, Any] = field(default_factory=dict)
     activated: bool = False
+    pending_tool_execution: PendingToolExecution | None = None
     _version: int = field(default=0, compare=False, repr=False)
-
-    @property
-    def has_pending_tool_execution(self) -> bool:
-        """Whether a tool execution is pending resume."""
-        return "tool_use_message" in self.context
 
     def activate(self) -> None:
         """Activate the interrupt state."""
@@ -70,13 +82,14 @@ class _InterruptState:
         self._version += 1
 
     def deactivate(self) -> None:
-        """Deacitvate the interrupt state.
+        """Deactivate the interrupt state.
 
-        Interrupts and context are cleared.
+        Interrupts, context, and pending tool execution are cleared.
         """
         self.interrupts = {}
         self.context = {}
         self.activated = False
+        self.pending_tool_execution = None
         self._version += 1
 
     def end_tool_cycle(self) -> None:
@@ -88,6 +101,7 @@ class _InterruptState:
         }
         self.context = {}
         self.activated = False
+        self.pending_tool_execution = None
         self._version += 1
 
     def end_interrupt_cycle(self) -> None:
@@ -139,11 +153,19 @@ class _InterruptState:
         self.context["responses"] = contents
         self._version += 1
 
+    def set_pending_tool_results(self, completed_tool_results: list["ToolResult"]) -> None:
+        """Update completed results for a pending tool execution."""
+        if self.pending_tool_execution is None:
+            return
+
+        self.pending_tool_execution.completed_tool_results = completed_tool_results
+        self._version += 1
+
     def _get_version(self) -> int:
         """Get the current version number of the interrupt state.
 
         The version is incremented each time the state is mutated — activate(), deactivate(),
-        resume(), end_tool_cycle(), or end_interrupt_cycle().
+        resume(), set_pending_tool_results(), end_tool_cycle(), or end_interrupt_cycle().
         Consumers can compare versions to detect changes without requiring
         explicit dirty flag clearing.
 
@@ -166,19 +188,45 @@ class _InterruptState:
                 if not interrupt_id.startswith(_AGENT_STREAM_INTERRUPT_ID_PREFIX)
             }
 
-        return {
+        data: dict[str, Any] = {
             "interrupts": {k: v.to_dict() for k, v in interrupts.items()},
             "context": self.context,
             "activated": self.activated,
         }
+        if self.pending_tool_execution is not None:
+            data["pending_tool_execution"] = asdict(self.pending_tool_execution)
+        return data
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "_InterruptState":
-        """Initiailize interrupt state from serialized interrupt state.
+        """Initialize interrupt state from serialized interrupt state.
 
-        Interrupt state can be serialized with the `to_dict` method.
+        Interrupt state can be serialized with the `to_dict` method. Legacy tool execution context
+        is migrated into the typed pending state.
         """
         activated = data["activated"]
+        context: dict[str, Any] = data["context"].copy()
+        pending_tool_execution_data = data.get("pending_tool_execution")
+        legacy_tool_use_message = context.pop("tool_use_message", None)
+        legacy_tool_results = context.pop("tool_results", []) if legacy_tool_use_message is not None else []
+
+        pending_tool_execution: PendingToolExecution | None
+        if pending_tool_execution_data is not None:
+            try:
+                pending_tool_execution = PendingToolExecution(**pending_tool_execution_data)
+            except TypeError as error:
+                # Avoid importing the types package while this module is still initializing.
+                from .types.exceptions import SessionException
+
+                raise SessionException(f"Failed to restore pending tool execution state: {error}") from error
+        elif legacy_tool_use_message is not None:
+            pending_tool_execution = PendingToolExecution(
+                assistant_message=cast("Message", legacy_tool_use_message),
+                completed_tool_results=cast(list["ToolResult"], legacy_tool_results),
+            )
+        else:
+            pending_tool_execution = None
+
         return cls(
             interrupts={
                 interrupt_id: Interrupt(**interrupt_data)
@@ -186,6 +234,7 @@ class _InterruptState:
                 # Mirror to_dict's filter — don't revive a stale response as a standing approval.
                 if activated or not interrupt_id.startswith(_AGENT_STREAM_INTERRUPT_ID_PREFIX)
             },
-            context=data["context"],
+            context=context,
             activated=activated,
+            pending_tool_execution=pending_tool_execution,
         )

--- a/strands-py/tests/strands/agent/test_agent.py
+++ b/strands-py/tests/strands/agent/test_agent.py
@@ -22,7 +22,7 @@ from strands.agent.conversation_manager.sliding_window_conversation_manager impo
 from strands.agent.state import AgentState
 from strands.handlers.callback_handler import PrintingCallbackHandler, null_callback_handler
 from strands.hooks import BeforeInvocationEvent, BeforeModelCallEvent, BeforeToolCallEvent
-from strands.interrupt import Interrupt
+from strands.interrupt import Interrupt, PendingToolExecution
 from strands.memory import MemoryManager, MemoryManagerConfig
 from strands.models.bedrock import DEFAULT_BEDROCK_MODEL_ID, BedrockModel
 from strands.session.repository_session_manager import RepositorySessionManager
@@ -1984,7 +1984,10 @@ def test_agent__call__resume_interrupt(mock_model, tool_decorated, agenerator):
         reason="test reason",
     )
 
-    agent._interrupt_state.context = {"tool_use_message": tool_use_message, "tool_results": []}
+    agent._interrupt_state.pending_tool_execution = PendingToolExecution(
+        assistant_message=tool_use_message,
+        completed_tool_results=[],
+    )
     agent._interrupt_state.interrupts[interrupt.id] = interrupt
     agent._interrupt_state.activate()
 

--- a/strands-py/tests/strands/agent/test_agent_cancellation.py
+++ b/strands-py/tests/strands/agent/test_agent_cancellation.py
@@ -317,7 +317,7 @@ async def test_cancel_during_tool_interrupt_resume_preserves_interrupt_state():
     interrupt_result = await agent.invoke_async("go")
     assert interrupt_result.stop_reason == "interrupt"
     assert agent._interrupt_state.activated
-    assert "tool_use_message" in agent._interrupt_state.context
+    assert agent._interrupt_state.pending_tool_execution is not None
 
     # Cancel the resume before the tool runs.
     agent.cancel()
@@ -328,7 +328,7 @@ async def test_cancel_during_tool_interrupt_resume_preserves_interrupt_state():
     assert cancelled_result.stop_reason == "cancelled"
     # The pending tool interrupt state survives the cancelled pass.
     assert agent._interrupt_state.activated
-    assert "tool_use_message" in agent._interrupt_state.context
+    assert agent._interrupt_state.pending_tool_execution is not None
 
 
 @pytest.mark.asyncio
@@ -570,6 +570,7 @@ async def test_hook_cancelled_tool_batch_does_not_replay_the_stored_tool_use():
     assert not agent._interrupt_state.activated
     assert not agent._interrupt_state.context
     assert not agent._interrupt_state.interrupts
+    assert agent._interrupt_state.pending_tool_execution is None
 
 
 def _approver_agent(ran, cancel_on_first_run=False):

--- a/strands-py/tests/strands/event_loop/test_event_loop.py
+++ b/strands-py/tests/strands/event_loop/test_event_loop.py
@@ -25,7 +25,7 @@ from strands.hooks import (
     HookRegistry,
     MessageAddedEvent,
 )
-from strands.interrupt import Interrupt, _InterruptState
+from strands.interrupt import Interrupt, PendingToolExecution, _InterruptState
 from strands.telemetry.metrics import EventLoopMetrics
 from strands.telemetry.tracer import Tracer
 from strands.tools.executors import ConcurrentToolExecutor, SequentialToolExecutor
@@ -1331,8 +1331,10 @@ async def test_event_loop_cycle_interrupts_preserved_when_after_tools_hook_raise
 
     # Interrupt state was preserved before the exception propagated.
     assert agent._interrupt_state.activated
-    assert agent._interrupt_state.context["tool_use_message"] == agent.messages[-1]
-    assert agent._interrupt_state.context["tool_results"] == []
+    assert agent._interrupt_state.pending_tool_execution == PendingToolExecution(
+        assistant_message=agent.messages[-1],
+        completed_tool_results=[],
+    )
 
 
 @pytest.mark.asyncio
@@ -1783,7 +1785,11 @@ async def test_event_loop_cycle_before_tools_interrupts_and_resume_without_model
         "v1:before_tools:fc7d4db5-7c70-583b-86ca-392fc71cadf6",
     ]
     assert execution_events == []
-    assert agent._interrupt_state.context == {"tool_use_message": agent.messages[1], "tool_results": []}
+    assert agent._interrupt_state.context == {}
+    assert agent._interrupt_state.pending_tool_execution == PendingToolExecution(
+        assistant_message=agent.messages[1],
+        completed_tool_results=[],
+    )
     assert model.stream.call_count == 1
 
     agent._interrupt_state.resume(
@@ -1875,9 +1881,10 @@ async def test_event_loop_cycle_interrupt(agent, model, tool_stream, agenerator,
     tru_state = agent._interrupt_state.to_dict()
     exp_state = {
         "activated": True,
-        "context": {
-            "tool_results": [],
-            "tool_use_message": {
+        "context": {},
+        "pending_tool_execution": {
+            "completed_tool_results": [],
+            "assistant_message": {
                 "content": [
                     {
                         "toolUse": {
@@ -1940,7 +1947,10 @@ async def test_event_loop_cycle_interrupt_resume(agent, model, tool, tool_times_
         },
     ]
 
-    agent._interrupt_state.context = {"tool_use_message": tool_use_message, "tool_results": tool_results}
+    agent._interrupt_state.pending_tool_execution = PendingToolExecution(
+        assistant_message=tool_use_message,
+        completed_tool_results=tool_results,
+    )
     agent._interrupt_state.interrupts[interrupt.id] = interrupt
     agent._interrupt_state.activate()
 

--- a/strands-py/tests/strands/test_interrupt.py
+++ b/strands-py/tests/strands/test_interrupt.py
@@ -1,6 +1,7 @@
 import pytest
 
-from strands.interrupt import _AGENT_STREAM_INTERRUPT_ID_PREFIX, Interrupt, _InterruptState
+from strands.interrupt import _AGENT_STREAM_INTERRUPT_ID_PREFIX, Interrupt, PendingToolExecution, _InterruptState
+from strands.types.exceptions import SessionException
 
 
 @pytest.fixture
@@ -32,7 +33,14 @@ def test_interrupt_state_activate():
 
 
 def test_interrupt_state_deactivate():
-    interrupt_state = _InterruptState(context={"test": "context"}, activated=True)
+    interrupt_state = _InterruptState(
+        context={"test": "context"},
+        activated=True,
+        pending_tool_execution=PendingToolExecution(
+            assistant_message={"role": "assistant", "content": []},
+            completed_tool_results=[],
+        ),
+    )
 
     interrupt_state.deactivate()
 
@@ -41,6 +49,7 @@ def test_interrupt_state_deactivate():
     tru_context = interrupt_state.context
     exp_context = {}
     assert tru_context == exp_context
+    assert interrupt_state.pending_tool_execution is None
 
 
 def test_interrupt_state_to_dict():
@@ -48,6 +57,10 @@ def test_interrupt_state_to_dict():
         interrupts={"test_id": Interrupt(id="test_id", name="test_name", reason="test reason")},
         context={"test": "context"},
         activated=True,
+        pending_tool_execution=PendingToolExecution(
+            assistant_message={"role": "assistant", "content": []},
+            completed_tool_results=[{"toolUseId": "tool-1", "status": "success", "content": []}],
+        ),
     )
 
     tru_data = interrupt_state.to_dict()
@@ -55,6 +68,10 @@ def test_interrupt_state_to_dict():
         "interrupts": {"test_id": {"id": "test_id", "name": "test_name", "reason": "test reason", "response": None}},
         "context": {"test": "context"},
         "activated": True,
+        "pending_tool_execution": {
+            "assistant_message": {"role": "assistant", "content": []},
+            "completed_tool_results": [{"toolUseId": "tool-1", "status": "success", "content": []}],
+        },
     }
     assert tru_data == exp_data
 
@@ -62,17 +79,122 @@ def test_interrupt_state_to_dict():
 def test_interrupt_state_from_dict():
     data = {
         "interrupts": {"test_id": {"id": "test_id", "name": "test_name", "reason": "test reason", "response": None}},
-        "context": {"test": "context"},
+        "context": {"test": "context", "tool_results": ["unrelated"]},
         "activated": True,
+        "pending_tool_execution": {
+            "assistant_message": {"role": "assistant", "content": []},
+            "completed_tool_results": [{"toolUseId": "tool-1", "status": "success", "content": []}],
+        },
     }
 
     tru_state = _InterruptState.from_dict(data)
     exp_state = _InterruptState(
         interrupts={"test_id": Interrupt(id="test_id", name="test_name", reason="test reason")},
-        context={"test": "context"},
+        context={"test": "context", "tool_results": ["unrelated"]},
         activated=True,
+        pending_tool_execution=PendingToolExecution(
+            assistant_message={"role": "assistant", "content": []},
+            completed_tool_results=[{"toolUseId": "tool-1", "status": "success", "content": []}],
+        ),
     )
     assert tru_state == exp_state
+
+
+def test_interrupt_state_from_dict_migrates_legacy_tool_context():
+    prompt = [{"interruptResponse": {"interruptId": "test_id", "response": "approved"}}]
+    data = {
+        "interrupts": {},
+        "context": {
+            "responses": prompt,
+            "tool_use_message": {"role": "assistant", "content": []},
+            "tool_results": [{"toolUseId": "tool-1", "status": "success", "content": []}],
+        },
+        "activated": True,
+    }
+
+    tru_state = _InterruptState.from_dict(data)
+    exp_state = _InterruptState(
+        context={"responses": prompt},
+        activated=True,
+        pending_tool_execution=PendingToolExecution(
+            assistant_message={"role": "assistant", "content": []},
+            completed_tool_results=[{"toolUseId": "tool-1", "status": "success", "content": []}],
+        ),
+    )
+    assert tru_state == exp_state
+    assert data["context"] == {
+        "responses": prompt,
+        "tool_use_message": {"role": "assistant", "content": []},
+        "tool_results": [{"toolUseId": "tool-1", "status": "success", "content": []}],
+    }
+
+
+def test_interrupt_state_from_dict_prefers_typed_pending_execution_over_legacy_context():
+    data = {
+        "interrupts": {},
+        "context": {
+            "responses": [],
+            "tool_use_message": {"role": "assistant", "content": [{"text": "legacy"}]},
+            "tool_results": [{"toolUseId": "legacy", "status": "success", "content": []}],
+        },
+        "activated": True,
+        "pending_tool_execution": {
+            "assistant_message": {"role": "assistant", "content": [{"text": "typed"}]},
+            "completed_tool_results": [{"toolUseId": "typed", "status": "success", "content": []}],
+        },
+    }
+
+    tru_state = _InterruptState.from_dict(data)
+    exp_state = _InterruptState(
+        context={"responses": []},
+        activated=True,
+        pending_tool_execution=PendingToolExecution(
+            assistant_message={"role": "assistant", "content": [{"text": "typed"}]},
+            completed_tool_results=[{"toolUseId": "typed", "status": "success", "content": []}],
+        ),
+    )
+    assert tru_state == exp_state
+    assert data["context"] == {
+        "responses": [],
+        "tool_use_message": {"role": "assistant", "content": [{"text": "legacy"}]},
+        "tool_results": [{"toolUseId": "legacy", "status": "success", "content": []}],
+    }
+
+
+def test_interrupt_state_pending_tool_execution_round_trip_is_independent():
+    interrupt_state = _InterruptState(
+        activated=True,
+        pending_tool_execution=PendingToolExecution(
+            assistant_message={"role": "assistant", "content": [{"text": "pending"}]},
+            completed_tool_results=[{"toolUseId": "tool-1", "status": "success", "content": []}],
+        ),
+    )
+
+    serialized_state = interrupt_state.to_dict()
+    tru_state = _InterruptState.from_dict(serialized_state)
+    exp_state = interrupt_state
+    assert tru_state == exp_state
+
+    serialized_state["pending_tool_execution"]["completed_tool_results"][0]["status"] = "error"
+    exp_pending_tool_execution = PendingToolExecution(
+        assistant_message={"role": "assistant", "content": [{"text": "pending"}]},
+        completed_tool_results=[{"toolUseId": "tool-1", "status": "success", "content": []}],
+    )
+    assert interrupt_state.pending_tool_execution == exp_pending_tool_execution
+
+
+def test_interrupt_state_from_dict_wraps_invalid_pending_tool_execution():
+    data = {
+        "interrupts": {},
+        "context": {},
+        "activated": True,
+        "pending_tool_execution": {"assistant_message": {"role": "assistant", "content": []}},
+    }
+
+    with pytest.raises(SessionException, match="Failed to restore pending tool execution state") as error_info:
+        _InterruptState.from_dict(data)
+
+    assert isinstance(error_info.value.__cause__, TypeError)
 
 
 def test_interrupt_state_resume():
@@ -171,6 +293,27 @@ def test_interrupt_state_version_increments_after_resume():
     assert interrupt_state._get_version() == initial_version + 1
 
 
+def test_interrupt_state_set_pending_tool_results_increments_version():
+    interrupt_state = _InterruptState(
+        pending_tool_execution=PendingToolExecution(
+            assistant_message={"role": "assistant", "content": []},
+            completed_tool_results=[],
+        )
+    )
+    initial_version = interrupt_state._get_version()
+    completed_tool_results = [{"toolUseId": "tool-1", "status": "success", "content": []}]
+
+    interrupt_state.set_pending_tool_results(completed_tool_results)
+
+    tru_pending_tool_execution = interrupt_state.pending_tool_execution
+    exp_pending_tool_execution = PendingToolExecution(
+        assistant_message={"role": "assistant", "content": []},
+        completed_tool_results=completed_tool_results,
+    )
+    assert tru_pending_tool_execution == exp_pending_tool_execution
+    assert interrupt_state._get_version() == initial_version + 1
+
+
 def test_interrupt_state_version_increments_independently():
     """Test that version increments independently for each operation."""
     interrupt_state = _InterruptState()
@@ -204,8 +347,12 @@ def test_interrupt_state_end_tool_cycle():
             unanswered_gate.id: unanswered_gate,
             tool_interrupt.id: tool_interrupt,
         },
-        context={"tool_use_message": {"role": "assistant"}, "tool_results": []},
+        context={"responses": []},
         activated=True,
+        pending_tool_execution=PendingToolExecution(
+            assistant_message={"role": "assistant", "content": []},
+            completed_tool_results=[],
+        ),
     )
 
     interrupt_state.end_tool_cycle()
@@ -215,16 +362,21 @@ def test_interrupt_state_end_tool_cycle():
     assert tru_interrupts == exp_interrupts
     assert interrupt_state.context == {}
     assert not interrupt_state.activated
+    assert interrupt_state.pending_tool_execution is None
 
 
 def test_interrupt_state_end_interrupt_cycle():
-    """Agent-stream interrupts are dropped; tool interrupts and context are untouched."""
+    """Agent-stream interrupts are dropped; tool execution state and context are untouched."""
     answered_gate = Interrupt(id=f"{_AGENT_STREAM_INTERRUPT_ID_PREFIX}answered", name="gate", response="approved")
     tool_interrupt = Interrupt(id="v1:tool_call:t1:abc", name="tool_gate")
     interrupt_state = _InterruptState(
         interrupts={answered_gate.id: answered_gate, tool_interrupt.id: tool_interrupt},
-        context={"tool_use_message": {"role": "assistant"}},
+        context={"responses": []},
         activated=True,
+        pending_tool_execution=PendingToolExecution(
+            assistant_message={"role": "assistant", "content": []},
+            completed_tool_results=[],
+        ),
     )
 
     interrupt_state.end_interrupt_cycle()
@@ -232,8 +384,12 @@ def test_interrupt_state_end_interrupt_cycle():
     tru_interrupts = interrupt_state.interrupts
     exp_interrupts = {tool_interrupt.id: tool_interrupt}
     assert tru_interrupts == exp_interrupts
-    assert interrupt_state.context == {"tool_use_message": {"role": "assistant"}}
+    assert interrupt_state.context == {"responses": []}
     assert interrupt_state.activated
+    assert interrupt_state.pending_tool_execution == PendingToolExecution(
+        assistant_message={"role": "assistant", "content": []},
+        completed_tool_results=[],
+    )
 
 
 def test_interrupt_state_end_interrupt_cycle_nothing_to_release():


### PR DESCRIPTION
## Description

This moves pending tool replay data out of `_InterruptState.context` and into a typed `PendingToolExecution` field. It keeps Python's existing `Message` and `list[ToolResult]` representations, and migrates the legacy context keys when loading older serialized interrupt state.

Existing serialized state remains readable. This change does not dual-write the legacy keys; rolling back to an older SDK while a tool interrupt is pending is unsupported, because a stale legacy copy could cause completed tools to run again.

## Related Issues

Resolves #3719

## Documentation PR

Not required. The middleware lifecycle notes are updated in this PR.

## Type of Change

Other (internal refactor)

## Testing

Ran `hatch run prepare`, including formatting, linting, full mypy, and the Python 3.10–3.14 test matrix.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
