### PR TITLE
fix(mcp): forward configured metadata on model-driven calls

### DIFF
--- a/site/src/content/docs/user-guide/concepts/tools/mcp-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/mcp-tools.mdx
@@ -81,6 +81,27 @@ with mcp_client:
     agent = Agent(tools=tools)
     agent("What is AWS Lambda?")  # Must be within context
 ```
+
+### Request Metadata
+
+To attach fixed metadata to every model-driven MCP tool call, pass `meta` when
+constructing the Python `MCPClient`. The payload is forwarded as the MCP
+request's standard `_meta` field:
+
+```python
+mcp_client = MCPClient(
+    lambda: stdio_client(
+        StdioServerParameters(
+            command="uvx",
+            args=["awslabs.aws-documentation-mcp-server@latest"],
+        )
+    ),
+    meta={"tenant_id": "tenant-a", "trace_source": "support-agent"},
+)
+```
+
+This is useful for server-side routing, tracing, and tenant context when the
+model invokes an MCP tool through the agent loop.
 </Tab>
 <Tab label="TypeScript">
 

--- a/strands-py/src/strands/tools/mcp/mcp_agent_tool.py
+++ b/strands-py/src/strands/tools/mcp/mcp_agent_tool.py
@@ -35,6 +35,7 @@ class MCPAgentTool(AgentTool):
         mcp_client: "MCPClient",
         name_override: str | None = None,
         timeout: timedelta | None = None,
+        meta: dict[str, Any] | None = None,
     ) -> None:
         """Initialize a new MCPAgentTool instance.
 
@@ -44,6 +45,7 @@ class MCPAgentTool(AgentTool):
             name_override: Optional name to use for the agent tool (for disambiguation)
                            If None, uses the original MCP tool name
             timeout: Optional timeout duration for tool execution
+            meta: Optional metadata to include with MCP tool calls
         """
         super().__init__()
         logger.debug("tool_name=<%s> | creating mcp agent tool", mcp_tool.name)
@@ -51,6 +53,7 @@ class MCPAgentTool(AgentTool):
         self.mcp_client = mcp_client
         self._agent_tool_name = name_override or mcp_tool.name
         self.timeout = timeout
+        self.meta = meta
 
     @property
     def tool_name(self) -> str:
@@ -119,11 +122,17 @@ class MCPAgentTool(AgentTool):
         """
         logger.debug("tool_name=<%s>, tool_use_id=<%s> | streaming", self.tool_name, tool_use["toolUseId"])
 
+        call_kwargs: dict[str, Any] = {
+            "tool_use_id": tool_use["toolUseId"],
+            "name": self.mcp_tool.name,  # Use original MCP name for server communication
+            "arguments": tool_use["input"],
+            "read_timeout_seconds": self.timeout,
+            "cancel_signal": getattr(invocation_state.get("agent"), "_cancel_signal", None),
+        }
+        if self.meta is not None:
+            call_kwargs["meta"] = self.meta
+
         result = await self.mcp_client.call_tool_async(
-            tool_use_id=tool_use["toolUseId"],
-            name=self.mcp_tool.name,  # Use original MCP name for server communication
-            arguments=tool_use["input"],
-            read_timeout_seconds=self.timeout,
-            cancel_signal=getattr(invocation_state.get("agent"), "_cancel_signal", None),
+            **call_kwargs,
         )
         yield ToolResultEvent(result)

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -245,6 +245,7 @@ class MCPClient(ToolProvider):
         elicitation_callback: ElicitationFnT | None = None,
         progress_callback: ProgressFnT | None = None,
         tasks_config: TasksConfig | None = None,
+        meta: dict[str, Any] | None = None,
     ) -> None:
         """Initialize a new MCP Server connection.
 
@@ -278,6 +279,7 @@ class MCPClient(ToolProvider):
             tasks_config: Configuration for MCP task-augmented execution for long-running tools.
                 If provided (not None), enables task-augmented execution for tools that support it.
                 See TasksConfig for details. This feature is experimental and subject to change.
+            meta: Optional metadata to include with MCP tool calls.
 
         Raises:
             ValueError: If neither or both of `transport_callable` and `url` are provided, if
@@ -295,6 +297,7 @@ class MCPClient(ToolProvider):
         self._connection_failed = False
         self._elicitation_callback = elicitation_callback
         self._progress_callback = progress_callback
+        self._meta = meta
 
         mcp_instrumentation()
         self._session_id = uuid.uuid4()
@@ -637,12 +640,16 @@ class MCPClient(ToolProvider):
                 self._tool_task_support_cache[tool.name] = task_support or "forbidden"
 
             # Apply prefix if specified
+            tool_kwargs: dict[str, Any] = {}
+            if self._meta is not None:
+                tool_kwargs["meta"] = self._meta
             if effective_prefix:
                 prefixed_name = f"{effective_prefix}_{tool.name}"
-                mcp_tool = MCPAgentTool(tool, self, name_override=prefixed_name)
+                tool_kwargs["name_override"] = prefixed_name
+                mcp_tool = MCPAgentTool(tool, self, **tool_kwargs)
                 logger.debug("tool_rename=<%s->%s> | renamed tool", tool.name, prefixed_name)
             else:
-                mcp_tool = MCPAgentTool(tool, self)
+                mcp_tool = MCPAgentTool(tool, self, **tool_kwargs)
 
             # Apply filters if specified
             if self._should_include_tool_with_filters(mcp_tool, effective_filters):

--- a/strands-py/tests/strands/tools/mcp/test_mcp_agent_tool.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_agent_tool.py
@@ -147,6 +147,24 @@ async def test_stream(mcp_agent_tool, mock_mcp_client, alist):
     )
 
 
+@pytest.mark.asyncio
+async def test_stream_forwards_configured_meta(mock_mcp_tool, mock_mcp_client, alist):
+    meta = {"trace_id": "trace-123", "tenant": "tenant-a"}
+    agent_tool = MCPAgentTool(mock_mcp_tool, mock_mcp_client, meta=meta)
+    tool_use = {"toolUseId": "test-meta", "name": "test_tool", "input": {}}
+
+    await alist(agent_tool.stream(tool_use, {}))
+
+    mock_mcp_client.call_tool_async.assert_called_once_with(
+        tool_use_id="test-meta",
+        name="test_tool",
+        arguments={},
+        read_timeout_seconds=None,
+        cancel_signal=None,
+        meta=meta,
+    )
+
+
 def test_timeout_initialization(mock_mcp_tool, mock_mcp_client):
     timeout = timedelta(seconds=30)
     agent_tool = MCPAgentTool(mock_mcp_tool, mock_mcp_client, timeout=timeout)

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client_tool_provider.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client_tool_provider.py
@@ -328,13 +328,14 @@ async def test_rejected_filter_string_match(mock_transport):
 
 
 @pytest.mark.asyncio
-async def test_prefix_renames_tools(mock_transport):
-    """Test that prefix properly renames tools."""
+async def test_prefix_and_meta_configure_tools(mock_transport):
+    """Test that prefix and metadata are passed to adapted tools."""
     # Create a mock MCP tool (not MCPAgentTool)
     mock_mcp_tool = MagicMock()
     mock_mcp_tool.name = "original_name"
 
-    client = MCPClient(mock_transport, prefix="prefix")
+    meta = {"trace_id": "trace-123"}
+    client = MCPClient(mock_transport, prefix="prefix", meta=meta)
     client._tool_provider_started = True
 
     # Mock the session active state
@@ -364,7 +365,9 @@ async def test_prefix_renames_tools(mock_transport):
         result = client.list_tools_sync(prefix="prefix")
 
         # Should create MCPAgentTool with prefixed name
-        mock_agent_tool_class.assert_called_once_with(mock_mcp_tool, client, name_override="prefix_original_name")
+        mock_agent_tool_class.assert_called_once_with(
+            mock_mcp_tool, client, name_override="prefix_original_name", meta=meta
+        )
 
         assert len(result) == 1
         assert result[0] is mock_agent_tool


### PR DESCRIPTION
## Description

`MCPClient.call_tool_async` already supports the MCP standard `_meta` field, but model-driven calls made through `MCPAgentTool.stream()` could not configure it. This adds an optional `meta` payload to `MCPClient`, carries it into adapted tools, and forwards it on each model-driven MCP tool call while preserving the existing default behavior when omitted.

## Related Issues

Resolves: #3517

## Documentation PR

The Python MCP tools guide now documents configuring request metadata for routing, tracing, and tenant context.

## Type of Change

Bug fix

## Testing

- Focused MCP tests: 51 passed
- MCP test suite: 258 passed, 1 deselected; the remaining baseline failure is `test_call_tool_sync_embedded_image_blob`, which cannot find the pre-existing `tests_integ/resources/yellow.png` path
- Ruff format check and lint: passed
- Mypy on changed MCP source files: passed
- Documentation site build: passed; Astro reported existing warnings but no build errors

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added tests that prove the fix is effective
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.