### PR TITLE
fix(models): warn and skip cachePoint message blocks instead of raising

### DIFF
--- a/strands-py/src/strands/models/gemini.py
+++ b/strands-py/src/strands/models/gemini.py
@@ -248,6 +248,9 @@ class GeminiModel(Model):
                 if _has_location_source(content):
                     logger.warning("Location sources are not supported by Gemini | skipping content block")
                     continue
+                if "cachePoint" in content:
+                    logger.warning("cachePoint content block is not supported by Gemini | skipping")
+                    continue
                 parts.append(self._format_request_content_part(content, tool_use_id_to_name))
 
             contents.append(

--- a/strands-py/src/strands/models/mistral.py
+++ b/strands-py/src/strands/models/mistral.py
@@ -223,6 +223,10 @@ class MistralModel(Model):
                     logger.warning("Location sources are not supported by Mistral | skipping content block")
                     continue
 
+                if "cachePoint" in content:
+                    logger.warning("cachePoint content block is not supported by Mistral | skipping")
+                    continue
+
                 if "text" in content:
                     formatted_content = self._format_request_message_content(content)
                     if isinstance(formatted_content, str):

--- a/strands-py/src/strands/models/openai.py
+++ b/strands-py/src/strands/models/openai.py
@@ -412,6 +412,9 @@ class OpenAIModel(Model):
                 if _has_location_source(content):
                     logger.warning("Location sources are not supported by OpenAI | skipping content block")
                     continue
+                if "cachePoint" in content:
+                    logger.warning("cachePoint content block is not supported by OpenAI | skipping")
+                    continue
                 filtered_contents.append(content)
 
             formatted_contents = [cls.format_request_message_content(content) for content in filtered_contents]

--- a/strands-py/src/strands/models/openai_responses.py
+++ b/strands-py/src/strands/models/openai_responses.py
@@ -637,10 +637,15 @@ class OpenAIResponsesModel(Model):
                     "reasoningContent is not yet supported in multi-turn conversations with the Responses API"
                 )
 
+            if any("cachePoint" in content for content in contents):
+                logger.warning("cachePoint content block is not supported by OpenAI Responses | skipping")
+
             formatted_contents = [
                 cls._format_request_message_content(content, role=role)
                 for content in contents
-                if not any(block_type in content for block_type in ["toolResult", "toolUse", "reasoningContent"])
+                if not any(
+                    block_type in content for block_type in ["toolResult", "toolUse", "reasoningContent", "cachePoint"]
+                )
             ]
 
             formatted_tool_calls = [

--- a/strands-py/tests/strands/models/test_gemini.py
+++ b/strands-py/tests/strands/models/test_gemini.py
@@ -1587,6 +1587,17 @@ def test_format_request_filters_s3_source_image(model, caplog):
     assert "Location sources are not supported by Gemini" in caplog.text
 
 
+def test_format_request_skips_message_cache_point(model, caplog):
+    caplog.set_level(logging.WARNING, logger="strands.models.gemini")
+
+    messages = [{"role": "user", "content": [{"text": "durable prefix"}, {"cachePoint": {"type": "default"}}]}]
+
+    request = model._format_request(messages, None, None, None)
+
+    assert request["contents"][0]["parts"] == [{"text": "durable prefix"}]
+    assert "cachePoint content block is not supported by Gemini" in caplog.text
+
+
 def test_format_request_filters_location_source_document(model, caplog):
     """Test that documents with Location sources are filtered out with warning."""
     caplog.set_level(logging.WARNING, logger="strands.models.gemini")

--- a/strands-py/tests/strands/models/test_mistral.py
+++ b/strands-py/tests/strands/models/test_mistral.py
@@ -779,6 +779,17 @@ def test_format_request_filters_s3_source_image(model, caplog):
     assert "Location sources are not supported by Mistral" in caplog.text
 
 
+def test_format_request_skips_message_cache_point(model, caplog):
+    caplog.set_level(logging.WARNING, logger="strands.models.mistral")
+
+    messages = [{"role": "user", "content": [{"text": "durable prefix"}, {"cachePoint": {"type": "default"}}]}]
+
+    formatted_messages = model._format_request_messages(messages)
+
+    assert formatted_messages[0]["content"] == "durable prefix"
+    assert "cachePoint content block is not supported by Mistral" in caplog.text
+
+
 def test_format_request_filters_location_source_document(model, caplog):
     """Test that documents with Location sources are filtered out with warning."""
     caplog.set_level(logging.WARNING, logger="strands.models.mistral")

--- a/strands-py/tests/strands/models/test_openai.py
+++ b/strands-py/tests/strands/models/test_openai.py
@@ -1817,6 +1817,17 @@ def test_format_request_filters_s3_source_image(model, caplog):
     assert "Location sources are not supported by OpenAI" in caplog.text
 
 
+def test_format_request_skips_message_cache_point(model, caplog):
+    caplog.set_level(logging.WARNING, logger="strands.models.openai")
+
+    messages = [{"role": "user", "content": [{"text": "durable prefix"}, {"cachePoint": {"type": "default"}}]}]
+
+    request = model.format_request(messages)
+
+    assert request["messages"][0]["content"] == [{"text": "durable prefix", "type": "text"}]
+    assert "cachePoint content block is not supported by OpenAI" in caplog.text
+
+
 def test_format_request_filters_location_source_document(model, caplog):
     """Test that documents with Location sources are filtered out with warning."""
     caplog.set_level(logging.WARNING, logger="strands.models.openai")

--- a/strands-py/tests/strands/models/test_openai_responses.py
+++ b/strands-py/tests/strands/models/test_openai_responses.py
@@ -419,6 +419,16 @@ def test_format_request_messages_assistant_non_text_content_dropped(caplog):
     assert "content_type=<input_image>" in caplog.text
 
 
+def test_format_request_messages_skips_message_cache_point(caplog):
+    messages = [{"role": "user", "content": [{"text": "durable prefix"}, {"cachePoint": {"type": "default"}}]}]
+
+    with caplog.at_level(logging.WARNING, logger="strands.models.openai_responses"):
+        result = OpenAIResponsesModel._format_request_messages(messages)
+
+    assert result == [{"role": "user", "content": [{"type": "input_text", "text": "durable prefix"}]}]
+    assert "cachePoint content block is not supported by OpenAI Responses" in caplog.text
+
+
 def test_format_request_messages_assistant_only_non_text_content_dropped_entirely(caplog):
     """An assistant turn with only non-text content collapses to nothing and is omitted."""
     messages = [


### PR DESCRIPTION
## Description

A `cachePoint` content block that is valid on Bedrock/Anthropic crashed the moment a user switched to another provider: OpenAI, Gemini, OpenAI Responses, and LiteLLM's message path all raised `TypeError: content_type=<cachePoint> | unsupported type`, and Mistral dropped it silently with no signal. That breaks the portability rule — the same conversation content should never crash on a provider switch, and a silently-dropped cache hint should at least warn.

Each provider now warns and skips a message-path `cachePoint`, matching the TypeScript SDK's behavior and the existing warn-and-skip treatment of unsupported blocks (e.g. location sources). The skip lives in each provider's message-content loop alongside those siblings rather than in the leaf formatter, which must return a block and can't cleanly skip. LiteLLM inherits the OpenAI message path, so its message-path fix comes for free (and reuses the "OpenAI" wording); its system-prompt path — the only one that renders `cachePoint` to `cache_control` — is untouched.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

Ran the OpenAI, Gemini, Mistral, OpenAI Responses, and LiteLLM unit suites — no regressions in the existing location-source / cachePoint drop / cachePoint-render cases. Separately exercised the portability guarantee end to end: fed one `messages` list containing a `cachePoint` block through every provider's `format_request`, confirming each returns a request dict (no `TypeError`), emits exactly one warning naming the provider, and drops the block from the wire payload. `hatch fmt --linter` (ruff + mypy strict) is clean.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.