### PR TITLE
fix(telemetry): close spans on cancellation

### DIFF
--- a/strands-py/src/strands/agent/_agent_as_tool.py
+++ b/strands-py/src/strands/agent/_agent_as_tool.py
@@ -7,8 +7,11 @@ so it can be passed to another agent's tool list.
 from __future__ import annotations
 
 import copy
+import inspect
 import logging
 import threading
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
 
 from typing_extensions import override
@@ -28,6 +31,18 @@ DELEGATION_DESCRIPTION_SUFFIX = (
     " Calling this tool will return its response directly to the user as the final answer."
     " It should be the only tool called in the turn."
 )
+
+
+@asynccontextmanager
+async def _close_async_iterator(events: AsyncIterator[Any]) -> AsyncIterator[None]:
+    """Close an async iterator on exit when its implementation supports it."""
+    try:
+        yield
+    finally:
+        if aclose := getattr(events, "aclose", None):
+            close_result = aclose()
+            if inspect.isawaitable(close_result):
+                await close_result
 
 
 class _AgentAsTool(AgentTool):
@@ -217,11 +232,13 @@ class _AgentAsTool(AgentTool):
             logger.debug("tool_name=<%s>, tool_use_id=<%s> | invoking agent", self._tool_name, tool_use_id)
 
             result = None
-            async for event in self._agent.stream_async(prompt):
-                if "result" in event:
-                    result = event["result"]
-                else:
-                    yield AgentAsToolStreamEvent(tool_use, event, self)
+            events = self._agent.stream_async(prompt)
+            async with _close_async_iterator(events):
+                async for event in events:
+                    if "result" in event:
+                        result = event["result"]
+                    else:
+                        yield AgentAsToolStreamEvent(tool_use, event, self)
 
             if result is None:
                 yield ToolResultEvent(

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -14,6 +14,7 @@ import logging
 import threading
 import warnings
 from collections.abc import AsyncGenerator, AsyncIterator, Callable, Mapping
+from contextlib import aclosing
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
@@ -1266,16 +1267,17 @@ class Agent(AgentBase):
                     # The result is the last EventLoopStopEvent, not the last event overall:
                     # AgentStreamStage middleware may yield trailing events after the stop event.
                     stop_event: EventLoopStopEvent | None = None
-                    async for event in events:
-                        event.prepare(invocation_state=merged_state)
+                    async with aclosing(events):
+                        async for event in events:
+                            event.prepare(invocation_state=merged_state)
 
-                        if isinstance(event, EventLoopStopEvent):
-                            stop_event = event
+                            if isinstance(event, EventLoopStopEvent):
+                                stop_event = event
 
-                        if event.is_callback_event:
-                            as_dict = event.as_dict()
-                            callback_handler(**as_dict)
-                            yield as_dict
+                            if event.is_callback_event:
+                                as_dict = event.as_dict()
+                                callback_handler(**as_dict)
+                                yield as_dict
 
                     if stop_event is None:
                         raise RuntimeError(
@@ -1285,13 +1287,15 @@ class Agent(AgentBase):
 
                     result = AgentResult(*stop_event["stop"])
                     callback_handler(result=result)
-                    yield AgentResultEvent(result=result).as_dict()
-
                     self._end_agent_trace_span(response=result)
+                    yield AgentResultEvent(result=result).as_dict()
 
                 except Exception as e:
                     self._end_agent_trace_span(error=e)
                     self._concurrency.complete(begin.registered_token, error=e)
+                    raise
+                except BaseException as cancellation:
+                    self._end_agent_trace_span(cancellation=cancellation)
                     raise
 
         finally:
@@ -1377,14 +1381,16 @@ class Agent(AgentBase):
                     _interrupts=dict(self._interrupt_state.interrupts) if self._interrupt_state.activated else {},
                 )
                 try:
-                    async for event in self._middleware_registry.invoke(
+                    events = self._middleware_registry.invoke(
                         AgentStreamStage,
                         middleware_context,
                         self._make_agent_stream_terminal(structured_output_context, limits, pass_progress),
-                    ):
-                        if isinstance(event, EventLoopStopEvent):
-                            agent_result = AgentResult(*event["stop"])
-                        yield event
+                    )
+                    async with aclosing(events):
+                        async for event in events:
+                            if isinstance(event, EventLoopStopEvent):
+                                agent_result = AgentResult(*event["stop"])
+                            yield event
 
                     # A resumed AgentStreamStage interrupt that finished without tool execution
                     # never hits the tool path's deactivate(), so clear the interrupt state here.
@@ -1484,25 +1490,26 @@ class Agent(AgentBase):
         async def terminal(ctx: "AgentStreamContext") -> AsyncGenerator[TypedEvent, None]:
             # Execute the event loop cycle with retry logic for context limits
             events = self._execute_event_loop_cycle(ctx.invocation_state, structured_output_context, limits)
-            async for event in events:
-                if isinstance(event, EventLoopStopEvent):
-                    pass_progress.event_loop_produced_result = True
+            async with aclosing(events):
+                async for event in events:
+                    if isinstance(event, EventLoopStopEvent):
+                        pass_progress.event_loop_produced_result = True
 
-                # Signal from the model provider that the message sent by the user should be redacted,
-                # likely due to a guardrail.
-                if (
-                    isinstance(event, ModelStreamChunkEvent)
-                    and event.chunk
-                    and event.chunk.get("redactContent")
-                    and event.chunk["redactContent"].get("redactUserContentMessage")
-                ):
-                    self.messages[-1]["content"] = self._redact_user_content(
-                        self.messages[-1]["content"],
-                        str(event.chunk["redactContent"]["redactUserContentMessage"]),
-                    )
-                    if self._session_manager:
-                        self._session_manager.redact_latest_message(self.messages[-1], self)
-                yield event
+                    # Signal from the model provider that the message sent by the user should be redacted,
+                    # likely due to a guardrail.
+                    if (
+                        isinstance(event, ModelStreamChunkEvent)
+                        and event.chunk
+                        and event.chunk.get("redactContent")
+                        and event.chunk["redactContent"].get("redactUserContentMessage")
+                    ):
+                        self.messages[-1]["content"] = self._redact_user_content(
+                            self.messages[-1]["content"],
+                            str(event.chunk["redactContent"]["redactUserContentMessage"]),
+                        )
+                        if self._session_manager:
+                            self._session_manager.redact_latest_message(self.messages[-1], self)
+                    yield event
 
         return terminal
 
@@ -1539,8 +1546,9 @@ class Agent(AgentBase):
                 structured_output_context=structured_output_context,
                 limits=limits,
             )
-            async for event in events:
-                yield event
+            async with aclosing(events):
+                async for event in events:
+                    yield event
 
         except ContextWindowOverflowException as e:
             # Try reducing the context size and retrying
@@ -1551,8 +1559,9 @@ class Agent(AgentBase):
                 self._session_manager.sync_agent(self)
 
             events = self._execute_event_loop_cycle(invocation_state, structured_output_context, limits)
-            async for event in events:
-                yield event
+            async with aclosing(events):
+                async for event in events:
+                    yield event
 
         finally:
             if structured_output_context:
@@ -1658,16 +1667,21 @@ class Agent(AgentBase):
     def _end_agent_trace_span(
         self,
         response: AgentResult | None = None,
-        error: Exception | None = None,
+        error: BaseException | None = None,
+        cancellation: BaseException | None = None,
     ) -> None:
         """Ends a trace span for the agent.
 
         Args:
-            span: The span to end.
             response: Response to record as a trace attribute.
             error: Error to record as a trace attribute.
+            cancellation: Cancellation that aborted the invocation.
         """
         if self.trace_span:
+            if cancellation is not None:
+                self.tracer._end_span_with_cancellation(self.trace_span, cancellation)
+                return
+
             trace_attributes: dict[str, Any] = {
                 "span": self.trace_span,
             }

--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -11,7 +11,8 @@ The event loop allows agents to:
 import copy
 import logging
 import uuid
-from collections.abc import AsyncGenerator, Callable
+from collections.abc import AsyncGenerator, Callable, Iterator
+from contextlib import aclosing, contextmanager
 from typing import TYPE_CHECKING, Any
 
 from opentelemetry import trace as trace_api
@@ -62,6 +63,26 @@ logger = logging.getLogger(__name__)
 MAX_ATTEMPTS = 6
 INITIAL_DELAY = 4
 MAX_DELAY = 240  # 4 minutes
+
+
+@contextmanager
+def _end_span_on_cancellation(tracer: Tracer, span: Any) -> Iterator[None]:
+    """End a span when control flow exits through a non-error cancellation.
+
+    Args:
+        tracer: Tracer that owns the span.
+        span: Span to end on cancellation.
+
+    Yields:
+        Control to the guarded span lifecycle.
+    """
+    try:
+        yield
+    except BaseException as cancellation:
+        if isinstance(cancellation, Exception):
+            raise
+        tracer._end_span_with_cancellation(span, cancellation)
+        raise
 
 
 def _check_limits(agent: "Agent", limits: Limits | None) -> StopReason | None:
@@ -281,7 +302,7 @@ async def event_loop_cycle(
     )
     invocation_state["event_loop_cycle_span"] = cycle_span
 
-    with trace_api.use_span(cycle_span, end_on_exit=False):
+    with _end_span_on_cancellation(tracer, cycle_span), trace_api.use_span(cycle_span, end_on_exit=False):
         try:
             # Resume a tool interrupt by replaying its stored message instead of calling the model.
             if agent._interrupt_state.activated and "tool_use_message" in agent._interrupt_state.context:
@@ -295,9 +316,10 @@ async def event_loop_cycle(
                 model_events = _handle_model_execution(
                     agent, cycle_span, cycle_trace, invocation_state, tracer, structured_output_context
                 )
-                async for model_event in model_events:
-                    if not isinstance(model_event, ModelStopReason):
-                        yield model_event
+                async with aclosing(model_events):
+                    async for model_event in model_events:
+                        if not isinstance(model_event, ModelStopReason):
+                            yield model_event
 
                 stop_reason, message, *_ = model_event["stop"]
                 yield ModelMessageEvent(message=message)
@@ -353,8 +375,9 @@ async def event_loop_cycle(
                     structured_output_context=structured_output_context,
                     limits=limits,
                 )
-                async for tool_event in tool_events:
-                    yield tool_event
+                async with aclosing(tool_events):
+                    async for tool_event in tool_events:
+                        yield tool_event
 
                 return
 
@@ -380,8 +403,9 @@ async def event_loop_cycle(
                     structured_output_context=structured_output_context,
                     limits=limits,
                 )
-                async for typed_event in events:
-                    yield typed_event
+                async with aclosing(events):
+                    async for typed_event in events:
+                        yield typed_event
                 return
 
             tracer.end_event_loop_cycle_span(cycle_span, message)
@@ -442,8 +466,9 @@ async def recurse_event_loop(
         structured_output_context=structured_output_context,
         limits=limits,
     )
-    async for event in events:
-        yield event
+    async with aclosing(events):
+        async for event in events:
+            yield event
 
     recursive_trace.end()
 
@@ -558,13 +583,15 @@ async def _handle_model_execution(
             # Run through middleware chain. The last yielded event is ModelStopReason
             # which serves as both the streaming result event and the middleware result.
             last_event = None
-            async for event in agent._middleware_registry.invoke(
+            events = agent._middleware_registry.invoke(
                 InvokeModelStage,
                 middleware_context,
                 _make_invoke_model_terminal(agent, cycle_span, tracer, model_state_snapshot),
-            ):
-                last_event = event
-                yield event
+            )
+            async with aclosing(events):
+                async for event in events:
+                    last_event = event
+                    yield event
 
             if last_event is None:
                 raise RuntimeError(
@@ -683,7 +710,7 @@ def _make_invoke_model_terminal(
         )
         with trace_api.use_span(model_invoke_span, end_on_exit=False):
             try:
-                async for event in stream_messages(
+                events = stream_messages(
                     ctx.model,
                     system_prompt_str,
                     ctx.messages,
@@ -694,13 +721,18 @@ def _make_invoke_model_terminal(
                     model_state=model_state,
                     dynamic_trailing_blocks=ctx.dynamic_trailing_blocks,
                     cancel_signal=agent._cancel_signal,
-                ):
-                    yield event
+                )
+                async with aclosing(events):
+                    async for event in events:
+                        yield event
 
                 stop_reason, message, usage, metrics = event["stop"]
                 tracer.end_model_invoke_span(model_invoke_span, message, usage, metrics, stop_reason)
             except Exception as e:
                 tracer.end_span_with_error(model_invoke_span, str(e), e)
+                raise
+            except BaseException as cancellation:
+                tracer._end_span_with_cancellation(model_invoke_span, cancellation)
                 raise
 
     return terminal
@@ -728,6 +760,9 @@ async def _stop_for_interrupts(
     agent._interrupt_state.activate()
 
     agent.event_loop_metrics.end_cycle(cycle_start_time, cycle_trace)
+    if cycle_span:
+        tracer.end_event_loop_cycle_span(span=cycle_span, message=message)
+
     yield EventLoopStopEvent(
         "interrupt",
         message,
@@ -736,9 +771,6 @@ async def _stop_for_interrupts(
         interrupts,
         structured_output=structured_output_result,
     )
-    # End the cycle span before yielding the recursive cycle.
-    if cycle_span:
-        tracer.end_event_loop_cycle_span(span=cycle_span, message=message)
 
 
 async def _handle_tool_execution(
@@ -844,11 +876,12 @@ async def _handle_tool_execution(
             tool_events = agent.tool_executor._execute(
                 agent, tool_uses, tool_results, cycle_trace, cycle_span, invocation_state, structured_output_context
             )
-            async for tool_event in tool_events:
-                if isinstance(tool_event, ToolInterruptEvent):
-                    interrupts.extend(tool_event["tool_interrupt_event"]["interrupts"])
+            async with aclosing(tool_events):
+                async for tool_event in tool_events:
+                    if isinstance(tool_event, ToolInterruptEvent):
+                        interrupts.extend(tool_event["tool_interrupt_event"]["interrupts"])
 
-                yield tool_event
+                    yield tool_event
 
             if structured_output_context.is_enabled:
                 if structured_output_result := structured_output_context.extract_result(tool_uses):
@@ -964,5 +997,6 @@ async def _handle_tool_execution(
         structured_output_context=structured_output_context,
         limits=limits,
     )
-    async for event in events:
-        yield event
+    async with aclosing(events):
+        async for event in events:
+            yield event

--- a/strands-py/src/strands/event_loop/streaming.py
+++ b/strands-py/src/strands/event_loop/streaming.py
@@ -1,12 +1,14 @@
 """Utilities for handling streaming responses from language models."""
 
 import copy
+import inspect
 import json
 import logging
 import threading
 import time
 import warnings
 from collections.abc import AsyncGenerator, AsyncIterable
+from contextlib import aclosing
 from typing import Any
 
 from ..models.model import Model
@@ -450,43 +452,49 @@ async def process_stream(
     usage: Usage = Usage(inputTokens=0, outputTokens=0, totalTokens=0)
     metrics: Metrics = Metrics(latencyMs=0, timeToFirstByteMs=0)
 
-    async for chunk in chunks:
-        # Check for cancellation during stream processing
-        if cancel_signal and cancel_signal.is_set():
-            logger.debug("cancellation detected during stream processing")
-            # Return cancelled stop reason with cancellation message
-            # The incomplete message in state["message"] is discarded and never added to agent.messages
-            yield ModelStopReason(
-                stop_reason="cancelled",
-                message={"role": "assistant", "content": [{"text": "Cancelled by user"}]},
-                usage=usage,
-                metrics=metrics,
-            )
-            return
+    try:
+        async for chunk in chunks:
+            # Check for cancellation during stream processing
+            if cancel_signal and cancel_signal.is_set():
+                logger.debug("cancellation detected during stream processing")
+                # Return cancelled stop reason with cancellation message
+                # The incomplete message in state["message"] is discarded and never added to agent.messages
+                yield ModelStopReason(
+                    stop_reason="cancelled",
+                    message={"role": "assistant", "content": [{"text": "Cancelled by user"}]},
+                    usage=usage,
+                    metrics=metrics,
+                )
+                return
 
-        # Track first byte time when we get first content
-        if first_byte_time is None and ("contentBlockDelta" in chunk or "contentBlockStart" in chunk):
-            first_byte_time = time.time()
-        yield ModelStreamChunkEvent(chunk=chunk)
+            # Track first byte time when we get first content
+            if first_byte_time is None and ("contentBlockDelta" in chunk or "contentBlockStart" in chunk):
+                first_byte_time = time.time()
+            yield ModelStreamChunkEvent(chunk=chunk)
 
-        if "messageStart" in chunk:
-            state["message"] = handle_message_start(chunk["messageStart"], state["message"])
-        elif "contentBlockStart" in chunk:
-            state["current_tool_use"] = handle_content_block_start(chunk["contentBlockStart"])
-        elif "contentBlockDelta" in chunk:
-            state, typed_event = handle_content_block_delta(chunk["contentBlockDelta"], state)
-            yield typed_event
-        elif "contentBlockStop" in chunk:
-            state = handle_content_block_stop(state)
-        elif "messageStop" in chunk:
-            stop_reason = handle_message_stop(chunk["messageStop"], state["message"].get("content", []))
-        elif "metadata" in chunk:
-            time_to_first_byte_ms = (
-                int(1000 * (first_byte_time - start_time)) if (start_time and first_byte_time) else None
-            )
-            usage, metrics = extract_usage_metrics(chunk["metadata"], time_to_first_byte_ms)
-        elif "redactContent" in chunk:
-            handle_redact_content(chunk["redactContent"], state)
+            if "messageStart" in chunk:
+                state["message"] = handle_message_start(chunk["messageStart"], state["message"])
+            elif "contentBlockStart" in chunk:
+                state["current_tool_use"] = handle_content_block_start(chunk["contentBlockStart"])
+            elif "contentBlockDelta" in chunk:
+                state, typed_event = handle_content_block_delta(chunk["contentBlockDelta"], state)
+                yield typed_event
+            elif "contentBlockStop" in chunk:
+                state = handle_content_block_stop(state)
+            elif "messageStop" in chunk:
+                stop_reason = handle_message_stop(chunk["messageStop"], state["message"].get("content", []))
+            elif "metadata" in chunk:
+                time_to_first_byte_ms = (
+                    int(1000 * (first_byte_time - start_time)) if (start_time and first_byte_time) else None
+                )
+                usage, metrics = extract_usage_metrics(chunk["metadata"], time_to_first_byte_ms)
+            elif "redactContent" in chunk:
+                handle_redact_content(chunk["redactContent"], state)
+    finally:
+        if aclose := getattr(chunks, "aclose", None):
+            close_result = aclose()
+            if inspect.isawaitable(close_result):
+                await close_result
 
     yield ModelStopReason(stop_reason=stop_reason, message=state["message"], usage=usage, metrics=metrics)
 
@@ -545,5 +553,7 @@ async def stream_messages(
         **({"dynamic_trailing_blocks": dynamic_trailing_blocks} if dynamic_trailing_blocks else {}),
     )
 
-    async for event in process_stream(chunks, start_time, cancel_signal):
-        yield event
+    events = process_stream(chunks, start_time, cancel_signal)
+    async with aclosing(events):
+        async for event in events:
+            yield event

--- a/strands-py/src/strands/telemetry/tracer.py
+++ b/strands-py/src/strands/telemetry/tracer.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 REDACTED_VALUE = "[REDACTED]"
+_CANCELLATION_TYPE_KEY = "strands.cancellation.type"
 
 
 class JSONEncoder(json.JSONEncoder):
@@ -283,8 +284,9 @@ class Tracer:
         self,
         span: Span,
         attributes: dict[str, AttributeValue] | None = None,
-        error: Exception | None = None,
+        error: BaseException | None = None,
         error_message: str | None = None,
+        cancelled: bool = False,
     ) -> None:
         """Generic helper method to end a span.
 
@@ -293,6 +295,7 @@ class Tracer:
             attributes: Optional attributes to set before ending the span
             error: Optional exception if an error occurred
             error_message: Optional error message to set in the span status
+            cancelled: Whether the operation ended through cancellation.
         """
         if not span or not span.is_recording():
             return
@@ -312,14 +315,14 @@ class Tracer:
                 span.record_exception(error)
             elif error_message:
                 span.set_status(StatusCode.ERROR, error_message)
-            else:
+            elif not cancelled:
                 span.set_status(StatusCode.OK)
         except Exception as e:
             logger.warning("error=<%s> | error while ending span", e, exc_info=True)
         finally:
             span.end()
 
-    def end_span_with_error(self, span: Span, error_message: str, exception: Exception | None = None) -> None:
+    def end_span_with_error(self, span: Span, error_message: str, exception: BaseException | None = None) -> None:
         """End a span with error status.
 
         Args:
@@ -332,6 +335,19 @@ class Tracer:
 
         error = exception or Exception(error_message)
         self._end_span(span, error=error, error_message=error_message)
+
+    def _end_span_with_cancellation(self, span: Span, cancellation: BaseException) -> None:
+        """End a cancelled span without marking the operation successful or failed.
+
+        Args:
+            span: The span to end.
+            cancellation: The exception that cancelled the operation.
+        """
+        self._end_span(
+            span,
+            attributes={_CANCELLATION_TYPE_KEY: type(cancellation).__name__},
+            cancelled=True,
+        )
 
     def _add_event(
         self, span: Span | None, event_name: str, event_attributes: Attributes, to_span_attributes: bool = False
@@ -558,7 +574,9 @@ class Tracer:
 
         return span
 
-    def end_tool_call_span(self, span: Span, tool_result: ToolResult | None, error: Exception | None = None) -> None:
+    def end_tool_call_span(
+        self, span: Span, tool_result: ToolResult | None, error: BaseException | None = None
+    ) -> None:
         """End a tool call span with results.
 
         Args:
@@ -769,7 +787,7 @@ class Tracer:
         self,
         span: Span,
         response: AgentResult | None = None,
-        error: Exception | None = None,
+        error: BaseException | None = None,
     ) -> None:
         """End an agent span with results and metrics.
 

--- a/strands-py/src/strands/tools/decorator.py
+++ b/strands-py/src/strands/tools/decorator.py
@@ -46,6 +46,7 @@ import inspect
 import json
 import logging
 from collections.abc import Callable
+from contextlib import aclosing
 from typing import (
     Annotated,
     Any,
@@ -622,8 +623,9 @@ class DecoratedFunctionTool(AgentTool, Generic[P, R]):
             # Async-generators, yield streaming events and final tool result
             if inspect.isasyncgenfunction(self._tool_func):
                 sub_events = self._tool_func(**validated_input)  # type: ignore
-                async for sub_event in sub_events:
-                    yield ToolStreamEvent(tool_use, sub_event)
+                async with aclosing(sub_events):
+                    async for sub_event in sub_events:
+                        yield ToolStreamEvent(tool_use, sub_event)
 
                 # The last event is the result
                 yield self._wrap_tool_result(tool_use_id, sub_event)

--- a/strands-py/src/strands/tools/executors/_executor.py
+++ b/strands-py/src/strands/tools/executors/_executor.py
@@ -8,6 +8,7 @@ import abc
 import logging
 import time
 from collections.abc import AsyncGenerator
+from contextlib import aclosing
 from typing import TYPE_CHECKING, Any, cast
 
 from opentelemetry import trace as trace_api
@@ -243,32 +244,34 @@ class ToolExecutor(abc.ABC):
                 )
 
                 result_event: ToolResultEvent | None = None
-                async for event in agent._middleware_registry.invoke(
+                events = agent._middleware_registry.invoke(
                     ExecuteToolStage,
                     middleware_context,
                     _make_execute_tool_terminal(kwargs),
-                ):
-                    # Tool-originated interrupt: a ToolInterruptEvent yielded from tool.stream()
-                    # (including sub-agent interrupts propagated via _AgentAsTool). Distinct from
-                    # the middleware-initiated InterruptException handled below — this one rides
-                    # the event stream rather than unwinding it. Register its interrupts so
-                    # _interrupt_state.resume() can locate them by id, surface the event, and
-                    # short-circuit here: a halted tool has no result, so the after-hook and the
-                    # result handling below are intentionally skipped.
-                    if isinstance(event, ToolInterruptEvent):
-                        for interrupt in event.interrupts:
-                            agent._interrupt_state.interrupts.setdefault(interrupt.id, interrupt)
-                        yield event
-                        return
+                )
+                async with aclosing(events):
+                    async for event in events:
+                        # Tool-originated interrupt: a ToolInterruptEvent yielded from tool.stream()
+                        # (including sub-agent interrupts propagated via _AgentAsTool). Distinct from
+                        # the middleware-initiated InterruptException handled below — this one rides
+                        # the event stream rather than unwinding it. Register its interrupts so
+                        # _interrupt_state.resume() can locate them by id, surface the event, and
+                        # short-circuit here: a halted tool has no result, so the after-hook and the
+                        # result handling below are intentionally skipped.
+                        if isinstance(event, ToolInterruptEvent):
+                            for interrupt in event.interrupts:
+                                agent._interrupt_state.interrupts.setdefault(interrupt.id, interrupt)
+                            yield event
+                            return
 
-                    # Capture the result but keep draining: middleware may yield trailing
-                    # events after it, and the last ToolResultEvent wins (matching the model
-                    # stage). It is re-emitted only after AfterToolCallEvent runs, since hooks
-                    # may rewrite it. All non-result events flow through as they arrive.
-                    if isinstance(event, ToolResultEvent):
-                        result_event = event
-                    else:
-                        yield event
+                        # Capture the result but keep draining: middleware may yield trailing
+                        # events after it, and the last ToolResultEvent wins (matching the model
+                        # stage). It is re-emitted only after AfterToolCallEvent runs, since hooks
+                        # may rewrite it. All non-result events flow through as they arrive.
+                        if isinstance(event, ToolResultEvent):
+                            result_event = event
+                        else:
+                            yield event
 
                 if result_event is None:
                     raise RuntimeError(
@@ -365,31 +368,49 @@ class ToolExecutor(abc.ABC):
         tool_trace = Trace(f"Tool: {tool_name}", parent_id=cycle_trace.id, raw_name=tool_name)
         tool_start_time = time.time()
 
-        with trace_api.use_span(tool_call_span):
-            async for event in ToolExecutor._stream(
-                agent, tool_use, tool_results, invocation_state, structured_output_context, **kwargs
-            ):
-                yield event
+        with trace_api.use_span(tool_call_span, end_on_exit=False):
+            try:
+                events = ToolExecutor._stream(
+                    agent, tool_use, tool_results, invocation_state, structured_output_context, **kwargs
+                )
+                terminal_event_seen = False
+                async with aclosing(events):
+                    async for event in events:
+                        if isinstance(event, ToolInterruptEvent):
+                            tool_duration = time.time() - tool_start_time
+                            if ToolExecutor._is_agent(agent):
+                                agent.event_loop_metrics.add_tool_usage(tool_use, tool_duration, tool_trace, False)
+                            cycle_trace.add_child(tool_trace)
+                            tracer.end_tool_call_span(tool_call_span, tool_result=None)
+                            terminal_event_seen = True
+                            yield event
+                            continue
 
-            if isinstance(event, ToolInterruptEvent):
-                tool_duration = time.time() - tool_start_time
-                if ToolExecutor._is_agent(agent):
-                    agent.event_loop_metrics.add_tool_usage(tool_use, tool_duration, tool_trace, False)
-                cycle_trace.add_child(tool_trace)
-                tracer.end_tool_call_span(tool_call_span, tool_result=None)
-                return
+                        if isinstance(event, ToolResultEvent):
+                            result = event.tool_result
+                            tool_success = result.get("status") == "success"
+                            tool_duration = time.time() - tool_start_time
+                            message = Message(role="user", content=[{"toolResult": result}])
+                            if ToolExecutor._is_agent(agent):
+                                agent.event_loop_metrics.add_tool_usage(
+                                    tool_use, tool_duration, tool_trace, tool_success, message
+                                )
+                            cycle_trace.add_child(tool_trace)
+                            tracer.end_tool_call_span(tool_call_span, result, error=event.exception)
+                            terminal_event_seen = True
+                            yield event
+                            continue
 
-            result_event = cast(ToolResultEvent, event)
-            result = result_event.tool_result
+                        yield event
 
-            tool_success = result.get("status") == "success"
-            tool_duration = time.time() - tool_start_time
-            message = Message(role="user", content=[{"toolResult": result}])
-            if ToolExecutor._is_agent(agent):
-                agent.event_loop_metrics.add_tool_usage(tool_use, tool_duration, tool_trace, tool_success, message)
-            cycle_trace.add_child(tool_trace)
-
-            tracer.end_tool_call_span(tool_call_span, result, error=result_event.exception)
+                if not terminal_event_seen:
+                    raise RuntimeError("Tool stream produced no terminal event")
+            except Exception as error:
+                tracer.end_span_with_error(tool_call_span, str(error), error)
+                raise
+            except BaseException as cancellation:
+                tracer._end_span_with_cancellation(tool_call_span, cancellation)
+                raise
 
     @abc.abstractmethod
     # pragma: no cover
@@ -471,22 +492,24 @@ def _make_execute_tool_terminal(
         yielded_any = False
         last_raw_event: Any = None
         try:
-            async for event in ctx.tool.stream(tool_use, ctx.invocation_state, **extra_kwargs):
-                if isinstance(event, ToolInterruptEvent):
-                    yield event
-                    return
+            events = ctx.tool.stream(tool_use, ctx.invocation_state, **extra_kwargs)
+            async with aclosing(events):
+                async for event in events:
+                    if isinstance(event, ToolInterruptEvent):
+                        yield event
+                        return
 
-                if isinstance(event, ToolResultEvent):
-                    # Re-emit so the exception decorated tools attach rides along as the result.
-                    yield ToolResultEvent(event.tool_result, exception=event.exception)
-                    return
+                    if isinstance(event, ToolResultEvent):
+                        # Re-emit so the exception decorated tools attach rides along as the result.
+                        yield ToolResultEvent(event.tool_result, exception=event.exception)
+                        return
 
-                if isinstance(event, ToolStreamEvent):
-                    yield event
-                else:
-                    yield ToolStreamEvent(tool_use, event)
-                yielded_any = True
-                last_raw_event = event
+                    if isinstance(event, ToolStreamEvent):
+                        yield event
+                    else:
+                        yield ToolStreamEvent(tool_use, event)
+                    yielded_any = True
+                    last_raw_event = event
         except InterruptException:
             # A tool-raised interrupt must halt the agent — let it unwind rather than
             # becoming an error result (matches TS re-throwing InterruptError).

--- a/strands-py/src/strands/tools/executors/concurrent.py
+++ b/strands-py/src/strands/tools/executors/concurrent.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from collections.abc import AsyncGenerator
+from contextlib import aclosing
 from typing import TYPE_CHECKING, Any
 
 from typing_extensions import override
@@ -122,10 +123,11 @@ class ConcurrentToolExecutor(ToolExecutor):
             events = ToolExecutor._stream_with_trace(
                 agent, tool_use, tool_results, cycle_trace, cycle_span, invocation_state, structured_output_context
             )
-            async for event in events:
-                task_queue.put_nowait((task_id, event))
-                await task_event.wait()
-                task_event.clear()
+            async with aclosing(events):
+                async for event in events:
+                    task_queue.put_nowait((task_id, event))
+                    await task_event.wait()
+                    task_event.clear()
 
         except Exception as e:
             task_queue.put_nowait((task_id, e))

--- a/strands-py/src/strands/tools/executors/sequential.py
+++ b/strands-py/src/strands/tools/executors/sequential.py
@@ -1,6 +1,7 @@
 """Sequential tool executor implementation."""
 
 from collections.abc import AsyncGenerator
+from contextlib import aclosing
 from typing import TYPE_CHECKING, Any
 
 from typing_extensions import override
@@ -61,11 +62,12 @@ class SequentialToolExecutor(ToolExecutor):
             events = ToolExecutor._stream_with_trace(
                 agent, tool_use, tool_results, cycle_trace, cycle_span, invocation_state, structured_output_context
             )
-            async for event in events:
-                if isinstance(event, ToolInterruptEvent):
-                    interrupted = True
+            async with aclosing(events):
+                async for event in events:
+                    if isinstance(event, ToolInterruptEvent):
+                        interrupted = True
 
-                yield event
+                    yield event
 
             if interrupted:
                 break

--- a/strands-py/tests/strands/agent/test_agent.py
+++ b/strands-py/tests/strands/agent/test_agent.py
@@ -1,3 +1,4 @@
+import asyncio
 import copy
 import importlib
 import json
@@ -6,11 +7,15 @@ import textwrap
 import threading
 import unittest.mock
 import warnings
+from collections import Counter
 from collections.abc import AsyncGenerator
 from typing import Any
 from uuid import uuid4
 
 import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from pydantic import BaseModel
 
 import strands
@@ -26,7 +31,7 @@ from strands.interrupt import Interrupt
 from strands.memory import MemoryManager, MemoryManagerConfig
 from strands.models.bedrock import DEFAULT_BEDROCK_MODEL_ID, BedrockModel
 from strands.session.repository_session_manager import RepositorySessionManager
-from strands.telemetry.tracer import serialize
+from strands.telemetry.tracer import Tracer, serialize
 from strands.types._events import EventLoopStopEvent, ModelStreamEvent
 from strands.types.agent import ConcurrentInvocationMode
 from strands.types.content import ContentBlock, Messages
@@ -1485,6 +1490,275 @@ async def test_agent_stream_async_creates_and_ends_span_on_success(
 
     # Verify span was ended with the result
     mock_tracer.end_agent_span.assert_called_once_with(span=mock_span, response=expected_response)
+
+
+@pytest.mark.asyncio
+@unittest.mock.patch("strands.agent.agent.get_tracer")
+async def test_agent_stream_async_ends_span_before_result_yield(mock_get_tracer, mock_event_loop_cycle, mock_model):
+    # Guards terminal-result span ordering for https://github.com/strands-agents/harness-sdk/issues/3609.
+    mock_tracer = unittest.mock.MagicMock()
+    mock_span = unittest.mock.MagicMock()
+    mock_tracer.start_agent_span.return_value = mock_span
+    mock_get_tracer.return_value = mock_tracer
+
+    async def test_event_loop(*args, **kwargs):
+        yield EventLoopStopEvent("stop", {"role": "assistant", "content": [{"text": "Agent Response"}]}, {}, {})
+
+    mock_event_loop_cycle.side_effect = test_event_loop
+    agent = Agent(model=mock_model)
+    stream = agent.stream_async("test prompt")
+
+    try:
+        while True:
+            tru_event = await anext(stream)
+            if "result" in tru_event:
+                break
+
+        exp_response = AgentResult(
+            stop_reason="stop",
+            message={"role": "assistant", "content": [{"text": "Agent Response"}]},
+            metrics={},
+            state={},
+        )
+        mock_tracer.end_agent_span.assert_called_once_with(span=mock_span, response=exp_response)
+    finally:
+        await stream.aclose()
+
+
+@pytest.mark.asyncio
+@unittest.mock.patch("strands.agent.agent.get_tracer")
+async def test_agent_stream_async_ends_span_on_cancellation(mock_get_tracer, mock_event_loop_cycle, mock_model, alist):
+    # Guards root-span cancellation for https://github.com/strands-agents/harness-sdk/issues/3609.
+    mock_tracer = unittest.mock.MagicMock()
+    mock_span = unittest.mock.MagicMock()
+    mock_tracer.start_agent_span.return_value = mock_span
+    mock_get_tracer.return_value = mock_tracer
+    cancellation = asyncio.CancelledError()
+
+    async def cancelled_event_loop(*args, **kwargs):
+        raise cancellation
+        yield
+
+    mock_event_loop_cycle.side_effect = cancelled_event_loop
+    agent = Agent(model=mock_model)
+
+    with pytest.raises(asyncio.CancelledError):
+        await alist(agent.stream_async("test prompt"))
+
+    mock_tracer._end_span_with_cancellation.assert_called_once_with(mock_span, cancellation)
+
+
+@pytest.mark.asyncio
+async def test_agent_stream_async_early_close_ends_all_started_spans():
+    # Guards synchronous delegated-generator cleanup for https://github.com/strands-agents/harness-sdk/issues/3609.
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    tracer = Tracer()
+    tracer.tracer_provider = provider
+    tracer.tracer = provider.get_tracer(tracer.service_name)
+
+    model_started = asyncio.Event()
+    model_closed = asyncio.Event()
+    never_complete = asyncio.Event()
+
+    class ClosableSlowModel(MockedModelProvider):
+        async def stream(self, *args, **kwargs):
+            try:
+                model_started.set()
+                yield {"messageStart": {"role": "assistant"}}
+                await never_complete.wait()
+            finally:
+                model_closed.set()
+
+    model = ClosableSlowModel([])
+
+    with (
+        unittest.mock.patch("strands.agent.agent.get_tracer", return_value=tracer),
+        unittest.mock.patch("strands.event_loop.event_loop.get_tracer", return_value=tracer),
+    ):
+        agent = Agent(model=model, callback_handler=None)
+        stream = agent.stream_async("test prompt")
+        try:
+            while not model_started.is_set():
+                await anext(stream)
+        finally:
+            await stream.aclose()
+
+    assert model_closed.is_set()
+    provider.force_flush()
+    tru_span_names = {span.name.split()[0] for span in exporter.get_finished_spans()}
+    exp_span_names = {"invoke_agent", "execute_event_loop_cycle", "chat"}
+    assert tru_span_names == exp_span_names
+
+
+@pytest.mark.asyncio
+async def test_agent_stream_async_early_close_ends_started_tool_span():
+    # Guards synchronous tool-generator cleanup for https://github.com/strands-agents/harness-sdk/issues/3609.
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    tracer = Tracer()
+    tracer.tracer_provider = provider
+    tracer.tracer = provider.get_tracer(tracer.service_name)
+
+    model = MockedModelProvider(
+        [
+            {
+                "role": "assistant",
+                "content": [
+                    {"toolUse": {"toolUseId": "tool-id", "name": "weather", "input": {}}},
+                ],
+            }
+        ]
+    )
+
+    tool_started = asyncio.Event()
+    tool_closed = asyncio.Event()
+    never_complete = asyncio.Event()
+
+    @strands.tool(name="weather")
+    async def weather() -> AsyncGenerator[Any, None]:
+        try:
+            tool_started.set()
+            yield "partial"
+            await never_complete.wait()
+        finally:
+            tool_closed.set()
+
+    with (
+        unittest.mock.patch("strands.agent.agent.get_tracer", return_value=tracer),
+        unittest.mock.patch("strands.event_loop.event_loop.get_tracer", return_value=tracer),
+        unittest.mock.patch("strands.tools.executors._executor.get_tracer", return_value=tracer),
+    ):
+        agent = Agent(model=model, tools=[weather], callback_handler=None)
+        stream = agent.stream_async("test prompt")
+        try:
+            while not tool_started.is_set():
+                await anext(stream)
+        finally:
+            await stream.aclose()
+
+    assert tool_closed.is_set()
+    provider.force_flush()
+    tru_span_names = {span.name.split()[0] for span in exporter.get_finished_spans()}
+    exp_span_names = {"invoke_agent", "execute_event_loop_cycle", "chat", "execute_tool"}
+    assert tru_span_names == exp_span_names
+
+
+@pytest.mark.asyncio
+async def test_agent_stream_async_early_close_ends_recursive_cycle_spans():
+    # Guards recursive-cycle cleanup for https://github.com/strands-agents/harness-sdk/issues/3609.
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    tracer = Tracer()
+    tracer.tracer_provider = provider
+    tracer.tracer = provider.get_tracer(tracer.service_name)
+
+    second_model_started = asyncio.Event()
+    never_complete = asyncio.Event()
+
+    class RecursiveSlowModel(MockedModelProvider):
+        async def stream(self, *args, **kwargs):
+            if self.index == 1:
+                second_model_started.set()
+                yield {"messageStart": {"role": "assistant"}}
+                await never_complete.wait()
+                return
+
+            async for event in super().stream(*args, **kwargs):
+                yield event
+
+    model = RecursiveSlowModel(
+        [
+            {
+                "role": "assistant",
+                "content": [
+                    {"toolUse": {"toolUseId": "tool-id", "name": "weather", "input": {}}},
+                ],
+            },
+            {"role": "assistant", "content": [{"text": "unused"}]},
+        ]
+    )
+
+    @strands.tool(name="weather")
+    def weather():
+        return "sunny"
+
+    with (
+        unittest.mock.patch("strands.agent.agent.get_tracer", return_value=tracer),
+        unittest.mock.patch("strands.event_loop.event_loop.get_tracer", return_value=tracer),
+        unittest.mock.patch("strands.tools.executors._executor.get_tracer", return_value=tracer),
+    ):
+        agent = Agent(model=model, tools=[weather], callback_handler=None)
+        stream = agent.stream_async("test prompt")
+        try:
+            while not second_model_started.is_set():
+                await anext(stream)
+        finally:
+            await stream.aclose()
+
+    provider.force_flush()
+    tru_span_names = Counter(span.name.split()[0] for span in exporter.get_finished_spans())
+    exp_span_names = Counter({"invoke_agent": 1, "execute_event_loop_cycle": 2, "chat": 2, "execute_tool": 1})
+    assert tru_span_names == exp_span_names
+
+
+@pytest.mark.asyncio
+async def test_agent_stream_async_early_close_ends_forced_structured_output_spans():
+    # Guards forced structured-output recursion for https://github.com/strands-agents/harness-sdk/issues/3609.
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    tracer = Tracer()
+    tracer.tracer_provider = provider
+    tracer.tracer = provider.get_tracer(tracer.service_name)
+
+    second_model_started = asyncio.Event()
+    never_complete = asyncio.Event()
+
+    class StructuredResult(BaseModel):
+        answer: str
+
+    class ForcedOutputSlowModel(MockedModelProvider):
+        async def stream(self, *args, **kwargs):
+            if self.index == 1:
+                second_model_started.set()
+                yield {"messageStart": {"role": "assistant"}}
+                await never_complete.wait()
+                return
+
+            async for event in super().stream(*args, **kwargs):
+                yield event
+
+    model = ForcedOutputSlowModel(
+        [
+            {"role": "assistant", "content": [{"text": "not structured"}]},
+            {"role": "assistant", "content": [{"text": "unused"}]},
+        ]
+    )
+
+    with (
+        unittest.mock.patch("strands.agent.agent.get_tracer", return_value=tracer),
+        unittest.mock.patch("strands.event_loop.event_loop.get_tracer", return_value=tracer),
+    ):
+        agent = Agent(model=model, callback_handler=None)
+        stream = agent.stream_async("test prompt", structured_output_model=StructuredResult)
+        try:
+            while not second_model_started.is_set():
+                await anext(stream)
+        finally:
+            await stream.aclose()
+
+    provider.force_flush()
+    tru_span_names = Counter(span.name.split()[0] for span in exporter.get_finished_spans())
+    exp_span_names = Counter({"invoke_agent": 1, "execute_event_loop_cycle": 2, "chat": 2})
+    assert tru_span_names == exp_span_names
 
 
 @unittest.mock.patch("strands.agent.agent.get_tracer")

--- a/strands-py/tests/strands/agent/test_agent_as_tool.py
+++ b/strands-py/tests/strands/agent/test_agent_as_tool.py
@@ -1,5 +1,6 @@
 """Tests for _AgentAsTool - the agent-as-tool adapter."""
 
+import asyncio
 from unittest.mock import MagicMock
 
 import pytest
@@ -131,6 +132,31 @@ async def test_stream_success(tool, mock_agent, tool_use, agent_result):
     assert len(result_events) == 1
     assert result_events[0]["tool_result"]["status"] == "success"
     assert result_events[0]["tool_result"]["content"][0]["text"] == "response text\n"
+
+
+@pytest.mark.asyncio
+async def test_stream_close_closes_agent_stream(tool, mock_agent, tool_use):
+    started = asyncio.Event()
+    closed = asyncio.Event()
+    never_complete = asyncio.Event()
+
+    async def slow_stream():
+        try:
+            started.set()
+            yield {"event": "partial"}
+            await never_complete.wait()
+        finally:
+            closed.set()
+
+    mock_agent.stream_async.return_value = slow_stream()
+    stream = tool.stream(tool_use, {})
+    try:
+        while not started.is_set():
+            await anext(stream)
+    finally:
+        await stream.aclose()
+
+    assert closed.is_set()
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests/strands/event_loop/test_event_loop.py
+++ b/strands-py/tests/strands/event_loop/test_event_loop.py
@@ -8,6 +8,7 @@ import pytest
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import StatusCode
 
 import strands
 import strands._middleware
@@ -658,6 +659,73 @@ async def test_event_loop_cycle_creates_spans(
     assert call_kwargs["system_prompt_content"] == [{"text": agent.system_prompt}]
     mock_tracer.end_model_invoke_span.assert_called_once()
     mock_tracer.end_event_loop_cycle_span.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_event_loop_tracing_ends_spans_on_timeout(agent, model, alist):
+    # Guards cancellation-safe span export for https://github.com/strands-agents/harness-sdk/issues/3609.
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    tracer = Tracer()
+    tracer.tracer_provider = provider
+    tracer.tracer = provider.get_tracer(tracer.service_name)
+
+    model_started = asyncio.Event()
+    never_complete = asyncio.Event()
+
+    async def slow_stream():
+        model_started.set()
+        yield {"messageStart": {"role": "assistant"}}
+        await never_complete.wait()
+
+    agent.trace_span = None
+    agent._system_prompt_content = None
+    model.config = {"model_id": "test-model"}
+    model.stream.return_value = slow_stream()
+
+    with patch("strands.event_loop.event_loop.get_tracer", return_value=tracer):
+        stream = strands.event_loop.event_loop.event_loop_cycle(agent=agent, invocation_state={})
+        task = asyncio.create_task(alist(stream))
+        await asyncio.wait_for(model_started.wait(), timeout=1)
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(task, timeout=0.01)
+
+    provider.force_flush()
+    tru_spans = {span.name: span for span in exporter.get_finished_spans()}
+    exp_span_names = {"chat", "execute_event_loop_cycle"}
+    assert set(tru_spans) == exp_span_names
+    assert all(span.status.status_code == StatusCode.UNSET for span in tru_spans.values())
+    assert all(span.attributes["strands.cancellation.type"] == "CancelledError" for span in tru_spans.values())
+
+
+@pytest.mark.asyncio
+async def test_stop_for_interrupts_ends_cycle_span_before_yield(agent, messages, mock_tracer):
+    # Guards terminal-event span ordering for https://github.com/strands-agents/harness-sdk/issues/3609.
+    agent.event_loop_metrics = MagicMock()
+    cycle_span = MagicMock()
+    cycle_trace = MagicMock()
+    interrupt = Interrupt(id="interrupt-id", name="approval")
+    stream = strands.event_loop.event_loop._stop_for_interrupts(
+        agent=agent,
+        message=messages[0],
+        tool_results=[],
+        interrupts=[interrupt],
+        cycle_start_time=0,
+        cycle_trace=cycle_trace,
+        cycle_span=cycle_span,
+        invocation_state={"request_state": {}},
+        tracer=mock_tracer,
+    )
+
+    try:
+        tru_event = await anext(stream)
+        exp_stop_reason = "interrupt"
+        assert tru_event["stop"][0] == exp_stop_reason
+        mock_tracer.end_event_loop_cycle_span.assert_called_once_with(span=cycle_span, message=messages[0])
+    finally:
+        await stream.aclose()
 
 
 @patch("strands.event_loop.event_loop.get_tracer")

--- a/strands-py/tests/strands/telemetry/test_tracer.py
+++ b/strands-py/tests/strands/telemetry/test_tracer.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import os
@@ -106,6 +107,24 @@ def test_end_span(mock_span):
     # Check that set_attributes was called with the provided attributes
     mock_span.set_attributes.assert_called_once_with({"key": "value"})
     mock_span.set_status.assert_called_once_with(StatusCode.OK)
+    mock_span.end.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "cancellation",
+    [asyncio.CancelledError(), GeneratorExit(), KeyboardInterrupt(), SystemExit()],
+)
+def test_end_span_with_cancellation(mock_span, cancellation):
+    # Guards cancellation status and attribution for https://github.com/strands-agents/harness-sdk/issues/3609.
+    tracer = Tracer()
+
+    tracer._end_span_with_cancellation(mock_span, cancellation)
+
+    tru_attributes = mock_span.set_attributes.call_args.args[0]
+    exp_attributes = {"strands.cancellation.type": type(cancellation).__name__}
+    assert tru_attributes == exp_attributes
+    mock_span.set_status.assert_not_called()
+    mock_span.record_exception.assert_not_called()
     mock_span.end.assert_called_once()
 
 

--- a/strands-py/tests/strands/tools/executors/test_executor.py
+++ b/strands-py/tests/strands/tools/executors/test_executor.py
@@ -1,13 +1,18 @@
+import asyncio
 import unittest.mock
 from unittest.mock import ANY, MagicMock
 
 import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 import strands
 from strands.experimental.hooks.events import BidiAfterToolCallEvent
 from strands.hooks import AfterToolCallEvent, BeforeToolCallEvent
 from strands.interrupt import Interrupt
 from strands.telemetry.metrics import Trace
+from strands.telemetry.tracer import Tracer
 from strands.tools.executors._executor import ToolExecutor
 from strands.types._events import ToolCancelEvent, ToolInterruptEvent, ToolResultEvent, ToolStreamEvent
 from strands.types.tools import ToolUse
@@ -995,6 +1000,106 @@ async def test_executor_stream_with_trace_error(
     assert error_arg is not None
     assert isinstance(error_arg, RuntimeError)
     assert "Tool error" in str(error_arg)
+
+
+@pytest.mark.asyncio
+async def test_executor_stream_with_trace_ends_span_on_escaping_error(
+    executor, tracer, agent, tool_results, cycle_trace, cycle_span, invocation_state, alist
+):
+    # Guards tool-span error cleanup for https://github.com/strands-agents/harness-sdk/issues/3609.
+    tool_use: ToolUse = {"name": "exception_tool", "toolUseId": "1", "input": {}}
+    error = RuntimeError("tool stream failed")
+
+    async def error_stream(*args, **kwargs):
+        raise error
+        yield
+
+    with unittest.mock.patch.object(ToolExecutor, "_stream", new=error_stream):
+        stream = executor._stream_with_trace(agent, tool_use, tool_results, cycle_trace, cycle_span, invocation_state)
+        with pytest.raises(RuntimeError, match="tool stream failed"):
+            await alist(stream)
+
+    tool_span = tracer.start_tool_call_span.return_value
+    tracer.end_span_with_error.assert_called_once_with(tool_span, str(error), error)
+
+
+@pytest.mark.asyncio
+async def test_executor_stream_with_trace_ends_span_on_cancellation(
+    executor, tracer, agent, tool_results, cycle_trace, cycle_span, invocation_state, alist
+):
+    # Guards tool-span cancellation cleanup for https://github.com/strands-agents/harness-sdk/issues/3609.
+    tool_use: ToolUse = {"name": "weather_tool", "toolUseId": "1", "input": {}}
+    cancellation = asyncio.CancelledError()
+
+    async def cancelled_stream(*args, **kwargs):
+        raise cancellation
+        yield
+
+    with unittest.mock.patch.object(ToolExecutor, "_stream", new=cancelled_stream):
+        stream = executor._stream_with_trace(agent, tool_use, tool_results, cycle_trace, cycle_span, invocation_state)
+        with pytest.raises(asyncio.CancelledError):
+            await alist(stream)
+
+    tool_span = tracer.start_tool_call_span.return_value
+    tracer._end_span_with_cancellation.assert_called_once_with(tool_span, cancellation)
+
+
+@pytest.mark.asyncio
+async def test_executor_stream_with_trace_ends_span_before_interrupt_yield(
+    executor, agent, tool_results, cycle_trace, invocation_state
+):
+    # Guards terminal interrupt ordering for https://github.com/strands-agents/harness-sdk/issues/3609.
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    real_tracer = Tracer()
+    real_tracer.tracer_provider = provider
+    real_tracer.tracer = provider.get_tracer(real_tracer.service_name)
+
+    tool_use: ToolUse = {"name": "weather_tool", "toolUseId": "1", "input": {}}
+    interrupt_event = ToolInterruptEvent(tool_use, [Interrupt(id="interrupt-id", name="approval")])
+
+    async def interrupt_stream(*args, **kwargs):
+        yield interrupt_event
+
+    with (
+        unittest.mock.patch.object(strands.tools.executors._executor, "get_tracer", return_value=real_tracer),
+        unittest.mock.patch.object(ToolExecutor, "_stream", new=interrupt_stream),
+    ):
+        stream = executor._stream_with_trace(agent, tool_use, tool_results, cycle_trace, None, invocation_state)
+        try:
+            tru_event = await anext(stream)
+            provider.force_flush()
+            assert tru_event is interrupt_event
+            assert [span.name for span in exporter.get_finished_spans()] == ["execute_tool weather_tool"]
+        finally:
+            await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_executor_stream_with_trace_ends_span_before_result_yield(
+    executor, agent, tool_results, cycle_trace, invocation_state
+):
+    # Guards terminal result ordering for https://github.com/strands-agents/harness-sdk/issues/3609.
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    real_tracer = Tracer()
+    real_tracer.tracer_provider = provider
+    real_tracer.tracer = provider.get_tracer(real_tracer.service_name)
+
+    tool_use: ToolUse = {"name": "weather_tool", "toolUseId": "1", "input": {}}
+    with unittest.mock.patch.object(strands.tools.executors._executor, "get_tracer", return_value=real_tracer):
+        stream = executor._stream_with_trace(agent, tool_use, tool_results, cycle_trace, None, invocation_state)
+        try:
+            tru_event = await anext(stream)
+            provider.force_flush()
+            assert isinstance(tru_event, ToolResultEvent)
+            assert [span.name for span in exporter.get_finished_spans()] == ["execute_tool weather_tool"]
+        finally:
+            await stream.aclose()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Cancelled or interrupted Python agent invocations can leave active OpenTelemetry spans unended, so exporters drop the trace. This also breaks downstream trace consumers such as AgentCore Evaluations.

This draft makes timeout, task cancellation, explicit stream close, and terminal interrupt/result paths close their complete agent/cycle/model/tool iterator and span chain. Routine cancellation remains `StatusCode.UNSET` with `strands.cancellation.type`; successful and failing paths retain their existing `OK` and `ERROR` semantics. It preserves the original diagnosis and credit from @Di-Is in #2068.

Callout: a plain `async for ...: break` without retaining and explicitly closing the iterator still depends on Python async-generator finalization. Memory/extraction spans are also outside this draft, so it does not claim the entire issue is resolved.

## Related Issues

Related to #3609

Related to #2068

## Documentation PR

N/A — no documentation change is required for this internal lifecycle fix.

## Type of Change

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
