### PR TITLE
feat(models): add tools_ttl to CacheConfig and deprecate cache_tools (#3893)

### DIFF
--- a/strands-py/src/strands/models/_validation.py
+++ b/strands-py/src/strands/models/_validation.py
@@ -107,17 +107,20 @@ def warn_on_cache_config_not_supported(
         )
 
 
-def _warn_on_deprecated_cache_tools(config_dict: Mapping[str, Any]) -> None:
+def _warn_on_deprecated_cache_tools(config_dict: Mapping[str, Any], *, stacklevel: int = 4) -> None:
     """Warn that the model-level ``cache_tools`` option is deprecated.
 
     Args:
         config_dict: The model configuration being set.
+        stacklevel: Frames to skip so the warning points at the caller rather than the SDK internals.
+            Providers pass the depth for their own call site, which differs by how deeply the warning
+            is nested below the public entry point.
     """
     if config_dict.get("cache_tools"):
         warnings.warn(
             "cache_tools is deprecated. Use CacheConfig(tools_ttl=...) instead.",
             DeprecationWarning,
-            stacklevel=4,
+            stacklevel=stacklevel,
         )
 
 

--- a/strands-py/src/strands/models/_validation.py
+++ b/strands-py/src/strands/models/_validation.py
@@ -107,6 +107,20 @@ def warn_on_cache_config_not_supported(
         )
 
 
+def _warn_on_deprecated_cache_tools(config_dict: Mapping[str, Any]) -> None:
+    """Warn that the model-level ``cache_tools`` option is deprecated.
+
+    Args:
+        config_dict: The model configuration being set.
+    """
+    if config_dict.get("cache_tools"):
+        warnings.warn(
+            "cache_tools is deprecated. Use CacheConfig(tools_ttl=...) instead.",
+            DeprecationWarning,
+            stacklevel=4,
+        )
+
+
 def _has_location_source(content: ContentBlock) -> bool:
     """Check if a content block contains a location source.
 

--- a/strands-py/src/strands/models/anthropic.py
+++ b/strands-py/src/strands/models/anthropic.py
@@ -71,8 +71,8 @@ class AnthropicModel(Model):
         Attributes:
             cache_config: Configuration for prompt caching. Adds a cache point to the last user message,
                 caching everything before it. Caching is off when unset.
-            cache_tools: Caches the tool definitions (deprecated, use CacheConfig(tools_ttl=...)). When set,
-                takes precedence over cache_config.tools_ttl.
+            cache_tools: Caches the tool definitions (deprecated, use CacheConfig(tools_ttl=...)). Superseded
+                by an explicitly set cache_config.tools_ttl.
             max_tokens: Maximum number of tokens to generate.
             model_id: Calude model ID (e.g., "claude-3-7-sonnet-latest").
                 For a complete list of supported models, see
@@ -100,7 +100,7 @@ class AnthropicModel(Model):
             **model_config: Configuration options for the Anthropic model.
         """
         validate_config_keys(model_config, self.AnthropicConfig)
-        _warn_on_deprecated_cache_tools(model_config)
+        _warn_on_deprecated_cache_tools(model_config, stacklevel=3)
         self.config = AnthropicModel.AnthropicConfig(**model_config)
 
         logger.debug("config=<%s> | initializing", self.config)
@@ -116,7 +116,7 @@ class AnthropicModel(Model):
             **model_config: Configuration overrides.
         """
         validate_config_keys(model_config, self.AnthropicConfig)
-        _warn_on_deprecated_cache_tools(model_config)
+        _warn_on_deprecated_cache_tools(model_config, stacklevel=3)
         self.config.update(model_config)
 
     @override
@@ -310,25 +310,36 @@ class AnthropicModel(Model):
         return False
 
     def _resolve_tools_cache(self) -> dict[str, Any] | None:
-        """Return the Anthropic ``cache_control`` payload for tool definitions, if enabled."""
-        cache_tools = self.config.get("cache_tools")
-        if cache_tools:
-            ttl = cache_tools.ttl if isinstance(cache_tools, CacheToolsConfig) else None
-            if not ttl:
-                cache_config = self.config.get("cache_config")
-                if cache_config and cache_config.ttl and cache_config.strategy in ("auto", "anthropic"):
-                    ttl = cache_config.ttl
-            return self._format_cache_control(ttl)
+        """Return the Anthropic ``cache_control`` payload for tool definitions, if enabled.
 
+        An explicitly set ``cache_config.tools_ttl`` takes precedence; when it is left unset (None) the
+        deprecated model-level ``cache_tools`` applies instead so existing configs keep working.
+        """
         cache_config = self.config.get("cache_config")
-        if cache_config is None or cache_config.strategy not in ("auto", "anthropic"):
+        if cache_config is None or cache_config.tools_ttl is None:
+            return self._resolve_deprecated_cache_tools()
+
+        if cache_config.tools_ttl is False or cache_config.strategy not in ("auto", "anthropic"):
             return None
 
         tools_ttl = cache_config.tools_ttl
-        if tools_ttl is False:
+        ttl = tools_ttl if isinstance(tools_ttl, str) else cache_config.ttl
+        return self._format_cache_control(ttl)
+
+    def _resolve_deprecated_cache_tools(self) -> dict[str, Any] | None:
+        """Resolve tool caching from the deprecated model-level ``cache_tools`` option.
+
+        Reached only when ``cache_config.tools_ttl`` is unset; an explicit ``tools_ttl`` supersedes this path.
+        """
+        cache_tools = self.config.get("cache_tools")
+        if not cache_tools:
             return None
 
-        ttl = tools_ttl if isinstance(tools_ttl, str) else cache_config.ttl
+        ttl = cache_tools.ttl if isinstance(cache_tools, CacheToolsConfig) else None
+        if not ttl:
+            cache_config = self.config.get("cache_config")
+            if cache_config and cache_config.ttl and cache_config.strategy in ("auto", "anthropic"):
+                ttl = cache_config.ttl
         return self._format_cache_control(ttl)
 
     @staticmethod

--- a/strands-py/src/strands/models/anthropic.py
+++ b/strands-py/src/strands/models/anthropic.py
@@ -6,7 +6,6 @@
 import base64
 import json
 import logging
-import warnings
 from collections.abc import AsyncGenerator
 from typing import Any, TypeVar, cast
 
@@ -22,7 +21,7 @@ from ..types.exceptions import ContextWindowOverflowException, ModelThrottledExc
 from ..types.streaming import StreamEvent
 from ..types.tools import ToolChoice, ToolChoiceToolDict, ToolSpec
 from ._defaults import resolve_config_metadata
-from ._validation import _has_location_source, validate_config_keys
+from ._validation import _has_location_source, _warn_on_deprecated_cache_tools, validate_config_keys
 from .model import BaseModelConfig, CacheConfig, CacheToolsConfig, Model
 
 logger = logging.getLogger(__name__)
@@ -101,6 +100,7 @@ class AnthropicModel(Model):
             **model_config: Configuration options for the Anthropic model.
         """
         validate_config_keys(model_config, self.AnthropicConfig)
+        _warn_on_deprecated_cache_tools(model_config)
         self.config = AnthropicModel.AnthropicConfig(**model_config)
 
         logger.debug("config=<%s> | initializing", self.config)
@@ -116,6 +116,7 @@ class AnthropicModel(Model):
             **model_config: Configuration overrides.
         """
         validate_config_keys(model_config, self.AnthropicConfig)
+        _warn_on_deprecated_cache_tools(model_config)
         self.config.update(model_config)
 
     @override
@@ -312,11 +313,6 @@ class AnthropicModel(Model):
         """Return the Anthropic ``cache_control`` payload for tool definitions, if enabled."""
         cache_tools = self.config.get("cache_tools")
         if cache_tools:
-            warnings.warn(
-                "cache_tools is deprecated. Use CacheConfig(tools_ttl=...) instead.",
-                DeprecationWarning,
-                stacklevel=3,
-            )
             ttl = cache_tools.ttl if isinstance(cache_tools, CacheToolsConfig) else None
             if not ttl:
                 cache_config = self.config.get("cache_config")

--- a/strands-py/src/strands/models/anthropic.py
+++ b/strands-py/src/strands/models/anthropic.py
@@ -6,6 +6,7 @@
 import base64
 import json
 import logging
+import warnings
 from collections.abc import AsyncGenerator
 from typing import Any, TypeVar, cast
 
@@ -71,7 +72,8 @@ class AnthropicModel(Model):
         Attributes:
             cache_config: Configuration for prompt caching. Adds a cache point to the last user message,
                 caching everything before it. Caching is off when unset.
-            cache_tools: Caches the tool definitions.
+            cache_tools: Caches the tool definitions (deprecated, use CacheConfig(tools_ttl=...)). When set,
+                takes precedence over cache_config.tools_ttl.
             max_tokens: Maximum number of tokens to generate.
             model_id: Calude model ID (e.g., "claude-3-7-sonnet-latest").
                 For a complete list of supported models, see
@@ -306,6 +308,43 @@ class AnthropicModel(Model):
 
         return False
 
+    def _resolve_tools_cache(self) -> tuple[str | None, bool]:
+        """Resolve whether the tool block carries a cache point and which TTL it uses.
+
+        The deprecated model-level ``cache_tools`` takes precedence: when it is set, a ``DeprecationWarning`` is
+        emitted and its TTL is used, so existing configurations keep working unchanged. When ``cache_tools`` is
+        unset, ``cache_config.tools_ttl`` drives the decision, mirroring ``system_prompt_ttl`` - a TTL string sets
+        the tools section's own duration, True derives it from ``cache_config.ttl``, and False disables it. A
+        section that carries no TTL of its own inherits ``cache_config.ttl``.
+
+        Returns:
+            A ``(ttl, enabled)`` pair: the TTL to emit (or None for the API default) and whether to cache tools.
+        """
+        cache_tools = self.config.get("cache_tools")
+        if cache_tools:
+            warnings.warn(
+                "cache_tools is deprecated. Use CacheConfig(tools_ttl=...) instead.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            ttl = cache_tools.ttl if isinstance(cache_tools, CacheToolsConfig) else None
+            if not ttl:
+                cache_config = self.config.get("cache_config")
+                if cache_config and cache_config.ttl and cache_config.strategy in ("auto", "anthropic"):
+                    ttl = cache_config.ttl
+            return ttl, True
+
+        cache_config = self.config.get("cache_config")
+        if cache_config is None or cache_config.strategy not in ("auto", "anthropic"):
+            return None, False
+
+        tools_ttl = cache_config.tools_ttl
+        if tools_ttl is False:
+            return None, False
+
+        ttl = tools_ttl if isinstance(tools_ttl, str) else cache_config.ttl
+        return ttl, True
+
     @staticmethod
     def _format_cache_control(ttl: str | None) -> dict[str, Any]:
         """Build an Anthropic ``cache_control`` value.
@@ -418,15 +457,10 @@ class AnthropicModel(Model):
         ]
 
         # A cache_control on the final tool caches all of them, so one cache point suffices.
-        cache_tools = self.config.get("cache_tools")
-        if cache_tools and tools:
-            ttl = cache_tools.ttl if isinstance(cache_tools, CacheToolsConfig) else None
-
-            if not ttl:
-                cache_config = self.config.get("cache_config")
-                if cache_config and cache_config.ttl and cache_config.strategy in ("auto", "anthropic"):
-                    ttl = cache_config.ttl
-            tools[-1]["cache_control"] = self._format_cache_control(ttl)
+        if tools:
+            tools_ttl, tools_enabled = self._resolve_tools_cache()
+            if tools_enabled:
+                tools[-1]["cache_control"] = self._format_cache_control(tools_ttl)
 
         system = self._format_system_prompt(system_prompt, system_prompt_content)
 

--- a/strands-py/src/strands/models/anthropic.py
+++ b/strands-py/src/strands/models/anthropic.py
@@ -308,18 +308,8 @@ class AnthropicModel(Model):
 
         return False
 
-    def _resolve_tools_cache(self) -> tuple[str | None, bool]:
-        """Resolve whether the tool block carries a cache point and which TTL it uses.
-
-        The deprecated model-level ``cache_tools`` takes precedence: when it is set, a ``DeprecationWarning`` is
-        emitted and its TTL is used, so existing configurations keep working unchanged. When ``cache_tools`` is
-        unset, ``cache_config.tools_ttl`` drives the decision, mirroring ``system_prompt_ttl`` - a TTL string sets
-        the tools section's own duration, True derives it from ``cache_config.ttl``, and False disables it. A
-        section that carries no TTL of its own inherits ``cache_config.ttl``.
-
-        Returns:
-            A ``(ttl, enabled)`` pair: the TTL to emit (or None for the API default) and whether to cache tools.
-        """
+    def _resolve_tools_cache(self) -> dict[str, Any] | None:
+        """Return the Anthropic ``cache_control`` payload for tool definitions, if enabled."""
         cache_tools = self.config.get("cache_tools")
         if cache_tools:
             warnings.warn(
@@ -332,18 +322,18 @@ class AnthropicModel(Model):
                 cache_config = self.config.get("cache_config")
                 if cache_config and cache_config.ttl and cache_config.strategy in ("auto", "anthropic"):
                     ttl = cache_config.ttl
-            return ttl, True
+            return self._format_cache_control(ttl)
 
         cache_config = self.config.get("cache_config")
         if cache_config is None or cache_config.strategy not in ("auto", "anthropic"):
-            return None, False
+            return None
 
         tools_ttl = cache_config.tools_ttl
         if tools_ttl is False:
-            return None, False
+            return None
 
         ttl = tools_ttl if isinstance(tools_ttl, str) else cache_config.ttl
-        return ttl, True
+        return self._format_cache_control(ttl)
 
     @staticmethod
     def _format_cache_control(ttl: str | None) -> dict[str, Any]:
@@ -457,10 +447,8 @@ class AnthropicModel(Model):
         ]
 
         # A cache_control on the final tool caches all of them, so one cache point suffices.
-        if tools:
-            tools_ttl, tools_enabled = self._resolve_tools_cache()
-            if tools_enabled:
-                tools[-1]["cache_control"] = self._format_cache_control(tools_ttl)
+        if tools and (cache_control := self._resolve_tools_cache()):
+            tools[-1]["cache_control"] = cache_control
 
         system = self._format_system_prompt(system_prompt, system_prompt_content)
 

--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -165,7 +165,7 @@ class BedrockModel(Model):
             cache_tools: Cache point type for tools (deprecated, use CacheConfig(tools_ttl=...)). Pass a string
                 (e.g. "default") to cache the tools with no explicit TTL, or a CacheToolsConfig instance to set
                 both type and TTL (e.g. "1h"). Inherits cache_config.ttl if specified, otherwise it takes the
-                Bedrock default. When set, takes precedence over cache_config.tools_ttl.
+                Bedrock default. Superseded by an explicitly set cache_config.tools_ttl.
             guardrail_id: ID of the guardrail to apply
             guardrail_trace: Guardrail trace mode. Defaults to enabled.
             guardrail_version: Version of the guardrail to apply
@@ -329,7 +329,8 @@ class BedrockModel(Model):
             **model_config: Configuration overrides.
         """
         validate_config_keys(model_config, self.BedrockConfig)
-        _warn_on_deprecated_cache_tools(model_config)
+        # __init__ delegates here, so the caller sits at stacklevel 4 on the constructor path.
+        _warn_on_deprecated_cache_tools(model_config, stacklevel=4)
         self.config.update(model_config)
 
     @override
@@ -561,43 +562,51 @@ class BedrockModel(Model):
     def _build_tools_cache_point(self) -> list[dict[str, Any]]:
         """Build the cache point block appended to ``toolConfig.tools`` when tool caching is configured.
 
-        The deprecated model-level ``cache_tools`` takes precedence: when it is set, its type/TTL drive the
-        point, so existing configurations keep working unchanged. When ``cache_tools`` is unset,
-        ``cache_config.tools_ttl`` drives the point, mirroring ``system_prompt_ttl`` - a TTL string sets the
-        tools section's own duration, True derives it from ``cache_config.ttl``, and False disables it. Either
-        way, a section that carries no TTL of its own inherits ``cache_config.ttl``.
+        An explicitly set ``cache_config.tools_ttl`` drives the point, mirroring ``system_prompt_ttl`` - a TTL
+        string sets the tools section's own duration, True derives it from ``cache_config.ttl``, and False
+        disables it; a section that carries no TTL of its own inherits ``cache_config.ttl``. When ``tools_ttl``
+        is left unset (None), the deprecated model-level ``cache_tools`` drives the point instead so existing
+        configurations keep working unchanged.
 
         Returns:
             A single-element list containing the cache point block, or an empty list when tool caching is off.
         """
-        cache_tools = self.config.get("cache_tools")
-        if cache_tools:
-            if isinstance(cache_tools, CacheToolsConfig):
-                cache_type, ttl = cache_tools.type, cache_tools.ttl
-            else:
-                cache_type, ttl = cache_tools, None
-
-            if not ttl:
-                cache_config = self.config.get("cache_config")
-                if cache_config and cache_config.ttl and self._cache_strategy == "anthropic":
-                    ttl = cache_config.ttl
-
-            cache_point: dict[str, Any] = {"type": cache_type}
-            if ttl:
-                cache_point["ttl"] = ttl
-
-            return [{"cachePoint": cache_point}]
-
         cache_config = self.config.get("cache_config")
-        if not cache_config or self._cache_strategy != "anthropic":
-            return []
+        if cache_config is None or cache_config.tools_ttl is None:
+            return self._build_deprecated_cache_tools_point(cache_config)
 
         tools_ttl = cache_config.tools_ttl
-        if tools_ttl is False:
+        if tools_ttl is False or self._cache_strategy != "anthropic":
             return []
 
         ttl = tools_ttl if isinstance(tools_ttl, str) else cache_config.ttl
-        cache_point = {"type": "default"}
+        cache_point: dict[str, Any] = {"type": "default"}
+        if ttl:
+            cache_point["ttl"] = ttl
+
+        return [{"cachePoint": cache_point}]
+
+    def _build_deprecated_cache_tools_point(self, cache_config: CacheConfig | None) -> list[dict[str, Any]]:
+        """Build the tools cache point from the deprecated model-level ``cache_tools`` option.
+
+        Reached only when ``cache_config.tools_ttl`` is unset; an explicit ``tools_ttl`` supersedes this path.
+
+        Returns:
+            A single-element list containing the cache point block, or an empty list when ``cache_tools`` is off.
+        """
+        cache_tools = self.config.get("cache_tools")
+        if not cache_tools:
+            return []
+
+        if isinstance(cache_tools, CacheToolsConfig):
+            cache_type, ttl = cache_tools.type, cache_tools.ttl
+        else:
+            cache_type, ttl = cache_tools, None
+
+        if not ttl and cache_config and cache_config.ttl and self._cache_strategy == "anthropic":
+            ttl = cache_config.ttl
+
+        cache_point: dict[str, Any] = {"type": cache_type}
         if ttl:
             cache_point["ttl"] = ttl
 

--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -35,7 +35,7 @@ from ..types.streaming import CitationsDelta, StreamEvent
 from ..types.tools import ToolChoice, ToolSpec
 from ._defaults import resolve_config_metadata
 from ._strict_schema import ensure_strict_json_schema
-from ._validation import validate_config_keys
+from ._validation import _warn_on_deprecated_cache_tools, validate_config_keys
 from .model import BaseModelConfig, CacheConfig, CacheToolsConfig, Model
 
 logger = logging.getLogger(__name__)
@@ -329,6 +329,7 @@ class BedrockModel(Model):
             **model_config: Configuration overrides.
         """
         validate_config_keys(model_config, self.BedrockConfig)
+        _warn_on_deprecated_cache_tools(model_config)
         self.config.update(model_config)
 
     @override
@@ -560,22 +561,17 @@ class BedrockModel(Model):
     def _build_tools_cache_point(self) -> list[dict[str, Any]]:
         """Build the cache point block appended to ``toolConfig.tools`` when tool caching is configured.
 
-        The deprecated model-level ``cache_tools`` takes precedence: when it is set, a ``DeprecationWarning``
-        is emitted and its type/TTL drive the point, so existing configurations keep working unchanged. When
-        ``cache_tools`` is unset, ``cache_config.tools_ttl`` drives the point, mirroring ``system_prompt_ttl`` -
-        a TTL string sets the tools section's own duration, True derives it from ``cache_config.ttl``, and False
-        disables it. Either way, a section that carries no TTL of its own inherits ``cache_config.ttl``.
+        The deprecated model-level ``cache_tools`` takes precedence: when it is set, its type/TTL drive the
+        point, so existing configurations keep working unchanged. When ``cache_tools`` is unset,
+        ``cache_config.tools_ttl`` drives the point, mirroring ``system_prompt_ttl`` - a TTL string sets the
+        tools section's own duration, True derives it from ``cache_config.ttl``, and False disables it. Either
+        way, a section that carries no TTL of its own inherits ``cache_config.ttl``.
 
         Returns:
             A single-element list containing the cache point block, or an empty list when tool caching is off.
         """
         cache_tools = self.config.get("cache_tools")
         if cache_tools:
-            warnings.warn(
-                "cache_tools is deprecated. Use CacheConfig(tools_ttl=...) instead.",
-                DeprecationWarning,
-                stacklevel=3,
-            )
             if isinstance(cache_tools, CacheToolsConfig):
                 cache_type, ttl = cache_tools.type, cache_tools.ttl
             else:

--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -162,9 +162,10 @@ class BedrockModel(Model):
             additional_response_field_paths: Additional response field paths to extract
             cache_prompt: Cache point type for the system prompt (deprecated, use cache_config)
             cache_config: Configuration for prompt caching. Use CacheConfig(strategy="auto") for automatic caching.
-            cache_tools: Cache point type for tools. Pass a string (e.g. "default") to cache the tools with
-                no explicit TTL, or a CacheToolsConfig instance to set both type and TTL (e.g. "1h"). Inherits
-                cache_config.ttl if specified, otherwise it takes the Bedrock default.
+            cache_tools: Cache point type for tools (deprecated, use CacheConfig(tools_ttl=...)). Pass a string
+                (e.g. "default") to cache the tools with no explicit TTL, or a CacheToolsConfig instance to set
+                both type and TTL (e.g. "1h"). Inherits cache_config.ttl if specified, otherwise it takes the
+                Bedrock default. When set, takes precedence over cache_config.tools_ttl.
             guardrail_id: ID of the guardrail to apply
             guardrail_trace: Guardrail trace mode. Defaults to enabled.
             guardrail_version: Version of the guardrail to apply
@@ -557,28 +558,50 @@ class BedrockModel(Model):
         return not any("cachePoint" in block for block in system_blocks)
 
     def _build_tools_cache_point(self) -> list[dict[str, Any]]:
-        """Build the cache point block appended to ``toolConfig.tools`` if ``cache_tools`` is configured.
+        """Build the cache point block appended to ``toolConfig.tools`` when tool caching is configured.
 
-        A ``cache_tools`` that carries no TTL of its own inherits ``cache_config.ttl``
+        The deprecated model-level ``cache_tools`` takes precedence: when it is set, a ``DeprecationWarning``
+        is emitted and its type/TTL drive the point, so existing configurations keep working unchanged. When
+        ``cache_tools`` is unset, ``cache_config.tools_ttl`` drives the point, mirroring ``system_prompt_ttl`` -
+        a TTL string sets the tools section's own duration, True derives it from ``cache_config.ttl``, and False
+        disables it. Either way, a section that carries no TTL of its own inherits ``cache_config.ttl``.
 
         Returns:
-            A single-element list containing the cache point block, or an empty list if no cache_tools is set.
+            A single-element list containing the cache point block, or an empty list when tool caching is off.
         """
         cache_tools = self.config.get("cache_tools")
-        if not cache_tools:
+        if cache_tools:
+            warnings.warn(
+                "cache_tools is deprecated. Use CacheConfig(tools_ttl=...) instead.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            if isinstance(cache_tools, CacheToolsConfig):
+                cache_type, ttl = cache_tools.type, cache_tools.ttl
+            else:
+                cache_type, ttl = cache_tools, None
+
+            if not ttl:
+                cache_config = self.config.get("cache_config")
+                if cache_config and cache_config.ttl and self._cache_strategy == "anthropic":
+                    ttl = cache_config.ttl
+
+            cache_point: dict[str, Any] = {"type": cache_type}
+            if ttl:
+                cache_point["ttl"] = ttl
+
+            return [{"cachePoint": cache_point}]
+
+        cache_config = self.config.get("cache_config")
+        if not cache_config or self._cache_strategy != "anthropic":
             return []
 
-        if isinstance(cache_tools, CacheToolsConfig):
-            cache_type, ttl = cache_tools.type, cache_tools.ttl
-        else:
-            cache_type, ttl = cache_tools, None
+        tools_ttl = cache_config.tools_ttl
+        if tools_ttl is False:
+            return []
 
-        if not ttl:
-            cache_config = self.config.get("cache_config")
-            if cache_config and cache_config.ttl and self._cache_strategy == "anthropic":
-                ttl = cache_config.ttl
-
-        cache_point: dict[str, Any] = {"type": cache_type}
+        ttl = tools_ttl if isinstance(tools_ttl, str) else cache_config.ttl
+        cache_point = {"type": "default"}
         if ttl:
             cache_point["ttl"] = ttl
 

--- a/strands-py/src/strands/models/model.py
+++ b/strands-py/src/strands/models/model.py
@@ -154,13 +154,15 @@ class CacheConfig:
         tools_ttl: Cache the tool definitions, auto-injecting a cache point on the tool block so repeated calls
             with the same tools hit the cache. A TTL string (e.g. "1h") sets this section's own
             duration and is honored as written; True derives the duration from ``ttl``; False disables it.
+            None (the default) leaves it unset, deferring to the deprecated model-level ``cache_tools``;
+            any explicit value — including False — takes precedence over ``cache_tools``.
     """
 
     strategy: Literal["auto", "anthropic"] = "auto"
     ttl: str | None = None
     system_prompt_ttl: bool | str = True
     cache_key: str | None = None
-    tools_ttl: bool | str = False
+    tools_ttl: bool | str | None = None
 
 
 @dataclass

--- a/strands-py/src/strands/models/model.py
+++ b/strands-py/src/strands/models/model.py
@@ -150,20 +150,20 @@ class CacheConfig:
             the same static system prefix hit the cache. A TTL string (e.g. "1h") sets this section's own
             duration and is honored as written; True derives the duration from ``ttl``; False disables it.
             A hand-placed system cache point is honored rather than doubled.
+        cache_key: Stable identity a provider can use to route its cache. Defaults to None.
         tools_ttl: Cache the tool definitions, auto-injecting a cache point on the tool block so repeated calls
             with the same tools hit the cache. Mirrors ``system_prompt_ttl``: a TTL string (e.g. "5m") sets this
             section's own duration and is honored as written; True derives the duration from ``ttl``; False
             disables it. The model-level ``cache_tools`` parameter is deprecated but, when set, takes precedence
             over this field so existing configurations keep working unchanged. Defaults to False; it will default
             to True once caching is enabled by default (matching TypeScript's ``toolsTTL``).
-        cache_key: Stable identity a provider can use to route its cache. Defaults to None.
     """
 
     strategy: Literal["auto", "anthropic"] = "auto"
     ttl: str | None = None
     system_prompt_ttl: bool | str = True
-    tools_ttl: bool | str = False
     cache_key: str | None = None
+    tools_ttl: bool | str = False
 
 
 @dataclass

--- a/strands-py/src/strands/models/model.py
+++ b/strands-py/src/strands/models/model.py
@@ -150,12 +150,19 @@ class CacheConfig:
             the same static system prefix hit the cache. A TTL string (e.g. "1h") sets this section's own
             duration and is honored as written; True derives the duration from ``ttl``; False disables it.
             A hand-placed system cache point is honored rather than doubled.
+        tools_ttl: Cache the tool definitions, auto-injecting a cache point on the tool block so repeated calls
+            with the same tools hit the cache. Mirrors ``system_prompt_ttl``: a TTL string (e.g. "5m") sets this
+            section's own duration and is honored as written; True derives the duration from ``ttl``; False
+            disables it. The model-level ``cache_tools`` parameter is deprecated but, when set, takes precedence
+            over this field so existing configurations keep working unchanged. Defaults to False; it will default
+            to True once caching is enabled by default (matching TypeScript's ``toolsTTL``).
         cache_key: Stable identity a provider can use to route its cache. Defaults to None.
     """
 
     strategy: Literal["auto", "anthropic"] = "auto"
     ttl: str | None = None
     system_prompt_ttl: bool | str = True
+    tools_ttl: bool | str = False
     cache_key: str | None = None
 
 

--- a/strands-py/src/strands/models/model.py
+++ b/strands-py/src/strands/models/model.py
@@ -152,11 +152,8 @@ class CacheConfig:
             A hand-placed system cache point is honored rather than doubled.
         cache_key: Stable identity a provider can use to route its cache. Defaults to None.
         tools_ttl: Cache the tool definitions, auto-injecting a cache point on the tool block so repeated calls
-            with the same tools hit the cache. Mirrors ``system_prompt_ttl``: a TTL string (e.g. "5m") sets this
-            section's own duration and is honored as written; True derives the duration from ``ttl``; False
-            disables it. The model-level ``cache_tools`` parameter is deprecated but, when set, takes precedence
-            over this field so existing configurations keep working unchanged. Defaults to False; it will default
-            to True once caching is enabled by default (matching TypeScript's ``toolsTTL``).
+            with the same tools hit the cache. A TTL string (e.g. "1h") sets this section's own
+            duration and is honored as written; True derives the duration from ``ttl``; False disables it.
     """
 
     strategy: Literal["auto", "anthropic"] = "auto"

--- a/strands-py/tests/strands/models/test_anthropic.py
+++ b/strands-py/tests/strands/models/test_anthropic.py
@@ -1553,7 +1553,10 @@ class TestPromptCaching:
 
         breakpoints = self._breakpoints(model.format_request(messages, tool_specs))
 
-        assert ("tools", "t2", {"type": "ephemeral", "ttl": "1h"}) in breakpoints
+        assert breakpoints == [
+            ("tools", "t2", {"type": "ephemeral", "ttl": "1h"}),
+            ("messages", 0, {"type": "ephemeral", "ttl": "1h"}),
+        ]
 
     def test_tools_ttl_string_sets_the_section_duration(self, model, messages, tool_specs):
         """A tools_ttl string sets the tools section's own duration rather than deriving from the shared ttl."""
@@ -1561,7 +1564,10 @@ class TestPromptCaching:
 
         breakpoints = self._breakpoints(model.format_request(messages, tool_specs))
 
-        assert ("tools", "t2", {"type": "ephemeral", "ttl": "5m"}) in breakpoints
+        assert breakpoints == [
+            ("tools", "t2", {"type": "ephemeral", "ttl": "5m"}),
+            ("messages", 0, {"type": "ephemeral", "ttl": "1h"}),
+        ]
 
     def test_tools_ttl_true_without_shared_ttl_stays_untimed(self, model, messages, tool_specs):
         """With nothing to derive from, tools_ttl=True still caches the tools but at the API default."""
@@ -1569,7 +1575,10 @@ class TestPromptCaching:
 
         breakpoints = self._breakpoints(model.format_request(messages, tool_specs))
 
-        assert ("tools", "t2", {"type": "ephemeral"}) in breakpoints
+        assert breakpoints == [
+            ("tools", "t2", {"type": "ephemeral"}),
+            ("messages", 0, {"type": "ephemeral"}),
+        ]
 
     def test_tools_ttl_false_disables_the_tools_cache_point(self, model, messages, tool_specs):
         """tools_ttl=False disables tool caching even when the shared ttl is set."""
@@ -1580,15 +1589,15 @@ class TestPromptCaching:
         assert not any(bp[0] == "tools" for bp in breakpoints)
 
     def test_tools_ttl_defaults_to_off(self, model, messages, tool_specs):
-        """tools_ttl defaults to False, so cache_config alone does not cache the tools yet."""
+        """tools_ttl defaults to None (unset), so cache_config alone does not cache the tools yet."""
         model.update_config(cache_config=CacheConfig(strategy="auto", ttl="1h"))
 
         breakpoints = self._breakpoints(model.format_request(messages, tool_specs))
 
         assert not any(bp[0] == "tools" for bp in breakpoints)
 
-    def test_cache_tools_takes_precedence_over_tools_ttl(self, model, messages, tool_specs):
-        """The deprecated cache_tools wins over the new tools_ttl when both are set."""
+    def test_tools_ttl_takes_precedence_over_deprecated_cache_tools(self, model, messages, tool_specs):
+        """An explicitly set tools_ttl wins over the deprecated cache_tools when both are set."""
         with pytest.warns(DeprecationWarning, match="cache_tools is deprecated"):
             model.update_config(
                 cache_config=CacheConfig(strategy="auto", ttl="1h", tools_ttl="5m"),
@@ -1597,7 +1606,22 @@ class TestPromptCaching:
 
         breakpoints = self._breakpoints(model.format_request(messages, tool_specs))
 
-        assert ("tools", "t2", {"type": "ephemeral", "ttl": "1h"}) in breakpoints
+        assert breakpoints == [
+            ("tools", "t2", {"type": "ephemeral", "ttl": "5m"}),
+            ("messages", 0, {"type": "ephemeral", "ttl": "1h"}),
+        ]
+
+    def test_tools_ttl_false_overrides_deprecated_cache_tools(self, model, messages, tool_specs):
+        """tools_ttl=False disables tool caching even when the deprecated cache_tools is set."""
+        with pytest.warns(DeprecationWarning, match="cache_tools is deprecated"):
+            model.update_config(
+                cache_config=CacheConfig(strategy="auto", ttl="1h", tools_ttl=False),
+                cache_tools=CacheToolsConfig(ttl="1h"),
+            )
+
+        breakpoints = self._breakpoints(model.format_request(messages, tool_specs))
+
+        assert not any(bp[0] == "tools" for bp in breakpoints)
 
     def test_both_options_produce_two_breakpoints(self, model, messages, tool_specs):
         model.update_config(cache_config=CacheConfig(strategy="auto"), cache_tools="default")

--- a/strands-py/tests/strands/models/test_anthropic.py
+++ b/strands-py/tests/strands/models/test_anthropic.py
@@ -1433,6 +1433,7 @@ class TestCountTokens:
         assert result >= 0
 
 
+@pytest.mark.filterwarnings("ignore:cache_tools is deprecated:DeprecationWarning")
 class TestPromptCaching:
     """Prompt caching via ``cache_config`` / ``cache_tools``.
 
@@ -1542,11 +1543,9 @@ class TestPromptCaching:
         assert self._breakpoints(model.format_request(messages, tool_specs)) == [("tools", "t2", {"type": "ephemeral"})]
 
     def test_cache_tools_emits_deprecation_warning(self, model, messages, tool_specs):
-        """cache_tools is deprecated in favor of CacheConfig(tools_ttl=...); using it warns."""
-        model.update_config(cache_tools="default")
-
+        """cache_tools is deprecated in favor of CacheConfig(tools_ttl=...); setting it warns."""
         with pytest.warns(DeprecationWarning, match="cache_tools is deprecated. Use CacheConfig"):
-            model.format_request(messages, tool_specs)
+            model.update_config(cache_tools="default")
 
     def test_tools_ttl_true_derives_from_shared_ttl(self, model, messages, tool_specs):
         """tools_ttl=True mirrors system_prompt_ttl: it derives the tools section duration from cache_config.ttl."""
@@ -1590,13 +1589,13 @@ class TestPromptCaching:
 
     def test_cache_tools_takes_precedence_over_tools_ttl(self, model, messages, tool_specs):
         """The deprecated cache_tools wins over the new tools_ttl when both are set."""
-        model.update_config(
-            cache_config=CacheConfig(strategy="auto", ttl="1h", tools_ttl="5m"),
-            cache_tools=CacheToolsConfig(ttl="1h"),
-        )
-
         with pytest.warns(DeprecationWarning, match="cache_tools is deprecated"):
-            breakpoints = self._breakpoints(model.format_request(messages, tool_specs))
+            model.update_config(
+                cache_config=CacheConfig(strategy="auto", ttl="1h", tools_ttl="5m"),
+                cache_tools=CacheToolsConfig(ttl="1h"),
+            )
+
+        breakpoints = self._breakpoints(model.format_request(messages, tool_specs))
 
         assert ("tools", "t2", {"type": "ephemeral", "ttl": "1h"}) in breakpoints
 

--- a/strands-py/tests/strands/models/test_anthropic.py
+++ b/strands-py/tests/strands/models/test_anthropic.py
@@ -1541,6 +1541,65 @@ class TestPromptCaching:
 
         assert self._breakpoints(model.format_request(messages, tool_specs)) == [("tools", "t2", {"type": "ephemeral"})]
 
+    def test_cache_tools_emits_deprecation_warning(self, model, messages, tool_specs):
+        """cache_tools is deprecated in favor of CacheConfig(tools_ttl=...); using it warns."""
+        model.update_config(cache_tools="default")
+
+        with pytest.warns(DeprecationWarning, match="cache_tools is deprecated. Use CacheConfig"):
+            model.format_request(messages, tool_specs)
+
+    def test_tools_ttl_true_derives_from_shared_ttl(self, model, messages, tool_specs):
+        """tools_ttl=True mirrors system_prompt_ttl: it derives the tools section duration from cache_config.ttl."""
+        model.update_config(cache_config=CacheConfig(strategy="auto", ttl="1h", tools_ttl=True))
+
+        breakpoints = self._breakpoints(model.format_request(messages, tool_specs))
+
+        assert ("tools", "t2", {"type": "ephemeral", "ttl": "1h"}) in breakpoints
+
+    def test_tools_ttl_string_sets_the_section_duration(self, model, messages, tool_specs):
+        """A tools_ttl string sets the tools section's own duration rather than deriving from the shared ttl."""
+        model.update_config(cache_config=CacheConfig(strategy="auto", ttl="1h", tools_ttl="5m"))
+
+        breakpoints = self._breakpoints(model.format_request(messages, tool_specs))
+
+        assert ("tools", "t2", {"type": "ephemeral", "ttl": "5m"}) in breakpoints
+
+    def test_tools_ttl_true_without_shared_ttl_stays_untimed(self, model, messages, tool_specs):
+        """With nothing to derive from, tools_ttl=True still caches the tools but at the API default."""
+        model.update_config(cache_config=CacheConfig(strategy="auto", tools_ttl=True))
+
+        breakpoints = self._breakpoints(model.format_request(messages, tool_specs))
+
+        assert ("tools", "t2", {"type": "ephemeral"}) in breakpoints
+
+    def test_tools_ttl_false_disables_the_tools_cache_point(self, model, messages, tool_specs):
+        """tools_ttl=False disables tool caching even when the shared ttl is set."""
+        model.update_config(cache_config=CacheConfig(strategy="auto", ttl="1h", tools_ttl=False))
+
+        breakpoints = self._breakpoints(model.format_request(messages, tool_specs))
+
+        assert not any(bp[0] == "tools" for bp in breakpoints)
+
+    def test_tools_ttl_defaults_to_off(self, model, messages, tool_specs):
+        """tools_ttl defaults to False, so cache_config alone does not cache the tools yet."""
+        model.update_config(cache_config=CacheConfig(strategy="auto", ttl="1h"))
+
+        breakpoints = self._breakpoints(model.format_request(messages, tool_specs))
+
+        assert not any(bp[0] == "tools" for bp in breakpoints)
+
+    def test_cache_tools_takes_precedence_over_tools_ttl(self, model, messages, tool_specs):
+        """The maintainer decision: the deprecated cache_tools wins over the new tools_ttl when both are set."""
+        model.update_config(
+            cache_config=CacheConfig(strategy="auto", ttl="1h", tools_ttl="5m"),
+            cache_tools=CacheToolsConfig(ttl="1h"),
+        )
+
+        with pytest.warns(DeprecationWarning, match="cache_tools is deprecated"):
+            breakpoints = self._breakpoints(model.format_request(messages, tool_specs))
+
+        assert ("tools", "t2", {"type": "ephemeral", "ttl": "1h"}) in breakpoints
+
     def test_both_options_produce_two_breakpoints(self, model, messages, tool_specs):
         model.update_config(cache_config=CacheConfig(strategy="auto"), cache_tools="default")
 

--- a/strands-py/tests/strands/models/test_anthropic.py
+++ b/strands-py/tests/strands/models/test_anthropic.py
@@ -1589,7 +1589,7 @@ class TestPromptCaching:
         assert not any(bp[0] == "tools" for bp in breakpoints)
 
     def test_cache_tools_takes_precedence_over_tools_ttl(self, model, messages, tool_specs):
-        """The maintainer decision: the deprecated cache_tools wins over the new tools_ttl when both are set."""
+        """The deprecated cache_tools wins over the new tools_ttl when both are set."""
         model.update_config(
             cache_config=CacheConfig(strategy="auto", ttl="1h", tools_ttl="5m"),
             cache_tools=CacheToolsConfig(ttl="1h"),

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -5006,7 +5006,7 @@ def test_format_request_tools_ttl_false_disables_the_tools_cache_point(bedrock_c
 
 
 def test_format_request_tools_ttl_defaults_to_off(bedrock_client, messages, tool_spec):
-    """tools_ttl defaults to False, so cache_config alone does not cache the tools yet."""
+    """tools_ttl defaults to None (unset), so cache_config alone does not cache the tools yet."""
     _ = bedrock_client
     model = BedrockModel(
         model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
@@ -5031,8 +5031,8 @@ def test_format_request_tools_ttl_is_off_for_a_model_without_caching(bedrock_cli
     assert not any("cachePoint" in tool for tool in tru_request["toolConfig"]["tools"])
 
 
-def test_format_request_cache_tools_takes_precedence_over_tools_ttl(bedrock_client, messages, tool_spec):
-    """The deprecated cache_tools wins over the new tools_ttl when both are set."""
+def test_format_request_tools_ttl_takes_precedence_over_deprecated_cache_tools(bedrock_client, messages, tool_spec):
+    """An explicitly set tools_ttl wins over the deprecated cache_tools when both are set."""
     _ = bedrock_client
     with pytest.warns(DeprecationWarning, match="cache_tools is deprecated"):
         model = BedrockModel(
@@ -5043,7 +5043,22 @@ def test_format_request_cache_tools_takes_precedence_over_tools_ttl(bedrock_clie
 
     tru_point = model.format_request(messages, tool_specs=[tool_spec])["toolConfig"]["tools"][-1]
 
-    assert tru_point == {"cachePoint": {"type": "default", "ttl": "1h"}}
+    assert tru_point == {"cachePoint": {"type": "default", "ttl": "5m"}}
+
+
+def test_format_request_tools_ttl_false_overrides_deprecated_cache_tools(bedrock_client, messages, tool_spec):
+    """tools_ttl=False disables tool caching even when the deprecated cache_tools is set."""
+    _ = bedrock_client
+    with pytest.warns(DeprecationWarning, match="cache_tools is deprecated"):
+        model = BedrockModel(
+            model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
+            cache_config=CacheConfig(strategy="auto", ttl="1h", tools_ttl=False),
+            cache_tools=CacheToolsConfig(ttl="1h"),
+        )
+
+    tru_request = model.format_request(messages, tool_specs=[tool_spec])
+
+    assert not any("cachePoint" in tool for tool in tru_request["toolConfig"]["tools"])
 
 
 def test_format_request_applies_the_configured_ttl_to_a_system_cache_point(bedrock_client, messages):

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -4963,6 +4963,20 @@ def test_format_request_tools_ttl_string_sets_the_section_duration(bedrock_clien
     assert tru_point == {"cachePoint": {"type": "default", "ttl": "5m"}}
 
 
+def test_format_request_tools_ttl_string_stands_the_system_point_down(bedrock_client, messages, tool_spec):
+    """A shorter tools_ttl leaves the auto system cache point at the provider default."""
+    _ = bedrock_client
+    model = BedrockModel(
+        model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
+        cache_config=CacheConfig(strategy="auto", ttl="1h", tools_ttl="5m"),
+    )
+
+    request = model.format_request(messages, tool_specs=[tool_spec], system_prompt_content=[{"text": "static"}])
+
+    assert request["toolConfig"]["tools"][-1] == {"cachePoint": {"type": "default", "ttl": "5m"}}
+    assert {"cachePoint": {"type": "default"}} in request["system"]
+
+
 def test_format_request_tools_ttl_true_without_shared_ttl_stays_untimed(bedrock_client, messages, tool_spec):
     """With nothing to derive from, tools_ttl=True still caches the tools but at the provider default."""
     _ = bedrock_client

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -4920,12 +4920,114 @@ def test_format_request_cache_tools_config_without_ttl(model, messages, model_id
 
 def test_format_request_cache_tools_string_backward_compat(model, messages, model_id, tool_spec, cache_type):
     """Test that passing cache_tools as a string still produces a cachePoint with only type."""
-    model.update_config(cache_tools=cache_type)
+    with pytest.warns(DeprecationWarning, match="cache_tools is deprecated"):
+        model.update_config(cache_tools=cache_type)
 
-    tru_request = model.format_request(messages, tool_specs=[tool_spec])
+        tru_request = model.format_request(messages, tool_specs=[tool_spec])
 
     exp_cache_point = {"cachePoint": {"type": cache_type}}
     assert tru_request["toolConfig"]["tools"][-1] == exp_cache_point
+
+
+def test_format_request_cache_tools_emits_deprecation_warning(model, messages, tool_spec):
+    """cache_tools is deprecated in favor of CacheConfig(tools_ttl=...); using it warns."""
+    model.update_config(cache_tools="default")
+
+    with pytest.warns(DeprecationWarning, match="cache_tools is deprecated. Use CacheConfig"):
+        model.format_request(messages, tool_specs=[tool_spec])
+
+
+def test_format_request_tools_ttl_true_derives_from_shared_ttl(bedrock_client, messages, tool_spec):
+    """tools_ttl=True mirrors system_prompt_ttl: it derives the tools section duration from cache_config.ttl."""
+    _ = bedrock_client
+    model = BedrockModel(
+        model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
+        cache_config=CacheConfig(strategy="auto", ttl="1h", tools_ttl=True),
+    )
+
+    tru_point = model.format_request(messages, tool_specs=[tool_spec])["toolConfig"]["tools"][-1]
+
+    assert tru_point == {"cachePoint": {"type": "default", "ttl": "1h"}}
+
+
+def test_format_request_tools_ttl_string_sets_the_section_duration(bedrock_client, messages, tool_spec):
+    """A tools_ttl string sets the tools section's own duration rather than deriving from the shared ttl."""
+    _ = bedrock_client
+    model = BedrockModel(
+        model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
+        cache_config=CacheConfig(strategy="auto", ttl="1h", tools_ttl="5m"),
+    )
+
+    tru_point = model.format_request(messages, tool_specs=[tool_spec])["toolConfig"]["tools"][-1]
+
+    assert tru_point == {"cachePoint": {"type": "default", "ttl": "5m"}}
+
+
+def test_format_request_tools_ttl_true_without_shared_ttl_stays_untimed(bedrock_client, messages, tool_spec):
+    """With nothing to derive from, tools_ttl=True still caches the tools but at the provider default."""
+    _ = bedrock_client
+    model = BedrockModel(
+        model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
+        cache_config=CacheConfig(strategy="auto", tools_ttl=True),
+    )
+
+    tru_point = model.format_request(messages, tool_specs=[tool_spec])["toolConfig"]["tools"][-1]
+
+    assert tru_point == {"cachePoint": {"type": "default"}}
+
+
+def test_format_request_tools_ttl_false_disables_the_tools_cache_point(bedrock_client, messages, tool_spec):
+    """tools_ttl=False disables tool caching even when the shared ttl is set."""
+    _ = bedrock_client
+    model = BedrockModel(
+        model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
+        cache_config=CacheConfig(strategy="auto", ttl="1h", tools_ttl=False),
+    )
+
+    tru_request = model.format_request(messages, tool_specs=[tool_spec])
+
+    assert not any("cachePoint" in tool for tool in tru_request["toolConfig"]["tools"])
+
+
+def test_format_request_tools_ttl_defaults_to_off(bedrock_client, messages, tool_spec):
+    """tools_ttl defaults to False, so cache_config alone does not cache the tools yet."""
+    _ = bedrock_client
+    model = BedrockModel(
+        model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
+        cache_config=CacheConfig(strategy="auto", ttl="1h"),
+    )
+
+    tru_request = model.format_request(messages, tool_specs=[tool_spec])
+
+    assert not any("cachePoint" in tool for tool in tru_request["toolConfig"]["tools"])
+
+
+def test_format_request_tools_ttl_is_off_for_a_model_without_caching(bedrock_client, messages, tool_spec):
+    """tools_ttl only reaches the wire under an active anthropic strategy, matching the tools point rule."""
+    _ = bedrock_client
+    model = BedrockModel(
+        model_id="amazon.nova-pro-v1:0",
+        cache_config=CacheConfig(strategy="auto", ttl="1h", tools_ttl=True),
+    )
+
+    tru_request = model.format_request(messages, tool_specs=[tool_spec])
+
+    assert not any("cachePoint" in tool for tool in tru_request["toolConfig"]["tools"])
+
+
+def test_format_request_cache_tools_takes_precedence_over_tools_ttl(bedrock_client, messages, tool_spec):
+    """The maintainer decision: the deprecated cache_tools wins over the new tools_ttl when both are set."""
+    _ = bedrock_client
+    model = BedrockModel(
+        model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
+        cache_config=CacheConfig(strategy="auto", ttl="1h", tools_ttl="5m"),
+        cache_tools=CacheToolsConfig(ttl="1h"),
+    )
+
+    with pytest.warns(DeprecationWarning, match="cache_tools is deprecated"):
+        tru_point = model.format_request(messages, tool_specs=[tool_spec])["toolConfig"]["tools"][-1]
+
+    assert tru_point == {"cachePoint": {"type": "default", "ttl": "1h"}}
 
 
 def test_format_request_applies_the_configured_ttl_to_a_system_cache_point(bedrock_client, messages):

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -32,6 +32,10 @@ from strands.types.tools import ToolSpec
 
 FORMATTED_DEFAULT_MODEL_ID = DEFAULT_BEDROCK_MODEL_ID
 
+# cache_tools is deprecated in favor of CacheConfig(tools_ttl=...); tests that deliberately exercise the
+# backward-compat path emit its config-time DeprecationWarning, and assert it explicitly where relevant.
+pytestmark = pytest.mark.filterwarnings("ignore:cache_tools is deprecated:DeprecationWarning")
+
 
 @pytest.fixture
 def session_cls():
@@ -4930,11 +4934,9 @@ def test_format_request_cache_tools_string_backward_compat(model, messages, mode
 
 
 def test_format_request_cache_tools_emits_deprecation_warning(model, messages, tool_spec):
-    """cache_tools is deprecated in favor of CacheConfig(tools_ttl=...); using it warns."""
-    model.update_config(cache_tools="default")
-
+    """cache_tools is deprecated in favor of CacheConfig(tools_ttl=...); setting it warns."""
     with pytest.warns(DeprecationWarning, match="cache_tools is deprecated. Use CacheConfig"):
-        model.format_request(messages, tool_specs=[tool_spec])
+        model.update_config(cache_tools="default")
 
 
 def test_format_request_tools_ttl_true_derives_from_shared_ttl(bedrock_client, messages, tool_spec):
@@ -5030,16 +5032,16 @@ def test_format_request_tools_ttl_is_off_for_a_model_without_caching(bedrock_cli
 
 
 def test_format_request_cache_tools_takes_precedence_over_tools_ttl(bedrock_client, messages, tool_spec):
-    """The maintainer decision: the deprecated cache_tools wins over the new tools_ttl when both are set."""
+    """The deprecated cache_tools wins over the new tools_ttl when both are set."""
     _ = bedrock_client
-    model = BedrockModel(
-        model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
-        cache_config=CacheConfig(strategy="auto", ttl="1h", tools_ttl="5m"),
-        cache_tools=CacheToolsConfig(ttl="1h"),
-    )
-
     with pytest.warns(DeprecationWarning, match="cache_tools is deprecated"):
-        tru_point = model.format_request(messages, tool_specs=[tool_spec])["toolConfig"]["tools"][-1]
+        model = BedrockModel(
+            model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
+            cache_config=CacheConfig(strategy="auto", ttl="1h", tools_ttl="5m"),
+            cache_tools=CacheToolsConfig(ttl="1h"),
+        )
+
+    tru_point = model.format_request(messages, tool_specs=[tool_spec])["toolConfig"]["tools"][-1]
 
     assert tru_point == {"cachePoint": {"type": "default", "ttl": "1h"}}
 

--- a/strands-py/tests/strands/models/test_model.py
+++ b/strands-py/tests/strands/models/test_model.py
@@ -685,3 +685,16 @@ class TestCacheConfig:
     def test_cache_key_round_trips(self):
         """cache_key preserves the value it was constructed with."""
         assert CacheConfig(cache_key="tenant-42").cache_key == "tenant-42"
+
+    def test_positional_cache_key_remains_backward_compatible(self):
+        """The fourth positional argument still maps to cache_key."""
+        config = CacheConfig("auto", "1h", True, "tenant-42")
+
+        assert config.cache_key == "tenant-42"
+        assert config.tools_ttl is False
+
+    def test_tools_ttl_can_still_be_set_explicitly(self):
+        """tools_ttl remains available via keyword construction."""
+        config = CacheConfig(tools_ttl="5m")
+
+        assert config.tools_ttl == "5m"

--- a/strands-py/tests/strands/models/test_model.py
+++ b/strands-py/tests/strands/models/test_model.py
@@ -685,16 +685,3 @@ class TestCacheConfig:
     def test_cache_key_round_trips(self):
         """cache_key preserves the value it was constructed with."""
         assert CacheConfig(cache_key="tenant-42").cache_key == "tenant-42"
-
-    def test_positional_cache_key_remains_backward_compatible(self):
-        """The fourth positional argument still maps to cache_key."""
-        config = CacheConfig("auto", "1h", True, "tenant-42")
-
-        assert config.cache_key == "tenant-42"
-        assert config.tools_ttl is False
-
-    def test_tools_ttl_can_still_be_set_explicitly(self):
-        """tools_ttl remains available via keyword construction."""
-        config = CacheConfig(tools_ttl="5m")
-
-        assert config.tools_ttl == "5m"


### PR DESCRIPTION
## Description

Python `CacheConfig` needs the same tool-cache TTL control that the TypeScript SDK already exposes, without breaking existing callers still using the older `cache_tools` model option.

### Motivation

Issue #3893 asks for a first-class `tools_ttl` field on Python `CacheConfig` so tool caching can be configured alongside the existing cache controls instead of through the model-level `cache_tools` escape hatch. The important constraint is backward compatibility: existing applications that still pass `cache_tools` should keep their current behavior while getting a clear migration path.

### Public API Changes

`CacheConfig` now includes `tools_ttl: bool | str = False`, matching the existing `system_prompt_ttl` shape and the TypeScript SDK's `toolsTTL` capability.

```python
# Before
agent = Agent(
    model=BedrockModel(
        cache_config=CacheConfig(ttl="5m"),
        cache_tools=True,
    )
)

# After
agent = Agent(
    model=BedrockModel(
        cache_config=CacheConfig(ttl="5m", tools_ttl=True),
    )
)
```

`cache_tools` remains supported for compatibility, emits a `DeprecationWarning`, and still takes precedence when both controls are set so existing configurations do not change behavior silently.

### Breaking Changes

This PR intentionally preserves the current `cache_tools` behavior. The only user-visible change is the new deprecation warning directing callers toward `CacheConfig(tools_ttl=...)`.

Resolves: #3893

## Related Issues

#3893

## Documentation PR

No separate docs PR is needed. The new field is documented inline on `CacheConfig`, alongside the existing cache configuration fields.

## Type of Change

New feature

## Testing

- `pytest tests/strands/models/test_bedrock.py tests/strands/models/test_anthropic.py tests/strands/models/test_model.py` -> 466 passed
- `ruff check src/strands/models tests/strands/models` -> clean for the touched files
- `ruff format --check src/strands/models tests/strands/models` -> changed regions clean
- `mypy src/strands/models/model.py src/strands/models/bedrock.py src/strands/models/anthropic.py` -> success
- [ ] I ran `hatch run prepare` (not available in this environment)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

I use a coding assistant to help implement, and I review and take responsibility for the final change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
