### PR TITLE
feat(typescript): add sessionId getter to Agent

### DIFF
--- a/strands-ts/docs/TESTING.md
+++ b/strands-ts/docs/TESTING.md
@@ -135,6 +135,7 @@ describe('ClassName', () => {
 - Nested `describe` blocks group related test scenarios
 - Use descriptive test names without "should" prefix
 - Group tests by functionality or scenario
+- Prefer top-level `import` — only use dynamic `import()` when the module must load after `vi.mock()` or is platform-gated
 
 ## Writing Effective Tests
 

--- a/strands-ts/src/__fixtures__/agent-helpers.ts
+++ b/strands-ts/src/__fixtures__/agent-helpers.ts
@@ -76,6 +76,9 @@ export function createMockAgent(data?: MockAgentData): MockAgent {
     get sandbox(): Sandbox {
       return defaultSandbox.get()
     },
+    get sessionId(): string {
+      return 'test-ses'
+    },
     addHook: <T extends HookableEvent>(eventType: HookableEventConstructor<T>, callback: HookCallback<T>) => {
       trackedHooks.push({
         eventType: eventType as HookableEventConstructor<HookableEvent>,

--- a/strands-ts/src/agent/__tests__/agent.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.test.ts
@@ -2284,4 +2284,31 @@ describe('normalizeToolUseNames', () => {
       })
     })
   })
+
+  describe('sessionId', () => {
+    it('returns a stable 8-character string when no session manager is attached', () => {
+      const agent = new Agent({ model: new MockMessageModel() })
+
+      const first = agent.sessionId
+      const second = agent.sessionId
+
+      expect(first).toBe(second)
+      expect(first).toHaveLength(8)
+    })
+
+    it('returns different IDs for different agent instances', () => {
+      const agent1 = new Agent({ model: new MockMessageModel() })
+      const agent2 = new Agent({ model: new MockMessageModel() })
+
+      expect(agent1.sessionId).not.toBe(agent2.sessionId)
+    })
+
+    it('delegates to sessionManager when attached', async () => {
+      const { SessionManager } = await import('../../session/session-manager.js')
+      const sessionManager = new SessionManager({ sessionId: 'my-session' })
+      const agent = new Agent({ model: new MockMessageModel(), sessionManager })
+
+      expect(agent.sessionId).toBe('my-session')
+    })
+  })
 })

--- a/strands-ts/src/agent/__tests__/agent.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
 import { Agent, type ToolList } from '../agent.js'
+import { SessionManager } from '../../session/session-manager.js'
 import { McpClient } from '../../mcp/index.js'
 import { McpTool } from '../../tools/mcp-tool.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
@@ -2303,8 +2304,7 @@ describe('normalizeToolUseNames', () => {
       expect(agent1.sessionId).not.toBe(agent2.sessionId)
     })
 
-    it('delegates to sessionManager when attached', async () => {
-      const { SessionManager } = await import('../../session/session-manager.js')
+    it('delegates to sessionManager when attached', () => {
       const sessionManager = new SessionManager({ sessionId: 'my-session' })
       const agent = new Agent({ model: new MockMessageModel(), sessionManager })
 

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -481,6 +481,8 @@ export class Agent implements LocalAgent, InvokableAgent {
    * The session manager for saving and restoring agent sessions, if configured.
    */
   public readonly sessionManager?: SessionManager | undefined
+
+  private _sessionId?: string
   /**
    * The memory manager for cross-session memory retrieval and storage, if configured.
    */
@@ -501,6 +503,20 @@ export class Agent implements LocalAgent, InvokableAgent {
    */
   get sandbox(): Sandbox {
     return this._sandbox || defaultSandbox.get()
+  }
+
+  /**
+   * A stable, unique identifier for the current conversation session.
+   *
+   * If a SessionManager is attached, delegates to its sessionId.
+   * Otherwise, lazily generates and caches a random 8-character hex string.
+   */
+  get sessionId(): string {
+    if (this.sessionManager) return this.sessionManager.sessionId
+    if (!this._sessionId) {
+      this._sessionId = globalThis.crypto.randomUUID().slice(0, 8)
+    }
+    return this._sessionId
   }
 
   private readonly _hooksRegistry: HookRegistryImplementation

--- a/strands-ts/src/session/session-manager.ts
+++ b/strands-ts/src/session/session-manager.ts
@@ -116,6 +116,13 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
     return 'strands:session-manager'
   }
 
+  /**
+   * The session identifier for this session manager.
+   */
+  get sessionId(): string {
+    return this._sessionId
+  }
+
   constructor(config: SessionManagerConfig) {
     this._sessionId = validateIdentifier(config.sessionId ?? 'default-session')
     this._configStorage = config.storage

--- a/strands-ts/src/types/agent.ts
+++ b/strands-ts/src/types/agent.ts
@@ -257,6 +257,16 @@ export interface LocalAgent {
   readonly id: string
 
   /**
+   * A stable, unique identifier for the current conversation session.
+   *
+   * Resolution order:
+   * 1. If a SessionManager is attached, returns its session ID.
+   * 2. Otherwise, returns a lazily-generated random 8-character hex string
+   *    cached for the lifetime of the agent instance.
+   */
+  readonly sessionId: string
+
+  /**
    * App state storage accessible to tools and application logic.
    */
   appState: StateStore


### PR DESCRIPTION
## Summary

Exposes session id getter for use throughout SDK & generates random session id if none

## Description
Add a sessionId getter to the Agent class that provides a stable, unique identifier for the current conversation session. Resolution order:
1. If a SessionManager is attached, returns its session ID.
2. Otherwise, lazily generates a random 8-char hex string cached for the agent's lifetime.

This unblocks the context stash's storage key pattern (context/<sessionId>/...) by giving plugins a deterministic namespace readable in initAgent().

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [ ] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
