### PR TITLE
feat(ts): add backgroundTasks to Agent

### DIFF
--- a/strands-ts/src/__tests__/index.test.ts
+++ b/strands-ts/src/__tests__/index.test.ts
@@ -48,9 +48,11 @@ describe('index', () => {
         contextError: typeof SDK.ContextWindowOverflowError
         // Model provider
         provider: typeof SDK.BedrockModel
+        backgroundTasksConfig: SDK.BackgroundTasksConfig
       } = {
         contextError: SDK.ContextWindowOverflowError,
         provider: SDK.BedrockModel,
+        backgroundTasksConfig: { waitForCompletion: false, maxConcurrency: 2, timeout: 5_000 },
       }
       expect(_typeCheck).toBeDefined()
     })

--- a/strands-ts/src/agent/__tests__/agent-delegation.test.ts
+++ b/strands-ts/src/agent/__tests__/agent-delegation.test.ts
@@ -37,13 +37,14 @@ describe('AgentDelegation integration', () => {
         type: 'toolUseBlock',
         name: 'TechSupport',
         toolUseId: 'call-1',
-        input: { input: 'My wifi does not work' },
+        input: { input: 'My wifi does not work', _background_execution: true },
       })
 
       const orchestrator = new Agent({
         model: orchestratorModel,
         name: 'Orchestrator',
         tools: [billingAgent.asTool({ delegate: true }), techAgent.asTool({ delegate: true })],
+        backgroundTasks: {},
         printer: false,
       })
 

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -124,6 +124,8 @@ import {
   createTokenUsageMiddleware,
 } from '../context-manager/modes/agentic/agentic-context.js'
 import { ContextManager } from '../context-manager/context-manager.js'
+import { BackgroundTasks } from '../background-tasks/background-tasks.js'
+import type { BackgroundTasksConfig } from '../background-tasks/types.js'
 
 /**
  * Recursive type definition for nested tool arrays.
@@ -255,6 +257,8 @@ export type AgentConfig = {
    * Plugins to register with the agent.
    */
   plugins?: Plugin[]
+  /** Background tool execution configuration. */
+  backgroundTasks?: boolean | BackgroundTasksConfig
   /**
    * Retry strategy (or strategies) for failed model/tool calls.
    *
@@ -548,6 +552,7 @@ export class Agent implements LocalAgent, InvokableAgent {
   private readonly _checkpointing: boolean
   /** Direct tool caller — created via {@link ToolCaller.create} factory. */
   private readonly _toolCaller: ToolCallerProxy
+  private readonly _backgroundTasks: BackgroundTasks | undefined
 
   /**
    * Creates an instance of the Agent.
@@ -644,12 +649,37 @@ export class Agent implements LocalAgent, InvokableAgent {
     const hasAgentDelegation = (config?.plugins ?? []).some((p) => p.name === 'strands:agent-delegation')
 
     const contextManagerPlugin = config?.contextManager instanceof ContextManager ? config.contextManager : undefined
+    this._backgroundTasks = config?.backgroundTasks
+      ? new BackgroundTasks(
+          config.backgroundTasks === true ? {} : config.backgroundTasks,
+          (tool, context, middlewareInterrupt) =>
+            this._toolExecutor.executeBackground(
+              {
+                agent: this,
+                middlewareRegistry: this._middlewareRegistry,
+                // Isolate mutable local trace state from overlapping agent work. OTel spans
+                // still use the global provider; local traces are not added to AgentResult.traces.
+                tracer: new Tracer(config?.traceAttributes),
+                meter: this._meter,
+                cancelSignal: context.cancelSignal,
+                toolInterrupt: context.interrupt,
+                middlewareInterrupt,
+                toolGuard: (selectedTool) => this._backgroundTasks!.assertToolCanRun(selectedTool),
+              },
+              context.toolUse,
+              tool,
+              context.invocationState,
+              (event) => this._invokeCallbacks(event)
+            )
+        )
+      : undefined
 
     this._pluginRegistry = new PluginRegistry([
       ...(this._modelRouter ? [this._modelRouter] : []),
       this._conversationManager,
       ...retryStrategies,
       ...(config?.plugins ?? []),
+      ...(this._backgroundTasks ? [this._backgroundTasks] : []),
       ...(!hasAgentDelegation ? [new AgentDelegation()] : []),
       ...((config?.contextManager === 'auto' || config?.contextManager === 'agentic') && !hasOffloader
         ? [
@@ -1482,7 +1512,9 @@ export class Agent implements LocalAgent, InvokableAgent {
    * ```
    */
   public loadSnapshot(snapshot: Snapshot): void {
+    if (this._initialized) this._backgroundTasks?.assertCanLoadSnapshot()
     loadSnapshotInternal(this, snapshot)
+    if (this._initialized && 'state' in snapshot.data) this._backgroundTasks?._loadAppState()
   }
 
   /**
@@ -2440,6 +2472,10 @@ export class Agent implements LocalAgent, InvokableAgent {
             tracer: this._tracer,
             meter: this._meter,
             cancelSignal: this._abortSignal,
+            ...(this._backgroundTasks && {
+              backgroundTasks: this._backgroundTasks,
+              backgroundTaskPassId: assistantMessage.trackingId,
+            }),
           },
           {
             toolUseBlocks,

--- a/strands-ts/src/background-tasks/__tests__/background-tasks.test.ts
+++ b/strands-ts/src/background-tasks/__tests__/background-tasks.test.ts
@@ -1,0 +1,435 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+
+import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
+import { Agent } from '../../agent/agent.js'
+import { AfterToolCallEvent, BeforeToolCallEvent, InitializedEvent } from '../../hooks/events.js'
+import { Interrupt } from '../../interrupt.js'
+import { ExecuteToolStage, InvokeModelStage } from '../../middleware/index.js'
+import { tool } from '../../tools/tool-factory.js'
+import { InterruptResponseContent } from '../../types/interrupt.js'
+import type { ToolUseBlock } from '../../types/messages.js'
+import type { ToolSpec } from '../../tools/types.js'
+import type { BackgroundTask } from '../types.js'
+
+const BACKGROUND_TASKS_STATE_KEY = 'strands.backgroundTasks'
+
+function deliveries(agent: Agent): ToolUseBlock[] {
+  const blocks = agent.messages.flatMap((message) => message.content)
+  return blocks.filter(
+    (block): block is ToolUseBlock => block.type === 'toolUseBlock' && block.name === 'strands_background_task_result'
+  )
+}
+
+function persistedTasks(agent: Agent): BackgroundTask[] | undefined {
+  return agent.appState.get(BACKGROUND_TASKS_STATE_KEY) as unknown as BackgroundTask[] | undefined
+}
+
+describe('BackgroundTasks', () => {
+  it('dispatches selected calls through the normal tool pipeline and delivers their results', async () => {
+    const work = tool({
+      name: 'work',
+      description: 'Perform work.',
+      inputSchema: z.object({ value: z.string() }),
+      callback: ({ value }) => `done:${value}`,
+    })
+    const model = new MockMessageModel()
+      .addTurn({
+        type: 'toolUseBlock',
+        name: 'work',
+        toolUseId: 'work-use',
+        input: { value: 'background', _background_execution: true },
+      })
+      .addTurn({ type: 'textBlock', text: 'Tasks admitted.' })
+      .addTurn({ type: 'textBlock', text: 'Result received.' })
+    const agent = new Agent({
+      model,
+      tools: [work],
+      backgroundTasks: { agentic: [work] },
+      printer: false,
+    })
+    let toolSpecs: readonly ToolSpec[] | undefined
+    let middlewareCalls = 0
+    let retried = false
+    agent.addMiddleware(InvokeModelStage, async function* (context, next) {
+      toolSpecs ??= context.toolSpecs
+      return yield* next(context)
+    })
+    agent.addHook(AfterToolCallEvent, (event) => {
+      if (!retried) {
+        retried = true
+        event.retry = true
+      }
+    })
+    agent.addMiddleware(ExecuteToolStage, async function* (context, next) {
+      middlewareCalls++
+      return yield* next(context)
+    })
+
+    await agent.invoke('Run work.')
+
+    expect(middlewareCalls).toBe(2)
+    expect(toolSpecs?.find((spec) => spec.name === 'work')?.inputSchema?.properties).toHaveProperty(
+      '_background_execution'
+    )
+    const [delivery] = deliveries(agent)
+    expect(delivery).toEqual({
+      type: 'toolUseBlock',
+      name: 'strands_background_task_result',
+      toolUseId: expect.any(String),
+      input: { toolName: 'work' },
+    })
+    expect(agent.messages.flatMap((message) => message.content)).toContainEqual({
+      type: 'toolResultBlock',
+      toolUseId: delivery!.toolUseId,
+      status: 'success',
+      content: [{ type: 'textBlock', text: 'done:background' }],
+    })
+  })
+
+  it('applies always and never policies per tool', async () => {
+    const executions: string[] = []
+    const seenInputs: unknown[] = []
+    const background = tool({
+      name: 'background',
+      description: 'Run in the background.',
+      inputSchema: z.object({}).passthrough(),
+      callback: (input) => {
+        seenInputs.push(input)
+        executions.push('background')
+      },
+    })
+    const foreground = tool({
+      name: 'foreground',
+      description: 'Run in the foreground.',
+      inputSchema: z.object({}).passthrough(),
+      callback: (input) => {
+        seenInputs.push(input)
+        executions.push('foreground')
+      },
+    })
+    const incompatible = tool({
+      name: 'summarize_context',
+      description: 'Cannot run in the background.',
+      inputSchema: z.object({}),
+      callback: () => executions.push('incompatible'),
+    })
+    const model = new MockMessageModel()
+      .addTurn([
+        {
+          type: 'toolUseBlock',
+          name: 'foreground',
+          toolUseId: 'background-use',
+          input: { _background_execution: false },
+        },
+        {
+          type: 'toolUseBlock',
+          name: 'foreground',
+          toolUseId: 'foreground-use',
+          input: { _background_execution: true },
+        },
+        { type: 'toolUseBlock', name: 'foreground', toolUseId: 'incompatible-use', input: {} },
+      ])
+      .addTurn({ type: 'textBlock', text: 'Task admitted.' })
+      .addTurn({ type: 'textBlock', text: 'Result received.' })
+    const agent = new Agent({
+      model,
+      tools: [background, foreground],
+      backgroundTasks: { always: [background, incompatible], never: ['*'] },
+      printer: false,
+    })
+    let toolSpecs: readonly ToolSpec[] | undefined
+    agent.addMiddleware(InvokeModelStage, async function* (context, next) {
+      toolSpecs ??= context.toolSpecs
+      return yield* next(context)
+    })
+    agent.addHook(BeforeToolCallEvent, (event) => {
+      if (event.toolUse.toolUseId === 'background-use') event.toolUse.name = 'background'
+      if (event.toolUse.toolUseId === 'incompatible-use') event.selectedTool = incompatible
+    })
+
+    await agent.invoke('Run both.')
+
+    expect(executions.sort()).toEqual(['background', 'foreground'])
+    expect(seenInputs).toEqual([{}, {}])
+    expect(executions).not.toContain('incompatible')
+    expect(deliveries(agent)).toEqual([
+      {
+        type: 'toolUseBlock',
+        name: 'strands_background_task_result',
+        toolUseId: expect.any(String),
+        input: { toolName: 'background' },
+      },
+    ])
+    for (const name of ['background', 'foreground']) {
+      expect(toolSpecs?.find((spec) => spec.name === name)?.inputSchema?.properties).not.toHaveProperty(
+        '_background_execution'
+      )
+    }
+  })
+
+  it('rejects conflicting tool policies', () => {
+    const work = tool({
+      name: 'work',
+      description: 'Perform work.',
+      inputSchema: z.object({}),
+      callback: () => 'done',
+    })
+
+    expect(
+      () =>
+        new Agent({
+          model: new MockMessageModel(),
+          tools: [work],
+          backgroundTasks: { always: [work], never: [work] },
+        })
+    ).toThrow("Tool 'work' cannot be configured as both 'always' and 'never'")
+  })
+
+  it('delivers work that finishes between invocations', async () => {
+    let release!: () => void
+    const released = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const work = tool({
+      name: 'work',
+      description: 'Perform deferred work.',
+      inputSchema: z.object({}),
+      callback: async () => {
+        await released
+        return 'done'
+      },
+    })
+    const model = new MockMessageModel()
+      .addTurn({
+        type: 'toolUseBlock',
+        name: 'work',
+        toolUseId: 'work-use',
+        input: { _background_execution: true },
+      })
+      .addTurn({ type: 'textBlock', text: 'Task admitted.' })
+    const agent = new Agent({
+      model,
+      tools: [work],
+      backgroundTasks: { waitForCompletion: false },
+      printer: false,
+    })
+
+    await agent.invoke('Run work.')
+    expect(deliveries(agent)).toEqual([])
+    expect(() => agent.loadSnapshot(agent.takeSnapshot({ include: ['state'] }))).toThrow(
+      'Cannot load a snapshot while background tasks are still tracked'
+    )
+
+    release()
+    await expect
+      .poll(() => persistedTasks(agent))
+      .toEqual([
+        {
+          taskId: expect.any(String),
+          toolUseId: 'work-use',
+          toolName: 'work',
+          status: 'completed',
+          createdAt: expect.any(String),
+          lastUpdatedAt: expect.any(String),
+          result: { content: [{ text: 'done' }] },
+        },
+      ])
+    const snapshot = agent.takeSnapshot({ preset: 'session' })
+    const restored = new Agent({
+      model: new MockMessageModel().addTurn({ type: 'textBlock', text: 'Result received.' }),
+      tools: [],
+      backgroundTasks: {},
+      printer: false,
+    })
+    restored.loadSnapshot(snapshot)
+    await restored.invoke('Continue.')
+
+    expect(deliveries(restored)).toHaveLength(1)
+    expect(persistedTasks(restored)).toBeUndefined()
+  })
+
+  it('fails interrupted work restored from appState', async () => {
+    const createdAt = '2026-08-27T12:00:00.000Z'
+    const source = new Agent({ model: new MockMessageModel(), tools: [], printer: false })
+    const interrupt = new Interrupt({
+      id: 'tool:working:approve',
+      name: 'approve',
+      reason: 'Approve restored work?',
+      source: 'tool',
+    })
+    source.appState.set(BACKGROUND_TASKS_STATE_KEY, [
+      {
+        taskId: 'working',
+        toolUseId: 'working-use',
+        toolName: 'working-work',
+        status: 'input_required',
+        createdAt,
+        lastUpdatedAt: createdAt,
+        interrupts: [interrupt],
+      },
+    ])
+    source._interruptState.registerInterrupt(interrupt)
+    source._interruptState.activate()
+    const snapshot = source.takeSnapshot({ preset: 'session' })
+    const agent = new Agent({
+      model: new MockMessageModel().addTurn({ type: 'textBlock', text: 'Results received.' }),
+      tools: [],
+      backgroundTasks: {},
+      printer: false,
+    })
+    agent.addHook(InitializedEvent, () => agent.loadSnapshot(snapshot))
+
+    await agent.initialize()
+
+    expect(persistedTasks(agent)?.find((task) => task.taskId === 'working')).toEqual({
+      taskId: 'working',
+      toolUseId: 'working-use',
+      toolName: 'working-work',
+      status: 'failed',
+      createdAt,
+      lastUpdatedAt: expect.any(String),
+      error: { type: 'executionError', message: expect.any(String) },
+    })
+    await expect(
+      agent.tool.strands_manage_background_task!.invoke(
+        { mode: 'cancel', taskId: 'working' },
+        { recordDirectToolCall: false }
+      )
+    ).resolves.toEqual({
+      type: 'toolResultBlock',
+      toolUseId: expect.any(String),
+      status: 'success',
+      content: [{ type: 'jsonBlock', json: { taskId: 'working', status: 'failed' } }],
+    })
+
+    await agent.invoke('Continue.')
+
+    expect(deliveries(agent)).toEqual([
+      {
+        type: 'toolUseBlock',
+        name: 'strands_background_task_result',
+        toolUseId: 'working',
+        input: { toolName: 'working-work' },
+      },
+    ])
+  })
+
+  it('surfaces and resumes interrupts from detached tools', async () => {
+    let blockedStarted!: () => void
+    const blockedToolStarted = new Promise<void>((resolve) => {
+      blockedStarted = resolve
+    })
+    const approval = tool({
+      name: 'approval',
+      description: 'Wait for approval.',
+      inputSchema: z.object({}),
+      callback: () => 'approved',
+    })
+    const blocked = tool({
+      name: 'blocked',
+      description: 'Wait for release.',
+      inputSchema: z.object({}),
+      callback: async (_input, context) => {
+        blockedStarted()
+        await new Promise<void>((resolve) => {
+          context!.cancelSignal.addEventListener('abort', () => resolve(), { once: true })
+        })
+        return 'cancelled'
+      },
+    })
+    const model = new MockMessageModel()
+      .addTurn([
+        {
+          type: 'toolUseBlock',
+          name: 'approval',
+          toolUseId: 'approval-use',
+          input: { _background_execution: true },
+        },
+        {
+          type: 'toolUseBlock',
+          name: 'blocked',
+          toolUseId: 'blocked-use',
+          input: { _background_execution: true },
+        },
+      ])
+      .addTurn({ type: 'textBlock', text: 'Task admitted.' })
+      .addTurn({ type: 'textBlock', text: 'Task resumed.' })
+      .addTurn({ type: 'textBlock', text: 'Result received.' })
+    const agent = new Agent({ model, tools: [approval, blocked], backgroundTasks: {}, printer: false })
+    let toolSpecs: readonly ToolSpec[] | undefined
+    let response: string | undefined
+    agent.addMiddleware(InvokeModelStage, async function* (context, next) {
+      toolSpecs ??= context.toolSpecs
+      return yield* next(context)
+    })
+    agent.addMiddleware(ExecuteToolStage, async function* (context, next) {
+      if (context.toolUse.name === 'approval') {
+        response = context.interrupt<string>({ name: 'approve', reason: 'Approve work?' }).response
+      }
+      return yield* next(context)
+    })
+
+    const interrupted = await agent.invoke('Run approval.')
+    expect(interrupted.stopReason).toBe('interrupt')
+    expect(interrupted.interrupts).toEqual([
+      {
+        id: expect.any(String),
+        name: 'approve',
+        reason: 'Approve work?',
+        source: 'middleware',
+      },
+    ])
+
+    await blockedToolStarted
+    expect(
+      toolSpecs?.find((spec) => spec.name === 'strands_manage_background_task')?.inputSchema?.properties
+    ).not.toHaveProperty('_background_execution')
+    const blockedTask = persistedTasks(agent)?.find((task) => task.toolName === 'blocked')
+    expect(blockedTask).toBeDefined()
+    await expect(
+      agent.tool.strands_manage_background_task!.invoke(
+        { mode: 'get', taskId: blockedTask!.taskId },
+        { recordDirectToolCall: false }
+      )
+    ).resolves.toEqual({
+      type: 'toolResultBlock',
+      toolUseId: expect.any(String),
+      status: 'success',
+      content: [
+        {
+          type: 'jsonBlock',
+          json: {
+            taskId: blockedTask!.taskId,
+            toolUseId: 'blocked-use',
+            toolName: 'blocked',
+            status: 'working',
+            createdAt: expect.any(String),
+            lastUpdatedAt: expect.any(String),
+          },
+        },
+      ],
+    })
+    await expect(
+      agent.tool.strands_manage_background_task!.invoke(
+        { mode: 'cancel', taskId: blockedTask!.taskId },
+        { recordDirectToolCall: false }
+      )
+    ).resolves.toEqual({
+      type: 'toolResultBlock',
+      toolUseId: expect.any(String),
+      status: 'success',
+      content: [{ type: 'jsonBlock', json: { taskId: blockedTask!.taskId, status: 'cancelled' } }],
+    })
+
+    await agent.invoke([
+      new InterruptResponseContent({
+        interruptId: interrupted.interrupts![0]!.id,
+        response: 'yes',
+      }),
+    ])
+
+    expect(response).toBe('yes')
+    expect(deliveries(agent)).toHaveLength(2)
+  })
+})

--- a/strands-ts/src/background-tasks/background-tasks.ts
+++ b/strands-ts/src/background-tasks/background-tasks.ts
@@ -61,12 +61,22 @@ export class BackgroundTasks implements Plugin {
     this._manageTool = tool({
       name: MANAGE_TOOL_NAME,
       description:
-        'Inspect or cancel a background task. Completed results are delivered automatically; do not poll with this tool.',
+        'List, inspect, or cancel background tasks. Completed results are delivered automatically; do not poll with this tool.',
       inputSchema: z.object({
-        mode: z.enum(['get', 'cancel']).describe('Whether to inspect or cancel the background task.'),
-        taskId: z.string().min(1).describe('The background task ID returned when the task was dispatched.'),
+        mode: z.enum(['list', 'get', 'cancel']).describe('Whether to list, inspect, or cancel background tasks.'),
+        taskId: z
+          .string()
+          .min(1)
+          .optional()
+          .describe('The background task ID returned when the task was dispatched. Required for get and cancel.'),
       }),
       callback: async ({ mode, taskId }) => {
+        if (mode === 'list') {
+          return {
+            tasks: [...this._tasks.values()].map(({ taskId, toolName, status }) => ({ taskId, toolName, status })),
+          }
+        }
+        if (!taskId) throw new TypeError(`Task ID is required for mode '${mode}'`)
         const task = this._tasks.get(taskId)
         if (!task) throw new BackgroundTaskNotFoundError(taskId)
         if (mode === 'get') return task
@@ -178,7 +188,20 @@ export class BackgroundTasks implements Plugin {
       return new ToolResultBlock({
         toolUseId: toolUse.toolUseId,
         status: 'success',
-        content: [new TextBlock(`Background task dispatched.\n\nTask ID: ${task.taskId}`)],
+        content: [
+          new TextBlock(
+            [
+              'Background task dispatched.',
+              '',
+              `Task ID: ${task.taskId}`,
+              `Tool: ${task.toolName}`,
+              `Status: ${task.status}`,
+              '',
+              'The task is running in the background. Continue without waiting or polling.',
+              'The final result will be delivered automatically when the task completes.',
+            ].join('\n')
+          ),
+        ],
       })
     } catch (error) {
       logger.warn(`error=<${error}> | background task admission failed`)
@@ -401,7 +424,7 @@ function resolvePolicy(config: BackgroundTasksConfig): ReadonlyMap<string, 'neve
 
   for (const [mode, selectors] of assignments) {
     for (const selector of selectors) {
-      const name = selector === '*' ? selector : selector.name
+      const name = typeof selector === 'string' ? selector : selector.name
       const existing = policy.get(name)
       if (existing && existing !== mode) {
         throw new TypeError(`Tool '${name}' cannot be configured as both '${existing}' and '${mode}'`)

--- a/strands-ts/src/background-tasks/background-tasks.ts
+++ b/strands-ts/src/background-tasks/background-tasks.ts
@@ -1,0 +1,427 @@
+import { z } from 'zod'
+
+import { continuations } from '../agent/continuation.js'
+import { AgentAsTool } from '../agent/agent-as-tool.js'
+import { AfterInvocationEvent, BeforeModelCallEvent, InitializedEvent } from '../hooks/events.js'
+import { HookOrder } from '../hooks/types.js'
+import { InterruptError } from '../interrupt.js'
+import { logger } from '../logging/logger.js'
+import { InvokeModelStage, type ExecuteToolContext } from '../middleware/index.js'
+import type { Plugin } from '../plugins/plugin.js'
+import { STRUCTURED_OUTPUT_TOOL_NAME } from '../tools/structured-output-tool.js'
+import { tool } from '../tools/tool-factory.js'
+import type { Tool, ToolContext } from '../tools/tool.js'
+import type { ToolSpec } from '../tools/types.js'
+import { Message, TextBlock, ToolResultBlock, ToolUseBlock, toolResultContentFromData } from '../types/messages.js'
+
+import { BackgroundTaskNotFoundError } from './errors.js'
+import { InProcessTaskManager } from './in-process/manager.js'
+
+import type { Agent } from '../agent/agent.js'
+import type { ToolUseData } from '../hooks/events.js'
+import type { InvocationState, LocalAgent } from '../types/agent.js'
+import type { BackgroundTaskManager } from './manager.js'
+import { isTaskStatusTerminal, type BackgroundTask, type BackgroundTasksConfig } from './types.js'
+
+const BACKGROUND_TASKS_STATE_KEY = 'strands.backgroundTasks'
+const BACKGROUND_PROPERTY = '_background_execution'
+const MANAGE_TOOL_NAME = 'strands_manage_background_task'
+const COMPOSITE_SCHEMA_KEYS = ['$ref', 'allOf', 'anyOf', 'oneOf', 'not', 'if', 'then', 'else'] as const
+const FOREGROUND_TOOL_NAMES = new Set([
+  MANAGE_TOOL_NAME,
+  STRUCTURED_OUTPUT_TOOL_NAME,
+  'summarize_context',
+  'truncate_context',
+  'pin_context',
+])
+
+/** @internal */
+export class BackgroundTasks implements Plugin {
+  readonly name = 'strands:background-tasks'
+
+  private readonly _config: BackgroundTasksConfig
+  private readonly _executeTool
+  private readonly _policy: ReturnType<typeof resolvePolicy>
+  private readonly _manageTool: Tool
+  private readonly _tasks = new Map<string, BackgroundTask>()
+  private _agent!: Agent
+  private _manager!: BackgroundTaskManager
+
+  constructor(
+    config: BackgroundTasksConfig,
+    executeTool: (
+      tool: Tool,
+      context: ToolContext,
+      middlewareInterrupt: ExecuteToolContext['interrupt']
+    ) => Promise<ToolResultBlock>
+  ) {
+    this._config = config
+    this._executeTool = executeTool
+    this._policy = resolvePolicy(config)
+    this._manageTool = tool({
+      name: MANAGE_TOOL_NAME,
+      description:
+        'Inspect or cancel a background task. Completed results are delivered automatically; do not poll with this tool.',
+      inputSchema: z.object({
+        mode: z.enum(['get', 'cancel']).describe('Whether to inspect or cancel the background task.'),
+        taskId: z.string().min(1).describe('The background task ID returned when the task was dispatched.'),
+      }),
+      callback: async ({ mode, taskId }) => {
+        const task = this._tasks.get(taskId)
+        if (!task) throw new BackgroundTaskNotFoundError(taskId)
+        if (mode === 'get') return task
+        const cancelled = isTaskStatusTerminal(task.status) ? task : await this._manager.cancel(taskId)
+        return { taskId: cancelled.taskId, status: cancelled.status }
+      },
+    })
+  }
+
+  getTools(): Tool[] {
+    return [this._manageTool]
+  }
+
+  initAgent(agent: LocalAgent): void {
+    this._agent = agent as Agent
+    for (const tool of agent.toolRegistry.list()) {
+      const policy = this._policyFor(tool)
+      if (!policy?.exact || policy.mode === 'never') continue
+      const toolName = tool.name
+      if (!canExecuteInBackground(tool)) throw new TypeError(`Tool '${toolName}' cannot run in the background`)
+      if (policy.mode === 'agentic' && !canSelectBackground(tool)) {
+        throw new TypeError(`Tool '${toolName}' cannot use agentic background selection`)
+      }
+    }
+    this._manager = new InProcessTaskManager(this._agent, this._executeTool, {
+      ...(this._config.maxConcurrency !== undefined && { maxConcurrency: this._config.maxConcurrency }),
+      ...(this._config.timeout !== undefined && { timeout: this._config.timeout }),
+      onTaskUpdated: (task): void => {
+        this._tasks.set(task.taskId, task)
+        this._persistTasks()
+      },
+    })
+
+    agent.addMiddleware(InvokeModelStage.Input, async (context) => ({
+      ...context,
+      toolSpecs: context.toolSpecs.map((spec) => {
+        const tool = agent.toolRegistry.get(spec.name)
+        const policy = this._policyFor(tool)
+        if (policy?.mode !== 'agentic') return spec
+        if (!canExecuteInBackground(tool)) {
+          if (policy.exact) throw new TypeError(`Tool '${spec.name}' cannot use agentic background selection`)
+          return spec
+        }
+        const transformed = addBackgroundSelection(spec)
+        if (!transformed && policy.exact) {
+          throw new TypeError(`Tool '${spec.name}' cannot use agentic background selection`)
+        }
+        return transformed ?? spec
+      }),
+    }))
+
+    agent.addHook(BeforeModelCallEvent, (event) => this._beforeModelCall(event))
+    agent.addHook(AfterInvocationEvent, (event) => this._afterInvocation(event))
+    agent.addHook(InitializedEvent, () => this._loadAppState(), { order: HookOrder.SDK_LAST })
+  }
+
+  /**
+   * Decides foreground vs background. Strips `_background_execution` from
+   * `toolUse.input` so the real tool never sees the selection flag.
+   *
+   * @returns `true` to submit as background, a `ToolResultBlock` admission
+   *   error, or `undefined` to run in the foreground.
+   */
+  routeToolCall(
+    toolUse: ToolUseData,
+    requestedTool: Tool | undefined,
+    effectiveTool: Tool | undefined
+  ): true | ToolResultBlock | undefined {
+    let selected = false
+    if (
+      toolUse.input !== null &&
+      typeof toolUse.input === 'object' &&
+      !Array.isArray(toolUse.input) &&
+      BACKGROUND_PROPERTY in toolUse.input
+    ) {
+      const { [BACKGROUND_PROPERTY]: value, ...input } = toolUse.input
+      if (typeof value !== 'boolean') {
+        return toolError(toolUse.toolUseId, `'${BACKGROUND_PROPERTY}' must be a boolean`)
+      }
+      if (this._policyFor(requestedTool)?.mode === 'agentic') selected = value
+      toolUse.input = input
+    }
+
+    const policy = this._policyFor(effectiveTool)
+    if (!policy || policy.mode === 'never') return
+    if (!canExecuteInBackground(effectiveTool)) {
+      return policy.exact
+        ? toolError(toolUse.toolUseId, `Tool '${toolUse.name}' cannot run in the background`)
+        : undefined
+    }
+    if (policy.mode === 'agentic' && !canSelectBackground(effectiveTool)) {
+      return policy.exact
+        ? toolError(toolUse.toolUseId, `Tool '${toolUse.name}' cannot use agentic background selection`)
+        : undefined
+    }
+    return policy.mode === 'always' || selected ? true : undefined
+  }
+
+  async submitToolCall(
+    toolUse: ToolUseData,
+    invocationState: InvocationState,
+    passId: string,
+    tool: Tool
+  ): Promise<ToolResultBlock> {
+    if (this._agent.cancelSignal.aborted) return toolError(toolUse.toolUseId, 'Tool execution cancelled')
+
+    try {
+      const task = await this._manager.submit(toolUse, invocationState, passId, tool)
+      return new ToolResultBlock({
+        toolUseId: toolUse.toolUseId,
+        status: 'success',
+        content: [new TextBlock(`Background task dispatched.\n\nTask ID: ${task.taskId}`)],
+      })
+    } catch (error) {
+      logger.warn(`error=<${error}> | background task admission failed`)
+      return toolError(toolUse.toolUseId, 'Background task admission failed')
+    }
+  }
+
+  assertToolCanRun(tool: Tool | undefined): void {
+    const policy = this._policyFor(tool)
+    if (!canExecuteInBackground(tool) || !policy || policy.mode === 'never') {
+      throw new Error('Tool cannot run in the background')
+    }
+  }
+
+  assertCanLoadSnapshot(): void {
+    if (this._manager.hasTasks()) {
+      throw new Error('Cannot load a snapshot while background tasks are still tracked')
+    }
+  }
+
+  private async _beforeModelCall(event: BeforeModelCallEvent): Promise<void> {
+    const interruptState = this._agent._interruptState
+    const responses = interruptState.resumeResponses
+    if (responses) {
+      const inputTasks = (await this._manager.list()).filter((task) => task.status === 'input_required')
+      const taskInterruptIds = new Set(
+        inputTasks.flatMap((task) => task.interrupts?.map((interrupt) => interrupt.id) ?? [])
+      )
+      for (const task of inputTasks) {
+        const interruptIds = new Set(task.interrupts?.map((interrupt) => interrupt.id))
+        const taskResponses = responses
+          .map((content) => content.interruptResponse)
+          .filter((response) => interruptIds.has(response.interruptId))
+        if (taskResponses.length > 0) await this._manager.resume(task.taskId, taskResponses)
+      }
+      if (Object.keys(interruptState.interrupts).every((id) => taskInterruptIds.has(id))) {
+        interruptState.deactivate()
+      }
+    }
+
+    const tasks = [...this._tasks.values()]
+    const interrupts = tasks.flatMap((task) => (task.status === 'input_required' ? (task.interrupts ?? []) : []))
+    if (interrupts.length > 0) throw new InterruptError([...interrupts])
+    this._deliverReady(event, tasks)
+  }
+
+  private async _afterInvocation(event: AfterInvocationEvent): Promise<void> {
+    const agent = event.agent as Agent
+    if (agent._interruptState.activated) return
+    let tasks = [...this._tasks.values()]
+    while (
+      this._config.waitForCompletion !== false &&
+      !agent.cancelSignal.aborted &&
+      !tasks.some((task) => task.status === 'input_required') &&
+      tasks.some((task) => !isTaskStatusTerminal(task.status))
+    ) {
+      await this._awaitNextSettlement(tasks, agent.cancelSignal)
+      tasks = [...this._tasks.values()]
+    }
+    if (tasks.some((task) => task.status === 'input_required')) {
+      event.resume ??= []
+      return
+    }
+    this._deliverReady(event, tasks)
+  }
+
+  /** Races pending-task settlement against invocation cancellation. */
+  private async _awaitNextSettlement(tasks: readonly BackgroundTask[], cancelSignal: AbortSignal): Promise<void> {
+    let abort: () => void
+    const cancelled = new Promise<void>((resolve) => {
+      abort = resolve
+      if (cancelSignal.aborted) {
+        resolve()
+      } else {
+        cancelSignal.addEventListener('abort', abort, { once: true })
+      }
+    })
+    try {
+      await Promise.race([
+        cancelled,
+        ...tasks.filter((task) => !isTaskStatusTerminal(task.status)).map((task) => this._manager.wait(task.taskId)),
+      ])
+    } finally {
+      cancelSignal.removeEventListener('abort', abort!)
+    }
+  }
+
+  private _deliverReady(event: BeforeModelCallEvent | AfterInvocationEvent, tasks: readonly BackgroundTask[]): void {
+    const terminalTasks = tasks.filter((task) => isTaskStatusTerminal(task.status))
+    if (terminalTasks.length === 0) return
+
+    const taskIds = terminalTasks.map((task) => task.taskId)
+    continuations.addInput(event, {
+      args: terminalTasks.flatMap((task) => {
+        const content = task.result?.content.map(toolResultContentFromData) ?? [
+          new TextBlock(task.error?.message ?? 'Background task cancelled'),
+        ]
+        return [
+          new Message({
+            role: 'assistant',
+            content: [
+              new ToolUseBlock({
+                name: 'strands_background_task_result',
+                toolUseId: task.taskId,
+                input: { toolName: task.toolName },
+              }),
+            ],
+          }),
+          new Message({
+            role: 'user',
+            content: [
+              new ToolResultBlock({
+                toolUseId: task.taskId,
+                status: task.status === 'completed' ? 'success' : 'error',
+                content,
+              }),
+            ],
+          }),
+        ]
+      }),
+      onAppended: async () => {
+        const liveTaskIds = new Set((await this._manager.list()).map((task) => task.taskId))
+        const managerTaskIds = taskIds.filter((taskId) => liveTaskIds.has(taskId))
+        await this._manager.remove(managerTaskIds)
+        for (const taskId of taskIds) this._tasks.delete(taskId)
+        this._persistTasks()
+      },
+    })
+  }
+
+  _loadAppState(): void {
+    this._tasks.clear()
+    const storedTasks =
+      (this._agent.appState.get(BACKGROUND_TASKS_STATE_KEY) as unknown as BackgroundTask[] | undefined) ?? []
+    const recoveredInterruptIds = new Set<string>()
+    for (const task of storedTasks) {
+      if (!isTaskStatusTerminal(task.status)) {
+        for (const interrupt of task.interrupts ?? []) recoveredInterruptIds.add(interrupt.id)
+      }
+      this._tasks.set(task.taskId, recoverTask(task))
+    }
+    for (const interruptId of recoveredInterruptIds) delete this._agent._interruptState.interrupts[interruptId]
+    if (this._agent._interruptState.activated && this._agent._interruptState.getInterruptsList().length === 0) {
+      this._agent._interruptState.deactivate()
+    }
+    this._persistTasks()
+  }
+
+  private _persistTasks(): void {
+    if (this._tasks.size === 0) {
+      this._agent.appState.delete(BACKGROUND_TASKS_STATE_KEY)
+      return
+    }
+    this._agent.appState.set(BACKGROUND_TASKS_STATE_KEY, [...this._tasks.values()])
+  }
+
+  private _policyFor(
+    tool: Tool | undefined
+  ): { readonly mode: 'never' | 'agentic' | 'always'; readonly exact: boolean } | undefined {
+    if (!tool) return undefined
+    const exact = this._policy.get(tool.name)
+    if (exact) return { mode: exact, exact: true }
+    const wildcard = this._policy.get('*')
+    return wildcard ? { mode: wildcard, exact: false } : undefined
+  }
+}
+
+function toolError(toolUseId: string, message: string): ToolResultBlock {
+  return new ToolResultBlock({
+    toolUseId,
+    status: 'error',
+    content: [new TextBlock(message)],
+    error: new Error(message),
+  })
+}
+
+function canExecuteInBackground(tool: Tool | undefined): tool is Tool {
+  return tool !== undefined && !FOREGROUND_TOOL_NAMES.has(tool.name) && !(tool instanceof AgentAsTool && tool.delegate)
+}
+
+function canSelectBackground(tool: Tool): boolean {
+  return addBackgroundSelection(tool.toolSpec) !== undefined
+}
+
+function addBackgroundSelection(toolSpec: ToolSpec): ToolSpec | undefined {
+  const schema = toolSpec.inputSchema ?? {}
+  if (
+    COMPOSITE_SCHEMA_KEYS.some((key) => schema[key] !== undefined) ||
+    (schema.type !== undefined && schema.type !== 'object') ||
+    (schema.properties !== undefined && (typeof schema.properties !== 'object' || Array.isArray(schema.properties))) ||
+    schema.properties?.[BACKGROUND_PROPERTY] !== undefined ||
+    schema.required?.includes(BACKGROUND_PROPERTY)
+  ) {
+    return
+  }
+  return {
+    ...toolSpec,
+    inputSchema: {
+      ...schema,
+      type: 'object',
+      properties: {
+        ...schema.properties,
+        [BACKGROUND_PROPERTY]: {
+          type: 'boolean',
+          description: 'Run this tool in the background and continue without waiting for its result.',
+        },
+      },
+    },
+  }
+}
+
+function resolvePolicy(config: BackgroundTasksConfig): ReadonlyMap<string, 'never' | 'agentic' | 'always'> {
+  const hasExplicitWildcard = config.always?.includes('*') || config.never?.includes('*')
+  const assignments = [
+    ['agentic', config.agentic ?? (hasExplicitWildcard ? [] : ['*'])],
+    ['always', config.always ?? []],
+    ['never', config.never ?? []],
+  ] as const
+  const policy = new Map<string, 'never' | 'agentic' | 'always'>()
+
+  for (const [mode, selectors] of assignments) {
+    for (const selector of selectors) {
+      const name = selector === '*' ? selector : selector.name
+      const existing = policy.get(name)
+      if (existing && existing !== mode) {
+        throw new TypeError(`Tool '${name}' cannot be configured as both '${existing}' and '${mode}'`)
+      }
+      policy.set(name, mode)
+    }
+  }
+
+  return policy
+}
+
+function recoverTask(task: BackgroundTask): BackgroundTask {
+  if (!isTaskStatusTerminal(task.status)) {
+    const { interrupts: _interrupts, ...persisted } = task
+    return {
+      ...persisted,
+      status: 'failed',
+      lastUpdatedAt: new Date().toISOString(),
+      error: { type: 'executionError', message: 'Background task cannot resume after restoring persisted state' },
+    }
+  }
+  return task
+}

--- a/strands-ts/src/background-tasks/in-process/manager.ts
+++ b/strands-ts/src/background-tasks/in-process/manager.ts
@@ -1,6 +1,8 @@
 import type { Agent } from '../../agent/agent.js'
 import type { ToolUseData } from '../../hooks/events.js'
 import { InterruptError, InterruptState } from '../../interrupt.js'
+import { createMiddlewareInterrupt } from '../../middleware/interrupt.js'
+import type { ExecuteToolContext } from '../../middleware/index.js'
 import type { InvocationState } from '../../types/agent.js'
 import { InterruptResponseContent, type InterruptParams, type InterruptResponse } from '../../types/interrupt.js'
 import type { JSONValue } from '../../types/json.js'
@@ -29,6 +31,7 @@ export interface InProcessTaskManagerConfig {
   readonly maxConcurrency?: number
   /** Per-execution timeout in milliseconds. Defaults to `Infinity`. */
   readonly timeout?: number
+  readonly onTaskUpdated?: (task: BackgroundTask) => void
 }
 
 /** Executes approved tool calls as in-process background tasks. @internal */
@@ -40,16 +43,13 @@ export class InProcessTaskManager implements BackgroundTaskManager {
   private readonly _taskIdBySubmission = new Map<string, string>()
   private readonly _taskWaiters = new Map<string, Set<(task: BackgroundTask) => void>>()
 
-  /**
-   * Creates an in-process background task manager.
-   *
-   * @param agent - Agent whose registered tools execute background work.
-   * @param executeTool - Executes an approved tool through the Agent's tool pipeline.
-   * @param config - Execution limits.
-   */
   constructor(
     agent: Agent,
-    executeTool: (tool: Tool, context: ToolContext) => Promise<ToolResultBlock>,
+    executeTool: (
+      tool: Tool,
+      context: ToolContext,
+      middlewareInterrupt: ExecuteToolContext['interrupt']
+    ) => Promise<ToolResultBlock>,
     config: InProcessTaskManagerConfig = {}
   ) {
     this._agent = agent
@@ -59,17 +59,18 @@ export class InProcessTaskManager implements BackgroundTaskManager {
       timeout: config.timeout ?? Infinity,
       execute: (context): Promise<InProcessTaskExecutionOutcome> => this._executeToolTask(context),
       onTaskUpdated: (record): void => {
+        const task = toBackgroundTask(record)
         if (isTaskStatusTerminal(record.status)) {
           this._executions.delete(record.invocationStateId)
         }
         if (record.status === 'input_required' || isTaskStatusTerminal(record.status)) {
-          this._notifyTaskWaiters(record)
+          this._notifyTaskWaiters(task)
         }
+        config.onTaskUpdated?.(task)
       },
     })
   }
 
-  /** {@inheritDoc BackgroundTaskManager.submit} */
   async submit(
     toolUse: Readonly<ToolUseData>,
     invocationState: InvocationState,
@@ -95,23 +96,23 @@ export class InProcessTaskManager implements BackgroundTaskManager {
     return toBackgroundTask(record)
   }
 
-  /** {@inheritDoc BackgroundTaskManager.get} */
   async get(taskId: string): Promise<BackgroundTask | undefined> {
     const record = this._engine.get(taskId)
     return record ? toBackgroundTask(record) : undefined
   }
 
-  /** {@inheritDoc BackgroundTaskManager.list} */
   async list(): Promise<readonly BackgroundTask[]> {
     return this._engine.list().map(toBackgroundTask)
   }
 
-  /** {@inheritDoc BackgroundTaskManager.cancel} */
+  hasTasks(): boolean {
+    return this._taskIdBySubmission.size > 0
+  }
+
   async cancel(taskId: string): Promise<BackgroundTask> {
     return toBackgroundTask(this._engine.cancel(taskId, { reason: 'Cancellation requested' }))
   }
 
-  /** {@inheritDoc BackgroundTaskManager.wait} */
   async wait(taskId: string): Promise<BackgroundTask> {
     const current = this._engine.get(taskId)
     if (!current) throw new BackgroundTaskNotFoundError(taskId)
@@ -131,7 +132,6 @@ export class InProcessTaskManager implements BackgroundTaskManager {
     })
   }
 
-  /** {@inheritDoc BackgroundTaskManager.waitForIdle} */
   async waitForIdle(options?: { readonly timeout?: number }): Promise<void> {
     const timeout = options?.timeout
     if (timeout !== undefined) assertTimerDelay('wait timeout', timeout)
@@ -146,7 +146,6 @@ export class InProcessTaskManager implements BackgroundTaskManager {
     }
   }
 
-  /** {@inheritDoc BackgroundTaskManager.resume} */
   async resume(taskId: string, responses: readonly InterruptResponse[]): Promise<BackgroundTask> {
     return toBackgroundTask(
       this._engine.resume(taskId, (state) => {
@@ -168,7 +167,6 @@ export class InProcessTaskManager implements BackgroundTaskManager {
     )
   }
 
-  /** {@inheritDoc BackgroundTaskManager.remove} */
   async remove(taskIds: readonly string[]): Promise<void> {
     const uniqueTaskIds = new Set(taskIds)
     for (const taskId of uniqueTaskIds) {
@@ -192,22 +190,27 @@ export class InProcessTaskManager implements BackgroundTaskManager {
     const interruptState = context.state ? InterruptState.fromJSON(context.state) : new InterruptState()
     try {
       return toolTaskOutcome(
-        await this._executeTool(execution.tool, {
-          agent: this._agent,
-          invocationState: execution.invocationState,
-          cancelSignal: context.cancelSignal,
-          toolUse: execution.toolUse,
-          interrupt: <T = JSONValue>(params: InterruptParams): T =>
-            interruptTool<T>(interruptState, context.taskId, params),
-        })
+        await this._executeTool(
+          execution.tool,
+          {
+            agent: this._agent,
+            invocationState: execution.invocationState,
+            cancelSignal: context.cancelSignal,
+            toolUse: execution.toolUse,
+            interrupt: <T = JSONValue>(params: InterruptParams): T =>
+              interruptTool<T>(interruptState, context.taskId, params),
+          },
+          createMiddlewareInterrupt(interruptState, `middleware:${context.taskId}`)
+        )
       )
     } catch (error) {
       if (error instanceof InterruptError) {
-        const taskInterruptPrefix = `tool:${context.taskId}:`
         const taskOwnsInterrupts =
           error.interrupts.length > 0 &&
           error.interrupts.every(
-            (interrupt) => interrupt.source === 'tool' && interrupt.id.startsWith(taskInterruptPrefix)
+            (interrupt) =>
+              (interrupt.source === 'middleware' || interrupt.source === 'tool') &&
+              interrupt.id.startsWith(`${interrupt.source}:${context.taskId}:`)
           )
         if (!taskOwnsInterrupts) throw error
 
@@ -219,10 +222,9 @@ export class InProcessTaskManager implements BackgroundTaskManager {
     }
   }
 
-  private _notifyTaskWaiters(record: InProcessTaskRecord): void {
-    const waiters = this._taskWaiters.get(record.taskId)
+  private _notifyTaskWaiters(task: BackgroundTask): void {
+    const waiters = this._taskWaiters.get(task.taskId)
     if (!waiters) return
-    const task = toBackgroundTask(record)
     for (const waiter of waiters) waiter(task)
   }
 }

--- a/strands-ts/src/background-tasks/manager.ts
+++ b/strands-ts/src/background-tasks/manager.ts
@@ -22,6 +22,8 @@ export interface BackgroundTaskManager {
   get(taskId: string): Promise<BackgroundTask | undefined>
   /** Lists the tasks currently tracked by the manager. */
   list(): Promise<readonly BackgroundTask[]>
+  /** Whether the manager is tracking any tasks (including terminal ones not yet removed). */
+  hasTasks(): boolean
   /**
    * Requests cancellation of one task.
    *

--- a/strands-ts/src/background-tasks/types.ts
+++ b/strands-ts/src/background-tasks/types.ts
@@ -6,12 +6,12 @@ import type { ToolResultContentData } from '../types/messages.js'
 export interface BackgroundTasksConfig {
   /** Wait for background work before an invocation returns. Defaults to `true`. */
   readonly waitForCompletion?: boolean
-  /** Tools whose execution mode is selected by the model. Defaults to `['*']`. */
-  readonly agentic?: readonly (Tool | '*')[]
-  /** Tools that always execute in the background. */
-  readonly always?: readonly (Tool | '*')[]
-  /** Tools that never execute in the background. */
-  readonly never?: readonly (Tool | '*')[]
+  /** Tools or registered tool names whose execution mode is selected by the model. Defaults to `['*']`. */
+  readonly agentic?: readonly (Tool | string)[]
+  /** Tools or registered tool names that always execute in the background. */
+  readonly always?: readonly (Tool | string)[]
+  /** Tools or registered tool names that never execute in the background. */
+  readonly never?: readonly (Tool | string)[]
   /** Maximum number of physically executing background tasks. Defaults to `4`. */
   readonly maxConcurrency?: number
   /** Per-execution timeout in milliseconds. Defaults to `Infinity`. */

--- a/strands-ts/src/background-tasks/types.ts
+++ b/strands-ts/src/background-tasks/types.ts
@@ -1,5 +1,22 @@
 import type { Interrupt } from '../interrupt.js'
+import type { Tool } from '../tools/tool.js'
 import type { ToolResultContentData } from '../types/messages.js'
+
+/** Configures background tool execution. */
+export interface BackgroundTasksConfig {
+  /** Wait for background work before an invocation returns. Defaults to `true`. */
+  readonly waitForCompletion?: boolean
+  /** Tools whose execution mode is selected by the model. Defaults to `['*']`. */
+  readonly agentic?: readonly (Tool | '*')[]
+  /** Tools that always execute in the background. */
+  readonly always?: readonly (Tool | '*')[]
+  /** Tools that never execute in the background. */
+  readonly never?: readonly (Tool | '*')[]
+  /** Maximum number of physically executing background tasks. Defaults to `4`. */
+  readonly maxConcurrency?: number
+  /** Per-execution timeout in milliseconds. Defaults to `Infinity`. */
+  readonly timeout?: number
+}
 
 /** Background task lifecycle status. @internal */
 export type BackgroundTaskStatus = 'queued' | 'working' | 'input_required' | 'completed' | 'failed' | 'cancelled'

--- a/strands-ts/src/index.ts
+++ b/strands-ts/src/index.ts
@@ -14,6 +14,7 @@ export { StateStore } from './state-store.js'
 // Agent types
 export { AgentResult } from './types/agent.js'
 export type { AgentConfig, ToolList, ToolExecutorStrategy } from './agent/agent.js'
+export type { BackgroundTasksConfig } from './background-tasks/types.js'
 export type { AgentAsToolOptions } from './agent/agent-as-tool.js'
 export type { ToolCaller, ToolCallerProxy, ToolHandle, DirectToolCallOptions } from './agent/tool-caller.js'
 export type { InvocationState, InvokeArgs, InvokeOptions, LocalAgent } from './types/agent.js'

--- a/strands-ts/src/tools/executors/executor.ts
+++ b/strands-ts/src/tools/executors/executor.ts
@@ -7,6 +7,7 @@ import { deepCopy } from '../../types/json.js'
 import { TextBlock, ToolResultBlock } from '../../types/messages.js'
 
 import type { Agent } from '../../agent/agent.js'
+import type { BackgroundTasks } from '../../background-tasks/background-tasks.js'
 import type { ToolUseData } from '../../hooks/events.js'
 import type { ExecuteToolContext, ExecuteToolResult, MiddlewareRegistry } from '../../middleware/index.js'
 import type { Meter } from '../../telemetry/meter.js'
@@ -33,6 +34,11 @@ export interface ToolExecutorOptions {
   readonly meter: Meter
   /** Cancellation signal scoped to this executor invocation. */
   readonly cancelSignal: AbortSignal
+  readonly toolInterrupt?: ToolContext['interrupt']
+  readonly middlewareInterrupt?: ExecuteToolContext['interrupt']
+  readonly toolGuard?: (tool: Tool | undefined) => void
+  readonly backgroundTasks?: BackgroundTasks
+  readonly backgroundTaskPassId?: string
 }
 
 /**
@@ -71,6 +77,30 @@ export abstract class ToolExecutor {
     options: ToolExecutorOptions,
     input: ToolExecutionInput
   ): AsyncGenerator<AgentStreamEvent, void, undefined>
+
+  async executeBackground(
+    options: ToolExecutorOptions,
+    toolUse: ToolUseData,
+    tool: Tool,
+    invocationState: InvocationState,
+    onEvent: (event: AgentStreamEvent) => Promise<unknown>
+  ): Promise<ToolResultBlock> {
+    while (true) {
+      const generator = this._executeToolAttempt(options, tool, toolUse, invocationState)
+      try {
+        let next = await generator.next()
+        while (!next.done) {
+          await onEvent(next.value)
+          next = await generator.next()
+        }
+        if (!this._shouldRetry(next.value, options.cancelSignal)) {
+          return this._normalizeToolResultId(next.value.result, toolUse.toolUseId)
+        }
+      } finally {
+        await generator.return(undefined as never)
+      }
+    }
+  }
 
   // Tool lookup and tool-body failures become ToolResultBlocks so the model can
   // respond to them; lifecycle and middleware failures may still propagate.
@@ -130,20 +160,28 @@ export abstract class ToolExecutor {
         return this._normalizeToolResultId(afterToolCallEvent.result, toolUseBlock.toolUseId)
       }
 
-      const toolResult = this._normalizeToolResultId(
-        yield* this._executeToolWithMiddleware(options, effectiveTool, toolUse, invocationState),
-        toolUseBlock.toolUseId
-      )
-      const error = toolResult.error
-      const afterToolCallEvent = new AfterToolCallEvent({
-        agent: options.agent,
+      const route = options.backgroundTasks?.routeToolCall(toolUse, registryTool, effectiveTool)
+      if (route === true) {
+        // No AfterToolCallEvent is emitted for the dispatch ack. BeforeToolCallEvent
+        // already fired above; the background run later emits the matching
+        // AfterToolCallEvent.
+        return this._normalizeToolResultId(
+          await options.backgroundTasks!.submitToolCall(
+            toolUse,
+            invocationState,
+            options.backgroundTaskPassId!,
+            effectiveTool!
+          ),
+          toolUseBlock.toolUseId
+        )
+      }
+      const afterToolCallEvent = yield* this._executeToolAttempt(
+        options,
+        effectiveTool,
         toolUse,
-        tool: effectiveTool,
-        result: toolResult,
         invocationState,
-        ...(error !== undefined && { error }),
-      })
-      yield afterToolCallEvent
+        route
+      )
 
       if (this._shouldRetry(afterToolCallEvent, options.cancelSignal)) {
         continue
@@ -153,6 +191,29 @@ export abstract class ToolExecutor {
       // observe the same value.
       return this._normalizeToolResultId(afterToolCallEvent.result, toolUseBlock.toolUseId)
     }
+  }
+
+  private async *_executeToolAttempt(
+    options: ToolExecutorOptions,
+    tool: Tool | undefined,
+    toolUse: ToolUseData,
+    invocationState: InvocationState,
+    result?: ToolResultBlock
+  ): AsyncGenerator<AgentStreamEvent, AfterToolCallEvent, undefined> {
+    const toolResult = this._normalizeToolResultId(
+      yield* this._executeToolWithMiddleware(options, tool, toolUse, invocationState, result),
+      toolUse.toolUseId
+    )
+    const event = new AfterToolCallEvent({
+      agent: options.agent,
+      toolUse,
+      tool,
+      result: toolResult,
+      invocationState,
+      ...(toolResult.error !== undefined && { error: toolResult.error }),
+    })
+    yield event
+    return event
   }
 
   private _shouldRetry(afterToolCallEvent: AfterToolCallEvent, cancelSignal: AbortSignal): boolean {
@@ -193,7 +254,8 @@ export abstract class ToolExecutor {
     options: ToolExecutorOptions,
     tool: Tool | undefined,
     toolUse: ToolUseData,
-    invocationState: InvocationState
+    invocationState: InvocationState,
+    result?: ToolResultBlock
   ): AsyncGenerator<AgentStreamEvent, ToolResultBlock, undefined> {
     const context: ExecuteToolContext = {
       agent: options.agent,
@@ -201,10 +263,9 @@ export abstract class ToolExecutor {
       toolUse: deepCopy(toolUse) as unknown as ToolUseData,
       invocationState,
       cancelSignal: options.cancelSignal,
-      interrupt: createMiddlewareInterrupt(
-        options.agent._interruptState,
-        `middleware:executeTool:${toolUse.toolUseId}`
-      ),
+      interrupt:
+        options.middlewareInterrupt ??
+        createMiddlewareInterrupt(options.agent._interruptState, `middleware:executeTool:${toolUse.toolUseId}`),
     }
 
     // async function* does not bind lexical `this`; capture the executor for the terminal callback.
@@ -216,13 +277,17 @@ export abstract class ToolExecutor {
       async function* (
         middlewareContext: ExecuteToolContext
       ): AsyncGenerator<AgentStreamEvent, ExecuteToolResult, undefined> {
-        const result = yield* executor._executeToolCore(
-          options,
-          middlewareContext.tool,
-          middlewareContext.toolUse,
-          middlewareContext.invocationState
-        )
-        return { result }
+        options.toolGuard?.(middlewareContext.tool)
+        return {
+          result:
+            result ??
+            (yield* executor._executeToolCore(
+              options,
+              middlewareContext.tool,
+              middlewareContext.toolUse,
+              middlewareContext.invocationState
+            )),
+        }
       }
     )
     return middlewareResult.result
@@ -258,7 +323,9 @@ export abstract class ToolExecutor {
           invocationState,
           cancelSignal: options.cancelSignal,
           interrupt: <T = JSONValue>(params: InterruptParams): T =>
-            interruptFromAgent<T>(options.agent, `tool:${toolUse.toolUseId}:${params.name}`, params, 'tool'),
+            options.toolInterrupt
+              ? options.toolInterrupt<T>(params)
+              : interruptFromAgent<T>(options.agent, `tool:${toolUse.toolUseId}:${params.name}`, params, 'tool'),
         }
 
         // Iterate manually to wrap raw tool events at the agent boundary and


### PR DESCRIPTION
## Description

Adding a new, explicitly opt-in first-class param to Agent, `backgroundTasks: boolean | BackgroundTasksConfig`.

The mechanism is integrated with the Agent via an internal `BackgroundTasks` plugin that routes eligible tool calls between foreground and background execution, persists task state in Agent `appState`, surfaces task interrupts at safe Agent boundaries, and delivers terminal outcomes as a synthetic assistant tool use followed by a matching user tool result. Background execution continues through the standard tool middleware, hook, retry, tracing, and cancellation paths.

This completes the in-process Background Tasks implementation for TypeScript.

```mermaid
flowchart LR
    A["Agent"] -->|"tool call"| P["BackgroundTasks"]

    P -->|"foreground"| X["ToolExecutor"]
    P -->|"background"| M["InProcessTaskManager"]
    M -->|"schedule / manage"| E["InProcessTaskEngine"]
    E -->|"execute via callback"| X

    M -->|"completed results"| P
    P -.->|"deliver via hooks"| A

    classDef focus fill:#2da44e,stroke:#116329,color:#fff,stroke-width:3px
    class P focus
```

- **`BackgroundTasks`** connects the feature to the Agent, chooses foreground or background execution, persists delivery state, and delivers finished results through hooks.
- **`InProcessTaskManager`** turns approved tool calls into tasks and provides the operations used to inspect, wait for, cancel, resume, and remove them.
- **`InProcessTaskEngine`** schedules local task execution and handles concurrency, cancellation, timeouts, and pause/resume state.

### Public API Changes

`AgentConfig` now accepts `backgroundTasks`. Once enabled, tools can be selected by the model through the injected `_background_execution` boolean, forced into the background with `always`, or kept in the foreground with `never`.

Default (mechanism is opt-in):

```typescript
const agent = new Agent({
  model,
  tools: [deepResearch, updateRecord],
  backgroundTasks: true
})
```

With extra configuration:

```typescript
const agent = new Agent({
  model,
  tools: [deepResearch, updateRecord],
  backgroundTasks: {
    agentic: [deepResearch],
    never: [updateRecord],
    maxConcurrency: 4,
    timeout: 60_000,
    waitForCompletion: false,
  },
})
```

The integration also registers the foreground-only `strands_manage_background_task` tool so the model can inspect or cancel a dispatched task. Completed results are delivered automatically and do not require polling.

## Related Issues

Part of #2496

Design: #3531

Engine prerequisite: #3838

Manager prerequisite: #3876

## Documentation PR

Will follow in a separate PR

## Type of Change

New feature

## Testing

Validated with the full Node and Chromium suites and the standard TypeScript build, lint, formatting, type-check, browser-bundle, and package gates.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
