### PR TITLE
fix(openai): append the format to tool-result document filenames

### DIFF
--- a/strands-ts/src/models/openai/__tests__/responses.test.ts
+++ b/strands-ts/src/models/openai/__tests__/responses.test.ts
@@ -351,7 +351,7 @@ describe("OpenAIModel (api: 'responses')", () => {
             new ToolResultBlock({
               toolUseId: 'doc_tool',
               status: 'success',
-              content: [new DocumentBlock({ name: 'report.pdf', format: 'pdf', source: { bytes: docBytes } })],
+              content: [new DocumentBlock({ name: 'report', format: 'pdf', source: { bytes: docBytes } })],
             }),
           ],
         }),
@@ -366,6 +366,26 @@ describe("OpenAIModel (api: 'responses')", () => {
           filename: 'report.pdf',
         },
       ])
+    })
+
+    it('does not double the extension when a document name already carries it', async () => {
+      const docBytes = new Uint8Array([5, 6, 7, 8])
+      const messages = [
+        new Message({ role: 'user', content: [new TextBlock('read')] }),
+        new Message({
+          role: 'user',
+          content: [
+            new ToolResultBlock({
+              toolUseId: 'doc_tool',
+              status: 'success',
+              content: [new DocumentBlock({ name: 'report.pdf', format: 'pdf', source: { bytes: docBytes } })],
+            }),
+          ],
+        }),
+      ]
+      const req = await runOnce({}, messages)
+      const out = req.input.find((i: any) => i.type === 'function_call_output')
+      expect(out.output[0].filename).toBe('report.pdf')
     })
 
     it('keeps tool result output as a plain string when only text is present', async () => {

--- a/strands-ts/src/models/openai/responses-adapter.ts
+++ b/strands-ts/src/models/openai/responses-adapter.ts
@@ -292,11 +292,13 @@ function formatToolResultOutput(resultBlock: ToolResultBlock): string | Response
         if (docBlock.source.type === 'documentSourceBytes') {
           const base64 = encodeBase64(docBlock.source.bytes)
           const mimeType = toMimeType(docBlock.format) || `application/${docBlock.format}`
+          const suffix = `.${docBlock.format}`
+          const filename = docBlock.name.endsWith(suffix) ? docBlock.name : `${docBlock.name}${suffix}`
           hasMedia = true
           parts.push({
             type: 'input_file',
             file_data: `data:${mimeType};base64,${base64}`,
-            filename: docBlock.name,
+            filename,
           })
         } else {
           logger.warn(


### PR DESCRIPTION
## Description

The TypeScript Responses adapter sends a tool-result document's `name` verbatim as the `input_file` filename. Converse-shaped document names carry no extension — the `format` field types the document, and dots are invalid in `name` — while Bedrock Mantle types an `input_file` by its filename's extension, so any tool that returns a document breaks the very next model call:

```
400 Unsupported file type: 'sample-0e6deb8f'. Supported: PDF, DOCX, XLSX, CSV, TXT, MD, HTML, and video (.mp4, .webm, .mov, .avi, .mkv).
```

The Python responses model has appended the format to tool-result filenames since #3674. This applies the same rule to the TypeScript tool-result path — append the format unless the name already ends with it — restoring parity between the SDKs. The message-content site (`formatDocumentInput`) stays as-is, matching Python's, which #3674 flags as a possible follow-up.

## Related Issues

Python twin: #3673, resolved by #3674.

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

The existing tool-result document test now uses an extension-less Converse-shaped name and asserts the appended extension, with a second case pinning that an already-suffixed name is not doubled (the old fixture's `report.pdf` name — one Converse itself rejects — had masked the gap). Ran the TypeScript pre-commit suite (`npm run check`).

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
