### PR TITLE
fix(mcp): pass list pagination as params for the mcp 2.x version

### DIFF
--- a/strands-py/src/strands/tools/mcp/_compat.py
+++ b/strands-py/src/strands/tools/mcp/_compat.py
@@ -21,7 +21,16 @@ import httpx
 from mcp import ClientSession
 from mcp.types import ServerCapabilities
 
-__all__ = ["MCP_V2", "GetSessionIdCallback", "MCPError", "negotiate_session", "streamable_http_transport"]
+__all__ = [
+    "MCP_V2",
+    "GetSessionIdCallback",
+    "MCPError",
+    "negotiate_session",
+    "next_cursor",
+    "resource_templates",
+    "streamable_http_transport",
+    "task_support",
+]
 
 # Feature-probed rather than version-parsed so pre-releases and backports
 # resolve by capability: `ClientSession.discover` is the 2.x replacement for
@@ -42,6 +51,57 @@ except ImportError:
     from collections.abc import Callable
 
     GetSessionIdCallback = Callable[[], str | None]  # type: ignore[misc, assignment]
+
+
+def next_cursor(list_result: Any) -> str | None:
+    """Read a paginated list result's continuation cursor, on either `mcp` major line.
+
+    `mcp` 2.x renamed the pydantic result models' camelCase fields to
+    snake_case, so the field is `next_cursor` there and `nextCursor` on 1.x.
+
+    Args:
+        list_result: A `List*Result` returned by a session `list_*` method.
+
+    Returns:
+        The cursor for the next page, or None on the last page.
+    """
+    cursor: str | None = list_result.next_cursor if MCP_V2 else list_result.nextCursor
+    return cursor
+
+
+def resource_templates(list_result: Any) -> list[Any]:
+    """Read a list result's resource templates, on either `mcp` major line.
+
+    `mcp` 2.x renamed the pydantic result models' camelCase fields to
+    snake_case, so the field is `resource_templates` there and
+    `resourceTemplates` on 1.x.
+
+    Args:
+        list_result: A `ListResourceTemplatesResult` returned by the session.
+
+    Returns:
+        The resource templates in this page of the result.
+    """
+    templates: list[Any] = list_result.resource_templates if MCP_V2 else list_result.resourceTemplates
+    return templates
+
+
+def task_support(tool: Any) -> str | None:
+    """Read a tool's declared task execution support level, on either `mcp` major line.
+
+    `mcp` 2.x renamed the pydantic model fields to snake_case, so the field
+    is `execution.task_support` there and `execution.taskSupport` on 1.x.
+
+    Args:
+        tool: A `Tool` from a list tools result.
+
+    Returns:
+        The declared support level, or None when the tool does not declare one.
+    """
+    if tool.execution is None:
+        return None
+    support: str | None = tool.execution.task_support if MCP_V2 else tool.execution.taskSupport
+    return support
 
 
 async def negotiate_session(session: ClientSession) -> tuple[str | None, ServerCapabilities | None]:

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -25,7 +25,7 @@ from importlib.metadata import version as pkg_version
 from pathlib import Path
 from re import Pattern
 from types import TracebackType
-from typing import Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 from urllib.parse import urlparse
 
 import anyio
@@ -46,6 +46,7 @@ from mcp.types import (
     ListPromptsResult,
     ListResourcesResult,
     ListResourceTemplatesResult,
+    PaginatedRequestParams,
     ReadResourceResult,
     TextResourceContents,
 )
@@ -61,15 +62,36 @@ from ...types.exceptions import MCPClientInitializationError, ToolProviderExcept
 from ...types.media import ImageFormat
 from ...types.tools import AgentTool, ToolResultContent, ToolResultStatus
 from ..tool_provider import ToolProvider
-from ._compat import MCPError, negotiate_session, streamable_http_transport
+from ._compat import (
+    MCPError,
+    negotiate_session,
+    next_cursor,
+    resource_templates,
+    streamable_http_transport,
+    task_support,
+)
 from .mcp_agent_tool import MCPAgentTool
 from .mcp_instrumentation import inject_trace_context, mcp_instrumentation
 from .mcp_tasks import DEFAULT_TASK_CONFIG, DEFAULT_TASK_POLL_TIMEOUT, DEFAULT_TASK_TTL, TasksConfig
 from .mcp_types import MCPClientCredentials, MCPToolResult, MCPTransport
 
+if TYPE_CHECKING:
+    # Only the mcp 1.x line spells this name; the runtime import stays inside
+    # the tasks-enabled branch of __init__.
+    from mcp.types import TaskExecutionMode
+
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
+
+
+def _pagination_params(pagination_token: str | None) -> PaginatedRequestParams | None:
+    """Build the params object for a paginated list_* request.
+
+    The session list methods' `cursor` keyword is deprecated on the mcp 1.x
+    line and removed on 2.x; `params` is the form both lines accept.
+    """
+    return PaginatedRequestParams(cursor=pagination_token) if pagination_token is not None else None
 
 
 class _MCPCallCancelledError(RuntimeError):
@@ -620,7 +642,9 @@ class MCPClient(ToolProvider):
         effective_filters = self._tool_filters if tool_filters is None else tool_filters
 
         async def _list_tools_async() -> ListToolsResult:
-            return await cast(ClientSession, self._background_thread_session).list_tools(cursor=pagination_token)
+            return await cast(ClientSession, self._background_thread_session).list_tools(
+                params=_pagination_params(pagination_token)
+            )
 
         list_tools_response: ListToolsResult = self._invoke_on_background_thread(_list_tools_async()).result()
         self._log_debug_with_thread("received %d tools from MCP server", len(list_tools_response.tools))
@@ -629,10 +653,7 @@ class MCPClient(ToolProvider):
         for tool in list_tools_response.tools:
             if self._is_tasks_enabled():
                 # Cache taskSupport for task-augmented execution decisions
-                task_support = None
-                if tool.execution is not None and tool.execution.taskSupport is not None:
-                    task_support = tool.execution.taskSupport
-                self._tool_task_support_cache[tool.name] = task_support or "forbidden"
+                self._tool_task_support_cache[tool.name] = cast("TaskExecutionMode", task_support(tool) or "forbidden")
 
             # Apply prefix if specified
             if effective_prefix:
@@ -647,7 +668,7 @@ class MCPClient(ToolProvider):
                 mcp_tools.append(mcp_tool)
 
         self._log_debug_with_thread("successfully adapted %d MCP tools", len(mcp_tools))
-        return PaginatedList[MCPAgentTool](mcp_tools, token=list_tools_response.nextCursor)
+        return PaginatedList[MCPAgentTool](mcp_tools, token=next_cursor(list_tools_response))
 
     def list_prompts_sync(self, pagination_token: str | None = None) -> ListPromptsResult:
         """Synchronously retrieves the list of available prompts from the MCP server.
@@ -666,7 +687,9 @@ class MCPClient(ToolProvider):
             raise MCPClientInitializationError(CLIENT_SESSION_NOT_RUNNING_ERROR_MESSAGE)
 
         async def _list_prompts_async() -> ListPromptsResult:
-            return await cast(ClientSession, self._background_thread_session).list_prompts(cursor=pagination_token)
+            return await cast(ClientSession, self._background_thread_session).list_prompts(
+                params=_pagination_params(pagination_token)
+            )
 
         list_prompts_result: ListPromptsResult = self._invoke_on_background_thread(_list_prompts_async()).result()
         self._log_debug_with_thread("received %d prompts from MCP server", len(list_prompts_result.prompts))
@@ -714,7 +737,9 @@ class MCPClient(ToolProvider):
             raise MCPClientInitializationError(CLIENT_SESSION_NOT_RUNNING_ERROR_MESSAGE)
 
         async def _list_resources_async() -> ListResourcesResult:
-            return await cast(ClientSession, self._background_thread_session).list_resources(cursor=pagination_token)
+            return await cast(ClientSession, self._background_thread_session).list_resources(
+                params=_pagination_params(pagination_token)
+            )
 
         list_resources_result: ListResourcesResult = self._invoke_on_background_thread(_list_resources_async()).result()
         self._log_debug_with_thread("received %d resources from MCP server", len(list_resources_result.resources))
@@ -761,14 +786,14 @@ class MCPClient(ToolProvider):
 
         async def _list_resource_templates_async() -> ListResourceTemplatesResult:
             return await cast(ClientSession, self._background_thread_session).list_resource_templates(
-                cursor=pagination_token
+                params=_pagination_params(pagination_token)
             )
 
         list_resource_templates_result: ListResourceTemplatesResult = self._invoke_on_background_thread(
             _list_resource_templates_async()
         ).result()
         self._log_debug_with_thread(
-            "received %d resource templates from MCP server", len(list_resource_templates_result.resourceTemplates)
+            "received %d resource templates from MCP server", len(resource_templates(list_resource_templates_result))
         )
 
         return list_resource_templates_result

--- a/strands-py/tests/strands/tools/mcp/test__compat.py
+++ b/strands-py/tests/strands/tools/mcp/test__compat.py
@@ -9,10 +9,11 @@ the `MCP_V2` flag forced.
 """
 
 import importlib
+import inspect
 import sys
 from collections.abc import Callable
 from contextlib import asynccontextmanager
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import mcp.client.streamable_http as streamable_http_module
@@ -45,6 +46,81 @@ def test_installed_line_exposes_expected_transport_names():
         assert hasattr(streamable_http_module, "streamablehttp_client")
 
 
+def test_installed_line_list_methods_accept_params():
+    """Test that the session list_* methods accept the `params` keyword on the installed line.
+
+    `MCPClient` passes pagination as `params` only: the `cursor` keyword is
+    deprecated on 1.x and removed on 2.x, while `params` exists on both lines
+    (added in 1.23.0, the dependency floor).
+    """
+    from mcp import ClientSession
+
+    for method_name in ("list_tools", "list_prompts", "list_resources", "list_resource_templates"):
+        method_parameters = inspect.signature(getattr(ClientSession, method_name)).parameters
+        assert "params" in method_parameters, method_name
+
+
+def test_installed_line_spells_the_accessor_read_fields_as_expected():
+    """Test that every model field a `_compat` accessor reads exists on the installed line's models."""
+    from mcp.types import ListResourceTemplatesResult, ListToolsResult, ToolExecution
+
+    if _compat.MCP_V2:
+        assert "next_cursor" in ListToolsResult.model_fields
+        assert "resource_templates" in ListResourceTemplatesResult.model_fields
+        assert "task_support" in ToolExecution.model_fields
+    else:
+        assert "nextCursor" in ListToolsResult.model_fields
+        assert "resourceTemplates" in ListResourceTemplatesResult.model_fields
+        assert "taskSupport" in ToolExecution.model_fields
+
+
+def test_next_cursor_v1_reads_the_camel_case_field(monkeypatch):
+    """Test that the 1.x branch reads the result's `nextCursor` field."""
+    monkeypatch.setattr(_compat, "MCP_V2", False)
+
+    assert _compat.next_cursor(SimpleNamespace(nextCursor="page-2")) == "page-2"
+
+
+def test_next_cursor_v2_reads_the_snake_case_field(monkeypatch):
+    """Test that the 2.x branch reads the result's `next_cursor` field."""
+    monkeypatch.setattr(_compat, "MCP_V2", True)
+
+    assert _compat.next_cursor(SimpleNamespace(next_cursor="page-2")) == "page-2"
+
+
+def test_resource_templates_v1_reads_the_camel_case_field(monkeypatch):
+    """Test that the 1.x branch reads the result's `resourceTemplates` field."""
+    monkeypatch.setattr(_compat, "MCP_V2", False)
+
+    assert _compat.resource_templates(SimpleNamespace(resourceTemplates=["template"])) == ["template"]
+
+
+def test_resource_templates_v2_reads_the_snake_case_field(monkeypatch):
+    """Test that the 2.x branch reads the result's `resource_templates` field."""
+    monkeypatch.setattr(_compat, "MCP_V2", True)
+
+    assert _compat.resource_templates(SimpleNamespace(resource_templates=["template"])) == ["template"]
+
+
+def test_task_support_v1_reads_the_camel_case_field(monkeypatch):
+    """Test that the 1.x branch reads the tool's `execution.taskSupport` field."""
+    monkeypatch.setattr(_compat, "MCP_V2", False)
+
+    assert _compat.task_support(SimpleNamespace(execution=SimpleNamespace(taskSupport="optional"))) == "optional"
+
+
+def test_task_support_v2_reads_the_snake_case_field(monkeypatch):
+    """Test that the 2.x branch reads the tool's `execution.task_support` field."""
+    monkeypatch.setattr(_compat, "MCP_V2", True)
+
+    assert _compat.task_support(SimpleNamespace(execution=SimpleNamespace(task_support="optional"))) == "optional"
+
+
+def test_task_support_returns_none_for_a_tool_without_execution():
+    """Test that a tool with no execution block declares no task support level."""
+    assert _compat.task_support(SimpleNamespace(execution=None)) is None
+
+
 def test_mcp_error_resolves_to_installed_exception():
     """Test that MCPError is the mcp package's error type regardless of its spelling."""
     import mcp.shared.exceptions as mcp_exceptions
@@ -75,6 +151,15 @@ def test_installed_v2_line_exposes_negotiate_auto():
     from mcp.client.client import negotiate_auto
 
     assert callable(negotiate_auto)
+
+
+@requires_mcp_v2
+def test_installed_v2_session_exposes_negotiation_attributes():
+    """Test that the session attributes the 2.x negotiation branch reads exist on the real ClientSession."""
+    from mcp import ClientSession
+
+    assert hasattr(ClientSession, "instructions")
+    assert hasattr(ClientSession, "server_capabilities")
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client.py
@@ -12,6 +12,7 @@ from mcp.types import (
     ListPromptsResult,
     ListResourcesResult,
     ListResourceTemplatesResult,
+    PaginatedRequestParams,
     Prompt,
     PromptMessage,
     ReadResourceResult,
@@ -76,7 +77,7 @@ def test_list_tools_sync(mock_transport, mock_session):
     with MCPClient(mock_transport["transport_callable"]) as client:
         tools = client.list_tools_sync()
 
-        mock_session.list_tools.assert_called_once_with(cursor=None)
+        mock_session.list_tools.assert_called_once_with(params=None)
 
         assert len(tools) == 1
         assert tools[0].tool_name == "test_tool"
@@ -99,7 +100,7 @@ def test_list_tools_sync_with_pagination_token(mock_transport, mock_session):
     with MCPClient(mock_transport["transport_callable"]) as client:
         tools = client.list_tools_sync(pagination_token="current_page_token")
 
-        mock_session.list_tools.assert_called_once_with(cursor="current_page_token")
+        mock_session.list_tools.assert_called_once_with(params=PaginatedRequestParams(cursor="current_page_token"))
         assert len(tools) == 1
         assert tools[0].tool_name == "test_tool"
         assert tools.pagination_token == "next_page_token"
@@ -113,7 +114,7 @@ def test_list_tools_sync_without_pagination_token(mock_transport, mock_session):
     with MCPClient(mock_transport["transport_callable"]) as client:
         tools = client.list_tools_sync()
 
-        mock_session.list_tools.assert_called_once_with(cursor=None)
+        mock_session.list_tools.assert_called_once_with(params=None)
         assert len(tools) == 1
         assert tools[0].tool_name == "test_tool"
         assert tools.pagination_token is None
@@ -868,7 +869,7 @@ def test_list_prompts_sync(mock_transport, mock_session):
     with MCPClient(mock_transport["transport_callable"]) as client:
         result = client.list_prompts_sync()
 
-        mock_session.list_prompts.assert_called_once_with(cursor=None)
+        mock_session.list_prompts.assert_called_once_with(params=None)
         assert len(result.prompts) == 1
         assert result.prompts[0].name == "test_prompt"
         assert result.nextCursor is None
@@ -882,7 +883,7 @@ def test_list_prompts_sync_with_pagination_token(mock_transport, mock_session):
     with MCPClient(mock_transport["transport_callable"]) as client:
         result = client.list_prompts_sync(pagination_token="current_page_token")
 
-        mock_session.list_prompts.assert_called_once_with(cursor="current_page_token")
+        mock_session.list_prompts.assert_called_once_with(params=PaginatedRequestParams(cursor="current_page_token"))
         assert len(result.prompts) == 1
         assert result.prompts[0].name == "test_prompt"
         assert result.nextCursor == "next_page_token"
@@ -1261,7 +1262,7 @@ def test_list_resources_sync(mock_transport, mock_session):
     with MCPClient(mock_transport["transport_callable"]) as client:
         result = client.list_resources_sync()
 
-        mock_session.list_resources.assert_called_once_with(cursor=None)
+        mock_session.list_resources.assert_called_once_with(params=None)
         assert len(result.resources) == 1
         assert result.resources[0].name == "test.txt"
         assert str(result.resources[0].uri) == "file://documents/test.txt"
@@ -1278,7 +1279,7 @@ def test_list_resources_sync_with_pagination_token(mock_transport, mock_session)
     with MCPClient(mock_transport["transport_callable"]) as client:
         result = client.list_resources_sync(pagination_token="current_page")
 
-        mock_session.list_resources.assert_called_once_with(cursor="current_page")
+        mock_session.list_resources.assert_called_once_with(params=PaginatedRequestParams(cursor="current_page"))
         assert len(result.resources) == 1
         assert result.resources[0].name == "test.txt"
         assert result.nextCursor == "next_page"
@@ -1352,7 +1353,7 @@ def test_list_resource_templates_sync(mock_transport, mock_session):
     with MCPClient(mock_transport["transport_callable"]) as client:
         result = client.list_resource_templates_sync()
 
-        mock_session.list_resource_templates.assert_called_once_with(cursor=None)
+        mock_session.list_resource_templates.assert_called_once_with(params=None)
         assert len(result.resourceTemplates) == 1
         assert result.resourceTemplates[0].name == "document_template"
         assert result.resourceTemplates[0].uriTemplate == "file://documents/{name}"
@@ -1374,7 +1375,9 @@ def test_list_resource_templates_sync_with_pagination_token(mock_transport, mock
     with MCPClient(mock_transport["transport_callable"]) as client:
         result = client.list_resource_templates_sync(pagination_token="current_page")
 
-        mock_session.list_resource_templates.assert_called_once_with(cursor="current_page")
+        mock_session.list_resource_templates.assert_called_once_with(
+            params=PaginatedRequestParams(cursor="current_page")
+        )
         assert len(result.resourceTemplates) == 1
         assert result.resourceTemplates[0].name == "document_template"
         assert result.nextCursor == "next_page"


### PR DESCRIPTION
## Description
*Follow-up `mcp` 2.x series. Nothing changes for current installs while the pin holds `<2`.*

`mcp` 2.x changed both directions of the paginated `list_*` calls. The session list methods no longer take the `cursor` keyword (already deprecated on 1.x), and the result models' fields are snake_case, so `ListToolsResult.nextCursor` is spelled `next_cursor`. `MCPClient` used both 1.x spellings, so listing tools, prompts, resources, or resource templates on the 2.x raises `TypeError` at the request, and once past that, `AttributeError` at the cursor read. Both failures were reproduced against a live `mcp` 2.x server.

Requests now pass pagination as `params=PaginatedRequestParams(cursor=...)`, which both versions accept it. The response cursor is read through a new `_compat.next_cursor()` accessor that picks the installed version's spelling, following the `_compat` rule that renames resolve in one place. 

The new tests assert against the installed `mcp` package's real signatures and model fields rather than mocks, so a rename on either line fails the suite.

## Related Issues

#1659

## Documentation PR

No documentation changes needed; the compat module is internal.

## Type of Change

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`
- Full MCP unit suite passes on `mcp` 1.x; the compat tests pass against `mcp==2.0.*` in the `unit-test-mcp-v2` CI job.
- Exercised end to end on `mcp` 2.0.x against an in-process 2026-07-28 server: `list_tools_sync` completes, including the pagination-token read.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
