### PR TITLE
feat(context-manager): add L1 stash for durable storage of offloaded content

### DIFF
--- a/strands-ts/src/context-manager/__tests__/retrieval-tool.test.ts
+++ b/strands-ts/src/context-manager/__tests__/retrieval-tool.test.ts
@@ -13,13 +13,13 @@ function encodeJSON(value: unknown): Uint8Array {
 
 describe('retrieval tool', () => {
   function makeStashWithTextBlock(text: string): { stash: Stash; refPromise: Promise<string> } {
-    const stash = new Stash(new InMemoryStorage(), 'test-session')
+    const stash = new Stash(new InMemoryStorage(), 'test-session', 'test-agent')
     const refPromise = stash.store('tool-1', 0, encodeJSON({ text }))
     return { stash, refPromise }
   }
 
   it('has the correct tool name', () => {
-    const stash = new Stash(new InMemoryStorage(), 'test-session')
+    const stash = new Stash(new InMemoryStorage(), 'test-session', 'test-agent')
     const retrievalTool = createRetrievalTool(stash)
     expect(retrievalTool.name).toBe(RETRIEVAL_TOOL_NAME)
   })
@@ -60,7 +60,7 @@ describe('retrieval tool', () => {
   })
 
   it('returns error for unknown reference', async () => {
-    const stash = new Stash(new InMemoryStorage(), 'test-session')
+    const stash = new Stash(new InMemoryStorage(), 'test-session', 'test-agent')
     const retrievalTool = createRetrievalTool(stash)
 
     const result = (await invoke(retrievalTool, { reference: 'nonexistent' })) as string
@@ -68,7 +68,7 @@ describe('retrieval tool', () => {
   })
 
   it('retrieves image content as JSON', async () => {
-    const stash = new Stash(new InMemoryStorage(), 'test-session')
+    const stash = new Stash(new InMemoryStorage(), 'test-session', 'test-agent')
     const imageData = { image: { format: 'png', source: { bytes: 'iVBORw0KGgo=' } } }
     const ref = await stash.store('tool-img', 0, encodeJSON(imageData))
     const retrievalTool = createRetrievalTool(stash)
@@ -78,7 +78,7 @@ describe('retrieval tool', () => {
   })
 
   it('retrieves JSON content as parsed object', async () => {
-    const stash = new Stash(new InMemoryStorage(), 'test-session')
+    const stash = new Stash(new InMemoryStorage(), 'test-session', 'test-agent')
     const json = { key: 'value', nested: [1, 2, 3] }
     const ref = await stash.store('tool-json', 0, encodeJSON({ json }))
     const retrievalTool = createRetrievalTool(stash)
@@ -88,7 +88,7 @@ describe('retrieval tool', () => {
   })
 
   it('returns error when searching non-text content', async () => {
-    const stash = new Stash(new InMemoryStorage(), 'test-session')
+    const stash = new Stash(new InMemoryStorage(), 'test-session', 'test-agent')
     const imageData = { image: { format: 'png', source: { bytes: 'iVBORw0KGgo=' } } }
     const ref = await stash.store('tool-img', 0, encodeJSON(imageData))
     const retrievalTool = createRetrievalTool(stash)

--- a/strands-ts/src/context-manager/__tests__/retrieval-tool.test.ts
+++ b/strands-ts/src/context-manager/__tests__/retrieval-tool.test.ts
@@ -2,32 +2,35 @@ import { describe, it, expect } from 'vitest'
 import { createRetrievalTool, RETRIEVAL_TOOL_NAME } from '../retrieval-tool.js'
 import { Stash } from '../stash.js'
 import { InMemoryStorage } from '../../storage/in-memory-storage.js'
-import { ImageBlock } from '../../types/media.js'
 
 function invoke(retrievalTool: ReturnType<typeof createRetrievalTool>, input: unknown): Promise<unknown> {
   return (retrievalTool as unknown as { invoke(input: unknown): Promise<unknown> }).invoke(input)
 }
 
+function encodeJSON(value: unknown): Uint8Array {
+  return new TextEncoder().encode(JSON.stringify(value))
+}
+
 describe('retrieval tool', () => {
-  function makeStashWithContent(text: string): { stash: Stash; refPromise: Promise<string> } {
-    const stash = new Stash(new InMemoryStorage())
-    const refPromise = stash.store('tool-1', 0, new TextEncoder().encode(text), 'text/plain')
+  function makeStashWithTextBlock(text: string): { stash: Stash; refPromise: Promise<string> } {
+    const stash = new Stash(new InMemoryStorage(), 'test-session')
+    const refPromise = stash.store('tool-1', 0, encodeJSON({ text }))
     return { stash, refPromise }
   }
 
   it('has the correct tool name', () => {
-    const stash = new Stash(new InMemoryStorage())
+    const stash = new Stash(new InMemoryStorage(), 'test-session')
     const retrievalTool = createRetrievalTool(stash)
     expect(retrievalTool.name).toBe(RETRIEVAL_TOOL_NAME)
   })
 
   it('retrieves full text content', async () => {
-    const { stash, refPromise } = makeStashWithContent('hello world\nline two')
+    const { stash, refPromise } = makeStashWithTextBlock('hello world\nline two')
     const ref = await refPromise
     const retrievalTool = createRetrievalTool(stash)
 
     const result = await invoke(retrievalTool, { reference: ref })
-    expect(result).toBe('hello world\nline two')
+    expect(result).toEqual({ text: 'hello world\nline two' })
   })
 
   it('searches with pattern', async () => {
@@ -35,7 +38,7 @@ describe('retrieval tool', () => {
       { length: 20 },
       (_, index) => `line ${index + 1}: ${index % 3 === 0 ? 'ERROR' : 'ok'}`
     ).join('\n')
-    const { stash, refPromise } = makeStashWithContent(text)
+    const { stash, refPromise } = makeStashWithTextBlock(text)
     const ref = await refPromise
     const retrievalTool = createRetrievalTool(stash)
 
@@ -46,7 +49,7 @@ describe('retrieval tool', () => {
 
   it('returns line range', async () => {
     const text = Array.from({ length: 50 }, (_, index) => `line ${index + 1}`).join('\n')
-    const { stash, refPromise } = makeStashWithContent(text)
+    const { stash, refPromise } = makeStashWithTextBlock(text)
     const ref = await refPromise
     const retrievalTool = createRetrievalTool(stash)
 
@@ -57,42 +60,40 @@ describe('retrieval tool', () => {
   })
 
   it('returns error for unknown reference', async () => {
-    const stash = new Stash(new InMemoryStorage())
+    const stash = new Stash(new InMemoryStorage(), 'test-session')
     const retrievalTool = createRetrievalTool(stash)
 
     const result = (await invoke(retrievalTool, { reference: 'nonexistent' })) as string
     expect(result).toContain('Error: reference not found')
   })
 
-  it('retrieves binary content as native ImageBlock', async () => {
-    const stash = new Stash(new InMemoryStorage())
-    const imageBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47])
-    const ref = await stash.store('tool-img', 0, imageBytes, 'image/png')
+  it('retrieves image content as JSON', async () => {
+    const stash = new Stash(new InMemoryStorage(), 'test-session')
+    const imageData = { image: { format: 'png', source: { bytes: 'iVBORw0KGgo=' } } }
+    const ref = await stash.store('tool-img', 0, encodeJSON(imageData))
     const retrievalTool = createRetrievalTool(stash)
 
     const result = await invoke(retrievalTool, { reference: ref })
-    expect(result).toBeInstanceOf(ImageBlock)
-    expect((result as ImageBlock).format).toBe('png')
-    expect((result as ImageBlock).source.type).toBe('imageSourceBytes')
+    expect(result).toEqual(imageData)
   })
 
   it('retrieves JSON content as parsed object', async () => {
-    const stash = new Stash(new InMemoryStorage())
+    const stash = new Stash(new InMemoryStorage(), 'test-session')
     const json = { key: 'value', nested: [1, 2, 3] }
-    const ref = await stash.store('tool-json', 0, new TextEncoder().encode(JSON.stringify(json)), 'application/json')
+    const ref = await stash.store('tool-json', 0, encodeJSON({ json }))
     const retrievalTool = createRetrievalTool(stash)
 
     const result = await invoke(retrievalTool, { reference: ref })
-    expect(result).toEqual(json)
+    expect(result).toEqual({ json })
   })
 
-  it('returns error when searching binary content', async () => {
-    const stash = new Stash(new InMemoryStorage())
-    const imageBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47])
-    const ref = await stash.store('tool-img', 0, imageBytes, 'image/png')
+  it('returns error when searching non-text content', async () => {
+    const stash = new Stash(new InMemoryStorage(), 'test-session')
+    const imageData = { image: { format: 'png', source: { bytes: 'iVBORw0KGgo=' } } }
+    const ref = await stash.store('tool-img', 0, encodeJSON(imageData))
     const retrievalTool = createRetrievalTool(stash)
 
     const result = (await invoke(retrievalTool, { reference: ref, pattern: 'test' })) as string
-    expect(result).toContain('cannot search binary content')
+    expect(result).toContain('cannot search non-text content')
   })
 })

--- a/strands-ts/src/context-manager/__tests__/retrieval-tool.test.ts
+++ b/strands-ts/src/context-manager/__tests__/retrieval-tool.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import { createRetrievalTool, RETRIEVAL_TOOL_NAME } from '../retrieval-tool.js'
+import { Stash } from '../stash.js'
+import { InMemoryStorage } from '../../storage/in-memory-storage.js'
+import { ImageBlock } from '../../types/media.js'
+
+function invoke(retrievalTool: ReturnType<typeof createRetrievalTool>, input: unknown): Promise<unknown> {
+  return (retrievalTool as unknown as { invoke(input: unknown): Promise<unknown> }).invoke(input)
+}
+
+describe('retrieval tool', () => {
+  function makeStashWithContent(text: string): { stash: Stash; refPromise: Promise<string> } {
+    const stash = new Stash(new InMemoryStorage())
+    const refPromise = stash.store('tool-1', 0, new TextEncoder().encode(text), 'text/plain')
+    return { stash, refPromise }
+  }
+
+  it('has the correct tool name', () => {
+    const stash = new Stash(new InMemoryStorage())
+    const retrievalTool = createRetrievalTool(stash)
+    expect(retrievalTool.name).toBe(RETRIEVAL_TOOL_NAME)
+  })
+
+  it('retrieves full text content', async () => {
+    const { stash, refPromise } = makeStashWithContent('hello world\nline two')
+    const ref = await refPromise
+    const retrievalTool = createRetrievalTool(stash)
+
+    const result = await invoke(retrievalTool, { reference: ref })
+    expect(result).toBe('hello world\nline two')
+  })
+
+  it('searches with pattern', async () => {
+    const text = Array.from(
+      { length: 20 },
+      (_, index) => `line ${index + 1}: ${index % 3 === 0 ? 'ERROR' : 'ok'}`
+    ).join('\n')
+    const { stash, refPromise } = makeStashWithContent(text)
+    const ref = await refPromise
+    const retrievalTool = createRetrievalTool(stash)
+
+    const result = (await invoke(retrievalTool, { reference: ref, pattern: 'ERROR' })) as string
+    expect(result).toContain('ERROR')
+    expect(result).toContain('match')
+  })
+
+  it('returns line range', async () => {
+    const text = Array.from({ length: 50 }, (_, index) => `line ${index + 1}`).join('\n')
+    const { stash, refPromise } = makeStashWithContent(text)
+    const ref = await refPromise
+    const retrievalTool = createRetrievalTool(stash)
+
+    const result = (await invoke(retrievalTool, { reference: ref, line_range: { start: 5, end: 10 } })) as string
+    expect(result).toContain('line 5')
+    expect(result).toContain('line 10')
+    expect(result).not.toContain('line 11')
+  })
+
+  it('returns error for unknown reference', async () => {
+    const stash = new Stash(new InMemoryStorage())
+    const retrievalTool = createRetrievalTool(stash)
+
+    const result = (await invoke(retrievalTool, { reference: 'nonexistent' })) as string
+    expect(result).toContain('Error: reference not found')
+  })
+
+  it('retrieves binary content as native ImageBlock', async () => {
+    const stash = new Stash(new InMemoryStorage())
+    const imageBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47])
+    const ref = await stash.store('tool-img', 0, imageBytes, 'image/png')
+    const retrievalTool = createRetrievalTool(stash)
+
+    const result = await invoke(retrievalTool, { reference: ref })
+    expect(result).toBeInstanceOf(ImageBlock)
+    expect((result as ImageBlock).format).toBe('png')
+    expect((result as ImageBlock).source.type).toBe('imageSourceBytes')
+  })
+
+  it('retrieves JSON content as parsed object', async () => {
+    const stash = new Stash(new InMemoryStorage())
+    const json = { key: 'value', nested: [1, 2, 3] }
+    const ref = await stash.store('tool-json', 0, new TextEncoder().encode(JSON.stringify(json)), 'application/json')
+    const retrievalTool = createRetrievalTool(stash)
+
+    const result = await invoke(retrievalTool, { reference: ref })
+    expect(result).toEqual(json)
+  })
+
+  it('returns error when searching binary content', async () => {
+    const stash = new Stash(new InMemoryStorage())
+    const imageBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47])
+    const ref = await stash.store('tool-img', 0, imageBytes, 'image/png')
+    const retrievalTool = createRetrievalTool(stash)
+
+    const result = (await invoke(retrievalTool, { reference: ref, pattern: 'test' })) as string
+    expect(result).toContain('cannot search binary content')
+  })
+})

--- a/strands-ts/src/context-manager/__tests__/stash-integration.test.ts
+++ b/strands-ts/src/context-manager/__tests__/stash-integration.test.ts
@@ -64,7 +64,7 @@ describe('Offload strategies with stash', () => {
   describe('truncate + stash', () => {
     it('persists original content to stash before truncating', async () => {
       const storage = new InMemoryStorage()
-      const stash = new Stash(storage, 'test-session')
+      const stash = new Stash(storage, 'test-session', 'test-agent')
       const largeText = 'important data '.repeat(1000)
       const messages = [makeToolResultMessage(largeText)]
       await stashAll(stash, messages)
@@ -84,7 +84,7 @@ describe('Offload strategies with stash', () => {
     })
 
     it('includes stash reference in the truncated preview', async () => {
-      const stash = new Stash(new InMemoryStorage(), 'test-session')
+      const stash = new Stash(new InMemoryStorage(), 'test-session', 'test-agent')
       const largeText = 'x'.repeat(20000)
       const messages = [makeToolResultMessage(largeText)]
       await stashAll(stash, messages)
@@ -114,7 +114,7 @@ describe('Offload strategies with stash', () => {
 
   describe('drop + stash', () => {
     it('persists original content before dropping', async () => {
-      const stash = new Stash(new InMemoryStorage(), 'test-session')
+      const stash = new Stash(new InMemoryStorage(), 'test-session', 'test-agent')
       const largeText = 'critical information '.repeat(500)
       const messages = [makeToolResultMessage(largeText)]
       await stashAll(stash, messages)
@@ -133,7 +133,7 @@ describe('Offload strategies with stash', () => {
     })
 
     it('includes stash reference in the drop marker', async () => {
-      const stash = new Stash(new InMemoryStorage(), 'test-session')
+      const stash = new Stash(new InMemoryStorage(), 'test-session', 'test-agent')
       const largeText = 'x'.repeat(20000)
       const messages = [makeToolResultMessage(largeText)]
       await stashAll(stash, messages)
@@ -150,7 +150,7 @@ describe('Offload strategies with stash', () => {
 
   describe('binary content stashing', () => {
     it('stashes image content from tool results', async () => {
-      const stash = new Stash(new InMemoryStorage(), 'test-session')
+      const stash = new Stash(new InMemoryStorage(), 'test-session', 'test-agent')
       const imageBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
       const messages = [
         new Message({
@@ -182,7 +182,7 @@ describe('Offload strategies with stash', () => {
     })
 
     it('stashes each block independently when mixed content', async () => {
-      const stash = new Stash(new InMemoryStorage(), 'test-session')
+      const stash = new Stash(new InMemoryStorage(), 'test-session', 'test-agent')
       const imageBytes = new Uint8Array([0xff, 0xd8])
       const messages = [
         new Message({
@@ -226,7 +226,7 @@ describe('Offload strategies with stash', () => {
 
   describe('eager stashing via storeMessage', () => {
     it('persists tool result content on message arrival', async () => {
-      const stash = new Stash(new InMemoryStorage(), 'test-session')
+      const stash = new Stash(new InMemoryStorage(), 'test-session', 'test-agent')
       const largeText = 'important data '.repeat(500)
       const message = makeToolResultMessage(largeText, 'call-1')
 
@@ -240,7 +240,7 @@ describe('Offload strategies with stash', () => {
     })
 
     it('persists text blocks from assistant messages on arrival', async () => {
-      const stash = new Stash(new InMemoryStorage(), 'test-session')
+      const stash = new Stash(new InMemoryStorage(), 'test-session', 'test-agent')
       const assistantText = 'important analysis '.repeat(200)
       const message = new Message({ role: 'assistant', content: [new TextBlock(assistantText)] })
 
@@ -255,7 +255,7 @@ describe('Offload strategies with stash', () => {
 
   describe('retrieval loop prevention', () => {
     it('does not offload retrieve_context tool results when stash is active', async () => {
-      const stash = new Stash(new InMemoryStorage(), 'test-session')
+      const stash = new Stash(new InMemoryStorage(), 'test-session', 'test-agent')
       const largeRetrievalResult = 'retrieved content '.repeat(1000)
 
       const messages = [

--- a/strands-ts/src/context-manager/__tests__/stash-integration.test.ts
+++ b/strands-ts/src/context-manager/__tests__/stash-integration.test.ts
@@ -175,7 +175,7 @@ describe('Offload strategies with stash', () => {
       expect(keys.length).toBe(1)
 
       const retrieved = await stash.retrieve(keys[0]!)
-      expect(retrieved!.contentType).toBe('application/json')
+      expect(retrieved).not.toBeNull()
       const data = retrieved!.data as { image: { format: string; source: { bytes: string } } }
       expect(data.image.format).toBe('png')
       expect(data.image.source.bytes).toBeDefined()

--- a/strands-ts/src/context-manager/__tests__/stash-integration.test.ts
+++ b/strands-ts/src/context-manager/__tests__/stash-integration.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect } from 'vitest'
+import { Offload } from '../strategies/offload/index.js'
+import { Stash } from '../stash.js'
+import { RETRIEVAL_TOOL_NAME } from '../retrieval-tool.js'
+import { InMemoryStorage } from '../../storage/in-memory-storage.js'
+import { Message, TextBlock, ToolResultBlock, ToolUseBlock } from '../../types/messages.js'
+import { ImageBlock } from '../../types/media.js'
+import { createMockAgent } from '../../__fixtures__/agent-helpers.js'
+import type { ContextState } from '../types.js'
+
+function makeToolResultMessage(text: string, toolUseId = 'tool-123'): Message {
+  return new Message({
+    role: 'user',
+    content: [
+      new ToolResultBlock({
+        toolUseId,
+        status: 'success',
+        content: [new TextBlock(text)],
+      }),
+    ],
+  })
+}
+
+function heuristicCountTokens(messages: Message[]): number {
+  let total = 0
+  for (const message of messages) {
+    for (const block of message.content) {
+      if (block instanceof TextBlock) {
+        total += Math.ceil(block.text.length / 4)
+      } else if (block instanceof ToolResultBlock) {
+        for (const content of block.content) {
+          if (content instanceof TextBlock) total += Math.ceil(content.text.length / 4)
+          else total += Math.ceil(JSON.stringify(content).length / 2)
+        }
+      } else {
+        total += Math.ceil(JSON.stringify(block).length / 2)
+      }
+    }
+  }
+  return total
+}
+
+async function stashAll(stash: Stash, messages: Message[]): Promise<void> {
+  for (const message of messages) await stash.storeMessage(message)
+}
+
+function makeContext(messages: Message[], stash?: Stash, utilization = 0.5): ContextState {
+  const agent = createMockAgent({
+    messages,
+    extra: { model: { countTokens: async (msgs: Message[]) => heuristicCountTokens(msgs) } } as never,
+  })
+  const base: ContextState = {
+    messages,
+    agent,
+    utilization,
+  }
+  if (stash) {
+    return { ...base, stash }
+  }
+  return base
+}
+
+describe('Offload strategies with stash', () => {
+  describe('truncate + stash', () => {
+    it('persists original content to stash before truncating', async () => {
+      const storage = new InMemoryStorage()
+      const stash = new Stash(storage)
+      const largeText = 'important data '.repeat(1000)
+      const messages = [makeToolResultMessage(largeText)]
+      await stashAll(stash, messages)
+      const strategy = Offload.truncate('toolResults')
+      const context = makeContext(messages, stash)
+
+      const acted = await strategy.apply(context)
+
+      expect(acted).toBe(true)
+
+      const keys = await stash.list()
+      expect(keys.length).toBe(1)
+
+      const retrieved = await stash.retrieve(keys[0]!)
+      expect(retrieved).not.toBeNull()
+      expect(new TextDecoder().decode(retrieved!.content)).toBe(largeText)
+    })
+
+    it('includes stash reference in the truncated preview', async () => {
+      const stash = new Stash(new InMemoryStorage())
+      const largeText = 'x'.repeat(20000)
+      const messages = [makeToolResultMessage(largeText)]
+      await stashAll(stash, messages)
+      const strategy = Offload.truncate('toolResults')
+      const context = makeContext(messages, stash)
+
+      await strategy.apply(context)
+
+      const block = messages[0]!.content[0] as ToolResultBlock
+      const text = (block.content[0] as TextBlock).text
+      expect(text).toContain('[Stashed: ref:')
+    })
+
+    it('does not stash when no stash is configured', async () => {
+      const largeText = 'x'.repeat(20000)
+      const messages = [makeToolResultMessage(largeText)]
+      const strategy = Offload.truncate('toolResults')
+      const context = makeContext(messages)
+
+      await strategy.apply(context)
+
+      const block = messages[0]!.content[0] as ToolResultBlock
+      const text = (block.content[0] as TextBlock).text
+      expect(text).not.toContain('[Stashed:')
+    })
+  })
+
+  describe('drop + stash', () => {
+    it('persists original content before dropping', async () => {
+      const stash = new Stash(new InMemoryStorage())
+      const largeText = 'critical information '.repeat(500)
+      const messages = [makeToolResultMessage(largeText)]
+      await stashAll(stash, messages)
+      const strategy = Offload.drop('toolResults')
+      const context = makeContext(messages, stash)
+
+      const acted = await strategy.apply(context)
+
+      expect(acted).toBe(true)
+
+      const keys = await stash.list()
+      expect(keys.length).toBe(1)
+
+      const retrieved = await stash.retrieve(keys[0]!)
+      expect(new TextDecoder().decode(retrieved!.content)).toBe(largeText)
+    })
+
+    it('includes stash reference in the drop marker', async () => {
+      const stash = new Stash(new InMemoryStorage())
+      const largeText = 'x'.repeat(20000)
+      const messages = [makeToolResultMessage(largeText)]
+      await stashAll(stash, messages)
+      const strategy = Offload.drop('toolResults')
+      const context = makeContext(messages, stash)
+
+      await strategy.apply(context)
+
+      const block = messages[0]!.content[0] as ToolResultBlock
+      const text = (block.content[0] as TextBlock).text
+      expect(text).toContain('[Dropped] ref:')
+    })
+  })
+
+  describe('binary content stashing', () => {
+    it('stashes image content from tool results', async () => {
+      const stash = new Stash(new InMemoryStorage())
+      const imageBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+      const messages = [
+        new Message({
+          role: 'user',
+          content: [
+            new ToolResultBlock({
+              toolUseId: 'tool-img',
+              status: 'success',
+              content: [new ImageBlock({ format: 'png', source: { bytes: imageBytes } })],
+            }),
+          ],
+        }),
+      ]
+      await stashAll(stash, messages)
+      const strategy = Offload.drop('toolResults')
+      const context = makeContext(messages, stash)
+
+      const acted = await strategy.apply(context)
+
+      expect(acted).toBe(true)
+      const keys = await stash.list()
+      expect(keys.length).toBe(1)
+
+      const retrieved = await stash.retrieve(keys[0]!)
+      expect(retrieved!.contentType).toBe('image/png')
+      expect(retrieved!.content).toEqual(imageBytes)
+    })
+
+    it('stashes each block independently when mixed content', async () => {
+      const stash = new Stash(new InMemoryStorage())
+      const imageBytes = new Uint8Array([0xff, 0xd8])
+      const messages = [
+        new Message({
+          role: 'user',
+          content: [
+            new ToolResultBlock({
+              toolUseId: 'tool-mixed',
+              status: 'success',
+              content: [
+                new TextBlock('description of image'),
+                new ImageBlock({ format: 'jpeg', source: { bytes: imageBytes } }),
+              ],
+            }),
+          ],
+        }),
+      ]
+      await stashAll(stash, messages)
+      const strategy = Offload.drop('toolResults')
+      const context = makeContext(messages, stash)
+
+      await strategy.apply(context)
+
+      const keys = await stash.list()
+      expect(keys.length).toBe(2)
+
+      const entries = await Promise.all(keys.map((key) => stash.retrieve(key)))
+      const textEntry = entries.find((entry) => entry!.contentType === 'text/plain')
+      const imageEntry = entries.find((entry) => entry!.contentType === 'image/jpeg')
+
+      expect(textEntry).not.toBeNull()
+      expect(new TextDecoder().decode(textEntry!.content)).toBe('description of image')
+
+      expect(imageEntry).not.toBeNull()
+      expect(imageEntry!.content).toEqual(imageBytes)
+    })
+  })
+
+  describe('eager stashing via storeMessage', () => {
+    it('persists tool result content on message arrival', async () => {
+      const stash = new Stash(new InMemoryStorage())
+      const largeText = 'important data '.repeat(500)
+      const message = makeToolResultMessage(largeText, 'call-1')
+
+      await stash.storeMessage(message)
+
+      const keys = await stash.list()
+      expect(keys.length).toBe(1)
+      const retrieved = await stash.retrieve(keys[0]!)
+      expect(retrieved).not.toBeNull()
+      expect(new TextDecoder().decode(retrieved!.content)).toBe(largeText)
+    })
+
+    it('persists text blocks from assistant messages on arrival', async () => {
+      const stash = new Stash(new InMemoryStorage())
+      const assistantText = 'important analysis '.repeat(200)
+      const message = new Message({ role: 'assistant', content: [new TextBlock(assistantText)] })
+
+      await stash.storeMessage(message)
+
+      const keys = await stash.list()
+      expect(keys.length).toBe(1)
+      const retrieved = await stash.retrieve(keys[0]!)
+      expect(new TextDecoder().decode(retrieved!.content)).toBe(assistantText)
+    })
+  })
+
+  describe('retrieval loop prevention', () => {
+    it('does not offload retrieve_context tool results when stash is active', async () => {
+      const stash = new Stash(new InMemoryStorage())
+      const largeRetrievalResult = 'retrieved content '.repeat(1000)
+
+      const messages = [
+        new Message({
+          role: 'assistant',
+          content: [new ToolUseBlock({ toolUseId: 'call-1', name: RETRIEVAL_TOOL_NAME, input: {} })],
+        }),
+        new Message({
+          role: 'user',
+          content: [
+            new ToolResultBlock({
+              toolUseId: 'call-1',
+              status: 'success',
+              content: [new TextBlock(largeRetrievalResult)],
+            }),
+          ],
+        }),
+      ]
+      const strategy = Offload.truncate('toolResults')
+      const context = makeContext(messages, stash)
+
+      const acted = await strategy.apply(context)
+
+      expect(acted).toBe(false)
+      const block = messages[1]!.content[0] as ToolResultBlock
+      const text = (block.content[0] as TextBlock).text
+      expect(text).toBe(largeRetrievalResult)
+    })
+
+    it('offloads retrieve_context results when no stash (stash not configured)', async () => {
+      const largeRetrievalResult = 'retrieved content '.repeat(1000)
+
+      const messages = [
+        new Message({
+          role: 'assistant',
+          content: [new ToolUseBlock({ toolUseId: 'call-1', name: RETRIEVAL_TOOL_NAME, input: {} })],
+        }),
+        new Message({
+          role: 'user',
+          content: [
+            new ToolResultBlock({
+              toolUseId: 'call-1',
+              status: 'success',
+              content: [new TextBlock(largeRetrievalResult)],
+            }),
+          ],
+        }),
+      ]
+      const strategy = Offload.truncate('toolResults')
+      const context = makeContext(messages)
+
+      const acted = await strategy.apply(context)
+
+      expect(acted).toBe(true)
+    })
+  })
+})

--- a/strands-ts/src/context-manager/__tests__/stash-integration.test.ts
+++ b/strands-ts/src/context-manager/__tests__/stash-integration.test.ts
@@ -64,7 +64,7 @@ describe('Offload strategies with stash', () => {
   describe('truncate + stash', () => {
     it('persists original content to stash before truncating', async () => {
       const storage = new InMemoryStorage()
-      const stash = new Stash(storage)
+      const stash = new Stash(storage, 'test-session')
       const largeText = 'important data '.repeat(1000)
       const messages = [makeToolResultMessage(largeText)]
       await stashAll(stash, messages)
@@ -80,11 +80,11 @@ describe('Offload strategies with stash', () => {
 
       const retrieved = await stash.retrieve(keys[0]!)
       expect(retrieved).not.toBeNull()
-      expect(new TextDecoder().decode(retrieved!.content)).toBe(largeText)
+      expect((retrieved!.data as { text: string }).text).toBe(largeText)
     })
 
     it('includes stash reference in the truncated preview', async () => {
-      const stash = new Stash(new InMemoryStorage())
+      const stash = new Stash(new InMemoryStorage(), 'test-session')
       const largeText = 'x'.repeat(20000)
       const messages = [makeToolResultMessage(largeText)]
       await stashAll(stash, messages)
@@ -114,7 +114,7 @@ describe('Offload strategies with stash', () => {
 
   describe('drop + stash', () => {
     it('persists original content before dropping', async () => {
-      const stash = new Stash(new InMemoryStorage())
+      const stash = new Stash(new InMemoryStorage(), 'test-session')
       const largeText = 'critical information '.repeat(500)
       const messages = [makeToolResultMessage(largeText)]
       await stashAll(stash, messages)
@@ -129,11 +129,11 @@ describe('Offload strategies with stash', () => {
       expect(keys.length).toBe(1)
 
       const retrieved = await stash.retrieve(keys[0]!)
-      expect(new TextDecoder().decode(retrieved!.content)).toBe(largeText)
+      expect((retrieved!.data as { text: string }).text).toBe(largeText)
     })
 
     it('includes stash reference in the drop marker', async () => {
-      const stash = new Stash(new InMemoryStorage())
+      const stash = new Stash(new InMemoryStorage(), 'test-session')
       const largeText = 'x'.repeat(20000)
       const messages = [makeToolResultMessage(largeText)]
       await stashAll(stash, messages)
@@ -150,7 +150,7 @@ describe('Offload strategies with stash', () => {
 
   describe('binary content stashing', () => {
     it('stashes image content from tool results', async () => {
-      const stash = new Stash(new InMemoryStorage())
+      const stash = new Stash(new InMemoryStorage(), 'test-session')
       const imageBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
       const messages = [
         new Message({
@@ -175,12 +175,14 @@ describe('Offload strategies with stash', () => {
       expect(keys.length).toBe(1)
 
       const retrieved = await stash.retrieve(keys[0]!)
-      expect(retrieved!.contentType).toBe('image/png')
-      expect(retrieved!.content).toEqual(imageBytes)
+      expect(retrieved!.contentType).toBe('application/json')
+      const data = retrieved!.data as { image: { format: string; source: { bytes: string } } }
+      expect(data.image.format).toBe('png')
+      expect(data.image.source.bytes).toBeDefined()
     })
 
     it('stashes each block independently when mixed content', async () => {
-      const stash = new Stash(new InMemoryStorage())
+      const stash = new Stash(new InMemoryStorage(), 'test-session')
       const imageBytes = new Uint8Array([0xff, 0xd8])
       const messages = [
         new Message({
@@ -207,20 +209,24 @@ describe('Offload strategies with stash', () => {
       expect(keys.length).toBe(2)
 
       const entries = await Promise.all(keys.map((key) => stash.retrieve(key)))
-      const textEntry = entries.find((entry) => entry!.contentType === 'text/plain')
-      const imageEntry = entries.find((entry) => entry!.contentType === 'image/jpeg')
+      const textEntry = entries.find(
+        (entry) => entry && typeof entry.data === 'object' && entry.data !== null && 'text' in entry.data
+      )
+      const imageEntry = entries.find(
+        (entry) => entry && typeof entry.data === 'object' && entry.data !== null && 'image' in entry.data
+      )
 
       expect(textEntry).not.toBeNull()
-      expect(new TextDecoder().decode(textEntry!.content)).toBe('description of image')
+      expect((textEntry!.data as { text: string }).text).toBe('description of image')
 
       expect(imageEntry).not.toBeNull()
-      expect(imageEntry!.content).toEqual(imageBytes)
+      expect((imageEntry!.data as { image: { format: string } }).image.format).toBe('jpeg')
     })
   })
 
   describe('eager stashing via storeMessage', () => {
     it('persists tool result content on message arrival', async () => {
-      const stash = new Stash(new InMemoryStorage())
+      const stash = new Stash(new InMemoryStorage(), 'test-session')
       const largeText = 'important data '.repeat(500)
       const message = makeToolResultMessage(largeText, 'call-1')
 
@@ -230,11 +236,11 @@ describe('Offload strategies with stash', () => {
       expect(keys.length).toBe(1)
       const retrieved = await stash.retrieve(keys[0]!)
       expect(retrieved).not.toBeNull()
-      expect(new TextDecoder().decode(retrieved!.content)).toBe(largeText)
+      expect((retrieved!.data as { text: string }).text).toBe(largeText)
     })
 
     it('persists text blocks from assistant messages on arrival', async () => {
-      const stash = new Stash(new InMemoryStorage())
+      const stash = new Stash(new InMemoryStorage(), 'test-session')
       const assistantText = 'important analysis '.repeat(200)
       const message = new Message({ role: 'assistant', content: [new TextBlock(assistantText)] })
 
@@ -243,13 +249,13 @@ describe('Offload strategies with stash', () => {
       const keys = await stash.list()
       expect(keys.length).toBe(1)
       const retrieved = await stash.retrieve(keys[0]!)
-      expect(new TextDecoder().decode(retrieved!.content)).toBe(assistantText)
+      expect((retrieved!.data as { text: string }).text).toBe(assistantText)
     })
   })
 
   describe('retrieval loop prevention', () => {
     it('does not offload retrieve_context tool results when stash is active', async () => {
-      const stash = new Stash(new InMemoryStorage())
+      const stash = new Stash(new InMemoryStorage(), 'test-session')
       const largeRetrievalResult = 'retrieved content '.repeat(1000)
 
       const messages = [

--- a/strands-ts/src/context-manager/__tests__/stash.test.ts
+++ b/strands-ts/src/context-manager/__tests__/stash.test.ts
@@ -5,7 +5,7 @@ import { InMemoryStorage } from '../../storage/in-memory-storage.js'
 describe('Stash', () => {
   describe('store and retrieve', () => {
     it('round-trips text content', async () => {
-      const stash = new Stash(new InMemoryStorage(), 'test-session')
+      const stash = new Stash(new InMemoryStorage(), 'test-session', 'test-agent')
       const data = { type: 'text', text: 'hello world' }
       const ref = await stash.store('tool-123', 0, new TextEncoder().encode(JSON.stringify(data)))
 
@@ -18,7 +18,7 @@ describe('Stash', () => {
     })
 
     it('round-trips JSON content', async () => {
-      const stash = new Stash(new InMemoryStorage(), 'test-session')
+      const stash = new Stash(new InMemoryStorage(), 'test-session', 'test-agent')
       const data = { key: 'value', count: 42 }
       const ref = await stash.store('tool-456', 1, new TextEncoder().encode(JSON.stringify(data)))
 
@@ -29,13 +29,13 @@ describe('Stash', () => {
     })
 
     it('returns null for unknown references', async () => {
-      const stash = new Stash(new InMemoryStorage(), 'test-session')
+      const stash = new Stash(new InMemoryStorage(), 'test-session', 'test-agent')
       const result = await stash.retrieve('nonexistent')
       expect(result).toBeNull()
     })
 
     it('produces deterministic keys from the same id and blockIndex', async () => {
-      const stash = new Stash(new InMemoryStorage(), 'test-session')
+      const stash = new Stash(new InMemoryStorage(), 'test-session', 'test-agent')
       const content = new TextEncoder().encode(JSON.stringify('data'))
       const ref1 = await stash.store('tool-1', 0, content)
       const ref2 = await stash.store('tool-1', 0, content)
@@ -44,7 +44,7 @@ describe('Stash', () => {
     })
 
     it('produces different keys for different id or blockIndex', async () => {
-      const stash = new Stash(new InMemoryStorage(), 'test-session')
+      const stash = new Stash(new InMemoryStorage(), 'test-session', 'test-agent')
       const content = new TextEncoder().encode(JSON.stringify('data'))
       const ref1 = await stash.store('tool-1', 0, content)
       const ref2 = await stash.store('tool-1', 1, content)
@@ -57,7 +57,7 @@ describe('Stash', () => {
 
   describe('list', () => {
     it('lists all stored references', async () => {
-      const stash = new Stash(new InMemoryStorage(), 'test-session')
+      const stash = new Stash(new InMemoryStorage(), 'test-session', 'test-agent')
       const content = new TextEncoder().encode(JSON.stringify('data'))
       const ref1 = await stash.store('tool-a', 0, content)
       const ref2 = await stash.store('tool-b', 0, content)
@@ -70,7 +70,7 @@ describe('Stash', () => {
 
   describe('delete', () => {
     it('removes a stashed entry', async () => {
-      const stash = new Stash(new InMemoryStorage(), 'test-session')
+      const stash = new Stash(new InMemoryStorage(), 'test-session', 'test-agent')
       const content = new TextEncoder().encode(JSON.stringify('data'))
       const ref = await stash.store('tool-x', 0, content)
 
@@ -83,7 +83,7 @@ describe('Stash', () => {
   describe('namespacing', () => {
     it('does not conflict with other storage users', async () => {
       const storage = new InMemoryStorage()
-      const stash = new Stash(storage, 'test-session')
+      const stash = new Stash(storage, 'test-session', 'test-agent')
 
       const content = new TextEncoder().encode(JSON.stringify('stash data'))
       await stash.store('tool-1', 0, content)
@@ -91,7 +91,7 @@ describe('Stash', () => {
       await storage.write('other-key', new TextEncoder().encode('other'))
 
       const topKeys = await storage.list('')
-      expect(topKeys.some((key) => key.startsWith('context-stash/'))).toBe(true)
+      expect(topKeys.some((key) => key.startsWith('context/'))).toBe(true)
       expect(topKeys).toContain('other-key')
     })
   })

--- a/strands-ts/src/context-manager/__tests__/stash.test.ts
+++ b/strands-ts/src/context-manager/__tests__/stash.test.ts
@@ -13,7 +13,6 @@ describe('Stash', () => {
 
       const result = await stash.retrieve(ref)
       expect(result).not.toBeNull()
-      expect(result!.contentType).toBe('application/json')
       expect(result!.data).toEqual(data)
     })
 
@@ -24,7 +23,6 @@ describe('Stash', () => {
 
       const result = await stash.retrieve(ref)
       expect(result).not.toBeNull()
-      expect(result!.contentType).toBe('application/json')
       expect(result!.data).toEqual(data)
     })
 

--- a/strands-ts/src/context-manager/__tests__/stash.test.ts
+++ b/strands-ts/src/context-manager/__tests__/stash.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest'
+import { Stash } from '../stash.js'
+import { InMemoryStorage } from '../../storage/in-memory-storage.js'
+
+describe('Stash', () => {
+  describe('store and retrieve', () => {
+    it('round-trips text content', async () => {
+      const stash = new Stash(new InMemoryStorage())
+      const content = new TextEncoder().encode('hello world')
+      const ref = await stash.store('tool-123', 0, content, 'text/plain')
+
+      expect(ref).toContain('tool-123')
+
+      const result = await stash.retrieve(ref)
+      expect(result).not.toBeNull()
+      expect(result!.contentType).toBe('text/plain')
+      expect(new TextDecoder().decode(result!.content)).toBe('hello world')
+    })
+
+    it('round-trips JSON content', async () => {
+      const stash = new Stash(new InMemoryStorage())
+      const json = JSON.stringify({ key: 'value', count: 42 })
+      const content = new TextEncoder().encode(json)
+      const ref = await stash.store('tool-456', 1, content, 'application/json')
+
+      const result = await stash.retrieve(ref)
+      expect(result).not.toBeNull()
+      expect(result!.contentType).toBe('application/json')
+      expect(new TextDecoder().decode(result!.content)).toBe(json)
+    })
+
+    it('returns null for unknown references', async () => {
+      const stash = new Stash(new InMemoryStorage())
+      const result = await stash.retrieve('nonexistent')
+      expect(result).toBeNull()
+    })
+
+    it('generates unique references for multiple stores', async () => {
+      const stash = new Stash(new InMemoryStorage())
+      const content = new TextEncoder().encode('data')
+      const ref1 = await stash.store('tool-1', 0, content, 'text/plain')
+      const ref2 = await stash.store('tool-1', 0, content, 'text/plain')
+
+      expect(ref1).not.toBe(ref2)
+    })
+  })
+
+  describe('list', () => {
+    it('lists all stored references', async () => {
+      const stash = new Stash(new InMemoryStorage())
+      const content = new TextEncoder().encode('data')
+      const ref1 = await stash.store('tool-a', 0, content, 'text/plain')
+      const ref2 = await stash.store('tool-b', 0, content, 'text/plain')
+
+      const keys = await stash.list()
+      expect(keys).toContain(ref1)
+      expect(keys).toContain(ref2)
+    })
+  })
+
+  describe('delete', () => {
+    it('removes a stashed entry', async () => {
+      const stash = new Stash(new InMemoryStorage())
+      const content = new TextEncoder().encode('data')
+      const ref = await stash.store('tool-x', 0, content, 'text/plain')
+
+      await stash.delete(ref)
+      const result = await stash.retrieve(ref)
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('namespacing', () => {
+    it('does not conflict with other storage users', async () => {
+      const storage = new InMemoryStorage()
+      const stash = new Stash(storage)
+
+      const content = new TextEncoder().encode('stash data')
+      await stash.store('tool-1', 0, content, 'text/plain')
+
+      await storage.write('other-key', new TextEncoder().encode('other'))
+
+      const topKeys = await storage.list('')
+      expect(topKeys.some((key) => key.startsWith('context-stash/'))).toBe(true)
+      expect(topKeys).toContain('other-key')
+    })
+  })
+})

--- a/strands-ts/src/context-manager/__tests__/stash.test.ts
+++ b/strands-ts/src/context-manager/__tests__/stash.test.ts
@@ -5,52 +5,62 @@ import { InMemoryStorage } from '../../storage/in-memory-storage.js'
 describe('Stash', () => {
   describe('store and retrieve', () => {
     it('round-trips text content', async () => {
-      const stash = new Stash(new InMemoryStorage())
-      const content = new TextEncoder().encode('hello world')
-      const ref = await stash.store('tool-123', 0, content, 'text/plain')
+      const stash = new Stash(new InMemoryStorage(), 'test-session')
+      const data = { type: 'text', text: 'hello world' }
+      const ref = await stash.store('tool-123', 0, new TextEncoder().encode(JSON.stringify(data)))
 
       expect(ref).toContain('tool-123')
 
       const result = await stash.retrieve(ref)
       expect(result).not.toBeNull()
-      expect(result!.contentType).toBe('text/plain')
-      expect(new TextDecoder().decode(result!.content)).toBe('hello world')
+      expect(result!.contentType).toBe('application/json')
+      expect(result!.data).toEqual(data)
     })
 
     it('round-trips JSON content', async () => {
-      const stash = new Stash(new InMemoryStorage())
-      const json = JSON.stringify({ key: 'value', count: 42 })
-      const content = new TextEncoder().encode(json)
-      const ref = await stash.store('tool-456', 1, content, 'application/json')
+      const stash = new Stash(new InMemoryStorage(), 'test-session')
+      const data = { key: 'value', count: 42 }
+      const ref = await stash.store('tool-456', 1, new TextEncoder().encode(JSON.stringify(data)))
 
       const result = await stash.retrieve(ref)
       expect(result).not.toBeNull()
       expect(result!.contentType).toBe('application/json')
-      expect(new TextDecoder().decode(result!.content)).toBe(json)
+      expect(result!.data).toEqual(data)
     })
 
     it('returns null for unknown references', async () => {
-      const stash = new Stash(new InMemoryStorage())
+      const stash = new Stash(new InMemoryStorage(), 'test-session')
       const result = await stash.retrieve('nonexistent')
       expect(result).toBeNull()
     })
 
-    it('generates unique references for multiple stores', async () => {
-      const stash = new Stash(new InMemoryStorage())
-      const content = new TextEncoder().encode('data')
-      const ref1 = await stash.store('tool-1', 0, content, 'text/plain')
-      const ref2 = await stash.store('tool-1', 0, content, 'text/plain')
+    it('produces deterministic keys from the same id and blockIndex', async () => {
+      const stash = new Stash(new InMemoryStorage(), 'test-session')
+      const content = new TextEncoder().encode(JSON.stringify('data'))
+      const ref1 = await stash.store('tool-1', 0, content)
+      const ref2 = await stash.store('tool-1', 0, content)
+
+      expect(ref1).toBe(ref2)
+    })
+
+    it('produces different keys for different id or blockIndex', async () => {
+      const stash = new Stash(new InMemoryStorage(), 'test-session')
+      const content = new TextEncoder().encode(JSON.stringify('data'))
+      const ref1 = await stash.store('tool-1', 0, content)
+      const ref2 = await stash.store('tool-1', 1, content)
+      const ref3 = await stash.store('tool-2', 0, content)
 
       expect(ref1).not.toBe(ref2)
+      expect(ref1).not.toBe(ref3)
     })
   })
 
   describe('list', () => {
     it('lists all stored references', async () => {
-      const stash = new Stash(new InMemoryStorage())
-      const content = new TextEncoder().encode('data')
-      const ref1 = await stash.store('tool-a', 0, content, 'text/plain')
-      const ref2 = await stash.store('tool-b', 0, content, 'text/plain')
+      const stash = new Stash(new InMemoryStorage(), 'test-session')
+      const content = new TextEncoder().encode(JSON.stringify('data'))
+      const ref1 = await stash.store('tool-a', 0, content)
+      const ref2 = await stash.store('tool-b', 0, content)
 
       const keys = await stash.list()
       expect(keys).toContain(ref1)
@@ -60,9 +70,9 @@ describe('Stash', () => {
 
   describe('delete', () => {
     it('removes a stashed entry', async () => {
-      const stash = new Stash(new InMemoryStorage())
-      const content = new TextEncoder().encode('data')
-      const ref = await stash.store('tool-x', 0, content, 'text/plain')
+      const stash = new Stash(new InMemoryStorage(), 'test-session')
+      const content = new TextEncoder().encode(JSON.stringify('data'))
+      const ref = await stash.store('tool-x', 0, content)
 
       await stash.delete(ref)
       const result = await stash.retrieve(ref)
@@ -73,10 +83,10 @@ describe('Stash', () => {
   describe('namespacing', () => {
     it('does not conflict with other storage users', async () => {
       const storage = new InMemoryStorage()
-      const stash = new Stash(storage)
+      const stash = new Stash(storage, 'test-session')
 
-      const content = new TextEncoder().encode('stash data')
-      await stash.store('tool-1', 0, content, 'text/plain')
+      const content = new TextEncoder().encode(JSON.stringify('stash data'))
+      await stash.store('tool-1', 0, content)
 
       await storage.write('other-key', new TextEncoder().encode('other'))
 

--- a/strands-ts/src/context-manager/context-manager.ts
+++ b/strands-ts/src/context-manager/context-manager.ts
@@ -137,5 +137,4 @@ export class ContextManager implements Plugin {
     }
     return anyActed
   }
-
 }

--- a/strands-ts/src/context-manager/context-manager.ts
+++ b/strands-ts/src/context-manager/context-manager.ts
@@ -5,12 +5,17 @@
  */
 
 import type { Plugin } from '../plugins/plugin.js'
+import type { Tool } from '../tools/tool.js'
+import { Message, ToolResultBlock, ToolUseBlock } from '../types/messages.js'
 import type { LocalAgent } from '../types/agent.js'
-import { AfterModelCallEvent, BeforeModelCallEvent } from '../hooks/events.js'
+import { AfterModelCallEvent, BeforeModelCallEvent, MessageAddedEvent } from '../hooks/events.js'
 import { ContextWindowOverflowError } from '../errors.js'
+import { InMemoryStorage } from '../storage/in-memory-storage.js'
 import { logger } from '../logging/logger.js'
 import type { ContextManagerConfig, ContextStrategy, ContextState } from './types.js'
 import { EmergencyTruncateStrategy, Offload } from './strategies/offload/index.js'
+import { Stash } from './stash.js'
+import { createRetrievalTool, RETRIEVAL_TOOL_NAME } from './retrieval-tool.js'
 
 /**
  * Manages context reduction for an agent's conversation.
@@ -30,6 +35,9 @@ export class ContextManager implements Plugin {
   readonly name = 'strands:context-manager'
 
   private readonly _strategies: ContextStrategy[]
+  private readonly _stash: Stash | undefined
+  private readonly _retrievalToolUseIds = new Set<string>()
+  private _retrievalTool: Tool | undefined
 
   constructor(config?: ContextManagerConfig) {
     this._strategies = [
@@ -39,11 +47,31 @@ export class ContextManager implements Plugin {
       ]),
       new EmergencyTruncateStrategy(),
     ]
+    if (config?.stash !== false) {
+      this._stash = new Stash(config?.stash?.storage ?? new InMemoryStorage())
+    }
+  }
+
+  getTools(): Tool[] {
+    if (!this._stash) return []
+    if (!this._retrievalTool) {
+      this._retrievalTool = createRetrievalTool(this._stash)
+    }
+    return [this._retrievalTool]
   }
 
   initAgent(agent: LocalAgent): void {
     for (const strategy of this._strategies) {
-      strategy.init?.(agent)
+      strategy.init?.(agent, this._stash)
+    }
+
+    if (this._stash) {
+      const stash = this._stash
+      agent.addHook(MessageAddedEvent, async (event) => {
+        this._trackRetrievalToolUseIds(event.message)
+        if (this._isRetrievalResult(event.message)) return
+        await stash.storeMessage(event.message)
+      })
     }
 
     agent.addHook(BeforeModelCallEvent, async (event) => {
@@ -83,6 +111,7 @@ export class ContextManager implements Plugin {
       messages,
       agent,
       utilization: agent.model.estimateUtilization(inputTokens),
+      ...(this._stash ? { stash: this._stash } : {}),
     }
 
     let anyActed = false
@@ -101,5 +130,23 @@ export class ContextManager implements Plugin {
       }
     }
     return anyActed
+  }
+
+  private _trackRetrievalToolUseIds(message: Message): void {
+    if (message.role !== 'assistant') return
+    for (const block of message.content) {
+      if (block instanceof ToolUseBlock && block.name === RETRIEVAL_TOOL_NAME) {
+        this._retrievalToolUseIds.add(block.toolUseId)
+      }
+    }
+  }
+
+  private _isRetrievalResult(message: Message): boolean {
+    for (const block of message.content) {
+      if (block instanceof ToolResultBlock && this._retrievalToolUseIds.has(block.toolUseId)) {
+        return true
+      }
+    }
+    return false
   }
 }

--- a/strands-ts/src/context-manager/context-manager.ts
+++ b/strands-ts/src/context-manager/context-manager.ts
@@ -64,7 +64,7 @@ export class ContextManager implements Plugin {
 
   initAgent(agent: LocalAgent): void {
     if (this._stashStorage !== false) {
-      this._stash = new Stash(this._stashStorage, agent.sessionId)
+      this._stash = new Stash(this._stashStorage, agent.sessionId, agent.id)
     }
 
     if (this._stash) {

--- a/strands-ts/src/context-manager/context-manager.ts
+++ b/strands-ts/src/context-manager/context-manager.ts
@@ -49,8 +49,10 @@ export class ContextManager implements Plugin {
       ]),
       new EmergencyTruncateStrategy(),
     ]
-    this._stashStorage = config?.stash === false ? false : (config?.stash?.storage ?? new InMemoryStorage())
-    this._enableRetrievalTool = config?.stash !== false && config?.stash?.retrievalTool !== false
+    const stashConfig = config?.stash
+    const stashObj = typeof stashConfig === 'object' ? stashConfig : undefined
+    this._stashStorage = stashConfig === false ? false : (stashObj?.storage ?? new InMemoryStorage())
+    this._enableRetrievalTool = stashConfig !== false && stashObj?.retrievalTool !== false
   }
 
   getTools(): Tool[] {

--- a/strands-ts/src/context-manager/context-manager.ts
+++ b/strands-ts/src/context-manager/context-manager.ts
@@ -11,6 +11,7 @@ import type { LocalAgent } from '../types/agent.js'
 import { AfterModelCallEvent, BeforeModelCallEvent, MessageAddedEvent } from '../hooks/events.js'
 import { ContextWindowOverflowError } from '../errors.js'
 import { InMemoryStorage } from '../storage/in-memory-storage.js'
+import type { Storage } from '../storage/storage.js'
 import { logger } from '../logging/logger.js'
 import type { ContextManagerConfig, ContextStrategy, ContextState } from './types.js'
 import { EmergencyTruncateStrategy, Offload } from './strategies/offload/index.js'
@@ -35,8 +36,9 @@ export class ContextManager implements Plugin {
   readonly name = 'strands:context-manager'
 
   private readonly _strategies: ContextStrategy[]
-  private readonly _stash: Stash | undefined
+  private readonly _stashStorage: Storage | false
   private readonly _retrievalToolUseIds = new Set<string>()
+  private _stash: Stash | undefined
   private _retrievalTool: Tool | undefined
 
   constructor(config?: ContextManagerConfig) {
@@ -47,12 +49,11 @@ export class ContextManager implements Plugin {
       ]),
       new EmergencyTruncateStrategy(),
     ]
-    if (config?.stash !== false) {
-      this._stash = new Stash(config?.stash?.storage ?? new InMemoryStorage())
-    }
+    this._stashStorage = config?.stash === false ? false : (config?.stash?.storage ?? new InMemoryStorage())
   }
 
   getTools(): Tool[] {
+    if (this._stashStorage === false) return []
     if (!this._stash) return []
     if (!this._retrievalTool) {
       this._retrievalTool = createRetrievalTool(this._stash)
@@ -61,17 +62,20 @@ export class ContextManager implements Plugin {
   }
 
   initAgent(agent: LocalAgent): void {
-    for (const strategy of this._strategies) {
-      strategy.init?.(agent, this._stash)
+    if (this._stashStorage !== false) {
+      this._stash = new Stash(this._stashStorage, agent.sessionId)
     }
 
     if (this._stash) {
       const stash = this._stash
       agent.addHook(MessageAddedEvent, async (event) => {
         this._trackRetrievalToolUseIds(event.message)
-        if (this._isRetrievalResult(event.message)) return
-        await stash.storeMessage(event.message)
+        await stash.storeMessage(event.message, this._retrievalToolUseIds)
       })
+    }
+
+    for (const strategy of this._strategies) {
+      strategy.init?.(agent, this._stash)
     }
 
     agent.addHook(BeforeModelCallEvent, async (event) => {
@@ -139,14 +143,5 @@ export class ContextManager implements Plugin {
         this._retrievalToolUseIds.add(block.toolUseId)
       }
     }
-  }
-
-  private _isRetrievalResult(message: Message): boolean {
-    for (const block of message.content) {
-      if (block instanceof ToolResultBlock && this._retrievalToolUseIds.has(block.toolUseId)) {
-        return true
-      }
-    }
-    return false
   }
 }

--- a/strands-ts/src/context-manager/context-manager.ts
+++ b/strands-ts/src/context-manager/context-manager.ts
@@ -6,7 +6,6 @@
 
 import type { Plugin } from '../plugins/plugin.js'
 import type { Tool } from '../tools/tool.js'
-import { Message, ToolResultBlock, ToolUseBlock } from '../types/messages.js'
 import type { LocalAgent } from '../types/agent.js'
 import { AfterModelCallEvent, BeforeModelCallEvent, MessageAddedEvent } from '../hooks/events.js'
 import { ContextWindowOverflowError } from '../errors.js'
@@ -16,7 +15,7 @@ import { logger } from '../logging/logger.js'
 import type { ContextManagerConfig, ContextStrategy, ContextState } from './types.js'
 import { EmergencyTruncateStrategy, Offload } from './strategies/offload/index.js'
 import { Stash } from './stash.js'
-import { createRetrievalTool, RETRIEVAL_TOOL_NAME } from './retrieval-tool.js'
+import { createRetrievalTool, trackRetrievalToolUseIds } from './retrieval-tool.js'
 
 /**
  * Manages context reduction for an agent's conversation.
@@ -37,6 +36,7 @@ export class ContextManager implements Plugin {
 
   private readonly _strategies: ContextStrategy[]
   private readonly _stashStorage: Storage | false
+  private readonly _enableRetrievalTool: boolean
   private readonly _retrievalToolUseIds = new Set<string>()
   private _stash: Stash | undefined
   private _retrievalTool: Tool | undefined
@@ -50,10 +50,11 @@ export class ContextManager implements Plugin {
       new EmergencyTruncateStrategy(),
     ]
     this._stashStorage = config?.stash === false ? false : (config?.stash?.storage ?? new InMemoryStorage())
+    this._enableRetrievalTool = config?.stash !== false && config?.stash?.retrievalTool !== false
   }
 
   getTools(): Tool[] {
-    if (this._stashStorage === false) return []
+    if (!this._enableRetrievalTool) return []
     if (!this._stash) return []
     if (!this._retrievalTool) {
       this._retrievalTool = createRetrievalTool(this._stash)
@@ -68,9 +69,10 @@ export class ContextManager implements Plugin {
 
     if (this._stash) {
       const stash = this._stash
+      const skipSet = this._retrievalToolUseIds
       agent.addHook(MessageAddedEvent, async (event) => {
-        this._trackRetrievalToolUseIds(event.message)
-        await stash.storeMessage(event.message, this._retrievalToolUseIds)
+        trackRetrievalToolUseIds(event.message, skipSet)
+        await stash.storeMessage(event.message, skipSet)
       })
     }
 
@@ -136,12 +138,4 @@ export class ContextManager implements Plugin {
     return anyActed
   }
 
-  private _trackRetrievalToolUseIds(message: Message): void {
-    if (message.role !== 'assistant') return
-    for (const block of message.content) {
-      if (block instanceof ToolUseBlock && block.name === RETRIEVAL_TOOL_NAME) {
-        this._retrievalToolUseIds.add(block.toolUseId)
-      }
-    }
-  }
 }

--- a/strands-ts/src/context-manager/retrieval-tool.ts
+++ b/strands-ts/src/context-manager/retrieval-tool.ts
@@ -1,0 +1,119 @@
+/**
+ * Retrieval tool for accessing stashed (L1) content.
+ *
+ * Registered automatically when the ContextManager has storage configured.
+ *
+ * @internal
+ */
+
+import { z } from 'zod'
+import { tool } from '../tools/tool-factory.js'
+import { isSearchableContent, searchContent } from '../vended-plugins/context-offloader/search.js'
+import { ImageBlock, VideoBlock, DocumentBlock } from '../types/media.js'
+import type { ImageFormat, VideoFormat, DocumentFormat } from '../types/media.js'
+import type { JSONValue } from '../types/json.js'
+import type { Tool } from '../tools/tool.js'
+import type { Stash } from './stash.js'
+
+export const RETRIEVAL_TOOL_NAME = 'retrieve_context'
+
+const DEFAULT_MAX_RESULT_TOKENS = 10_000
+const CHARS_PER_TOKEN = 4
+
+const retrievalInputSchema = z.object({
+  reference: z.string().describe('The reference key from the offload placeholder.'),
+  pattern: z.string().optional().describe('Regex or keyword to grep for. Returns matching lines with context.'),
+  line_range: z
+    .object({
+      start: z.number().int().min(1).describe('First line to return (1-indexed).'),
+      end: z.number().int().min(1).describe('Last line to return (1-indexed).'),
+    })
+    .optional()
+    .describe('Return only this span of lines.'),
+  context_lines: z.number().int().min(0).optional().describe('Lines of context around each match (default: 5).'),
+})
+
+/**
+ * Creates the retrieval tool for the given stash.
+ *
+ * @param stash - The stash instance to retrieve from
+ * @param maxResultTokens - Maximum tokens in the retrieval result
+ * @returns A Tool that can retrieve stashed content
+ *
+ * @internal
+ */
+export function createRetrievalTool(stash: Stash, maxResultTokens?: number): Tool {
+  const maxChars = (maxResultTokens ?? DEFAULT_MAX_RESULT_TOKENS) * CHARS_PER_TOKEN
+
+  return tool({
+    name: RETRIEVAL_TOOL_NAME,
+    description:
+      'Retrieve content that was offloaded from context.\n\n' +
+      'When content is offloaded (truncated, dropped, or summarized), the original is ' +
+      'persisted and a reference key is left in its place. Use this tool with that ' +
+      'reference to access the original content.\n\n' +
+      'Options:\n' +
+      '  - pattern: regex/keyword to find matching lines with context\n' +
+      '  - line_range: { start, end } to read a specific span\n' +
+      '  - Without pattern/line_range: returns the full original content\n\n' +
+      'Examples:\n' +
+      '  { reference: "1_toolu_abc_0", pattern: "error" }\n' +
+      '  { reference: "1_toolu_abc_0", line_range: { start: 10, end: 25 } }\n' +
+      '  { reference: "1_toolu_abc_0" }',
+    inputSchema: retrievalInputSchema,
+    callback: async (input) => {
+      const result = await stash.retrieve(input.reference)
+      if (!result) {
+        return `Error: reference not found: ${input.reference}`
+      }
+
+      if (!input.pattern && !input.line_range) {
+        return decodeContent(result.content, result.contentType, input.reference)
+      }
+
+      if (!isSearchableContent(result.contentType)) {
+        return `Error: cannot search binary content (${result.contentType}). Omit pattern/line_range to retrieve full content.`
+      }
+
+      const text = new TextDecoder().decode(result.content)
+      const contextLines = input.context_lines ?? 5
+
+      return searchContent(
+        text,
+        { pattern: input.pattern, line_range: input.line_range, context_lines: contextLines },
+        maxChars
+      )
+    },
+  })
+}
+
+function decodeContent(content: Uint8Array, contentType: string, reference: string): JSONValue {
+  if (contentType.startsWith('text/')) {
+    return new TextDecoder().decode(content)
+  }
+  if (contentType === 'application/json') {
+    const text = new TextDecoder().decode(content)
+    try {
+      return JSON.parse(text) as JSONValue
+    } catch {
+      return text
+    }
+  }
+  if (contentType.startsWith('image/')) {
+    const format = contentType.slice(contentType.indexOf('/') + 1)
+    return new ImageBlock({ format: format as ImageFormat, source: { bytes: content } }) as unknown as JSONValue
+  }
+  if (contentType.startsWith('video/')) {
+    const format = contentType.slice(contentType.indexOf('/') + 1)
+    return new VideoBlock({ format: format as VideoFormat, source: { bytes: content } }) as unknown as JSONValue
+  }
+  if (contentType.startsWith('application/')) {
+    const format = contentType.slice(contentType.indexOf('/') + 1)
+    return new DocumentBlock({
+      format: format as DocumentFormat,
+      name: reference,
+      source: { bytes: content },
+    }) as unknown as JSONValue
+  }
+  return new TextDecoder('utf-8', { fatal: false }).decode(content)
+}

--- a/strands-ts/src/context-manager/retrieval-tool.ts
+++ b/strands-ts/src/context-manager/retrieval-tool.ts
@@ -9,8 +9,6 @@
 import { z } from 'zod'
 import { tool } from '../tools/tool-factory.js'
 import { isSearchableContent, searchContent } from '../vended-plugins/context-offloader/search.js'
-import { ImageBlock, VideoBlock, DocumentBlock } from '../types/media.js'
-import type { ImageFormat, VideoFormat, DocumentFormat } from '../types/media.js'
 import type { JSONValue } from '../types/json.js'
 import type { Tool } from '../tools/tool.js'
 import type { Stash } from './stash.js'
@@ -68,14 +66,14 @@ export function createRetrievalTool(stash: Stash, maxResultTokens?: number): Too
       }
 
       if (!input.pattern && !input.line_range) {
-        return decodeContent(result.content, result.contentType, input.reference)
+        return result.data as JSONValue
       }
 
-      if (!isSearchableContent(result.contentType)) {
-        return `Error: cannot search binary content (${result.contentType}). Omit pattern/line_range to retrieve full content.`
+      const text = extractText(result.data)
+      if (!text || !isSearchableContent('text/plain')) {
+        return `Error: cannot search non-text content. Omit pattern/line_range to retrieve full content.`
       }
 
-      const text = new TextDecoder().decode(result.content)
       const contextLines = input.context_lines ?? 5
 
       return searchContent(
@@ -87,33 +85,15 @@ export function createRetrievalTool(stash: Stash, maxResultTokens?: number): Too
   })
 }
 
-function decodeContent(content: Uint8Array, contentType: string, reference: string): JSONValue {
-  if (contentType.startsWith('text/')) {
-    return new TextDecoder().decode(content)
-  }
-  if (contentType === 'application/json') {
-    const text = new TextDecoder().decode(content)
-    try {
-      return JSON.parse(text) as JSONValue
-    } catch {
-      return text
+function extractText(data: unknown): string | null {
+  if (typeof data === 'string') return data
+  if (data && typeof data === 'object') {
+    if ('text' in data && typeof (data as Record<string, unknown>).text === 'string') {
+      return (data as Record<string, unknown>).text as string
+    }
+    if ('json' in data) {
+      return JSON.stringify((data as Record<string, unknown>).json, null, 2)
     }
   }
-  if (contentType.startsWith('image/')) {
-    const format = contentType.slice(contentType.indexOf('/') + 1)
-    return new ImageBlock({ format: format as ImageFormat, source: { bytes: content } }) as unknown as JSONValue
-  }
-  if (contentType.startsWith('video/')) {
-    const format = contentType.slice(contentType.indexOf('/') + 1)
-    return new VideoBlock({ format: format as VideoFormat, source: { bytes: content } }) as unknown as JSONValue
-  }
-  if (contentType.startsWith('application/')) {
-    const format = contentType.slice(contentType.indexOf('/') + 1)
-    return new DocumentBlock({
-      format: format as DocumentFormat,
-      name: reference,
-      source: { bytes: content },
-    }) as unknown as JSONValue
-  }
-  return new TextDecoder('utf-8', { fatal: false }).decode(content)
+  return null
 }

--- a/strands-ts/src/context-manager/retrieval-tool.ts
+++ b/strands-ts/src/context-manager/retrieval-tool.ts
@@ -11,6 +11,7 @@ import { tool } from '../tools/tool-factory.js'
 import { isSearchableContent, searchContent } from '../vended-plugins/context-offloader/search.js'
 import type { JSONValue } from '../types/json.js'
 import type { Tool } from '../tools/tool.js'
+import { Message, ToolUseBlock } from '../types/messages.js'
 import type { Stash } from './stash.js'
 
 export const RETRIEVAL_TOOL_NAME = 'retrieve_context'
@@ -83,6 +84,21 @@ export function createRetrievalTool(stash: Stash, maxResultTokens?: number): Too
       )
     },
   })
+}
+
+/**
+ * Tracks toolUseIds from retrieval tool invocations so their results
+ * can be excluded from stashing (prevents retrieval loops).
+ *
+ * @internal
+ */
+export function trackRetrievalToolUseIds(message: Message, skipSet: Set<string>): void {
+  if (message.role !== 'assistant') return
+  for (const block of message.content) {
+    if (block instanceof ToolUseBlock && block.name === RETRIEVAL_TOOL_NAME) {
+      skipSet.add(block.toolUseId)
+    }
+  }
 }
 
 function extractText(data: unknown): string | null {

--- a/strands-ts/src/context-manager/stash.ts
+++ b/strands-ts/src/context-manager/stash.ts
@@ -1,0 +1,194 @@
+/**
+ * L1 stash: durable storage for offloaded context content.
+ *
+ * When the ContextManager offloads content from the context window, the
+ * original is persisted here so the agent can retrieve it on demand via the
+ * retrieval tool.
+ *
+ * @internal
+ */
+
+import { resolveNamespace, type Storage } from '../storage/storage.js'
+import { Message, TextBlock, JsonBlock, ToolResultBlock } from '../types/messages.js'
+import type { ContentBlock, ToolResultContent } from '../types/messages.js'
+import { ImageBlock, VideoBlock, DocumentBlock } from '../types/media.js'
+import { logger } from '../logging/logger.js'
+
+const STASH_PREFIX = 'context-stash'
+
+/** A reference to stashed content. */
+export interface StashRef {
+  /** Storage key for retrieval. */
+  ref: string
+  /** MIME content type of the stored content. */
+  contentType: string
+}
+
+function frameContent(content: Uint8Array, contentType: string): Uint8Array {
+  const ctBytes = new TextEncoder().encode(contentType)
+  const frame = new Uint8Array(2 + ctBytes.length + content.length)
+  frame[0] = (ctBytes.length >> 8) & 0xff
+  frame[1] = ctBytes.length & 0xff
+  frame.set(ctBytes, 2)
+  frame.set(content, 2 + ctBytes.length)
+  return frame
+}
+
+function unframeContent(frame: Uint8Array): { content: Uint8Array; contentType: string } {
+  const ctLen = (frame[0]! << 8) | frame[1]!
+  const contentType = new TextDecoder().decode(frame.subarray(2, 2 + ctLen))
+  const content = frame.subarray(2 + ctLen)
+  return { content, contentType }
+}
+
+function serializeContentBlock(block: ToolResultContent): { bytes: Uint8Array | undefined; contentType: string } {
+  if (block instanceof TextBlock) {
+    return { bytes: new TextEncoder().encode(block.text), contentType: 'text/plain' }
+  }
+  if (block instanceof JsonBlock) {
+    return { bytes: new TextEncoder().encode(JSON.stringify(block.json, null, 2)), contentType: 'application/json' }
+  }
+  if (block instanceof ImageBlock) {
+    if (block.source.type === 'imageSourceBytes') {
+      return { bytes: block.source.bytes, contentType: `image/${block.format}` }
+    }
+    return { bytes: undefined, contentType: `image/${block.format}` }
+  }
+  if (block instanceof VideoBlock) {
+    if (block.source.type === 'videoSourceBytes') {
+      return { bytes: block.source.bytes, contentType: `video/${block.format}` }
+    }
+    return { bytes: undefined, contentType: `video/${block.format}` }
+  }
+  if (block instanceof DocumentBlock) {
+    if (block.source.type === 'documentSourceBytes') {
+      return { bytes: block.source.bytes, contentType: `application/${block.format}` }
+    }
+    if (block.source.type === 'documentSourceText') {
+      return { bytes: new TextEncoder().encode(block.source.text), contentType: 'text/plain' }
+    }
+    return { bytes: undefined, contentType: `application/${block.format}` }
+  }
+  return { bytes: undefined, contentType: 'application/octet-stream' }
+}
+
+/**
+ * Wraps a Storage backend with key management and content framing for the
+ * ContextManager's L1 stash.
+ *
+ * @internal
+ */
+export class Stash {
+  private readonly _storage: Storage
+  private readonly _sessionId: string
+  private readonly _refsByBlock = new WeakMap<ContentBlock | ToolResultContent, StashRef[]>()
+  private _counter = 0
+
+  constructor(storage: Storage) {
+    this._sessionId = Math.random().toString(36).slice(2, 8)
+    this._storage = resolveNamespace(storage, STASH_PREFIX)
+  }
+
+  /**
+   * Store raw content and return a reference key.
+   *
+   * @param toolUseId - The toolUseId this content belongs to
+   * @param blockIndex - Index of the block within the tool result
+   * @param content - Raw content bytes
+   * @param contentType - MIME type of the content
+   * @returns Reference key for retrieval
+   */
+  async store(toolUseId: string, blockIndex: number, content: Uint8Array, contentType: string): Promise<string> {
+    this._counter++
+    const key = `${this._sessionId}_${this._counter}_${toolUseId}_${blockIndex}`
+    const framed = frameContent(content, contentType)
+    await this._storage.write(key, framed)
+    return key
+  }
+
+  /**
+   * Look up pre-computed refs for a content block.
+   * Returns refs populated by a prior {@link storeMessage} call, or empty if the block
+   * was never eagerly stashed (e.g. retrieval results that were excluded).
+   *
+   * @param block - The content block to look up
+   * @returns Array of stash references
+   */
+  getRefs(block: ContentBlock): StashRef[] {
+    return this._refsByBlock.get(block) ?? []
+  }
+
+  /**
+   * Eagerly stash all content from a message on arrival.
+   * Called via MessageAddedEvent so content is persisted before any strategy runs.
+   * Refs are keyed by the block object itself (WeakMap), so they auto-GC when
+   * the block is replaced during offloading.
+   *
+   * @param message - The message whose content should be persisted
+   */
+  async storeMessage(message: Message): Promise<void> {
+    for (const block of message.content) {
+      if (block instanceof ToolResultBlock) {
+        const refs = await this._storeToolResult(block).catch((error) => {
+          logger.debug(`toolUseId=<${block.toolUseId}>, error=<${error}> | failed to stash tool result`)
+          return [] as StashRef[]
+        })
+        if (refs.length > 0) this._refsByBlock.set(block, refs)
+      } else if (block instanceof TextBlock && block.text.length > 0) {
+        try {
+          const key = `text_${message.trackingId ?? 'msg'}`
+          const ref = await this.store(key, 0, new TextEncoder().encode(block.text), 'text/plain')
+          this._refsByBlock.set(block, [{ ref, contentType: 'text/plain' }])
+        } catch (error) {
+          logger.debug(`trackingId=<${message.trackingId}>, error=<${error}> | failed to stash text block`)
+        }
+      }
+    }
+  }
+
+  /**
+   * Retrieve previously stashed content.
+   *
+   * @param reference - Key returned by a previous store call
+   * @returns Content bytes and content type, or null if not found
+   */
+  async retrieve(reference: string): Promise<{ content: Uint8Array; contentType: string } | null> {
+    const data = await this._storage.read(reference)
+    if (data === null) return null
+    return unframeContent(data)
+  }
+
+  /**
+   * List all stashed references.
+   */
+  async list(): Promise<string[]> {
+    return this._storage.list('')
+  }
+
+  /**
+   * Delete a stashed entry.
+   */
+  async delete(reference: string): Promise<void> {
+    await this._storage.delete(reference)
+    logger.debug(`reference=<${reference}> | stash entry deleted`)
+  }
+
+  private async _storeToolResult(block: ToolResultBlock): Promise<StashRef[]> {
+    if (block.content.length === 0) return []
+
+    const refs: StashRef[] = []
+    for (let blockIndex = 0; blockIndex < block.content.length; blockIndex++) {
+      const item = block.content[blockIndex]!
+      const serialized = serializeContentBlock(item)
+      if (!serialized.bytes) {
+        logger.debug(
+          `toolUseId=<${block.toolUseId}>, blockIndex=<${blockIndex}> | skipped non-byte content (${serialized.contentType})`
+        )
+        continue
+      }
+      const ref = await this.store(block.toolUseId, blockIndex, serialized.bytes, serialized.contentType)
+      refs.push({ ref, contentType: serialized.contentType })
+    }
+    return refs
+  }
+}

--- a/strands-ts/src/context-manager/stash.ts
+++ b/strands-ts/src/context-manager/stash.ts
@@ -9,27 +9,11 @@
  */
 
 import { resolveNamespace, type Storage } from '../storage/storage.js'
-import {
-  Message,
-  TextBlock,
-  ToolResultBlock,
-  ToolUseBlock,
-  CachePointBlock,
-  ReasoningBlock,
-} from '../types/messages.js'
+import { Message, ToolResultBlock, ToolUseBlock, CachePointBlock, ReasoningBlock } from '../types/messages.js'
 import type { ContentBlock, ToolResultContent } from '../types/messages.js'
-import { ImageBlock, VideoBlock, DocumentBlock, AudioBlock } from '../types/media.js'
 import { logger } from '../logging/logger.js'
 
 const STASH_PREFIX = 'context'
-
-/** A reference to stashed content. */
-export interface StashRef {
-  /** Storage key for retrieval. */
-  ref: string
-  /** MIME content type of the stored content. */
-  contentType: string
-}
 
 function encode(value: unknown): Uint8Array {
   return new TextEncoder().encode(JSON.stringify(value))
@@ -39,20 +23,11 @@ function decode(bytes: Uint8Array): unknown {
   return JSON.parse(new TextDecoder().decode(bytes))
 }
 
-function contentTypeOf(block: ContentBlock | ToolResultContent): string {
-  if (block instanceof TextBlock) return 'text/plain'
-  if (block instanceof ImageBlock) return `image/${block.format}`
-  if (block instanceof VideoBlock) return `video/${block.format}`
-  if (block instanceof DocumentBlock) return `application/${block.format}`
-  if (block instanceof AudioBlock) return `audio/${block.format}`
-  return 'application/json'
-}
-
 /** Format stash refs for display in placeholders. Returns '' when refs is empty. */
-export function formatStashRefs(refs: StashRef[]): string {
+export function formatStashRefs(refs: string[]): string {
   if (refs.length === 0) return ''
-  if (refs.length === 1) return ` ref: ${refs[0]!.ref} (${refs[0]!.contentType})`
-  return ` refs: ${refs.map((r) => `${r.ref} (${r.contentType})`).join(', ')}`
+  if (refs.length === 1) return ` ref: ${refs[0]!}`
+  return ` refs: ${refs.join(', ')}`
 }
 
 /**
@@ -63,7 +38,7 @@ export function formatStashRefs(refs: StashRef[]): string {
  */
 export class Stash {
   private readonly _storage: Storage
-  private readonly _refsByBlock = new WeakMap<ContentBlock | ToolResultContent, StashRef[]>()
+  private readonly _refsByBlock = new WeakMap<ContentBlock | ToolResultContent, string[]>()
 
   constructor(storage: Storage, sessionId: string, agentId: string) {
     this._storage = resolveNamespace(storage, `${STASH_PREFIX}/${sessionId}/scopes/agent/${agentId}`)
@@ -94,7 +69,7 @@ export class Stash {
    * @param block - The content block to look up
    * @returns Array of stash references
    */
-  getRefs(block: ContentBlock): StashRef[] {
+  getRefs(block: ContentBlock): string[] {
     return this._refsByBlock.get(block) ?? []
   }
 
@@ -114,7 +89,7 @@ export class Stash {
         if (skipToolUseIds?.has(block.toolUseId)) continue
         const refs = await this._storeToolResult(block).catch((error) => {
           logger.debug(`toolUseId=<${block.toolUseId}>, error=<${error}> | failed to stash tool result`)
-          return [] as StashRef[]
+          return [] as string[]
         })
         if (refs.length > 0) this._refsByBlock.set(block, refs)
       } else if (block instanceof ToolUseBlock || block instanceof CachePointBlock || block instanceof ReasoningBlock) {
@@ -122,7 +97,7 @@ export class Stash {
       } else {
         try {
           const ref = await this.store(message.trackingId, blockIndex, encode(block.toJSON()))
-          this._refsByBlock.set(block, [{ ref, contentType: contentTypeOf(block) }])
+          this._refsByBlock.set(block, [ref])
         } catch (error) {
           logger.debug(`trackingId=<${message.trackingId}>, error=<${error}> | failed to stash block`)
         }
@@ -136,10 +111,10 @@ export class Stash {
    * @param reference - Key returned by a previous store call
    * @returns The deserialized block data (from `toJSON()`), or null if not found
    */
-  async retrieve(reference: string): Promise<{ data: unknown; contentType: string } | null> {
+  async retrieve(reference: string): Promise<{ data: unknown } | null> {
     const bytes = await this._storage.read(reference)
     if (bytes === null) return null
-    return { data: decode(bytes), contentType: 'application/json' }
+    return { data: decode(bytes) }
   }
 
   /**
@@ -157,14 +132,14 @@ export class Stash {
     logger.debug(`reference=<${reference}> | stash entry deleted`)
   }
 
-  private async _storeToolResult(block: ToolResultBlock): Promise<StashRef[]> {
+  private async _storeToolResult(block: ToolResultBlock): Promise<string[]> {
     if (block.content.length === 0) return []
 
-    const refs: StashRef[] = []
+    const refs: string[] = []
     for (let blockIndex = 0; blockIndex < block.content.length; blockIndex++) {
       const item = block.content[blockIndex]!
       const ref = await this.store(block.toolUseId, blockIndex, encode(item.toJSON()))
-      refs.push({ ref, contentType: contentTypeOf(item) })
+      refs.push(ref)
     }
     return refs
   }

--- a/strands-ts/src/context-manager/stash.ts
+++ b/strands-ts/src/context-manager/stash.ts
@@ -9,9 +9,9 @@
  */
 
 import { resolveNamespace, type Storage } from '../storage/storage.js'
-import { Message, TextBlock, JsonBlock, ToolResultBlock } from '../types/messages.js'
+import { Message, TextBlock, ToolResultBlock, ToolUseBlock, CachePointBlock, ReasoningBlock } from '../types/messages.js'
 import type { ContentBlock, ToolResultContent } from '../types/messages.js'
-import { ImageBlock, VideoBlock, DocumentBlock } from '../types/media.js'
+import { ImageBlock, VideoBlock, DocumentBlock, AudioBlock } from '../types/media.js'
 import { logger } from '../logging/logger.js'
 
 const STASH_PREFIX = 'context-stash'
@@ -24,52 +24,21 @@ export interface StashRef {
   contentType: string
 }
 
-function frameContent(content: Uint8Array, contentType: string): Uint8Array {
-  const ctBytes = new TextEncoder().encode(contentType)
-  const frame = new Uint8Array(2 + ctBytes.length + content.length)
-  frame[0] = (ctBytes.length >> 8) & 0xff
-  frame[1] = ctBytes.length & 0xff
-  frame.set(ctBytes, 2)
-  frame.set(content, 2 + ctBytes.length)
-  return frame
+function encode(value: unknown): Uint8Array {
+  return new TextEncoder().encode(JSON.stringify(value))
 }
 
-function unframeContent(frame: Uint8Array): { content: Uint8Array; contentType: string } {
-  const ctLen = (frame[0]! << 8) | frame[1]!
-  const contentType = new TextDecoder().decode(frame.subarray(2, 2 + ctLen))
-  const content = frame.subarray(2 + ctLen)
-  return { content, contentType }
+function decode(bytes: Uint8Array): unknown {
+  return JSON.parse(new TextDecoder().decode(bytes))
 }
 
-function serializeContentBlock(block: ToolResultContent): { bytes: Uint8Array | undefined; contentType: string } {
-  if (block instanceof TextBlock) {
-    return { bytes: new TextEncoder().encode(block.text), contentType: 'text/plain' }
-  }
-  if (block instanceof JsonBlock) {
-    return { bytes: new TextEncoder().encode(JSON.stringify(block.json, null, 2)), contentType: 'application/json' }
-  }
-  if (block instanceof ImageBlock) {
-    if (block.source.type === 'imageSourceBytes') {
-      return { bytes: block.source.bytes, contentType: `image/${block.format}` }
-    }
-    return { bytes: undefined, contentType: `image/${block.format}` }
-  }
-  if (block instanceof VideoBlock) {
-    if (block.source.type === 'videoSourceBytes') {
-      return { bytes: block.source.bytes, contentType: `video/${block.format}` }
-    }
-    return { bytes: undefined, contentType: `video/${block.format}` }
-  }
-  if (block instanceof DocumentBlock) {
-    if (block.source.type === 'documentSourceBytes') {
-      return { bytes: block.source.bytes, contentType: `application/${block.format}` }
-    }
-    if (block.source.type === 'documentSourceText') {
-      return { bytes: new TextEncoder().encode(block.source.text), contentType: 'text/plain' }
-    }
-    return { bytes: undefined, contentType: `application/${block.format}` }
-  }
-  return { bytes: undefined, contentType: 'application/octet-stream' }
+function contentTypeOf(block: ContentBlock | ToolResultContent): string {
+  if (block instanceof TextBlock) return 'text/plain'
+  if (block instanceof ImageBlock) return `image/${block.format}`
+  if (block instanceof VideoBlock) return `video/${block.format}`
+  if (block instanceof DocumentBlock) return `application/${block.format}`
+  if (block instanceof AudioBlock) return `audio/${block.format}`
+  return 'application/json'
 }
 
 /**
@@ -80,29 +49,26 @@ function serializeContentBlock(block: ToolResultContent): { bytes: Uint8Array | 
  */
 export class Stash {
   private readonly _storage: Storage
-  private readonly _sessionId: string
   private readonly _refsByBlock = new WeakMap<ContentBlock | ToolResultContent, StashRef[]>()
-  private _counter = 0
 
-  constructor(storage: Storage) {
-    this._sessionId = Math.random().toString(36).slice(2, 8)
-    this._storage = resolveNamespace(storage, STASH_PREFIX)
+  constructor(storage: Storage, sessionId: string) {
+    this._storage = resolveNamespace(storage, `${STASH_PREFIX}/${sessionId}`)
   }
 
   /**
-   * Store raw content and return a reference key.
+   * Store a serialized block and return a deterministic reference key.
    *
-   * @param toolUseId - The toolUseId this content belongs to
+   * Keys are deterministic (`<id>_<blockIndex>`) so they can be recomputed
+   * after a process restart or snapshot restore without the WeakMap cache.
+   *
+   * @param id - Identifier component for the key (e.g. toolUseId)
    * @param blockIndex - Index of the block within the tool result
-   * @param content - Raw content bytes
-   * @param contentType - MIME type of the content
+   * @param data - Serialized bytes to persist
    * @returns Reference key for retrieval
    */
-  async store(toolUseId: string, blockIndex: number, content: Uint8Array, contentType: string): Promise<string> {
-    this._counter++
-    const key = `${this._sessionId}_${this._counter}_${toolUseId}_${blockIndex}`
-    const framed = frameContent(content, contentType)
-    await this._storage.write(key, framed)
+  async store(id: string, blockIndex: number, data: Uint8Array): Promise<string> {
+    const key = `${id}_${blockIndex}`
+    await this._storage.write(key, data)
     return key
   }
 
@@ -125,37 +91,41 @@ export class Stash {
    * the block is replaced during offloading.
    *
    * @param message - The message whose content should be persisted
+   * @param skipToolUseIds - ToolUseIds to skip (e.g. retrieval tool results)
    */
-  async storeMessage(message: Message): Promise<void> {
-    for (const block of message.content) {
+  async storeMessage(message: Message, skipToolUseIds?: ReadonlySet<string>): Promise<void> {
+    for (let blockIndex = 0; blockIndex < message.content.length; blockIndex++) {
+      const block = message.content[blockIndex]!
       if (block instanceof ToolResultBlock) {
+        if (skipToolUseIds?.has(block.toolUseId)) continue
         const refs = await this._storeToolResult(block).catch((error) => {
           logger.debug(`toolUseId=<${block.toolUseId}>, error=<${error}> | failed to stash tool result`)
           return [] as StashRef[]
         })
         if (refs.length > 0) this._refsByBlock.set(block, refs)
-      } else if (block instanceof TextBlock && block.text.length > 0) {
+      } else if (block instanceof ToolUseBlock || block instanceof CachePointBlock || block instanceof ReasoningBlock) {
+        continue
+      } else {
         try {
-          const key = `text_${message.trackingId ?? 'msg'}`
-          const ref = await this.store(key, 0, new TextEncoder().encode(block.text), 'text/plain')
-          this._refsByBlock.set(block, [{ ref, contentType: 'text/plain' }])
+          const ref = await this.store(message.trackingId, blockIndex, encode(block.toJSON()))
+          this._refsByBlock.set(block, [{ ref, contentType: contentTypeOf(block) }])
         } catch (error) {
-          logger.debug(`trackingId=<${message.trackingId}>, error=<${error}> | failed to stash text block`)
+          logger.debug(`trackingId=<${message.trackingId}>, error=<${error}> | failed to stash block`)
         }
       }
     }
   }
 
   /**
-   * Retrieve previously stashed content.
+   * Retrieve previously stashed content as its serialized JSON form.
    *
    * @param reference - Key returned by a previous store call
-   * @returns Content bytes and content type, or null if not found
+   * @returns The deserialized block data (from `toJSON()`), or null if not found
    */
-  async retrieve(reference: string): Promise<{ content: Uint8Array; contentType: string } | null> {
-    const data = await this._storage.read(reference)
-    if (data === null) return null
-    return unframeContent(data)
+  async retrieve(reference: string): Promise<{ data: unknown; contentType: string } | null> {
+    const bytes = await this._storage.read(reference)
+    if (bytes === null) return null
+    return { data: decode(bytes), contentType: 'application/json' }
   }
 
   /**
@@ -179,15 +149,8 @@ export class Stash {
     const refs: StashRef[] = []
     for (let blockIndex = 0; blockIndex < block.content.length; blockIndex++) {
       const item = block.content[blockIndex]!
-      const serialized = serializeContentBlock(item)
-      if (!serialized.bytes) {
-        logger.debug(
-          `toolUseId=<${block.toolUseId}>, blockIndex=<${blockIndex}> | skipped non-byte content (${serialized.contentType})`
-        )
-        continue
-      }
-      const ref = await this.store(block.toolUseId, blockIndex, serialized.bytes, serialized.contentType)
-      refs.push({ ref, contentType: serialized.contentType })
+      const ref = await this.store(block.toolUseId, blockIndex, encode(item.toJSON()))
+      refs.push({ ref, contentType: contentTypeOf(item) })
     }
     return refs
   }

--- a/strands-ts/src/context-manager/stash.ts
+++ b/strands-ts/src/context-manager/stash.ts
@@ -41,10 +41,11 @@ function contentTypeOf(block: ContentBlock | ToolResultContent): string {
   return 'application/json'
 }
 
-/** Format stash refs for display in placeholders. */
+/** Format stash refs for display in placeholders. Returns '' when refs is empty. */
 export function formatStashRefs(refs: StashRef[]): string {
-  if (refs.length === 1) return `ref: ${refs[0]!.ref} (${refs[0]!.contentType})`
-  return `refs: ${refs.map((r) => `${r.ref} (${r.contentType})`).join(', ')}`
+  if (refs.length === 0) return ''
+  if (refs.length === 1) return ` ref: ${refs[0]!.ref} (${refs[0]!.contentType})`
+  return ` refs: ${refs.map((r) => `${r.ref} (${r.contentType})`).join(', ')}`
 }
 
 /**

--- a/strands-ts/src/context-manager/stash.ts
+++ b/strands-ts/src/context-manager/stash.ts
@@ -10,7 +10,7 @@
 
 import { resolveNamespace, type Storage } from '../storage/storage.js'
 import { Message, ToolResultBlock, ToolUseBlock, CachePointBlock, ReasoningBlock } from '../types/messages.js'
-import type { ContentBlock, ToolResultContent } from '../types/messages.js'
+import type { ContentBlock } from '../types/messages.js'
 import { logger } from '../logging/logger.js'
 
 const STASH_PREFIX = 'context'
@@ -38,7 +38,6 @@ export function formatStashRefs(refs: string[]): string {
  */
 export class Stash {
   private readonly _storage: Storage
-  private readonly _refsByBlock = new WeakMap<ContentBlock | ToolResultContent, string[]>()
 
   constructor(storage: Storage, sessionId: string, agentId: string) {
     this._storage = resolveNamespace(storage, `${STASH_PREFIX}/${sessionId}/scopes/agent/${agentId}`)
@@ -48,7 +47,7 @@ export class Stash {
    * Store a serialized block and return a deterministic reference key.
    *
    * Keys are deterministic (`<id>_<blockIndex>`) so they can be recomputed
-   * after a process restart or snapshot restore without the WeakMap cache.
+   * via {@link refsFor} after a process restart or snapshot restore.
    *
    * @param id - Identifier component for the key (e.g. toolUseId)
    * @param blockIndex - Index of the block within the tool result
@@ -62,22 +61,27 @@ export class Stash {
   }
 
   /**
-   * Look up pre-computed refs for a content block.
-   * Returns refs populated by a prior {@link storeMessage} call, or empty if the block
-   * was never eagerly stashed (e.g. retrieval results that were excluded).
+   * Compute the deterministic reference keys for a content block.
    *
-   * @param block - The content block to look up
-   * @returns Array of stash references
+   * For a {@link ToolResultBlock}, returns one key per inner content item
+   * (`<toolUseId>_<i>`). For any other block, returns a single key
+   * (`<trackingId>_<blockIndex>`).
+   *
+   * @param block - The content block
+   * @param message - The message containing the block
+   * @param blockIndex - Index of the block within the message
+   * @returns Array of reference keys
    */
-  getRefs(block: ContentBlock): string[] {
-    return this._refsByBlock.get(block) ?? []
+  refsFor(block: ContentBlock, message: Message, blockIndex: number): string[] {
+    if (block instanceof ToolResultBlock) {
+      return Array.from({ length: block.content.length }, (_, index) => `${block.toolUseId}_${index}`)
+    }
+    return [`${message.trackingId}_${blockIndex}`]
   }
 
   /**
    * Eagerly stash all content from a message on arrival.
    * Called via MessageAddedEvent so content is persisted before any strategy runs.
-   * Refs are keyed by the block object itself (WeakMap), so they auto-GC when
-   * the block is replaced during offloading.
    *
    * @param message - The message whose content should be persisted
    * @param skipToolUseIds - ToolUseIds to skip (e.g. retrieval tool results)
@@ -87,17 +91,14 @@ export class Stash {
       const block = message.content[blockIndex]!
       if (block instanceof ToolResultBlock) {
         if (skipToolUseIds?.has(block.toolUseId)) continue
-        const refs = await this._storeToolResult(block).catch((error) => {
+        await this._storeToolResult(block).catch((error) => {
           logger.debug(`toolUseId=<${block.toolUseId}>, error=<${error}> | failed to stash tool result`)
-          return [] as string[]
         })
-        if (refs.length > 0) this._refsByBlock.set(block, refs)
       } else if (block instanceof ToolUseBlock || block instanceof CachePointBlock || block instanceof ReasoningBlock) {
         continue
       } else {
         try {
-          const ref = await this.store(message.trackingId, blockIndex, encode(block.toJSON()))
-          this._refsByBlock.set(block, [ref])
+          await this.store(message.trackingId, blockIndex, encode(block.toJSON()))
         } catch (error) {
           logger.debug(`trackingId=<${message.trackingId}>, error=<${error}> | failed to stash block`)
         }
@@ -132,15 +133,10 @@ export class Stash {
     logger.debug(`reference=<${reference}> | stash entry deleted`)
   }
 
-  private async _storeToolResult(block: ToolResultBlock): Promise<string[]> {
-    if (block.content.length === 0) return []
-
-    const refs: string[] = []
+  private async _storeToolResult(block: ToolResultBlock): Promise<void> {
     for (let blockIndex = 0; blockIndex < block.content.length; blockIndex++) {
       const item = block.content[blockIndex]!
-      const ref = await this.store(block.toolUseId, blockIndex, encode(item.toJSON()))
-      refs.push(ref)
+      await this.store(block.toolUseId, blockIndex, encode(item.toJSON()))
     }
-    return refs
   }
 }

--- a/strands-ts/src/context-manager/stash.ts
+++ b/strands-ts/src/context-manager/stash.ts
@@ -9,7 +9,14 @@
  */
 
 import { resolveNamespace, type Storage } from '../storage/storage.js'
-import { Message, TextBlock, ToolResultBlock, ToolUseBlock, CachePointBlock, ReasoningBlock } from '../types/messages.js'
+import {
+  Message,
+  TextBlock,
+  ToolResultBlock,
+  ToolUseBlock,
+  CachePointBlock,
+  ReasoningBlock,
+} from '../types/messages.js'
 import type { ContentBlock, ToolResultContent } from '../types/messages.js'
 import { ImageBlock, VideoBlock, DocumentBlock, AudioBlock } from '../types/media.js'
 import { logger } from '../logging/logger.js'

--- a/strands-ts/src/context-manager/stash.ts
+++ b/strands-ts/src/context-manager/stash.ts
@@ -14,7 +14,7 @@ import type { ContentBlock, ToolResultContent } from '../types/messages.js'
 import { ImageBlock, VideoBlock, DocumentBlock, AudioBlock } from '../types/media.js'
 import { logger } from '../logging/logger.js'
 
-const STASH_PREFIX = 'context-stash'
+const STASH_PREFIX = 'context'
 
 /** A reference to stashed content. */
 export interface StashRef {
@@ -58,8 +58,8 @@ export class Stash {
   private readonly _storage: Storage
   private readonly _refsByBlock = new WeakMap<ContentBlock | ToolResultContent, StashRef[]>()
 
-  constructor(storage: Storage, sessionId: string) {
-    this._storage = resolveNamespace(storage, `${STASH_PREFIX}/${sessionId}`)
+  constructor(storage: Storage, sessionId: string, agentId: string) {
+    this._storage = resolveNamespace(storage, `${STASH_PREFIX}/${sessionId}/scopes/agent/${agentId}`)
   }
 
   /**

--- a/strands-ts/src/context-manager/stash.ts
+++ b/strands-ts/src/context-manager/stash.ts
@@ -41,6 +41,12 @@ function contentTypeOf(block: ContentBlock | ToolResultContent): string {
   return 'application/json'
 }
 
+/** Format stash refs for display in placeholders. */
+export function formatStashRefs(refs: StashRef[]): string {
+  if (refs.length === 1) return `ref: ${refs[0]!.ref} (${refs[0]!.contentType})`
+  return `refs: ${refs.map((r) => `${r.ref} (${r.contentType})`).join(', ')}`
+}
+
 /**
  * Wraps a Storage backend with key management and content framing for the
  * ContextManager's L1 stash.

--- a/strands-ts/src/context-manager/strategies/offload/base.ts
+++ b/strands-ts/src/context-manager/strategies/offload/base.ts
@@ -64,13 +64,6 @@ function finiteOrUndefined(value: number | undefined): number | undefined {
   return typeof value === 'number' && Number.isFinite(value) ? Math.max(0, value) : undefined
 }
 
-/** Format stash refs for display in placeholders. */
-export function formatStashRefs(refs: StashRef[]): string {
-  if (refs.length === 1) return `ref: ${refs[0]!.ref} (${refs[0]!.contentType})`
-  return `refs: ${refs.map((r) => `${r.ref} (${r.contentType})`).join(', ')}`
-}
-
-export type { StashRef }
 
 /**
  * Builds a toolUseId → toolName map from all assistant messages in the conversation.

--- a/strands-ts/src/context-manager/strategies/offload/base.ts
+++ b/strands-ts/src/context-manager/strategies/offload/base.ts
@@ -6,7 +6,14 @@
 
 import { logger } from '../../../logging/logger.js'
 import { MessageAddedEvent } from '../../../hooks/events.js'
-import { Message, TextBlock, ToolResultBlock, ToolUseBlock, CachePointBlock, ReasoningBlock } from '../../../types/messages.js'
+import {
+  Message,
+  TextBlock,
+  ToolResultBlock,
+  ToolUseBlock,
+  CachePointBlock,
+  ReasoningBlock,
+} from '../../../types/messages.js'
 import type { ContentBlock } from '../../../types/messages.js'
 import type { LocalAgent } from '../../../types/agent.js'
 import type { ContextStrategy, ContextState } from '../../types.js'
@@ -63,7 +70,6 @@ export interface OffloadStrategyBuilder extends ContextStrategy {
 function finiteOrUndefined(value: number | undefined): number | undefined {
   return typeof value === 'number' && Number.isFinite(value) ? Math.max(0, value) : undefined
 }
-
 
 /**
  * Builds a toolUseId → toolName map from all assistant messages in the conversation.
@@ -411,13 +417,7 @@ export abstract class BaseOffloadStrategy implements ContextStrategy {
       if (tokens <= effectiveThreshold) continue
 
       const stashRefs = this._stash?.getRefs(block) ?? []
-      const replacement = await this._replaceBlock(
-        block,
-        tokens,
-        message,
-        agent,
-        stashRefs
-      )
+      const replacement = await this._replaceBlock(block, tokens, message, agent, stashRefs)
       if (replacement && replacement !== block) {
         ;(message.content as unknown[])[blockIndex] = replacement
         acted = true

--- a/strands-ts/src/context-manager/strategies/offload/base.ts
+++ b/strands-ts/src/context-manager/strategies/offload/base.ts
@@ -6,7 +6,7 @@
 
 import { logger } from '../../../logging/logger.js'
 import { MessageAddedEvent } from '../../../hooks/events.js'
-import { Message, TextBlock, ToolResultBlock, ToolUseBlock } from '../../../types/messages.js'
+import { Message, TextBlock, ToolResultBlock, ToolUseBlock, CachePointBlock, ReasoningBlock } from '../../../types/messages.js'
 import type { ContentBlock } from '../../../types/messages.js'
 import type { LocalAgent } from '../../../types/agent.js'
 import type { ContextStrategy, ContextState } from '../../types.js'
@@ -386,6 +386,9 @@ export abstract class BaseOffloadStrategy implements ContextStrategy {
 
   /** Whether a block is eligible for offload given the current target and filters. */
   protected _blockMatchesTarget(block: ContentBlock, message: Message, toolNameMap: Map<string, string>): boolean {
+    if (block instanceof ToolUseBlock) return false
+    if (block instanceof CachePointBlock) return false
+    if (block instanceof ReasoningBlock) return false
     if (block instanceof TextBlock) return targetMatchesMessage(this._target, message)
     if (block instanceof ToolResultBlock) {
       if (this._stash && toolNameMap.get(block.toolUseId) === RETRIEVAL_TOOL_NAME) return false
@@ -394,6 +397,7 @@ export abstract class BaseOffloadStrategy implements ContextStrategy {
         toolMatchesTarget(block, this._target, toolNameMap, this._includeFilter, this._excludeFilter)
       )
     }
+    if (this._target === '*' || this._target === undefined) return true
     return false
   }
 
@@ -415,7 +419,7 @@ export abstract class BaseOffloadStrategy implements ContextStrategy {
 
       const stashRefs = this._stash?.getRefs(block) ?? []
       const replacement = await this._replaceBlock(
-        block as TextBlock | ToolResultBlock,
+        block,
         tokens,
         message,
         agent,
@@ -473,7 +477,7 @@ export abstract class BaseOffloadStrategy implements ContextStrategy {
 
   /** Transform a block. Return the replacement, or null to skip. */
   protected abstract _replaceBlock(
-    block: TextBlock | ToolResultBlock,
+    block: ContentBlock,
     tokens: number,
     message: Message,
     agent: LocalAgent,

--- a/strands-ts/src/context-manager/strategies/offload/base.ts
+++ b/strands-ts/src/context-manager/strategies/offload/base.ts
@@ -416,7 +416,7 @@ export abstract class BaseOffloadStrategy implements ContextStrategy {
       const tokens = await agent.model.countTokens([new Message({ role: message.role, content: [block] })])
       if (tokens <= effectiveThreshold) continue
 
-      const stashRefs = this._stash?.getRefs(block) ?? []
+      const stashRefs = this._stash?.refsFor(block, message, blockIndex) ?? []
       const replacement = await this._replaceBlock(block, tokens, message, agent, stashRefs)
       if (replacement && replacement !== block) {
         ;(message.content as unknown[])[blockIndex] = replacement

--- a/strands-ts/src/context-manager/strategies/offload/base.ts
+++ b/strands-ts/src/context-manager/strategies/offload/base.ts
@@ -17,7 +17,7 @@ import {
 import type { ContentBlock } from '../../../types/messages.js'
 import type { LocalAgent } from '../../../types/agent.js'
 import type { ContextStrategy, ContextState } from '../../types.js'
-import type { Stash, StashRef } from '../../stash.js'
+import type { Stash } from '../../stash.js'
 import { RETRIEVAL_TOOL_NAME } from '../../retrieval-tool.js'
 
 /**
@@ -474,7 +474,7 @@ export abstract class BaseOffloadStrategy implements ContextStrategy {
     tokens: number,
     message: Message,
     agent: LocalAgent,
-    stashRefs: StashRef[]
+    stashRefs: string[]
   ): Promise<ContentBlock | null>
 }
 

--- a/strands-ts/src/context-manager/strategies/offload/base.ts
+++ b/strands-ts/src/context-manager/strategies/offload/base.ts
@@ -10,6 +10,8 @@ import { Message, TextBlock, ToolResultBlock, ToolUseBlock } from '../../../type
 import type { ContentBlock } from '../../../types/messages.js'
 import type { LocalAgent } from '../../../types/agent.js'
 import type { ContextStrategy, ContextState } from '../../types.js'
+import type { Stash, StashRef } from '../../stash.js'
+import { RETRIEVAL_TOOL_NAME } from '../../retrieval-tool.js'
 
 /**
  * Target for offload operations. This union is intentionally extensible — new
@@ -61,6 +63,14 @@ export interface OffloadStrategyBuilder extends ContextStrategy {
 function finiteOrUndefined(value: number | undefined): number | undefined {
   return typeof value === 'number' && Number.isFinite(value) ? Math.max(0, value) : undefined
 }
+
+/** Format stash refs for display in placeholders. */
+export function formatStashRefs(refs: StashRef[]): string {
+  if (refs.length === 1) return `ref: ${refs[0]!.ref} (${refs[0]!.contentType})`
+  return `refs: ${refs.map((r) => `${r.ref} (${r.contentType})`).join(', ')}`
+}
+
+export type { StashRef }
 
 /**
  * Builds a toolUseId → toolName map from all assistant messages in the conversation.
@@ -276,6 +286,7 @@ export abstract class BaseOffloadStrategy implements ContextStrategy {
   protected readonly _removalRatio: number = 0.3
   protected readonly _includeFilter: Set<string> | undefined
   protected readonly _excludeFilter: Set<string> | undefined
+  protected _stash: Stash | undefined
 
   constructor(target?: OffloadTarget, conditions?: OffloadConditions) {
     if (Array.isArray(target) && target.length === 0) {
@@ -297,7 +308,8 @@ export abstract class BaseOffloadStrategy implements ContextStrategy {
     return this._utilizationThreshold !== undefined
   }
 
-  init(agent: LocalAgent): void {
+  init(agent: LocalAgent, stash?: Stash): void {
+    this._stash = stash
     if (this._isMessageLevel) return
     if (this._preserveRecent > 0) return
     agent.addHook(MessageAddedEvent, async (event) => {
@@ -308,6 +320,7 @@ export abstract class BaseOffloadStrategy implements ContextStrategy {
   }
 
   async apply(context: ContextState): Promise<boolean> {
+    if (context.stash) this._stash = context.stash
     if (this._isMessageLevel) {
       if (context.utilization < this._utilizationThreshold!) return false
       return this._applyPerMessage(context)
@@ -375,6 +388,7 @@ export abstract class BaseOffloadStrategy implements ContextStrategy {
   protected _blockMatchesTarget(block: ContentBlock, message: Message, toolNameMap: Map<string, string>): boolean {
     if (block instanceof TextBlock) return targetMatchesMessage(this._target, message)
     if (block instanceof ToolResultBlock) {
+      if (this._stash && toolNameMap.get(block.toolUseId) === RETRIEVAL_TOOL_NAME) return false
       return (
         this._target === undefined ||
         toolMatchesTarget(block, this._target, toolNameMap, this._includeFilter, this._excludeFilter)
@@ -399,10 +413,15 @@ export abstract class BaseOffloadStrategy implements ContextStrategy {
       const tokens = await agent.model.countTokens([new Message({ role: message.role, content: [block] })])
       if (tokens <= effectiveThreshold) continue
 
-      const replacement = await this._replaceBlock(block as TextBlock | ToolResultBlock, tokens, message, agent)
+      const stashRefs = this._stash?.getRefs(block) ?? []
+      const replacement = await this._replaceBlock(
+        block as TextBlock | ToolResultBlock,
+        tokens,
+        message,
+        agent,
+        stashRefs
+      )
       if (replacement && replacement !== block) {
-        // Intentional in-place mutation: per-block replacement shrinks existing message content
-        // rather than constructing a new Message (unlike message-level removal which uses new objects).
         ;(message.content as unknown[])[blockIndex] = replacement
         acted = true
       }
@@ -457,7 +476,8 @@ export abstract class BaseOffloadStrategy implements ContextStrategy {
     block: TextBlock | ToolResultBlock,
     tokens: number,
     message: Message,
-    agent: LocalAgent
+    agent: LocalAgent,
+    stashRefs: StashRef[]
   ): Promise<ContentBlock | null>
 }
 
@@ -480,8 +500,8 @@ export class EmergencyTruncateStrategy extends BaseOffloadStrategy {
     super('*')
   }
 
-  override init(): void {
-    // No eager hooks — this only fires on overflow
+  override init(_agent: LocalAgent, stash?: Stash): void {
+    this._stash = stash
   }
 
   override async apply(context: ContextState): Promise<boolean> {

--- a/strands-ts/src/context-manager/strategies/offload/drop.ts
+++ b/strands-ts/src/context-manager/strategies/offload/drop.ts
@@ -9,8 +9,8 @@ import { Message, TextBlock, ToolResultBlock } from '../../../types/messages.js'
 import type { ContentBlock } from '../../../types/messages.js'
 import type { LocalAgent } from '../../../types/agent.js'
 import type { ContextStrategy } from '../../types.js'
-import { BaseOffloadStrategy } from './base.js'
-import type { OffloadConditions } from './base.js'
+import { BaseOffloadStrategy, formatStashRefs } from './base.js'
+import type { OffloadConditions, StashRef } from './base.js'
 
 export const DROPPED_MARKER = '[Dropped]'
 
@@ -29,14 +29,16 @@ export class DropStrategy extends BaseOffloadStrategy {
     block: TextBlock | ToolResultBlock,
     _tokens: number,
     message: Message,
-    _agent: LocalAgent
+    _agent: LocalAgent,
+    stashRefs: StashRef[]
   ): Promise<ContentBlock | null> {
     if (block instanceof ToolResultBlock) {
       logger.debug(`toolUseId=<${block.toolUseId}> | dropped tool result from context window`)
+      const marker = stashRefs.length > 0 ? `${DROPPED_MARKER} ${formatStashRefs(stashRefs)}` : DROPPED_MARKER
       return new ToolResultBlock({
         toolUseId: block.toolUseId,
         status: block.status,
-        content: [new TextBlock(DROPPED_MARKER)],
+        content: [new TextBlock(marker)],
       })
     }
     logger.debug(`trackingId=<${message.trackingId}> | dropped text block from context window`)

--- a/strands-ts/src/context-manager/strategies/offload/drop.ts
+++ b/strands-ts/src/context-manager/strategies/offload/drop.ts
@@ -26,7 +26,7 @@ export class DropStrategy extends BaseOffloadStrategy {
   }
 
   protected async _replaceBlock(
-    block: TextBlock | ToolResultBlock,
+    block: ContentBlock,
     _tokens: number,
     message: Message,
     _agent: LocalAgent,
@@ -41,7 +41,8 @@ export class DropStrategy extends BaseOffloadStrategy {
         content: [new TextBlock(marker)],
       })
     }
-    logger.debug(`trackingId=<${message.trackingId}> | dropped text block from context window`)
-    return new TextBlock(DROPPED_MARKER)
+    const refSuffix = stashRefs.length > 0 ? ` ${formatStashRefs(stashRefs)}` : ''
+    logger.debug(`trackingId=<${message.trackingId}> | dropped block from context window`)
+    return new TextBlock(`${DROPPED_MARKER}${refSuffix}`)
   }
 }

--- a/strands-ts/src/context-manager/strategies/offload/drop.ts
+++ b/strands-ts/src/context-manager/strategies/offload/drop.ts
@@ -34,17 +34,17 @@ export class DropStrategy extends BaseOffloadStrategy {
     _agent: LocalAgent,
     stashRefs: StashRef[]
   ): Promise<ContentBlock | null> {
+    const marker = `${DROPPED_MARKER}${formatStashRefs(stashRefs)}`
+
     if (block instanceof ToolResultBlock) {
       logger.debug(`toolUseId=<${block.toolUseId}> | dropped tool result from context window`)
-      const marker = stashRefs.length > 0 ? `${DROPPED_MARKER} ${formatStashRefs(stashRefs)}` : DROPPED_MARKER
       return new ToolResultBlock({
         toolUseId: block.toolUseId,
         status: block.status,
         content: [new TextBlock(marker)],
       })
     }
-    const refSuffix = stashRefs.length > 0 ? ` ${formatStashRefs(stashRefs)}` : ''
     logger.debug(`trackingId=<${message.trackingId}> | dropped block from context window`)
-    return new TextBlock(`${DROPPED_MARKER}${refSuffix}`)
+    return new TextBlock(marker)
   }
 }

--- a/strands-ts/src/context-manager/strategies/offload/drop.ts
+++ b/strands-ts/src/context-manager/strategies/offload/drop.ts
@@ -10,7 +10,6 @@ import type { ContentBlock } from '../../../types/messages.js'
 import type { LocalAgent } from '../../../types/agent.js'
 import type { ContextStrategy } from '../../types.js'
 import { formatStashRefs } from '../../stash.js'
-import type { StashRef } from '../../stash.js'
 import { BaseOffloadStrategy } from './base.js'
 import type { OffloadConditions } from './base.js'
 
@@ -32,7 +31,7 @@ export class DropStrategy extends BaseOffloadStrategy {
     _tokens: number,
     message: Message,
     _agent: LocalAgent,
-    stashRefs: StashRef[]
+    stashRefs: string[]
   ): Promise<ContentBlock | null> {
     const marker = `${DROPPED_MARKER}${formatStashRefs(stashRefs)}`
 

--- a/strands-ts/src/context-manager/strategies/offload/drop.ts
+++ b/strands-ts/src/context-manager/strategies/offload/drop.ts
@@ -9,8 +9,10 @@ import { Message, TextBlock, ToolResultBlock } from '../../../types/messages.js'
 import type { ContentBlock } from '../../../types/messages.js'
 import type { LocalAgent } from '../../../types/agent.js'
 import type { ContextStrategy } from '../../types.js'
-import { BaseOffloadStrategy, formatStashRefs } from './base.js'
-import type { OffloadConditions, StashRef } from './base.js'
+import { formatStashRefs } from '../../stash.js'
+import type { StashRef } from '../../stash.js'
+import { BaseOffloadStrategy } from './base.js'
+import type { OffloadConditions } from './base.js'
 
 export const DROPPED_MARKER = '[Dropped]'
 

--- a/strands-ts/src/context-manager/strategies/offload/summarize.ts
+++ b/strands-ts/src/context-manager/strategies/offload/summarize.ts
@@ -18,7 +18,6 @@ import {
   type SummarizeConfig,
 } from '../../methods/summarize.js'
 import { formatStashRefs } from '../../stash.js'
-import type { StashRef } from '../../stash.js'
 import {
   BaseOffloadStrategy,
   collectRemovableWithPair,
@@ -104,7 +103,7 @@ export class SummarizeStrategy extends BaseOffloadStrategy {
     tokens: number,
     message: Message,
     agent: LocalAgent,
-    stashRefs: StashRef[]
+    stashRefs: string[]
   ): Promise<ContentBlock | null> {
     const model = this._resolveModel(agent)
     if (!model) return null

--- a/strands-ts/src/context-manager/strategies/offload/summarize.ts
+++ b/strands-ts/src/context-manager/strategies/offload/summarize.ts
@@ -130,7 +130,9 @@ export class SummarizeStrategy extends BaseOffloadStrategy {
       if (!summary) return null
 
       logger.debug(`trackingId=<${message.trackingId}>, tokens=<${tokens}> | summarized text block`)
-      return new TextBlock(`${SUMMARIZED_PREFIX} ~${tokens.toLocaleString()} tokens]\n\n${summary}`)
+      return new TextBlock(
+        `${SUMMARIZED_PREFIX} ~${tokens.toLocaleString()} tokens |${formatStashRefs(stashRefs)}]\n\n${summary}`
+      )
     }
 
     logger.debug(`trackingId=<${message.trackingId}>, tokens=<${tokens}> | offloaded media block`)

--- a/strands-ts/src/context-manager/strategies/offload/summarize.ts
+++ b/strands-ts/src/context-manager/strategies/offload/summarize.ts
@@ -100,7 +100,7 @@ export class SummarizeStrategy extends BaseOffloadStrategy {
   }
 
   protected async _replaceBlock(
-    block: TextBlock | ToolResultBlock,
+    block: ContentBlock,
     tokens: number,
     message: Message,
     agent: LocalAgent,
@@ -124,11 +124,17 @@ export class SummarizeStrategy extends BaseOffloadStrategy {
       })
     }
 
-    const summary = await summarizeContent([new TextBlock(block.text)], model, this._config)
-    if (!summary) return null
+    if (block instanceof TextBlock) {
+      const summary = await summarizeContent([new TextBlock(block.text)], model, this._config)
+      if (!summary) return null
 
-    logger.debug(`trackingId=<${message.trackingId}>, tokens=<${tokens}> | summarized text block`)
-    return new TextBlock(`${SUMMARIZED_PREFIX} ~${tokens.toLocaleString()} tokens]\n\n${summary}`)
+      logger.debug(`trackingId=<${message.trackingId}>, tokens=<${tokens}> | summarized text block`)
+      return new TextBlock(`${SUMMARIZED_PREFIX} ~${tokens.toLocaleString()} tokens]\n\n${summary}`)
+    }
+
+    const refSuffix = stashRefs.length > 0 ? ` ${formatStashRefs(stashRefs)}` : ''
+    logger.debug(`trackingId=<${message.trackingId}>, tokens=<${tokens}> | offloaded media block`)
+    return new TextBlock(`[Offloaded: ~${tokens} tokens${refSuffix}]`)
   }
 
   private _resolveModel(agent: LocalAgent): Model | undefined {

--- a/strands-ts/src/context-manager/strategies/offload/summarize.ts
+++ b/strands-ts/src/context-manager/strategies/offload/summarize.ts
@@ -118,7 +118,9 @@ export class SummarizeStrategy extends BaseOffloadStrategy {
         toolUseId: block.toolUseId,
         status: block.status,
         content: [
-          new TextBlock(`${SUMMARIZED_PREFIX} ~${tokens.toLocaleString()} tokens |${formatStashRefs(stashRefs)}]\n\n${summary}`),
+          new TextBlock(
+            `${SUMMARIZED_PREFIX} ~${tokens.toLocaleString()} tokens |${formatStashRefs(stashRefs)}]\n\n${summary}`
+          ),
         ],
       })
     }

--- a/strands-ts/src/context-manager/strategies/offload/summarize.ts
+++ b/strands-ts/src/context-manager/strategies/offload/summarize.ts
@@ -20,9 +20,12 @@ import {
 import {
   BaseOffloadStrategy,
   collectRemovableWithPair,
+  formatStashRefs,
+  spliceWithPairs,
   repairAlternation,
   type OffloadConditions,
   type OffloadTarget,
+  type StashRef,
 } from './base.js'
 
 export class SummarizeStrategy extends BaseOffloadStrategy {
@@ -86,14 +89,7 @@ export class SummarizeStrategy extends BaseOffloadStrategy {
       ],
     })
 
-    // Remove summarized messages, tracking the lowest removal point for insertion
-    let lowestIndex = messages.length
-    for (const message of safe) {
-      const index = messages.indexOf(message)
-      if (index === -1) continue
-      if (index < lowestIndex) lowestIndex = index
-      messages.splice(index, 1)
-    }
+    const { lowestIndex } = spliceWithPairs(messages, safe)
 
     const insertIndex = Math.max(1, Math.min(lowestIndex, messages.length))
     messages.splice(insertIndex, 0, summaryMessage)
@@ -107,7 +103,8 @@ export class SummarizeStrategy extends BaseOffloadStrategy {
     block: TextBlock | ToolResultBlock,
     tokens: number,
     message: Message,
-    agent: LocalAgent
+    agent: LocalAgent,
+    stashRefs: StashRef[]
   ): Promise<ContentBlock | null> {
     const model = this._resolveModel(agent)
     if (!model) return null
@@ -116,11 +113,14 @@ export class SummarizeStrategy extends BaseOffloadStrategy {
       const summary = await summarizeContent(toolResultToContentBlocks(block.content), model, this._config)
       if (!summary) return null
 
+      const refSuffix = stashRefs.length > 0 ? ` ${formatStashRefs(stashRefs)}` : ''
       logger.debug(`toolUseId=<${block.toolUseId}>, tokens=<${tokens}> | summarized tool result`)
       return new ToolResultBlock({
         toolUseId: block.toolUseId,
         status: block.status,
-        content: [new TextBlock(`${SUMMARIZED_PREFIX} ~${tokens.toLocaleString()} tokens]\n\n${summary}`)],
+        content: [
+          new TextBlock(`${SUMMARIZED_PREFIX} ~${tokens.toLocaleString()} tokens |${refSuffix}]\n\n${summary}`),
+        ],
       })
     }
 

--- a/strands-ts/src/context-manager/strategies/offload/summarize.ts
+++ b/strands-ts/src/context-manager/strategies/offload/summarize.ts
@@ -113,13 +113,12 @@ export class SummarizeStrategy extends BaseOffloadStrategy {
       const summary = await summarizeContent(toolResultToContentBlocks(block.content), model, this._config)
       if (!summary) return null
 
-      const refSuffix = stashRefs.length > 0 ? ` ${formatStashRefs(stashRefs)}` : ''
       logger.debug(`toolUseId=<${block.toolUseId}>, tokens=<${tokens}> | summarized tool result`)
       return new ToolResultBlock({
         toolUseId: block.toolUseId,
         status: block.status,
         content: [
-          new TextBlock(`${SUMMARIZED_PREFIX} ~${tokens.toLocaleString()} tokens |${refSuffix}]\n\n${summary}`),
+          new TextBlock(`${SUMMARIZED_PREFIX} ~${tokens.toLocaleString()} tokens |${formatStashRefs(stashRefs)}]\n\n${summary}`),
         ],
       })
     }
@@ -132,9 +131,8 @@ export class SummarizeStrategy extends BaseOffloadStrategy {
       return new TextBlock(`${SUMMARIZED_PREFIX} ~${tokens.toLocaleString()} tokens]\n\n${summary}`)
     }
 
-    const refSuffix = stashRefs.length > 0 ? ` ${formatStashRefs(stashRefs)}` : ''
     logger.debug(`trackingId=<${message.trackingId}>, tokens=<${tokens}> | offloaded media block`)
-    return new TextBlock(`[Offloaded: ~${tokens} tokens${refSuffix}]`)
+    return new TextBlock(`[Offloaded: ~${tokens} tokens${formatStashRefs(stashRefs)}]`)
   }
 
   private _resolveModel(agent: LocalAgent): Model | undefined {

--- a/strands-ts/src/context-manager/strategies/offload/summarize.ts
+++ b/strands-ts/src/context-manager/strategies/offload/summarize.ts
@@ -17,15 +17,15 @@ import {
   toolResultToContentBlocks,
   type SummarizeConfig,
 } from '../../methods/summarize.js'
+import { formatStashRefs } from '../../stash.js'
+import type { StashRef } from '../../stash.js'
 import {
   BaseOffloadStrategy,
   collectRemovableWithPair,
-  formatStashRefs,
   spliceWithPairs,
   repairAlternation,
   type OffloadConditions,
   type OffloadTarget,
-  type StashRef,
 } from './base.js'
 
 export class SummarizeStrategy extends BaseOffloadStrategy {

--- a/strands-ts/src/context-manager/strategies/offload/truncate.ts
+++ b/strands-ts/src/context-manager/strategies/offload/truncate.ts
@@ -84,7 +84,7 @@ export class TruncateStrategy extends BaseOffloadStrategy {
   }
 
   protected async _replaceBlock(
-    block: TextBlock | ToolResultBlock,
+    block: ContentBlock,
     tokens: number,
     message: Message,
     _agent: LocalAgent,
@@ -98,8 +98,13 @@ export class TruncateStrategy extends BaseOffloadStrategy {
       }
       return truncated
     }
-    logger.debug(`trackingId=<${message.trackingId}>, tokens=<${tokens}> | truncated text block`)
-    return truncateTextBlock(block, this._truncateConfig)
+    if (block instanceof TextBlock) {
+      logger.debug(`trackingId=<${message.trackingId}>, tokens=<${tokens}> | truncated text block`)
+      return truncateTextBlock(block, this._truncateConfig)
+    }
+    const refSuffix = stashRefs.length > 0 ? ` ${formatStashRefs(stashRefs)}` : ''
+    logger.debug(`trackingId=<${message.trackingId}>, tokens=<${tokens}> | offloaded media block`)
+    return new TextBlock(`[Offloaded: ~${tokens} tokens${refSuffix}]`)
   }
 }
 

--- a/strands-ts/src/context-manager/strategies/offload/truncate.ts
+++ b/strands-ts/src/context-manager/strategies/offload/truncate.ts
@@ -93,7 +93,7 @@ export class TruncateStrategy extends BaseOffloadStrategy {
     if (block instanceof ToolResultBlock) {
       logger.debug(`toolUseId=<${block.toolUseId}>, tokens=<${tokens}> | truncated tool result`)
       const truncated = truncateToolResultBlock(block, this._truncateConfig)
-      if (stashRefs.length > 0 && truncated !== block) {
+      if (truncated !== block) {
         return appendStashRefs(truncated, stashRefs)
       }
       return truncated
@@ -102,18 +102,20 @@ export class TruncateStrategy extends BaseOffloadStrategy {
       logger.debug(`trackingId=<${message.trackingId}>, tokens=<${tokens}> | truncated text block`)
       return truncateTextBlock(block, this._truncateConfig)
     }
-    const refSuffix = stashRefs.length > 0 ? ` ${formatStashRefs(stashRefs)}` : ''
     logger.debug(`trackingId=<${message.trackingId}>, tokens=<${tokens}> | offloaded media block`)
-    return new TextBlock(`[Offloaded: ~${tokens} tokens${refSuffix}]`)
+    return new TextBlock(`[Offloaded: ~${tokens} tokens${formatStashRefs(stashRefs)}]`)
   }
 }
 
 function appendStashRefs(block: ToolResultBlock, stashRefs: StashRef[]): ToolResultBlock {
+  const refs = formatStashRefs(stashRefs)
+  if (!refs) return block
+
   const content = [...block.content]
   for (let index = 0; index < content.length; index++) {
     const item = content[index]!
     if (item instanceof TextBlock) {
-      content[index] = new TextBlock(`${item.text}\n\n[Stashed: ${formatStashRefs(stashRefs)}]`)
+      content[index] = new TextBlock(`${item.text}\n\n[Stashed:${refs}]`)
       return new ToolResultBlock({
         toolUseId: block.toolUseId,
         status: block.status,

--- a/strands-ts/src/context-manager/strategies/offload/truncate.ts
+++ b/strands-ts/src/context-manager/strategies/offload/truncate.ts
@@ -11,7 +11,6 @@ import type { LocalAgent } from '../../../types/agent.js'
 import type { ContextStrategy, ContextState } from '../../types.js'
 import { truncateToolResultBlock, truncateTextBlock, type TruncateConfig } from '../../methods/truncate.js'
 import { formatStashRefs } from '../../stash.js'
-import type { StashRef } from '../../stash.js'
 import {
   BaseOffloadStrategy,
   spliceWithPairs,
@@ -88,7 +87,7 @@ export class TruncateStrategy extends BaseOffloadStrategy {
     tokens: number,
     message: Message,
     _agent: LocalAgent,
-    stashRefs: StashRef[]
+    stashRefs: string[]
   ): Promise<ContentBlock | null> {
     if (block instanceof ToolResultBlock) {
       logger.debug(`toolUseId=<${block.toolUseId}>, tokens=<${tokens}> | truncated tool result`)
@@ -109,7 +108,7 @@ export class TruncateStrategy extends BaseOffloadStrategy {
   }
 }
 
-function appendStashRefs(block: ToolResultBlock, stashRefs: StashRef[]): ToolResultBlock {
+function appendStashRefs(block: ToolResultBlock, stashRefs: string[]): ToolResultBlock {
   const refs = formatStashRefs(stashRefs)
   if (!refs) return block
 

--- a/strands-ts/src/context-manager/strategies/offload/truncate.ts
+++ b/strands-ts/src/context-manager/strategies/offload/truncate.ts
@@ -100,7 +100,9 @@ export class TruncateStrategy extends BaseOffloadStrategy {
     }
     if (block instanceof TextBlock) {
       logger.debug(`trackingId=<${message.trackingId}>, tokens=<${tokens}> | truncated text block`)
-      return truncateTextBlock(block, this._truncateConfig)
+      const truncated = truncateTextBlock(block, this._truncateConfig)
+      const refs = formatStashRefs(stashRefs)
+      return refs ? new TextBlock(`${truncated.text}\n\n[Stashed:${refs}]`) : truncated
     }
     logger.debug(`trackingId=<${message.trackingId}>, tokens=<${tokens}> | offloaded media block`)
     return new TextBlock(`[Offloaded: ~${tokens} tokens${formatStashRefs(stashRefs)}]`)

--- a/strands-ts/src/context-manager/strategies/offload/truncate.ts
+++ b/strands-ts/src/context-manager/strategies/offload/truncate.ts
@@ -10,14 +10,14 @@ import type { ContentBlock } from '../../../types/messages.js'
 import type { LocalAgent } from '../../../types/agent.js'
 import type { ContextStrategy, ContextState } from '../../types.js'
 import { truncateToolResultBlock, truncateTextBlock, type TruncateConfig } from '../../methods/truncate.js'
+import { formatStashRefs } from '../../stash.js'
+import type { StashRef } from '../../stash.js'
 import {
   BaseOffloadStrategy,
-  formatStashRefs,
   spliceWithPairs,
   repairAlternation,
   type OffloadConditions,
   type OffloadTarget,
-  type StashRef,
 } from './base.js'
 
 export class TruncateStrategy extends BaseOffloadStrategy {

--- a/strands-ts/src/context-manager/strategies/offload/truncate.ts
+++ b/strands-ts/src/context-manager/strategies/offload/truncate.ts
@@ -12,10 +12,12 @@ import type { ContextStrategy, ContextState } from '../../types.js'
 import { truncateToolResultBlock, truncateTextBlock, type TruncateConfig } from '../../methods/truncate.js'
 import {
   BaseOffloadStrategy,
+  formatStashRefs,
   spliceWithPairs,
   repairAlternation,
   type OffloadConditions,
   type OffloadTarget,
+  type StashRef,
 } from './base.js'
 
 export class TruncateStrategy extends BaseOffloadStrategy {
@@ -85,13 +87,34 @@ export class TruncateStrategy extends BaseOffloadStrategy {
     block: TextBlock | ToolResultBlock,
     tokens: number,
     message: Message,
-    _agent: LocalAgent
+    _agent: LocalAgent,
+    stashRefs: StashRef[]
   ): Promise<ContentBlock | null> {
     if (block instanceof ToolResultBlock) {
       logger.debug(`toolUseId=<${block.toolUseId}>, tokens=<${tokens}> | truncated tool result`)
-      return truncateToolResultBlock(block, this._truncateConfig)
+      const truncated = truncateToolResultBlock(block, this._truncateConfig)
+      if (stashRefs.length > 0 && truncated !== block) {
+        return appendStashRefs(truncated, stashRefs)
+      }
+      return truncated
     }
     logger.debug(`trackingId=<${message.trackingId}>, tokens=<${tokens}> | truncated text block`)
     return truncateTextBlock(block, this._truncateConfig)
   }
+}
+
+function appendStashRefs(block: ToolResultBlock, stashRefs: StashRef[]): ToolResultBlock {
+  const content = [...block.content]
+  for (let index = 0; index < content.length; index++) {
+    const item = content[index]!
+    if (item instanceof TextBlock) {
+      content[index] = new TextBlock(`${item.text}\n\n[Stashed: ${formatStashRefs(stashRefs)}]`)
+      return new ToolResultBlock({
+        toolUseId: block.toolUseId,
+        status: block.status,
+        content,
+      })
+    }
+  }
+  return block
 }

--- a/strands-ts/src/context-manager/types.ts
+++ b/strands-ts/src/context-manager/types.ts
@@ -79,9 +79,9 @@ export interface ContextManagerConfig {
    * L1 stash configuration. The stash persists offloaded content so the agent can
    * retrieve it on demand via the `retrieve_context` tool.
    *
-   * - Omit or `{}` → stash enabled with InMemoryStorage (default)
+   * - Omit or `true` → stash enabled with InMemoryStorage (default)
    * - `{ storage }` → stash enabled with the given backend
    * - `false` → stash disabled (no persistence, no retrieval tool)
    */
-  stash?: StashConfig | false
+  stash?: StashConfig | boolean
 }

--- a/strands-ts/src/context-manager/types.ts
+++ b/strands-ts/src/context-manager/types.ts
@@ -2,6 +2,8 @@
  * Configuration types for the ContextManager.
  */
 
+import type { Storage } from '../storage/storage.js'
+import type { Stash } from './stash.js'
 import type { LocalAgent } from '../types/agent.js'
 import type { Message } from '../types/messages.js'
 
@@ -20,7 +22,7 @@ export interface ContextStrategy {
    * Called once when the ContextManager is attached to an agent.
    * Strategies can use this to register hooks (e.g., eager offloading on message arrival).
    */
-  init?(agent: LocalAgent): void
+  init?(agent: LocalAgent, stash?: Stash): void
 
   /**
    * Attempt to reduce context. Returns true if it made changes, false if it
@@ -41,6 +43,20 @@ export interface ContextState {
 
   /** Current context utilization ratio (0-1+). Above 1.0 means overflow. */
   utilization: number
+
+  /** L1 stash for persisting offloaded content. Present when storage is configured. */
+  stash?: Stash
+}
+
+/**
+ * Full configuration for a ContextManager instance.
+ */
+/**
+ * Configuration for the L1 stash (offloaded content persistence).
+ */
+export interface StashConfig {
+  /** Storage backend. Defaults to InMemoryStorage when omitted. */
+  storage?: Storage
 }
 
 /**
@@ -54,4 +70,14 @@ export interface ContextManagerConfig {
    * threshold wins. When omitted, uses the default pipeline.
    */
   strategies?: ContextStrategy[]
+
+  /**
+   * L1 stash configuration. The stash persists offloaded content so the agent can
+   * retrieve it on demand via the `retrieve_context` tool.
+   *
+   * - Omit or `{}` → stash enabled with InMemoryStorage (default)
+   * - `{ storage }` → stash enabled with the given backend
+   * - `false` → stash disabled (no persistence, no retrieval tool)
+   */
+  stash?: StashConfig | false
 }

--- a/strands-ts/src/context-manager/types.ts
+++ b/strands-ts/src/context-manager/types.ts
@@ -54,6 +54,13 @@ export interface ContextState {
 export interface StashConfig {
   /** Storage backend. Defaults to InMemoryStorage when omitted. */
   storage?: Storage
+
+  /**
+   * Whether to register the `retrieve_context` tool for the agent.
+   * Set to `false` to keep stash persistence without exposing the retrieval tool.
+   * Defaults to `true`.
+   */
+  retrievalTool?: false
 }
 
 /**

--- a/strands-ts/src/context-manager/types.ts
+++ b/strands-ts/src/context-manager/types.ts
@@ -49,9 +49,6 @@ export interface ContextState {
 }
 
 /**
- * Full configuration for a ContextManager instance.
- */
-/**
  * Configuration for the L1 stash (offloaded content persistence).
  */
 export interface StashConfig {


### PR DESCRIPTION
## Summary

Adds an L1 stash to the ContextManager that durably stores content before offload strategies replace it in the context window. The agent can retrieve stashed content on demand via an auto-registered `retrieve_context` tool.

## API / Developer Experience

### Default behavior (zero config)

The stash is **enabled by default** with in-memory storage. No configuration needed:

```typescript
const agent = new Agent({
  contextManager: new ContextManager()
})
```

When content is offloaded, the agent sees placeholders like:

```
[Stashed: ref: toolu_abc123_0]
[Dropped] ref: toolu_abc123_0
[Summarized: ~4,200 tokens | ref: toolu_abc123_0]
```

The agent can call `retrieve_context` with the ref to get the original content back.

### Custom storage backend

```typescript
const agent = new Agent({
  contextManager: new ContextManager({
    stash: { storage: new LocalFileStorage('./stash') }
  })
})
```

### Disable the retrieval tool (keep stash persistence)

```typescript
const agent = new Agent({
  contextManager: new ContextManager({
    stash: { retrievalTool: false }
  })
})
```

### Disable stash entirely

```typescript
const agent = new Agent({
  contextManager: new ContextManager({
    stash: false  // no persistence, no retrieval tool
  })
})
```

### Retrieval tool capabilities

The `retrieve_context` tool supports:

```jsonc
// Full content retrieval
{ "reference": "toolu_abc123_0" }

// Pattern search (grep with context lines)
{ "reference": "toolu_abc123_0", "pattern": "error", "context_lines": 5 }

// Line range extraction
{ "reference": "toolu_abc123_0", "line_range": { "start": 10, "end": 25 } }
```

## Design

### Storage key paths (aligned with design doc §3)

Storage namespace mirrors the session snapshot layout for lifecycle cleanup, per-agent isolation, and cross-agent discoverability:

```
context/<sessionId>/scopes/agent/<agentId>/<key>
```

Where `<key>` is `<toolUseId>_<blockIndex>` for tool results or `<trackingId>_<blockIndex>` for other blocks.

This gives us:
- **Lifecycle cleanup**: deleting a session cleans up all associated stash content
- **Per-agent isolation**: two agents sharing storage + session don't pollute each other
- **Cross-agent discoverability**: an orchestrator can `list("context/<sessionId>/scopes/agent/<peerId>/")` to browse a peer agent's stored content

Keys are deterministic so they can be recomputed after a process restart or snapshot restore.

### Eager stashing via `MessageAddedEvent`

Content is persisted the moment a message arrives (before any strategy runs). The stash hook is registered **before** strategy init to ensure content is stored before any eager offload strategy fires.

When a strategy offloads a block, it calls `stash.refsFor(block, message, blockIndex)` to compute the deterministic reference keys for placeholders — no per-block caching needed since the key format is stable.

### Retrieval loop prevention

The `MessageAddedEvent` hook tracks `toolUseId`s from `retrieve_context` calls and skips stashing their results at the **per-block** level (not per-message). This prevents the "retrieve → re-offload → retrieve" infinite loop without skipping sibling tool results in batched messages.

### All-block offloading

All non-structural content blocks can be offloaded: text, tool results, images, video, documents, and audio. Excluded blocks: `ToolUseBlock` (would orphan the pair), `CachePointBlock` (structural), `ReasoningBlock` (must stay verbatim).

Media blocks get a text placeholder on offload: `[Offloaded: ~N tokens ref: <key>]`

### `toJSON()` serialization

All blocks are stored via `encode(block.toJSON())` — the standard serialization format. No manual byte encoding or special-casing per content type. Retrieval returns the deserialized JSON data directly.

### Storage failures

Failures during eager stashing are logged at debug level and don't interrupt the agent — the content simply won't be retrievable if the strategy later offloads it.

## Key files

| File | Role |
|------|------|
| `stash.ts` | Stash class — deterministic keys, session/agent namespace, eager persistence, `refsFor()`, `formatStashRefs()` |
| `retrieval-tool.ts` | `retrieve_context` tool factory, `trackRetrievalToolUseIds()` |
| `types.ts` | `StashConfig` (with `retrievalTool` option), `ContextManagerConfig.stash` |
| `context-manager.ts` | Hook registration (stash before strategies), stash init with `agent.sessionId` + `agent.id` |
| `strategies/offload/base.ts` | `_blockMatchesTarget` (all-block support), ref computation in `_transformBlocks` |

## Test plan

- [x] Unit tests for `Stash` (store, retrieve, deterministic keys, list, delete, namespacing)
- [x] Unit tests for `retrieve_context` tool (full retrieval, pattern search, line ranges)
- [x] Integration tests for stash + offload strategies (truncate, drop, summarize)
- [x] Retrieval loop prevention (per-block skip via `skipToolUseIds`)
- [x] All-block stashing (tool results, text, media blocks)
- [x] Eager stashing via `storeMessage` with `toJSON()` serialization
- [x] `npm test` passes (85 context-manager tests)