### PR TITLE
fix(tools): normalize_schema/normalize_tool_spec must not mutate the caller's dict

### DIFF
--- a/strands-py/src/strands/tools/tools.py
+++ b/strands-py/src/strands/tools/tools.py
@@ -132,19 +132,17 @@ def normalize_schema(schema: dict[str, Any], *, _depth: int = 0) -> dict[str, An
     if _depth > _MAX_SCHEMA_DEPTH:
         raise ValueError(f"tool inputSchema nesting exceeds {_MAX_SCHEMA_DEPTH} levels")
 
-    # Start with a complete copy to preserve all existing properties
+    # Copy "properties" too: dict.copy() is shallow, so it would otherwise still alias the caller's.
     normalized = schema.copy()
+    normalized["properties"] = dict(normalized.get("properties", {}))
 
     # Ensure essential structure exists
     normalized.setdefault("type", "object")
-    normalized.setdefault("properties", {})
     normalized.setdefault("required", [])
 
     # Process properties recursively
-    if "properties" in normalized:
-        properties = normalized["properties"]
-        for prop_name, prop_def in properties.items():
-            normalized["properties"][prop_name] = _normalize_property(prop_name, prop_def, _depth=_depth)
+    for prop_name, prop_def in normalized["properties"].items():
+        normalized["properties"][prop_name] = _normalize_property(prop_name, prop_def, _depth=_depth)
 
     return normalized
 
@@ -166,6 +164,8 @@ def normalize_tool_spec(tool_spec: ToolSpec) -> ToolSpec:
     # Handle inputSchema
     if "inputSchema" in normalized:
         if isinstance(normalized["inputSchema"], dict):
+            # Copy inputSchema too, for the same shallow-copy reason as above.
+            normalized["inputSchema"] = dict(normalized["inputSchema"])
             if "json" in normalized["inputSchema"]:
                 # Schema is already in correct format, just normalize inner schema
                 normalized["inputSchema"]["json"] = normalize_schema(normalized["inputSchema"]["json"])

--- a/strands-py/tests/strands/tools/test_registry.py
+++ b/strands-py/tests/strands/tools/test_registry.py
@@ -2,6 +2,7 @@
 Tests for the SDK tool registry module.
 """
 
+import copy
 import json
 import logging
 import sys
@@ -15,6 +16,7 @@ from strands.tools.decorator import DecoratedFunctionTool, tool
 from strands.tools.loader import _TOOL_MODULE_PREFIX
 from strands.tools.mcp import MCPClient
 from strands.tools.registry import ToolRegistry
+from strands.tools.tools import normalize_tool_spec
 
 
 @pytest.fixture(autouse=True)
@@ -80,6 +82,10 @@ def test_register_tool_with_similar_name_raises():
 def test_get_all_tool_specs_returns_right_tool_specs():
     tool_1 = strands.tool(lambda a: a, name="tool_1")
     tool_2 = strands.tool(lambda b: b, name="tool_2")
+    # Deep copy: tool_1.tool_spec is checked for mutation below, so the snapshot must not
+    # share any nested dict with it (a shallow .copy() would, and could hide a regression).
+    raw_tool_1_spec = copy.deepcopy(tool_1.tool_spec)
+    raw_tool_2_spec = copy.deepcopy(tool_2.tool_spec)
 
     tool_registry = ToolRegistry()
 
@@ -88,10 +94,14 @@ def test_get_all_tool_specs_returns_right_tool_specs():
 
     tool_specs = tool_registry.get_all_tool_specs()
 
+    # Compared against the normalized form (get_all_tool_specs fills in defaults); the
+    # tool's own tool_spec must stay untouched (#3910).
     assert tool_specs == [
-        tool_1.tool_spec,
-        tool_2.tool_spec,
+        normalize_tool_spec(raw_tool_1_spec),
+        normalize_tool_spec(raw_tool_2_spec),
     ]
+    assert tool_1.tool_spec == raw_tool_1_spec
+    assert tool_2.tool_spec == raw_tool_2_spec
 
 
 def test_scan_module_for_tools():

--- a/strands-py/tests/strands/tools/test_tools.py
+++ b/strands-py/tests/strands/tools/test_tools.py
@@ -432,6 +432,68 @@ def test_normalize_tool_spec_empty_input_schema():
     assert normalized == expected
 
 
+def test_normalize_schema_does_not_mutate_caller_schema():
+    """normalize_schema must not write into the schema dict the caller passed in (#3910)."""
+    schema = {"type": "object", "properties": {"name": {}}}
+    original = {"type": "object", "properties": {"name": {}}}
+
+    normalize_schema(schema)
+
+    assert schema == original
+
+
+def test_normalize_schema_does_not_mutate_nested_object_properties():
+    """The recursive object-schema path must not mutate the caller's nested property dict either."""
+    schema = {
+        "type": "object",
+        "properties": {"data": {"type": "object", "properties": {"id": {}}}},
+    }
+    original = {
+        "type": "object",
+        "properties": {"data": {"type": "object", "properties": {"id": {}}}},
+    }
+
+    normalize_schema(schema)
+
+    assert schema == original
+
+
+def test_normalize_tool_spec_does_not_mutate_caller_tool_spec():
+    """normalize_tool_spec must not write into the tool_spec dict the caller passed in (#3910)."""
+    tool_spec = {
+        "name": "demo",
+        "description": "demo",
+        "inputSchema": {"json": {"type": "object", "properties": {"query": {}}}},
+    }
+    original = {
+        "name": "demo",
+        "description": "demo",
+        "inputSchema": {"json": {"type": "object", "properties": {"query": {}}}},
+    }
+
+    normalize_tool_spec(tool_spec)
+
+    assert tool_spec == original
+
+
+def test_normalize_tool_spec_direct_schema_does_not_mutate_caller_tool_spec():
+    """Same guarantee on the "direct schema" (no "json" key yet) branch."""
+    tool_spec = {
+        "name": "demo",
+        "description": "demo",
+        "inputSchema": {"type": "object", "properties": {"query": {}}},
+    }
+    original = {
+        "name": "demo",
+        "description": "demo",
+        "inputSchema": {"type": "object", "properties": {"query": {}}},
+    }
+
+    normalize_tool_spec(tool_spec)
+
+    assert tool_spec == original
+
+
 def test_validate_tool_use_with_valid_input():
     tool_use: ToolUse = {
         "name": "valid",


### PR DESCRIPTION
## Root cause

`normalize_schema` and `normalize_tool_spec` (`strands-py/src/strands/tools/tools.py`) each
start with `schema.copy()` / `tool_spec.copy()`. That copy is shallow, so the nested
`properties` / `inputSchema` dict in the copy is still the exact same object as the one on
the caller's original. Both functions then write into that shared nested dict (setting
normalized property values, or replacing `inputSchema["json"]`), which mutates the caller's
original schema or tool spec as a side effect, contradicting the docstring's own claim of a
"copy-then-normalize approach to preserve all original schema properties."

This is not just a theoretical aliasing bug: `ToolRegistry.get_all_tools_config()` calls
`spec = tool.tool_spec.copy()` (also shallow, with a comment claiming it's "a deep copy to
avoid modifying the original") and then `normalize_tool_spec(spec)`, so every call
permanently rewrites the registered tool's own stored `tool_spec` in place.

## Fix

Copy the nested `properties` dict in `normalize_schema` and the nested `inputSchema` dict in
`normalize_tool_spec` before writing into them, so neither function ever touches an object
the caller still holds a reference to. The recursive nested-object-schema path goes through
the same `normalize_schema` call, so it gets the same protection without a separate change.

## Verified

- New regression tests (`test_normalize_schema_does_not_mutate_caller_schema`,
  `..._does_not_mutate_nested_object_properties`, `test_normalize_tool_spec_does_not_mutate_caller_tool_spec`,
  `..._direct_schema_does_not_mutate_caller_tool_spec`) fail on `main` (`bc37995`) and pass on
  this branch, run in a clean `python:3.10-slim` and `python:3.14-slim` container against the
  real module (`strands.tools.tools.__file__` provenance printed both sides).
- `test_get_all_tool_specs_returns_right_tool_specs` in `test_registry.py` was asserting the
  registry's normalized output against `tool.tool_spec` directly, which only passed because
  the bug had already mutated `tool.tool_spec` into the normalized shape by the time the
  assertion ran. Updated it to compare against an explicit `normalize_tool_spec` call on a
  deep-copied snapshot, plus an explicit assertion that the tool's own `tool_spec` is
  unchanged after registration.
- Full `tests/strands/tools/` directory (599 tests): 597 pass, 2 pre-existing failures in
  `test_mcp_client.py::test_mcp_client_client_info_passed` unrelated to this change
  (`No package metadata was found for strands-agents`, a packaging/env issue reproduced
  identically on unmodified `main`).
- `ruff check` and `ruff format --check` on the changed files: clean.
- Not verified: the full `hatch test` matrix (Windows/macOS legs, and the `bidi` extras,
  which this change does not touch) was not run locally; only the base runtime dependencies
  plus the affected test files were exercised in Docker.

Fixes #3910
