### PR TITLE
feat(python): add session_id property to Agent

### DIFF
--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -12,6 +12,7 @@ The Agent interface supports two complementary interaction patterns:
 import copy
 import logging
 import threading
+import uuid
 import warnings
 from collections.abc import AsyncGenerator, AsyncIterator, Callable, Mapping
 from dataclasses import dataclass
@@ -494,7 +495,10 @@ class Agent(AgentBase):
         # Initialize session management functionality
         self._session_manager = session_manager
         if self._session_manager:
+            self._session_id: str = getattr(self._session_manager, "session_id", None) or uuid.uuid4().hex[:8]
             self.hooks.add_hook(self._session_manager)
+        else:
+            self._session_id = uuid.uuid4().hex[:8]
 
         # Allow conversation_managers to subscribe to hooks
         self.hooks.add_hook(self.conversation_manager)
@@ -679,6 +683,16 @@ class Agent(AgentBase):
     def storage(self) -> Storage | None:
         """Default storage backend for agent subsystems."""
         return self._storage
+
+    @property
+    def session_id(self) -> str:
+        """Identifier for the current conversation session.
+
+        When a session manager is attached, returns its persistent, caller-supplied
+        session ID. Otherwise, returns a random 8-character hex string generated at
+        construction time (unique per agent instance but not persisted across restarts).
+        """
+        return self._session_id
 
     @property
     def system_prompt(self) -> str | None:

--- a/strands-py/src/strands/session/session_manager.py
+++ b/strands-py/src/strands/session/session_manager.py
@@ -37,6 +37,9 @@ class SessionManager(HookProvider, ABC):
     for an agent, and should be persisted in the session.
     """
 
+    session_id: str
+    """The unique session identifier for this session manager."""
+
     def register_hooks(self, registry: HookRegistry, **kwargs: Any) -> None:
         """Register hooks for persisting the agent to the session."""
         # After the normal Agent initialization behavior, call the session initialize function to restore the agent

--- a/strands-py/tests/strands/agent/test_agent.py
+++ b/strands-py/tests/strands/agent/test_agent.py
@@ -1619,6 +1619,31 @@ def test_agent_state_get_breaks_deep_dict_reference():
     json.dumps(agent.state.get())
 
 
+def test_session_id_without_session_manager():
+    agent = Agent(model=MockedModelProvider([]))
+
+    first = agent.session_id
+    second = agent.session_id
+
+    assert first == second
+    assert len(first) == 8
+
+
+def test_session_id_different_per_instance():
+    agent1 = Agent(model=MockedModelProvider([]))
+    agent2 = Agent(model=MockedModelProvider([]))
+
+    assert agent1.session_id != agent2.session_id
+
+
+def test_session_id_delegates_to_session_manager():
+    mock_session_repository = MockedSessionRepository()
+    session_manager = RepositorySessionManager(session_id="my-session", session_repository=mock_session_repository)
+    agent = Agent(model=MockedModelProvider([]), session_manager=session_manager)
+
+    assert agent.session_id == "my-session"
+
+
 def test_agent_session_management():
     mock_session_repository = MockedSessionRepository()
     session_manager = RepositorySessionManager(session_id="123", session_repository=mock_session_repository)


### PR DESCRIPTION


## Description
Port of the TypeScript sessionId getter. Resolution order:
1. If a SessionManager is attached, returns its session_id.
2. Otherwise, lazily generates a random 8-char hex string cached for the agent's lifetime.

Also adds session_id type annotation to the SessionManager ABC to formalize the contract both concrete implementations already satisfy.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [ ] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
