### PR TITLE
fix(openai): append the format to message document filenames

### DIFF
--- a/strands-ts/src/models/openai/__tests__/responses.test.ts
+++ b/strands-ts/src/models/openai/__tests__/responses.test.ts
@@ -471,6 +471,49 @@ describe("OpenAIModel (api: 'responses')", () => {
       const req = await runOnce({}, messages)
       expect(req.input[0]).toEqual({ role: 'user', content: [{ type: 'input_text', text: 'quoted passage' }] })
     })
+
+    it('formats a user message document as input_file with the format appended to the filename', async () => {
+      const docBytes = new Uint8Array([5, 6, 7, 8])
+      const messages = [
+        new Message({
+          role: 'user',
+          content: [
+            new TextBlock('read this'),
+            new DocumentBlock({ name: 'report', format: 'pdf', source: { bytes: docBytes } }),
+          ],
+        }),
+      ]
+      const req = await runOnce({}, messages)
+      expect(req.input[0]).toEqual({
+        role: 'user',
+        content: [
+          { type: 'input_text', text: 'read this' },
+          {
+            type: 'input_file',
+            file_data: expect.stringMatching(/^data:application\/pdf;base64,/),
+            filename: 'report.pdf',
+          },
+        ],
+      })
+    })
+
+    it('does not double the extension when a message document name already carries it', async () => {
+      const docBytes = new Uint8Array([5, 6, 7, 8])
+      const messages = [
+        new Message({
+          role: 'user',
+          content: [new DocumentBlock({ name: 'report.pdf', format: 'pdf', source: { bytes: docBytes } })],
+        }),
+      ]
+      const req = await runOnce({}, messages)
+      expect(req.input[0].content).toEqual([
+        {
+          type: 'input_file',
+          file_data: expect.stringMatching(/^data:application\/pdf;base64,/),
+          filename: 'report.pdf',
+        },
+      ])
+    })
   })
 
   describe('stream event mapping', () => {

--- a/strands-ts/src/models/openai/responses-adapter.ts
+++ b/strands-ts/src/models/openai/responses-adapter.ts
@@ -330,10 +330,12 @@ function formatDocumentInput(docBlock: DocumentBlock): Record<string, unknown> |
   if (docBlock.source.type === 'documentSourceBytes') {
     const base64 = encodeBase64(docBlock.source.bytes)
     const mimeType = toMimeType(docBlock.format) || `application/${docBlock.format}`
+    const suffix = `.${docBlock.format}`
+    const filename = docBlock.name.endsWith(suffix) ? docBlock.name : `${docBlock.name}${suffix}`
     return {
       type: 'input_file',
       file_data: `data:${mimeType};base64,${base64}`,
-      filename: docBlock.name,
+      filename,
     }
   }
   logger.warn(`source_type=<${docBlock.source.type}> | only byte source documents supported in responses api`)


### PR DESCRIPTION
## Description

The TypeScript Responses adapter sends a user message document's `name` verbatim as the `input_file` filename (`formatDocumentInput`). Converse-shaped document names carry no extension — the `format` field types the document, and dots are invalid in `name` — while Bedrock Mantle types an `input_file` by its filename's extension, so a conversation that carries a document breaks the model call with `400 Unsupported file type`.

#3901 applied the append rule to the TypeScript tool-result path and left this site as-is, matching Python at the time; Python's message-content site has since been fixed in #3912. Same rule here: append the format unless the name already ends with it.

## Related Issues

Tool-result twin: #3901. Python twin of this fix: #3912.

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

Two new cases: a user message document with a Converse-shaped extension-less name asserts the appended extension, and a second pins that an already-suffixed name is not doubled. Ran the TypeScript pre-commit suite (`npm run check`).

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
