### PR TITLE
fix(ts): support content blocks in AfterToolsEvent.endTurn and simplify delegation

### DIFF
--- a/site/src/content/docs/user-guide/concepts/agents/hooks.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/hooks.mdx
@@ -404,7 +404,7 @@ Most event properties are read-only to prevent unintended modifications. However
     - `result` - Mutable. Rewrite the `ToolResultBlock` before it propagates to the model. See [Result Modification](#result-modification).
 
 - `AfterToolsEvent`
-    - `endTurn` - Halt the agent loop after the tool batch without calling the model again. Set `true` for a default final assistant message, or a string to use as the final assistant message. The returned result has `stopReason="endTurn"`.
+    - `endTurn` - Halt the agent loop after the tool batch without calling the model again. Set `true` for a default final assistant message, a string to use as the final assistant message, or a `ContentBlock[]` to use as the final assistant message content directly. The returned result has `stopReason="endTurn"`.
 
 - `AfterInvocationEvent`
     - `resume` - Trigger a follow-up agent invocation with new input. Setting it re-enters the agent loop under the same invocation lock. See [Invocation resume](#invocation-resume).

--- a/site/src/content/docs/user-guide/concepts/agents/hooks.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/hooks.mdx
@@ -404,7 +404,7 @@ Most event properties are read-only to prevent unintended modifications. However
     - `result` - Mutable. Rewrite the `ToolResultBlock` before it propagates to the model. See [Result Modification](#result-modification).
 
 - `AfterToolsEvent`
-    - `endTurn` - Halt the agent loop after the tool batch without calling the model again. Set `true` for a default final assistant message, a string to use as the final assistant message, or a `ContentBlock[]` to use as the final assistant message content directly. The returned result has `stopReason="endTurn"`.
+    - `endTurn` - Halt the agent loop after the tool batch without calling the model again. Set `true` for a default final assistant message, a string to use as the final assistant message, or a list of content blocks to use as the final assistant message content directly. The returned result has `stopReason="endTurn"`.
 
 - `AfterInvocationEvent`
     - `resume` - Trigger a follow-up agent invocation with new input. Setting it re-enters the agent loop under the same invocation lock. See [Invocation resume](#invocation-resume).

--- a/strands-ts/src/agent/__tests__/agent-delegation.test.ts
+++ b/strands-ts/src/agent/__tests__/agent-delegation.test.ts
@@ -10,11 +10,17 @@
 import { describe, it, expect } from 'vitest'
 import { z } from 'zod'
 import { Agent } from '../agent.js'
-import { AfterToolCallEvent, AfterToolsEvent, BeforeToolCallEvent, StreamEvent } from '../../hooks/events.js'
+import {
+  AfterToolCallEvent,
+  AfterToolsEvent,
+  BeforeToolCallEvent,
+  MessageAddedEvent,
+  StreamEvent,
+} from '../../hooks/events.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
 import { createMockTool } from '../../__fixtures__/tool-helpers.js'
 import { AgentAsTool } from '../agent-as-tool.js'
-import { ToolResultBlock, TextBlock } from '../../types/messages.js'
+import { Message, ToolResultBlock, TextBlock } from '../../types/messages.js'
 
 describe('AgentDelegation integration', () => {
   describe('basic routing', () => {
@@ -120,6 +126,42 @@ describe('AgentDelegation integration', () => {
       expect(result.stopReason).toBe('endTurn')
       const textBlocks = result.lastMessage.content.filter((b) => b.type === 'textBlock')
       expect((textBlocks[0] as { text: string }).text).toBe('Specialist answer')
+    })
+
+    it('cancels all tools when two delegation tools are called simultaneously, then retries', async () => {
+      const billingModel = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Billing response' })
+      const techModel = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Tech response' })
+
+      const billingAgent = new Agent({ model: billingModel, name: 'Billing', printer: false })
+      const techAgent = new Agent({ model: techModel, name: 'TechSupport', printer: false })
+
+      // Turn 1: model calls BOTH delegation tools simultaneously (invalid)
+      // Turn 2: model retries with just one delegation tool (valid)
+      const orchestratorModel = new MockMessageModel()
+        .addTurn([
+          { type: 'toolUseBlock', name: 'Billing', toolUseId: 'bill-1', input: { input: 'refund' } },
+          { type: 'toolUseBlock', name: 'TechSupport', toolUseId: 'tech-1', input: { input: 'wifi' } },
+        ])
+        .addTurn({
+          type: 'toolUseBlock',
+          name: 'TechSupport',
+          toolUseId: 'tech-2',
+          input: { input: 'wifi' },
+        })
+
+      const orchestrator = new Agent({
+        model: orchestratorModel,
+        name: 'Orchestrator',
+        tools: [billingAgent.asTool({ delegate: true }), techAgent.asTool({ delegate: true })],
+        printer: false,
+      })
+
+      const result = await orchestrator.invoke('Handle both billing and tech')
+
+      // After the retry, the delegation succeeds with the single tool
+      expect(result.stopReason).toBe('endTurn')
+      const textBlocks = result.lastMessage.content.filter((b) => b.type === 'textBlock')
+      expect((textBlocks[0] as { text: string }).text).toBe('Tech response')
     })
   })
 
@@ -278,6 +320,47 @@ describe('AgentDelegation integration', () => {
       expect(result.stopReason).toBe('endTurn')
       const textBlocks = result.lastMessage.content.filter((b) => b.type === 'textBlock')
       expect((textBlocks[0] as { text: string }).text).toBe('Got the sub-agent response, done.')
+    })
+
+    it('does not enforce single-call constraint for stateful models with runtime-added tools', async () => {
+      class StatefulModel extends MockMessageModel {
+        override get stateful(): boolean {
+          return true
+        }
+      }
+
+      const subModel = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Sub response' })
+      const subAgent = new Agent({ model: subModel, name: 'Sub', printer: false })
+
+      const calculator = createMockTool('calculator', () => 'Result: 42')
+
+      // Model calls BOTH calculator and delegation tool simultaneously.
+      // With a stateful model, this should NOT be cancelled.
+      const statefulModel = new StatefulModel()
+        .addTurn([
+          { type: 'toolUseBlock', name: 'calculator', toolUseId: 'calc-1', input: {} },
+          { type: 'toolUseBlock', name: 'Sub', toolUseId: 'del-1', input: { input: 'help' } },
+        ])
+        .addTurn({ type: 'textBlock', text: 'Both tools ran successfully.' })
+
+      // Create agent with only the regular tool so init-time check passes
+      const orchestrator = new Agent({
+        model: statefulModel,
+        name: 'Orchestrator',
+        tools: [calculator],
+        printer: false,
+      })
+
+      // Add delegation tool after initialization
+      await orchestrator.initialize()
+      orchestrator.toolRegistry.add(subAgent.asTool({ delegate: true }))
+
+      const result = await orchestrator.invoke('Do both')
+
+      // Both tools ran normally — no cancellation, no delegation
+      expect(result.stopReason).toBe('endTurn')
+      const textBlocks = result.lastMessage.content.filter((b) => b.type === 'textBlock')
+      expect((textBlocks[0] as { text: string }).text).toBe('Both tools ran successfully.')
     })
   })
 
@@ -561,6 +644,43 @@ describe('AgentDelegation integration', () => {
       // Delegation suppressed — structured output takes over
       expect(result.stopReason).toBe('toolUse')
       expect(result.structuredOutput).toEqual({ answer: 'Sub answer' })
+    })
+  })
+
+  describe('delegation emits correct MessageAddedEvents', () => {
+    it('emits exactly one assistant MessageAddedEvent with delegated content (no placeholder)', async () => {
+      const subModel = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Balance: $42' })
+      const subAgent = new Agent({ model: subModel, name: 'billing', printer: false })
+
+      const orchestratorModel = new MockMessageModel().addTurn({
+        type: 'toolUseBlock',
+        name: 'billing',
+        toolUseId: 'c1',
+        input: { input: 'check' },
+      })
+
+      const orchestrator = new Agent({
+        model: orchestratorModel,
+        name: 'Orchestrator',
+        tools: [subAgent.asTool({ delegate: true })],
+        printer: false,
+      })
+
+      const assistantMessages: Message[] = []
+      orchestrator.addHook(MessageAddedEvent, (event) => {
+        if (event.agent === orchestrator && event.message.role === 'assistant') {
+          assistantMessages.push(event.message)
+        }
+      })
+
+      await orchestrator.invoke('Check balance')
+
+      // Two assistant MessageAddedEvents: toolUse turn, then the delegated content
+      expect(assistantMessages).toHaveLength(2)
+      expect(assistantMessages[1]!.content).toEqual([new TextBlock('Balance: $42')])
+
+      // History ends with the delegated content, no placeholder
+      expect(orchestrator.messages.map((m) => m.role)).toEqual(['user', 'assistant', 'user', 'assistant'])
     })
   })
 })

--- a/strands-ts/src/agent/__tests__/agent-delegation.test.ts
+++ b/strands-ts/src/agent/__tests__/agent-delegation.test.ts
@@ -3,8 +3,8 @@
  * with delegation tools using a mock model.
  *
  * Tests exercise the complete path: Agent constructor auto-registration,
- * BeforeToolsEvent enforcement, AfterToolsEvent early exit, and
- * AgentStreamStage result transformation.
+ * BeforeToolsEvent enforcement, AfterToolsEvent early exit with content blocks,
+ * and event streaming unwrapping.
  */
 
 import { describe, it, expect } from 'vitest'
@@ -84,34 +84,6 @@ describe('AgentDelegation integration', () => {
       expect(textBlocks).toHaveLength(1)
       expect((textBlocks[0] as { text: string }).text).toBe('The answer is 42.')
     })
-
-    it('delegation tool triggers handoff when called alone alongside regular tools in registry', async () => {
-      const techModel = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Router fixed!' })
-      const techAgent = new Agent({ model: techModel, name: 'TechSupport', printer: false })
-
-      const calculator = createMockTool('calculator', () => 'Result: 42')
-
-      // Model calls the delegation tool (alone)
-      const orchestratorModel = new MockMessageModel().addTurn({
-        type: 'toolUseBlock',
-        name: 'TechSupport',
-        toolUseId: 'tech-1',
-        input: { input: 'Fix my router' },
-      })
-
-      const orchestrator = new Agent({
-        model: orchestratorModel,
-        name: 'Orchestrator',
-        tools: [calculator, techAgent.asTool({ delegate: true })],
-        printer: false,
-      })
-
-      const result = await orchestrator.invoke('Fix my router')
-
-      expect(result.stopReason).toBe('endTurn')
-      const textBlocks = result.lastMessage.content.filter((b) => b.type === 'textBlock')
-      expect((textBlocks[0] as { text: string }).text).toBe('Router fixed!')
-    })
   })
 
   describe('single-call enforcement', () => {
@@ -148,42 +120,6 @@ describe('AgentDelegation integration', () => {
       expect(result.stopReason).toBe('endTurn')
       const textBlocks = result.lastMessage.content.filter((b) => b.type === 'textBlock')
       expect((textBlocks[0] as { text: string }).text).toBe('Specialist answer')
-    })
-
-    it('cancels all tools when two delegation tools are called simultaneously, then retries', async () => {
-      const billingModel = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Billing response' })
-      const techModel = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Tech response' })
-
-      const billingAgent = new Agent({ model: billingModel, name: 'Billing', printer: false })
-      const techAgent = new Agent({ model: techModel, name: 'TechSupport', printer: false })
-
-      // Turn 1: model calls BOTH delegation tools simultaneously (invalid)
-      // Turn 2: model retries with just one delegation tool (valid)
-      const orchestratorModel = new MockMessageModel()
-        .addTurn([
-          { type: 'toolUseBlock', name: 'Billing', toolUseId: 'bill-1', input: { input: 'refund' } },
-          { type: 'toolUseBlock', name: 'TechSupport', toolUseId: 'tech-1', input: { input: 'wifi' } },
-        ])
-        .addTurn({
-          type: 'toolUseBlock',
-          name: 'TechSupport',
-          toolUseId: 'tech-2',
-          input: { input: 'wifi' },
-        })
-
-      const orchestrator = new Agent({
-        model: orchestratorModel,
-        name: 'Orchestrator',
-        tools: [billingAgent.asTool({ delegate: true }), techAgent.asTool({ delegate: true })],
-        printer: false,
-      })
-
-      const result = await orchestrator.invoke('Handle both billing and tech')
-
-      // After the retry, the delegation succeeds with the single tool
-      expect(result.stopReason).toBe('endTurn')
-      const textBlocks = result.lastMessage.content.filter((b) => b.type === 'textBlock')
-      expect((textBlocks[0] as { text: string }).text).toBe('Tech response')
     })
   })
 
@@ -269,38 +205,35 @@ describe('AgentDelegation integration', () => {
     })
   })
 
-  describe('non-text delegation', () => {
-    it('delegates successfully when sub-agent returns empty text (e.g. image-only response)', async () => {
-      // Simulate a sub-agent whose toString() returns '' — this happens when the
-      // sub-agent's lastMessage contains only non-text content (image, document, video).
-      // AgentAsTool wraps it in TextBlock(''), so the ToolResultBlock has a single
-      // empty TextBlock. extractText() returns '' for this, which previously caused
-      // endTurn to be falsy and the early-exit check to fail.
+  describe('blank content skips delegation', () => {
+    it('skips delegation when sub-agent returns empty text and loop continues', async () => {
       const emptyTextModel = new MockMessageModel().addTurn({ type: 'textBlock', text: '' })
-      const imageAgent = new Agent({ model: emptyTextModel, name: 'ImageAgent', printer: false })
+      const emptyAgent = new Agent({ model: emptyTextModel, name: 'EmptyAgent', printer: false })
 
-      // Orchestrator model has ONLY one turn (the delegation tool call).
-      // If the early-exit fails and the orchestrator tries a second model call,
-      // MockMessageModel throws "All turns have been consumed" — so the test
-      // implicitly verifies no extra model call occurs.
-      const orchestratorModel = new MockMessageModel().addTurn({
-        type: 'toolUseBlock',
-        name: 'ImageAgent',
-        toolUseId: 'img-1',
-        input: { input: 'Generate an image' },
-      })
+      // Turn 1: delegation tool call (sub-agent returns empty text → delegation skipped)
+      // Turn 2: model produces a follow-up response since the loop continues
+      const orchestratorModel = new MockMessageModel()
+        .addTurn({
+          type: 'toolUseBlock',
+          name: 'EmptyAgent',
+          toolUseId: 'empty-1',
+          input: { input: 'go' },
+        })
+        .addTurn({ type: 'textBlock', text: 'I continued.' })
 
       const orchestrator = new Agent({
         model: orchestratorModel,
         name: 'Orchestrator',
-        tools: [imageAgent.asTool({ delegate: true })],
+        tools: [emptyAgent.asTool({ delegate: true })],
         printer: false,
       })
 
-      const result = await orchestrator.invoke('Generate an image')
+      const result = await orchestrator.invoke('go')
 
-      // Delegation MUST trigger even when the sub-agent returns empty text
+      // Delegation skipped — loop continued to the model's second turn
       expect(result.stopReason).toBe('endTurn')
+      const textBlocks = result.lastMessage.content.filter((b) => b.type === 'textBlock')
+      expect((textBlocks[0] as { text: string }).text).toBe('I continued.')
     })
   })
 
@@ -345,47 +278,6 @@ describe('AgentDelegation integration', () => {
       expect(result.stopReason).toBe('endTurn')
       const textBlocks = result.lastMessage.content.filter((b) => b.type === 'textBlock')
       expect((textBlocks[0] as { text: string }).text).toBe('Got the sub-agent response, done.')
-    })
-
-    it('does not enforce single-call constraint for stateful models with runtime-added tools', async () => {
-      class StatefulModel extends MockMessageModel {
-        override get stateful(): boolean {
-          return true
-        }
-      }
-
-      const subModel = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Sub response' })
-      const subAgent = new Agent({ model: subModel, name: 'Sub', printer: false })
-
-      const calculator = createMockTool('calculator', () => 'Result: 42')
-
-      // Model calls BOTH calculator and delegation tool simultaneously.
-      // With a stateful model, this should NOT be cancelled.
-      const statefulModel = new StatefulModel()
-        .addTurn([
-          { type: 'toolUseBlock', name: 'calculator', toolUseId: 'calc-1', input: {} },
-          { type: 'toolUseBlock', name: 'Sub', toolUseId: 'del-1', input: { input: 'help' } },
-        ])
-        .addTurn({ type: 'textBlock', text: 'Both tools ran successfully.' })
-
-      // Create agent with only the regular tool so init-time check passes
-      const orchestrator = new Agent({
-        model: statefulModel,
-        name: 'Orchestrator',
-        tools: [calculator],
-        printer: false,
-      })
-
-      // Add delegation tool after initialization
-      await orchestrator.initialize()
-      orchestrator.toolRegistry.add(subAgent.asTool({ delegate: true }))
-
-      const result = await orchestrator.invoke('Do both')
-
-      // Both tools ran normally — no cancellation, no delegation
-      expect(result.stopReason).toBe('endTurn')
-      const textBlocks = result.lastMessage.content.filter((b) => b.type === 'textBlock')
-      expect((textBlocks[0] as { text: string }).text).toBe('Both tools ran successfully.')
     })
   })
 
@@ -465,28 +357,6 @@ describe('AgentDelegation integration', () => {
       })
 
       await expect(orchestrator.initialize()).rejects.toThrow(/not supported with stateful models/)
-    })
-
-    it('does not throw for stateful models without delegation tools', async () => {
-      class StatefulModel extends MockMessageModel {
-        override get stateful(): boolean {
-          return true
-        }
-      }
-
-      const subModel = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hi' })
-      const subAgent = new Agent({ model: subModel, name: 'Sub', printer: false })
-
-      const statefulModel = new StatefulModel().addTurn({ type: 'textBlock', text: 'Hi' })
-
-      const orchestrator = new Agent({
-        model: statefulModel,
-        name: 'Orchestrator',
-        tools: [subAgent.asTool()], // delegate: false (default)
-        printer: false,
-      })
-
-      await expect(orchestrator.initialize()).resolves.toBeUndefined()
     })
   })
 
@@ -654,6 +524,43 @@ describe('AgentDelegation integration', () => {
       expect(result.stopReason).toBe('endTurn')
       const textBlocks = result.lastMessage.content.filter((b) => b.type === 'textBlock')
       expect((textBlocks[0] as { text: string }).text).toBe('PARENT_FOLLOW_UP')
+    })
+  })
+
+  describe('structured output suppresses delegation', () => {
+    it('does not trigger delegation when parent has a structured output schema', async () => {
+      const subModel = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Sub answer' })
+      const subAgent = new Agent({ model: subModel, name: 'Sub', printer: false })
+
+      // Turn 1: calls delegation tool (delegation skipped because structured output schema is set)
+      // Turn 2: calls the structured output tool as forced
+      const orchestratorModel = new MockMessageModel()
+        .addTurn({
+          type: 'toolUseBlock',
+          name: 'Sub',
+          toolUseId: 'del-1',
+          input: { input: 'go' },
+        })
+        .addTurn({
+          type: 'toolUseBlock',
+          name: 'strands_structured_output',
+          toolUseId: 'so-1',
+          input: { answer: 'Sub answer' },
+        })
+
+      const orchestrator = new Agent({
+        model: orchestratorModel,
+        name: 'Orchestrator',
+        tools: [subAgent.asTool({ delegate: true })],
+        structuredOutputSchema: z.object({ answer: z.string() }),
+        printer: false,
+      })
+
+      const result = await orchestrator.invoke('go')
+
+      // Delegation suppressed — structured output takes over
+      expect(result.stopReason).toBe('toolUse')
+      expect(result.structuredOutput).toEqual({ answer: 'Sub answer' })
     })
   })
 })

--- a/strands-ts/src/agent/__tests__/agent.hook.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.hook.test.ts
@@ -1066,6 +1066,25 @@ describe('Agent Hooks Integration', () => {
       expect(model.callCount).toBe(2)
     })
 
+    it('treats empty array endTurn as falsy (does not halt)', async () => {
+      const { tool, model } = makeSingleToolSetup()
+      const agent = new Agent({ model, tools: [tool] })
+      agent.addHook(AfterToolsEvent, (event: AfterToolsEvent) => {
+        event.endTurn = []
+      })
+
+      const result = await agent.invoke('Test')
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          type: 'agentResult',
+          stopReason: 'endTurn',
+          lastMessage: expect.objectContaining({ role: 'assistant' }),
+        })
+      )
+      expect(model.callCount).toBe(2)
+    })
+
     it('halts with content blocks when endTurn is a ContentBlock array', async () => {
       const { tool, model } = makeSingleToolSetup()
       const agent = new Agent({ model, tools: [tool] })
@@ -1075,19 +1094,27 @@ describe('Agent Hooks Integration', () => {
 
       const result = await agent.invoke('Test')
 
-      expect(result).toEqual(
-        expect.objectContaining({
-          type: 'agentResult',
-          stopReason: 'endTurn',
-          lastMessage: expect.objectContaining({
-            role: 'assistant',
-            content: expect.arrayContaining([
-              expect.objectContaining({ type: 'textBlock', text: 'delegated response' }),
-            ]),
-          }),
-        })
-      )
+      expect(result.stopReason).toBe('endTurn')
+      expect(result.lastMessage.content).toEqual([new TextBlock('delegated response')])
+      expect(agent.messages.at(-1)!.content).toEqual([new TextBlock('delegated response')])
       expect(model.callCount).toBe(1)
+    })
+
+    it('shallow-copies the endTurn array so later mutation does not affect history', async () => {
+      const { tool, model } = makeSingleToolSetup()
+      const agent = new Agent({ model, tools: [tool] })
+      const hookList = [new TextBlock('from hook')]
+      agent.addHook(AfterToolsEvent, (event: AfterToolsEvent) => {
+        event.endTurn = hookList
+      })
+
+      await agent.invoke('Test')
+
+      // Mutate the hook's list after the invocation returns
+      hookList.push(new TextBlock('MUTATED AFTER THE FACT'))
+
+      // The committed message must be unchanged — the event loop shallow-copied
+      expect(agent.messages.at(-1)!.content).toEqual([new TextBlock('from hook')])
     })
 
     it('appends tool results and default endTurn message to conversation history', async () => {

--- a/strands-ts/src/agent/__tests__/agent.hook.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.hook.test.ts
@@ -1066,6 +1066,30 @@ describe('Agent Hooks Integration', () => {
       expect(model.callCount).toBe(2)
     })
 
+    it('halts with content blocks when endTurn is a ContentBlock array', async () => {
+      const { tool, model } = makeSingleToolSetup()
+      const agent = new Agent({ model, tools: [tool] })
+      agent.addHook(AfterToolsEvent, (event: AfterToolsEvent) => {
+        event.endTurn = [new TextBlock('delegated response')]
+      })
+
+      const result = await agent.invoke('Test')
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          type: 'agentResult',
+          stopReason: 'endTurn',
+          lastMessage: expect.objectContaining({
+            role: 'assistant',
+            content: expect.arrayContaining([
+              expect.objectContaining({ type: 'textBlock', text: 'delegated response' }),
+            ]),
+          }),
+        })
+      )
+      expect(model.callCount).toBe(1)
+    })
+
     it('appends tool results and default endTurn message to conversation history', async () => {
       const { tool, model } = makeSingleToolSetup()
       const agent = new Agent({ model, tools: [tool] })

--- a/strands-ts/src/agent/agent-delegation.ts
+++ b/strands-ts/src/agent/agent-delegation.ts
@@ -4,18 +4,11 @@
  * When a tool is configured with `delegate: true`, this plugin ensures:
  * 1. The delegation tool is the only tool called in the turn (single-call constraint)
  * 2. The agent loop exits immediately after a successful delegation (via endTurn)
- * 3. The AgentResult is transformed with `stopReason: 'endTurn'` and the tool's content
+ * 3. The delegation tool's content blocks become the final assistant message
  * 4. Streaming events from the delegate agent are surfaced natively in the parent stream
- *
- * The final delegation message is produced in middleware after the core loop exits.
- * It is written to `agent.messages` and yielded to stream consumers, but does not
- * fire `MessageAddedEvent` hooks via `invokeCallbacks`. `SessionManager` with
- * `saveLatestOn: 'invocation'` (default) is unaffected; `saveLatestOn: 'message'`
- * may persist the endTurn placeholder instead of the delegation content.
  */
 
 import type { Plugin } from '../plugins/plugin.js'
-import { AgentResult } from '../types/agent.js'
 import type { LocalAgent, AgentStreamEvent } from '../types/agent.js'
 import type { ContentBlock } from '../types/messages.js'
 import {
@@ -23,21 +16,15 @@ import {
   AfterToolsEvent,
   BeforeModelCallEvent,
   BeforeToolsEvent,
-  MessageAddedEvent,
   StreamEvent,
   ToolStreamUpdateEvent,
 } from '../hooks/events.js'
 import { HookOrder } from '../hooks/types.js'
-import { AgentStreamStage, ExecuteToolStage } from '../middleware/index.js'
-import type {
-  AgentStreamContext,
-  AgentStreamResult,
-  ExecuteToolContext,
-  ExecuteToolResult,
-  MiddlewareNext,
-} from '../middleware/index.js'
-import { Message, TextBlock, ToolResultBlock, ToolUseBlock } from '../types/messages.js'
+import { ExecuteToolStage } from '../middleware/index.js'
+import type { ExecuteToolContext, ExecuteToolResult, MiddlewareNext } from '../middleware/index.js'
+import { TextBlock, ToolResultBlock, ToolUseBlock } from '../types/messages.js'
 import { AgentAsTool } from './agent-as-tool.js'
+import { STRUCTURED_OUTPUT_TOOL_NAME } from '../tools/structured-output-tool.js'
 
 /**
  * Checks whether a tool registered on the agent is a delegation AgentAsTool.
@@ -68,8 +55,6 @@ interface DelegationState {
   toolUseCount: number
   /** Tool use ID of the delegation tool that succeeded (set by AfterToolCallEvent). */
   toolUseId?: string
-  /** Set by _onAfterTools when delegation triggers endTurn. Used by _handleStream to detect delegation. */
-  endTurnViaDelegation?: boolean
 }
 
 /**
@@ -92,7 +77,7 @@ interface DelegationState {
 export class AgentDelegation implements Plugin {
   readonly name = 'strands:agent-delegation'
 
-  /** Per-agent delegation state, created in _onBeforeTools and consumed in _handleStream. */
+  /** Per-agent delegation state, created in _onBeforeTools and consumed in _onAfterTools. */
   private readonly _state = new WeakMap<LocalAgent, DelegationState>()
 
   initAgent(agent: LocalAgent): void {
@@ -124,15 +109,6 @@ export class AgentDelegation implements Plugin {
     // async function* doesn't bind lexical `this`; capture for the terminal callback.
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this
-    agent.addMiddleware(
-      AgentStreamStage,
-      async function* (
-        context: AgentStreamContext,
-        next: MiddlewareNext<AgentStreamContext, AgentStreamResult, AgentStreamEvent>
-      ): AsyncGenerator<AgentStreamEvent, AgentStreamResult, undefined> {
-        return yield* self._handleStream(context, next)
-      }
-    )
 
     // ExecuteToolStage middleware: unwraps inner agent streaming events for delegation tools
     // so they appear as native events in the parent agent's stream.
@@ -196,15 +172,12 @@ export class AgentDelegation implements Plugin {
   }
 
   /**
-   * AfterToolsEvent hook: signals the agent loop to stop via endTurn when
-   * delegation succeeded.
+   * AfterToolsEvent hook: sets endTurn to delegation content blocks when
+   * delegation succeeded with meaningful content.
    *
-   * This hook runs at `HookOrder.SDK_LAST` (100). If a hook with a higher
-   * numeric order mutates a ToolResultBlock's status from success to error,
-   * the endTurn signal has already been committed and the loop will still exit.
-   * In practice, no SDK or vended plugin registers AfterToolsEvent hooks above
-   * SDK_LAST, and mutating committed ToolResultBlock status in AfterToolsEvent
-   * is not a documented or supported pattern.
+   * This hook runs at `HookOrder.SDK_LAST` (100) so no hook can invalidate the
+   * tool result after this hook commits endTurn; mutating a committed
+   * ToolResultBlock's status is not a supported pattern.
    */
   private _onAfterTools(event: AfterToolsEvent): void {
     if (event.agent.model.stateful) return
@@ -221,8 +194,18 @@ export class AgentDelegation implements Plugin {
       return
     }
 
-    event.endTurn = true
-    state.endTurnViaDelegation = true
+    // Skip delegation when the parent expects structured output.
+    if (event.agent.toolRegistry.get(STRUCTURED_OUTPUT_TOOL_NAME)) {
+      return
+    }
+
+    // Skip delegation when the tool result has no meaningful content.
+    const endTurnContent = toContentBlocks(resultBlock)
+    if (endTurnContent.length === 0 || endTurnContent.every((block) => 'text' in block && block.text === '')) {
+      return
+    }
+
+    event.endTurn = endTurnContent
   }
 
   /**
@@ -232,11 +215,6 @@ export class AgentDelegation implements Plugin {
    * For delegation tools in a multi-tool batch, returns an error result without
    * executing the tool. For valid single-tool delegation, unwraps inner agent
    * streaming events so they appear as native events in the parent stream.
-   *
-   * A post-init middleware registered inside this one can still bypass the check
-   * by spreading a modified context with a different `tool` to `next()`. This is a
-   * framework-level trust boundary, not addressable at the plugin level.
-   * The sanctioned path for tool replacement is `BeforeToolCallEvent.selectedTool`.
    */
   private async *_handleToolExecution(
     context: ExecuteToolContext,
@@ -288,84 +266,5 @@ export class AgentDelegation implements Plugin {
       result = await gen.next()
     }
     return result.value
-  }
-
-  /**
-   * AgentStreamStage middleware: transforms the AgentResult on delegation.
-   *
-   * When the main loop exits via endTurn triggered by delegation (identified by
-   * the `endTurnViaDelegation` flag on DelegationState), this middleware replaces
-   * the default endTurn result with the proper delegation result: the sub-agent's
-   * content from the tool-result message.
-   */
-  private async *_handleStream(
-    context: AgentStreamContext,
-    next: MiddlewareNext<AgentStreamContext, AgentStreamResult, AgentStreamEvent>
-  ): AsyncGenerator<AgentStreamEvent, AgentStreamResult, undefined> {
-    // Clear any stale state from a prior failed invocation.
-    this._state.delete(context.agent)
-
-    let streamResult: AgentStreamResult
-    try {
-      streamResult = yield* next(context)
-    } catch (error) {
-      this._state.delete(context.agent)
-      throw error
-    }
-
-    const state = this._state.get(context.agent)
-    this._state.delete(context.agent)
-
-    if (!state?.toolUseId || !state.endTurnViaDelegation) return streamResult
-
-    // Only transform if the result stopped via endTurn.
-    // Other stop reasons pass through unchanged.
-    if (streamResult.result.stopReason !== 'endTurn') return streamResult
-
-    // Find the delegation tool's result in agent.messages. The tool-result
-    // message is the last user message before the endTurn assistant message.
-    const messages = context.agent.messages
-    let resultBlock: ToolResultBlock | undefined
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const msg = messages[i]
-      if (msg && msg.role === 'user') {
-        resultBlock = msg.content.find(
-          (block): block is ToolResultBlock => block instanceof ToolResultBlock && block.toolUseId === state.toolUseId
-        )
-        break
-      }
-    }
-
-    if (!resultBlock || resultBlock.status === 'error') return streamResult
-
-    const delegationMessage = new Message({
-      role: 'assistant',
-      content: toContentBlocks(resultBlock),
-    })
-
-    // Replace the endTurn message the main loop appended with the delegation content.
-    const lastMessage = messages[messages.length - 1]
-    if (lastMessage?.role === 'assistant') {
-      messages[messages.length - 1] = delegationMessage
-    } else {
-      messages.push(delegationMessage)
-    }
-
-    yield new MessageAddedEvent({
-      agent: context.agent,
-      message: delegationMessage,
-      invocationState: streamResult.result.invocationState,
-    })
-
-    // Replace AgentResult with the delegation tool's content
-    return {
-      result: new AgentResult({
-        stopReason: 'endTurn',
-        lastMessage: delegationMessage,
-        invocationState: streamResult.result.invocationState,
-        ...(streamResult.result.metrics !== undefined && { metrics: streamResult.result.metrics }),
-        ...(streamResult.result.traces !== undefined && { traces: streamResult.result.traces }),
-      }),
-    }
   }
 }

--- a/strands-ts/src/agent/agent-delegation.ts
+++ b/strands-ts/src/agent/agent-delegation.ts
@@ -175,9 +175,11 @@ export class AgentDelegation implements Plugin {
    * AfterToolsEvent hook: sets endTurn to delegation content blocks when
    * delegation succeeded with meaningful content.
    *
-   * This hook runs at `HookOrder.SDK_LAST` (100) so no hook can invalidate the
-   * tool result after this hook commits endTurn; mutating a committed
-   * ToolResultBlock's status is not a supported pattern.
+   * This hook runs at `HookOrder.SDK_LAST` (100), after every SDK and vended-plugin
+   * hook. A hook registered above that order still runs afterwards and could flip
+   * a `ToolResultBlock` to error, but `endTurn` is already committed and the loop
+   * will exit anyway — mutating a committed `ToolResultBlock`'s status is not a
+   * supported pattern.
    */
   private _onAfterTools(event: AfterToolsEvent): void {
     if (event.agent.model.stateful) return

--- a/strands-ts/src/agent/agent-delegation.ts
+++ b/strands-ts/src/agent/agent-delegation.ts
@@ -25,6 +25,7 @@ import type { ExecuteToolContext, ExecuteToolResult, MiddlewareNext } from '../m
 import { TextBlock, ToolResultBlock, ToolUseBlock } from '../types/messages.js'
 import { AgentAsTool } from './agent-as-tool.js'
 import { STRUCTURED_OUTPUT_TOOL_NAME } from '../tools/structured-output-tool.js'
+import { logger } from '../logging/logger.js'
 
 /**
  * Checks whether a tool registered on the agent is a delegation AgentAsTool.
@@ -198,12 +199,14 @@ export class AgentDelegation implements Plugin {
 
     // Skip delegation when the parent expects structured output.
     if (event.agent.toolRegistry.get(STRUCTURED_OUTPUT_TOOL_NAME)) {
+      logger.debug(`tool_use_id=<${state.toolUseId}> | parent requires structured output, skipping delegation`)
       return
     }
 
     // Skip delegation when the tool result has no meaningful content.
     const endTurnContent = toContentBlocks(resultBlock)
     if (endTurnContent.length === 0 || endTurnContent.every((block) => 'text' in block && block.text === '')) {
+      logger.debug(`tool_use_id=<${state.toolUseId}> | delegation produced blank content, skipping delegation`)
       return
     }
 

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -1734,11 +1734,15 @@ export class Agent implements LocalAgent, InvokableAgent {
           // Hook requested halt: exit without calling the model again
           const { afterToolsEvent } = toolsResult
           if (afterToolsEvent.endTurn) {
-            const endTurnText =
-              typeof afterToolsEvent.endTurn === 'string'
-                ? afterToolsEvent.endTurn
-                : 'Turn ended early by hook after tool execution'
-            const lastMessage = new Message({ role: 'assistant', content: [new TextBlock(endTurnText)] })
+            const endTurnValue = afterToolsEvent.endTurn
+            const endTurnContent: ContentBlock[] = Array.isArray(endTurnValue)
+              ? [...endTurnValue]
+              : [
+                  new TextBlock(
+                    typeof endTurnValue === 'string' ? endTurnValue : 'Turn ended early by hook after tool execution'
+                  ),
+                ]
+            const lastMessage = new Message({ role: 'assistant', content: endTurnContent })
             yield this._appendMessage(lastMessage, invocationState)
 
             result = new AgentResult({

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -1731,10 +1731,10 @@ export class Agent implements LocalAgent, InvokableAgent {
           this._meter.endCycle(cycleStartTime)
           this._tracer.endAgentLoopSpan(cycleSpan)
 
-          // Hook requested halt: exit without calling the model again
+          // Hook requested halt with content: exit without calling the model again.
           const { afterToolsEvent } = toolsResult
-          if (afterToolsEvent.endTurn) {
-            const endTurnValue = afterToolsEvent.endTurn
+          const endTurnValue = afterToolsEvent.endTurn
+          if (endTurnValue === true || (endTurnValue !== false && endTurnValue.length > 0)) {
             const endTurnContent: ContentBlock[] = Array.isArray(endTurnValue)
               ? [...endTurnValue]
               : [

--- a/strands-ts/src/hooks/__tests__/events.test.ts
+++ b/strands-ts/src/hooks/__tests__/events.test.ts
@@ -764,7 +764,7 @@ describe('AfterToolsEvent', () => {
     expect(event._shouldReverseCallbacks()).toBe(true)
   })
 
-  it('defaults endTurn to false and accepts boolean or string', () => {
+  it('defaults endTurn to false and accepts boolean, string, or ContentBlock array', () => {
     const agent = new Agent()
     const message = new Message({ role: 'user', content: [] })
     const event = new AfterToolsEvent({ agent, message, invocationState: {} })
@@ -776,6 +776,10 @@ describe('AfterToolsEvent', () => {
 
     event.endTurn = 'enough information gathered'
     expect(event.endTurn).toBe('enough information gathered')
+
+    const blocks = [new TextBlock('delegated')]
+    event.endTurn = blocks
+    expect(event.endTurn).toBe(blocks)
   })
 })
 

--- a/strands-ts/src/hooks/__tests__/events.test.ts
+++ b/strands-ts/src/hooks/__tests__/events.test.ts
@@ -764,22 +764,12 @@ describe('AfterToolsEvent', () => {
     expect(event._shouldReverseCallbacks()).toBe(true)
   })
 
-  it('defaults endTurn to false and accepts boolean, string, or ContentBlock array', () => {
+  it('defaults endTurn to false', () => {
     const agent = new Agent()
     const message = new Message({ role: 'user', content: [] })
     const event = new AfterToolsEvent({ agent, message, invocationState: {} })
 
     expect(event.endTurn).toBe(false)
-
-    event.endTurn = true
-    expect(event.endTurn).toBe(true)
-
-    event.endTurn = 'enough information gathered'
-    expect(event.endTurn).toBe('enough information gathered')
-
-    const blocks = [new TextBlock('delegated')]
-    event.endTurn = blocks
-    expect(event.endTurn).toBe(blocks)
   })
 })
 

--- a/strands-ts/src/hooks/events.ts
+++ b/strands-ts/src/hooks/events.ts
@@ -788,13 +788,14 @@ export class AfterToolsEvent extends HookableEvent {
    * (`"Turn ended early by hook after tool execution"`) is appended as the
    * final assistant message. When set to a string, that string is used instead
    * of the default — the string becomes literal assistant content (a
-   * `TextBlock`), not a reason or label. Contrast with
+   * `TextBlock`), not a reason or label. When set to a `ContentBlock[]`, those
+   * blocks become the final assistant message content directly. Contrast with
    * {@link BeforeToolCallEvent.cancel | cancel} fields on other events, where
    * the string is a cancellation reason.
    *
-   * In both cases `stopReason` on the returned `AgentResult` is `'endTurn'`.
+   * In all cases `stopReason` on the returned `AgentResult` is `'endTurn'`.
    */
-  endTurn: boolean | string = false
+  endTurn: boolean | string | ContentBlock[] = false
 
   constructor(data: { agent: LocalAgent; message: Message; invocationState: InvocationState }) {
     super()

--- a/strands-ts/src/hooks/events.ts
+++ b/strands-ts/src/hooks/events.ts
@@ -789,9 +789,9 @@ export class AfterToolsEvent extends HookableEvent {
    * final assistant message. When set to a string, that string is used instead
    * of the default — the string becomes literal assistant content (a
    * `TextBlock`), not a reason or label. When set to a `ContentBlock[]`, those
-   * blocks become the final assistant message content directly. Contrast with
-   * {@link BeforeToolCallEvent.cancel | cancel} fields on other events, where
-   * the string is a cancellation reason.
+   * blocks become the final assistant message content directly (shallow-copied).
+   * Contrast with {@link BeforeToolCallEvent.cancel | cancel} fields on other events,
+   * where the string is a cancellation reason.
    *
    * In all cases `stopReason` on the returned `AgentResult` is `'endTurn'`.
    */


### PR DESCRIPTION
## Description

Ports the `end_turn_content` fixes from the Python SDK to TypeScript.

**`AfterToolsEvent.endTurn` accepts `ContentBlock[]`** — hooks can now set `endTurn` to a list of content blocks that become the final assistant message directly, in addition to `true` (default message) or a string.

**Delegation plugin simplified** — removed the `AgentStreamStage` middleware entirely. The delegation plugin now sets `event.endTurn` to the content blocks directly in `_onAfterTools`, letting the event loop handle the rest. This eliminates the post-loop message replacement and the `MessageAddedEvent` workaround.

**Empty content guard** — delegation is skipped when the tool result has no meaningful content (empty or all-blank text blocks), allowing the loop to continue to the model.

**Structured output guard** — delegation is skipped when the parent agent has a structured output schema registered, so structured output extraction takes priority.

## Related Issues

Closes https://github.com/strands-agents/harness-sdk/issues/3808 on the TS side.

## Documentation PR

Documentation updated in this PR: `site/src/content/docs/user-guide/concepts/agents/hooks.mdx`.

## Type of Change

Bug fix

## Testing

- [x] I ran `npm run test`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.