### PR TITLE
feat: add strands-xa11y to integrations catalog

### DIFF
--- a/site/src/content/catalog/strands-xa11y.yaml
+++ b/site/src/content/catalog/strands-xa11y.yaml
@@ -1,0 +1,9 @@
+name: strands-xa11y
+description: Give agents computer use on macOS, Windows, and Linux. Control native desktop apps through the OS accessibility tree.
+integrationType: tool
+languages:
+  python:
+    package: strands-xa11y
+github: https://github.com/xa11y/xa11y
+docsUrl: https://xa11y.dev/guides/strands/
+addedDate: 2026-08-22


### PR DESCRIPTION
## Integration submission

<!-- This template is for adding or updating an entry on the integrations page at strandsagents.com/integrations.
     Full submission guide and YAML field reference: https://strandsagents.com/docs/integrations/get-featured/
     The site build validates your YAML against the schema automatically — a CI failure here is a schema error in your entry file. -->

**Package name:** strands-xa11y
**Integration type:** tool
**Languages published:** Python
**GitHub repo:** https://github.com/xa11y/xa11y
**What it does:** Gives Strands agents computer use on macOS, Windows, and Linux by driving native desktop apps through the OS accessibility tree.
**Relationship to service:** community-built
**Docs link included:** docsUrl — https://xa11y.dev/guides/strands/

### Submitter checklist

#### Package
- [x] This is a reusable integration (library/plugin/provider), not an example agent or application built with Strands
- [x] Published to PyPI and/or npm under the exact `package` name in my entry (registry links are derived from it) — or this is a guide-only entry (no `package` in any language block) with a `docsUrl` pointing at the vendor's Strands guide
- [x] GitHub repository is public and includes a license

#### Entry
- [x] Description accurately states what the package does in one sentence
- [x] `integrationType` matches what the package actually is
- [x] All URLs are working (`github`, and `docsUrl` if set)
- [x] `addedDate` is set to today (the date I opened this PR)
- [x] `featured` and `badges` are left unset — those are granted by the Strands team

#### Docs (only if setting a `docsUrl`)
- [x] The linked page documents using this integration with Strands Agents

#### Conduct
- [x] I am the package maintainer, or I have the maintainer's explicit consent to list it
- [x] Entry uses the package's real name with no trademark misuse

---

### For reviewers

- Package installs cleanly and imports without error against the current SDK release (guide-only entries: the `docsUrl` guide's setup steps work instead)
- Description matches what the package's README says it does
- No existing catalog entry for this package (`site/src/content/catalog/`)
- All URLs are reachable and resolve to the expected destinations
- `addedDate` matches the submission date and `featured`/`badges` are unset (CI labels the PR `catalog: editorial-review` if a non-maintainer sets them)
- The `docsUrl` page (if set) is a real Strands integration guide, not a generic product page
