### PR TITLE
chore(python): deprecate LlamaAPI model provider

### DIFF
--- a/site/src/content/docs/user-guide/concepts/model-providers/llamaapi.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/llamaapi.mdx
@@ -10,6 +10,13 @@ sourceLinks:
   - path: strands-py/src/strands/models/llamaapi.py
 ---
 
+:::caution[Deprecated]
+The Llama API service has been deprecated by Meta, and Strands' `LlamaAPIModel` provider is deprecated
+along with it. It will be removed in a future release. Migrate to another provider that hosts Llama or
+comparable models — for example [Amazon Bedrock](./amazon-bedrock), [Ollama](./ollama), or
+[OpenAI](./openai).
+:::
+
 [Llama API](https://llama.developer.meta.com?utm_source=partner-strandsagent&utm_medium=website) is a Meta-hosted API service that helps you integrate Llama models into your applications quickly and efficiently.
 
 Llama API provides access to Llama models through a simple API interface, with inference provided by Meta, so you can focus on building AI-powered solutions without managing your own inference infrastructure.

--- a/site/src/content/docs/user-guide/concepts/model-providers/llamaapi.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/llamaapi.mdx
@@ -12,12 +12,11 @@ sourceLinks:
 
 :::caution[Deprecated]
 The Llama API service has been deprecated by Meta, and Strands' `LlamaAPIModel` provider is deprecated
-along with it. It will be removed in a future release. Migrate to another provider that hosts Llama or
-comparable models — for example [Amazon Bedrock](./amazon-bedrock), [Ollama](./ollama), or
-[OpenAI](./openai).
+along with it. It will be removed in v2.0.0. Use [Amazon Bedrock](./amazon-bedrock),
+[Ollama](./ollama), or [OpenAI](./openai) instead.
 :::
 
-[Llama API](https://llama.developer.meta.com?utm_source=partner-strandsagent&utm_medium=website) is a Meta-hosted API service that helps you integrate Llama models into your applications quickly and efficiently.
+Llama API is a Meta-hosted API service that helps you integrate Llama models into your applications quickly and efficiently.
 
 Llama API provides access to Llama models through a simple API interface, with inference provided by Meta, so you can focus on building AI-powered solutions without managing your own inference infrastructure.
 

--- a/strands-py/src/strands/models/llamaapi.py
+++ b/strands-py/src/strands/models/llamaapi.py
@@ -1,23 +1,22 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 """Llama API model provider.
 
-Deprecated: The Llama API service (https://llama.developer.meta.com/) has been deprecated by Meta.
-This provider will be removed in a future release. Migrate to another provider (e.g. Bedrock,
-Anthropic, OpenAI, Ollama) that hosts Llama or comparable models.
+Deprecated: The Llama API service has been deprecated by Meta. This provider will be removed
+in v2.0.0. Migrate to another provider (BedrockModel, OllamaModel, or OpenAIModel) that hosts
+Llama or comparable models.
 """
 
 import base64
 import json
 import logging
 import mimetypes
-import warnings
 from collections.abc import AsyncGenerator
 from typing import Any, TypeVar, cast
 
 import llama_api_client
 from llama_api_client import LlamaAPIClient
 from pydantic import BaseModel
-from typing_extensions import Unpack, override
+from typing_extensions import Unpack, deprecated, override
 
 from ..types.content import ContentBlock, Messages
 from ..types.exceptions import ContextWindowOverflowException, ModelThrottledException
@@ -28,22 +27,19 @@ from .model import BaseModelConfig, Model
 
 logger = logging.getLogger(__name__)
 
-_DEPRECATION_MESSAGE = (
-    "LlamaAPIModel is deprecated and will be removed in a future release. "
-    "The underlying Llama API service (https://llama.developer.meta.com/) has been deprecated by Meta. "
-    "Migrate to another provider that hosts Llama or comparable models "
-    "(for example, BedrockModel, OllamaModel, or OpenAIModel)."
-)
-
 T = TypeVar("T", bound=BaseModel)
 
 
+@deprecated(
+    "LlamaAPIModel is deprecated and will be removed in v2.0.0. "
+    "The underlying Llama API service has been deprecated by Meta. "
+    "Use BedrockModel, OllamaModel, or OpenAIModel instead."
+)
 class LlamaAPIModel(Model):
     """Llama API model provider implementation.
 
     Deprecated: The Llama API service has been deprecated by Meta. This class will be removed
-    in a future release. Use another provider (e.g. BedrockModel, OllamaModel, OpenAIModel) that
-    hosts Llama or comparable models.
+    in v2.0.0. Use BedrockModel, OllamaModel, or OpenAIModel instead.
     """
 
     OVERFLOW_MESSAGES = {
@@ -86,8 +82,6 @@ class LlamaAPIModel(Model):
             client_args: Arguments for the Llama API client.
             **model_config: Configuration options for the Llama API model.
         """
-        warnings.warn(_DEPRECATION_MESSAGE, DeprecationWarning, stacklevel=2)
-
         validate_config_keys(model_config, self.LlamaConfig)
         self.config = LlamaAPIModel.LlamaConfig(**model_config)
         logger.debug("config=<%s> | initializing", self.config)

--- a/strands-py/src/strands/models/llamaapi.py
+++ b/strands-py/src/strands/models/llamaapi.py
@@ -1,13 +1,16 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 """Llama API model provider.
 
-- Docs: https://llama.developer.meta.com/
+Deprecated: The Llama API service (https://llama.developer.meta.com/) has been deprecated by Meta.
+This provider will be removed in a future release. Migrate to another provider (e.g. Bedrock,
+Anthropic, OpenAI, Ollama) that hosts Llama or comparable models.
 """
 
 import base64
 import json
 import logging
 import mimetypes
+import warnings
 from collections.abc import AsyncGenerator
 from typing import Any, TypeVar, cast
 
@@ -25,11 +28,23 @@ from .model import BaseModelConfig, Model
 
 logger = logging.getLogger(__name__)
 
+_DEPRECATION_MESSAGE = (
+    "LlamaAPIModel is deprecated and will be removed in a future release. "
+    "The underlying Llama API service (https://llama.developer.meta.com/) has been deprecated by Meta. "
+    "Migrate to another provider that hosts Llama or comparable models "
+    "(for example, BedrockModel, OllamaModel, or OpenAIModel)."
+)
+
 T = TypeVar("T", bound=BaseModel)
 
 
 class LlamaAPIModel(Model):
-    """Llama API model provider implementation."""
+    """Llama API model provider implementation.
+
+    Deprecated: The Llama API service has been deprecated by Meta. This class will be removed
+    in a future release. Use another provider (e.g. BedrockModel, OllamaModel, OpenAIModel) that
+    hosts Llama or comparable models.
+    """
 
     OVERFLOW_MESSAGES = {
         "this model's maximum context length is",
@@ -71,6 +86,8 @@ class LlamaAPIModel(Model):
             client_args: Arguments for the Llama API client.
             **model_config: Configuration options for the Llama API model.
         """
+        warnings.warn(_DEPRECATION_MESSAGE, DeprecationWarning, stacklevel=2)
+
         validate_config_keys(model_config, self.LlamaConfig)
         self.config = LlamaAPIModel.LlamaConfig(**model_config)
         logger.debug("config=<%s> | initializing", self.config)

--- a/strands-py/tests/strands/models/test_llamaapi.py
+++ b/strands-py/tests/strands/models/test_llamaapi.py
@@ -49,6 +49,13 @@ def test__init__model_configs(llamaapi_client, model_id):
     assert tru_temperature == exp_temperature
 
 
+def test__init__emits_deprecation_warning(llamaapi_client, model_id):
+    _ = llamaapi_client
+
+    with pytest.warns(DeprecationWarning, match="LlamaAPIModel is deprecated"):
+        LlamaAPIModel(model_id=model_id)
+
+
 def test_update_config(model, model_id):
     model.update_config(model_id=model_id)
 

--- a/strands-py/tests/strands/models/test_llamaapi.py
+++ b/strands-py/tests/strands/models/test_llamaapi.py
@@ -443,9 +443,10 @@ def test_config_validation_warns_on_unknown_keys(llamaapi_client, captured_warni
     """Test that unknown config keys emit a warning."""
     LlamaAPIModel(model_id="test-model", invalid_param="test")
 
-    assert len(captured_warnings) == 1
-    assert "Invalid configuration parameters" in str(captured_warnings[0].message)
-    assert "invalid_param" in str(captured_warnings[0].message)
+    user_warnings = [warning for warning in captured_warnings if issubclass(warning.category, UserWarning)]
+    assert len(user_warnings) == 1
+    assert "Invalid configuration parameters" in str(user_warnings[0].message)
+    assert "invalid_param" in str(user_warnings[0].message)
 
 
 def test_update_config_validation_warns_on_unknown_keys(model, captured_warnings):


### PR DESCRIPTION
## Description

Meta has deprecated the [Llama API service](https://llama.developer.meta.com/), so the `LlamaAPIModel` provider in `strands-py` is deprecated in turn and will be removed in a future release.

Changes:
- `strands-py/src/strands/models/llamaapi.py` — module docstring and `LlamaAPIModel` class docstring now mark the provider as deprecated; `__init__` emits a `DeprecationWarning` (`stacklevel=2`) with migration guidance pointing to `BedrockModel`, `OllamaModel`, and `OpenAIModel` as alternatives that host Llama or comparable models.
- `strands-py/tests/strands/models/test_llamaapi.py` — new `test__init__emits_deprecation_warning` covers the new warning.
- `site/src/content/docs/user-guide/concepts/model-providers/llamaapi.mdx` — added a `:::caution[Deprecated]` callout at the top of the page linking users to the recommended alternatives.

Follows the existing deprecation pattern in `strands.experimental.hooks.multiagent` and `strands.experimental.steering` (`warnings.warn(..., DeprecationWarning, stacklevel=2)` as per the developer-facing rule in `strands-py/AGENTS.md`).

## Related Issues

<!-- Link to related issues if applicable -->

## Documentation PR

Docs update is included in this PR under `site/`.

## Type of Change

Other: deprecation notice for an existing provider

## Testing

- Added a unit test asserting the `DeprecationWarning` fires on `LlamaAPIModel(...)` construction.
- Unable to run `hatch run prepare` in this environment (no Python toolchain available); the change is small and mirrors the deprecation pattern already used elsewhere in the SDK.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings (aside from the intentional `DeprecationWarning` this PR adds)
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.