### PR TITLE
fix(file-editor): stop str_replace and insert from rewriting untouched bytes

### DIFF
--- a/strands-ts/src/vended-tools/file-editor/__tests__/file-editor.test.node.ts
+++ b/strands-ts/src/vended-tools/file-editor/__tests__/file-editor.test.node.ts
@@ -359,6 +359,152 @@ describe('fileEditor tool', () => {
           fileEditor.invoke({ command: 'str_replace', path: dirPath, old_str: 'OLD', new_str: 'NEW' }, context)
         ).rejects.toThrow('directory')
       })
+
+      it('rejects empty old_str', async () => {
+        const filePath = await createTestFile('test.txt', 'some content')
+        await expect(
+          fileEditor.invoke({ command: 'str_replace', path: filePath, old_str: '', new_str: 'x' }, context)
+        ).rejects.toThrow('must not be empty')
+      })
+
+      it('preserves tabs and CRLF outside the edited region', async () => {
+        const content = 'func a() {\n\treturn 1\n}\r\n\r\nfunc b() {\n\treturn 2\n}\n'
+        const filePath = await createTestFile('preserve.go', content)
+        await fileEditor.invoke(
+          { command: 'str_replace', path: filePath, old_str: '\treturn 1', new_str: '\treturn 10' },
+          context
+        )
+        const updated = await fs.readFile(filePath, 'utf-8')
+        expect(updated).toBe('func a() {\n\treturn 10\n}\r\n\r\nfunc b() {\n\treturn 2\n}\n')
+      })
+
+      it('reports correct line numbers for repeated multi-line old_str', async () => {
+        const content = 'if (x) {\n  do()\n}\nspacer\nif (x) {\n  do()\n}\n'
+        const filePath = await createTestFile('multi.txt', content)
+        await expect(
+          fileEditor.invoke(
+            { command: 'str_replace', path: filePath, old_str: 'if (x) {\n  do()\n}', new_str: 'z' },
+            context
+          )
+        ).rejects.toThrow(/lines \[1,5\]/)
+      })
+
+      it('preserves a file that is entirely tabs', async () => {
+        const content = '\t\t\tfirst\n\t\t\tsecond\n\t\t\tthird\n'
+        const filePath = await createTestFile('tabs.txt', content)
+        await fileEditor.invoke(
+          { command: 'str_replace', path: filePath, old_str: '\t\t\tsecond', new_str: '\t\t\treplaced' },
+          context
+        )
+        const updated = await fs.readFile(filePath, 'utf-8')
+        expect(updated).toBe('\t\t\tfirst\n\t\t\treplaced\n\t\t\tthird\n')
+      })
+
+      it('preserves an all-CRLF file when editing one line', async () => {
+        const content = 'line1\r\nline2\r\nline3\r\n'
+        const filePath = await createTestFile('crlf.txt', content)
+        await fileEditor.invoke(
+          { command: 'str_replace', path: filePath, old_str: 'line2', new_str: 'changed' },
+          context
+        )
+        const updated = await fs.readFile(filePath, 'utf-8')
+        expect(updated).toBe('line1\r\nchanged\r\nline3\r\n')
+      })
+
+      it('handles old_str that spans multiple lines', async () => {
+        const content = 'function hello() {\n  console.log("hi")\n  return true\n}\n'
+        const filePath = await createTestFile('span.ts', content)
+        await fileEditor.invoke(
+          {
+            command: 'str_replace',
+            path: filePath,
+            old_str: '  console.log("hi")\n  return true',
+            new_str: '  return false',
+          },
+          context
+        )
+        const updated = await fs.readFile(filePath, 'utf-8')
+        expect(updated).toBe('function hello() {\n  return false\n}\n')
+      })
+
+      it('handles replacing with empty string (deletion)', async () => {
+        const content = 'keep\ndelete me\nkeep too\n'
+        const filePath = await createTestFile('delete.txt', content)
+        await fileEditor.invoke({ command: 'str_replace', path: filePath, old_str: 'delete me\n' }, context)
+        const updated = await fs.readFile(filePath, 'utf-8')
+        expect(updated).toBe('keep\nkeep too\n')
+      })
+
+      it('handles special regex characters in old_str', async () => {
+        const content = 'price is $100.00 (USD)\nother line\n'
+        const filePath = await createTestFile('regex.txt', content)
+        await fileEditor.invoke(
+          { command: 'str_replace', path: filePath, old_str: '$100.00 (USD)', new_str: '$200.00 (EUR)' },
+          context
+        )
+        const updated = await fs.readFile(filePath, 'utf-8')
+        expect(updated).toBe('price is $200.00 (EUR)\nother line\n')
+      })
+
+      it('preserves binary-like content outside the edit', async () => {
+        const content = 'normal\n\x00\x01\x02\n\ttabbed\nnormal again\n'
+        const filePath = await createTestFile('binary.txt', content)
+        await fileEditor.invoke(
+          { command: 'str_replace', path: filePath, old_str: 'normal again', new_str: 'done' },
+          context
+        )
+        const updated = await fs.readFile(filePath, 'utf-8')
+        expect(updated).toBe('normal\n\x00\x01\x02\n\ttabbed\ndone\n')
+      })
+
+      it('handles replacement at the very start of file', async () => {
+        const content = 'first line\nsecond\n'
+        const filePath = await createTestFile('start.txt', content)
+        await fileEditor.invoke(
+          { command: 'str_replace', path: filePath, old_str: 'first line', new_str: 'new first' },
+          context
+        )
+        const updated = await fs.readFile(filePath, 'utf-8')
+        expect(updated).toBe('new first\nsecond\n')
+      })
+
+      it('handles replacement at the very end of file', async () => {
+        const content = 'first\nlast line'
+        const filePath = await createTestFile('end.txt', content)
+        await fileEditor.invoke(
+          { command: 'str_replace', path: filePath, old_str: 'last line', new_str: 'new last' },
+          context
+        )
+        const updated = await fs.readFile(filePath, 'utf-8')
+        expect(updated).toBe('first\nnew last')
+      })
+
+      it('handles replacement that makes file larger', async () => {
+        const content = 'x\n'
+        const filePath = await createTestFile('grow.txt', content)
+        await fileEditor.invoke(
+          {
+            command: 'str_replace',
+            path: filePath,
+            old_str: 'x',
+            new_str: 'a very long replacement string that is much bigger',
+          },
+          context
+        )
+        const updated = await fs.readFile(filePath, 'utf-8')
+        expect(updated).toBe('a very long replacement string that is much bigger\n')
+      })
+
+      it('handles mixed tabs and spaces without corrupting either', async () => {
+        const content = '\tindented with tab\n    indented with spaces\n  \tmixed\n'
+        const filePath = await createTestFile('mixed.txt', content)
+        await fileEditor.invoke(
+          { command: 'str_replace', path: filePath, old_str: '    indented with spaces', new_str: '    changed' },
+          context
+        )
+        const updated = await fs.readFile(filePath, 'utf-8')
+        expect(updated).toBe('\tindented with tab\n    changed\n  \tmixed\n')
+      })
     })
   })
 

--- a/strands-ts/src/vended-tools/file-editor/file-editor.ts
+++ b/strands-ts/src/vended-tools/file-editor/file-editor.ts
@@ -169,28 +169,30 @@ function buildStrReplaceResult(
   newStr: string | undefined,
   filePath: string
 ): { newContent: string; snippet: string; startLine: number } {
-  const fileContent = originalContent.replace(/\t/g, '        ')
-  const expandedOldStr = oldStr.replace(/\t/g, '        ')
-  const expandedNewStr = newStr ? newStr.replace(/\t/g, '        ') : ''
+  if (oldStr.length === 0) {
+    throw new Error(`No replacement was performed, old_str must not be empty.`)
+  }
 
-  const occurrences = (fileContent.match(new RegExp(escapeRegExp(expandedOldStr), 'g')) || []).length
-  if (occurrences === 0) {
+  const replacement = newStr ?? ''
+  const occurrences = findOccurrences(originalContent, oldStr)
+
+  if (occurrences.length === 0) {
     throw new Error(`No replacement was performed, old_str \`${oldStr}\` did not appear verbatim in ${filePath}.`)
   }
-  if (occurrences > 1) {
-    const lines = fileContent.split('\n')
-    const lineNumbers = lines
-      .map((line, index) => (line.includes(expandedOldStr) ? index + 1 : -1))
-      .filter((num) => num !== -1)
+  if (occurrences.length > 1) {
+    const lineNumbers = occurrences.map((occurrence) => occurrence.line)
     throw new Error(
       `No replacement was performed. Multiple occurrences of old_str \`${oldStr}\` in lines ${JSON.stringify(lineNumbers)}. Please ensure it is unique`
     )
   }
 
-  const newContent = fileContent.replace(expandedOldStr, () => expandedNewStr)
-  const replacementLine = fileContent.substring(0, fileContent.indexOf(expandedOldStr)).split('\n').length - 1
-  const insertedLines = expandedNewStr.split('\n').length
-  const originalLines = expandedOldStr.split('\n').length
+  const matchIndex = occurrences[0]!.offset
+  const newContent =
+    originalContent.slice(0, matchIndex) + replacement + originalContent.slice(matchIndex + oldStr.length)
+
+  const replacementLine = originalContent.substring(0, matchIndex).split('\n').length - 1
+  const insertedLines = replacement.split('\n').length
+  const originalLines = oldStr.split('\n').length
   const lineDifference = insertedLines - originalLines
 
   const newLines = newContent.split('\n')
@@ -211,11 +213,8 @@ function buildInsertResult(
   insertLine: number,
   newStr: string
 ): { newContent: string; snippet: string; startLine: number } {
-  const fileText = originalContent.replace(/\t/g, '        ')
-  const expandedNewStr = newStr.replace(/\t/g, '        ')
-
-  const fileTextLines = fileText.split('\n')
-  const nLines = fileTextLines.length
+  const fileLines = originalContent.split('\n')
+  const nLines = fileLines.length
 
   if (insertLine < 0 || insertLine > nLines) {
     throw new Error(
@@ -223,18 +222,33 @@ function buildInsertResult(
     )
   }
 
-  const newStrLines = expandedNewStr.split('\n')
-  const newFileTextLines =
-    fileText === ''
+  const newStrLines = newStr.split('\n')
+  const newFileLines =
+    originalContent === ''
       ? newStrLines
-      : [...fileTextLines.slice(0, insertLine), ...newStrLines, ...fileTextLines.slice(insertLine)]
+      : [...fileLines.slice(0, insertLine), ...newStrLines, ...fileLines.slice(insertLine)]
 
-  const newContent = newFileTextLines.join('\n')
+  const newContent = newFileLines.join('\n')
   const snippetStartLine = Math.max(0, insertLine - SNIPPET_LINES)
-  const snippetEndLine = Math.min(newFileTextLines.length, insertLine + newStrLines.length + SNIPPET_LINES)
-  const snippet = newFileTextLines.slice(snippetStartLine, snippetEndLine).join('\n')
+  const snippetEndLine = Math.min(newFileLines.length, insertLine + newStrLines.length + SNIPPET_LINES)
+  const snippet = newFileLines.slice(snippetStartLine, snippetEndLine).join('\n')
 
   return { newContent, snippet, startLine: snippetStartLine }
+}
+
+/**
+ * Finds all non-overlapping occurrences of `needle` in `haystack`,
+ * returning each match's byte offset and 1-based line number.
+ */
+function findOccurrences(haystack: string, needle: string): Array<{ offset: number; line: number }> {
+  const results: Array<{ offset: number; line: number }> = []
+  let position = 0
+  while ((position = haystack.indexOf(needle, position)) !== -1) {
+    const line = haystack.substring(0, position).split('\n').length
+    results.push({ offset: position, line })
+    position += needle.length
+  }
+  return results
 }
 
 /**
@@ -251,13 +265,6 @@ function makeOutput(fileContent: string, fileDescriptor: string, initLine: numbe
   })
 
   return `Here's the result of running \`cat -n\` on ${fileDescriptor}:\n${numberedLines.join('\n')}\n`
-}
-
-/**
- * Escapes special regex characters in a string.
- */
-function escapeRegExp(string: string): string {
-  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
 // ---- Sandbox-routed I/O helpers ----


### PR DESCRIPTION


## Summary

- `str_replace` and `insert` tab-expanded the entire file before writing it back — a one-line edit silently converted every `\t` to 8 spaces and mangled CRLF line endings across untouched regions
- Multi-line duplicate detection reported `in lines []` because `line.includes(multiLineStr)` can never match a string containing `\n`

Both are fixed by matching and splicing against the original bytes directly instead of transforming the file content first.

## Test plan

- [x] Verify the old code fails the byte-preservation test (tabs become spaces)
- [x] Verify the fix passes — only the matched region changes
- [x] 66 tests pass (54 existing + 12 new edge cases: all-tab files, all-CRLF, multi-line spans, regex metacharacters, file start/end edits, mixed whitespace, deletions)
- [x] Build, lint, type-check clean

Fixes #3175 (defects B and C).
