### PR TITLE
Fix: Agent As Tool: Pass invocation state and additional arguments to subagent

### DIFF
--- a/strands-py/src/strands/agent/_agent_as_tool.py
+++ b/strands-py/src/strands/agent/_agent_as_tool.py
@@ -217,7 +217,7 @@ class _AgentAsTool(AgentTool):
             logger.debug("tool_name=<%s>, tool_use_id=<%s> | invoking agent", self._tool_name, tool_use_id)
 
             result = None
-            async for event in self._agent.stream_async(prompt):
+            async for event in self._agent.stream_async(prompt, invocation_state=invocation_state, **kwargs):
                 if "result" in event:
                     result = event["result"]
                 else:

--- a/strands-py/src/strands/agent/_agent_as_tool.py
+++ b/strands-py/src/strands/agent/_agent_as_tool.py
@@ -217,7 +217,7 @@ class _AgentAsTool(AgentTool):
             logger.debug("tool_name=<%s>, tool_use_id=<%s> | invoking agent", self._tool_name, tool_use_id)
 
             result = None
-            async for event in self._agent.stream_async(prompt, invocation_state=dict(invocation_state), **kwargs):
+            async for event in self._agent.stream_async(prompt, invocation_state=dict(invocation_state)):
                 if "result" in event:
                     result = event["result"]
                 else:

--- a/strands-py/src/strands/agent/_agent_as_tool.py
+++ b/strands-py/src/strands/agent/_agent_as_tool.py
@@ -217,7 +217,7 @@ class _AgentAsTool(AgentTool):
             logger.debug("tool_name=<%s>, tool_use_id=<%s> | invoking agent", self._tool_name, tool_use_id)
 
             result = None
-            async for event in self._agent.stream_async(prompt, invocation_state=invocation_state, **kwargs):
+            async for event in self._agent.stream_async(prompt, invocation_state=dict(invocation_state), **kwargs):
                 if "result" in event:
                     result = event["result"]
                 else:

--- a/strands-py/tests/strands/agent/test_agent_as_tool.py
+++ b/strands-py/tests/strands/agent/test_agent_as_tool.py
@@ -140,7 +140,18 @@ async def test_stream_passes_input_to_agent(tool, mock_agent, tool_use, agent_re
     async for _ in tool.stream(tool_use, {}):
         pass
 
-    mock_agent.stream_async.assert_called_once_with("hello")
+    mock_agent.stream_async.assert_called_once_with("hello", invocation_state={})
+
+
+@pytest.mark.asyncio
+async def test_stream_forwards_invocation_state_and_kwargs(tool, mock_agent, tool_use, agent_result):
+    mock_agent.stream_async.return_value = _mock_stream_async(agent_result)
+
+    invocation_state = {"request_id": "req-1"}
+    async for _ in tool.stream(tool_use, invocation_state, extra="value"):
+        pass
+
+    mock_agent.stream_async.assert_called_once_with("hello", invocation_state=invocation_state, extra="value")
 
 
 @pytest.mark.asyncio
@@ -155,7 +166,7 @@ async def test_stream_empty_input(tool, mock_agent, agent_result):
     async for _ in tool.stream(empty_tool_use, {}):
         pass
 
-    mock_agent.stream_async.assert_called_once_with("")
+    mock_agent.stream_async.assert_called_once_with("", invocation_state={})
 
 
 @pytest.mark.asyncio
@@ -170,7 +181,7 @@ async def test_stream_string_input(tool, mock_agent, agent_result):
     async for _ in tool.stream(tool_use, {}):
         pass
 
-    mock_agent.stream_async.assert_called_once_with("direct string")
+    mock_agent.stream_async.assert_called_once_with("direct string", invocation_state={})
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

When an Agent is exposed as a tool, the tool's stream() method receives an
invocation_state dict and additional **kwargs from the parent agent's tool-execution flow. Previously,
these were dropped, ie: stream() only forwarded the resolved prompt to the sub-agent's
stream_async() but nothing else.

This meant the sub-agent ran without any of the invocation context (e.g. request_id and other
caller-supplied state) or extra keyword arguments that the parent agent had for the invocation — the
sub-agent was effectively invoked in isolation, breaking parity with how the parent agent itself is
invoked.

The changes in this PR forward both invocation_state and **kwargs through to the wrapped agent.
Now the sub-agent invocation carries the same invocation state and additional arguments the tool was called
with, so context propagates correctly across the parent → sub-agent boundary.

## Related Issues

#3931 

## Documentation PR

N/A — no documentation change is required.


## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
