### PR TITLE
fix: harden vercel document test

### DIFF
--- a/strands-ts/test/integ/agent.test.ts
+++ b/strands-ts/test/integ/agent.test.ts
@@ -189,7 +189,7 @@ describe.each(allProviders)('Agent with $name', ({ name, skip, createModel, mode
         const docBlock = new DocumentBlock({
           name: 'test-document',
           format: 'txt',
-          source: { text: 'The document contains the word ZEBRA.' },
+          source: { text: 'The animal described here is a ZEBRA.' },
         })
 
         // Create image block
@@ -210,7 +210,7 @@ describe.each(allProviders)('Agent with $name', ({ name, skip, createModel, mode
                 docBlock,
                 imageBlock,
                 new TextBlock(
-                  'I shared a document and an image. What animal is in the document and what color is the image? Answer briefly.'
+                  'What animal is named in the text I shared, and what color is the image? Answer briefly.'
                 ),
               ],
             }),
@@ -273,10 +273,7 @@ describe.each(allProviders)('Agent with $name', ({ name, skip, createModel, mode
         printer: false,
       })
 
-      const result = await agent.invoke([
-        new TextBlock('What is the secret code word in the document? Answer in one word.'),
-        docBlock,
-      ])
+      const result = await agent.invoke([new TextBlock('What is the secret code word? Answer in one word.'), docBlock])
 
       expect(result.stopReason).toBe('endTurn')
       const textContent = result.lastMessage.content.find((block) => block.type === 'textBlock')


### PR DESCRIPTION
## Description

The `Media Blocks > handles multiple media blocks in single request` integ case failed deterministically against `VercelModel (Bedrock)`: it planted a text-source `DocumentBlock` and asked "what animal is in the **document**", but the Vercel provider delivers a text-source document as a plain text part with no document framing (native Bedrock wraps it in a `document` object). The model then truthfully answered "there is no document shared, only an image" and never echoed the keyword — a mismatch `retry` can't recover.

The keyword still reaches the model as text on every provider; only the document *framing* differs. These prompts now ask about the shared *text/content* rather than "the document", so the assertion checks the invariant that actually holds cross-provider — the block's content was delivered — instead of a provider-specific labeling detail. The same latent fragility in the sibling `handles document input` case is fixed the same way. Provider behavior is unchanged (the Vercel text-part conversion is intentional and locked in by its unit tests).

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

Ran `npm run build`, `npm run type-check`, and `eslint` on the changed file — all clean. The integ suite runs against every provider in `allProviders` in CI (it skips locally without injected provider credentials), which exercises the previously failing `VercelModel (Bedrock)` path end to end.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
