### PR TITLE
fix(ci): treat empty integration test reports as a no-op

### DIFF
--- a/.github/scripts/upload-integ-test-metrics.py
+++ b/.github/scripts/upload-integ-test-metrics.py
@@ -3,7 +3,7 @@ import sys
 import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
 from dataclasses import dataclass
-from typing import Any, Literal, TypedDict
+from typing import Any, Literal, Optional, TypedDict
 import os
 import boto3
 
@@ -32,15 +32,15 @@ class TestResult:
     outcome: Literal['failed', 'skipped', 'passed']
 
 
-def parse_junit_xml(xml_file_path: str) -> list[TestResult]:
+def parse_junit_xml(xml_file_path: str) -> Optional[list[TestResult]]:
     try:
         tree = ET.parse(xml_file_path)
     except FileNotFoundError:
         print(f"Warning: XML file not found: {xml_file_path}")
-        return []
+        return None
     except ET.ParseError as e:
         print(f"Warning: Failed to parse XML: {e}")
-        return []
+        return None
 
     results = []
     root = tree.getroot()
@@ -136,9 +136,11 @@ def main():
     region = os.environ.get('AWS_REGION', 'us-east-1')
 
     test_results = parse_junit_xml(xml_file)
-    if not test_results:
-        print("No test results found")
+    if test_results is None:
         sys.exit(1)
+    if not test_results:
+        print("No test results to publish")
+        return
 
     print(f"Found {len(test_results)} test results")
     metric_data = build_metric_data(test_results, repository, sdk)


### PR DESCRIPTION
## Description

TypeScript integration runs can legitimately produce a JUnit report with zero tests. The `upload-metrics` CI had been treating that valid empty report the same as a missing/malformed report, causing `upload-metrics` to fail.

This PR treats valid zero-test reports as no-ops, preventing such failures.

## Related Issues

Follow-up to #3970

## Type of Change

Bug fix

## Testing

Replayed the zero-test JUnit artifact from a failing CI run and verified the uploader exits successfully. Verified missing and malformed reports still exit with code 1.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
