### PR TITLE
fix(python): simplify agent delegation by making end_turn accept content blocks

### DIFF
--- a/site/src/content/docs/user-guide/concepts/agents/hooks.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/hooks.mdx
@@ -374,7 +374,7 @@ Most event properties are read-only to prevent unintended modifications. However
     - `exception` *(read-only)* - The original exception if the tool raised one, otherwise `None`. See [Exception Handling](#exception-handling).
 
 - [`AfterToolsEvent`](@api/python/strands.hooks.events#AfterToolsEvent)
-    - `end_turn` - Halt the agent loop after the tool batch without calling the model again. Set `True` for a default final assistant message, or a string to use as the final assistant message. The returned result has `stop_reason="end_turn"`.
+    - `end_turn` - Halt the agent loop after the tool batch without calling the model again. Set `True` for a default final assistant message, a string to use as the final assistant message, or a list of content blocks to use as the final assistant message content directly. The returned result has `stop_reason="end_turn"`.
 
 - [`AfterInvocationEvent`](@api/python/strands.hooks.events#AfterInvocationEvent)
     - `resume` - Trigger a follow-up agent invocation with new input. See [Invocation resume](#invocation-resume).

--- a/strands-py/src/strands/agent/_agent_delegation.py
+++ b/strands-py/src/strands/agent/_agent_delegation.py
@@ -166,7 +166,7 @@ class AgentDelegation(Plugin):
         state.tool_use_id = event.tool_use.get("toolUseId")
 
     def _on_after_tools(self, event: AfterToolsEvent) -> None:
-        """Set end_turn to delegation content blocks when delegation succeeded.
+        """Set end_turn to delegation content blocks when delegation succeeded with meaningful content.
 
         This hook runs at ``HookOrder.SDK_LAST`` (100) so no hook can invalidate the tool
         result after this hook commits end_turn; mutating a committed tool result's status
@@ -207,7 +207,16 @@ class AgentDelegation(Plugin):
             )
             return
 
-        event.end_turn = _to_content_blocks(result_block)
+        # Skip delegation when the tool result has no content
+        end_turn_content = _to_content_blocks(result_block)
+        if not end_turn_content or all(block.get("text", None) == "" for block in end_turn_content):
+            logger.debug(
+                "tool_use_id=<%s> | delegation produced blank content, skipping end_turn",
+                state.tool_use_id,
+            )
+            return
+
+        event.end_turn = end_turn_content
 
     # --- Middleware ---
 

--- a/strands-py/src/strands/agent/_agent_delegation.py
+++ b/strands-py/src/strands/agent/_agent_delegation.py
@@ -63,9 +63,7 @@ def _to_content_blocks(tool_result: ToolResult) -> list[ContentBlock]:
     raw_content = tool_result.get("content", [])
     result: list[ContentBlock] = []
     for block in raw_content:
-        if "text" in block:
-            result.append({"text": block["text"]})
-        elif "json" in block:
+        if "json" in block:
             result.append({"text": json_module.dumps(block["json"])})
         else:
             result.append(cast(ContentBlock, block))

--- a/strands-py/src/strands/agent/_agent_delegation.py
+++ b/strands-py/src/strands/agent/_agent_delegation.py
@@ -4,13 +4,8 @@ When a tool is configured with ``delegate=True``, this plugin ensures:
 
 1. The delegation tool is the only tool called in the turn (single-call constraint)
 2. The agent loop exits immediately after a successful delegation (via end_turn)
-3. The AgentResult is transformed with the delegation tool's content as the last message
+3. The delegation tool's content blocks become the final assistant message
 4. Streaming events from the delegate agent are surfaced natively in the parent stream
-
-The final delegation message is produced in middleware after the core loop exits.
-``MessageAddedEvent`` subscribers will see the end_turn placeholder followed by a second
-event with the real delegation content (no session manager), or no event for the real
-content at all (session manager attached).
 """
 
 from __future__ import annotations
@@ -22,7 +17,7 @@ from collections.abc import AsyncGenerator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
-from .._middleware.stages import AgentStreamContext, AgentStreamStage, ExecuteToolContext, ExecuteToolStage
+from .._middleware.stages import ExecuteToolContext, ExecuteToolStage
 from .._middleware.types import MiddlewareNext
 from ..hooks import (
     AfterToolCallEvent,
@@ -30,12 +25,11 @@ from ..hooks import (
     BeforeModelCallEvent,
     BeforeToolsEvent,
     HookOrder,
-    MessageAddedEvent,
 )
 from ..plugins import Plugin
-from ..types._events import AgentAsToolStreamEvent, EventLoopStopEvent, ToolResultEvent, TypedEvent
-from ..types.content import ContentBlock, _ensure_tracking_id
-from ..types.content import Message as MessageType
+from ..types._events import AgentAsToolStreamEvent, ToolResultEvent, TypedEvent
+from ..types.content import ContentBlock
+from ..types.tools import ToolResult
 from ._agent_as_tool import _AgentAsTool
 
 if TYPE_CHECKING:
@@ -54,9 +48,6 @@ class _DelegationState:
     tool_use_id: str | None = None
     """Tool use ID of the delegation tool that succeeded."""
 
-    end_turn_via_delegation: bool = False
-    """Whether this plugin ended turn."""
-
 
 def _is_delegation_tool(agent: Agent, tool_name: str) -> bool:
     """Check whether a tool registered on the agent is a delegation AgentAsTool."""
@@ -64,7 +55,7 @@ def _is_delegation_tool(agent: Agent, tool_name: str) -> bool:
     return isinstance(tool, _AgentAsTool) and tool.delegate
 
 
-def _to_content_blocks(tool_result: dict) -> list[ContentBlock]:
+def _to_content_blocks(tool_result: ToolResult) -> list[ContentBlock]:
     """Convert ToolResult content into ContentBlocks for an assistant message.
 
     JSON blocks are serialized to text (matching TS's ``toContentBlocks``).
@@ -77,29 +68,8 @@ def _to_content_blocks(tool_result: dict) -> list[ContentBlock]:
         elif "json" in block:
             result.append({"text": json_module.dumps(block["json"])})
         else:
-            result.append(block)
+            result.append(cast(ContentBlock, block))
     return result
-
-
-def _find_delegation_result(messages: list, tool_use_id: str) -> dict | None:
-    """Find the delegation tool's successful result in the agent messages.
-
-    Searches backwards for the last user message containing a successful tool
-    result matching the given tool_use_id. Returns None if not found or errored.
-    """
-    for i in range(len(messages) - 1, -1, -1):
-        msg = messages[i]
-        if msg.get("role") != "user":
-            continue
-        for block in msg.get("content", []):
-            if not isinstance(block, dict) or "toolResult" not in block:
-                continue
-            tool_result = block["toolResult"]
-            if tool_result.get("toolUseId") == tool_use_id:
-                if tool_result.get("status") == "error":
-                    return None
-                return dict(tool_result)
-    return None
 
 
 class AgentDelegation(Plugin):
@@ -147,7 +117,6 @@ class AgentDelegation(Plugin):
         agent.add_hook(self._on_before_model_call, BeforeModelCallEvent)
 
         agent._middleware_registry.add_middleware(ExecuteToolStage, self._handle_tool_execution)
-        agent._middleware_registry.add_middleware(AgentStreamStage, self._handle_stream)
 
     # --- Hooks ---
 
@@ -197,13 +166,11 @@ class AgentDelegation(Plugin):
         state.tool_use_id = event.tool_use.get("toolUseId")
 
     def _on_after_tools(self, event: AfterToolsEvent) -> None:
-        """Set end_turn when delegation succeeded and the result is still valid.
+        """Set end_turn to delegation content blocks when delegation succeeded.
 
-        This hook runs at ``HookOrder.SDK_LAST`` (100). If a hook with a higher numeric order
-        mutates a tool result's status from success to error, the end_turn signal has already
-        been committed and the loop will still exit; ``_handle_stream`` re-verifies the result
-        as defence in depth. No SDK or vended plugin registers AfterToolsEvent hooks above
-        SDK_LAST, and mutating a committed tool result's status there is not a supported pattern.
+        This hook runs at ``HookOrder.SDK_LAST`` (100) so no hook can invalidate the tool
+        result after this hook commits end_turn; mutating a committed tool result's status
+        is not a supported pattern.
         """
         if event.agent.model.stateful:
             return
@@ -240,8 +207,7 @@ class AgentDelegation(Plugin):
             )
             return
 
-        event.end_turn = True
-        state.end_turn_via_delegation = True
+        event.end_turn = _to_content_blocks(result_block)
 
     # --- Middleware ---
 
@@ -299,87 +265,5 @@ class AgentDelegation(Plugin):
                     yield TypedEvent(inner_data)
                 else:
                     yield event
-            else:
-                yield event
-
-    async def _handle_stream(
-        self,
-        context: AgentStreamContext,
-        next_fn: MiddlewareNext,
-    ) -> AsyncGenerator[TypedEvent, None]:
-        """AgentStreamStage middleware: replace the terminal stop with delegation content.
-
-        Events before the first stop are yielded immediately. Once a stop appears,
-        the tail is buffered and replayed with the stop replaced (or unchanged).
-        """
-        self._state.pop(context.agent, None)
-
-        tail_buffer: list[TypedEvent] = []
-        buffering = False
-
-        try:
-            async for event in next_fn(context):
-                if buffering:
-                    tail_buffer.append(event)
-                elif isinstance(event, EventLoopStopEvent):
-                    buffering = True
-                    tail_buffer.append(event)
-                else:
-                    yield event
-        except Exception:
-            self._state.pop(context.agent, None)
-            for event in tail_buffer:
-                yield event
-            raise
-
-        state = self._state.pop(context.agent, None)
-
-        if state is None or not state.tool_use_id or not state.end_turn_via_delegation:
-            for event in tail_buffer:
-                yield event
-            return
-
-        # Re-verify the delegation result is still successful in committed history.
-        messages = context.agent.messages
-        tool_result = _find_delegation_result(messages, state.tool_use_id)
-        if tool_result is None:
-            logger.debug(
-                "tool_use_id=<%s> | delegation result no longer successful in history, "
-                "skipping delegation transformation",
-                state.tool_use_id,
-            )
-            for event in tail_buffer:
-                yield event
-            return
-
-        delegation_content = _to_content_blocks(tool_result)
-        delegation_message: MessageType = {"role": "assistant", "content": delegation_content}
-        _ensure_tracking_id(delegation_message)
-
-        # Replace the placeholder message the event loop persisted.
-        session_manager = getattr(context.agent, "_session_manager", None)
-        if messages and messages[-1].get("role") == "assistant":
-            messages[-1] = delegation_message
-            if session_manager is not None:
-                session_manager.redact_latest_message(delegation_message, context.agent)
-            else:
-                await context.agent.hooks.invoke_callbacks_async(
-                    MessageAddedEvent(agent=context.agent, message=delegation_message)
-                )
-        else:
-            messages.append(delegation_message)
-            await context.agent.hooks.invoke_callbacks_async(
-                MessageAddedEvent(agent=context.agent, message=delegation_message)
-            )
-
-        # Replay tail with stop replaced by delegation terminal.
-        for event in tail_buffer:
-            if isinstance(event, EventLoopStopEvent):
-                yield EventLoopStopEvent(
-                    "end_turn",
-                    delegation_message,
-                    context.agent.event_loop_metrics,
-                    context.invocation_state.get("request_state", {}),
-                )
             else:
                 yield event

--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -907,12 +907,14 @@ async def _handle_tool_execution(
 
     # Hook requested halt: exit without calling the model again.
     if after_tools_event.end_turn:
-        end_turn_text = (
-            after_tools_event.end_turn
-            if isinstance(after_tools_event.end_turn, str)
-            else "Turn ended early by hook after tool execution"
-        )
-        end_turn_message: Message = {"role": "assistant", "content": [{"text": end_turn_text}]}
+        end_turn_value = after_tools_event.end_turn
+        if isinstance(end_turn_value, list):
+            end_turn_content = list(end_turn_value)
+        elif isinstance(end_turn_value, str):
+            end_turn_content = [{"text": end_turn_value}]
+        else:
+            end_turn_content = [{"text": "Turn ended early by hook after tool execution"}]
+        end_turn_message: Message = {"role": "assistant", "content": end_turn_content}
         await agent._append_messages(end_turn_message)
         yield EventLoopStopEvent(
             "end_turn",

--- a/strands-py/src/strands/hooks/events.py
+++ b/strands-py/src/strands/hooks/events.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from ..agent.agent_result import AgentResult
 
 from ..types.agent import AgentInput
-from ..types.content import Message, Messages
+from ..types.content import ContentBlock, Message, Messages
 from ..types.interrupt import _Interruptible
 from ..types.streaming import StopReason
 from ..types.tools import AgentTool, ToolResult, ToolUse
@@ -185,15 +185,15 @@ class AfterToolsEvent(HookEvent):
     Attributes:
         message: The user-role message containing the tool results.
         invocation_state: State and configuration passed through the agent invocation.
-        end_turn: When set, the agent loop halts after this tool batch without
-            calling the model again. If a string, that string becomes the content of
-            a final assistant text message. If True, a default message is used.
-            In both cases stop_reason on the returned result is "end_turn".
+        end_turn: When set, the agent loop halts after this tool batch without calling the
+            model again. A string becomes the final assistant text. A list of content blocks
+            becomes the final assistant message content. If True, a default message
+            is used. In any case, the stop_reason is "end_turn".
     """
 
     message: Message
     invocation_state: dict[str, Any]
-    end_turn: bool | str = False
+    end_turn: bool | str | list[ContentBlock] = False
 
     def _can_write(self, name: str) -> bool:
         return name == "end_turn"

--- a/strands-py/tests/strands/agent/hooks/test_events.py
+++ b/strands-py/tests/strands/agent/hooks/test_events.py
@@ -181,13 +181,6 @@ def test_after_tools_event_fields_default_and_writability(after_tools_event, age
     assert tru_event == exp_event
     assert tru_event.end_turn is False
 
-    tru_event.end_turn = True
-    assert tru_event.end_turn is True
-    tru_event.end_turn = "enough gathered"
-    assert tru_event.end_turn == "enough gathered"
-    tru_event.end_turn = [{"text": "delegated"}]
-    assert tru_event.end_turn == [{"text": "delegated"}]
-
     with pytest.raises(AttributeError, match="Property agent is not writable"):
         tru_event.agent = Mock()
     with pytest.raises(AttributeError, match="Property message is not writable"):

--- a/strands-py/tests/strands/agent/hooks/test_events.py
+++ b/strands-py/tests/strands/agent/hooks/test_events.py
@@ -185,6 +185,8 @@ def test_after_tools_event_fields_default_and_writability(after_tools_event, age
     assert tru_event.end_turn is True
     tru_event.end_turn = "enough gathered"
     assert tru_event.end_turn == "enough gathered"
+    tru_event.end_turn = [{"text": "delegated"}]
+    assert tru_event.end_turn == [{"text": "delegated"}]
 
     with pytest.raises(AttributeError, match="Property agent is not writable"):
         tru_event.agent = Mock()

--- a/strands-py/tests/strands/agent/test_agent_delegation.py
+++ b/strands-py/tests/strands/agent/test_agent_delegation.py
@@ -339,7 +339,6 @@ def test_to_content_blocks_converts_text_json_and_passthrough():
     assert tru_blocks[0] == {"text": "hi"}
     assert json_module.loads(tru_blocks[1]["text"]) == {"k": 1}
     assert tru_blocks[2] == {"image": {"format": "png", "source": {"bytes": b"x"}}}
-    assert tru_blocks[3] == {"text": "both"}
 
 
 # --- Child structured output serialization ---

--- a/strands-py/tests/strands/agent/test_agent_delegation.py
+++ b/strands-py/tests/strands/agent/test_agent_delegation.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, PropertyMock
 
 import pytest
 
-from strands._middleware.stages import AgentStreamContext, ExecuteToolContext
+from strands._middleware.stages import ExecuteToolContext
 from strands.agent._agent_as_tool import DELEGATION_DESCRIPTION_SUFFIX, _AgentAsTool
 from strands.agent._agent_delegation import AgentDelegation, _DelegationState, _to_content_blocks
 from strands.agent.agent import Agent
@@ -19,7 +19,7 @@ from strands.hooks import (
 )
 from strands.interrupt import _InterruptState
 from strands.telemetry.metrics import EventLoopMetrics
-from strands.types._events import EventLoopStopEvent, ToolResultEvent, TypedEvent
+from strands.types._events import ToolResultEvent
 from tests.fixtures.mocked_model_provider import MockedModelProvider
 
 # --- Helpers ---
@@ -72,11 +72,6 @@ def test_as_tool_delegate_true_adds_suffix():
     tool = Agent(name="sub", description="Billing", callback_handler=None).as_tool(delegate=True)
     assert tool.delegate is True
     assert tool._description == "Billing" + DELEGATION_DESCRIPTION_SUFFIX
-
-
-def test_as_tool_delegate_false_no_suffix():
-    tool = Agent(name="sub", description="Billing", callback_handler=None).as_tool()
-    assert DELEGATION_DESCRIPTION_SUFFIX not in tool._description
 
 
 def test_as_tool_custom_description_with_delegate():
@@ -217,25 +212,6 @@ def test_on_after_tool_call_retry_swap_preserves_different_id():
     assert plugin._state[parent].tool_use_id == "t1"
 
 
-def test_on_after_tool_call_foreign_stop_not_touched():
-    """Delegation never clears stop_event_loop it didn't set."""
-    tool = _make_delegation_tool()
-    parent = Agent(name="p", tools=[tool], callback_handler=None)
-    plugin = _get_plugin(parent)
-    plugin._state[parent] = _DelegationState(tool_use_id="other", tool_use_count=1)
-
-    invocation_state = {"request_state": {"stop_event_loop": True}}
-    event = AfterToolCallEvent(
-        agent=parent,
-        selected_tool=tool,
-        tool_use={"toolUseId": "t99", "name": "sub", "input": {}},
-        invocation_state=invocation_state,
-        result={"toolUseId": "t99", "status": "success", "content": [{"text": "ok"}]},
-    )
-    plugin._on_after_tool_call(event)
-    assert invocation_state["request_state"]["stop_event_loop"] is True
-
-
 # --- AfterToolsEvent end_turn ---
 
 
@@ -246,18 +222,8 @@ def test_on_after_tools_sets_end_turn_on_success():
     plugin._state[parent] = _DelegationState(tool_use_id="t1", tool_use_count=1)
 
     tru_event = _fire_after_tools(parent, plugin)
-    assert tru_event.end_turn is True
-
-
-def test_on_after_tools_skips_when_result_is_error():
-    tool = _make_delegation_tool()
-    parent = Agent(name="p", tools=[tool], callback_handler=None)
-    plugin = _get_plugin(parent)
-    plugin._state[parent] = _DelegationState(tool_use_id="t1", tool_use_count=1)
-
-    tru_event = _fire_after_tools(parent, plugin, status="error")
-    assert not tru_event.end_turn
-    assert plugin._state[parent].tool_use_id is None
+    assert isinstance(tru_event.end_turn, list)
+    assert tru_event.end_turn == [{"text": "x"}]
 
 
 def test_on_after_tools_suppressed_with_structured_output():
@@ -301,144 +267,6 @@ def test_on_after_tools_skips_when_result_absent(content):
     assert plugin._state[parent].tool_use_id is None
 
 
-# --- _handle_stream ordering ---
-
-
-@pytest.mark.asyncio
-async def test_handle_stream_non_delegation_preserves_trailing():
-    parent = Agent(name="p", callback_handler=None)
-    plugin = _get_plugin(parent)
-    ctx = AgentStreamContext(agent=parent, messages=[], invocation_state={"request_state": {}}, _interrupts={})
-
-    a = TypedEvent({"a": 1})
-    stop = EventLoopStopEvent("end_turn", {"role": "assistant", "content": []}, parent.event_loop_metrics, {})
-    b = TypedEvent({"b": 2})
-
-    async def inner(c):
-        yield a
-        yield stop
-        yield b
-
-    tru_events = [e async for e in plugin._handle_stream(ctx, inner)]
-    exp_events = [a, stop, b]
-    assert tru_events == exp_events
-
-
-@pytest.mark.asyncio
-async def test_handle_stream_non_delegation_multiple_stops_preserved():
-    parent = Agent(name="p", callback_handler=None)
-    plugin = _get_plugin(parent)
-    ctx = AgentStreamContext(agent=parent, messages=[], invocation_state={"request_state": {}}, _interrupts={})
-
-    s1 = EventLoopStopEvent("end_turn", {"role": "assistant", "content": []}, parent.event_loop_metrics, {})
-    mid = TypedEvent({"mid": 1})
-    s2 = EventLoopStopEvent("end_turn", {"role": "assistant", "content": []}, parent.event_loop_metrics, {})
-
-    async def inner(c):
-        yield s1
-        yield mid
-        yield s2
-
-    tru_events = [e async for e in plugin._handle_stream(ctx, inner)]
-    exp_events = [s1, mid, s2]
-    assert tru_events == exp_events
-
-
-@pytest.mark.asyncio
-async def test_handle_stream_delegation_replaces_stop_with_trailing():
-    """Delegation replaces stop; trailing events keep position; exactly one terminal."""
-    tool = _make_delegation_tool()
-    parent = Agent(name="p", tools=[tool], callback_handler=None)
-    plugin = _get_plugin(parent)
-
-    parent.messages.extend(
-        [
-            {"role": "assistant", "content": [{"toolUse": {"toolUseId": "t1", "name": "sub", "input": {}}}]},
-            {
-                "role": "user",
-                "content": [{"toolResult": {"toolUseId": "t1", "status": "success", "content": [{"text": "answer"}]}}],
-            },
-            {"role": "assistant", "content": [{"text": "placeholder"}]},
-        ]
-    )
-
-    ctx = AgentStreamContext(agent=parent, messages=[], invocation_state={"request_state": {}}, _interrupts={})
-    pre = TypedEvent({"pre": 1})
-    stop = EventLoopStopEvent("end_turn", parent.messages[-1], parent.event_loop_metrics, {})
-    trail = TypedEvent({"trail": 1})
-
-    async def inner(c):
-        plugin._state[parent] = _DelegationState(tool_use_id="t1", end_turn_via_delegation=True, tool_use_count=1)
-        yield pre
-        yield stop
-        yield trail
-
-    tru_events = [e async for e in plugin._handle_stream(ctx, inner)]
-
-    assert tru_events[0] is pre
-    tru_stops = [e for e in tru_events if isinstance(e, EventLoopStopEvent)]
-    assert len(tru_stops) == 1
-    assert tru_stops[0]["stop"][1]["content"][0]["text"] == "answer"
-    assert tru_events[-1] is trail
-    assert "tracking_id" in parent.messages[-1]
-
-
-@pytest.mark.asyncio
-async def test_handle_stream_reverify_failure_replays_original():
-    """If the tool result is mutated to error after _on_after_tools, original stop replays."""
-    tool = _make_delegation_tool()
-    parent = Agent(name="p", tools=[tool], callback_handler=None)
-    plugin = _get_plugin(parent)
-
-    parent.messages.extend(
-        [
-            {"role": "assistant", "content": [{"toolUse": {"toolUseId": "t1", "name": "sub", "input": {}}}]},
-            {
-                "role": "user",
-                "content": [{"toolResult": {"toolUseId": "t1", "status": "error", "content": [{"text": "failed"}]}}],
-            },
-            {"role": "assistant", "content": [{"text": "placeholder"}]},
-        ]
-    )
-
-    ctx = AgentStreamContext(agent=parent, messages=[], invocation_state={"request_state": {}}, _interrupts={})
-    original_stop = EventLoopStopEvent("end_turn", parent.messages[-1], parent.event_loop_metrics, {})
-
-    async def inner(c):
-        plugin._state[parent] = _DelegationState(tool_use_id="t1", end_turn_via_delegation=True, tool_use_count=1)
-        yield original_stop
-
-    tru_events = [e async for e in plugin._handle_stream(ctx, inner)]
-    assert len(tru_events) == 1
-    assert tru_events[0] is original_stop
-
-
-@pytest.mark.asyncio
-async def test_handle_stream_absent_tool_result_skips_delegation():
-    """When the tool result for the delegation toolUseId is absent from history, delegation is skipped."""
-    tool = _make_delegation_tool()
-    parent = Agent(name="p", tools=[tool], callback_handler=None)
-    plugin = _get_plugin(parent)
-
-    parent.messages.extend(
-        [
-            {"role": "assistant", "content": [{"toolUse": {"toolUseId": "t1", "name": "sub", "input": {}}}]},
-            {"role": "assistant", "content": [{"text": "placeholder"}]},
-        ]
-    )
-
-    ctx = AgentStreamContext(agent=parent, messages=[], invocation_state={"request_state": {}}, _interrupts={})
-    original_stop = EventLoopStopEvent("end_turn", parent.messages[-1], parent.event_loop_metrics, {})
-
-    async def inner(c):
-        plugin._state[parent] = _DelegationState(tool_use_id="t1", end_turn_via_delegation=True, tool_use_count=1)
-        yield original_stop
-
-    tru_events = [e async for e in plugin._handle_stream(ctx, inner)]
-    assert len(tru_events) == 1
-    assert tru_events[0] is original_stop
-
-
 # --- Stateful model rejection ---
 
 
@@ -449,12 +277,6 @@ def test_init_raises_with_delegation_on_stateful():
 
     with pytest.raises(ValueError, match="not supported with stateful models"):
         Agent(name="p", model=stateful, tools=[tool], callback_handler=None)
-
-
-def test_init_ok_without_delegation_on_stateful():
-    stateful = MagicMock()
-    type(stateful).stateful = PropertyMock(return_value=True)
-    Agent(name="p", model=stateful, callback_handler=None)
 
 
 @pytest.mark.asyncio
@@ -508,12 +330,14 @@ def test_to_content_blocks_converts_text_json_and_passthrough():
                 {"text": "hi"},
                 {"json": {"k": 1}},
                 {"image": {"format": "png", "source": {"bytes": b"x"}}},
+                {"text": "both", "json": {"k": 2}},
             ]
         }
     )
     assert tru_blocks[0] == {"text": "hi"}
     assert json_module.loads(tru_blocks[1]["text"]) == {"k": 1}
     assert tru_blocks[2] == {"image": {"format": "png", "source": {"bytes": b"x"}}}
+    assert tru_blocks[3] == {"text": "both"}
 
 
 # --- Child structured output serialization ---
@@ -613,6 +437,125 @@ async def test_full_delegation_error_recovery():
     assert "recovered" in str(tru_result.message["content"]).lower()
 
 
+@pytest.mark.asyncio
+async def test_full_delegation_blank_content_halts_loop():
+    """Empty content from the delegate becomes a blank text block via backfill, and the loop still halts."""
+    sub = Agent(
+        model=MockedModelProvider([{"role": "assistant", "content": []}]),
+        name="empty_sub",
+        callback_handler=None,
+    )
+    orch = Agent(
+        model=MockedModelProvider(
+            [
+                {
+                    "role": "assistant",
+                    "content": [{"toolUse": {"toolUseId": "c1", "name": "empty_sub", "input": {"input": "go"}}}],
+                },
+                # If delegation fails to halt, the loop would consume this second response
+                {"role": "assistant", "content": [{"text": "SHOULD NOT REACH"}]},
+            ]
+        ),
+        name="orch",
+        tools=[sub.as_tool(delegate=True)],
+        callback_handler=None,
+    )
+
+    tru_message_added_count = []
+    orch.add_hook(lambda event: tru_message_added_count.append(event.message), MessageAddedEvent)
+
+    tru_result = await orch.invoke_async("go")
+    assert tru_result.stop_reason == "end_turn"
+    assert tru_result.message["content"] == [{"text": ""}]
+    # 4 MessageAddedEvents: user prompt, assistant tool-use, user tool-result, assistant end_turn
+    assert len(tru_message_added_count) == 4
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("with_session_manager", [False, True])
+async def test_delegation_fires_one_message_added_event_with_real_content(with_session_manager):
+    """A delegation turn emits exactly one assistant MessageAddedEvent carrying the delegate's content.
+
+    Guards https://github.com/strands-agents/harness-sdk/issues/3808: subscribers must see the
+    delegated content once, whether or not a session manager is attached.
+    """
+    from strands.session.repository_session_manager import RepositorySessionManager
+    from tests.fixtures.mock_session_repository import MockedSessionRepository
+
+    session_manager = None
+    if with_session_manager:
+        session_manager = RepositorySessionManager(session_id="s1", session_repository=MockedSessionRepository())
+
+    sub = Agent(
+        model=MockedModelProvider([{"role": "assistant", "content": [{"text": "Balance: $42"}]}]),
+        name="billing",
+        callback_handler=None,
+    )
+    orch = Agent(
+        model=MockedModelProvider(
+            [
+                {
+                    "role": "assistant",
+                    "content": [{"toolUse": {"toolUseId": "c1", "name": "billing", "input": {"input": "check"}}}],
+                }
+            ]
+        ),
+        name="orch",
+        tools=[sub.as_tool(delegate=True)],
+        session_manager=session_manager,
+        callback_handler=None,
+    )
+
+    tru_assistant_messages: list = []
+    orch.add_hook(
+        lambda event: (
+            tru_assistant_messages.append(event.message)
+            if event.message["role"] == "assistant" and any("text" in b for b in event.message.get("content", []))
+            else None
+        ),
+        MessageAddedEvent,
+    )
+
+    await orch.invoke_async("Check balance")
+
+    exp_content = [{"text": "Balance: $42"}]
+    assert len(tru_assistant_messages) == 1
+    assert tru_assistant_messages[0]["content"] == exp_content
+
+
+@pytest.mark.asyncio
+async def test_foreign_hook_end_turn_string_not_clobbered_by_delegation():
+    """A non-delegation hook setting end_turn to a string produces the expected assistant message."""
+    from strands import tool
+
+    @tool
+    def my_tool(input: str) -> str:
+        return "done"
+
+    parent = Agent(
+        model=MockedModelProvider(
+            [
+                {
+                    "role": "assistant",
+                    "content": [{"toolUse": {"toolUseId": "t1", "name": "my_tool", "input": {"input": "go"}}}],
+                }
+            ]
+        ),
+        name="p",
+        tools=[my_tool],
+        callback_handler=None,
+    )
+
+    def force_end(event: AfterToolsEvent):
+        event.end_turn = "Custom halt message"
+
+    parent.add_hook(force_end, AfterToolsEvent)
+
+    tru_result = await parent.invoke_async("go")
+    assert tru_result.stop_reason == "end_turn"
+    assert tru_result.message["content"] == [{"text": "Custom halt message"}]
+
+
 # --- Session persistence ---
 
 
@@ -707,8 +650,7 @@ async def test_ordering_guard_late_hook_flipping_result_prevents_end_turn():
     Order priority always wins: DEFAULT (0) runs before SDK_LAST (100). Reverse ordering only flips
     registration order *within* one order tier, so delegation's SDK_LAST hook runs last and reads the
     already-mutated committed message. Its own check in _on_after_tools is what declines to set
-    end_turn here; _handle_stream's re-verification is a second line of defence that does not fire in
-    this scenario.
+    end_turn here.
     """
     sub = Agent(
         model=MockedModelProvider([{"role": "assistant", "content": [{"text": "answer"}]}]),
@@ -742,110 +684,6 @@ async def test_ordering_guard_late_hook_flipping_result_prevents_end_turn():
     tru_result = await orch.invoke_async("Do it")
     assert tru_result.stop_reason == "end_turn"
     assert "continued" in str(tru_result.message["content"]).lower()
-
-
-# --- MessageAddedEvent during delegation ---
-
-
-@pytest.mark.asyncio
-async def test_message_added_event_fires_for_delegation_message():
-    """MessageAddedEvent fires for the placeholder and then the real delegation content."""
-    sub = Agent(
-        model=MockedModelProvider([{"role": "assistant", "content": [{"text": "Balance: $42"}]}]),
-        name="billing",
-        callback_handler=None,
-    )
-
-    orch = Agent(
-        model=MockedModelProvider(
-            [
-                {
-                    "role": "assistant",
-                    "content": [{"toolUse": {"toolUseId": "c1", "name": "billing", "input": {"input": "check"}}}],
-                }
-            ]
-        ),
-        name="orch",
-        tools=[sub.as_tool(delegate=True)],
-        callback_handler=None,
-    )
-
-    received_messages = []
-
-    def on_message_added(event: MessageAddedEvent):
-        received_messages.append(event.message)
-
-    orch.add_hook(on_message_added, MessageAddedEvent)
-    await orch.invoke_async("Check balance")
-
-    # Expected: user prompt, assistant tool_use, tool_result, end_turn placeholder, delegation content
-    assert len(received_messages) == 5
-
-    tru_placeholders = [
-        m
-        for m in received_messages
-        if m["role"] == "assistant" and any("Turn ended early" in str(b.get("text", "")) for b in m.get("content", []))
-    ]
-    assert len(tru_placeholders) == 1
-
-    tru_delegation = [
-        m
-        for m in received_messages
-        if m["role"] == "assistant" and any("$42" in str(b.get("text", "")) for b in m.get("content", []))
-    ]
-    assert len(tru_delegation) == 1
-
-    # Placeholder comes before delegation content
-    assert received_messages.index(tru_placeholders[0]) < received_messages.index(tru_delegation[0])
-
-
-@pytest.mark.asyncio
-async def test_session_manager_suppresses_delegation_message_added_event():
-    """With a session manager, subscribers see the placeholder but not the delegation content event."""
-    from strands.session.repository_session_manager import RepositorySessionManager
-    from tests.fixtures.mock_session_repository import MockedSessionRepository
-
-    repo = MockedSessionRepository()
-    session_mgr = RepositorySessionManager(session_id="s1", session_repository=repo)
-
-    sub = Agent(
-        model=MockedModelProvider([{"role": "assistant", "content": [{"text": "Balance: $42"}]}]),
-        name="billing",
-        callback_handler=None,
-    )
-
-    orch = Agent(
-        model=MockedModelProvider(
-            [
-                {
-                    "role": "assistant",
-                    "content": [{"toolUse": {"toolUseId": "c1", "name": "billing", "input": {"input": "check"}}}],
-                }
-            ]
-        ),
-        name="orch",
-        tools=[sub.as_tool(delegate=True)],
-        session_manager=session_mgr,
-        callback_handler=None,
-    )
-
-    received_messages = []
-
-    def on_message_added(event: MessageAddedEvent):
-        received_messages.append(event.message)
-
-    orch.add_hook(on_message_added, MessageAddedEvent)
-    await orch.invoke_async("Check balance")
-
-    tru_delegation = [
-        m
-        for m in received_messages
-        if m["role"] == "assistant" and any("$42" in str(b.get("text", "")) for b in m.get("content", []))
-    ]
-    assert len(tru_delegation) == 0
-
-    # But agent.messages still reflects the delegation content
-    assert any("$42" in str(b.get("text", "")) for b in orch.messages[-1].get("content", []))
 
 
 # --- Middleware single-call guard ---
@@ -915,10 +753,10 @@ async def test_delegation_preserves_content_verbatim_across_hops():
         callback_handler=None,
     )
 
-    result = await top.invoke_async("run")
+    tru_result = await top.invoke_async("run")
 
-    assert len(result.message["content"]) == 1
-    delivered_text = result.message["content"][0]["text"]
+    assert len(tru_result.message["content"]) == 1
+    delivered_text = tru_result.message["content"][0]["text"]
     assert delivered_text == exact_payload, f"Expected verbatim {exact_payload!r}, got {delivered_text!r}"
 
 
@@ -998,3 +836,52 @@ async def test_delegation_preserves_citations_alongside_text():
     assert len(content) == 2
     assert content[0]["text"] == plain_text
     assert content[1]["text"] == cited_text
+
+
+@pytest.mark.asyncio
+async def test_full_delegation_json_content_serialized_to_text():
+    """JSON content blocks from a delegate are serialized to text in the parent's final assistant message.
+
+    This guards the _to_content_blocks wiring at the _on_after_tools call site — without it a raw
+    {"json": ...} block would leak into the assistant message verbatim.
+    """
+    json_payload = {"status": "ok", "count": 3}
+
+    sub = Agent(
+        model=MockedModelProvider([{"role": "assistant", "content": [{"text": "unused"}]}]),
+        name="leaf",
+        callback_handler=None,
+    )
+    tool = sub.as_tool(delegate=True)
+
+    fake_result = AgentResult(
+        stop_reason="end_turn",
+        message={"role": "assistant", "content": [{"json": json_payload}]},
+        metrics=EventLoopMetrics(),
+        state={},
+    )
+
+    async def fake_stream(prompt):
+        yield {"result": fake_result}
+
+    tool._agent.stream_async = fake_stream
+
+    orch = Agent(
+        model=MockedModelProvider(
+            [
+                {
+                    "role": "assistant",
+                    "content": [{"toolUse": {"toolUseId": "c1", "name": "leaf", "input": {"input": "go"}}}],
+                }
+            ]
+        ),
+        name="orch",
+        tools=[tool],
+        callback_handler=None,
+    )
+
+    tru_result = await orch.invoke_async("go")
+
+    exp_content = [{"text": json_module.dumps(json_payload)}]
+    assert tru_result.message["content"] == exp_content
+    assert orch.messages[-1]["content"] == exp_content

--- a/strands-py/tests/strands/agent/test_agent_delegation.py
+++ b/strands-py/tests/strands/agent/test_agent_delegation.py
@@ -467,8 +467,18 @@ async def test_full_delegation_blank_content_skips_delegation():
 
 
 @pytest.mark.asyncio
-async def test_delegation_emits_correct_history_and_single_assistant_event():
-    """A delegation turn produces a correct history and emits exactly one assistant MessageAddedEvent."""
+@pytest.mark.parametrize("with_session_manager", [False, True])
+async def test_delegation_emits_correct_history_and_single_assistant_event(with_session_manager):
+    """A delegation turn produces a correct history and emits exactly one assistant MessageAddedEvent.
+
+    Subscribers must see the delegated content exactly once, whether or not a session manager is attached (#3808).
+    """
+    session_manager = (
+        RepositorySessionManager(session_id="s1", session_repository=MockedSessionRepository())
+        if with_session_manager
+        else None
+    )
+
     sub = Agent(
         model=MockedModelProvider([{"role": "assistant", "content": [{"text": "Balance: $42"}]}]),
         name="billing",
@@ -485,6 +495,7 @@ async def test_delegation_emits_correct_history_and_single_assistant_event():
         ),
         name="orch",
         tools=[sub.as_tool(delegate=True)],
+        session_manager=session_manager,
         callback_handler=None,
     )
 

--- a/strands-py/tests/strands/agent/test_agent_delegation.py
+++ b/strands-py/tests/strands/agent/test_agent_delegation.py
@@ -332,7 +332,6 @@ def test_to_content_blocks_converts_text_json_and_passthrough():
                 {"text": "hi"},
                 {"json": {"k": 1}},
                 {"image": {"format": "png", "source": {"bytes": b"x"}}},
-                {"text": "both", "json": {"k": 2}},
             ]
         }
     )

--- a/strands-py/tests/strands/agent/test_agent_delegation.py
+++ b/strands-py/tests/strands/agent/test_agent_delegation.py
@@ -438,8 +438,8 @@ async def test_full_delegation_error_recovery():
 
 
 @pytest.mark.asyncio
-async def test_full_delegation_blank_content_halts_loop():
-    """Empty content from the delegate becomes a blank text block via backfill, and the loop still halts."""
+async def test_full_delegation_blank_content_skips_delegation():
+    """When a delegate returns empty content, delegation is skipped and the loop continues to the model."""
     sub = Agent(
         model=MockedModelProvider([{"role": "assistant", "content": []}]),
         name="empty_sub",
@@ -452,8 +452,8 @@ async def test_full_delegation_blank_content_halts_loop():
                     "role": "assistant",
                     "content": [{"toolUse": {"toolUseId": "c1", "name": "empty_sub", "input": {"input": "go"}}}],
                 },
-                # If delegation fails to halt, the loop would consume this second response
-                {"role": "assistant", "content": [{"text": "SHOULD NOT REACH"}]},
+                # Delegation skipped — the loop continues and the model produces this response.
+                {"role": "assistant", "content": [{"text": "I continued."}]},
             ]
         ),
         name="orch",
@@ -461,14 +461,9 @@ async def test_full_delegation_blank_content_halts_loop():
         callback_handler=None,
     )
 
-    tru_message_added_count = []
-    orch.add_hook(lambda event: tru_message_added_count.append(event.message), MessageAddedEvent)
-
     tru_result = await orch.invoke_async("go")
     assert tru_result.stop_reason == "end_turn"
-    assert tru_result.message["content"] == [{"text": ""}]
-    # 4 MessageAddedEvents: user prompt, assistant tool-use, user tool-result, assistant end_turn
-    assert len(tru_message_added_count) == 4
+    assert "I continued." in str(tru_result.message["content"])
 
 
 @pytest.mark.asyncio
@@ -518,8 +513,6 @@ async def test_delegation_emits_correct_history_and_single_assistant_event():
     assert "toolResult" in orch.messages[2]["content"][0]
     assert orch.messages[3]["role"] == "assistant"
     assert orch.messages[3]["content"] == exp_content
-
-
 
 
 # --- Session persistence ---

--- a/strands-py/tests/strands/agent/test_agent_delegation.py
+++ b/strands-py/tests/strands/agent/test_agent_delegation.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from unittest.mock import MagicMock, PropertyMock
 
 import pytest
+from pydantic import BaseModel
 
 from strands._middleware.stages import ExecuteToolContext
 from strands.agent._agent_as_tool import DELEGATION_DESCRIPTION_SUFFIX, _AgentAsTool
@@ -18,8 +19,12 @@ from strands.hooks import (
     MessageAddedEvent,
 )
 from strands.interrupt import _InterruptState
+from strands.session.repository_session_manager import RepositorySessionManager
 from strands.telemetry.metrics import EventLoopMetrics
+from strands.tools.structured_output.structured_output_tool import StructuredOutputTool
 from strands.types._events import ToolResultEvent
+from strands.vended_plugins.context_offloader import ContextOffloader, InMemoryStorage
+from tests.fixtures.mock_session_repository import MockedSessionRepository
 from tests.fixtures.mocked_model_provider import MockedModelProvider
 
 # --- Helpers ---
@@ -227,9 +232,6 @@ def test_on_after_tools_sets_end_turn_on_success():
 
 
 def test_on_after_tools_suppressed_with_structured_output():
-    from pydantic import BaseModel
-
-    from strands.tools.structured_output.structured_output_tool import StructuredOutputTool
 
     class R(BaseModel):
         x: int
@@ -345,8 +347,6 @@ def test_to_content_blocks_converts_text_json_and_passthrough():
 
 @pytest.mark.asyncio
 async def test_child_structured_output_datetime_serializes_cleanly():
-    from pydantic import BaseModel
-
     class S(BaseModel):
         at: datetime
 
@@ -472,20 +472,8 @@ async def test_full_delegation_blank_content_halts_loop():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("with_session_manager", [False, True])
-async def test_delegation_fires_one_message_added_event_with_real_content(with_session_manager):
-    """A delegation turn emits exactly one assistant MessageAddedEvent carrying the delegate's content.
-
-    Guards https://github.com/strands-agents/harness-sdk/issues/3808: subscribers must see the
-    delegated content once, whether or not a session manager is attached.
-    """
-    from strands.session.repository_session_manager import RepositorySessionManager
-    from tests.fixtures.mock_session_repository import MockedSessionRepository
-
-    session_manager = None
-    if with_session_manager:
-        session_manager = RepositorySessionManager(session_id="s1", session_repository=MockedSessionRepository())
-
+async def test_delegation_emits_correct_history_and_single_assistant_event():
+    """A delegation turn produces a correct history and emits exactly one assistant MessageAddedEvent."""
     sub = Agent(
         model=MockedModelProvider([{"role": "assistant", "content": [{"text": "Balance: $42"}]}]),
         name="billing",
@@ -502,7 +490,6 @@ async def test_delegation_fires_one_message_added_event_with_real_content(with_s
         ),
         name="orch",
         tools=[sub.as_tool(delegate=True)],
-        session_manager=session_manager,
         callback_handler=None,
     )
 
@@ -522,38 +509,17 @@ async def test_delegation_fires_one_message_added_event_with_real_content(with_s
     assert len(tru_assistant_messages) == 1
     assert tru_assistant_messages[0]["content"] == exp_content
 
+    # Verify the full orchestrator history shape.
+    assert len(orch.messages) == 4
+    assert orch.messages[0]["role"] == "user"
+    assert orch.messages[1]["role"] == "assistant"
+    assert "toolUse" in orch.messages[1]["content"][0]
+    assert orch.messages[2]["role"] == "user"
+    assert "toolResult" in orch.messages[2]["content"][0]
+    assert orch.messages[3]["role"] == "assistant"
+    assert orch.messages[3]["content"] == exp_content
 
-@pytest.mark.asyncio
-async def test_foreign_hook_end_turn_string_not_clobbered_by_delegation():
-    """A non-delegation hook setting end_turn to a string produces the expected assistant message."""
-    from strands import tool
 
-    @tool
-    def my_tool(input: str) -> str:
-        return "done"
-
-    parent = Agent(
-        model=MockedModelProvider(
-            [
-                {
-                    "role": "assistant",
-                    "content": [{"toolUse": {"toolUseId": "t1", "name": "my_tool", "input": {"input": "go"}}}],
-                }
-            ]
-        ),
-        name="p",
-        tools=[my_tool],
-        callback_handler=None,
-    )
-
-    def force_end(event: AfterToolsEvent):
-        event.end_turn = "Custom halt message"
-
-    parent.add_hook(force_end, AfterToolsEvent)
-
-    tru_result = await parent.invoke_async("go")
-    assert tru_result.stop_reason == "end_turn"
-    assert tru_result.message["content"] == [{"text": "Custom halt message"}]
 
 
 # --- Session persistence ---
@@ -561,9 +527,6 @@ async def test_foreign_hook_end_turn_string_not_clobbered_by_delegation():
 
 @pytest.mark.asyncio
 async def test_persisted_matches_in_memory_after_delegation():
-    from strands.session.repository_session_manager import RepositorySessionManager
-    from tests.fixtures.mock_session_repository import MockedSessionRepository
-
     repo = MockedSessionRepository()
     session_mgr = RepositorySessionManager(session_id="s1", session_repository=repo)
 
@@ -606,8 +569,6 @@ async def test_persisted_matches_in_memory_after_delegation():
 @pytest.mark.asyncio
 async def test_large_delegation_result_not_offloaded():
     """A delegation result exceeding the offloader threshold stays in context."""
-    from strands.vended_plugins.context_offloader import ContextOffloader, InMemoryStorage
-
     storage = InMemoryStorage()
     offloader = ContextOffloader(storage=storage, max_result_tokens=25, preview_tokens=10)
 

--- a/strands-py/tests/strands/event_loop/test_event_loop.py
+++ b/strands-py/tests/strands/event_loop/test_event_loop.py
@@ -1169,11 +1169,15 @@ async def test_event_loop_cycle_after_tools_order_and_message(agent, model, tool
 @pytest.mark.asyncio
 @pytest.mark.parametrize("executor_type", [SequentialToolExecutor, ConcurrentToolExecutor])
 @pytest.mark.parametrize(
-    ("end_turn", "expected_text"),
-    [(True, "Turn ended early by hook after tool execution"), ("stop now", "stop now")],
+    ("end_turn", "expected_content"),
+    [
+        (True, [{"text": "Turn ended early by hook after tool execution"}]),
+        ("stop now", [{"text": "stop now"}]),
+        ([{"text": "delegated"}], [{"text": "delegated"}]),
+    ],
 )
 async def test_event_loop_cycle_after_tools_end_turn_halts_loop(
-    agent, model, tool_stream, agenerator, alist, executor_type, end_turn, expected_text
+    agent, model, tool_stream, agenerator, alist, executor_type, end_turn, expected_content
 ):
     agent.tool_executor = executor_type()
 
@@ -1191,7 +1195,8 @@ async def test_event_loop_cycle_after_tools_end_turn_halts_loop(
     assert model.stream.call_count == 1
     tru_last_message = agent.messages[-1]
     assert tru_last_message["role"] == "assistant"
-    assert tru_last_message["content"] == [{"text": expected_text}]
+    assert tru_last_message["content"] == expected_content
+    assert events[-1]["stop"][1]["content"] == expected_content
 
 
 @pytest.mark.asyncio
@@ -1351,13 +1356,14 @@ async def test_event_loop_cycle_after_tools_not_fired_on_before_tools_interrupt(
 
 
 @pytest.mark.asyncio
-async def test_event_loop_cycle_after_tools_empty_string_end_turn_does_not_halt(
-    agent, model, tool_stream, agenerator, alist
+@pytest.mark.parametrize("falsy_end_turn", ["", []])
+async def test_event_loop_cycle_after_tools_falsy_end_turn_does_not_halt(
+    agent, model, tool_stream, agenerator, alist, falsy_end_turn
 ):
-    def set_empty_end_turn(event):
-        event.end_turn = ""
+    def set_falsy_end_turn(event):
+        event.end_turn = falsy_end_turn
 
-    agent.hooks.add_callback(AfterToolsEvent, set_empty_end_turn)
+    agent.hooks.add_callback(AfterToolsEvent, set_falsy_end_turn)
     model.stream.side_effect = [
         agenerator(tool_stream),
         agenerator([{"contentBlockDelta": {"delta": {"text": "done"}}}, {"contentBlockStop": {}}]),
@@ -1365,9 +1371,28 @@ async def test_event_loop_cycle_after_tools_empty_string_end_turn_does_not_halt(
 
     events = await alist(strands.event_loop.event_loop.event_loop_cycle(agent, invocation_state={}))
 
-    # An empty-string end_turn is falsy, so the loop continues to the next model call.
+    # A falsy end_turn does not halt — the loop continues to the next model call.
     assert events[-1]["stop"][0] == "end_turn"
     assert model.stream.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_event_loop_cycle_after_tools_end_turn_list_not_aliased(agent, model, tool_stream, agenerator, alist):
+    hook_list = [{"text": "from hook"}]
+
+    def set_list_end_turn(event):
+        event.end_turn = hook_list
+
+    agent.hooks.add_callback(AfterToolsEvent, set_list_end_turn)
+    model.stream.side_effect = [agenerator(tool_stream)]
+
+    await alist(strands.event_loop.event_loop.event_loop_cycle(agent, invocation_state={}))
+
+    # Mutate the hook's list after the invocation returns.
+    hook_list.append({"text": "MUTATED AFTER THE FACT"})
+
+    # The committed message must be unchanged — the event loop shallow-copied.
+    assert agent.messages[-1]["content"] == [{"text": "from hook"}]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

`AfterToolsEvent.end_turn` previously accepted only `bool | str`, which forced the `AgentDelegation` plugin to set `end_turn = True` to halt the loop, then intercept the resulting `EventLoopStopEvent` in an `AgentStreamStage` middleware to replace the placeholder assistant message with the delegate's actual content. This made delegation the only feature that post-hoc rewrote committed messages and fired a second `MessageAddedEvent` (or suppressed it depending on session manager presence).

By widening `end_turn` to also accept `list[ContentBlock]`, the delegation plugin can pass the delegate's content blocks directly at the point where it decides to halt: `_on_after_tools`. The event loop builds the final assistant message from those blocks with no post-processing needed, eliminating the `AgentStreamStage` middleware, the `_find_delegation_result` helper, the `end_turn_via_delegation` state flag, and the message-replacement logic entirely.

This PR only includes Python changes. The TS changes will be in a follow-up PR.

### Public API Changes

`AfterToolsEvent.end_turn` now accepts a third type:

```python
# Before
event.end_turn = True           # default text
event.end_turn = "halt reason"  # custom text

# After (additive)
event.end_turn = [{"text": "delegated content"}]  # content blocks used directly
```

## Related Issues

Closes https://github.com/strands-agents/harness-sdk/issues/3808 on the Python Side

## Documentation PR

Documentation updated in this PR: `site/src/content/docs/user-guide/concepts/agents/hooks.mdx`

## Type of Change

Bug fix

## Testing

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
