### PR TITLE
test: harden bedrock kb integ tests

### DIFF
--- a/strands-py/tests_integ/memory/_bedrock_kb_test_helpers.py
+++ b/strands-py/tests_integ/memory/_bedrock_kb_test_helpers.py
@@ -35,17 +35,22 @@ async def search_until(
     query: str,
     predicate: Callable[[MemoryEntry], bool] | None = None,
     *,
-    timeout_s: float = 60.0,
+    timeout_s: float = 150.0,
     interval_s: float = 2.0,
 ) -> MemoryEntry | None:
     """Poll a store search until an entry matches ``predicate`` (default: any result), or time out.
 
     Returns the matched entry, or ``None`` on timeout.
 
-    Use to absorb ``Retrieve`` propagation lag: even after a document reports INDEXED, a single search
-    can miss it. Also the only option when the written content has no test-known document id -
-    extraction rephrases what it writes and the add tool mints ids internally, so indexing can't be
-    awaited by id via :func:`wait_for_indexed`.
+    Two usage modes, both covered by the default budget:
+
+    - After :func:`wait_for_indexed`, to absorb ``Retrieve`` propagation lag - even after a document
+      reports INDEXED, a single search can miss it. Here the match lands on the first poll and the
+      budget is never consumed.
+    - Standalone, when the written content has no searchable test-known id: extraction rephrases what
+      it writes across an unknown number of documents, so there is no single id to await via
+      :func:`wait_for_indexed`. Here the poll must cover the whole write->index->retrieve pipeline,
+      so the default spans indexing latency (see :func:`wait_for_indexed`) plus retrieve lag.
     """
     if predicate is None:
         predicate = lambda _entry: True  # noqa: E731 - tiny default predicate

--- a/strands-py/tests_integ/memory/_bedrock_kb_test_helpers.py
+++ b/strands-py/tests_integ/memory/_bedrock_kb_test_helpers.py
@@ -14,7 +14,7 @@ from collections.abc import Callable
 from typing import Any
 from urllib.parse import urlparse
 
-from strands.memory.types import SearchOptions
+from strands.memory.types import MemoryEntry, SearchOptions
 from strands.vended_memory_stores.bedrock_knowledge_base import BedrockKnowledgeBaseStore
 
 # A best-effort cleanup callback queued during a test and drained by the owning fixture's teardown.
@@ -33,28 +33,29 @@ def unique_marker(label: str) -> str:
 async def search_until(
     store: BedrockKnowledgeBaseStore,
     query: str,
-    predicate: Callable[[str], bool] | None = None,
+    predicate: Callable[[MemoryEntry], bool] | None = None,
     *,
     timeout_s: float = 60.0,
     interval_s: float = 2.0,
-) -> str | None:
+) -> MemoryEntry | None:
     """Poll a store search until an entry matches ``predicate`` (default: any result), or time out.
 
-    Returns the matched entry's content, or ``None`` on timeout.
+    Returns the matched entry, or ``None`` on timeout.
 
-    Use when the written content has no test-known document id: extraction rephrases what it writes,
-    and the add tool mints ids internally, so indexing can't be awaited by id via
-    :func:`wait_for_indexed`.
+    Use to absorb ``Retrieve`` propagation lag: even after a document reports INDEXED, a single search
+    can miss it. Also the only option when the written content has no test-known document id -
+    extraction rephrases what it writes and the add tool mints ids internally, so indexing can't be
+    awaited by id via :func:`wait_for_indexed`.
     """
     if predicate is None:
-        predicate = lambda _content: True  # noqa: E731 - tiny default predicate
+        predicate = lambda _entry: True  # noqa: E731 - tiny default predicate
 
     deadline = time.monotonic() + timeout_s
     while True:
         entries = await store.search(query, SearchOptions(max_search_results=10))
         for entry in entries:
-            if predicate(entry.content):
-                return entry.content
+            if predicate(entry):
+                return entry
         if time.monotonic() >= deadline:
             return None
         await asyncio.sleep(interval_s)
@@ -66,13 +67,14 @@ def wait_for_indexed(
     data_source_id: str,
     document_identifier: dict[str, Any],
     *,
-    timeout_s: float = 30.0,
+    timeout_s: float = 120.0,
     interval_s: float = 2.0,
 ) -> None:
     """Poll until the document reaches INDEXED (or fails/times out).
 
-    Ingestion is async even for ``IngestKnowledgeBaseDocuments``; without this a subsequent
-    ``Retrieve`` can miss the document. The boto3 key casing matches the store
+    Ingestion is async even for ``IngestKnowledgeBaseDocuments`` and routinely takes upward of a
+    minute under load; without this a subsequent ``Retrieve`` can miss the document. The boto3 key
+    casing matches the store
     (``knowledgeBaseId``/``dataSourceId``/``documentIdentifiers``).
 
     Args:

--- a/strands-py/tests_integ/memory/test_bedrock_knowledge_base_memory_manager.py
+++ b/strands-py/tests_integ/memory/test_bedrock_knowledge_base_memory_manager.py
@@ -50,7 +50,9 @@ from ._bedrock_kb_test_helpers import (
     wait_for_indexed,
 )
 
-pytestmark = pytest.mark.asyncio
+# Bedrock KB ingestion is eventually consistent and routinely exceeds the global 90s per-test cap
+# once indexing (up to 120s), agent turns, and the follow-on search poll are serialized; raise it.
+pytestmark = [pytest.mark.asyncio, pytest.mark.timeout(300)]
 
 # The manager's default tool names (memory_manager.py: ``config.name ... else "search_memory"`` /
 # ``"add_memory"``). Kept here so an assertion can't silently go stale if a default changes.
@@ -264,7 +266,7 @@ class TestExtraction:
 
         # No flush: the trigger fires on its own; the write is in the background.
         assert await _wait_for(lambda: len(ids) > 0)
-        assert await search_until(store, marker, lambda content: marker in content) is not None
+        assert await search_until(store, marker, lambda entry: marker in entry.content) is not None
 
         # Drain any still-in-flight background writes so they're captured before cleanup.
         await memory_manager.flush()
@@ -295,7 +297,7 @@ class TestExtraction:
         # Turn 2: the trigger fires, draining buffered messages from both turns.
         await agent.invoke_async("Thanks. Keep that in mind.")
         assert await _wait_for(lambda: len(ids) > 0)
-        assert await search_until(store, marker, lambda content: marker in content) is not None
+        assert await search_until(store, marker, lambda entry: marker in entry.content) is not None
 
         await memory_manager.flush()
 
@@ -326,7 +328,7 @@ class TestExtraction:
         # flush() bypasses the trigger schedule and force-saves the buffered turn on demand.
         await memory_manager.flush()
         assert len(ids) > 0
-        assert await search_until(store, marker, lambda content: marker in content) is not None
+        assert await search_until(store, marker, lambda entry: marker in entry.content) is not None
 
 
 # --------------------------------------------------------------------------- #
@@ -530,4 +532,4 @@ class TestAddMemoryTool:
 
         assert _has_tool_use(agent.messages, ADD_TOOL)
         assert len(ids) > 0
-        assert await search_until(store, marker, lambda content: marker in content) is not None
+        assert await search_until(store, marker, lambda entry: marker in entry.content) is not None

--- a/strands-py/tests_integ/memory/test_bedrock_knowledge_base_store.py
+++ b/strands-py/tests_integ/memory/test_bedrock_knowledge_base_store.py
@@ -22,11 +22,14 @@ from ._bedrock_kb_test_helpers import (
     cleanup_custom_document,
     cleanup_s3_document,
     key_from_uri,
+    search_until,
     unique_marker,
     wait_for_indexed,
 )
 
-pytestmark = pytest.mark.asyncio
+# Bedrock KB ingestion is eventually consistent and routinely exceeds the global 90s per-test cap
+# once indexing (up to 120s) and the follow-on search poll are serialized; raise it for this suite.
+pytestmark = [pytest.mark.asyncio, pytest.mark.timeout(300)]
 
 
 @pytest.fixture(scope="session")
@@ -86,8 +89,7 @@ class TestCustomDataSource:
             kb_clients["agent"], kb_id, ds_id, {"dataSourceType": "CUSTOM", "custom": {"id": result.document_id}}
         )
 
-        entries = await store.search(marker, SearchOptions(max_search_results=10))
-        match = next((entry for entry in entries if marker in entry.content), None)
+        match = await search_until(store, marker, lambda entry: marker in entry.content)
         assert match is not None
         assert "launched in 2025" in match.content
 
@@ -120,8 +122,7 @@ class TestCustomDataSource:
             kb_clients["agent"], kb_id, ds_id, {"dataSourceType": "CUSTOM", "custom": {"id": result.document_id}}
         )
 
-        entries = await store.search(marker, SearchOptions(max_search_results=10))
-        assert any(marker in entry.content for entry in entries)
+        assert await search_until(store, marker, lambda entry: marker in entry.content) is not None
 
     async def test_scope_isolates_documents_from_other_scopes(
         self, skip_if_no_kb, bedrock_kb_context, kb_clients, cleanup_registrar
@@ -166,9 +167,9 @@ class TestCustomDataSource:
             kb_clients["agent"], kb_id, ds_id, {"dataSourceType": "CUSTOM", "custom": {"id": result.document_id}}
         )
 
-        entries_a = await store_a.search(marker, SearchOptions(max_search_results=10))
-        assert any(marker in entry.content for entry in entries_a)
+        assert await search_until(store_a, marker, lambda entry: marker in entry.content) is not None
 
+        # Absence is only meaningful once the doc is confirmed retrievable in scope A above.
         entries_b = await store_b.search(marker, SearchOptions(max_search_results=10))
         assert not any(marker in entry.content for entry in entries_b)
 
@@ -199,8 +200,7 @@ class TestCustomDataSource:
             kb_clients["agent"], kb_id, ds_id, {"dataSourceType": "CUSTOM", "custom": {"id": result.document_id}}
         )
 
-        entries = await store.search(marker, SearchOptions(max_search_results=10))
-        match = next((entry for entry in entries if marker in entry.content), None)
+        match = await search_until(store, marker, lambda entry: marker in entry.content)
         assert match is not None
         assert match.metadata is not None
         assert match.metadata.get("priority") == "high"
@@ -252,8 +252,7 @@ class TestS3DataSource:
 
         wait_for_indexed(kb_clients["agent"], kb_id, ds_id, {"dataSourceType": "S3", "s3": {"uri": result.document_id}})
 
-        entries = await store.search(marker, SearchOptions(max_search_results=10))
-        match = next((entry for entry in entries if marker in entry.content), None)
+        match = await search_until(store, marker, lambda entry: marker in entry.content)
         assert match is not None
         assert "answer is 42" in match.content
 
@@ -289,8 +288,7 @@ class TestS3DataSource:
 
         wait_for_indexed(kb_clients["agent"], kb_id, ds_id, {"dataSourceType": "S3", "s3": {"uri": result.document_id}})
 
-        entries = await store.search(marker, SearchOptions(max_search_results=10))
-        match = next((entry for entry in entries if marker in entry.content), None)
+        match = await search_until(store, marker, lambda entry: marker in entry.content)
         assert match is not None
         assert match.metadata is not None
         assert match.metadata.get("namespace") == scope
@@ -344,9 +342,9 @@ class TestS3DataSource:
 
         wait_for_indexed(kb_clients["agent"], kb_id, ds_id, {"dataSourceType": "S3", "s3": {"uri": result.document_id}})
 
-        entries_a = await store_a.search(marker, SearchOptions(max_search_results=10))
-        assert any(marker in entry.content for entry in entries_a)
+        assert await search_until(store_a, marker, lambda entry: marker in entry.content) is not None
 
+        # Absence is only meaningful once the doc is confirmed retrievable in scope A above.
         entries_b = await store_b.search(marker, SearchOptions(max_search_results=10))
         assert not any(marker in entry.content for entry in entries_b)
 
@@ -380,8 +378,7 @@ class TestS3DataSource:
 
         wait_for_indexed(kb_clients["agent"], kb_id, ds_id, {"dataSourceType": "S3", "s3": {"uri": result.document_id}})
 
-        entries = await store.search(marker, SearchOptions(max_search_results=10))
-        match = next((entry for entry in entries if marker in entry.content), None)
+        match = await search_until(store, marker, lambda entry: marker in entry.content)
         assert match is not None
         assert match.metadata is not None
         assert match.metadata.get("category") == "testing"


### PR DESCRIPTION
## Description

The `BedrockKnowledgeBaseStore` live integ tests fail intermittently with `RuntimeError: Document did not reach INDEXED within 30.0s`. Bedrock Knowledge Base ingestion is eventually consistent and routinely takes over a minute under load, so the 30s ceiling in `wait_for_indexed` was too tight. A second, quieter race hid behind it: even after a document reports INDEXED, the `Retrieve` path has its own propagation lag, so the single `store.search(...)` that followed could miss the just-indexed document and fail an otherwise-correct assertion.

This hardens the suite against both races rather than papering over them with retries: indexing now has a realistic 120s deadline, and the read side polls via the existing `search_until` helper (already used by the sibling memory-manager suite) instead of reading once. `search_until` now returns the matched `MemoryEntry` so callers can poll on metadata too, not just a content substring. Because a 120s indexing wait plus the search poll can now serialize past the global 90s per-test cap, the two live suites raise their per-test timeout to 300s.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

These are live tests that require the Bedrock KB test-infra (SSM params / `STRANDS_TEST_KB_*` overrides) and skip cleanly without credentials; CI runs them against pre-provisioned resources on PR.

Locally verified: `hatch fmt --linter` passes (ruff + mypy strict), and the full `tests_integ` collection/run has no import errors or unknown-marker warnings — the store suite's pure-constructor validation tests pass and the live KB tests skip cleanly without credentials. The end-to-end live run against the KB is left to CI.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
