### PR TITLE
docs(blog): a robot is anything that can introduce itself (MHS research preview)

### DIFF
--- a/site/src/content/blog/mhs-any-machine-can-introduce-itself.mdx
+++ b/site/src/content/blog/mhs-any-machine-can-introduce-itself.mdx
@@ -1,0 +1,105 @@
+---
+title: "A robot is anything that can introduce itself"
+date: 2026-08-27
+description: "What USB did for peripherals, the Model Hardware Standard aims to do for machines: a new way for any device to introduce itself, so an agent can discover it, read it, and compose behaviour across machines it has never seen. The peer-to-peer mesh underneath runs today, and Strands Robots is participating in the MHS research preview."
+authors:
+  - cagatay-cali
+tags:
+  - Physical AI
+  - Robotics
+  - Announcement
+draft: false
+---
+
+*What USB did for peripherals in 1996, the Model Hardware Standard aims to do for machines in 2026: a new way for any device to introduce itself, so an agent can discover it, read it, and compose behaviour across machines it has never seen, each within the limits it carries with it. Strands Robots is participating in the research preview, and the mesh underneath it already runs today.*
+
+## The mesh you already have
+
+`Robot("so100")` returns a MuJoCo simulation, with no GPU and no hardware, and `mode="real"` is the only switch that ever drives a servo. Either way, the robot comes up already on a peer-to-peer mesh. Start a second one and they find each other:
+
+```python
+from strands_robots import Robot
+
+a = Robot("so100")                 # sim by default; auto-joins the mesh
+b = Robot("so100")                 # a second peer
+print(a.mesh.peers)                # discovers b
+
+a.mesh.tell(b.peer_id, "pick up the cube")
+a.mesh.emergency_stop()            # broadcast E-STOP to every peer
+```
+
+`tell()` sends a command to one peer; `broadcast()` sends it to the whole fleet; both reach simulated and real robots the same way. `emergency_stop()` is the one that matters most: it halts every peer at once and latches a lockout, so a stopped robot stays stopped until a person clears it on the machine itself. Anyone can trigger the stop; no one can resume it over the network.
+
+The same robot can speak over more than one wire, and you choose which with an environment variable. `STRANDS_MESH_BACKEND` selects the Zenoh peer mesh on the LAN (default), AWS IoT Core for fleets across networks, a bridge across both, or, newest, `mhs`, which rides whatever transport the Model Hardware Standard selects. In every case, what moves across the wire is *commands*. What machines still lack is an agreed way to say what they are, and that is the other half a standard is for.
+
+## A robot is not a shape
+
+A robot can be an industrial arm, a humanoid, a 3D printer, a sensor, or an agent itself. What makes a machine workable for an agent is not that it has joints, but that the agent can ask it what it is. Line up four with nothing in common and ask each the same four questions:
+
+|              | printer            | temp sensor         | pendant       | an agent            |
+| ------------ | ------------------ | ------------------- | ------------- | ------------------- |
+| **READ**     | state, warmth      | temperature         | camera, mic   | goal, memory        |
+| **CHANGE**   | pause/resume/stop  | -                   | wake, mute    | its plan            |
+| **CALL**     | start print        | zero                | answer        | new agent session   |
+| **ANNOUNCE** | job complete       | threshold crossed   | presence      | task complete       |
+
+The empty cell is the interesting one: the sensor has nothing under **CHANGE** because it has nothing to move, and it is still a robot. So a robot is anything that can emit events, change its state or position, and announce results. MHS names exactly those four capabilities: `@sensor` (what you may read), `@control` (what you may change, and within what limits), `@rpc` (what you may call), and `@emit` (what the machine announces on its own).
+
+![Four unlike machines, a printer, a temperature sensor, a wearable pendant and a software agent, each described by the same four-line self-introduction: what can be read, changed, called, and announced. The sensor's change line is empty, because it has nothing to move.](./mhs/05_what_a_robot_is.svg)
+
+## Why a written-down tool definition can't keep up
+
+Language models keep getting more capable as they scale. Operating physical equipment did not get easier at the same rate, because the interface never changed: a machine is handed to an agent as a *tool definition*, a description written down once. That is a photograph of a moving thing, accurate the instant it's taken and drifting by the next. Picture a fleet of walkers actively switching the area they patrol: the snapshot goes stale the moment they move. A machine that introduces itself has no such problem, because what the agent reads is the machine's own account of what it is right now, with no second copy to keep in sync and no surprise when a machine the definition never heard of joins the mesh.
+
+![Two panels. On the left, a tool definition typed once by hand freezes three walking machines into fixed patrol zones. On the right the same fleet describes itself live and keeps rearranging: machines swap zones, one drops offline, a fourth the definition never heard of arrives. The hand-typed side drifts out of date; the live side needs nothing kept in sync.](./mhs/06_static_tool_vs_moving_fleet.svg)
+
+## Machines that change the room
+
+Picture quadruped machines patrolling a datacenter, each driven by an agent: one walks the aisles, reads the heat off the racks, and calls a person the moment a rack crosses a temperature threshold. It does not decide what to do about the hot rack; it names the condition and hands the judgement to a human. A digital agent changes data; a physical one changes the room it stands in. *(An illustrative design, not a recorded run.)*
+
+![A row of server racks with a four-legged machine patrolling the aisle under an agent's direction. Heat readings rise against a declared limit line; one crosses it and turns amber. The walker does not act on the rack; it announces the crossing to a person. Values shown are illustrative.](./mhs/07_datacenter_patrol.svg)
+
+## Composing machines that never met
+
+Then the machines compose. A colleague wanted to wear his agent: a coin-sized thing on a cord that sees what he sees and answers out loud. He described it once; an agent turned the sentence into a shape, worked out its weight before a gram of plastic existed, and sent it to the printer. It printed unwatched in under an hour and stopped at the very end, the part perfect, sealed in a warm chamber whose door is glass on a hinge with no motor, and whose entire vocabulary is three words: pause, resume, stop.
+
+So the machine that cannot open its own door asks one that can. On the far bench is a jointed arm, another peer. The printer publishes that the job is done and the chamber still warm; the arm waits on that declared temperature before reaching in, and grips against the weight the design computed before the first layer. Nobody translates between them; each carries its own limits.
+
+![A time-ordered handoff between a printer, a machine with an arm, and an agent on one shared connection. The printer publishes progress, then chamber temperature and a closed-door state, as readable information. The arm's reach is held back by an interlock tied to that temperature and only releases once it drops below a safe bound; the wait is the safety feature, not a delay.](./mhs/04_handoff_interlocked.svg)
+
+A device declares its bounds, its interlocks, and an emergency stop that anyone can trigger and only a person can clear, and every agent that connects inherits them. A limit stops being something an agent is asked to remember and becomes something the device will not let it cross.
+
+## Show me the code
+
+The mesh is one import, and the wire is one env var. The same fleet code runs on the LAN, across networks over AWS IoT Core, or on the transport MHS selects. You change where the messages travel, not the program:
+
+```bash
+python fleet.py                            # Zenoh peer mesh on the LAN (default)
+STRANDS_MESH_BACKEND=iot python fleet.py   # same fleet, across networks over AWS IoT Core
+STRANDS_MESH_BACKEND=mhs python fleet.py   # same fleet, on the wire MHS selects
+```
+
+Putting a robot on MHS's state plane is the next line, during the research preview, and an agent's own tools become procedures a machine can call, refusing anything you did not name:
+
+```python
+from strands_robots import Robot
+from strands_robots.mhs_connect import init_mhs_sync, expose_agent_tools
+
+robot = Robot("so101", peer_id="arm-1")            # a mesh peer today
+init_mhs_sync(robot, device_id="so101-lab-1")      # now discoverable on MHS
+
+Driver = expose_agent_tools(agent, include=["walk_forward", "get_state"])
+init_mhs_sync(Driver(), device_id="agent-1")       # mount it; agent now callable
+```
+
+The bounds are declared, not remembered. An emergency-stop slot published as `range=(0, 1)` with `safe=(1, 1)` accepts a halt from anywhere and refuses a remote resume, and that rule belongs to the device, not to whatever software is driving it.
+
+## What's real today, and what's next
+
+The mesh is real and open source: install Strands Robots and a fleet comes up describing itself to its peers, coordinating over `tell` and `broadcast`, and refusing a call that would move a robot until a person approves. The datacenter patrol and the printer-to-arm handoff are examples we use to explain the idea.
+
+That points at the **Model Hardware Standard (MHS)**: a new standard, introduced by Anthropic, for AI agents to safely operate physical equipment in scientific research and advanced manufacturing. Strands Robots is participating in the research preview. AWS is adding MHS support to Strands Robots, our SDK for connecting AI agents to physical hardware; participants receive a private pre-release version of the Strands Robots package for the duration of the research preview. The specification is provisional and not open source, access is by application while the safety design is validated, and MHS is not generally available yet.
+
+- Use the mesh today: [Strands Robots](https://github.com/strands-labs/robots) & [Strands Agents](https://strandsagents.com)
+- Model Hardware Standard, a research preview from Anthropic: [anthropic.com/news/model-hardware-standard-research-preview](https://www.anthropic.com/news/model-hardware-standard-research-preview)
+- Request research-preview access for Strands Robots: [discord.gg/strands](https://discord.gg/strands)

--- a/site/src/content/blog/mhs/04_handoff_interlocked.svg
+++ b/site/src/content/blog/mhs/04_handoff_interlocked.svg
@@ -1,0 +1,83 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1120 520" width="1120" height="520" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" role="img" aria-labelledby="ht hd">
+  <title id="ht">The handoff, and the bound it waits on</title>
+  <desc id="hd">A left-to-right flow between three peers on one shared connection. On the left the printer publishes readable state: print complete, chamber temperature, door closed. In the centre an interlock holds the reaching machine's open-door-and-reach procedure until the declared temperature crosses under its bound; the temperature counts down and a lock opens once it drops below the safe value; the wait is the safety feature, not a delay. On the right the arm reaches and grasps, parameterised by the mass the geometry kernel computed. Below, three answers: locked and wide open are the only two a machine can give today; a declared bound makes possible the third: yes, within these limits. Any peer may halt; no peer may remotely resume. Values are illustrative.</desc>
+
+  <rect width="1120" height="520" fill="#FBFAF7"/>
+
+  <text x="60" y="60" font-size="25" font-weight="600" fill="#20242B">The handoff, and the bound it waits on</text>
+  <text x="60" y="86" font-size="14" fill="#767C86">The reaching machine does not reach in until the printer's declared temperature crosses under the bound.</text>
+
+  <!-- LEFT: printer publishes declared state -->
+  <text x="60" y="150" font-size="11" letter-spacing="1.5" fill="#767C86">PRINTER · PUBLISHES STATE</text>
+  <g font-size="14.5">
+    <g opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.06;0.12;1" dur="16s" fill="freeze" repeatCount="indefinite"/>
+      <circle cx="72" cy="186" r="4.5" fill="#1F8A5B"/><text x="90" y="191" fill="#20242B">printComplete</text></g>
+    <g opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.12;0.18;1" dur="16s" fill="freeze" repeatCount="indefinite"/>
+      <circle cx="72" cy="230" r="4.5" fill="#C0792B"/><text x="90" y="235" fill="#20242B">chamberTemp</text></g>
+    <g opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.18;0.24;1" dur="16s" fill="freeze" repeatCount="indefinite"/>
+      <circle cx="72" cy="274" r="4.5" fill="#1F8A5B"/><text x="90" y="279" fill="#20242B">doorClosed = true</text></g>
+  </g>
+
+  <!-- arrow into the interlock -->
+  <path d="M300,230 H408" fill="none" stroke="#B7B2A6" stroke-width="1.5" marker-end="url(#ar)" opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.22;0.28;1" dur="16s" fill="freeze" repeatCount="indefinite"/></path>
+  <defs><marker id="ar" markerWidth="9" markerHeight="9" refX="6" refY="4.5" orient="auto"><path d="M0,0 L8,4.5 L0,9 z" fill="#B7B2A6"/></marker></defs>
+
+  <!-- CENTER: interlock card -->
+  <g opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.24;0.30;1" dur="16s" fill="freeze" repeatCount="indefinite"/>
+    <rect x="426" y="140" width="268" height="196" rx="14" fill="#FFFFFF" stroke="#C0792B" stroke-width="1.5"/>
+    <text x="560" y="172" text-anchor="middle" font-size="11" letter-spacing="2" fill="#C0792B">INTERLOCK</text>
+    <text x="560" y="192" text-anchor="middle" font-size="12.5" fill="#767C86">reach held until</text>
+  </g>
+  <!-- countdown temperature -->
+  <g text-anchor="middle" font-size="40" font-weight="600">
+    <text x="560" y="248" fill="#C0792B" opacity="0"><animate attributeName="opacity" values="0;0;1;1;0;0" keyTimes="0;0.30;0.34;0.44;0.46;1" dur="16s" fill="freeze" repeatCount="indefinite"/>62&#176;C</text>
+    <text x="560" y="248" fill="#C0792B" opacity="0"><animate attributeName="opacity" values="0;0;0;1;1;0;0" keyTimes="0;0.46;0.48;0.50;0.56;0.58;1" dur="16s" fill="freeze" repeatCount="indefinite"/>48&#176;C</text>
+    <text x="560" y="248" fill="#1F8A5B" opacity="0"><animate attributeName="opacity" values="0;0;0;1;1" keyTimes="0;0.56;0.58;0.60;1" dur="16s" fill="freeze" repeatCount="indefinite"/>39&#176;C</text>
+  </g>
+  <text x="560" y="274" text-anchor="middle" font-size="12.5" fill="#767C86" opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.30;0.34;1" dur="16s" fill="freeze" repeatCount="indefinite"/>bound: &#8804; 40&#176;C</text>
+  <!-- lock icon -->
+  <g transform="translate(560,296)" opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.30;0.34;1" dur="16s" fill="freeze" repeatCount="indefinite"/>
+    <rect x="-10" y="0" width="20" height="14" rx="2.5" fill="none" stroke="#C0792B" stroke-width="1.6"><animate attributeName="stroke" values="#C0792B;#C0792B;#1F8A5B;#1F8A5B" keyTimes="0;0.58;0.60;1" dur="16s" fill="freeze" repeatCount="indefinite"/></rect>
+    <path d="M-6,0 v-5 a6,6 0 0 1 12,0 v5" fill="none" stroke="#C0792B" stroke-width="1.6"><animate attributeName="d" values="M-6,0 v-5 a6,6 0 0 1 12,0 v5;M-6,0 v-5 a6,6 0 0 1 12,0 v5;M-6,0 v-6 a6,6 0 0 1 12,0 v2;M-6,0 v-6 a6,6 0 0 1 12,0 v2" keyTimes="0;0.58;0.62;1" dur="16s" fill="freeze" repeatCount="indefinite"/><animate attributeName="stroke" values="#C0792B;#C0792B;#1F8A5B;#1F8A5B" keyTimes="0;0.58;0.60;1" dur="16s" fill="freeze" repeatCount="indefinite"/></path>
+  </g>
+
+  <!-- arrow out to the arm -->
+  <path d="M712,230 H818" fill="none" stroke="#1F8A5B" stroke-width="1.5" marker-end="url(#arg)" opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.60;0.66;1" dur="16s" fill="freeze" repeatCount="indefinite"/></path>
+  <defs><marker id="arg" markerWidth="9" markerHeight="9" refX="6" refY="4.5" orient="auto"><path d="M0,0 L8,4.5 L0,9 z" fill="#1F8A5B"/></marker></defs>
+
+  <!-- RIGHT: the arm acts -->
+  <text x="840" y="150" font-size="11" letter-spacing="1.5" fill="#767C86">THE MACHINE THAT GRASPS</text>
+  <g font-size="14.5">
+    <g opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.62;0.68;1" dur="16s" fill="freeze" repeatCount="indefinite"/>
+      <circle cx="852" cy="200" r="4.5" fill="#1F8A5B"/><text x="870" y="205" fill="#20242B">openDoor · reach</text></g>
+    <g opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.72;0.78;1" dur="16s" fill="freeze" repeatCount="indefinite"/>
+      <circle cx="852" cy="248" r="4.5" fill="#1F8A5B"/><text x="870" y="253" fill="#20242B">grasp(mass 6.2 g)</text>
+      <text x="870" y="272" font-size="11.5" fill="#767C86">from the geometry kernel, not re-weighed</text></g>
+  </g>
+
+  <!-- agent note -->
+  <g opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.66;0.72;1" dur="16s" fill="freeze" repeatCount="indefinite"/>
+    <circle cx="72" cy="322" r="4.5" fill="#767C86"/><text x="90" y="327" font-size="14.5" fill="#767C86">agent reads state · cannot skip the bound</text></g>
+
+  <!-- footer: three answers -->
+  <line x1="60" y1="376" x2="1060" y2="376" stroke="#E4E0D6" stroke-width="1.25"/>
+  <text x="60" y="404" font-size="11" letter-spacing="1.6" fill="#C0792B">TWO ANSWERS A MACHINE CAN GIVE TODAY</text>
+  <text x="1060" y="404" text-anchor="end" font-size="11" letter-spacing="1.6" fill="#1F8A5B">THE THIRD · A DECLARED BOUND</text>
+  <g>
+    <rect x="60" y="416" width="280" height="50" rx="8" fill="#FFFFFF" stroke="#C0792B" stroke-width="1.3"/>
+    <text x="76" y="440" font-size="13.5" font-weight="600" fill="#20242B">LOCKED</text>
+    <text x="76" y="458" font-size="11.5" fill="#767C86">no remote start until a human walks over</text>
+  </g>
+  <g>
+    <rect x="356" y="416" width="280" height="50" rx="8" fill="#FFFFFF" stroke="#C0792B" stroke-width="1.3"/>
+    <text x="372" y="440" font-size="13.5" font-weight="600" fill="#20242B">WIDE OPEN</text>
+    <text x="372" y="458" font-size="11.5" fill="#767C86">anyone may start it, no bound at all</text>
+  </g>
+  <text x="660" y="447" text-anchor="middle" font-size="20" fill="#B7B2A6">&#8594;</text>
+  <g>
+    <rect x="684" y="416" width="376" height="50" rx="8" fill="#F1F7F3" stroke="#1F8A5B" stroke-width="1.5"/>
+    <text x="702" y="440" font-size="13.5" font-weight="600" fill="#1F8A5B">YES, WITHIN THESE LIMITS</text>
+    <text x="702" y="458" font-size="11.5" fill="#20242B">start released the moment the declared bound is met</text>
+  </g>
+  <text x="60" y="494" font-size="12" fill="#767C86">The wait is the safety feature, not a delay.  <tspan fill="#20242B">Any peer may halt · no peer may remotely resume.</tspan></text>
+</svg>

--- a/site/src/content/blog/mhs/05_what_a_robot_is.svg
+++ b/site/src/content/blog/mhs/05_what_a_robot_is.svg
@@ -1,0 +1,101 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1120 560" width="1120" height="560" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" role="img" aria-labelledby="rt rd">
+  <title id="rt">A robot is anything that can introduce itself</title>
+  <desc id="rd">Four unlike machines: a printer, a temperature sensor, a wearable pendant and a software agent, set across the top of a clean four-row table. Down the left are the four questions each one answers, tagged with the pillar that carries it: READ via the sensor pillar, CHANGE via the control pillar, CALL via the remote-call pillar, ANNOUNCE via the emit pillar. Each column fills with the same four-line shape. The sensor's CHANGE cell stays empty, because a sensor is a robot with nothing to move; the row is open-ended. Any values shown are illustrative.</desc>
+
+  <rect width="1120" height="560" fill="#FBFAF7"/>
+
+  <text x="60" y="66" font-size="27" font-weight="600" fill="#20242B" opacity="0">A robot is anything that can introduce itself
+    <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.02;0.06;1" dur="15s" fill="freeze" repeatCount="indefinite"/></text>
+  <text x="60" y="94" font-size="14" fill="#767C86" opacity="0">The same four lines fill in across machines that share nothing else; the category is declaration, not limbs.
+    <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.04;0.08;1" dur="15s" fill="freeze" repeatCount="indefinite"/></text>
+
+  <g stroke="#E4E0D6" stroke-width="1.25" opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.08;0.14;1" dur="15s" fill="freeze" repeatCount="indefinite"/>
+    <line x1="60" y1="232" x2="1060" y2="232"/>
+    <line x1="60" y1="308" x2="1060" y2="308"/>
+    <line x1="60" y1="384" x2="1060" y2="384"/>
+    <line x1="60" y1="460" x2="1060" y2="460"/>
+    <line x1="260" y1="132" x2="260" y2="516"/>
+    <line x1="460" y1="132" x2="460" y2="516"/>
+    <line x1="660" y1="132" x2="660" y2="516"/>
+    <line x1="860" y1="132" x2="860" y2="516"/>
+  </g>
+
+  <g opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.10;0.16;1" dur="15s" fill="freeze" repeatCount="indefinite"/>
+    <text x="76" y="276" font-size="14" font-weight="600" letter-spacing="1.6" fill="#20242B">READ</text>
+    <text x="76" y="294" font-size="12" fill="#1F8A5B">@sensor</text>
+    <text x="76" y="352" font-size="14" font-weight="600" letter-spacing="1.6" fill="#20242B">CHANGE</text>
+    <text x="76" y="370" font-size="12" fill="#1F8A5B">@control</text>
+    <text x="76" y="428" font-size="14" font-weight="600" letter-spacing="1.6" fill="#20242B">CALL</text>
+    <text x="76" y="446" font-size="12" fill="#1F8A5B">@rpc</text>
+    <text x="76" y="504" font-size="14" font-weight="600" letter-spacing="1.6" fill="#20242B">ANNOUNCE</text>
+    <text x="76" y="522" font-size="12" fill="#1F8A5B">@emit</text>
+  </g>
+
+  <g opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.18;0.24;1" dur="15s" fill="freeze" repeatCount="indefinite"/>
+    <g fill="none" stroke="#20242B" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <rect x="336" y="160" width="48" height="38" rx="4"/>
+      <line x1="346" y1="176" x2="374" y2="176"/>
+      <rect x="350" y="198" width="20" height="8" rx="1.5"/>
+    </g>
+    <text x="360" y="222" text-anchor="middle" font-size="13.5" fill="#20242B">printer</text>
+    <g font-size="14" fill="#20242B" text-anchor="middle">
+      <text x="360" y="277">state · warmth</text>
+      <text x="360" y="353">pause / resume / stop</text>
+      <text x="360" y="429">start print</text>
+      <text x="360" y="505">job complete</text>
+    </g>
+  </g>
+
+  <g opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.26;0.32;1" dur="15s" fill="freeze" repeatCount="indefinite"/>
+    <g fill="none" stroke="#20242B" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <line x1="560" y1="160" x2="560" y2="186"/>
+      <circle cx="560" cy="192" r="7"/>
+      <line x1="564" y1="167" x2="570" y2="167"/>
+      <line x1="564" y1="175" x2="570" y2="175"/>
+    </g>
+    <text x="560" y="222" text-anchor="middle" font-size="13.5" fill="#20242B">temperature sensor</text>
+    <g font-size="14" fill="#20242B" text-anchor="middle">
+      <text x="560" y="277">temperature</text>
+      <text x="560" y="429">zero</text>
+      <text x="560" y="505">threshold crossed</text>
+    </g>
+  </g>
+  <g opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.34;0.40;1" dur="15s" fill="freeze" repeatCount="indefinite"/>
+    <rect x="476" y="320" width="168" height="46" rx="6" fill="none" stroke="#C0792B" stroke-width="1.3" stroke-dasharray="5 5"/>
+    <text x="560" y="349" text-anchor="middle" font-size="12.5" fill="#C0792B">nothing to move</text>
+  </g>
+
+  <g opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.42;0.48;1" dur="15s" fill="freeze" repeatCount="indefinite"/>
+    <g fill="none" stroke="#20242B" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M748,160 L760,178 L772,160"/>
+      <circle cx="760" cy="176" r="2.6"/>
+      <rect x="746" y="182" width="28" height="26" rx="8"/>
+    </g>
+    <text x="760" y="222" text-anchor="middle" font-size="13.5" fill="#20242B">pendant</text>
+    <g font-size="14" fill="#20242B" text-anchor="middle">
+      <text x="760" y="277">camera · mic</text>
+      <text x="760" y="353">wake · mute</text>
+      <text x="760" y="429">answer</text>
+      <text x="760" y="505">presence</text>
+    </g>
+  </g>
+
+  <g opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.50;0.56;1" dur="15s" fill="freeze" repeatCount="indefinite"/>
+    <g fill="none" stroke="#20242B" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M960,160 L980,198 L940,198 Z"/>
+      <circle cx="960" cy="184" r="2.4" fill="#20242B" stroke="none"/>
+    </g>
+    <text x="960" y="222" text-anchor="middle" font-size="13.5" fill="#20242B">an agent</text>
+    <g font-size="14" fill="#20242B" text-anchor="middle">
+      <text x="960" y="277">goal · memory</text>
+      <text x="960" y="353">its plan</text>
+      <text x="960" y="429">new session</text>
+      <text x="960" y="505">task complete</text>
+    </g>
+  </g>
+
+  <g opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.58;0.64;1" dur="15s" fill="freeze" repeatCount="indefinite"/>
+    <text x="1088" y="188" text-anchor="middle" font-size="30" fill="#B7B2A6">&#8943;</text>
+    <text x="1088" y="212" text-anchor="middle" font-size="11" fill="#B7B2A6">open</text>
+  </g>
+</svg>

--- a/site/src/content/blog/mhs/06_static_tool_vs_moving_fleet.svg
+++ b/site/src/content/blog/mhs/06_static_tool_vs_moving_fleet.svg
@@ -1,0 +1,95 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1120 560" width="1120" height="560" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" role="img" aria-labelledby="ft fd">
+  <title id="ft">A tool definition is a snapshot. A fleet is not.</title>
+  <desc id="fd">Two panels. On the left, a hand-typed definition inside a frame lists three patrolling machines, each assigned a zone once and then frozen. On the right, the same fleet describes itself live and rearranges: two machines swap the zones they patrol, a third goes quiet and fades, and a fourth the definition never heard of arrives. As the right side moves, the now-stale lines on the left are struck through in amber and the newcomer has only an empty dashed slot. The written snapshot goes out of date the moment the fleet moves; the self-describing side needs nothing kept in sync.</desc>
+
+  <rect width="1120" height="560" fill="#FBFAF7"/>
+
+  <text x="60" y="66" font-size="27" font-weight="600" fill="#20242B" opacity="0">A tool definition is a snapshot; a fleet is not
+    <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.02;0.06;1" dur="16s" fill="freeze" repeatCount="indefinite"/></text>
+  <text x="60" y="94" font-size="14" fill="#767C86" opacity="0">The written-down version freezes the moment it is saved; the fleet keeps moving after.
+    <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.04;0.08;1" dur="16s" fill="freeze" repeatCount="indefinite"/></text>
+
+  <!-- headers -->
+  <text x="60" y="150" font-size="12.5" letter-spacing="1.5" fill="#767C86" opacity="0">TYPED ONCE, THEN FROZEN
+    <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.05;0.09;1" dur="16s" fill="freeze" repeatCount="indefinite"/></text>
+  <text x="600" y="150" font-size="12.5" letter-spacing="1.5" fill="#1F8A5B" opacity="0">DESCRIBING ITSELF, LIVE
+    <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.05;0.09;1" dur="16s" fill="freeze" repeatCount="indefinite"/></text>
+
+  <!-- LEFT: frozen definition card -->
+  <g opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.08;0.14;1" dur="16s" fill="freeze" repeatCount="indefinite"/>
+    <rect x="60" y="168" width="460" height="320" rx="10" fill="#FFFFFF" stroke="#E4E0D6" stroke-width="1.4"/>
+  </g>
+
+  <!-- left rows: a quadruped glyph + label, drawn once -->
+  <g fill="none" stroke="#20242B" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+    <g opacity="0" transform="translate(112,214)"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.12;0.18;1" dur="16s" fill="freeze" repeatCount="indefinite"/>
+      <rect x="-14" y="-8" width="28" height="10" rx="3"/><path d="M-10,2 v8 M-3,2 v8 M4,2 v8 M11,2 v8 M14,-3 L20,-8"/></g>
+    <g opacity="0" transform="translate(112,286)"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.14;0.20;1" dur="16s" fill="freeze" repeatCount="indefinite"/>
+      <rect x="-14" y="-8" width="28" height="10" rx="3"/><path d="M-10,2 v8 M-3,2 v8 M4,2 v8 M11,2 v8 M14,-3 L20,-8"/></g>
+    <g opacity="0" transform="translate(112,358)"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.16;0.22;1" dur="16s" fill="freeze" repeatCount="indefinite"/>
+      <rect x="-14" y="-8" width="28" height="10" rx="3"/><path d="M-10,2 v8 M-3,2 v8 M4,2 v8 M11,2 v8 M14,-3 L20,-8"/></g>
+  </g>
+  <g font-size="15" fill="#20242B" opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.16;0.22;1" dur="16s" fill="freeze" repeatCount="indefinite"/>
+    <text x="160" y="216">walker-1  &#8594;  north aisle</text>
+    <text x="160" y="288">walker-2  &#8594;  east aisle</text>
+    <text x="160" y="360">walker-3  &#8594;  west aisle</text>
+  </g>
+
+  <!-- amber strike-throughs as the fleet moves -->
+  <g stroke="#C0792B" stroke-width="2" stroke-linecap="round">
+    <line x1="160" y1="211" x2="356" y2="211" opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.48;0.52;1" dur="16s" fill="freeze" repeatCount="indefinite"/></line>
+    <line x1="160" y1="283" x2="352" y2="283" opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.50;0.54;1" dur="16s" fill="freeze" repeatCount="indefinite"/></line>
+    <line x1="160" y1="355" x2="356" y2="355" opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.58;0.62;1" dur="16s" fill="freeze" repeatCount="indefinite"/></line>
+  </g>
+
+  <!-- empty dashed slot for the newcomer -->
+  <g opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.68;0.74;1" dur="16s" fill="freeze" repeatCount="indefinite"/>
+    <rect x="96" y="410" width="388" height="40" rx="7" fill="none" stroke="#B7B2A6" stroke-width="1.3" stroke-dasharray="6 5"/>
+    <text x="116" y="435" font-size="13" fill="#B7B2A6">walker-4:  unknown to the definition</text>
+  </g>
+
+  <!-- divider -->
+  <line x1="560" y1="168" x2="560" y2="488" stroke="#E4E0D6" stroke-width="1.25" stroke-dasharray="2 6" opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.08;0.12;1" dur="16s" fill="freeze" repeatCount="indefinite"/></line>
+
+  <!-- RIGHT: live fleet -->
+  <g fill="none" stroke="#20242B" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+    <g opacity="0" transform="translate(652,214)"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.22;0.28;1" dur="16s" fill="freeze" repeatCount="indefinite"/>
+      <animateTransform attributeName="transform" additive="sum" type="translate" values="0 0;0 -2;0 0" dur="2.6s" repeatCount="indefinite"/>
+      <rect x="-14" y="-8" width="28" height="10" rx="3"/><path d="M-10,2 v8 M-3,2 v8 M4,2 v8 M11,2 v8 M14,-3 L20,-8"/></g>
+    <g opacity="0" transform="translate(652,286)"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.24;0.30;1" dur="16s" fill="freeze" repeatCount="indefinite"/>
+      <animateTransform attributeName="transform" additive="sum" type="translate" values="0 0;0 -2;0 0" dur="3.0s" repeatCount="indefinite"/>
+      <rect x="-14" y="-8" width="28" height="10" rx="3"/><path d="M-10,2 v8 M-3,2 v8 M4,2 v8 M11,2 v8 M14,-3 L20,-8"/></g>
+  </g>
+
+  <!-- walker-1: north -> east (crossfade) -->
+  <g font-size="15" fill="#20242B">
+    <text x="700" y="216" opacity="0">walker-1  &#8594;  <tspan fill="#767C86">north aisle</tspan><animate attributeName="opacity" values="0;0;1;1;0;0" keyTimes="0;0.28;0.32;0.42;0.48;1" dur="16s" fill="freeze" repeatCount="indefinite"/></text>
+    <text x="700" y="216" opacity="0">walker-1  &#8594;  <tspan fill="#1F8A5B">east aisle</tspan><animate attributeName="opacity" values="0;0;0;1;1" keyTimes="0;0.42;0.48;0.52;1" dur="16s" fill="freeze" repeatCount="indefinite"/></text>
+  </g>
+  <!-- walker-2: east -> north (crossfade) -->
+  <g font-size="15" fill="#20242B">
+    <text x="700" y="288" opacity="0">walker-2  &#8594;  <tspan fill="#767C86">east aisle</tspan><animate attributeName="opacity" values="0;0;1;1;0;0" keyTimes="0;0.30;0.34;0.42;0.48;1" dur="16s" fill="freeze" repeatCount="indefinite"/></text>
+    <text x="700" y="288" opacity="0">walker-2  &#8594;  <tspan fill="#1F8A5B">north aisle</tspan><animate attributeName="opacity" values="0;0;0;1;1" keyTimes="0;0.42;0.48;0.52;1" dur="16s" fill="freeze" repeatCount="indefinite"/></text>
+  </g>
+
+  <!-- walker-3: goes quiet, fades -->
+  <g>
+    <g fill="none" stroke="#20242B" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" transform="translate(652,358)" opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1;0.28;0.28" keyTimes="0;0.26;0.32;0.56;0.62;1" dur="16s" fill="freeze" repeatCount="indefinite"/>
+      <rect x="-14" y="-8" width="28" height="10" rx="3"/><path d="M-10,2 v8 M-3,2 v8 M4,2 v8 M11,2 v8 M14,-3 L20,-8"/></g>
+    <text x="700" y="360" font-size="15" fill="#20242B" opacity="0">walker-3  &#8594;  west aisle<animate attributeName="opacity" values="0;0;1;1;0.28;0.28" keyTimes="0;0.28;0.32;0.56;0.62;1" dur="16s" fill="freeze" repeatCount="indefinite"/></text>
+    <text x="700" y="380" font-size="12.5" fill="#767C86" opacity="0">gone quiet<animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.60;0.64;1" dur="16s" fill="freeze" repeatCount="indefinite"/></text>
+  </g>
+
+  <!-- walker-4: arrives, new -->
+  <g>
+    <g fill="none" stroke="#20242B" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" transform="translate(652,430)" opacity="0">
+      <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.66;0.72;1" dur="16s" fill="freeze" repeatCount="indefinite"/>
+      <animateTransform attributeName="transform" additive="sum" type="translate" values="0 0;0 -2;0 0" dur="2.8s" repeatCount="indefinite"/>
+      <rect x="-14" y="-8" width="28" height="10" rx="3"/><path d="M-10,2 v8 M-3,2 v8 M4,2 v8 M11,2 v8 M14,-3 L20,-8"/></g>
+    <g font-size="15" opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.66;0.72;1" dur="16s" fill="freeze" repeatCount="indefinite"/>
+      <text x="700" y="426" fill="#20242B">walker-4  &#8594;  <tspan fill="#1F8A5B">south aisle</tspan></text>
+      <text x="700" y="446" font-size="12.5" fill="#C0792B">new: the definition never heard of it</text>
+    </g>
+  </g>
+</svg>

--- a/site/src/content/blog/mhs/07_datacenter_patrol.svg
+++ b/site/src/content/blog/mhs/07_datacenter_patrol.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1120 560" width="1120" height="560" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" role="img" aria-labelledby="pt pd">
+  <title id="pt">Physical agents change the room</title>
+  <desc id="pd">A datacenter aisle. Five equipment racks stand in a row, and above each a temperature mark rises against a dashed declared-limit line. A four-legged machine patrols the aisle under an agent's direction. One rack's temperature climbs past the declared limit and turns amber; the walker does not touch the rack; it draws a line to a person and announces that the rack has crossed its limit, leaving the judgement to the person. It reads temperature via the sensor pillar, was called to patrol via the remote-call pillar, and announces via the emit pillar. Values are illustrative; this is a design, not a recorded run.</desc>
+
+  <rect width="1120" height="560" fill="#FBFAF7"/>
+
+  <text x="60" y="66" font-size="27" font-weight="600" fill="#20242B" opacity="0">Digital agents change bits; physical agents change the room
+    <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.02;0.06;1" dur="16s" fill="freeze" repeatCount="indefinite"/></text>
+  <text x="60" y="94" font-size="14" fill="#767C86" opacity="0">A walker reads the heat off the racks and names what it sees; it does not decide what to do.
+    <animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.04;0.08;1" dur="16s" fill="freeze" repeatCount="indefinite"/></text>
+
+  <!-- declared limit line -->
+  <line x1="120" y1="252" x2="880" y2="252" stroke="#C0792B" stroke-width="1.4" stroke-dasharray="7 6" opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.10;0.16;1" dur="16s" fill="freeze" repeatCount="indefinite"/></line>
+  <text x="886" y="256" font-size="12" fill="#C0792B" opacity="0">declared limit<animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.12;0.18;1" dur="16s" fill="freeze" repeatCount="indefinite"/></text>
+
+  <!-- floor -->
+  <line x1="80" y1="470" x2="1000" y2="470" stroke="#E4E0D6" stroke-width="1.5" opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.06;0.12;1" dur="16s" fill="freeze" repeatCount="indefinite"/></line>
+
+  <!-- racks -->
+  <g fill="none" stroke="#B7B2A6" stroke-width="1.4" stroke-linejoin="round" opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.08;0.14;1" dur="16s" fill="freeze" repeatCount="indefinite"/>
+    <g transform="translate(180,0)"><rect x="-40" y="320" width="80" height="150" rx="4"/><line x1="-32" y1="356" x2="32" y2="356"/><line x1="-32" y1="392" x2="32" y2="392"/><line x1="-32" y1="428" x2="32" y2="428"/></g>
+    <g transform="translate(340,0)"><rect x="-40" y="320" width="80" height="150" rx="4"/><line x1="-32" y1="356" x2="32" y2="356"/><line x1="-32" y1="392" x2="32" y2="392"/><line x1="-32" y1="428" x2="32" y2="428"/></g>
+    <g transform="translate(500,0)"><rect x="-40" y="320" width="80" height="150" rx="4"/><line x1="-32" y1="356" x2="32" y2="356"/><line x1="-32" y1="392" x2="32" y2="392"/><line x1="-32" y1="428" x2="32" y2="428"/></g>
+    <g transform="translate(660,0)"><rect x="-40" y="320" width="80" height="150" rx="4"/><line x1="-32" y1="356" x2="32" y2="356"/><line x1="-32" y1="392" x2="32" y2="392"/><line x1="-32" y1="428" x2="32" y2="428"/></g>
+    <g transform="translate(820,0)"><rect x="-40" y="320" width="80" height="150" rx="4"/><line x1="-32" y1="356" x2="32" y2="356"/><line x1="-32" y1="392" x2="32" y2="392"/><line x1="-32" y1="428" x2="32" y2="428"/></g>
+  </g>
+  <g font-size="11" fill="#B7B2A6" text-anchor="middle" opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.14;0.20;1" dur="16s" fill="freeze" repeatCount="indefinite"/>
+    <text x="180" y="490">rack 1</text><text x="340" y="490">rack 2</text><text x="500" y="490">rack 3</text><text x="660" y="490">rack 4</text><text x="820" y="490">rack 5</text>
+  </g>
+
+  <!-- temperature marks rising above each rack -->
+  <g stroke-width="6" stroke-linecap="round">
+    <line x1="180" y1="320" x2="180" y2="320" stroke="#767C86"><animate attributeName="y2" values="320;320;278;278" keyTimes="0;0.18;0.28;1" dur="16s" fill="freeze" repeatCount="indefinite"/></line>
+    <line x1="340" y1="320" x2="340" y2="320" stroke="#767C86"><animate attributeName="y2" values="320;320;270;270" keyTimes="0;0.18;0.28;1" dur="16s" fill="freeze" repeatCount="indefinite"/></line>
+    <line x1="500" y1="320" x2="500" y2="320" stroke="#767C86"><animate attributeName="y2" values="320;320;288;288" keyTimes="0;0.18;0.28;1" dur="16s" fill="freeze" repeatCount="indefinite"/></line>
+    <line x1="660" y1="320" x2="660" y2="320" stroke="#767C86"><animate attributeName="y2" values="320;320;276;276;226;226" keyTimes="0;0.18;0.28;0.50;0.58;1" dur="16s" fill="freeze" repeatCount="indefinite"/><animate attributeName="stroke" values="#767C86;#767C86;#C0792B;#C0792B" keyTimes="0;0.50;0.58;1" dur="16s" fill="freeze" repeatCount="indefinite"/></line>
+    <line x1="820" y1="320" x2="820" y2="320" stroke="#767C86"><animate attributeName="y2" values="320;320;282;282" keyTimes="0;0.18;0.28;1" dur="16s" fill="freeze" repeatCount="indefinite"/></line>
+  </g>
+
+  <!-- the walker patrols the aisle -->
+  <g>
+    <animateTransform attributeName="transform" type="translate" values="150 442;150 442;790 442;790 442" keyTimes="0;0.24;0.54;1" dur="16s" fill="freeze" repeatCount="indefinite"/>
+    <g fill="none" stroke="#20242B" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+      <animateTransform attributeName="transform" type="translate" values="0 0;0 -2.5;0 0" dur="0.7s" repeatCount="indefinite"/>
+      <rect x="-16" y="-9" width="32" height="12" rx="3.5"/>
+      <path d="M-12,3 v11 M-4,3 v11 M4,3 v11 M12,3 v11 M16,-4 L24,-11"/>
+    </g>
+  </g>
+
+  <!-- person at the end of the aisle -->
+  <g fill="none" stroke="#20242B" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.54;0.60;1" dur="16s" fill="freeze" repeatCount="indefinite"/>
+    <circle cx="962" cy="400" r="9"/>
+    <path d="M962,409 v34 M962,418 L946,428 M962,418 L978,428 M962,443 L951,468 M962,443 L973,468"/>
+  </g>
+
+  <!-- announcement: line to the person, then words -->
+  <line x1="700" y1="430" x2="944" y2="418" stroke="#C0792B" stroke-width="1.8" stroke-linecap="round" stroke-dasharray="2 8" opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.60;0.66;1" dur="16s" fill="freeze" repeatCount="indefinite"/></line>
+  <g opacity="0"><animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.64;0.70;1" dur="16s" fill="freeze" repeatCount="indefinite"/>
+    <text x="612" y="150" font-size="15" font-weight="600" fill="#C0792B">rack 4 crossed its declared limit</text>
+    <text x="612" y="172" font-size="13" fill="#767C86">hands the judgement to a person; does not act on the rack</text>
+  </g>
+
+  <!-- pillar tags -->
+  <g font-size="12" fill="#1F8A5B">
+    <text x="60" y="300" opacity="0">@sensor · reads temperature<animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.28;0.34;1" dur="16s" fill="freeze" repeatCount="indefinite"/></text>
+    <text x="60" y="524" opacity="0">@rpc · called to patrol<animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.30;0.36;1" dur="16s" fill="freeze" repeatCount="indefinite"/></text>
+    <text x="612" y="192" opacity="0">@emit · announces the crossing<animate attributeName="opacity" values="0;0;1;1" keyTimes="0;0.68;0.74;1" dur="16s" fill="freeze" repeatCount="indefinite"/></text>
+  </g>
+</svg>


### PR DESCRIPTION
## What

Adds a blog post to the Strands site announcing that **Strands Robots is participating in the Model Hardware Standard (MHS) research preview**, and framing it around the peer-to-peer robot mesh that ships **today**.

- New post: `site/src/content/blog/mhs-any-machine-can-introduce-itself.mdx`
- 4 inline SVG figures under `site/src/content/blog/mhs/` (self-contained, no external assets, no build artifacts)

**Docs-only** — no source, config, or dependency changes.

## The idea

A robot is anything that can *introduce itself*: emit events, change its state or position, and announce results. The post builds that from four capabilities (`@sensor` / `@control` / `@rpc` / `@emit`), shows the mesh you already get from `Robot(...)` (`tell` / `broadcast` / `emergency_stop`), and explains why a written-down tool definition drifts while a self-describing machine stays current. Safety is device-owned: declared bounds and interlocks, plus an emergency stop anyone can trigger and only a person can clear.

Positioning is honest about status: the mesh is real and open source today; MHS is a provisional, not-yet-GA research preview from Anthropic, access by application.

## Verification

- `astro` dev server renders the post at `/blog/mhs-any-machine-can-introduce-itself/` → HTTP 200
- All 4 SVGs are well-formed XML and serve through the image pipeline
- Prose + figure text are typography-clean (no stray em-dashes; consistent punctuation between body and figure alt text)

## Notes for reviewers

- `authors: [cagatay-cali]` — assumes that author id exists in the site config; flag if it needs to be registered.
- `date: 2026-08-27` and `draft: false` — adjust the publish date / draft flag to fit the release schedule.
- The commit message body is a short poem for MHS & Strands Robots. If a squash-merge prefers a plain body, feel free to replace it on merge.
