### PR TITLE
ci: disable dependabot version updates for the TypeScript SDK workspace

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,21 @@
 # Dependabot configuration.
 #
-# Shared conventions across every ecosystem below:
+# Version updates are DISABLED for the root npm workspace (the TypeScript
+# SDK, open-pull-requests-limit: 0). As an SDK we want each
+# dependency constraint to stay as wide as possible so the SDK composes with
+# as many consumer projects as possible, and npm bump PRs raise constraint
+# floors in strands-ts/package.json (any 0.x bump and every cross-major bump
+# moves the floor) — narrowing that range.
+# Security updates are not subject to the limit and still open PRs, picking up
+# the labels, commit prefix, and versioning-strategy configured on the block.
+# (pip is different: its `>=floor,<major+1` constraints mean bump PRs raise
+# the ceiling — widening support — so the Python blocks keep version updates.)
+#
+# Shared conventions across the version-updating ecosystems below:
 #   - cooldown: hold new updates for a few days before opening a PR so we don't
 #     churn on same-day releases. Majors get a long (30-day) window so a human
-#     can vet breaking changes before the PR lands.
+#     can vet breaking changes before the PR lands (github-actions is the
+#     exception — see its block).
 #   - groups: batch low-risk updates into grouped PRs — dev tooling in one,
 #     production minor/patch bumps in another. Major production updates are
 #     intentionally left ungrouped so they arrive as individual,
@@ -105,37 +117,22 @@ updates:
           - 'patch'
       # Major production updates aren't matched by any group, so they get individual
       # PRs — gated by the 30-day semver-major cooldown above for manual review.
-  # TypeScript SDK at the repo root. Same batching strategy as the Python SDK.
+  # TypeScript SDK at the repo root: security updates only (see header).
+  # `schedule` is inert with the limit at 0 but required by the schema;
+  # `versioning-strategy` still applies to security PRs — increase-if-necessary
+  # leaves a constraint alone when it already allows the patched release, so a
+  # security PR usually moves only the lockfile, not the manifest floor.
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'weekly'
-    open-pull-requests-limit: 100
+    open-pull-requests-limit: 0
     labels:
       - 'dependencies'
       - 'typescript'
     commit-message:
       prefix: 'ci(typescript)'
     versioning-strategy: increase-if-necessary
-    cooldown:
-      default-days: 5
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3
-    groups:
-      # All development dependencies in one PR.
-      development-dependencies:
-        dependency-type: 'development'
-        applies-to: version-updates
-      # Production minor + patch bumps in one PR.
-      production-minor:
-        dependency-type: 'production'
-        applies-to: version-updates
-        update-types:
-          - 'minor'
-          - 'patch'
-      # Major production updates aren't matched by any group, so they get individual
-      # PRs — gated by the 30-day semver-major cooldown above for manual review.
   # Documentation site (/site). Same batching strategy as the SDKs so docs
   # tooling bumps don't each open a separate PR and majors get the review window.
   - package-ecosystem: 'npm'
@@ -189,8 +186,9 @@ updates:
       pr-metrics-tools:
         patterns:
           - '*'
-  # GitHub Actions workflow pins. Low volume, so no grouping; the cooldown still
-  # holds majors back for review before the bump PR opens.
+  # GitHub Actions workflow pins. Low volume, so no grouping. Only `default-days`
+  # applies here — the semver-* cooldown windows are limited to ecosystems whose
+  # versions Dependabot treats as semver, which excludes github-actions.
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
@@ -200,6 +198,3 @@ updates:
       prefix: ci
     cooldown:
       default-days: 5
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3


### PR DESCRIPTION
## Description

Requested by `Unshure` in #3928: stop Dependabot from opening routine version-bump PRs for the SDK. As an SDK we want each dependency constraint to stay as wide as possible; the recurring npm bump PRs (#3314, #3621, #3650, #3734, #3895, #3928) rewrite constraint floors in `strands-ts/package.json`, narrowing the range of consumer projects the SDK composes with.

**What this does:**
- Sets `open-pull-requests-limit: 0` on the root npm block — GitHub's documented idiom for disabling **version** updates while **security** updates continue to open PRs (they are exempt from the limit and still pick up the block's labels, `ci(typescript)` prefix, and versioning-strategy).
- Removes the now-dead `groups`/`cooldown` from that block (both applied to version updates only).
- Drops the `semver-*` cooldown keys from the `github-actions` block: the cooldown docs limit those keys to semver ecosystems, which excludes github-actions, so they were inert. `default-days: 5` is retained.

**Deliberately untouched — flagging for your call, `Unshure`:**
- The two **pip** blocks (`strands-py`, `strands-mcp`) keep version updates. pip constraints here are `>=floor,<major+1`, so under `increase-if-necessary` a pip bump PR *widens* the range (e.g. #3868: `mypy <2.0.0` → `<3.0.0`) — the opposite of the npm behavior. Disabling them would work against the widest-range goal. Say the word if you'd rather they go too.
- `/site` and the pr-metrics tools keep version updates — internal-only, no consumer-facing constraints.

**After merge:** this only stops *new* version-bump PRs — #3928 itself (and any sibling open Dependabot version PRs) should be closed manually; Dependabot won't recreate them.

<details>
<summary>Verification & independent review ledger</summary>

**Verification**
- `check-jsonschema --builtin-schema vendor.dependabot .github/dependabot.yml` → `ok -- validation done`.
- Parsed both revisions and compared blocks: `pip /strands-py`, `pip /strands-mcp`, `npm /site`, `npm /.github/scripts/pr-metrics/tools` are identical to `main`; only `npm /` and `github-actions /` changed.
- Dependabot semantics verified against the options reference: `open-pull-requests-limit` — "Security update pull requests are not subject to this limit"; setting 0 disables version updates. `labels`/`commit-message`/`versioning-strategy` apply to security updates too; `cooldown`/`groups(applies-to: version-updates)` do not. `schedule` is inert with the limit at 0 but schema-required.

**Review ledger** (3 independent fresh-context review rounds, per my convergence process)
- Round 1: CHANGES REQUESTED — my draft also disabled the pip blocks on a rationale that's false for pip (bumps widen, not narrow); fixed by scoping to npm-root and deferring pip to the maintainer. Also flagged the github-actions `semver-*` keys.
- Round 2: CHANGES REQUESTED — two overstated comments in the file (claimed the semver keys are "rejected as invalid" — docs only say unsupported; claimed security PRs raise the vulnerable floor — usually they only move the lockfile). Both corrected to the reviewer's wording.
- Round 3: CHANGES REQUESTED on one residual comment (a parallel-edit race had reverted the round-2 fix); re-applied, plus tightened the header claim ("with every bump" → 0.x and cross-major bumps).
- Residual open point: none blocking. One judgment call surfaced above (pip scope) for the maintainer.

</details>

## Related Issues

Requested in #3928 (Dependabot PR — needs manual close after this merges).

## Documentation PR

n/a — CI configuration only.

## Type of Change

Other (please describe): dependency-management (Dependabot) configuration.

## Testing

Config-only change; `hatch run prepare` is n/a (no Python/TS code touched). Validated with `check-jsonschema --builtin-schema vendor.dependabot` and cross-checked every claim against the Dependabot options reference (details above).

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works (n/a — CI config)
- [x] I have updated the documentation accordingly (config header comments)
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
