### PR TITLE
fix(ts): close the model invoke span when the consumer breaks the stream

### DIFF
--- a/strands-ts/src/agent/__tests__/agent.tracer.test.node.ts
+++ b/strands-ts/src/agent/__tests__/agent.tracer.test.node.ts
@@ -310,6 +310,7 @@ describe('Agent tracer integration', () => {
 
       await expect(agent.invoke('Hi')).rejects.toThrow()
 
+      expect(tracer.endModelInvokeSpan).toHaveBeenCalledTimes(1)
       expect(tracer.endModelInvokeSpan).toHaveBeenCalledWith(
         { mock: 'modelSpan' },
         expect.objectContaining({ error: expect.any(Error) })

--- a/strands-ts/src/agent/__tests__/agent.tracer.test.node.ts
+++ b/strands-ts/src/agent/__tests__/agent.tracer.test.node.ts
@@ -270,6 +270,20 @@ describe('Agent tracer integration', () => {
   })
 
   describe('model invoke span lifecycle', () => {
+    it('ends the model invoke span once when the consumer breaks mid-model-response', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+      const agent = new Agent({ model })
+      const tracer = getLatestTracer()
+
+      for await (const event of agent.stream('Hi')) {
+        if (event.type === 'modelStreamUpdateEvent') break
+      }
+
+      expect(tracer.startModelInvokeSpan).toHaveBeenCalledTimes(1)
+      expect(tracer.endModelInvokeSpan).toHaveBeenCalledTimes(1)
+      expect(tracer.endModelInvokeSpan).toHaveBeenCalledWith({ mock: 'modelSpan' })
+    })
+
     it('starts and ends model span on successful model call', async () => {
       const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
       const agent = new Agent({ model })

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -2196,6 +2196,7 @@ export class Agent implements LocalAgent, InvokableAgent {
           ...(ctx.systemPrompt !== undefined && { systemPrompt: ctx.systemPrompt }),
         })
 
+        let modelSpanEnded = false
         try {
           // Wrap the snapshot into a StateStore for the model provider, which expects
           // get/set methods.
@@ -2224,11 +2225,19 @@ export class Agent implements LocalAgent, InvokableAgent {
             ...(usage && { usage }),
             ...(metrics && { metrics }),
           })
+          modelSpanEnded = true
 
           return { result: iterResult.value }
         } catch (error) {
           self._tracer.endModelInvokeSpan(modelSpan, { error: normalizeError(error) })
+          modelSpanEnded = true
           throw error
+        } finally {
+          // A consumer break closes this generator via .return(): finally runs but catch does not,
+          // so neither end call above fires and the span would stay open.
+          if (!modelSpanEnded) {
+            self._tracer.endModelInvokeSpan(modelSpan)
+          }
         }
       }
     )


### PR DESCRIPTION
## Description

The chat span in `_invokeModelWithMiddleware` was closed by two explicit calls: one on the happy path once the model stream drains, one in the `catch` on error. The inner generator yields between those two points. When a consumer breaks out of `for await` while the model is still streaming, the generator is closed through `.return()`, which runs `finally` blocks but not `catch`, so neither call happened and the span stayed open. `startModelInvokeSpan` ran once, `endModelInvokeSpan` never did, and the trace kept a dangling chat span with no output, usage or stop reason on it.

This adds a `modelSpanEnded` flag and a `finally` that closes the span only if nothing else already did, plus a regression test that breaks on `modelStreamUpdateEvent`.

I left the two existing calls exactly where they were instead of moving them into the `finally`. #3812 tried the move for the cycle span and it zeroed `metrics.totalDuration` and `averageCycleTime`, because closing unconditionally at the end of the block also runs on paths that had already reported their numbers. Guarding avoids that: the success and error paths are byte-identical to before, keeping their output, usage, metrics and error attributes, and only an early exit reaches the bare close.

On overlap with #3812 (closed unmerged): there was none. That PR touched the cycle span in `_runLoop` around L1543-1700, this one touches the chat span in `_invokeModelWithMiddleware` around L2193-2240. The cycle-span leak on the same break was tracked in #3800 and fixed by #4054 (merged 2026-08-31); this change covers the chat span.

## Related Issues

Resolves #3896

## Documentation PR

No documentation changes. The fix restores the documented span lifecycle rather than changing it.

## Type of Change

Bug fix

## Testing

- `npx vitest run src/agent/__tests__/agent.tracer.test.node.ts`: 38 passed
- `npx vitest run src/agent src/telemetry`: 47 files, 1188 passed, no type errors
- `npx tsc --noEmit --project src/tsconfig.json`: clean
- `npx eslint` and `npx prettier --check` on both changed files: clean
- Full pre-commit gate (build, `test:coverage`, lint, format, type-check): passed
- A/B on the new test: with `main`'s `agent.ts` restored it fails (`endModelInvokeSpan` called 0 times); with the fix, 1/1
- Metrics check, single-cycle `invoke()`: `main` reports `totalDuration/averageCycleTime` of 3/3, this branch 2/2. Both non-zero, and the gap is jitter on a mock turn rather than the collapse to 0 that #3812 hit.
- Mutation check on the new count assertion: deleting the `catch` branch's `modelSpanEnded = true` makes the error test report two calls instead of one, where the suite previously stayed green

- [ ] I ran `hatch run prepare`

`hatch run prepare` covers the Python package; this change is TypeScript only, so the equivalent here is the `strands-ts` pre-commit gate listed above, which passed.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


