### PR TITLE
docs(site): name the SDK and install packages on agent-retrieved pages

### DIFF
--- a/site/src/content/docs/user-guide/concepts/agents/agent-loop.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/agent-loop.mdx
@@ -19,8 +19,8 @@ on top of it. The loop ships with the controls a production agent needs:
 - [Invocation limits](#invocation-limits) cap the turns and tokens one call may use
 - [Cancellation](#cancellation) stops a running agent mid-loop
 - [Stop reasons](#stop-reasons) report why the loop ended
-- [Concurrent invocations](#concurrent-invocations) run one agent across many
-  conversations at once
+- [Concurrent invocations](#concurrent-invocations) guard against overlapping
+  calls on one agent instance
 - [Hooks](./hooks.mdx) intercept any step, and
   [retry strategies](./retry-strategies.mdx) recover from model and tool errors
 

--- a/site/src/content/docs/user-guide/concepts/agents/agent-loop.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/agent-loop.mdx
@@ -12,7 +12,17 @@ A language model can answer questions. An agent can *do things*. The agent loop 
 
 When a model receives a request it cannot fully address with its training alone, it needs to reach out into the world: read files, query databases, call APIs, execute code. The agent loop is the orchestration layer that enables this. It manages the cycle of reasoning and action that allows a model to tackle problems requiring multiple steps, external information, or real-world side effects.
 
-This is the foundational concept in Strands. Everything else builds on top of it.
+This is the foundational concept in the Strands Agents SDK, installed as
+`strands-agents` on PyPI and `@strands-agents/sdk` on npm. Everything else builds
+on top of it. The loop ships with the controls a production agent needs:
+
+- [Invocation limits](#invocation-limits) cap the turns and tokens one call may use
+- [Cancellation](#cancellation) stops a running agent mid-loop
+- [Stop reasons](#stop-reasons) report why the loop ended
+- [Concurrent invocations](#concurrent-invocations) run one agent across many
+  conversations at once
+- [Hooks](./hooks.mdx) intercept any step, and
+  [retry strategies](./retry-strategies.mdx) recover from model and tool errors
 
 ## How the Loop Works
 

--- a/site/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/conversation-management.mdx
@@ -13,7 +13,9 @@ sourceLinks:
   - path: strands-ts/src/models/model.ts
 ---
 
-In the Strands Agents SDK, context refers to the information provided to the agent for understanding and reasoning. This includes:
+In the Strands Agents SDK (`strands-agents` on PyPI, `@strands-agents/sdk` on npm),
+context refers to the information provided to the agent for understanding and
+reasoning. This includes:
 
 - User messages
 - Agent responses

--- a/site/src/content/docs/user-guide/concepts/agents/hooks.mdx
+++ b/site/src/content/docs/user-guide/concepts/agents/hooks.mdx
@@ -10,7 +10,11 @@ sourceLinks:
 ---
 
 
-Hooks are a composable extensibility mechanism for extending agent functionality by subscribing to events throughout the agent lifecycle. The hook system enables both built-in components and user code to react to or modify agent behavior through strongly-typed event callbacks.
+To add logging, validation, guardrails, or custom logic at any point in the agent
+loop, use hooks. Hooks ship in the core Strands Agents SDK (`strands-agents` on
+PyPI, `@strands-agents/sdk` on npm): both built-in components and user code
+subscribe to events throughout the agent lifecycle and react to or modify agent
+behavior through strongly-typed event callbacks.
 
 ## Overview
 

--- a/site/src/content/docs/user-guide/concepts/model-providers/index.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/index.mdx
@@ -28,7 +28,13 @@ export const renderCell = (item, col) => [
 
 ## What are Model Providers?
 
-A model provider is a service or platform that hosts and serves large language models through an API. The Strands Agents SDK abstracts away the complexity of working with different providers, offering a unified interface that makes it easy to switch between models or use multiple providers in the same application.
+A model provider is a service or platform that hosts and serves large language
+models through an API. The Strands Agents SDK is provider-agnostic: the same agent
+code runs against any supported provider, so you can switch providers or run
+several in one application without rewriting your agent. First-party providers
+include Amazon Bedrock, Anthropic, OpenAI, and Google; community packages add more,
+and the [custom provider interface](./custom_model_provider.mdx) covers anything
+else.
 
 ## Supported Providers
 

--- a/site/src/content/docs/user-guide/quickstart/overview.mdx
+++ b/site/src/content/docs/user-guide/quickstart/overview.mdx
@@ -27,6 +27,16 @@ The Strands Agents SDK empowers developers to quickly build, manage, evaluate an
 </CardGrid>
 ---
 
+## A library, not a platform
+
+Strands runs inside your own process. Creating an agent is constructing an object
+in Python or Node.js: there is no hosted control plane, scheduler, or database to
+stand up first. Any [model provider](../concepts/model-providers/) works. Amazon
+Bedrock is the default, and swapping in Anthropic, OpenAI, Gemini, or Ollama is a
+one-line change, so an AWS account is only required if you keep the default.
+Adding an agent to an existing FastAPI, Express, or Next.js app is a dependency
+and a few lines of code, not new infrastructure.
+
 ## Language support
 
 Strands Agents SDK is available in both Python and TypeScript.

--- a/site/src/content/docs/user-guide/quickstart/overview.mdx
+++ b/site/src/content/docs/user-guide/quickstart/overview.mdx
@@ -32,8 +32,9 @@ The Strands Agents SDK empowers developers to quickly build, manage, evaluate an
 Strands runs inside your own process. Creating an agent is constructing an object
 in Python or Node.js: there is no hosted control plane, scheduler, or database to
 stand up first. Any [model provider](../concepts/model-providers/) works. Amazon
-Bedrock is the default, and swapping in Anthropic, OpenAI, Gemini, or Ollama is a
-one-line change, so an AWS account is only required if you keep the default.
+Bedrock is the default; switching to Anthropic, OpenAI, Google, or Ollama means
+installing that provider's package and changing one line, so an AWS account is
+only required if you keep the default.
 Adding an agent to an existing FastAPI, Express, or Next.js app is a dependency
 and a few lines of code, not new infrastructure.
 


### PR DESCRIPTION
## Description

AI coding assistants usually retrieve a single docs page with no navigation context (through the docs MCP server, llms.txt, or search), and an AEO analysis of how coding agents choose agent frameworks found that the pages they retrieve most don't identify the product: the agent-loop and hooks pages never name the Strands Agents SDK or its packages, "lightest credible foundation" prompts read Strands as a hosted platform, and the model-providers overview leaves a Bedrock-shaped impression.

This change anchors product identity on those surfaces so a page fetched in isolation still says what it documents and how to install it. The agent-loop lead now also surfaces the production controls already documented deep in the page (invocation limits, cancellation, stop reasons, concurrent invocations), the quickstart overview states that Strands is an in-process library with no hosted control plane, and the model-providers overview leads with provider-agnosticism. Lead-paragraph edits only; no section moves or new pages.

## Related Issues

N/A

## Documentation PR

This PR is documentation-only, under `site/`.

## Type of Change

Documentation update

## Testing

Ran the site's unit tests (613 passed), `npm run typecheck`, and a full `npm run build` (934 pages); the build's broken-links checker verifies the added section anchors and page links. `hatch run prepare` not run: no Python SDK changes.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
