### PR TITLE
chore(python): update Bidi Bedrock dependencies

### DIFF
--- a/strands-py/pyproject.toml
+++ b/strands-py/pyproject.toml
@@ -79,9 +79,9 @@ a2a = [
 cedar = ["cedarpy==4.8.7", "cedar-policy-mcp-schema-generator==0.6.0"]
 
 bidi = [
-    "aws_sdk_bedrock_runtime>=0.9.0,<0.10.0; python_version>='3.12'",
+    "aws_sdk_bedrock_runtime[awscrt]>=0.11.0,<0.12.0; python_version>='3.12'",
     "prompt_toolkit>=3.0.0,<4.0.0",
-    "smithy-aws-core>=0.9.0,<0.10.0; python_version>='3.12'",
+    "smithy-aws-core>=0.11.0,<0.12.0; python_version>='3.12'",
     "smithy-core>=0.8.0,<0.9.0; python_version>='3.12'",
 ]
 bidi-google = ["google-genai>=2.0.0,<3.0.0"]
@@ -239,6 +239,7 @@ module = [
     "cedar_mcp_schema_generator",
     "smithy_aws_core.*",
     "smithy_core.*",
+    "smithy_http.*",
 ]
 ignore_missing_imports = true
 

--- a/strands-py/src/strands/experimental/bidi/models/nova_sonic.py
+++ b/strands-py/src/strands/experimental/bidi/models/nova_sonic.py
@@ -30,8 +30,8 @@ from collections.abc import AsyncGenerator
 from typing import Any, cast
 
 import boto3
-from aws_sdk_bedrock_runtime.client import BedrockRuntimeClient, InvokeModelWithBidirectionalStreamOperationInput
-from aws_sdk_bedrock_runtime.config import Config, HTTPAuthSchemeResolver, SigV4AuthScheme
+from aws_sdk_bedrock_runtime.client import AsyncBedrockRuntimeClient, InvokeModelWithBidirectionalStreamOperationInput
+from aws_sdk_bedrock_runtime.config import AsyncBedrockRuntimeConfig, HTTPAuthSchemeResolver, SigV4AuthScheme
 from aws_sdk_bedrock_runtime.models import (
     BidirectionalInputPayloadPart,
     InvokeModelWithBidirectionalStreamInputChunk,
@@ -41,6 +41,7 @@ from aws_sdk_bedrock_runtime.models import (
 from smithy_aws_core.identity.static import StaticCredentialsResolver
 from smithy_core.aio.eventstream import DuplexEventStream
 from smithy_core.shapes import ShapeID
+from smithy_http.aio.crt import AWSCRTHTTPClient
 
 from ....models._validation import validate_region
 from ....types._events import ToolResultEvent, ToolUseStreamEvent
@@ -261,7 +262,7 @@ class BidiNovaSonicModel(BidiModel):
         # Use static resolver with credentials configured as properties
         resolver = StaticCredentialsResolver()
 
-        config = Config(
+        config = await AsyncBedrockRuntimeConfig.resolve(
             endpoint_uri=f"https://bedrock-runtime.{self.region}.amazonaws.com",
             region=self.region,
             aws_credentials_identity_resolver=resolver,
@@ -271,10 +272,11 @@ class BidiNovaSonicModel(BidiModel):
             aws_access_key_id=credentials.access_key,
             aws_secret_access_key=credentials.secret_key,
             aws_session_token=credentials.token,
+            transport=AWSCRTHTTPClient(),
             user_agent_extra=_STRANDS_USER_AGENT_EXTRA,
         )
 
-        self._client = BedrockRuntimeClient(config=config)
+        self._client = AsyncBedrockRuntimeClient(config=config)
         logger.debug("region=<%s> | nova sonic client initialized", self.region)
 
         self._stream = await self._client.invoke_model_with_bidirectional_stream(
@@ -558,7 +560,7 @@ class BidiNovaSonicModel(BidiModel):
         logger.debug("nova connection cleanup starting")
 
         async def stop_events() -> None:
-            if not self._connection_id:
+            if not self._connection_id or not hasattr(self, "_stream"):
                 return
 
             await self._end_audio_input()
@@ -569,12 +571,24 @@ class BidiNovaSonicModel(BidiModel):
             if not hasattr(self, "_stream"):
                 return
 
-            await self._stream.close()
+            try:
+                await self._stream.close()
+            finally:
+                del self._stream
+
+        async def stop_client() -> None:
+            if not hasattr(self, "_client"):
+                return
+
+            try:
+                await self._client.close()
+            finally:
+                del self._client
 
         async def stop_connection() -> None:
             self._connection_id = None
 
-        await stop_all(stop_events, stop_stream, stop_connection)
+        await stop_all(stop_events, stop_stream, stop_client, stop_connection)
 
         logger.debug("nova connection closed")
 

--- a/strands-py/tests/strands/experimental/bidi/models/test_nova_sonic.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_nova_sonic.py
@@ -66,7 +66,7 @@ def mock_stream():
 @pytest.fixture
 def mock_client(mock_stream):
     """Mock Bedrock Runtime client."""
-    with patch("strands.experimental.bidi.models.nova_sonic.BedrockRuntimeClient") as mock_cls:
+    with patch("strands.experimental.bidi.models.nova_sonic.AsyncBedrockRuntimeClient") as mock_cls:
         mock_instance = AsyncMock()
         mock_instance.invoke_model_with_bidirectional_stream = AsyncMock(return_value=mock_stream)
         mock_cls.return_value = mock_instance
@@ -99,7 +99,7 @@ async def test_model_initialization(model_id, boto_session):
 @pytest.mark.asyncio
 async def test_start_sets_strands_user_agent_on_bedrock_runtime_client(model_id, boto_session, mock_stream):
     """Always set the Strands user agent marker on the generated Bedrock Runtime client."""
-    with patch("strands.experimental.bidi.models.nova_sonic.BedrockRuntimeClient") as mock_cls:
+    with patch("strands.experimental.bidi.models.nova_sonic.AsyncBedrockRuntimeClient") as mock_cls:
         mock_instance = AsyncMock()
         mock_instance.invoke_model_with_bidirectional_stream = AsyncMock(return_value=mock_stream)
         mock_cls.return_value = mock_instance
@@ -199,6 +199,7 @@ async def test_connection_lifecycle(nova_model, mock_client, mock_stream):
     # Test close
     await nova_model.stop()
     assert mock_stream.close.called
+    assert mock_client.close.called
 
     # Test connection with tools
     tools = [
@@ -217,6 +218,24 @@ async def test_connection_lifecycle(nova_model, mock_client, mock_stream):
 @pytest.mark.asyncio
 async def test_model_stop_alone(nova_model):
     await nova_model.stop()  # Should not raise
+
+
+@pytest.mark.asyncio
+async def test_model_stop_after_start_failure(model_id, boto_session):
+    with patch("strands.experimental.bidi.models.nova_sonic.AsyncBedrockRuntimeClient") as mock_cls:
+        mock_instance = AsyncMock()
+        mock_instance.invoke_model_with_bidirectional_stream.side_effect = RuntimeError("connection failed")
+        mock_cls.return_value = mock_instance
+
+        model = BidiNovaSonicModel(model_id=model_id, client_config={"boto_session": boto_session})
+
+        with pytest.raises(RuntimeError, match="connection failed"):
+            await model.start()
+
+        await model.stop()
+
+        mock_instance.close.assert_awaited_once()
+        assert model._connection_id is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Updates the Bidi Nova Sonic dependencies to the latest compatible minor versions:

- `aws-sdk-bedrock-runtime` from `0.9.x` to `0.11.x`
- `smithy-aws-core` from `0.9.x` to `0.11.x`
- retains `smithy-core` compatibility within `0.8.x`

Migrates Nova Sonic to `AsyncBedrockRuntimeClient` and `AsyncBedrockRuntimeConfig.resolve()`. The Bedrock SDK now makes its AWS CRT transport optional and otherwise defaults to AIOHTTP, which does not support bidirectional event streaming. The Bidi extra therefore installs the SDK's `awscrt` extra and explicitly selects `AWSCRTHTTPClient`.

The model now closes the async client during shutdown and safely handles cleanup when startup fails before a stream is established.

## Related Issues

None.

## Documentation PR

No documentation changes are needed; this updates internal dependency and client lifecycle behavior.

## Type of Change

Other: dependency maintenance

## Testing

- [x] I ran `hatch run prepare`
- [x] `hatch test -py=3.12 tests/strands/experimental/bidi` (230 passed)
- [x] `hatch test -py=3.13 tests/strands/experimental/bidi/models/test_nova_sonic.py -q` (38 passed)
- [x] Repository pre-commit checks (4,340 TypeScript tests, lint, formatting, and type checks)

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
