### PR TITLE
docs(changelog): sync strands-agents/evals backfill

### DIFF
--- a/site/src/content/changelog/evals/v1.2.0.md
+++ b/site/src/content/changelog/evals/v1.2.0.md
@@ -1,0 +1,17 @@
+---
+sdk: evals
+version: "1.2.0"
+tag: v1.2.0
+date: 2026-08-21
+releaseUrl: https://github.com/strands-agents/evals/releases/tag/v1.2.0
+packageUrl: https://pypi.org/project/strands-agents-evals/1.2.0/
+entries:
+  - { type: feat, breaking: false, scope: null, areas: [tracing], title: "add Claude Agents OpenInference integration tests", pr: 353, prUrl: "https://github.com/strands-agents/evals/pull/353", commit: "1f752dc", commitUrl: "https://github.com/strands-agents/evals/commit/1f752dc", author: liramon2 }
+  - { type: other, breaking: false, scope: null, areas: [community], title: "update mypy requirement from <2.0.0 to <3.0.0", pr: 368, prUrl: "https://github.com/strands-agents/evals/pull/368", commit: "deeb4cd", commitUrl: "https://github.com/strands-agents/evals/commit/deeb4cd", author: Unshure }
+  - { type: other, breaking: false, scope: null, areas: [community], title: "update opentelemetry-instrumentation-langchain requirement from <0.62.0,>=0.40.0 to >=0.40.0,<0.63.0", pr: 369, prUrl: "https://github.com/strands-agents/evals/pull/369", commit: "2127840", commitUrl: "https://github.com/strands-agents/evals/commit/2127840", author: Unshure }
+  - { type: fix, breaking: false, scope: null, areas: [tracing], title: "select root agent span by earliest start_time in multi-agent traces", pr: 371, prUrl: "https://github.com/strands-agents/evals/pull/371", commit: "70bcc5f", commitUrl: "https://github.com/strands-agents/evals/commit/70bcc5f", author: liramon2 }
+  - { type: fix, breaking: false, scope: null, areas: [evaluators], title: "reduce flakiness for integration tests targeting new session mappers", pr: 374, prUrl: "https://github.com/strands-agents/evals/pull/374", commit: "4ce6231", commitUrl: "https://github.com/strands-agents/evals/commit/4ce6231", author: liramon2 }
+  - { type: fix, breaking: false, scope: null, areas: [tracing], title: "change bridge_parent_gaps to return new spans instead of mutating in place", pr: 375, prUrl: "https://github.com/strands-agents/evals/pull/375", commit: "925e754", commitUrl: "https://github.com/strands-agents/evals/commit/925e754", author: liramon2 }
+  - { type: feat, breaking: false, scope: null, areas: [evaluators], title: "add skill-level evaluators for skill-equipped agents", pr: 330, prUrl: "https://github.com/strands-agents/evals/pull/330", commit: "dce1b8a", commitUrl: "https://github.com/strands-agents/evals/commit/dce1b8a", author: sangminwoo }
+  - { type: feat, breaking: false, scope: null, areas: [tracing], title: "add OpenAI Agents SDK support to OpenInference mapper", pr: 366, prUrl: "https://github.com/strands-agents/evals/pull/366", commit: "f123c03", commitUrl: "https://github.com/strands-agents/evals/commit/f123c03", author: liramon2 }
+---


### PR DESCRIPTION
Automated evals changelog backstop.