### PR TITLE
docs(community): add strands hackathon link

### DIFF
--- a/site/src/components/community/CommunityBulletin.astro
+++ b/site/src/components/community/CommunityBulletin.astro
@@ -1,6 +1,6 @@
 ---
 export interface BulletinItem {
-  type: 'event' | 'post' | 'integration'
+  type: 'event' | 'post' | 'integration' | 'hackathon'
   kicker: string
   title: string
   href?: string
@@ -34,6 +34,11 @@ const { items } = Astro.props
                   <svg viewBox="0 0 16 16" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.3">
                     <path d="M2.5 13.5l.9-2.9 7.6-7.6a1.4 1.4 0 0 1 2 2l-7.6 7.6z" />
                     <path d="M9.8 4.2l2 2" />
+                  </svg>
+                ) : item.type === 'hackathon' ? (
+                  <svg viewBox="0 0 16 16" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round">
+                    <rect x="1.5" y="2.5" width="13" height="9" rx="1.5" />
+                    <path d="M5.5 14.5h5M8 11.5v3" stroke-linecap="round" />
                   </svg>
                 ) : (
                   <svg viewBox="0 0 16 16" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.3">
@@ -147,6 +152,12 @@ const { items } = Astro.props
     border-color: rgba(127, 184, 216, 0.25);
   }
 
+  .icon--hackathon {
+    color: #b79ce0;
+    background: rgba(183, 156, 224, 0.08);
+    border-color: rgba(183, 156, 224, 0.25);
+  }
+
   .text {
     display: flex;
     flex-direction: column;
@@ -169,6 +180,12 @@ const { items } = Astro.props
     color: #23648f;
     background: rgba(35, 100, 143, 0.06);
     border-color: rgba(35, 100, 143, 0.25);
+  }
+
+  :global([data-theme='light']) .icon--hackathon {
+    color: #6b4ea0;
+    background: rgba(107, 78, 160, 0.06);
+    border-color: rgba(107, 78, 160, 0.25);
   }
 
   .kicker {

--- a/site/src/pages/community.astro
+++ b/site/src/pages/community.astro
@@ -63,6 +63,7 @@ const bulletin: BulletinItem[] = [
     kicker: 'Strands Hackathon',
     title: 'Compete for $40,000 in cash prizes',
     href: 'https://agentsforhumans.devpost.com/',
+    expires: '2026-09-14',
   },
   ...(nextEvent
     ? [

--- a/site/src/pages/community.astro
+++ b/site/src/pages/community.astro
@@ -58,6 +58,12 @@ const nextEvent = tickerEvents(events, today, 1)[0]
 const newestPost = posts[0]
 
 const bulletin: BulletinItem[] = [
+  {
+    type: 'hackathon' as const,
+    kicker: 'Strands Hackathon',
+    title: 'Compete for $40,000 in cash prizes',
+    href: 'https://agentsforhumans.devpost.com/',
+  },
   ...(nextEvent
     ? [
         {


### PR DESCRIPTION
## Description

Adds Strands [Hackathon link](https://agentsforhumans.devpost.com/) to Community Page. Will be updated when the hackathon closes on September 14th with a blog post on Hackathon winners.

## Related Issues

N/A

## Documentation PR

Documentation-only change under `site/`.

## Type of Change

Documentation update
<img width="1197" height="535" alt="Screenshot 2026-08-21 at 3 52 29 PM" src="https://github.com/user-attachments/assets/651b4f0c-55df-46d8-9c13-136cf8d245aa" />


## Testing

- [ ] I ran `hatch run prepare` (not applicable — documentation-only change)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.