### PR TITLE
fix(test-infra): grant Bidi integration test permissions

### DIFF
--- a/test-infra/lib/constructs/integ-test-role.ts
+++ b/test-infra/lib/constructs/integ-test-role.ts
@@ -129,7 +129,17 @@ export class IntegTestRole extends Construct {
           'arn:aws:bedrock:*:*:inference-profile/us.anthropic.claude-haiku-4-5-20251001-v1:0',
           'arn:aws:bedrock:*:*:inference-profile/global.anthropic.claude-sonnet-4-6',
           'arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-4-6',
+          'arn:aws:bedrock:*::foundation-model/amazon.nova-sonic-v1:0',
+          'arn:aws:bedrock:*::foundation-model/amazon.nova-2-sonic-v1:0',
         ],
+      }),
+    );
+
+    // Bidi integration tests use Polly to generate PCM audio input from test prompts.
+    this.role.addToPolicy(
+      new iam.PolicyStatement({
+        actions: ['polly:SynthesizeSpeech'],
+        resources: ['*'],
       }),
     );
 

--- a/test-infra/test/test-infra.test.ts
+++ b/test-infra/test/test-infra.test.ts
@@ -218,6 +218,31 @@ test('internal mode grants the Mantle actions the base-path drift tests need', (
   );
 });
 
+test('internal mode grants the permissions Bidi integration tests need', () => {
+  const template = synth({ internal: true });
+
+  const policies = template.findResources('AWS::IAM::Policy');
+  const statements = Object.values(policies).flatMap(
+    (p: any) => p.Properties?.PolicyDocument?.Statement ?? [],
+  );
+  const novaSonicStatement = statements.find((statement: any) => {
+    const actions = Array.isArray(statement.Action) ? statement.Action : [statement.Action];
+    const resources = Array.isArray(statement.Resource) ? statement.Resource : [statement.Resource];
+
+    return (
+      actions.includes('bedrock:InvokeModel') &&
+      resources.includes('arn:aws:bedrock:*::foundation-model/amazon.nova-sonic-v1:0') &&
+      resources.includes('arn:aws:bedrock:*::foundation-model/amazon.nova-2-sonic-v1:0')
+    );
+  });
+  const pollyStatement = statements.find(
+    (statement: any) => statement.Action === 'polly:SynthesizeSpeech',
+  );
+
+  expect(novaSonicStatement).toBeDefined();
+  expect(pollyStatement?.Resource).toBe('*');
+});
+
 test('community mode does not attach the legacy broad policy', () => {
   const template = synth({ internal: false });
 


### PR DESCRIPTION
## Summary
- allow the integration-test role to invoke Nova Sonic v1 and v2 foundation models
- allow Polly speech synthesis for the PCM audio generated by Bidi integration tests
- verify both grants in the test-infra CDK assertions

## Context
The Bidi integration job for #3952 failed because the shared test role could not invoke Nova Sonic or call `polly:SynthesizeSpeech`:
https://github.com/strands-agents/harness-sdk/actions/runs/32862867615/job/97850965697?pr=3952

The internal test-infra stack must be deployed before rerunning that job so the updated role policy takes effect.

## Testing
- `npm test -- --runInBand` in `test-infra`
- `npm run build` in `test-infra`
- repository pre-commit checks