### PR TITLE
fix(memory-py): make MemoryStore optional methods instantiable under type checkers

### DIFF
--- a/strands-py/src/strands/memory/types.py
+++ b/strands-py/src/strands/memory/types.py
@@ -251,6 +251,15 @@ class MemoryStoreConfig(TypedDict, total=False):
     extraction: ExtractionConfig | bool
 
 
+def _default_not_implemented(store: object, method: str) -> Any:
+    """Raise for a write sink invoked on a store that does not implement it.
+
+    The manager never routes to an unimplemented sink (``_has_method`` filters
+    them out); this guards direct calls on the inherited default.
+    """
+    raise NotImplementedError(f"{type(store).__name__} does not implement {method}.")
+
+
 class MemoryStore(Protocol):
     """Runtime contract for a memory store backend.
 
@@ -277,6 +286,11 @@ class MemoryStore(Protocol):
         ...
 
     # --- Optional methods: detect presence via ``_has_method`` / ``_has_write_sink``.
+    # Each carries a concrete default body so that explicit subclasses are
+    # instantiable under static type checkers; ``_has_method`` treats an
+    # inherited default as "not implemented", so runtime detection is unchanged.
+    # The write sinks raise through ``_default_not_implemented`` because a bare
+    # ``raise NotImplementedError`` body is itself treated as a stub by mypy.
 
     async def add(self, content: str, metadata: Metadata | None = None) -> Any:
         """Add a single piece of content to the store.
@@ -285,7 +299,7 @@ class MemoryStore(Protocol):
         extraction should tolerate duplicate writes. The resolved value is
         store-specific and not consumed by the manager.
         """
-        ...
+        return _default_not_implemented(self, "add")
 
     async def add_messages(self, messages: list[Message], context: AddMessagesContext | None = None) -> Any:
         """Ingest a batch of conversation messages, preserving role structure.
@@ -294,7 +308,7 @@ class MemoryStore(Protocol):
         hands the filtered batch straight here. The resolved value is
         store-specific.
         """
-        ...
+        return _default_not_implemented(self, "add_messages")
 
     async def initialize(self) -> None:
         """Perform async setup that must succeed before the agent runs.
@@ -302,11 +316,11 @@ class MemoryStore(Protocol):
         Called by the ``MemoryManager`` during ``init_agent``. Stores that require remote resources
         (e.g. resolving a knowledge base type) implement this; the default is a no-op.
         """
-        ...
+        return None
 
     def get_tools(self) -> list[AgentTool]:
         """Return store-specific tools to register alongside the manager's tools."""
-        ...
+        return []
 
 
 def _has_method(store: object, name: str) -> bool:

--- a/strands-py/tests/strands/memory/test_memory_manager.py
+++ b/strands-py/tests/strands/memory/test_memory_manager.py
@@ -53,7 +53,11 @@ from strands.memory.types import (
     MemoryEntry,
     MemoryInjectionConfig,
     MemorySearchOptions,
+    MemoryStore,
     MemoryToolConfig,
+    SearchOptions,
+    _has_method,
+    _has_write_sink,
 )
 from strands.tools.decorator import tool
 
@@ -260,6 +264,38 @@ def test_constructor_raises_when_writable_without_write_sink():
     broken = _store("broken", writable=True, sinks=set())
     with pytest.raises(Exception, match="no add or add_messages"):
         MemoryManager(stores=[broken])
+
+
+@pytest.mark.asyncio
+async def test_memory_store_subclass_inherited_defaults_are_not_capabilities():
+    """A ``MemoryStore`` subclass implementing only ``search`` is a read-only store.
+
+    Guards https://github.com/strands-agents/harness-sdk/issues/3965: the optional
+    protocol methods carry default bodies so explicit subclasses are instantiable
+    under static type checkers, and an inherited default must not register as an
+    implemented capability.
+    """
+
+    class SearchOnlyStore(MemoryStore):
+        def __init__(self) -> None:
+            self.name = "search-only"
+            self.description = None
+            self.max_search_results = None
+            self.writable = False
+            self.extraction = None
+
+        async def search(self, query: str, options: SearchOptions | None = None) -> list[MemoryEntry]:
+            return []
+
+    store = SearchOnlyStore()
+    for method in ("add", "add_messages", "initialize", "get_tools"):
+        assert not _has_method(store, method)
+    assert not _has_write_sink(store)
+
+    mm = MemoryManager(stores=[store])
+    assert "add_memory" not in _tool_names(mm)
+    with pytest.raises(Exception, match="no writable store matched"):
+        await mm.add("fact")
 
 
 def test_constructor_raises_when_add_tool_enabled_but_no_store_implements_add():


### PR DESCRIPTION
Closes #3965

## Problem

`MemoryStore`'s optional methods (`add`, `add_messages`, `initialize`, `get_tools`) had stub bodies, which type checkers treat as abstract. Any explicit subclass failed mypy instantiation — including the SDK's own `TestMemoryStore` and `BedrockKnowledgeBaseStore`:

```
error: Cannot instantiate abstract class "TestMemoryStore" with abstract
attributes "add_messages", "get_tools" and "initialize"  [abstract]
```

and implicit structural conformance required all five members, so the documented extension point (implement `search`, optionally `add`) could not be used in a mypy-checked codebase without `type: ignore`.

## Fix

Give each optional method a concrete default body. This composes with the existing runtime detection: `_has_method` already treats a method inherited from `MemoryStore` as not implemented, so capability detection is byte-for-byte unchanged. The write-sink defaults raise through a small helper because a bare `raise NotImplementedError` body is itself treated as a stub marker by mypy; `initialize` returns `None` explicitly for the same reason.

Python-only: the TypeScript `MemoryStore` interface already expresses optionality (`addMessages?`).

## Testing

- New regression test (links #3965): a `MemoryStore` subclass implementing only `search` is instantiable, registers no write sink and no tools via `_has_method`/`_has_write_sink`, and stays read-only through the manager (`add` raises "no writable store matched").
- mypy probe: instantiating `TestMemoryStore` and a search-only subclass both pass after the change, both fail before it.
- `tests/strands/memory/` + `tests/strands/vended_memory_stores/`: 305 passed.
- Full unit suite (excluding modules gated on optional provider deps absent in my env): 3,842 passed; the 4 telemetry errors reproduce identically on unmodified `main` (missing OTLP exporter in env).
- `ruff check` clean on both changed files; `mypy src/strands/memory/types.py` clean.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.