### PR TITLE
feat(memory-py): add FileMemoryStore

### DIFF
--- a/strands-py/src/strands/storage/in_memory_storage.py
+++ b/strands-py/src/strands/storage/in_memory_storage.py
@@ -4,8 +4,13 @@ from __future__ import annotations
 
 import builtins
 import threading
+from typing import TYPE_CHECKING
 
+from .search.keyword import KeywordSearchStrategy
 from .storage import _NamespacedStorage, _normalize_key, _normalize_prefix
+
+if TYPE_CHECKING:
+    from .storage import StorageSearchResult
 
 
 class InMemoryStorage:
@@ -89,6 +94,17 @@ class InMemoryStorage:
         with self._lock:
             keys = sorted(k for k in self._store if k.startswith(prefix))
         return keys
+
+    async def search(self, query: str) -> builtins.list[StorageSearchResult]:
+        """Search stored content by keyword token-overlap scoring.
+
+        Args:
+            query: Natural-language search query.
+
+        Returns:
+            All matches with relevance scores, ranked best-first.
+        """
+        return await KeywordSearchStrategy().search(self, query)
 
     def namespace(self, prefix: str) -> _NamespacedStorage:
         """Return a view of this storage with all keys prefixed.

--- a/strands-py/src/strands/storage/local_file_storage.py
+++ b/strands-py/src/strands/storage/local_file_storage.py
@@ -9,10 +9,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ..types.exceptions import StorageError
-from .storage import _NamespacedStorage, _normalize_key, _normalize_prefix
+from .search.keyword import KeywordSearchStrategy
+from .storage import _NAMESPACED, _normalize_key, _normalize_prefix
 
 if TYPE_CHECKING:
     from ..sandbox.base import Sandbox
+    from .storage import StorageSearchResult
 
 _TMP_MARKER = ".__strands_tmp"
 
@@ -39,8 +41,13 @@ class LocalFileStorage:
             base_dir: Root directory under which all keys are stored.
             sandbox: Optional sandbox to route I/O through.
         """
-        self._base_dir = base_dir
+        self._base_dir = os.path.normpath(base_dir)
         self._sandbox = sandbox
+
+    @property
+    def base_dir(self) -> str:
+        """The root directory under which all keys are stored."""
+        return self._base_dir
 
     def for_sandbox(self, sandbox: Sandbox) -> LocalFileStorage:
         """Return a copy bound to the given sandbox.
@@ -55,7 +62,10 @@ class LocalFileStorage:
         """
         if self._sandbox is sandbox:
             return self
-        return LocalFileStorage(self._base_dir, sandbox=sandbox)
+        bound = LocalFileStorage(self._base_dir, sandbox=sandbox)
+        if getattr(self, "_namespaced", None) is _NAMESPACED:
+            bound._namespaced = _NAMESPACED  # type: ignore[attr-defined]
+        return bound
 
     async def write(self, key: str, data: bytes) -> None:
         """Store data as a file, creating parent directories as needed.
@@ -178,20 +188,36 @@ class LocalFileStorage:
         except Exception as error:
             raise StorageError(f"Failed to list keys with prefix '{query}'") from error
 
-    def namespace(self, prefix: str) -> _NamespacedStorage:
-        """Return a view of this storage with all keys prefixed.
+    async def search(self, query: str) -> builtins.list[StorageSearchResult]:
+        """Search stored content by keyword token-overlap scoring.
 
-        The returned view preserves ``for_sandbox`` via delegation to the
-        underlying storage, so sandbox routing works even when storage is
-        pre-namespaced before being passed to a plugin.
+        Args:
+            query: Natural-language search query.
+
+        Returns:
+            All matches with relevance scores, ranked best-first.
+        """
+        return await KeywordSearchStrategy().search(self, query)
+
+    def namespace(self, prefix: str) -> LocalFileStorage:
+        """Return a new LocalFileStorage scoped to a subdirectory.
+
+        Unlike a generic ``_NamespacedStorage`` wrapper, this returns a real
+        ``LocalFileStorage`` whose ``base_dir`` incorporates the prefix. This
+        preserves access to ``base_dir`` for strategies that need the filesystem
+        path (e.g. index-based search), and ``for_sandbox`` continues to work.
 
         Args:
             prefix: Prefix to prepend to all keys.
 
         Returns:
-            A namespaced storage view.
+            A new LocalFileStorage rooted at the sub-path.
         """
-        return _NamespacedStorage(self, prefix)
+        normalized = _normalize_prefix(prefix).rstrip("/")
+        sub_dir = os.path.join(self._base_dir, *normalized.split("/")) if normalized else self._base_dir
+        scoped = LocalFileStorage(sub_dir, sandbox=self._sandbox)
+        scoped._namespaced = _NAMESPACED  # type: ignore[attr-defined]
+        return scoped
 
     def _path_for(self, key: str) -> str:
         """Map a normalized key to a filesystem path."""

--- a/strands-py/src/strands/storage/s3_storage.py
+++ b/strands-py/src/strands/storage/s3_storage.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import builtins
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from ..types.exceptions import StorageError
 from .storage import _NamespacedStorage, _normalize_key, _normalize_prefix
+
+if TYPE_CHECKING:
+    from .storage import StorageSearchResult
 
 _S3_PAGE_SIZE = 1000
 
@@ -173,6 +176,19 @@ class S3Storage:
             continuation_token = response.get("NextContinuationToken")
 
         return sorted(keys)
+
+    async def search(self, query: str) -> builtins.list[StorageSearchResult]:
+        """Search stored content by keyword token-overlap scoring.
+
+        Args:
+            query: Natural-language search query.
+
+        Returns:
+            All matches with relevance scores, ranked best-first.
+        """
+        from .search.keyword import KeywordSearchStrategy
+
+        return await KeywordSearchStrategy().search(self, query)
 
     def namespace(self, prefix: str) -> _NamespacedStorage:
         """Return a view of this storage with all keys prefixed.

--- a/strands-py/src/strands/storage/search/__init__.py
+++ b/strands-py/src/strands/storage/search/__init__.py
@@ -1,0 +1,16 @@
+"""Pluggable search strategies for storage backends.
+
+Each strategy encapsulates a single approach to searching stored content.
+Storage backends use :class:`KeywordSearchStrategy` by default; consumers
+(memory stores, context offloaders) can override with a different strategy.
+"""
+
+from ..storage import StorageSearchResult
+from .keyword import KeywordSearchStrategy
+from .types import SearchStrategy
+
+__all__ = [
+    "KeywordSearchStrategy",
+    "SearchStrategy",
+    "StorageSearchResult",
+]

--- a/strands-py/src/strands/storage/search/keyword.py
+++ b/strands-py/src/strands/storage/search/keyword.py
@@ -1,0 +1,90 @@
+"""Keyword search strategy using token-overlap scoring."""
+
+from __future__ import annotations
+
+import asyncio
+import builtins
+import re
+from typing import Any
+
+from ..storage import Storage, StorageSearchResult
+
+
+def tokenize(text: str) -> set[str]:
+    r"""Lowercase and split text into a set of word tokens, dropping empties.
+
+    Splits on any run of non-word characters (Unicode-aware). Ensures cross-SDK
+    compatibility with the TypeScript ``/[^\p{L}\p{N}_]+/u`` regex.
+
+    Args:
+        text: The text to tokenize.
+
+    Returns:
+        A set of lowercased word tokens.
+    """
+    return {token for token in re.split(r"\W+", text.lower()) if token}
+
+
+def token_overlap_score(query_tokens: set[str], content: str) -> int:
+    """Lexical relevance score: distinct query tokens present in the content.
+
+    A higher count means more of the query's words are present.
+    Returns 0 when there is no overlap.
+
+    Args:
+        query_tokens: Pre-tokenized query terms.
+        content: The content string to score against.
+
+    Returns:
+        Number of distinct query tokens found in the content.
+    """
+    return len(query_tokens & tokenize(content))
+
+
+class KeywordSearchStrategy:
+    """Keyword search strategy using token-overlap scoring.
+
+    Tokenizes the query and each stored entry (key + content), then scores by the
+    number of distinct query tokens that appear. Works on any storage backend with
+    ``list()`` and ``read()`` -- no index or embedding model required.
+
+    This is the default search strategy for all shipped storage backends.
+
+    Example:
+        ```python
+        from strands.storage.search import KeywordSearchStrategy
+
+        strategy = KeywordSearchStrategy()
+        results = await strategy.search(storage, "dark mode toggle")
+        ```
+    """
+
+    async def search(self, storage: Storage, query: str, **kwargs: Any) -> builtins.list[StorageSearchResult]:
+        """Search content in storage by keyword token-overlap scoring.
+
+        Args:
+            storage: The storage to search over.
+            query: A natural-language string query.
+            **kwargs: Unused; accepted for protocol compatibility.
+
+        Returns:
+            Matched keys with relevance scores, ranked best-first.
+        """
+        query_tokens = tokenize(query)
+        if not query_tokens:
+            return []
+
+        all_keys = await storage.list("")
+        all_data = await asyncio.gather(*(storage.read(key) for key in all_keys))
+
+        scored: builtins.list[StorageSearchResult] = []
+        for key, data in zip(all_keys, all_data, strict=True):
+            if data is None:
+                continue
+            content = data.decode("utf-8", errors="replace")
+            score = token_overlap_score(query_tokens, f"{key} {content}")
+            if score > 0:
+                scored.append(StorageSearchResult(key=key, score=score, data=data))
+
+        scored.sort(key=lambda result: result.score, reverse=True)
+        return scored

--- a/strands-py/src/strands/storage/search/types.py
+++ b/strands-py/src/strands/storage/search/types.py
@@ -1,0 +1,30 @@
+"""Pluggable search strategy protocol for storage backends."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from ..storage import Storage, StorageSearchResult
+
+
+class SearchStrategy(Protocol):
+    """A pluggable search strategy for storage backends.
+
+    Strategies encapsulate a single approach to searching stored content --
+    keyword/lexical scan, vector similarity, full-text index, etc. Storage
+    backends delegate their ``search()`` to a strategy, and consumers (memory
+    stores, context offloaders) can override the default.
+    """
+
+    async def search(self, storage: Storage, query: str, **kwargs: Any) -> list[StorageSearchResult]:
+        """Search content in storage matching query.
+
+        Args:
+            storage: The storage to search over.
+            query: A natural-language string query.
+            **kwargs: Strategy-specific options for forward compatibility.
+
+        Returns:
+            Matched keys with relevance scores, ranked best-first.
+        """
+        ...

--- a/strands-py/src/strands/storage/storage.py
+++ b/strands-py/src/strands/storage/storage.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import builtins
 import re
+from dataclasses import dataclass, field
 from typing import Protocol, runtime_checkable
 
 from typing_extensions import TypeVar
@@ -11,6 +12,7 @@ from typing_extensions import TypeVar
 from ..types.exceptions import StorageError
 
 ListQuery = TypeVar("ListQuery", default=str, contravariant=True)
+SearchQuery = TypeVar("SearchQuery", default=str, contravariant=True)
 
 _NAMESPACED: object = object()
 """Internal sentinel marking a storage view as already namespace-scoped.
@@ -18,6 +20,23 @@ _NAMESPACED: object = object()
 SDK constructs use this to detect whether the caller already scoped the storage,
 so the default auto-prefix can be skipped.
 """
+
+
+@dataclass
+class StorageSearchResult:
+    """A single result from a storage search call.
+
+    Attributes:
+        key: Storage key of the matched item.
+        score: Relevance score; higher values indicate greater relevance.
+            Backends using distance-based scoring (e.g. vector distance) must
+            invert to similarity before returning results.
+        data: Stored bytes, present only when the backend includes them.
+    """
+
+    key: str
+    score: float
+    data: bytes | None = field(default=None, repr=False)
 
 
 def _normalize_key(key: str) -> str:
@@ -71,7 +90,7 @@ def _normalize_prefix(prefix: str) -> str:
 
 
 @runtime_checkable
-class Storage(Protocol[ListQuery]):
+class Storage(Protocol[ListQuery, SearchQuery]):
     """A backend for storing and retrieving raw bytes under string keys.
 
     The interface is deliberately minimal — four operations over opaque bytes
@@ -143,6 +162,27 @@ class Storage(Protocol[ListQuery]):
         """
         ...
 
+    async def search(self, query: SearchQuery) -> builtins.list[StorageSearchResult]:
+        """Search stored content by query.
+
+        The default implementation uses :class:`~strands.storage.search.KeywordSearchStrategy`
+        (token-overlap scoring over all keys). Backends may override with a richer
+        strategy (vector similarity, full-text index, etc.).
+
+        The ``SearchQuery`` type parameter controls what this method accepts. It defaults
+        to ``str`` (a natural-language query). Implementations may widen it to accept
+        richer query objects (e.g. a pre-computed embedding vector with metadata filters).
+
+        Args:
+            query: A string query or backend-specific query object.
+
+        Returns:
+            Matched keys with relevance scores, ranked best-first.
+        """
+        from .search.keyword import KeywordSearchStrategy
+
+        return await KeywordSearchStrategy().search(self, query)
+
 
 class _NamespacedStorage:
     """A storage view that prepends a prefix to all keys.
@@ -177,6 +217,21 @@ class _NamespacedStorage:
         keys = await self._storage.list(f"{self._prefix}{query}")
         return [key[len(self._prefix) :] for key in keys]
 
+    async def search(self, query: str) -> builtins.list[StorageSearchResult]:
+        """Search within this namespace, filtering results to the prefix."""
+        results: builtins.list[StorageSearchResult] = await self._storage.search(query)
+        scoped: builtins.list[StorageSearchResult] = []
+        for result in results:
+            if result.key.startswith(self._prefix):
+                scoped.append(
+                    StorageSearchResult(
+                        key=result.key[len(self._prefix) :],
+                        score=result.score,
+                        data=result.data,
+                    )
+                )
+        return scoped
+
     def namespace(self, prefix: str) -> _NamespacedStorage:
         """Return a further-scoped view by nesting prefixes."""
         return _NamespacedStorage(self._storage, f"{self._prefix}{prefix}")
@@ -188,3 +243,25 @@ class _NamespacedStorage:
             return self
         bound = inner.for_sandbox(sandbox)
         return _NamespacedStorage(bound, self._prefix.rstrip("/"))
+
+
+def _resolve_namespace(storage: Storage, prefix: str) -> Storage:
+    """Return a namespaced view unless the storage is already namespaced.
+
+    If already marked with the internal ``_NAMESPACED`` sentinel, return as-is;
+    otherwise delegate to the storage's own ``namespace()`` method or wrap with
+    ``_NamespacedStorage``.
+
+    Args:
+        storage: The storage to scope.
+        prefix: Prefix to apply.
+
+    Returns:
+        A namespaced Storage view (or the original if already namespaced).
+    """
+    if getattr(storage, "_namespaced", None) is _NAMESPACED:
+        return storage
+    if hasattr(storage, "namespace"):
+        result: Storage = storage.namespace(prefix)
+        return result
+    return _NamespacedStorage(storage, prefix)

--- a/strands-py/src/strands/storage/storage.py
+++ b/strands-py/src/strands/storage/storage.py
@@ -181,7 +181,7 @@ class Storage(Protocol[ListQuery, SearchQuery]):
         """
         from .search.keyword import KeywordSearchStrategy
 
-        return await KeywordSearchStrategy().search(self, query)
+        return await KeywordSearchStrategy().search(self, query)  # type: ignore[arg-type]
 
 
 class _NamespacedStorage:

--- a/strands-py/src/strands/vended_memory_stores/__init__.py
+++ b/strands-py/src/strands/vended_memory_stores/__init__.py
@@ -7,23 +7,20 @@ imported from here or from its subpackage, e.g.
 
 from typing import Any
 
+from .file_memory_store import FileMemoryStore
+from .test_memory_store import TestMemoryStore
+
 __all__ = [
     "BedrockKnowledgeBaseStore",
+    "FileMemoryStore",
     "TestMemoryStore",
 ]
 
 
 def __getattr__(name: str) -> Any:
-    """Lazy load store implementations only when accessed.
-
-    This defers the import of optional dependencies until actually needed.
-    """
+    """Lazy load store implementations that pull optional dependencies."""
     if name == "BedrockKnowledgeBaseStore":
         from .bedrock_knowledge_base import BedrockKnowledgeBaseStore
 
         return BedrockKnowledgeBaseStore
-    if name == "TestMemoryStore":
-        from .test_memory_store import TestMemoryStore
-
-        return TestMemoryStore
     raise AttributeError(f"cannot import name '{name}' from '{__name__}' ({__file__})")

--- a/strands-py/src/strands/vended_memory_stores/file_memory_store/__init__.py
+++ b/strands-py/src/strands/vended_memory_stores/file_memory_store/__init__.py
@@ -1,0 +1,17 @@
+"""A file-based MemoryStore that stores knowledge as plain markdown files.
+
+Example:
+    ```python
+    from strands.vended_memory_stores.file_memory_store import FileMemoryStore
+
+    store = FileMemoryStore(name="agent-memory")
+    ```
+"""
+
+from .store import FileMemoryStore
+from .types import FileMemoryStoreConfig
+
+__all__ = [
+    "FileMemoryStore",
+    "FileMemoryStoreConfig",
+]

--- a/strands-py/src/strands/vended_memory_stores/file_memory_store/store.py
+++ b/strands-py/src/strands/vended_memory_stores/file_memory_store/store.py
@@ -1,0 +1,202 @@
+"""File-based memory store backed by the unified Storage interface.
+
+Stores knowledge as markdown files under a ``memory/`` storage namespace. Provides
+keyword-based search via ``search_memory`` (registered by MemoryManager).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import time
+from typing import TYPE_CHECKING
+
+from typing_extensions import Unpack
+
+from ...memory.extraction.model_extractor import ModelExtractor
+from ...memory.extraction.types import ExtractionConfig, ExtractionResult, Extractor, ExtractorContext
+from ...memory.types import MemoryEntry, MemoryStore, Metadata, SearchOptions
+from ...storage.local_file_storage import LocalFileStorage
+from ...storage.storage import _normalize_key, _resolve_namespace
+from .types import FileMemoryStoreConfig
+
+if TYPE_CHECKING:
+    from ...storage.storage import Storage
+    from ...types.content import Message
+
+_DEFAULT_EXTRACTION_FRAMING = (
+    "You extract durable facts worth remembering across future conversations from a transcript."
+)
+
+_OUTPUT_CONTRACT = (
+    'Return ONLY a JSON array of objects: {"content": string}.\n\n'
+    "Group related facts into a single entry. The first line is a markdown heading"
+    ' (e.g. "# User preferences", "# Project setup", "# Team conventions").'
+    " Put each fact on its own line below the heading.\n\n"
+    "If there is nothing worth remembering, return []."
+)
+
+_DEFAULT_MAX_SEARCH_RESULTS = 10
+_STORAGE_NAMESPACE = "memory"
+_MAX_SLUG_LENGTH = 50
+
+
+def _basename(key: str) -> str:
+    """Extract the filename stem (without .md extension) from a storage key."""
+    filename = key.rsplit("/", maxsplit=1)[-1]
+    return filename.removesuffix(".md")
+
+
+def _slugify(text: str) -> str:
+    """Convert text to a URL-safe kebab-case slug, truncated to 50 characters."""
+    slug = text.lower()
+    slug = re.sub(r"[^a-z0-9\s-]", "", slug)
+    slug = slug.strip()
+    slug = re.sub(r"\s+", "-", slug)
+    slug = slug[:_MAX_SLUG_LENGTH]
+    return slug.rstrip("-")
+
+
+def _create_key_aware_extractor(storage: Storage) -> Extractor:
+    """Create an extractor that injects existing topic headings so the model reuses them."""
+
+    class _KeyAwareExtractor:
+        async def extract(
+            self, messages: list[Message], context: ExtractorContext | None = None
+        ) -> list[ExtractionResult]:
+            existing_keys = await storage.list("")
+            headings = [_basename(key).replace("-", " ") for key in existing_keys]
+
+            prompt = f"{_DEFAULT_EXTRACTION_FRAMING}\n\n{_OUTPUT_CONTRACT}"
+            if headings:
+                prompt += (
+                    f"\n\nExisting topics: {', '.join(headings)}. "
+                    "Reuse an existing topic heading when new facts belong to it."
+                )
+
+            return await ModelExtractor(system_prompt=prompt).extract(messages, context)
+
+    return _KeyAwareExtractor()
+
+
+class FileMemoryStore(MemoryStore):
+    """A file-based memory store backed by the unified Storage interface.
+
+    Knowledge is stored as plain markdown files under a ``memory/`` storage namespace.
+    Retrieval uses keyword-based token-overlap scoring against filename and body content.
+
+    The storage backend defaults to :class:`~strands.storage.LocalFileStorage`. Keys are
+    auto-scoped under ``memory/<name>/`` (so a store named ``agent-memory`` with the
+    default backend writes to ``./.strands/memory/agent-memory/``).
+
+    Example:
+        ```python
+        from strands import Agent
+        from strands.memory import MemoryManager
+        from strands.vended_memory_stores.file_memory_store import FileMemoryStore
+
+        memory_store = FileMemoryStore(name="agent-memory")
+
+        agent = Agent(
+            model=model,
+            memory_manager=MemoryManager(stores=[memory_store], injection=False),
+        )
+        ```
+    """
+
+    def __init__(self, **config: Unpack[FileMemoryStoreConfig]) -> None:
+        """Initialize the FileMemoryStore.
+
+        Args:
+            **config: Store configuration. See :class:`FileMemoryStoreConfig`.
+        """
+        self.name: str = config["name"]
+        self.writable: bool = config.get("writable", True)
+        self.description: str | None = config.get("description")
+        self.max_search_results: int | None = config.get("max_search_results")
+
+        raw_storage = config.get("storage") or LocalFileStorage()
+        self._storage: Storage = _resolve_namespace(raw_storage, f"{_STORAGE_NAMESPACE}/{self.name}")
+        self.extraction: ExtractionConfig | bool | None = self._resolve_extraction(config)
+        self._write_lock = asyncio.Lock()
+
+    def _resolve_extraction(
+        self, config: FileMemoryStoreConfig
+    ) -> ExtractionConfig | bool | None:
+        extraction: ExtractionConfig | bool | None = config.get("extraction")
+        if extraction is None or extraction is False:
+            return extraction
+        if extraction is True:
+            return ExtractionConfig(extractor=_create_key_aware_extractor(self._storage))
+        if "extractor" not in extraction or extraction.get("extractor") is None:
+            result = ExtractionConfig(extractor=_create_key_aware_extractor(self._storage))
+            if "trigger" in extraction:
+                result["trigger"] = extraction["trigger"]
+            if "filter" in extraction:
+                result["filter"] = extraction["filter"]
+            return result
+        return extraction
+
+    async def search(self, query: str, options: SearchOptions | None = None) -> list[MemoryEntry]:
+        """Search knowledge files by keyword token-overlap scoring.
+
+        Args:
+            query: Natural-language search query.
+            options: Optional search configuration (e.g. max_search_results).
+
+        Returns:
+            Top matches ranked by relevance.
+        """
+        option_max = options.get("max_search_results") if options else None
+        if option_max is not None and option_max < 1:
+            raise ValueError("max_search_results must be >= 1")
+        max_results = (
+            option_max if option_max is not None
+            else self.max_search_results if self.max_search_results is not None
+            else _DEFAULT_MAX_SEARCH_RESULTS
+        )
+
+        results = await self._storage.search(query)
+        entries: list[MemoryEntry] = []
+        for result in results[:max_results]:
+            data = result.data if result.data is not None else await self._storage.read(result.key)
+            if data is not None:
+                entries.append(
+                    MemoryEntry(
+                        content=data.decode("utf-8", errors="replace").strip(),
+                        metadata={"path": result.key, "score": result.score},
+                    )
+                )
+        return entries
+
+    async def add(self, content: str, metadata: Metadata | None = None) -> str:
+        """Add a knowledge entry to the store.
+
+        The filename is derived from the first line of content (slugified, truncated to
+        50 chars). If a file with the same slug already exists, new facts (lines after
+        the heading) are appended rather than overwriting.
+
+        Args:
+            content: The knowledge content to store.
+            metadata: Unused; accepted for interface compatibility.
+
+        Returns:
+            The canonical storage key the entry was written under.
+        """
+        lines = content.split("\n")
+        first_line = re.sub(r"^#+\s*", "", lines[0])
+        slug = _slugify(first_line) or f"entry-{int(time.time() * 1000)}"
+        key = _normalize_key(f"{slug}.md").lower()
+
+        async with self._write_lock:
+            existing = await self._storage.read(key)
+            if existing:
+                existing_content = existing.decode("utf-8", errors="replace")
+                new_facts = "\n".join(lines[1:]).strip()
+                merged = f"{existing_content.rstrip()}\n{new_facts}" if new_facts else existing_content
+            else:
+                merged = content
+
+            await self._storage.write(key, merged.encode("utf-8"))
+
+        return key

--- a/strands-py/src/strands/vended_memory_stores/file_memory_store/types.py
+++ b/strands-py/src/strands/vended_memory_stores/file_memory_store/types.py
@@ -1,0 +1,25 @@
+"""Configuration types for the FileMemoryStore."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ...memory.types import MemoryStoreConfig
+
+if TYPE_CHECKING:
+    from ...storage.storage import Storage
+
+
+class FileMemoryStoreConfig(MemoryStoreConfig, total=False):
+    """Configuration for :class:`~strands.vended_memory_stores.file_memory_store.FileMemoryStore`.
+
+    Attributes:
+        storage: The unified Storage backend for file operations. Defaults to
+            LocalFileStorage at ``./.strands/``. Keys are auto-scoped under
+            ``memory/<name>/`` unless the provided storage is already namespaced, so
+            stores with distinct names safely share one backend. Two stores with the same
+            name on the same backend share storage -- give them different names (or
+            separate storage) to isolate them.
+    """
+
+    storage: Storage

--- a/strands-py/src/strands/vended_memory_stores/test_memory_store/store.py
+++ b/strands-py/src/strands/vended_memory_stores/test_memory_store/store.py
@@ -18,6 +18,7 @@ from typing_extensions import Unpack
 
 from ...memory.types import MemoryEntry, MemoryStore, Metadata, SearchOptions
 from ...storage import InMemoryStorage, LocalFileStorage, Storage
+from ...storage.search.keyword import token_overlap_score, tokenize
 from .types import TestMemoryAddResult, TestMemoryStoreConfig
 
 DEFAULT_MAX_SEARCH_RESULTS = 10
@@ -52,21 +53,6 @@ def _sanitize_name(name: str) -> str:
     return re.sub(r"[^\w\-.]", "_", sanitized, flags=re.ASCII)
 
 
-def _tokenize(text: str) -> set[str]:
-    r"""Lowercase and split text into a set of word tokens, dropping empties.
-
-    Splits on any run of non-word characters. Ensures cross-SDK compatibility.
-    """
-    return {token for token in re.split(r"\W+", text.lower()) if token}
-
-
-def _token_overlap_score(query_tokens: set[str], content: str) -> int:
-    """Lexical relevance score for one record.
-
-    The number of distinct query tokens that appear in the content; a higher count means more of the
-    query's words are present. Returns 0 when there is no overlap.
-    """
-    return len(query_tokens & _tokenize(content))
 
 
 class TestMemoryStore(MemoryStore):
@@ -187,7 +173,7 @@ class TestMemoryStore(MemoryStore):
             raise ValueError("TestMemoryStore: max_search_results must be at least 1.")
         limit = caller_max or self.max_search_results or DEFAULT_MAX_SEARCH_RESULTS
 
-        query_tokens = _tokenize(query)
+        query_tokens = tokenize(query)
         if not query_tokens:
             return []
 
@@ -195,7 +181,7 @@ class TestMemoryStore(MemoryStore):
 
         scored: list[tuple[dict[str, Any], int]] = []
         for record in records:
-            score = _token_overlap_score(query_tokens, record["content"])
+            score = token_overlap_score(query_tokens, record["content"])
             if score > 0:
                 scored.append((record, score))
 

--- a/strands-py/tests/strands/storage/search/test_keyword.py
+++ b/strands-py/tests/strands/storage/search/test_keyword.py
@@ -1,0 +1,127 @@
+"""Tests for the keyword search strategy."""
+
+import pytest
+
+from strands.storage.in_memory_storage import InMemoryStorage
+from strands.storage.search.keyword import KeywordSearchStrategy, token_overlap_score, tokenize
+
+
+class TestTokenize:
+    def test_splits_on_non_word_characters(self):
+        result = tokenize("hello world")
+        assert result == {"hello", "world"}
+
+    def test_lowercases_tokens(self):
+        result = tokenize("Hello WORLD")
+        assert result == {"hello", "world"}
+
+    def test_drops_empty_strings(self):
+        result = tokenize("  hello   world  ")
+        assert result == {"hello", "world"}
+
+    def test_empty_input_returns_empty_set(self):
+        assert tokenize("") == set()
+
+    def test_whitespace_only_returns_empty_set(self):
+        assert tokenize("   ") == set()
+
+    def test_includes_underscores_in_tokens(self):
+        result = tokenize("snake_case variable")
+        assert "snake_case" in result
+
+    def test_handles_unicode(self):
+        result = tokenize("café résumé")
+        assert "café" in result
+        assert "résumé" in result
+
+
+class TestTokenOverlapScore:
+    def test_counts_matching_tokens(self):
+        query_tokens = {"dark", "mode"}
+        score = token_overlap_score(query_tokens, "enable dark mode in settings")
+        assert score == 2
+
+    def test_returns_zero_for_no_overlap(self):
+        query_tokens = {"kubernetes", "deployment"}
+        score = token_overlap_score(query_tokens, "completely unrelated content")
+        assert score == 0
+
+    def test_case_insensitive(self):
+        query_tokens = {"dark", "mode"}
+        score = token_overlap_score(query_tokens, "Dark Mode Toggle")
+        assert score == 2
+
+
+class TestKeywordSearch:
+    @pytest.fixture
+    def storage(self):
+        return InMemoryStorage()
+
+    @pytest.mark.asyncio
+    async def test_returns_matching_entries_scored_by_token_overlap(self, storage):
+        await storage.write("notes/dark-mode.md", b"enable dark mode in settings")
+        await storage.write("notes/deploy.md", b"deploy to production")
+
+        results = await KeywordSearchStrategy().search(storage, "dark mode")
+
+        assert len(results) == 1
+        assert results[0].key == "notes/dark-mode.md"
+        assert results[0].score > 0
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_empty_query(self, storage):
+        await storage.write("key", b"content")
+        results = await KeywordSearchStrategy().search(storage, "")
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_whitespace_query(self, storage):
+        await storage.write("key", b"content")
+        results = await KeywordSearchStrategy().search(storage, "   ")
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_matches_case_insensitively(self, storage):
+        await storage.write("note.md", b"Dark Mode Toggle")
+        results = await KeywordSearchStrategy().search(storage, "dark mode")
+        assert len(results) == 1
+
+    @pytest.mark.asyncio
+    async def test_includes_key_in_scoring(self, storage):
+        await storage.write("dark-mode.md", b"some unrelated body")
+        results = await KeywordSearchStrategy().search(storage, "dark mode")
+        assert len(results) == 1
+        assert results[0].key == "dark-mode.md"
+
+    @pytest.mark.asyncio
+    async def test_ranks_by_score_descending(self, storage):
+        await storage.write("a.md", b"dark")
+        await storage.write("b.md", b"dark mode toggle feature")
+
+        results = await KeywordSearchStrategy().search(storage, "dark mode")
+
+        assert len(results) == 2
+        assert results[0].score >= results[1].score
+
+    @pytest.mark.asyncio
+    async def test_skips_keys_where_read_returns_none(self, storage):
+        await storage.write("exists.md", b"dark mode content")
+        storage._store["ghost.md"] = b"dark"
+        original_read = storage.read
+
+        async def patched_read(key):
+            if key == "ghost.md":
+                return None
+            return await original_read(key)
+
+        storage.read = patched_read
+
+        results = await KeywordSearchStrategy().search(storage, "dark")
+        assert len(results) == 1
+        assert results[0].key == "exists.md"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_no_matches(self, storage):
+        await storage.write("note.md", b"completely unrelated content")
+        results = await KeywordSearchStrategy().search(storage, "kubernetes deployment")
+        assert results == []

--- a/strands-py/tests/strands/storage/test_in_memory_storage.py
+++ b/strands-py/tests/strands/storage/test_in_memory_storage.py
@@ -91,3 +91,12 @@ class TestInMemoryStorage:
         await storage.write("key", data)
         data[0] = 0xFF
         assert await storage.read("key") == b"mutable"
+
+    @pytest.mark.asyncio
+    async def test_search_returns_matching_results(self, storage):
+        await storage.write("dark-mode.md", b"enable dark mode in settings")
+        await storage.write("deploy.md", b"deploy to production")
+        results = await storage.search("dark mode")
+        assert len(results) == 1
+        assert results[0].key == "dark-mode.md"
+        assert results[0].score > 0

--- a/strands-py/tests/strands/storage/test_local_file_storage.py
+++ b/strands-py/tests/strands/storage/test_local_file_storage.py
@@ -96,6 +96,29 @@ class TestLocalFileStorage:
         assert await ns.read("key") == b"value"
         assert await storage.read("scope/key") == b"value"
 
+    def test_namespace_returns_local_file_storage(self, storage, tmp_path):
+        from strands.storage.storage import _NAMESPACED
+
+        ns = storage.namespace("scope")
+        assert isinstance(ns, LocalFileStorage)
+        assert ns.base_dir == os.path.join(str(tmp_path), "scope")
+        assert ns._namespaced is _NAMESPACED
+
+    def test_normpath_prevents_trailing_slash_in_namespace(self, tmp_path):
+        storage = LocalFileStorage(str(tmp_path) + "/")
+        ns = storage.namespace("scope")
+        assert not ns.base_dir.endswith("/")
+        assert os.sep + "scope" in ns.base_dir
+
+    @pytest.mark.asyncio
+    async def test_search_returns_matching_results(self, storage):
+        await storage.write("notes/dark-mode.md", b"enable dark mode in settings")
+        await storage.write("notes/deploy.md", b"deploy to production")
+        results = await storage.search("dark mode")
+        assert len(results) == 1
+        assert results[0].key == "notes/dark-mode.md"
+        assert results[0].score > 0
+
     @pytest.mark.asyncio
     async def test_key_normalization(self, storage):
         await storage.write("//foo///bar//", b"data")
@@ -210,12 +233,15 @@ class TestLocalFileStorage:
     def test_namespace_preserves_for_sandbox(self, tmp_path):
         from unittest.mock import MagicMock
 
+        from strands.storage.storage import _NAMESPACED
+
         sandbox = MagicMock()
         storage = LocalFileStorage(str(tmp_path))
         ns = storage.namespace("scope")
         assert hasattr(ns, "for_sandbox")
         bound = ns.for_sandbox(sandbox)
         assert bound is not ns
+        assert bound._namespaced is _NAMESPACED
 
     @pytest.mark.asyncio
     async def test_list_prefix_narrows_directory(self, storage, tmp_path):

--- a/strands-py/tests/strands/storage/test_storage.py
+++ b/strands-py/tests/strands/storage/test_storage.py
@@ -127,6 +127,21 @@ class TestNamespacedStorage:
         assert keys == ["key1"]
 
 
+    @pytest.mark.asyncio
+    async def test_search_scopes_to_prefix(self, storage):
+        await storage.write("scope/a.md", b"dark mode toggle")
+        await storage.write("scope/b.md", b"light mode")
+        await storage.write("other/c.md", b"dark mode elsewhere")
+
+        ns = _NamespacedStorage(storage, "scope")
+        results = await ns.search("dark mode")
+
+        keys = [r.key for r in results]
+        assert "a.md" in keys
+        assert all(not r.key.startswith("scope/") for r in results)
+        assert all("other" not in r.key for r in results)
+
+
 class TestStorageProtocol:
     def test_isinstance_check(self):
         from strands.storage import InMemoryStorage, Storage

--- a/strands-py/tests/strands/storage/test_storage.py
+++ b/strands-py/tests/strands/storage/test_storage.py
@@ -7,6 +7,7 @@ from strands.storage.storage import (
     _NamespacedStorage,
     _normalize_key,
     _normalize_prefix,
+    _resolve_namespace,
 )
 from strands.types.exceptions import StorageError
 
@@ -132,3 +133,54 @@ class TestStorageProtocol:
 
         storage = InMemoryStorage()
         assert isinstance(storage, Storage)
+
+
+class TestResolveNamespace:
+    def test_returns_as_is_when_already_namespaced(self):
+        from strands.storage import InMemoryStorage
+
+        storage = InMemoryStorage()
+        namespaced = storage.namespace("prefix")
+        result = _resolve_namespace(namespaced, "another")
+        assert result is namespaced
+
+    def test_calls_namespace_method_when_available(self):
+        from strands.storage import InMemoryStorage
+
+        storage = InMemoryStorage()
+        result = _resolve_namespace(storage, "my-prefix")
+        assert getattr(result, "_namespaced", None) is _NAMESPACED
+
+    @pytest.mark.asyncio
+    async def test_scoped_view_writes_under_prefix(self):
+        from strands.storage import InMemoryStorage
+
+        storage = InMemoryStorage()
+        scoped = _resolve_namespace(storage, "data")
+        await scoped.write("key.txt", b"hello")
+        assert await storage.read("data/key.txt") == b"hello"
+
+    @pytest.mark.asyncio
+    async def test_wraps_with_namespaced_storage_as_fallback(self):
+        class BareStorage:
+            """A minimal storage with no namespace method."""
+
+            def __init__(self):
+                self._store = {}
+
+            async def write(self, key, data):
+                self._store[key] = data
+
+            async def read(self, key):
+                return self._store.get(key)
+
+            async def delete(self, key):
+                self._store.pop(key, None)
+
+            async def list(self, query=""):
+                return sorted(k for k in self._store if k.startswith(query))
+
+        storage = BareStorage()
+        scoped = _resolve_namespace(storage, "ns")
+        await scoped.write("file.md", b"content")
+        assert await storage.read("ns/file.md") == b"content"

--- a/strands-py/tests/strands/vended_memory_stores/file_memory_store/test_store.py
+++ b/strands-py/tests/strands/vended_memory_stores/file_memory_store/test_store.py
@@ -1,0 +1,304 @@
+"""Tests for FileMemoryStore."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from strands.storage.in_memory_storage import InMemoryStorage
+from strands.vended_memory_stores.file_memory_store import FileMemoryStore
+
+
+@pytest.fixture
+def storage():
+    return InMemoryStorage()
+
+
+@pytest.fixture
+def store(storage):
+    return FileMemoryStore(name="test-store", description="A test file memory store", storage=storage)
+
+
+class TestConstructor:
+    def test_sets_name_and_description(self, store):
+        assert store.name == "test-store"
+        assert store.description == "A test file memory store"
+
+    def test_defaults_writable_true(self, store):
+        assert store.writable is True
+
+    def test_respects_writable_false(self, storage):
+        read_only = FileMemoryStore(name="readonly", storage=storage, writable=False)
+        assert read_only.writable is False
+
+    def test_defaults_no_description_when_omitted(self, storage):
+        minimal = FileMemoryStore(name="minimal", storage=storage)
+        assert minimal.description is None
+
+    @pytest.mark.asyncio
+    async def test_auto_scopes_keys_under_memory_name(self, store, storage):
+        await store.add("User prefers dark mode")
+        assert await storage.read("memory/test-store/user-prefers-dark-mode.md") is not None
+        assert await storage.read("user-prefers-dark-mode.md") is None
+
+    @pytest.mark.asyncio
+    async def test_scopes_distinct_stores_on_shared_backend(self, storage):
+        store_a = FileMemoryStore(name="store-a", storage=storage)
+        store_b = FileMemoryStore(name="store-b", storage=storage)
+        await store_a.add("User prefers dark mode")
+        await store_b.add("User prefers light mode")
+
+        raw_a = await storage.read("memory/store-a/user-prefers-dark-mode.md")
+        raw_b = await storage.read("memory/store-b/user-prefers-light-mode.md")
+        assert raw_a is not None
+        assert b"dark mode" in raw_a
+        assert raw_b is not None
+        assert b"light mode" in raw_b
+
+        results_a = await store_a.search("mode")
+        results_b = await store_b.search("mode")
+        assert len(results_a) == 1
+        assert len(results_b) == 1
+
+    @pytest.mark.asyncio
+    async def test_does_not_re_scope_already_namespaced_storage(self, storage):
+        pre_scoped = storage.namespace("memory/scoped")
+        scoped_store = FileMemoryStore(name="scoped", storage=pre_scoped)
+        await scoped_store.add("User prefers dark mode")
+        assert await storage.read("memory/scoped/user-prefers-dark-mode.md") is not None
+        assert await storage.read("memory/scoped/memory/scoped/user-prefers-dark-mode.md") is None
+
+
+class TestAdd:
+    @pytest.mark.asyncio
+    async def test_writes_plain_markdown_content(self, store, storage):
+        await store.add("User prefers dark mode")
+        scoped = storage.namespace("memory/test-store")
+        data = await scoped.read("user-prefers-dark-mode.md")
+        assert data is not None
+        assert data.decode() == "User prefers dark mode"
+
+    @pytest.mark.asyncio
+    async def test_derives_filename_from_first_line(self, store, storage):
+        await store.add("The user likes vim keybindings\nMore details here")
+        scoped = storage.namespace("memory/test-store")
+        keys = await scoped.list("")
+        assert len(keys) == 1
+        assert keys[0] == "the-user-likes-vim-keybindings.md"
+
+    @pytest.mark.asyncio
+    async def test_truncates_slug_at_50_chars(self, store, storage):
+        long_content = (
+            "this is a very long sentence that should be truncated when used as a filename slug for storage"
+        )
+        await store.add(long_content)
+        scoped = storage.namespace("memory/test-store")
+        keys = await scoped.list("")
+        slug = keys[0].removesuffix(".md")
+        assert len(slug) <= 50
+
+    @pytest.mark.asyncio
+    async def test_appends_new_facts_to_existing_entry(self, store, storage):
+        await store.add("Python is great\nFast prototyping")
+        await store.add("Python is great\nBut it has a GIL.")
+        scoped = storage.namespace("memory/test-store")
+        keys = await scoped.list("")
+        assert len(keys) == 1
+        assert keys[0] == "python-is-great.md"
+        content = (await scoped.read("python-is-great.md")).decode()
+        assert content == "Python is great\nFast prototyping\nBut it has a GIL."
+
+    @pytest.mark.asyncio
+    async def test_does_not_duplicate_when_new_entry_has_only_heading(self, store, storage):
+        await store.add("Python is great\nFast prototyping")
+        await store.add("Python is great")
+        scoped = storage.namespace("memory/test-store")
+        content = (await scoped.read("python-is-great.md")).decode()
+        assert content == "Python is great\nFast prototyping"
+
+    @pytest.mark.asyncio
+    async def test_fallback_slug_when_content_produces_empty(self, store, storage):
+        await store.add("!!!???")
+        scoped = storage.namespace("memory/test-store")
+        keys = await scoped.list("")
+        assert len(keys) == 1
+        assert keys[0].startswith("entry-")
+        assert keys[0].endswith(".md")
+
+    @pytest.mark.asyncio
+    async def test_slugifies_special_characters(self, store, storage):
+        await store.add("User's #1 testing rule!")
+        scoped = storage.namespace("memory/test-store")
+        keys = await scoped.list("")
+        assert keys[0] == "users-1-testing-rule.md"
+
+    @pytest.mark.asyncio
+    async def test_returns_canonical_key(self, store):
+        key = await store.add("User prefers dark mode")
+        assert key == "user-prefers-dark-mode.md"
+
+    @pytest.mark.asyncio
+    async def test_returns_same_key_on_append(self, store):
+        key1 = await store.add("Python is great\nFirst fact")
+        key2 = await store.add("Python is great\nSecond fact")
+        assert key1 == key2
+
+    @pytest.mark.asyncio
+    async def test_strips_markdown_heading_prefix(self, store, storage):
+        await store.add("# User preferences\nLikes dark mode")
+        scoped = storage.namespace("memory/test-store")
+        keys = await scoped.list("")
+        assert keys[0] == "user-preferences.md"
+        content = (await scoped.read("user-preferences.md")).decode()
+        assert content == "# User preferences\nLikes dark mode"
+
+    @pytest.mark.asyncio
+    async def test_strips_multiple_heading_levels(self, store, storage):
+        await store.add("## Project setup\nTypeScript monorepo")
+        scoped = storage.namespace("memory/test-store")
+        keys = await scoped.list("")
+        assert keys[0] == "project-setup.md"
+
+    @pytest.mark.asyncio
+    async def test_no_trailing_hyphen_on_truncation(self, store):
+        content = "aaaa bbbbb ccccc ddddd eeeee fffff ggggg hhhhh iiiii jjjjj"
+        key = await store.add(content)
+        assert not key.startswith("-")
+        assert "-." not in key
+
+
+class TestSearch:
+    async def _populate(self, store):
+        await store.add("User prefers dark mode for all editors")
+        await store.add("Testing philosophy: integration first, mock at boundaries")
+        await store.add("Deploy process uses blue-green strategy")
+
+    @pytest.mark.asyncio
+    async def test_returns_matching_entries_by_keyword(self, store):
+        await self._populate(store)
+        results = await store.search("dark mode")
+        assert results[0].content == "User prefers dark mode for all editors"
+
+    @pytest.mark.asyncio
+    async def test_matches_against_filenames(self, store):
+        await self._populate(store)
+        results = await store.search("deploy")
+        assert results[0].content == "Deploy process uses blue-green strategy"
+
+    @pytest.mark.asyncio
+    async def test_case_insensitive(self, store):
+        await self._populate(store)
+        results = await store.search("DARK MODE")
+        assert results[0].content == "User prefers dark mode for all editors"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_no_matches(self, store):
+        await self._populate(store)
+        assert await store.search("quantum computing") == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_empty_query(self, store):
+        await self._populate(store)
+        assert await store.search("") == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_whitespace_query(self, store):
+        await self._populate(store)
+        assert await store.search("   ") == []
+
+    @pytest.mark.asyncio
+    async def test_respects_max_search_results_option(self, store):
+        await self._populate(store)
+        results = await store.search("process", {"max_search_results": 1})
+        assert len(results) == 1
+
+    @pytest.mark.asyncio
+    async def test_ranks_by_distinct_matching_tokens(self, store):
+        await self._populate(store)
+        await store.add("covers deploy, testing, and integration boundaries")
+        results = await store.search("deploy testing integration")
+        assert results[0].content == "covers deploy, testing, and integration boundaries"
+
+    @pytest.mark.asyncio
+    async def test_includes_path_in_metadata(self, store):
+        await self._populate(store)
+        results = await store.search("deploy")
+        assert results[0].metadata is not None
+        assert results[0].metadata["path"] == "deploy-process-uses-blue-green-strategy.md"
+
+    @pytest.mark.asyncio
+    async def test_uses_default_max_search_results(self, storage):
+        big_store = FileMemoryStore(name="big", storage=storage)
+        for index in range(15):
+            await big_store.add(f"Fact number {index}")
+        results = await big_store.search("fact")
+        assert len(results) == 10
+
+    @pytest.mark.asyncio
+    async def test_respects_config_max_search_results(self, storage):
+        custom_store = FileMemoryStore(name="custom", storage=storage, max_search_results=2)
+        for index in range(5):
+            await custom_store.add(f"Fact number {index}")
+        results = await custom_store.search("fact")
+        assert len(results) == 2
+
+
+class TestExtraction:
+    @pytest.mark.asyncio
+    async def test_extraction_true_creates_key_aware_extractor(self, storage):
+        store = FileMemoryStore(name="ext-test", storage=storage, extraction=True)
+        assert store.extraction is not None
+        assert store.extraction is not True
+        assert "extractor" in store.extraction
+
+    @pytest.mark.asyncio
+    async def test_extraction_dict_without_extractor_creates_key_aware(self, storage):
+        from strands.memory.extraction.types import MemoryMessageFilter
+
+        custom_filter = MemoryMessageFilter(exclude=["image"])
+        store = FileMemoryStore(name="ext-test", storage=storage, extraction={"filter": custom_filter})
+        assert store.extraction is not None
+        assert "extractor" in store.extraction
+        assert store.extraction["filter"] is custom_filter
+
+    @pytest.mark.asyncio
+    async def test_extraction_dict_with_extractor_preserves_it(self, storage):
+        custom_extractor = AsyncMock()
+        store = FileMemoryStore(name="ext-test", storage=storage, extraction={"extractor": custom_extractor})
+        assert store.extraction["extractor"] is custom_extractor
+
+    @pytest.mark.asyncio
+    async def test_extraction_false_returns_false(self, storage):
+        store = FileMemoryStore(name="ext-test", storage=storage, extraction=False)
+        assert store.extraction is False
+
+    @pytest.mark.asyncio
+    async def test_extraction_none_returns_none(self, storage):
+        store = FileMemoryStore(name="ext-test", storage=storage)
+        assert store.extraction is None
+
+
+    @pytest.mark.asyncio
+    async def test_key_aware_extractor_includes_headings_in_prompt(self, storage):
+        store = FileMemoryStore(name="ext-test", storage=storage, extraction=True)
+        await store.add("# User preferences\nPrefers dark mode\nUses vim")
+        await store.add("# Project setup\nTypeScript monorepo")
+
+        extractor = store.extraction["extractor"]
+
+        with patch(
+            "strands.vended_memory_stores.file_memory_store.store.ModelExtractor"
+        ) as mock_model_extractor_cls:
+            mock_instance = AsyncMock()
+            mock_instance.extract = AsyncMock(return_value=[])
+            mock_model_extractor_cls.return_value = mock_instance
+
+            messages = [{"role": "user", "content": [{"text": "I also prefer light themes"}]}]
+            await extractor.extract(messages, None)
+
+            mock_model_extractor_cls.assert_called_once()
+            call_kwargs = mock_model_extractor_cls.call_args[1]
+            system_prompt = call_kwargs["system_prompt"]
+            assert "Existing topics:" in system_prompt
+            assert "user preferences" in system_prompt
+            assert "project setup" in system_prompt
+            assert "Reuse an existing topic heading" in system_prompt

--- a/strands-py/tests/strands/vended_memory_stores/test_memory_store/test_store.py
+++ b/strands-py/tests/strands/vended_memory_stores/test_memory_store/test_store.py
@@ -80,11 +80,10 @@ def make_store(store_path: str):
 
 
 class TestPackageExport:
-    def test_lazy_export_from_parent_package(self):
-        # The store is documented as importable from the parent package via its lazy __getattr__.
-        from strands.vended_memory_stores import __getattr__
+    def test_export_from_parent_package(self):
+        from strands.vended_memory_stores import TestMemoryStore as Imported
 
-        assert __getattr__("TestMemoryStore") is TestMemoryStore
+        assert Imported is TestMemoryStore
 
     def test_unknown_attribute_raises(self):
         from strands.vended_memory_stores import __getattr__


### PR DESCRIPTION
## Summary

Python port of the TypeScript `FileMemoryStore` (#3825). Adds:

- `FileMemoryStore` — filesystem-backed memory store, persists knowledge as markdown files under `memory/<name>/`
- `SearchStrategy` protocol and `KeywordSearchStrategy` class under `strands.storage.search`
- `search()` method on the `Storage` protocol and all shipped backends
- `SearchQuery` type parameter on `Storage` protocol, mirroring TS `Storage<ListQuery, SearchQuery>`
- `LocalFileStorage.namespace()` returns a real `LocalFileStorage` (preserves `base_dir` for index-based strategies)

## Usage

```python
from strands import Agent
from strands.memory import MemoryManager
from strands.vended_memory_stores.file_memory_store import FileMemoryStore

store = FileMemoryStore(name="agent-memory")

agent = Agent(
    model=model,
    memory_manager=MemoryManager(stores=[store], injection=False),
)
```

## Test plan

- [x] `KeywordSearchStrategy` — scoring, ranking, empty queries, case insensitivity
- [x] `FileMemoryStore` — add, search, append-on-collision, slug generation, namespace isolation, extraction config
- [x] `LocalFileStorage.namespace()` — returns real instance, preserves sentinel, sandbox propagation
- [x] All shipped backends delegate `search()` to `KeywordSearchStrategy`
- [x] 288 storage + memory tests pass