### PR TITLE
docs(blog): add Agents for Humans hackathon challenge post

### DIFF
--- a/site/src/content/blog/an-agent-for-the-thing-you-keep-putting-off.mdx
+++ b/site/src/content/blog/an-agent-for-the-thing-you-keep-putting-off.mdx
@@ -1,0 +1,111 @@
+---
+title: "Hackathon Challenge: automate the one task you keep putting off"
+date: 2026-08-10
+description: "Pick the recurring chore you never quite get to and hand it to an agent. It is harder, and more interesting, than a cron job. There is also $40K in it."
+authors:
+  - strands-team
+tags:
+  - Use Cases
+  - Tools
+  - Community
+draft: false
+---
+
+Everyone has one. The recurring task you keep meaning to deal with and never quite do. Reconciling receipts against the credit card statement. Renewing the domain before it lapses. Chasing three people for the one document that unblocks everything else. Checking whether the thing you ordered actually shipped.
+
+Here is a challenge: pick exactly one of those and hand it to an agent.
+
+Not a script. You could already write a script. The ones worth picking resist scripting, which is the whole point.
+
+> This is the exact premise of [**Agents for Humans**](https://agentsforhumans.devpost.com/), the hackathon AWS is running from August 10 to September 14, 2026. Build an agent that handles a real task from everyday life, professional work, or your community, and you can [**win a share of $40,000**](https://agentsforhumans.devpost.com/). Every entrant gets $50 in AWS credits. Solo or team, open worldwide. The rest of this post is how to build one.
+
+## Why not just a cron job
+
+The tasks worth automating are the ones you have been avoiding, and you have been avoiding them for a reason. They involve judgment. The input is messy. The right action depends on what you find.
+
+Take "reconcile my receipts." A cron job can pull the statement. It cannot look at a $47.83 charge from `SQ *BLUE BOTTLE`, decide it is the coffee receipt sitting in your inbox from Tuesday, and flag the $200 one you do not recognize. That last step, the reading and matching and deciding, is the part you keep putting off. It is also the part an agent is actually good at.
+
+So the constraint that makes this fun: the task has to need judgment. If a `for` loop solves it, pick a harder task.
+
+## The smallest version that works
+
+Start with one tool and a model. In Strands, a tool is a plain function with a docstring. The docstring is what the model reads to decide when to call it.
+
+```python
+from strands import Agent, tool
+
+@tool
+def get_recent_charges(days: int) -> list[dict]:
+    """Return credit card charges from the last N days.
+
+    Each charge has a merchant, amount, and date.
+    """
+    # Your bank's API, a CSV export, a scraped statement: whatever you have.
+    return load_charges(since_days=days)
+
+agent = Agent(tools=[get_recent_charges])
+agent("Which charges from the last 7 days look unusual for me?")
+```
+
+That is a working agent. It decides on its own whether to call `get_recent_charges`, picks the argument, reads the result, and reasons about what "unusual" means for the charges it sees.
+
+You did not write the "is this unusual" logic. You described the data and asked the question. That is the trade: you give up writing the rules, and in return the agent handles cases you never enumerated.
+
+## Where it gets interesting
+
+One tool is a demo. The task you actually avoid needs two or three, and the judgment lives in how the agent chains them.
+
+```python
+from strands import Agent, tool
+
+@tool
+def get_recent_charges(days: int) -> list[dict]:
+    """Return credit card charges from the last N days."""
+    return load_charges(since_days=days)
+
+@tool
+def search_inbox(query: str) -> list[dict]:
+    """Search email for receipts matching a merchant or amount."""
+    return search_mail(query)
+
+@tool
+def flag_for_review(charge_id: str, reason: str) -> str:
+    """Mark a charge as needing human review, with a short reason."""
+    return mark_charge(charge_id, reason)
+
+agent = Agent(tools=[get_recent_charges, search_inbox, flag_for_review])
+agent("Match this week's charges to receipts in my inbox and flag anything you can't account for.")
+```
+
+Now there is no fixed script. The agent might pull the charges, search the inbox for each merchant, match what it can, and flag the rest. Or it might work merchant by merchant. The order is its call, and it will vary run to run:
+
+```
+# Example run:
+# 1. Agent calls get_recent_charges(days=7)
+# 2. For each charge, agent calls search_inbox with the merchant name
+# 3. Agent matches receipts it finds, reasons about the ones it doesn't
+# 4. Agent calls flag_for_review on two unmatched charges
+```
+
+You wrote three small functions. The coordination between them, the part that would have been a tangle of `if` statements, is the model's job.
+
+## The rules of the challenge
+
+Keep it honest and it stays worth doing:
+
+- **One real task.** Something you personally put off, not a toy. If you would not use it, it does not count.
+- **It has to need judgment.** No pure `for` loops. The agent should make a call you would otherwise make yourself.
+- **Give it real tools, not one god-function.** Two or three narrow functions the agent composes. That is where the behavior you did not hand-code shows up.
+- **Let it surprise you.** If every run does exactly what you predicted, the task was too easy. Pick a messier one.
+
+The tasks that make good agents are unglamorous on purpose. Nobody demos "renew the domain." But it is the honest test: a boring, real chore you have been avoiding, handled well enough that it drops off your list.
+
+The prize money helps. The better reason is that you already have a task in mind. You thought of it two paragraphs ago. If you want to [enter it](https://agentsforhumans.devpost.com/), submissions are open through September 14.
+
+## Start
+
+```bash
+pip install strands-agents strands-agents-tools
+```
+
+The [quickstart](https://strandsagents.com/) gets you to a running agent in a few minutes, and the [tools guide](https://strandsagents.com/latest/documentation/docs/user-guide/concepts/tools/) covers everything the `@tool` decorator can do. If you build something, tell us in [the Discord](https://discord.gg/strands) or open a discussion on [GitHub](https://github.com/strands-agents/harness-sdk/discussions). We want to see the boring task you never have to think about again.

--- a/site/src/util/blog.ts
+++ b/site/src/util/blog.ts
@@ -81,5 +81,6 @@ export function formatDate(date: Date): string {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
+    timeZone: 'UTC',
   })
 }


### PR DESCRIPTION
## Description

Adds a blog post for the **Agents for Humans** hackathon, written as a shareable build-challenge essay rather than a promotional announcement: pick one recurring, judgment-heavy chore you keep putting off and hand it to a Strands agent. The post builds up a real, runnable Strands example (one tool, then a few tools the agent composes), lays out "rules of the challenge," and links the hackathon (dates, $40K prize pool, $50 AWS credits) in a prominent callout near the top.

Backdated to the hackathon launch date (2026-08-10) so it reads as launch-day content.

While wiring up the post I found that blog dates rendered a day early in negative-offset (US) timezones, so this PR also includes a one-line fix.

### Files
- `site/src/content/blog/an-agent-for-the-thing-you-keep-putting-off.mdx` — the post (author: `strands-team`).
- `site/src/util/blog.ts` — `formatDate` now pins `timeZone: 'UTC'`, matching the already-UTC-pinned `changelog.ts` and `learn.ts`. Without it, a date authored as UTC midnight (`2026-08-10`) displayed as Aug 9 in US timezones.

## Related Issues

_None._

## Type of Change

Documentation update (plus a small `fix` to blog date rendering)

## Testing

Ran the docs area of the local merge gate (`.agents/skills/pre-push/run-checks.sh`) and exercised the change in the dev server:

- The post renders (HTTP 200), appears in the blog index, and the byline, tags, and reading time display correctly.
- After the `formatDate` fix the post shows **August 10, 2026**; spot-checked an existing post (Strands Labs) still renders its own date (February 23, 2026), confirming no regression.
- Voice check: no banned hype/hedge phrases, no em-dashes, no emoji, per `.agents/references/voice-guide.md`.

The gate's `format:check` and `typecheck:snippets` steps report failures, but they are **pre-existing and unrelated** — every one is in `site/src/content/docs/**/*.ts` files this PR does not touch, and they reproduce identically on a clean tree with this branch's files stashed (the TypeScript SDK is not built into `site/node_modules` locally; CI builds it first).

- [ ] I ran `hatch run prepare` (N/A — docs/site change only)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
