### PR TITLE
fix(catalog): update strands-tealtiger to integrationType: intervention

### DIFF
--- a/site/src/content/catalog/strands-tealtiger.yaml
+++ b/site/src/content/catalog/strands-tealtiger.yaml
@@ -1,0 +1,9 @@
+name: strands-tealtiger
+description: Deterministic governance plugin — tool allowlists, PII/secret detection, prompt injection defense, cost budgets, and kill switch. No LLM, no server, <2ms.
+integrationType: plugin
+languages:
+  python:
+    package: strands-tealtiger
+github: https://github.com/agentguard-ai/tealtiger
+docsUrl: https://docs.tealtiger.ai/integrations/strands
+addedDate: 2026-08-19

--- a/site/src/content/catalog/strands-tealtiger.yaml
+++ b/site/src/content/catalog/strands-tealtiger.yaml
@@ -1,6 +1,6 @@
 name: strands-tealtiger
-description: Deterministic governance plugin — tool allowlists, PII/secret detection, prompt injection defense, cost budgets, and kill switch. No LLM, no server, <2ms.
-integrationType: plugin
+description: Deterministic governance intervention — tool allowlists, PII/secret detection, prompt injection defense, cost budgets, and kill switch. No LLM, no server, <2ms.
+integrationType: intervention
 languages:
   python:
     package: strands-tealtiger


### PR DESCRIPTION
Follow-up to #3906 per @lizradway's feedback.

Updates `strands-tealtiger` catalog entry from `plugin` to `intervention` — the package now ships `TealTigerIntervention` implementing `InterventionHandler` with typed `Proceed`/`Deny` decisions from `before_tool_call`.

Published as v0.2.1: https://pypi.org/project/strands-tealtiger/0.2.1/

```python
from strands import Agent
from strands_tealtiger import TealTigerIntervention

agent = Agent(
    tools=[search, calculator],
    interventions=[TealTigerIntervention(
        mode="ENFORCE",
        allowed_tools=["search", "calculator"],
        pii_categories=["ssn", "credit_card"],
        budget_limit=5.0,
    )]
)
