### PR TITLE
feat(py): support multiple continuation inputs

### DIFF
--- a/strands-py/src/strands/agent/_continuation.py
+++ b/strands-py/src/strands/agent/_continuation.py
@@ -1,0 +1,224 @@
+"""Internal continuation handling for agent invocations.
+
+Coordinates continuation inputs contributed by hooks, including preparation,
+interrupt deferral, input combination, and append or abandonment callbacks.
+"""
+
+import inspect
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import cast
+
+from ..hooks.events import AfterInvocationEvent, BeforeModelCallEvent
+from ..types.agent import AgentInput
+from ..types.content import Messages
+
+logger = logging.getLogger(__name__)
+
+_ContinuationEvent = AfterInvocationEvent | BeforeModelCallEvent
+_STATE_ATTRIBUTE = "_continuation_state"
+_DEFERRED_INPUTS_ATTRIBUTE = "_deferred_continuation_inputs"
+
+
+@dataclass(frozen=True)
+class _ContinuationInput:
+    """One internal input contribution to an agent or model invocation.
+
+    When both callbacks are supplied, exactly one runs once. Callback failures
+    are logged and do not change the agent result.
+
+    Attributes:
+        args: Input that normalizes to one or more complete messages.
+        on_appended: Runs after the input is incorporated into agent history.
+        on_abandoned: Runs when the input cannot be incorporated into agent history.
+    """
+
+    args: AgentInput
+    on_appended: Callable[[], Awaitable[None] | None] | None = None
+    on_abandoned: Callable[[object], Awaitable[None] | None] | None = None
+
+
+@dataclass
+class _ContinuationState:
+    inputs: list[_ContinuationInput] = field(default_factory=list)
+    messages: Messages | None = None
+
+
+def add_input(event: _ContinuationEvent, input_: _ContinuationInput) -> None:
+    """Add an input contribution for an invocation event.
+
+    Args:
+        event: Event that owns the continuation input.
+        input_: Input and optional settlement callbacks to register.
+    """
+    state = _get_state(event) or _ContinuationState()
+    state.inputs.append(input_)
+    _set_state(event, state)
+
+
+async def prepare(
+    event: _ContinuationEvent,
+    normalize_input: Callable[[AgentInput], Awaitable[Messages]],
+    stop_reason: str | None = None,
+) -> Messages | None:
+    """Normalize registered inputs and prepare complete message sequences.
+
+    Args:
+        event: Event whose continuation inputs should be prepared.
+        normalize_input: Converts invocation input into messages.
+        stop_reason: Stop reason that determines whether inputs continue now or are deferred.
+
+    Returns:
+        The prepared messages, or ``None`` when no continuation is ready.
+    """
+    if stop_reason == "interrupt":
+        inputs = _consume_inputs(event)
+        if inputs:
+            stored_inputs = cast(list[_ContinuationInput], getattr(event.agent, _DEFERRED_INPUTS_ATTRIBUTE, []))
+            setattr(event.agent, _DEFERRED_INPUTS_ATTRIBUTE, [*stored_inputs, *inputs])
+        return None
+    if stop_reason is not None and stop_reason not in ("end_turn", "stop_sequence"):
+        return None
+
+    deferred_inputs: list[_ContinuationInput] = []
+    if isinstance(event, AfterInvocationEvent):
+        deferred_inputs = cast(
+            list[_ContinuationInput],
+            getattr(event.agent, _DEFERRED_INPUTS_ATTRIBUTE, []),
+        )
+        if hasattr(event.agent, _DEFERRED_INPUTS_ATTRIBUTE):
+            delattr(event.agent, _DEFERRED_INPUTS_ATTRIBUTE)
+    inputs = [*deferred_inputs, *_consume_inputs(event)]
+    accepted_inputs: list[_ContinuationInput] = []
+    messages: Messages = []
+    preparing_state = _ContinuationState(inputs=inputs)
+    _set_state(event, preparing_state)
+
+    for index, input_ in enumerate(inputs):
+        try:
+            normalized = await normalize_input(input_.args)
+            if not _is_complete_message_input(normalized):
+                raise TypeError("Continuation input must contain a complete message sequence")
+            messages.extend(normalized)
+            accepted_inputs.append(input_)
+        except Exception as error:
+            preparing_state.inputs = [*accepted_inputs, *inputs[index + 1 :]]
+            await _notify_abandoned(input_, error)
+
+    if not accepted_inputs:
+        _clear_state(event)
+        return None
+
+    _set_state(event, _ContinuationState(inputs=accepted_inputs, messages=messages))
+    return messages
+
+
+def combine(event: _ContinuationEvent | None, messages: Messages) -> Messages:
+    """Prepend prepared continuation messages to invocation messages.
+
+    Args:
+        event: Event whose prepared messages should be applied.
+        messages: Invocation messages to combine with the prepared messages.
+
+    Returns:
+        The combined messages, or the original messages when no continuation is ready.
+    """
+    state = _get_state(event) if event else None
+    if state is None or state.messages is None:
+        return messages
+    return [*state.messages, *messages]
+
+
+async def mark_appended(event: _ContinuationEvent | None) -> None:
+    """Mark prepared inputs as incorporated into agent history.
+
+    Args:
+        event: Event whose prepared inputs were appended.
+    """
+    if event is None:
+        return
+    state = _get_state(event)
+    if state is None or state.messages is None:
+        return
+
+    for input_ in _consume_inputs(event):
+        try:
+            if input_.on_appended is not None:
+                result = input_.on_appended()
+                if inspect.isawaitable(result):
+                    await result
+        except Exception as error:
+            logger.warning("error=<%s> | continuation append callback failed", error)
+
+
+async def abandon(event: _ContinuationEvent | None, reason: object) -> None:
+    """Abandon the inputs registered for an event.
+
+    Args:
+        event: Event whose inputs should be abandoned.
+        reason: Reason the inputs could not be incorporated.
+    """
+    if event is None:
+        return
+    for input_ in _consume_inputs(event):
+        await _notify_abandoned(input_, reason)
+
+
+# Hook events are unhashable and write-guarded, so continuation state uses private object attributes.
+def _get_state(event: _ContinuationEvent) -> _ContinuationState | None:
+    return getattr(event, _STATE_ATTRIBUTE, None)
+
+
+def _clear_state(event: _ContinuationEvent) -> None:
+    if hasattr(event, _STATE_ATTRIBUTE):
+        object.__delattr__(event, _STATE_ATTRIBUTE)
+
+
+def _set_state(event: _ContinuationEvent, state: _ContinuationState) -> None:
+    object.__setattr__(event, _STATE_ATTRIBUTE, state)
+
+
+def _consume_inputs(event: _ContinuationEvent) -> list[_ContinuationInput]:
+    state = _get_state(event)
+    _clear_state(event)
+    return state.inputs if state else []
+
+
+def _is_complete_message_input(messages: Messages) -> bool:
+    if not messages or messages[-1]["role"] != "user":
+        return False
+
+    pending_tool_use_ids: set[str] = set()
+    for message in messages:
+        if pending_tool_use_ids and message["role"] != "user":
+            return False
+
+        next_tool_use_ids: set[str] = set()
+        for block in message["content"]:
+            if "toolUse" in block:
+                tool_use_id = block["toolUse"]["toolUseId"]
+                if message["role"] != "assistant" or tool_use_id in next_tool_use_ids:
+                    return False
+                next_tool_use_ids.add(tool_use_id)
+            elif "toolResult" in block:
+                tool_use_id = block["toolResult"]["toolUseId"]
+                if message["role"] != "user" or tool_use_id not in pending_tool_use_ids:
+                    return False
+                pending_tool_use_ids.remove(tool_use_id)
+
+        if message["role"] == "user" and pending_tool_use_ids:
+            return False
+        pending_tool_use_ids = next_tool_use_ids
+
+    return not pending_tool_use_ids
+
+
+async def _notify_abandoned(input_: _ContinuationInput, reason: object) -> None:
+    try:
+        if input_.on_abandoned is not None:
+            result = input_.on_abandoned(reason)
+            if inspect.isawaitable(result):
+                await result
+    except Exception as error:
+        logger.warning("error=<%s> | continuation abandon callback failed", error)

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -52,6 +52,7 @@ from ..hooks import (
     AfterInvocationEvent,
     AgentInitializedEvent,
     BeforeInvocationEvent,
+    BeforeModelCallEvent,
     HookCallback,
     HookOrder,
     HookProvider,
@@ -93,6 +94,7 @@ from ..types.content import (
 from ..types.exceptions import ConcurrencyException, ContextWindowOverflowException
 from ..types.tools import AgentTool
 from ..types.traces import AttributeValue
+from . import _continuation
 from ._agent_as_tool import _AgentAsTool
 from ._concurrency import _ConcurrencyController
 from .agent_result import AgentResult
@@ -1379,28 +1381,31 @@ class Agent(AgentBase):
                     # The result is the last EventLoopStopEvent, not the last event overall:
                     # AgentStreamStage middleware may yield trailing events after the stop event.
                     stop_event: EventLoopStopEvent | None = None
-                    async for event in events:
-                        event.prepare(invocation_state=merged_state)
+                    try:
+                        async for event in events:
+                            event.prepare(invocation_state=merged_state)
 
-                        if isinstance(event, EventLoopStopEvent):
-                            stop_event = event
+                            if isinstance(event, EventLoopStopEvent):
+                                stop_event = event
 
-                        if event.is_callback_event:
-                            as_dict = event.as_dict()
-                            callback_handler(**as_dict)
-                            yield as_dict
+                            if event.is_callback_event:
+                                as_dict = event.as_dict()
+                                callback_handler(**as_dict)
+                                yield as_dict
 
-                    if stop_event is None:
-                        raise RuntimeError(
-                            "Agent stream produced no result event. AgentStreamStage middleware must "
-                            "forward events from next() and must not drop the terminal stop event."
-                        )
+                        if stop_event is None:
+                            raise RuntimeError(
+                                "Agent stream produced no result event. AgentStreamStage middleware must "
+                                "forward events from next() and must not drop the terminal stop event."
+                            )
 
-                    result = AgentResult(*stop_event["stop"])
-                    callback_handler(result=result)
-                    yield AgentResultEvent(result=result).as_dict()
+                        result = AgentResult(*stop_event["stop"])
+                        callback_handler(result=result)
+                        yield AgentResultEvent(result=result).as_dict()
 
-                    self._end_agent_trace_span(response=result)
+                        self._end_agent_trace_span(response=result)
+                    finally:
+                        await events.aclose()
 
                 except Exception as e:
                     self._end_agent_trace_span(error=e)
@@ -1442,11 +1447,19 @@ class Agent(AgentBase):
             Events from the event loop cycle.
         """
         current_messages: Messages | None = messages
+        continuation_event: AfterInvocationEvent | None = None
 
         while current_messages is not None:
-            before_invocation_event, _interrupts = await self.hooks.invoke_callbacks_async(
-                BeforeInvocationEvent(agent=self, invocation_state=invocation_state, messages=current_messages)
-            )
+            try:
+                before_invocation_event, _interrupts = await self.hooks.invoke_callbacks_async(
+                    BeforeInvocationEvent(agent=self, invocation_state=invocation_state, messages=current_messages)
+                )
+            except BaseException:
+                await _continuation.abandon(
+                    continuation_event,
+                    RuntimeError("Agent stream closed before continuation input was incorporated into agent history"),
+                )
+                raise
 
             if before_invocation_event.cancel:
                 cancel_text = (
@@ -1459,8 +1472,18 @@ class Agent(AgentBase):
                 yield EventLoopStopEvent(
                     "end_turn", cancel_message, self.event_loop_metrics, invocation_state.get("request_state", {})
                 )
-                await self.hooks.invoke_callbacks_async(
-                    AfterInvocationEvent(agent=self, invocation_state=invocation_state)
+                await _continuation.abandon(
+                    continuation_event, RuntimeError("Continuation was not incorporated into agent history")
+                )
+                after_invocation_event = AfterInvocationEvent(agent=self, invocation_state=invocation_state)
+                try:
+                    await self.hooks.invoke_callbacks_async(after_invocation_event)
+                except BaseException as error:
+                    await _continuation.abandon(after_invocation_event, error)
+                    raise
+                await _continuation.abandon(
+                    after_invocation_event,
+                    RuntimeError("Agent stream closed before continuation input was incorporated into agent history"),
                 )
                 return
 
@@ -1469,6 +1492,7 @@ class Agent(AgentBase):
             )
 
             agent_result: AgentResult | None = None
+            caught_error: BaseException | None = None
             try:
                 yield InitEventLoopEvent()
 
@@ -1478,7 +1502,8 @@ class Agent(AgentBase):
                 for message in self.messages:
                     _ensure_tracking_id(message)
 
-                await self._append_messages(*current_messages)
+                if continuation_event is None:
+                    await self._append_messages(*current_messages)
 
                 structured_output_context = StructuredOutputContext(
                     structured_output_model or self._default_structured_output_model,
@@ -1499,7 +1524,12 @@ class Agent(AgentBase):
                     async for event in self._middleware_registry.invoke(
                         AgentStreamStage,
                         middleware_context,
-                        self._make_agent_stream_terminal(structured_output_context, limits, pass_progress),
+                        self._make_agent_stream_terminal(
+                            structured_output_context,
+                            limits,
+                            pass_progress,
+                            continuation_event,
+                        ),
                     ):
                         if isinstance(event, EventLoopStopEvent):
                             agent_result = AgentResult(*event["stop"])
@@ -1553,32 +1583,69 @@ class Agent(AgentBase):
                     )
                     agent_result = AgentResult(*stop_event["stop"])
                     yield stop_event
-
+            except BaseException as error:
+                caught_error = error
+                raise
             finally:
                 if not self._interrupt_state.activated:
                     self._interrupt_state.end_interrupt_cycle()
 
                 self.conversation_manager.apply_management(self)
-                after_invocation_event, _interrupts = await self.hooks.invoke_callbacks_async(
-                    AfterInvocationEvent(agent=self, invocation_state=invocation_state, result=agent_result)
+                await _continuation.abandon(
+                    continuation_event, RuntimeError("Continuation was not incorporated into agent history")
+                )
+                after_invocation_event = AfterInvocationEvent(
+                    agent=self, invocation_state=invocation_state, result=agent_result
+                )
+                continuation_event = after_invocation_event
+                try:
+                    await self.hooks.invoke_callbacks_async(after_invocation_event)
+                except BaseException as error:
+                    await _continuation.abandon(after_invocation_event, error)
+                    continuation_event = None
+                    raise
+                if caught_error is not None:
+                    await _continuation.abandon(after_invocation_event, caught_error)
+                    continuation_event = None
+
+            stop_reason = agent_result.stop_reason if agent_result is not None else None
+            if stop_reason not in (None, "end_turn", "stop_sequence", "interrupt"):
+                await _continuation.abandon(
+                    after_invocation_event,
+                    RuntimeError(f"Continuation abandoned after {stop_reason}"),
                 )
 
-            # Convert resume input to messages for next iteration, or None to stop
-            if after_invocation_event.resume is not None:
-                logger.debug("resume=<True> | hook requested agent resume with new input")
-                # If in interrupt state, process interrupt responses before continuing.
-                # This mirrors the _interrupt_state.resume() call in stream_async and will
-                # raise TypeError if the resume input is not valid interrupt responses.
-                self._interrupt_state.resume(after_invocation_event.resume)
-                current_messages = await self._convert_prompt_to_messages(after_invocation_event.resume)
-            else:
-                current_messages = None
+            try:
+                continuation_messages = await _continuation.prepare(
+                    after_invocation_event,
+                    self._convert_prompt_to_messages,
+                    stop_reason,
+                )
+                has_continuation = continuation_messages is not None
+                continuation_event = after_invocation_event if has_continuation else None
+
+                if has_continuation or after_invocation_event.resume is not None:
+                    current_messages = []
+                    if after_invocation_event.resume is not None:
+                        logger.debug("resume=<True> | hook requested agent resume with new input")
+                        # If in interrupt state, process interrupt responses before continuing.
+                        # This mirrors the _interrupt_state.resume() call in stream_async and will
+                        # raise TypeError if the resume input is not valid interrupt responses.
+                        self._interrupt_state.resume(after_invocation_event.resume)
+                        current_messages = await self._convert_prompt_to_messages(after_invocation_event.resume)
+                else:
+                    current_messages = None
+            except BaseException as error:
+                await _continuation.abandon(continuation_event, error)
+                continuation_event = None
+                raise
 
     def _make_agent_stream_terminal(
         self,
         structured_output_context: StructuredOutputContext,
         limits: Limits | None,
         pass_progress: _PassProgress,
+        continuation_event: AfterInvocationEvent | None,
     ) -> Callable[["AgentStreamContext"], AsyncGenerator[TypedEvent, None]]:
         """Build the terminal for the AgentStreamStage middleware chain.
 
@@ -1594,6 +1661,8 @@ class Agent(AgentBase):
             limits: Optional per-invocation budget caps.
             pass_progress: Records whether the event loop produced this pass's result, which
                 determines whether resuming the pass would call the model again.
+            continuation_event: Event owning input that must be appended only if the middleware
+                chain reaches the terminal.
 
         Returns:
             An async generator function yielding the pass's events, ending with an
@@ -1601,6 +1670,10 @@ class Agent(AgentBase):
         """
 
         async def terminal(ctx: "AgentStreamContext") -> AsyncGenerator[TypedEvent, None]:
+            if continuation_event is not None:
+                messages = _continuation.combine(continuation_event, ctx.messages)
+                await self._append_continuation_messages(messages, continuation_event)
+
             # Execute the event loop cycle with retry logic for context limits
             events = self._execute_event_loop_cycle(ctx.invocation_state, structured_output_context, limits)
             async for event in events:
@@ -1830,6 +1903,34 @@ class Agent(AgentBase):
         for message in messages:
             _ensure_tracking_id(message)
             self.messages.append(message)
+            await self.hooks.invoke_callbacks_async(MessageAddedEvent(agent=self, message=message))
+
+    async def _append_continuation_messages(
+        self,
+        messages: Messages,
+        continuation_event: AfterInvocationEvent | BeforeModelCallEvent,
+    ) -> None:
+        added_messages: Messages = []
+        for message in messages:
+            last_message = self.messages[-1] if self.messages else None
+            if last_message is None or last_message["role"] != message["role"]:
+                _ensure_tracking_id(message)
+                self.messages.append(message)
+                added_messages.append(message)
+                continue
+
+            appended_message = copy.copy(last_message)
+            appended_message["content"] = [*last_message["content"], *message["content"]]
+            _ensure_tracking_id(appended_message)
+            self.messages[-1] = appended_message
+
+            if added_messages and added_messages[-1] is last_message:
+                added_messages[-1] = appended_message
+            else:
+                added_messages.append(appended_message)
+
+        await _continuation.mark_appended(continuation_event)
+        for message in added_messages:
             await self.hooks.invoke_callbacks_async(MessageAddedEvent(agent=self, message=message))
 
     def take_snapshot(

--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any
 from opentelemetry import trace as trace_api
 
 from .._middleware.stages import InvokeModelContext, InvokeModelStage
+from ..agent import _continuation
 from ..experimental.checkpoint import Checkpoint, CheckpointPosition
 from ..hooks import AfterModelCallEvent, AfterToolsEvent, BeforeModelCallEvent, BeforeToolsEvent
 from ..telemetry.metrics import Trace
@@ -496,9 +497,27 @@ async def _handle_model_execution(
                 invocation_state=invocation_state,
                 projected_input_tokens=projected_input_tokens,
             )
-            await agent.hooks.invoke_callbacks_async(before_model_call_event)
+            model_continuation: Messages | None = None
+            try:
+                await agent.hooks.invoke_callbacks_async(before_model_call_event)
+                model_continuation = await _continuation.prepare(
+                    before_model_call_event,
+                    agent._convert_prompt_to_messages,
+                )
+            finally:
+                if model_continuation is None:
+                    await _continuation.abandon(
+                        before_model_call_event,
+                        RuntimeError(
+                            "Agent stream closed before continuation input was incorporated into agent history"
+                        ),
+                    )
 
             if before_model_call_event.cancel:
+                await _continuation.abandon(
+                    before_model_call_event,
+                    RuntimeError("Continuation abandoned by BeforeModelCallEvent"),
+                )
                 cancel_text = (
                     before_model_call_event.cancel
                     if isinstance(before_model_call_event.cancel, str)
@@ -523,6 +542,17 @@ async def _handle_model_execution(
                     continue
                 yield ModelStopReason(stop_reason=stop_reason, message=message, usage=usage, metrics=metrics)
                 break
+
+            if model_continuation is not None:
+                await agent._append_continuation_messages(model_continuation, before_model_call_event)
+                try:
+                    projected_input_tokens = await _estimate_input_tokens(agent)
+                except Exception as error:
+                    projected_input_tokens = None
+                    logger.debug(
+                        "error=<%s> | token estimation failed after continuation input, proceeding without estimate",
+                        error,
+                    )
 
             if structured_output_context.forced_mode:
                 tool_spec = structured_output_context.get_tool_spec()

--- a/strands-py/tests/strands/agent/test__continuation.py
+++ b/strands-py/tests/strands/agent/test__continuation.py
@@ -1,0 +1,81 @@
+"""Tests for internal continuation input coordination."""
+
+import asyncio
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from strands import Agent
+from strands.agent._continuation import (
+    _ContinuationInput,
+    _is_complete_message_input,
+    abandon,
+    add_input,
+    prepare,
+)
+from strands.hooks import AfterInvocationEvent
+from strands.types.content import Message, Messages
+
+_USER_TEXT: Message = {"role": "user", "content": [{"text": "done"}]}
+_ASSISTANT_TEXT: Message = {"role": "assistant", "content": [{"text": "invalid"}]}
+_TOOL_USE: Message = {
+    "role": "assistant",
+    "content": [{"toolUse": {"name": "tool", "toolUseId": "tool-1", "input": {}}}],
+}
+_USER_TOOL_USE: Message = {
+    "role": "user",
+    "content": _TOOL_USE["content"],
+}
+_TOOL_RESULT: Message = {
+    "role": "user",
+    "content": [
+        {
+            "toolResult": {
+                "toolUseId": "tool-1",
+                "status": "success",
+                "content": [{"text": "done"}],
+            }
+        }
+    ],
+}
+
+
+@pytest.mark.asyncio
+async def test_prepare_preserves_inputs_deferred_across_interrupts() -> None:
+    agent = Mock(spec=Agent)
+    first_event = AfterInvocationEvent(agent=agent)
+    second_event = AfterInvocationEvent(agent=agent)
+    abandoned = Mock()
+    first_input = _ContinuationInput(args="first", on_abandoned=abandoned)
+    second_input = _ContinuationInput(args="second", on_abandoned=abandoned)
+    normalize_input = AsyncMock()
+
+    add_input(first_event, first_input)
+    add_input(second_event, second_input)
+    await prepare(first_event, normalize_input, "interrupt")
+    await prepare(second_event, normalize_input, "interrupt")
+
+    assert agent._deferred_continuation_inputs == [first_input, second_input]
+    normalize_input.assert_not_awaited()
+
+    next_event = AfterInvocationEvent(agent=agent)
+    with pytest.raises(asyncio.CancelledError):
+        await prepare(next_event, AsyncMock(side_effect=asyncio.CancelledError()))
+    await abandon(next_event, RuntimeError("cancelled"))
+
+    assert abandoned.call_count == 2
+
+
+@pytest.mark.parametrize(
+    ("messages", "expected"),
+    [
+        ([_USER_TEXT], True),
+        ([_TOOL_USE, _TOOL_RESULT, _USER_TEXT], True),
+        ([_TOOL_USE, _ASSISTANT_TEXT, _USER_TEXT], False),
+        ([_USER_TOOL_USE], False),
+        ([_TOOL_RESULT], False),
+        ([_TOOL_USE, _USER_TEXT], False),
+    ],
+)
+def test_validates_complete_message_sequences(messages: Messages, expected: bool) -> None:
+    assert _is_complete_message_input(messages) is expected

--- a/strands-py/tests/strands/agent/test_continuation.py
+++ b/strands-py/tests/strands/agent/test_continuation.py
@@ -1,0 +1,275 @@
+"""Tests for agent continuation input."""
+
+from collections.abc import AsyncGenerator
+from typing import Any, cast
+from unittest.mock import Mock
+
+import pytest
+
+from strands import Agent, tool
+from strands.agent._continuation import _ContinuationInput, add_input
+from strands.hooks import AfterInvocationEvent, BeforeModelCallEvent, MessageAddedEvent
+from strands.types.content import Message, MessageMetadata, Messages
+from strands.types.event_loop import StopReason, Usage
+from strands.types.tools import ToolContext
+from tests.fixtures.mocked_model_provider import MockedModelProvider
+
+
+def _text_of(message: Message) -> str:
+    return "".join(block["text"] for block in message["content"] if "text" in block)
+
+
+def _text_model(*turns: str) -> MockedModelProvider:
+    return MockedModelProvider([{"role": "assistant", "content": [{"text": text}]} for text in turns])
+
+
+def _capture_requests(model: MockedModelProvider, monkeypatch: pytest.MonkeyPatch) -> Mock:
+    stream = Mock(wraps=model.stream)
+    monkeypatch.setattr(model, "stream", stream)
+    return stream
+
+
+@pytest.mark.asyncio
+async def test_combines_multiple_follow_up_contributions_with_public_resume_input(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = _text_model("initial", "final")
+    stream = _capture_requests(model, monkeypatch)
+    appended: list[str] = []
+    abandoned = Mock(side_effect=RuntimeError("abandon callback failed"))
+    agent = Agent(model=model, callback_handler=None)
+    resumed = False
+
+    async def record_appended(args: str) -> None:
+        appended.append(args)
+        raise RuntimeError("append callback failed")
+
+    def add_follow_up(event: AfterInvocationEvent) -> None:
+        nonlocal resumed
+        if resumed:
+            return
+        resumed = True
+        for args in ("first", "second"):
+            add_input(
+                event,
+                _ContinuationInput(args=args, on_appended=lambda args=args: record_appended(args)),
+            )
+        add_input(
+            event,
+            _ContinuationInput(
+                args=[{"role": "assistant", "content": [{"text": "invalid"}]}],
+                on_abandoned=abandoned,
+            ),
+        )
+        event.resume = "public"
+
+    agent.hooks.add_callback(AfterInvocationEvent, add_follow_up)
+
+    await agent.invoke_async("start")
+
+    requests = [call.args[0] for call in stream.call_args_list]
+    assert [message["role"] for message in requests[1]] == ["user", "assistant", "user"]
+    assert _text_of(requests[1][-1]) == "firstsecondpublic"
+    assert [_text_of(message) for message in agent.messages] == ["start", "initial", "firstsecondpublic", "final"]
+    assert appended == ["first", "second"]
+    abandoned.assert_called_once()
+    assert str(abandoned.call_args.args[0]) == "Continuation input must contain a complete message sequence"
+
+
+@pytest.mark.asyncio
+async def test_retains_follow_up_input_through_failed_resume_attempts(monkeypatch: pytest.MonkeyPatch) -> None:
+    model = MockedModelProvider(
+        [
+            {
+                "role": "assistant",
+                "content": [{"toolUse": {"name": "confirm_tool", "toolUseId": "tool-1", "input": {}}}],
+            },
+            {"role": "assistant", "content": [{"text": "resumed"}]},
+            {"role": "assistant", "content": [{"text": "continued"}]},
+        ]
+    )
+    stream = _capture_requests(model, monkeypatch)
+    appended = Mock()
+    abandoned = Mock()
+
+    @tool(context=True)
+    def confirm_tool(tool_context: ToolContext) -> str:
+        """Require confirmation before completing."""
+        response = tool_context.interrupt("confirm", reason="Confirm?")
+        return f"confirmed:{response}"
+
+    agent = Agent(model=model, tools=[confirm_tool], callback_handler=None)
+    added = False
+
+    def add_follow_up(event: AfterInvocationEvent) -> None:
+        nonlocal added
+        if added:
+            return
+        added = True
+        add_input(
+            event,
+            _ContinuationInput(args="pending", on_appended=appended, on_abandoned=abandoned),
+        )
+
+    agent.hooks.add_callback(AfterInvocationEvent, add_follow_up)
+
+    interrupt_result = await agent.invoke_async("start")
+
+    assert interrupt_result.stop_reason == "interrupt"
+    assert interrupt_result.interrupts
+    appended.assert_not_called()
+    abandoned.assert_not_called()
+
+    with pytest.raises(TypeError, match="must resume from interrupt"):
+        await agent.invoke_async("invalid resume")
+    appended.assert_not_called()
+    abandoned.assert_not_called()
+
+    final_result = await agent.invoke_async(
+        [
+            {
+                "interruptResponse": {
+                    "interruptId": interrupt_result.interrupts[0].id,
+                    "response": "yes",
+                }
+            }
+        ]
+    )
+
+    assert final_result.stop_reason == "end_turn"
+    requests = [call.args[0] for call in stream.call_args_list]
+    assert _text_of(requests[2][-1]) == "pending"
+    appended.assert_called_once_with()
+    abandoned.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_preserves_unrecognized_stop_reason_instead_of_continuing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stop_reason = "provider_specific_stop"
+    model = _text_model("partial", "unreachable")
+    original_map = model.map_agent_message_to_events
+
+    def map_agent_message_to_events(
+        agent_message: Message,
+        usage: Usage | None = None,
+    ) -> list[dict[str, Any]]:
+        events = list(original_map(agent_message, usage))
+        for event in events:
+            if "messageStop" in event:
+                event["messageStop"]["stopReason"] = cast(StopReason, stop_reason)
+                break
+        return events
+
+    monkeypatch.setattr(model, "map_agent_message_to_events", map_agent_message_to_events)
+    abandoned = Mock()
+    agent = Agent(model=model, callback_handler=None)
+    added = False
+
+    def add_follow_up(event: AfterInvocationEvent) -> None:
+        nonlocal added
+        if added:
+            return
+        added = True
+        add_input(event, _ContinuationInput(args="pending", on_abandoned=abandoned))
+
+    agent.hooks.add_callback(AfterInvocationEvent, add_follow_up)
+
+    result = await agent.invoke_async("start")
+
+    assert result.stop_reason == stop_reason
+    assert model.index == 1
+    assert [_text_of(message) for message in agent.messages] == ["start", "partial"]
+    abandoned.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_appends_complete_tool_exchange_contributed_before_model_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = _text_model("final")
+    stream = _capture_requests(model, monkeypatch)
+    metadata: MessageMetadata = {"custom": {"pinned": True}}
+    initial_input: Message = {
+        "role": "user",
+        "content": [{"text": "start"}],
+        "tracking_id": "durable-1",
+        "metadata": metadata,
+    }
+    tool_use: Message = {
+        "role": "assistant",
+        "content": [{"toolUse": {"name": "background_result", "toolUseId": "delivery-1", "input": {}}}],
+    }
+    tool_result: Message = {
+        "role": "user",
+        "content": [
+            {
+                "toolResult": {
+                    "toolUseId": "delivery-1",
+                    "status": "success",
+                    "content": [{"text": "complete"}],
+                }
+            }
+        ],
+    }
+    appended = Mock()
+    added_messages: Messages = []
+    agent = Agent(model=model, callback_handler=None)
+
+    agent.hooks.add_callback(MessageAddedEvent, lambda event: added_messages.append(event.message))
+
+    def add_before_model_input(event: BeforeModelCallEvent) -> None:
+        add_input(event, _ContinuationInput(args="guidance"))
+
+        def on_appended() -> None:
+            assert agent.messages == [agent.messages[0], tool_use, tool_result]
+            appended()
+
+        add_input(
+            event,
+            _ContinuationInput(args=[tool_use, tool_result], on_appended=on_appended),
+        )
+
+    agent.hooks.add_callback(BeforeModelCallEvent, add_before_model_input)
+
+    await agent.invoke_async([initial_input])
+
+    request = stream.call_args_list[0].args[0]
+    assert [message["role"] for message in request] == ["user", "assistant", "user"]
+    assert _text_of(request[0]) == "startguidance"
+    assert agent.messages[0] == {
+        "role": "user",
+        "content": [{"text": "start"}, {"text": "guidance"}],
+        "tracking_id": "durable-1",
+        "metadata": metadata,
+    }
+    assert agent.messages[1:3] == [tool_use, tool_result]
+    assert agent.messages[3]["role"] == "assistant"
+    assert agent.messages[0] in added_messages
+    appended.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_abandons_follow_up_input_when_stream_closes_before_it_is_appended() -> None:
+    abandoned = Mock()
+    agent = Agent(model=_text_model("initial", "unreachable"), callback_handler=None)
+    added = False
+
+    def add_follow_up(event: AfterInvocationEvent) -> None:
+        nonlocal added
+        if added:
+            return
+        added = True
+        add_input(event, _ContinuationInput(args="pending", on_abandoned=abandoned))
+
+    agent.hooks.add_callback(AfterInvocationEvent, add_follow_up)
+
+    stream = agent.stream_async("start")
+    async for event in stream:
+        if event.get("start"):
+            await cast(AsyncGenerator[dict[str, Any], None], stream).aclose()
+            break
+
+    abandoned.assert_called_once()
+    assert [_text_of(message) for message in agent.messages] == ["start"]


### PR DESCRIPTION
## Description

Adds an internal continuation mechanism that lets multiple hooks contribute ordered input without competing for `AfterInvocationEvent.resume`.

Contributions can be added after an invocation for the next agent pass or before a model call for the current request. Each contribution is incorporated into agent history or abandoned independently, while existing public `resume` behavior remains unchanged.

## Related Issues

Port of TypeScript implementation merged in #3837

## Documentation PR

Not applicable. This change is internal.

## Type of Change

New feature

## Testing

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
