### PR TITLE
fix(models): reroute the Bedrock Mantle client when updateConfig crosses a base path

### DIFF
--- a/strands-ts/src/models/openai/__tests__/mantle.test.ts
+++ b/strands-ts/src/models/openai/__tests__/mantle.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import OpenAI from 'openai'
 import { isNode } from '../../../__fixtures__/environment.js'
 import { OpenAIModel } from '../index.js'
+import { logger } from '../../../logging/logger.js'
 
 vi.mock('openai', async (importOriginal) => {
   const actual = await importOriginal<typeof import('openai')>()
@@ -229,6 +230,43 @@ describe('OpenAIModel bedrockMantleConfig', () => {
       expect(baseURLFor({ modelId, bedrockMantleConfig: { region: 'us-west-2' } })).toBe(
         `https://bedrock-mantle.us-west-2.api.aws${expected}`
       )
+    })
+
+    // #3667: the Mantle client is built once in the constructor, so the base URL
+    // stays at the construction-time model's base path. Say so instead of
+    // silently mis-routing the next request.
+    it('warns that the Mantle base URL is fixed when updateConfig changes modelId', () => {
+      const model = new OpenAIModel({
+        modelId: 'openai.gpt-oss-120b',
+        bedrockMantleConfig: { region: 'us-west-2' },
+      })
+      const warnSpy = vi.spyOn(logger, 'warn')
+      model.updateConfig({ modelId: 'xai.grok-4.3' })
+      expect(model.getConfig().modelId).toBe('xai.grok-4.3')
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("'modelId' does not move the Bedrock Mantle base URL")
+      )
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('https://bedrock-mantle.us-west-2.api.aws/v1'))
+      warnSpy.mockRestore()
+    })
+
+    it('does not warn about the Mantle base URL when updateConfig leaves modelId alone', () => {
+      const model = new OpenAIModel({
+        modelId: 'openai.gpt-oss-120b',
+        bedrockMantleConfig: { region: 'us-west-2' },
+      })
+      const warnSpy = vi.spyOn(logger, 'warn')
+      model.updateConfig({ params: { temperature: 0.5 } })
+      expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('Bedrock Mantle base URL'))
+      warnSpy.mockRestore()
+    })
+
+    it('does not warn about the Mantle base URL when bedrockMantleConfig is not used', () => {
+      const model = new OpenAIModel({ modelId: 'gpt-5.4', client: {} as OpenAI })
+      const warnSpy = vi.spyOn(logger, 'warn')
+      model.updateConfig({ modelId: 'openai.gpt-oss-120b' })
+      expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('Bedrock Mantle base URL'))
+      warnSpy.mockRestore()
     })
   })
 

--- a/strands-ts/src/models/openai/__tests__/mantle.test.ts
+++ b/strands-ts/src/models/openai/__tests__/mantle.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import OpenAI from 'openai'
 import { isNode } from '../../../__fixtures__/environment.js'
 import { OpenAIModel } from '../index.js'
-import { logger } from '../../../logging/logger.js'
 
 vi.mock('openai', async (importOriginal) => {
   const actual = await importOriginal<typeof import('openai')>()
@@ -232,41 +231,78 @@ describe('OpenAIModel bedrockMantleConfig', () => {
       )
     })
 
-    // #3667: the Mantle client is built once in the constructor, so the base URL
-    // stays at the construction-time model's base path. Say so instead of
-    // silently mis-routing the next request.
-    it('warns that the Mantle base URL is fixed when updateConfig changes modelId', () => {
+    // #3667: a `modelId` swap across the base-path boundary rebuilds the Mantle
+    // client against the new base URL. The negative controls below pin the two
+    // ways that must NOT happen: within one base path, and off the Mantle path.
+    const clientCallCount = (): number => (OpenAI as unknown as { mock: { calls: unknown[][] } }).mock.calls.length
+    const lastClientArgs = (): { baseURL: string; apiKey: unknown } =>
+      (OpenAI as unknown as { mock: { calls: unknown[][] } }).mock.calls.at(-1)![0] as {
+        baseURL: string
+        apiKey: unknown
+      }
+
+    it('reroutes the Mantle base URL when updateConfig moves modelId across base paths', () => {
       const model = new OpenAIModel({
         modelId: 'openai.gpt-oss-120b',
         bedrockMantleConfig: { region: 'us-west-2' },
       })
-      const warnSpy = vi.spyOn(logger, 'warn')
+      expect(lastClientArgs().baseURL).toBe('https://bedrock-mantle.us-west-2.api.aws/v1')
+      const before = clientCallCount()
+
       model.updateConfig({ modelId: 'xai.grok-4.3' })
+
       expect(model.getConfig().modelId).toBe('xai.grok-4.3')
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining("'modelId' does not move the Bedrock Mantle base URL")
-      )
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('https://bedrock-mantle.us-west-2.api.aws/v1'))
-      warnSpy.mockRestore()
+      expect(clientCallCount()).toBe(before + 1)
+      expect(lastClientArgs().baseURL).toBe('https://bedrock-mantle.us-west-2.api.aws/openai/v1')
     })
 
-    it('does not warn about the Mantle base URL when updateConfig leaves modelId alone', () => {
+    // The memoized token provider lives in the setter's closure, so the rebuilt
+    // client must be handed the *same* setter rather than a fresh one.
+    it('reuses the construction-time api key setter when rerouting', () => {
       const model = new OpenAIModel({
         modelId: 'openai.gpt-oss-120b',
         bedrockMantleConfig: { region: 'us-west-2' },
       })
-      const warnSpy = vi.spyOn(logger, 'warn')
-      model.updateConfig({ params: { temperature: 0.5 } })
-      expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('Bedrock Mantle base URL'))
-      warnSpy.mockRestore()
+      const originalApiKey = lastClientArgs().apiKey
+
+      model.updateConfig({ modelId: 'xai.grok-4.3' })
+
+      expect(lastClientArgs().apiKey).toBe(originalApiKey)
     })
 
-    it('does not warn about the Mantle base URL when bedrockMantleConfig is not used', () => {
+    it('keeps the existing client when the new modelId stays on the same base path', () => {
+      const model = new OpenAIModel({
+        modelId: 'openai.gpt-oss-120b',
+        bedrockMantleConfig: { region: 'us-west-2' },
+      })
+      const before = clientCallCount()
+
+      model.updateConfig({ modelId: 'qwen.qwen3-32b' })
+
+      expect(model.getConfig().modelId).toBe('qwen.qwen3-32b')
+      expect(clientCallCount()).toBe(before)
+      expect(lastClientArgs().baseURL).toBe('https://bedrock-mantle.us-west-2.api.aws/v1')
+    })
+
+    it('keeps the existing client when updateConfig leaves modelId alone', () => {
+      const model = new OpenAIModel({
+        modelId: 'openai.gpt-oss-120b',
+        bedrockMantleConfig: { region: 'us-west-2' },
+      })
+      const before = clientCallCount()
+
+      model.updateConfig({ params: { temperature: 0.5 } })
+
+      expect(clientCallCount()).toBe(before)
+    })
+
+    it('does not touch the client when bedrockMantleConfig is not used', () => {
       const model = new OpenAIModel({ modelId: 'gpt-5.4', client: {} as OpenAI })
-      const warnSpy = vi.spyOn(logger, 'warn')
+      const before = clientCallCount()
+
       model.updateConfig({ modelId: 'openai.gpt-oss-120b' })
-      expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('Bedrock Mantle base URL'))
-      warnSpy.mockRestore()
+
+      expect(clientCallCount()).toBe(before)
     })
   })
 

--- a/strands-ts/src/models/openai/model.ts
+++ b/strands-ts/src/models/openai/model.ts
@@ -70,11 +70,21 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
   private _config: OpenAIModelConfig
   private _client: OpenAI
   /**
-   * Base URL baked into the Mantle client at construction, or `undefined` when
-   * the Mantle pathway is not in use. Kept so `updateConfig` can say which URL
-   * a later `modelId` change is stuck on.
+   * Base URL the current Mantle client points at, or `undefined` when the Mantle
+   * pathway is not in use. Mutable: `updateConfig` moves it when a new `modelId`
+   * resolves to the other base path.
    */
-  private readonly _mantleBaseUrl?: string
+  private _mantleBaseUrl?: string
+  /**
+   * State retained so `updateConfig` can rebuild the Mantle client on a base-path
+   * change. `_mantleApiKey` is the setter built at construction and is deliberately
+   * reused rather than re-created: {@link createMantleApiKeySetter} memoizes its
+   * token provider in a closure, so a fresh setter would drop the warm provider and
+   * re-import `@aws/bedrock-token-generator` on the next request.
+   */
+  private _mantleRegion?: string
+  private _mantleClientConfig?: OpenAIModelOptions['clientConfig']
+  private _mantleApiKey?: () => Promise<string>
 
   constructor(options: OpenAIModelOptions) {
     super()
@@ -110,6 +120,9 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
       const mantle = buildMantleClient(bedrockMantleConfig, apiKey, clientConfig, modelId)
       this._client = mantle.client
       this._mantleBaseUrl = mantle.baseURL
+      this._mantleRegion = mantle.region
+      this._mantleClientConfig = clientConfig
+      this._mantleApiKey = mantle.apiKey
     } else {
       const hasEnvKey =
         typeof process !== 'undefined' && typeof process.env !== 'undefined' && process.env.OPENAI_API_KEY
@@ -151,9 +164,10 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
    * invalidate the invariants the agent builds on top of `stateful` (message
    * history management, `previous_response_id` chaining).
    *
-   * Under `bedrockMantleConfig`, `modelId` still updates but the client's base
-   * URL does not — it is fixed at construction, so a swap across the Mantle
-   * base-path boundary is warned about rather than silently mis-routed.
+   * Under `bedrockMantleConfig`, a `modelId` that resolves to the other Mantle
+   * base path rebuilds the underlying client against the new base URL, so the
+   * next request is routed correctly instead of hitting the previous path.
+   * A swap within the same base path keeps the existing client.
    */
   updateConfig(modelConfig: OpenAIModelConfig & { api?: OpenAIApi }): void {
     const { api, stateful, ...rest } = modelConfig
@@ -167,10 +181,21 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
     }
 
     if (this._mantleBaseUrl !== undefined && rest.modelId !== undefined) {
-      logger.warn(
-        `modelId=<${rest.modelId}> | 'modelId' does not move the Bedrock Mantle base URL — it stays at ` +
-          `<${this._mantleBaseUrl}>, fixed at construction, so a model served from the other base path will fail`
-      )
+      const nextBaseUrl = bedrockMantleBaseUrl(this._mantleRegion!, rest.modelId)
+      // Only cross-boundary swaps need a new client; within one base path the
+      // existing connection is still correct and worth keeping alive.
+      if (nextBaseUrl !== this._mantleBaseUrl) {
+        logger.debug(
+          `modelId=<${rest.modelId}> | rerouting the Bedrock Mantle client from ` +
+            `<${this._mantleBaseUrl}> to <${nextBaseUrl}>`
+        )
+        this._client = new OpenAI({
+          ...this._mantleClientConfig,
+          baseURL: nextBaseUrl,
+          apiKey: this._mantleApiKey,
+        })
+        this._mantleBaseUrl = nextBaseUrl
+      }
     }
 
     if (this._api === 'responses') {
@@ -304,7 +329,7 @@ function buildMantleClient(
   apiKey: OpenAIModelOptions['apiKey'],
   clientConfig: OpenAIModelOptions['clientConfig'],
   modelId: string
-): { client: OpenAI; baseURL: string } {
+): { client: OpenAI; baseURL: string; region: string; apiKey: () => Promise<string> } {
   if (apiKey !== undefined) {
     throw new Error(
       "'apiKey' cannot be combined with 'bedrockMantleConfig'; the API key is derived from the Mantle config automatically."
@@ -324,13 +349,19 @@ function buildMantleClient(
   // Resolve the region eagerly so missing-region configuration fails fast.
   const region = resolveMantleRegion(bedrockMantleConfig)
   const baseURL = bedrockMantleBaseUrl(region, modelId)
+  // Built once and handed back so `updateConfig` can reuse it across reroutes:
+  // the setter memoizes its token provider, and it already mints a fresh bearer
+  // token per request, so there is nothing to refresh by rebuilding it.
+  const mantleApiKey = createMantleApiKeySetter(bedrockMantleConfig, region)
 
   return {
     client: new OpenAI({
       ...clientConfig,
       baseURL,
-      apiKey: createMantleApiKeySetter(bedrockMantleConfig, region),
+      apiKey: mantleApiKey,
     }),
     baseURL,
+    region,
+    apiKey: mantleApiKey,
   }
 }

--- a/strands-ts/src/models/openai/model.ts
+++ b/strands-ts/src/models/openai/model.ts
@@ -69,6 +69,12 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
   private readonly _api: OpenAIApi
   private _config: OpenAIModelConfig
   private _client: OpenAI
+  /**
+   * Base URL baked into the Mantle client at construction, or `undefined` when
+   * the Mantle pathway is not in use. Kept so `updateConfig` can say which URL
+   * a later `modelId` change is stuck on.
+   */
+  private readonly _mantleBaseUrl?: string
 
   constructor(options: OpenAIModelOptions) {
     super()
@@ -101,7 +107,9 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
       this._client = client
     } else if (bedrockMantleConfig) {
       const modelId = modelConfig.modelId ?? MODEL_DEFAULTS.openai.modelId
-      this._client = buildMantleClient(bedrockMantleConfig, apiKey, clientConfig, modelId)
+      const mantle = buildMantleClient(bedrockMantleConfig, apiKey, clientConfig, modelId)
+      this._client = mantle.client
+      this._mantleBaseUrl = mantle.baseURL
     } else {
       const hasEnvKey =
         typeof process !== 'undefined' && typeof process.env !== 'undefined' && process.env.OPENAI_API_KEY
@@ -142,6 +150,10 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
    * they are stripped with a warning. Changing either at runtime would
    * invalidate the invariants the agent builds on top of `stateful` (message
    * history management, `previous_response_id` chaining).
+   *
+   * Under `bedrockMantleConfig`, `modelId` still updates but the client's base
+   * URL does not — it is fixed at construction, so a swap across the Mantle
+   * base-path boundary is warned about rather than silently mis-routed.
    */
   updateConfig(modelConfig: OpenAIModelConfig & { api?: OpenAIApi }): void {
     const { api, stateful, ...rest } = modelConfig
@@ -151,6 +163,13 @@ export class OpenAIModel extends Model<OpenAIModelConfig> {
     if (stateful !== undefined) {
       logger.warn(
         `stateful=<${stateful}> | 'stateful' is construction-only and cannot be changed via updateConfig — ignoring`
+      )
+    }
+
+    if (this._mantleBaseUrl !== undefined && rest.modelId !== undefined) {
+      logger.warn(
+        `modelId=<${rest.modelId}> | 'modelId' does not move the Bedrock Mantle base URL — it stays at ` +
+          `<${this._mantleBaseUrl}>, fixed at construction, so a model served from the other base path will fail`
       )
     }
 
@@ -285,7 +304,7 @@ function buildMantleClient(
   apiKey: OpenAIModelOptions['apiKey'],
   clientConfig: OpenAIModelOptions['clientConfig'],
   modelId: string
-): OpenAI {
+): { client: OpenAI; baseURL: string } {
   if (apiKey !== undefined) {
     throw new Error(
       "'apiKey' cannot be combined with 'bedrockMantleConfig'; the API key is derived from the Mantle config automatically."
@@ -304,10 +323,14 @@ function buildMantleClient(
 
   // Resolve the region eagerly so missing-region configuration fails fast.
   const region = resolveMantleRegion(bedrockMantleConfig)
+  const baseURL = bedrockMantleBaseUrl(region, modelId)
 
-  return new OpenAI({
-    ...clientConfig,
-    baseURL: bedrockMantleBaseUrl(region, modelId),
-    apiKey: createMantleApiKeySetter(bedrockMantleConfig, region),
-  })
+  return {
+    client: new OpenAI({
+      ...clientConfig,
+      baseURL,
+      apiKey: createMantleApiKeySetter(bedrockMantleConfig, region),
+    }),
+    baseURL,
+  }
 }


### PR DESCRIPTION
## Description

Fixes #3667.

Under `bedrockMantleConfig`, `updateConfig({ modelId })` silently left the OpenAI client pointed at the base URL derived from the **construction-time** model id, so the next request carried the new model against the old model's Mantle route.

This PR takes **option 2** from the issue — `updateConfig` now reroutes: a `modelId` that resolves to the other Mantle base path rebuilds the client against the new base URL. A swap *within* one base path keeps the existing client.

> Earlier revisions of this PR implemented option 1 (warn instead of reroute). Per @opieter-aws's review the rerouting semantics are the intended ones, so the warning is gone and the tests that pinned it are now routing tests.

## Root cause

`this._client` had exactly three assignments in `strands-ts/src/models/openai/model.ts`, all inside the constructor; `stream()` only reads it (`:185`, `:243`). Nothing ever rebuilt the client.

The Mantle branch baked the base path in at construction:

```ts
// before this PR
return new OpenAI({
  ...clientConfig,
  baseURL: bedrockMantleBaseUrl(region, modelId),   // <- frozen here
  apiKey: createMantleApiKeySetter(bedrockMantleConfig, region),
})
```

`updateConfig` then merged `modelId` into `this._config` (and therefore into the request body's `model`) with no corresponding change to the route.

Result, straight from the issue's repro:

```
config.modelId after updateConfig: xai.grok-4.3
url=https://bedrock-mantle.us-east-1.api.aws/v1/responses  body.model=openai.gpt-oss-120b
url=https://bedrock-mantle.us-east-1.api.aws/v1/responses  body.model=xai.grok-4.3   <-- should be /openai/v1
```

Against live Mantle the second request is an HTTP 400 `validation_error` — the same user-visible failure as #3654, reached by a different route.

### Cross-SDK parity

Python does not have this gap: it re-resolves the client args on every request, re-reading `model_id` each time.

| | TypeScript (before) | TypeScript (after) | Python |
|---|---|---|---|
| where the client is built | constructor only | constructor, plus `updateConfig` on a base-path change | per request — `strands-py/src/strands/models/openai.py:681` |
| where `modelId` is read for routing | once, at construction | at construction and on every `updateConfig` | every call — `strands-py/src/strands/models/openai.py:135` |
| effect of `update_config(model_id=…)` | base URL stays put | base URL moves with the model | base URL moves with the model |

Note the middle column is not Python's *mechanism*: Python resolves per request (that is option 3 in the issue), whereas this converges on the same observable behaviour for the `updateConfig` pathway without reshaping how the TS provider owns its client. If you would rather go all the way to per-request resolution, say so and I will do that instead.

## Changes

`strands-ts/src/models/openai/model.ts`:

- `buildMantleClient` now returns `{ client, baseURL, region, apiKey }`. The constructor keeps `region`, `clientConfig` and the api key setter so `updateConfig` has everything a rebuild needs — previously the helper discarded all of it.
- `_mantleBaseUrl` is no longer `readonly`; it tracks the URL the current client points at.
- `updateConfig` resolves the incoming `modelId` to a base URL and rebuilds the client **only when it differs** from the current one, logging the reroute at `debug`.

### Two details worth calling out

**The api key setter is reused, not re-created.** `createMantleApiKeySetter` (`mantle.ts:147-158`) memoizes `tokenProviderPromise` in its closure and mints a fresh bearer token on every request. Passing the *same* setter into the rebuilt client keeps that provider warm; calling `createMantleApiKeySetter` again would silently drop it and re-`import('@aws/bedrock-token-generator')` on the next request. Because it already re-mints per request, there is nothing to refresh by rebuilding it.

**Rebuilding only across the base-path boundary.** A swap within the same path (`openai.gpt-oss-120b` → `qwen.qwen3-32b`, both `/v1`) does not need a new client, and throwing one away would discard its connection state and keep-alive for no gain. `stream()` reads `this._client` per call, so replacing it between turns is safe.

## Test gap this closes

`strands-ts/src/models/openai/__tests__/mantle.test.ts` had **zero** `updateConfig` calls before this PR — its `describe('base path resolution by model family')` block asserted only construction-time URLs. The post-`updateConfig` state was untested, which is exactly why the issue survived #3666's routing work.

Five tests in that existing block (the `OpenAI` constructor mock and the `@aws/bedrock-token-generator` mock are already there — no new files, no new mock scaffolding):

1. **the reroute** — `openai.gpt-oss-120b` (`/v1`) → `xai.grok-4.3` (`/openai/v1`): one additional `OpenAI` construction, and the new client carries the `/openai/v1` base URL;
2. **the setter is reused** — the rebuilt client receives the identical `apiKey` reference;
3. **negative control** — a swap within one base path (`→ qwen.qwen3-32b`) constructs no new client;
4. **negative control** — an `updateConfig` that does not touch `modelId` constructs no new client;
5. **negative control** — no `bedrockMantleConfig` at all constructs no new client.

### Both positives verified as discriminating

Test 1, with the rebuild condition forced off (`if (false && …)`):

```
 FAIL  src/models/openai/__tests__/mantle.test.ts > … >
 reroutes the Mantle base URL when updateConfig moves modelId across base paths
      Tests  1 failed | 56 passed (57)
```

Test 2, with the rebuild handed a freshly built setter instead of the retained one:

```
 FAIL  src/models/openai/__tests__/mantle.test.ts > … >
 reuses the construction-time api key setter when rerouting
      Tests  1 failed | 56 passed (57)
```

Both green with the change in place (57 passed).

## Checks run

| command | result |
|---|---|
| `bun run test` (full TS unit suite, `--project unit-node`) | 155 files, **4345 passed**, no type errors |
| `bun run lint` | clean |
| `npx prettier --check` on both touched files | clean |
| `npx tsc --noEmit` | no errors |

Not run: `test:integ` (needs live AWS/Mantle credentials).
