### PR TITLE
feat(catalog): add TealTiger governance pluginAdd strands-tealtiger plugin configuration

### DIFF
--- a/site/src/content/catalog/strands-tealtiger.yaml
+++ b/site/src/content/catalog/strands-tealtiger.yaml
@@ -1,0 +1,9 @@
+name: strands-tealtiger
+description: Deterministic governance plugin — tool allowlists, PII/secret detection, prompt injection defense, cost budgets, and kill switch. No LLM, no server, <2ms.
+integrationType: plugin
+languages:
+  python:
+    package: strands-tealtiger
+github: https://github.com/agentguard-ai/tealtiger
+docsUrl: https://docs.tealtiger.ai/integrations/strands
+addedDate: 2026-08-19


### PR DESCRIPTION
## What does this integration do?

TealTiger adds deterministic governance to Strands agents as a native Plugin. It intercepts `BeforeToolCallEvent` and `BeforeToolsEvent` to enforce:

- Tool allowlist/blocklist (glob patterns)
- PII detection (SSN, credit card, email, phone)
- Secret detection (API keys, tokens, credentials)
- Prompt injection defense (8 patterns, configurable threshold)
- Per-session cost budgets
- Kill switch (freeze/unfreeze)

All evaluation is in-process, regex-based, <2ms, no external server needed.

## Installation

```bash
pip install strands-tealtiger
```

## Quick example

```python
from strands import Agent
from strands_tealtiger import TealTigerPlugin

agent = Agent(
    tools=[search, calculator],
    plugins=[TealTigerPlugin(mode="ENFORCE", allowed_tools=["search", "calculator"])]
)
```

## Checklist

- [x] Package published to PyPI: https://pypi.org/project/strands-tealtiger/
- [x] `integrationType` is `plugin`
- [x] `docsUrl` points to live documentation
- [x] `github` points to public repository
- [x] `addedDate` is today's date
- [x] No `featured`, `badges`, or `maintainer` fields set
