### PR TITLE
fix(docs): address post-merge review comments on storage page

### DIFF
--- a/site/src/content/docs/user-guide/concepts/storage.mdx
+++ b/site/src/content/docs/user-guide/concepts/storage.mdx
@@ -98,11 +98,10 @@ Storage resolves in this order for each subsystem:
    error in TypeScript
 
 :::note
-Agent-level resolution applies to
-`SnapshotSessionManager` (Python) and `SessionManager`
-(TypeScript). Repository-based session managers configure
-their own persistence and do not read from the agent's
-storage.
+Python `SessionManager` is deprecated, and does not use
+the provided `Storage` parameter. Use
+`SnapshotSessionManager` in Python or `SessionManager` in
+TypeScript to take advantage of agent-level storage.
 :::
 
 ## Built-in backends
@@ -217,7 +216,11 @@ backend provides.
 
 When using agent-level storage, each subsystem scopes its keys
 under its own prefix automatically (`session/`, `offloader/`),
-so you never need to worry about collisions.
+so you never need to worry about collisions. If you write a
+custom plugin that consumes agent-level storage, call
+<Syntax py="storage.namespace('my-prefix/')" ts="storage.namespace('my-prefix/')" />
+to claim your own prefix and avoid overlapping with other
+subsystems.
 
 ## Next steps
 


### PR DESCRIPTION


## Description
- Reword note: Python SessionManager is deprecated, recommend SnapshotSessionManager for agent-level storage
- Expand scoping explanation: custom plugins should call .namespace() to claim their own prefix

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [ ] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
