### PR TITLE
fix(python): close agent trace span on BaseException cancellation

### DIFF
--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -1406,6 +1406,11 @@ class Agent(AgentBase):
                     self._end_agent_trace_span(error=e)
                     self._concurrency.complete(begin.registered_token, error=e)
                     raise
+                except BaseException as cancellation:
+                    # Waiter settlement deferred to the finally block (aborted path) — propagating
+                    # CancelledError into unrelated waiters would be incorrect.
+                    self._end_agent_trace_span(cancellation=cancellation)
+                    raise
 
         finally:
             if cancel_watcher is not None:
@@ -1778,15 +1783,20 @@ class Agent(AgentBase):
         self,
         response: AgentResult | None = None,
         error: Exception | None = None,
+        cancellation: BaseException | None = None,
     ) -> None:
         """Ends a trace span for the agent.
 
         Args:
-            span: The span to end.
             response: Response to record as a trace attribute.
             error: Error to record as a trace attribute.
+            cancellation: BaseException that cancelled the invocation (e.g. CancelledError).
         """
         if self.trace_span:
+            if cancellation is not None:
+                self.tracer.end_span_with_cancellation(self.trace_span, cancellation)
+                return
+
             trace_attributes: dict[str, Any] = {
                 "span": self.trace_span,
             }

--- a/strands-py/src/strands/telemetry/tracer.py
+++ b/strands-py/src/strands/telemetry/tracer.py
@@ -333,6 +333,28 @@ class Tracer:
         error = exception or Exception(error_message)
         self._end_span(span, error=error, error_message=error_message)
 
+    def end_span_with_cancellation(self, span: Span, cancellation: BaseException) -> None:
+        """End a span that was cancelled without marking it as success or failure.
+
+        Leaves the span status at its default UNSET (never sets OK or ERROR) and records
+        the cancellation type as an attribute so trace consumers can distinguish cancellation
+        from incomplete instrumentation.
+
+        Args:
+            span: The span to end.
+            cancellation: The BaseException that cancelled the operation.
+        """
+        if not span or not span.is_recording():
+            return
+
+        try:
+            span.set_attribute("gen_ai.event.end_time", datetime.now(timezone.utc).isoformat())
+            span.set_attribute("strands.cancellation.type", type(cancellation).__name__)
+        except Exception as exc:
+            logger.warning("error=<%s> | error while ending cancelled span", exc, exc_info=True)
+        finally:
+            span.end()
+
     def _add_event(
         self, span: Span | None, event_name: str, event_attributes: Attributes, to_span_attributes: bool = False
     ) -> None:

--- a/strands-py/tests/strands/agent/test_agent.py
+++ b/strands-py/tests/strands/agent/test_agent.py
@@ -1,3 +1,4 @@
+import asyncio
 import copy
 import importlib
 import json
@@ -11,6 +12,10 @@ from typing import Any
 from uuid import uuid4
 
 import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import StatusCode
 from pydantic import BaseModel
 
 import strands
@@ -26,7 +31,7 @@ from strands.interrupt import Interrupt
 from strands.memory import MemoryManager, MemoryManagerConfig
 from strands.models.bedrock import DEFAULT_BEDROCK_MODEL_ID, BedrockModel
 from strands.session.repository_session_manager import RepositorySessionManager
-from strands.telemetry.tracer import serialize
+from strands.telemetry.tracer import Tracer, serialize
 from strands.types._events import EventLoopStopEvent, ModelStreamEvent
 from strands.types.agent import ConcurrentInvocationMode
 from strands.types.content import ContentBlock, Messages
@@ -3495,3 +3500,69 @@ async def test_checkpoint_resume_schema_mismatch_raises_checkpoint_exception() -
     prompt = {"checkpointResume": {"checkpoint": {"schema_version": "0.1", "position": "after_model"}}}
     with pytest.raises(CheckpointException, match="schema version"):
         await agent.invoke_async(prompt)
+
+
+@pytest.mark.asyncio
+async def test_agent_span_ends_on_cancellation():
+    """Root agent span is exported when the invocation is cancelled via asyncio timeout."""
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    tracer = Tracer()
+    tracer.tracer_provider = provider
+    tracer.tracer = provider.get_tracer(tracer.service_name)
+
+    class SlowModel(MockedModelProvider):
+        async def stream(self, *args, **kwargs):
+            yield {"messageStart": {"role": "assistant"}}
+            yield {"contentBlockDelta": {"delta": {"text": "hi"}}}
+            await asyncio.sleep(10)
+
+    model = SlowModel([{"role": "assistant", "content": [{"text": "hi"}]}])
+
+    with unittest.mock.patch("strands.agent.agent.get_tracer", return_value=tracer):
+        agent = Agent(model=model, callback_handler=None)
+        with pytest.raises((asyncio.TimeoutError, asyncio.CancelledError)):
+            await asyncio.wait_for(agent.invoke_async("test"), timeout=0.1)
+
+    provider.force_flush()
+    spans = exporter.get_finished_spans()
+    agent_spans = [span for span in spans if span.name.startswith("invoke_agent")]
+    assert len(agent_spans) == 1
+    assert agent_spans[0].status.status_code == StatusCode.UNSET
+    assert agent_spans[0].attributes["strands.cancellation.type"] == "CancelledError"
+
+
+@pytest.mark.asyncio
+async def test_agent_span_ends_on_generator_exit():
+    """Root agent span is exported when consumer stops iterating (aclose/break)."""
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    tracer = Tracer()
+    tracer.tracer_provider = provider
+    tracer.tracer = provider.get_tracer(tracer.service_name)
+
+    class SlowModel(MockedModelProvider):
+        async def stream(self, *args, **kwargs):
+            yield {"messageStart": {"role": "assistant"}}
+            yield {"contentBlockDelta": {"delta": {"text": "hi"}}}
+            await asyncio.sleep(10)
+
+    model = SlowModel([{"role": "assistant", "content": [{"text": "hi"}]}])
+
+    with unittest.mock.patch("strands.agent.agent.get_tracer", return_value=tracer):
+        agent = Agent(model=model, callback_handler=None)
+        stream = agent.stream_async("test")
+        async for _event in stream:
+            break
+        await stream.aclose()
+
+    provider.force_flush()
+    spans = exporter.get_finished_spans()
+    agent_spans = [span for span in spans if span.name.startswith("invoke_agent")]
+    assert len(agent_spans) == 1
+    assert agent_spans[0].status.status_code == StatusCode.UNSET
+    assert agent_spans[0].attributes["strands.cancellation.type"] == "GeneratorExit"

--- a/strands-py/tests/strands/telemetry/test_tracer.py
+++ b/strands-py/tests/strands/telemetry/test_tracer.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import os
@@ -154,6 +155,43 @@ def test_end_span_with_error_prefers_explicit_message(mock_span):
 
     mock_span.set_status.assert_called_once_with(StatusCode.ERROR, "Explicit error message")
     mock_span.record_exception.assert_called_once_with(error)
+    mock_span.end.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "cancellation",
+    [asyncio.CancelledError(), KeyboardInterrupt(), SystemExit()],
+)
+def test_end_span_with_cancellation(mock_span, cancellation):
+    """Cancelled spans end with UNSET status and a cancellation type attribute."""
+    tracer = Tracer()
+
+    tracer.end_span_with_cancellation(mock_span, cancellation)
+
+    mock_span.set_attribute.assert_any_call("strands.cancellation.type", type(cancellation).__name__)
+    mock_span.set_status.assert_not_called()
+    mock_span.record_exception.assert_not_called()
+    mock_span.end.assert_called_once()
+
+
+def test_end_span_with_cancellation_not_recording(mock_span):
+    """No-op when the span is not recording."""
+    mock_span.is_recording.return_value = False
+    tracer = Tracer()
+
+    tracer.end_span_with_cancellation(mock_span, asyncio.CancelledError())
+
+    mock_span.set_attribute.assert_not_called()
+    mock_span.end.assert_not_called()
+
+
+def test_end_span_with_cancellation_attribute_error(mock_span):
+    """Span is still ended even when set_attribute raises."""
+    mock_span.set_attribute.side_effect = RuntimeError("oops")
+    tracer = Tracer()
+
+    tracer.end_span_with_cancellation(mock_span, asyncio.CancelledError())
+
     mock_span.end.assert_called_once()
 
 


### PR DESCRIPTION
 ## Description
<!-- Provide a detailed description of the changes in this PR -->

When an agent invocation is cancelled via asyncio.CancelledError, KeyboardInterrupt, or other BaseException subclasses, the root agent span was never ended because the existing except clause only catches Exception. This causes span exporters to drop the entire trace.

Add a targeted BaseException handler in stream_async() that ends the agent span with StatusCode.UNSET and a strands.cancellation.type attribute, distinguishing cancellation from success or failure.
## Related Issues

Related: #3609, #2068
<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix


## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [ ] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
