### PR TITLE
docs(catalog): point the aidress-mcp card at our Strands docs page

### DIFF
--- a/site/src/content/catalog/aidress-mcp.yaml
+++ b/site/src/content/catalog/aidress-mcp.yaml
@@ -4,5 +4,5 @@ integrationType: tool
 languages:
   python: {}
 github: https://github.com/Aidress-ai/Aidress
-docsUrl: https://aidress.ai/docs/mcp-server
+docsUrl: https://aidress.ai/docs/strands
 addedDate: 2026-08-12

--- a/site/src/content/catalog/aidress-mcp.yaml
+++ b/site/src/content/catalog/aidress-mcp.yaml
@@ -4,5 +4,5 @@ integrationType: tool
 languages:
   python: {}
 github: https://github.com/Aidress-ai/Aidress
-docsUrl: https://github.com/Aidress-ai/Aidress/blob/main/README_MCP.md
+docsUrl: https://aidress.ai/docs/mcp-server
 addedDate: 2026-08-12


### PR DESCRIPTION
Small follow-up to #3364, which added this entry last week.

`docsUrl` currently points at `README_MCP.md` on GitHub, which lands a visitor in effectively the same place as the card's `github` link. This repoints it at our Strands-specific documentation page:

```diff
-docsUrl: https://github.com/Aidress-ai/Aidress/blob/main/README_MCP.md
+docsUrl: https://aidress.ai/docs/strands
```

That page is about this integration specifically rather than our MCP server in general. It covers:

- **The `mcp` version-pin conflict, stated plainly.** `strands-agents` pins `mcp>=1.23.0,<2.0.0` and `aidress-mcp` pins `mcp>=2.0.0,<3.0.0`, so `pip install aidress-mcp` cannot resolve in a Strands environment — which is exactly why this entry declares `python: {}` and no `package:`. The page explains why that isn't a blocker: MCP negotiates protocol version over the wire, so Strands' own `mcp` 1.x client reaches the hosted endpoint with nothing installed. Verified against `strands-agents` 1.51.0 / `mcp` 1.29.0 — all 16 tools discovered, `verify_agent` returns successfully.
- **A quick start** using `MCPClient(lambda: streamablehttp_client(...))` and `Agent(tools=[client])`.
- **Two traps** worth knowing: `Agent(tools=[client])` must not be nested inside `with client:`, and `call_tool_sync` returns `content` as a JSON string.
- **Header-based auth**, since the env vars on our general MCP page do nothing for hosted callers.

This follows the "Link your own documentation" guidance on the Add Your Integration page — the page lives with the product, so it stays current as the integration evolves. `github` is unchanged, so the card keeps both links: repo and docs.

One-line change, no other fields touched. `featured`, `badges`, `maintainer` and registry fields remain unset, and no on-site docs page is added.

Verified the target renders before submitting. Our docs are client-rendered, so a plain `curl` returns only the app shell — I loaded the page in a browser to confirm the content is actually there rather than trusting a 200.
