### PR TITLE
fix(anthropic): surface context window overflow

### DIFF
--- a/strands-ts/src/__tests__/errors.test.ts
+++ b/strands-ts/src/__tests__/errors.test.ts
@@ -68,6 +68,15 @@ describe('ContextWindowOverflowError', () => {
       expect(error).toBeInstanceOf(ModelError)
     })
   })
+
+  describe('when instantiated with a cause', () => {
+    it('stores the cause event', () => {
+      const cause = { type: 'message_delta' }
+      const error = new ContextWindowOverflowError('context window overflow occurred', { cause })
+
+      expect(error.cause).toBe(cause)
+    })
+  })
 })
 
 describe('MaxTokensError', () => {

--- a/strands-ts/src/errors.ts
+++ b/strands-ts/src/errors.ts
@@ -41,9 +41,10 @@ export class ContextWindowOverflowError extends ModelError {
    * Creates a new ContextWindowOverflowError.
    *
    * @param message - Error message describing the context overflow
+   * @param options - Optional error options including the provider cause
    */
-  constructor(message: string) {
-    super(message)
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options)
     this.name = 'ContextWindowOverflowError'
   }
 }

--- a/strands-ts/src/models/__tests__/anthropic.test.ts
+++ b/strands-ts/src/models/__tests__/anthropic.test.ts
@@ -3,7 +3,7 @@ import Anthropic from '@anthropic-ai/sdk'
 import { isNode } from '../../__fixtures__/environment.js'
 import { AnthropicModel } from '../anthropic.js'
 import { ContextWindowOverflowError, ModelThrottledError } from '../../errors.js'
-import { collectIterator } from '../../__fixtures__/model-test-helpers.js'
+import { collectGenerator, collectIterator } from '../../__fixtures__/model-test-helpers.js'
 import {
   Message,
   TextBlock,
@@ -271,6 +271,31 @@ describe('AnthropicModel', () => {
       expect(events).toContainEqual({ type: 'modelMessageStopEvent', stopReason: 'toolUse' })
     })
 
+    it('throws ContextWindowOverflowError when Anthropic reports a context window overflow', async () => {
+      const overflowEvent = {
+        type: 'message_delta',
+        delta: { stop_reason: 'model_context_window_exceeded' },
+        usage: { output_tokens: 1 },
+      }
+      const mockClient = createMockClient(async function* () {
+        yield { type: 'message_start', message: { role: 'assistant', usage: { input_tokens: 1 } } }
+        yield overflowEvent
+      })
+      const provider = new AnthropicModel({ client: mockClient })
+      const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
+
+      await expect(collectIterator(provider.stream(messages))).rejects.toMatchObject({
+        name: 'ContextWindowOverflowError',
+        message: 'model_context_window_exceeded',
+        cause: overflowEvent,
+      })
+      await expect(collectGenerator(provider.streamAggregated(messages))).rejects.toMatchObject({
+        name: 'ContextWindowOverflowError',
+        message: 'model_context_window_exceeded',
+        cause: overflowEvent,
+      })
+    })
+
     it.each([
       ['pause_turn', 'pauseTurn'],
       ['refusal', 'refusal'],
@@ -378,14 +403,19 @@ describe('AnthropicModel', () => {
     })
 
     it('maps overload error to ContextWindowOverflowError', async () => {
+      const overflowError = new Error('prompt is too long')
       const mockClient = createMockClient(async function* () {
         yield { type: 'ping' } // Satisfy linter require-yield
-        throw new Error('prompt is too long')
+        throw overflowError
       })
       const provider = new AnthropicModel({ client: mockClient })
       const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
 
-      await expect(collectIterator(provider.stream(messages))).rejects.toThrow(ContextWindowOverflowError)
+      await expect(collectIterator(provider.stream(messages))).rejects.toMatchObject({
+        name: 'ContextWindowOverflowError',
+        message: 'prompt is too long',
+        cause: overflowError,
+      })
     })
 
     it.each([

--- a/strands-ts/src/models/anthropic.ts
+++ b/strands-ts/src/models/anthropic.ts
@@ -276,7 +276,11 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
               usage.outputTokens = event.usage.output_tokens
             }
             if (event.delta.stop_reason) {
-              stopReason = this._mapStopReason(event.delta.stop_reason)
+              const anthropicStopReason: string = event.delta.stop_reason
+              if (anthropicStopReason === 'model_context_window_exceeded') {
+                throw new ContextWindowOverflowError(anthropicStopReason, { cause: event })
+              }
+              stopReason = this._mapStopReason(anthropicStopReason)
             }
             break
 
@@ -298,7 +302,7 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
 
       const lowered = error.message.toLowerCase()
       if (CONTEXT_WINDOW_OVERFLOW_ERRORS.some((msg) => lowered.includes(msg))) {
-        throw new ContextWindowOverflowError(error.message)
+        throw new ContextWindowOverflowError(error.message, { cause: error })
       }
 
       const err = unknownError as Error & { status?: number }


### PR DESCRIPTION
## Description

Anthropic can end a stream with `model_context_window_exceeded`; treating that provider signal as a normal, unknown stop reason prevents callers from using the SDK's established context-overflow handling path. This change surfaces it as `ContextWindowOverflowError` while retaining the provider event or error as its cause.

### Public API Changes

`ContextWindowOverflowError` now accepts standard error options, allowing callers and providers to retain causal context:

```typescript
const error = new ContextWindowOverflowError('context window overflow', { cause: providerEvent })
```

## Related Issues

Resolves: #3769

## Documentation PR

No documentation changes are required.

## Type of Change

Bug fix

## Testing

- [x] `npm run build`
- [x] `npm run test:coverage`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run type-check`
- [x] `npm run check:browser-bundle`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
