### PR TITLE
feat(catalog): add attenu-guard (community intervention)

### DIFF
--- a/site/src/content/catalog/attenu-guard.yaml
+++ b/site/src/content/catalog/attenu-guard.yaml
@@ -1,0 +1,10 @@
+name: attenu-guard
+description: "Per-agent permission enforcement on every tool call and every agents-as-tools / swarm / graph handoff: a sub-agent's permissions are a computed subset of its parent's, and every decision lands in a hash-chained audit log verified offline."
+integrationType: intervention
+maintainedBy: community
+languages:
+  python:
+    package: attenu-guard
+github: https://github.com/attenu-io/attenu-guard
+docsUrl: https://github.com/attenu-io/attenu-guard/tree/main/examples/integrations/strands
+addedDate: 2026-08-26


### PR DESCRIPTION
Adds `site/src/content/catalog/attenu-guard.yaml` per the get-featured guide.

[attenu-guard](https://github.com/attenu-io/attenu-guard) (Apache-2.0, PyPI `attenu-guard`, extra `attenu-guard[strands]`) hooks Strands' public `BeforeToolCallEvent` and `BeforeNodeCallEvent` to check every tool call against the agent's permission set before it executes, and treats agents-as-tools, swarm and graph handoffs as the delegation point so a sub-agent's permissions are a computed subset of the parent's (chain ceilings, revocation). Decisions are written to a hash-chained audit log verified offline with `attenu-guard verify`. No monkeypatching or subclassing; tested against strands-agents 1.52.

Disclosure: I maintain attenu-guard.