### PR TITLE
docs: add DeepKeep integration to catalog

### DIFF
--- a/site/src/content/catalog/strands-deepkeep.yaml
+++ b/site/src/content/catalog/strands-deepkeep.yaml
@@ -1,0 +1,10 @@
+name: strands-deepkeep
+description: DeepKeep AI Firewall guardrails for Strands Agents using lifecycle hooks around model input and output.
+integrationType: plugin
+maintainedBy: partner
+languages:
+  python:
+    package: strands-deepkeep
+github: https://github.com/Deepkeepai/strands-deepkeep
+docsUrl: https://github.com/Deepkeepai/strands-deepkeep#readme
+addedDate: 2026-08-26


### PR DESCRIPTION
## Summary
- Add strands-deepkeep to the Strands integrations catalog
- List it as a Python plugin for DeepKeep AI Firewall guardrails
- Link to the package documentation and DeepKeep's AI Firewall page from the package README

## Validation
- npm test -- catalog

Package: https://pypi.org/project/strands-deepkeep/
Repository: https://github.com/Deepkeepai/strands-deepkeep