### PR TITLE
docs: add mem0-strands (memory-store)

### DIFF
--- a/site/src/content/catalog/mem0-strands.yaml
+++ b/site/src/content/catalog/mem0-strands.yaml
@@ -1,7 +1,6 @@
 name: mem0-strands
-description: 'Long-term memory for Strands agents, backed by Mem0: a native MemoryStore with automatic recall and server-side memory extraction, hosted or self-hosted.'
+description: 'Persistent long-term memory for Strands agents, enabled by Mem0: a native MemoryStore with automatic recall and server-side extraction.'
 integrationType: memory-store
-maintainedBy: partner
 languages:
   python:
     package: mem0-strands

--- a/site/src/content/catalog/mem0-strands.yaml
+++ b/site/src/content/catalog/mem0-strands.yaml
@@ -1,5 +1,5 @@
 name: mem0-strands
-description: 'Persistent long-term memory for Strands agents, backed by Mem0: a native MemoryStore with recall injection and server-side extraction, hosted or self-hosted.'
+description: 'Long-term memory for Strands agents, backed by Mem0: a native MemoryStore with automatic recall and server-side memory extraction, hosted or self-hosted.'
 integrationType: memory-store
 maintainedBy: partner
 languages:

--- a/site/src/content/catalog/mem0-strands.yaml
+++ b/site/src/content/catalog/mem0-strands.yaml
@@ -1,0 +1,10 @@
+name: mem0-strands
+description: 'Persistent long-term memory for Strands agents, backed by Mem0: a native MemoryStore with recall injection and server-side extraction, hosted or self-hosted.'
+integrationType: memory-store
+maintainedBy: partner
+languages:
+  python:
+    package: mem0-strands
+github: https://github.com/mem0ai/mem0/tree/main/integrations/mem0-strands
+docsUrl: https://docs.mem0.ai/integrations/strands
+addedDate: 2026-08-27

--- a/site/src/content/catalog/mem0-strands.yaml
+++ b/site/src/content/catalog/mem0-strands.yaml
@@ -6,4 +6,5 @@ languages:
     package: mem0-strands
 github: https://github.com/mem0ai/mem0/tree/main/integrations/mem0-strands
 docsUrl: https://docs.mem0.ai/integrations/strands
+maintainedBy: partner
 addedDate: 2026-08-27


### PR DESCRIPTION
## Integration submission

**Package name:** mem0-strands
**Integration type:** memory-store
**Languages published:** Python
**GitHub repo:** https://github.com/mem0ai/mem0
**What it does:** Persistent long-term memory for Strands agents as a native `MemoryStore`, backed by [Mem0](https://mem0.ai). The `MemoryManager` searches it and injects results every turn, and because it implements `add_messages`, extraction runs server-side on Mem0 with no extra client-side model call. Works with the hosted Mem0 Platform (an API key) or self-hosted Mem0 OSS (a config dict).
**Relationship to service:** official vendor integration (maintained by Mem0 in `mem0ai/mem0`)
**Docs link included:** docsUrl -> https://docs.mem0.ai/integrations/strands

### Submitter checklist

#### Package
- [x] This is a reusable integration (library/plugin/provider), not an example agent or application built with Strands
- [x] Published to PyPI and/or npm under the exact `package` name in my entry (registry links are derived from it) — or this is a guide-only entry (no `package` in any language block) with a `docsUrl` pointing at the vendor's Strands guide
- [x] GitHub repository is public and includes a license

#### Entry
- [x] Description accurately states what the package does in one sentence
- [x] `integrationType` matches what the package actually is
- [x] All URLs are working (`github`, and `docsUrl` if set)
- [x] `addedDate` is set to today (the date I opened this PR)
- [x] `featured` and `badges` are left unset — those are granted by the Strands team

#### Docs (only if setting a `docsUrl`)
- [x] The linked page documents using this integration with Strands Agents

#### Conduct
- [x] I am the package maintainer, or I have the maintainer's explicit consent to list it
- [x] Entry uses the package's real name with no trademark misuse
