### PR TITLE
fix(bidi): use shared Google API key in integration test

### DIFF
--- a/strands-py/tests_integ/bidi/test_bidirectional_agent.py
+++ b/strands-py/tests_integ/bidi/test_bidirectional_agent.py
@@ -102,8 +102,8 @@ PROVIDER_CONFIGS = {
             # Uses default model and config (audio output + transcription enabled)
         },
         "silence_duration": 1.5,  # Gemini has good VAD, similar to OpenAI
-        "env_vars": ["GOOGLE_AI_API_KEY"],
-        "skip_reason": "GOOGLE_AI_API_KEY not available",
+        "env_vars": ["GOOGLE_API_KEY"],
+        "skip_reason": "GOOGLE_API_KEY not available",
     },
 }
 


### PR DESCRIPTION
## Summary
- check `GOOGLE_API_KEY` when deciding whether Gemini Live integration tests can run
- align the skip reason with the API key name loaded by the shared integration-test setup

## Context
The Bidi integration rerun passed, but Gemini Live was skipped because its provider configuration checked `GOOGLE_AI_API_KEY` while the shared Secrets Manager loader exports and validates `GOOGLE_API_KEY`:
https://github.com/strands-agents/harness-sdk/actions/runs/32862867615/job/97869941114?pr=3952

## Testing
- collected the parameterized Bidi provider integration tests under Python 3.12
- verified Gemini availability with `GOOGLE_API_KEY` set
- Ruff and mypy
- repository pre-commit checks