### PR TITLE
fix(bedrock): detect Mantle context overflow errors

### DIFF
--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -54,6 +54,7 @@ BEDROCK_CONTEXT_WINDOW_OVERFLOW_MESSAGES = [
     "input length and `max_tokens` exceed context limit",
     "too many total text bytes",
     "prompt is too long",
+    "This model's maximum context length is",
 ]
 
 # Bedrock reports this exact substring for the Converse incompatibility tracked in #1223.

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -2251,6 +2251,7 @@ async def test_add_note_on_validation_exception_throughput(bedrock_client, model
         "input length and `max_tokens` exceed context limit",
         "too many total text bytes",
         "prompt is too long: 903884 tokens > 200000 maximum",
+        "This model's maximum context length is 202752 tokens.",
     ],
 )
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Fixes #3969 by recognizing the OpenAI-style Bedrock/Mantle context overflow prefix (`This model's maximum context length is`). This converts the provider `ValidationException` into `ContextWindowOverflowException`, allowing configured context managers to reduce context instead of retrying the same oversized conversation.

## Related Issues

Fixes #3969

## Type of Change

Bug fix

## Implementation and compatibility

Adds one stable error-message prefix to the existing Bedrock overflow classifier and one offline unit-test parameter. No public API, request shape, or provider behavior changes outside this previously unclassified vendor error form.

## Testing

- `python -m hatch test tests/strands/models/test_bedrock.py -k context_window_overflow -vv -n 0 --basetemp D:\project\tscodex\github_pr\_contrib\test-tmp-3969` — 5 passed
- `python -m hatch test tests/strands/models/test_bedrock.py -vv -n 0 --basetemp D:\project\tscodex\github_pr\_contrib\test-tmp-3969` — 275 passed
- `python -m ruff check src/strands/models/bedrock.py tests/strands/models/test_bedrock.py` — passed
- `git diff --check` — passed

Not run: full multi-Python suite, integration tests (require provider credentials), and `hatch-static-analysis` (environment synchronization stalled locally). `ruff format --check` reports two pre-existing formatting differences in unrelated lines of these already-touched files.

## Evidence self-audit

1. **Issue meaningful/reproducible:** Yes. #3969 is open and describes an exact `ValidationException` shape; before the change the new offline fixture raised raw `ClientError`, after it raises the SDK overflow exception.
2. **Requirements solved:** Yes. The parameterized regression test exercised the existing classification path and passes with the new prefix.
3. **Additional problems assessed:** Yes. The change is an additive substring in the existing private classifier; it does not change API, request payloads, state, or retry mechanics.
4. **Atomicity/consistency/races assessed:** Yes. This synchronous error classification has no shared mutable state, persistence, resource ownership, or concurrency changes.
5. **Tests sufficient:** Yes for this scope. The focused test covers existing formats plus the Mantle form; the full Bedrock unit module passed. Live integration is not needed because the provider client is mocked and the behavior is error translation.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of this focused change
- [x] My change is focused and reasonably small
- [x] I have added a regression test
- [x] No documentation changes are needed
- [x] No new warnings were introduced by the focused checks