### PR TITLE
feature: Add new ActorMemory plugin

### DIFF
--- a/strands-py/src/strands/_identifier.py
+++ b/strands-py/src/strands/_identifier.py
@@ -13,6 +13,7 @@ class Identifier(enum.Enum):
 
     AGENT = "agent"
     SESSION = "session"
+    ACTOR = "actor"
 
 
 def validate(id_: str, type_: Identifier) -> str:

--- a/strands-py/src/strands/vended_plugins/actor_memory/__init__.py
+++ b/strands-py/src/strands/vended_plugins/actor_memory/__init__.py
@@ -1,0 +1,20 @@
+"""Cross-session actor memory for Strands agents.
+
+This module provides the ``ActorMemory`` plugin, which persists small facts
+about an actor (a user, tenant, or other stable identity) so they are recalled
+in later sessions, independent of any particular ``session_id``.
+
+Example Usage:
+    ```python
+    from strands import Agent
+    from strands.vended_plugins.actor_memory import ActorMemory
+
+    agent = Agent(plugins=[ActorMemory(actor_id="user-123")])
+    ```
+"""
+
+from .plugin import ActorMemory
+
+__all__ = [
+    "ActorMemory",
+]

--- a/strands-py/src/strands/vended_plugins/actor_memory/plugin.py
+++ b/strands-py/src/strands/vended_plugins/actor_memory/plugin.py
@@ -1,0 +1,247 @@
+"""ActorMemory plugin for persisting facts about an actor across sessions.
+
+This module provides the ActorMemory plugin, which lets an agent remember
+durable facts about an actor (a user, tenant, or other stable identity) and
+recall them in later sessions. This is deliberately distinct from
+``SessionManager``: a ``SessionManager`` persists one conversation's full
+transcript and state, keyed by ``session_id`` — starting a new session starts
+blank. ``ActorMemory`` persists a small, curated set of facts keyed by
+``actor_id``, which survives across many separate sessions for the same actor.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+from ..._identifier import Identifier
+from ..._identifier import validate as validate_identifier
+from ...hooks.events import BeforeInvocationEvent
+from ...plugins import Plugin, hook
+from ...storage import LocalFileStorage, Storage
+from ...storage.storage import _NAMESPACED, _NamespacedStorage
+from ...tools.decorator import tool
+from ...types.content import SystemContentBlock
+
+if TYPE_CHECKING:
+    from ...agent.agent import Agent
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_STATE_KEY = "actor_memory"
+_DEFAULT_MAX_FACTS = 200
+
+_ACTOR_MEMORY_NAMESPACE = "actor_memory"
+_FACTS_KEY_SUFFIX = "facts.json"
+
+
+def _resolve_storage(storage: Storage) -> Storage:
+    """Namespace raw storage under "actor_memory"; pass an already namespaced view through."""
+    if getattr(storage, "_namespaced", None) is _NAMESPACED:
+        return storage
+    return _NamespacedStorage(storage, _ACTOR_MEMORY_NAMESPACE)
+
+
+def _facts_key(actor_id: str) -> str:
+    """Return the namespace-relative storage key for an actor's facts."""
+    return f"{actor_id}/{_FACTS_KEY_SUFFIX}"
+
+
+class ActorMemory(Plugin):
+    """Plugin that persists facts about an actor across separate agent sessions.
+
+    The plugin provides:
+
+    1. A ``remember`` tool the agent calls to persist a fact worth keeping
+       long term.
+    2. Injection of previously remembered facts into the system prompt before
+       each invocation, so a new session (a new ``session_id``, a new process,
+       a new ``Agent`` instance) still recalls what was learned before.
+
+    Facts are stored under a key scoped to ``actor_id``, not ``session_id`` —
+    the same actor's facts are visible across every session, while two
+    different actors never see each other's facts.
+
+    Args:
+        actor_id: Stable identity the facts are scoped to (a user, tenant, etc.).
+        storage: Backend for persisting facts. When omitted, resolves from the
+            agent's ``storage`` during initialization; if the agent has none either,
+            falls back to ``LocalFileStorage()`` (a ``./.strands/`` directory), so the
+            plugin works with no additional setup. Pass a shared backend (e.g. an
+            ``S3Storage`` already used elsewhere in the app) to persist facts
+            alongside other agent data.
+        max_facts: Maximum number of facts retained per actor. Oldest facts are
+            dropped once the limit is exceeded.
+
+    Example:
+        ```python
+        from strands import Agent
+        from strands.vended_plugins.actor_memory import ActorMemory
+
+        agent = Agent(plugins=[ActorMemory(actor_id="user-123")])
+        ```
+    """
+
+    name = "actor_memory"
+
+    def __init__(
+        self,
+        actor_id: str,
+        storage: Storage | None = None,
+        max_facts: int = _DEFAULT_MAX_FACTS,
+    ) -> None:
+        """Initialize the ActorMemory plugin.
+
+        Args:
+            actor_id: Stable identity the facts are scoped to.
+            storage: Backend for persisting facts. When omitted, resolved from
+                ``agent.storage`` (or ``LocalFileStorage()``) during ``init_agent``.
+            max_facts: Maximum number of facts retained per actor.
+
+        Raises:
+            ValueError: If ``actor_id`` is empty, is a relative-path segment (``.`` or ``..``),
+                normalizes to empty, or contains a path separator; or if ``max_facts`` is less
+                than 1.
+        """
+        actor_id = validate_identifier(actor_id, Identifier.ACTOR)
+        # validate_identifier permits ""/"."/".."/whitespace, which either collapse the actor's
+        # storage key onto another actor's or another namespace entirely. Reject those here.
+        if not actor_id.strip() or actor_id in (".", ".."):
+            raise ValueError(f"actor_id is not a valid actor identifier: {actor_id!r}")
+
+        if max_facts < 1:
+            raise ValueError("max_facts must be at least 1")
+
+        self._actor_id = actor_id
+        self._max_facts = max_facts
+        self._storage: Storage | None = _resolve_storage(storage) if storage is not None else None
+        self._facts_cache: list[str] | None = None
+        super().__init__()
+
+    async def init_agent(self, agent: Agent) -> None:
+        """Resolve the storage backend, defaulting to the agent's own storage.
+
+        Args:
+            agent: The agent instance to extend with actor memory.
+        """
+        if self._storage is None:
+            base_storage = agent.storage if agent.storage is not None else LocalFileStorage()
+            self._storage = _resolve_storage(base_storage)
+
+    @property
+    def _resolved_storage(self) -> Storage:
+        """Return the resolved storage, raising if the plugin was never attached to an agent."""
+        if self._storage is None:
+            raise RuntimeError(
+                "ActorMemory requires a storage backend. Provide storage in the constructor or "
+                "attach the plugin to an Agent via plugins=[...]."
+            )
+        return self._storage
+
+    async def _load_facts(self) -> list[str]:
+        """Load facts, from cache after the first read."""
+        if self._facts_cache is not None:
+            return list(self._facts_cache)
+
+        data = await self._resolved_storage.read(_facts_key(self._actor_id))
+        facts: list[str] = json.loads(data) if data else []
+        self._facts_cache = facts
+        return list(facts)
+
+    async def _save_facts(self, facts: list[str]) -> None:
+        """Persist facts to storage and update the cache."""
+        await self._resolved_storage.write(_facts_key(self._actor_id), json.dumps(facts).encode("utf-8"))
+        self._facts_cache = facts
+
+    @tool
+    async def remember(self, fact: str) -> str:
+        """Persist a fact about this actor so it is recalled in future sessions.
+
+        Use this when the user states a durable preference or a fact that
+        should hold beyond this conversation (e.g. "always answer in Spanish").
+        Do not use it for information relevant only to the current task.
+
+        Args:
+            fact: The fact to remember, stated concisely and in a way that
+                will still make sense read out of context in a future session.
+        """
+        facts = await self._load_facts()
+        if fact in facts:
+            return "Already remembered."
+
+        facts.append(fact)
+        if len(facts) > self._max_facts:
+            dropped_count, facts = len(facts) - self._max_facts, facts[-self._max_facts :]
+            logger.warning(
+                "actor_id=<%s>, max_facts=<%d>, dropped_count=<%d> | oldest facts dropped to stay within max_facts",
+                self._actor_id,
+                self._max_facts,
+                dropped_count,
+            )
+
+        await self._save_facts(facts)
+        logger.debug("actor_id=<%s>, fact_count=<%d> | fact remembered", self._actor_id, len(facts))
+        return "Remembered."
+
+    def _get_state(self, agent: Agent) -> dict[str, Any]:
+        """Get this plugin's agent state dict, raising if it was overwritten with a non-dict."""
+        state_data = agent.state.get(_DEFAULT_STATE_KEY)
+        if state_data is not None and not isinstance(state_data, dict):
+            raise TypeError(f"expected dict for state key '{_DEFAULT_STATE_KEY}', got {type(state_data).__name__}")
+        return state_data if state_data is not None else {}
+
+    @staticmethod
+    def _format_facts(facts: list[str]) -> str:
+        """Render remembered facts as a system-prompt block, or "" if there are none."""
+        if not facts:
+            return ""
+        lines = "\n".join(f"- {fact}" for fact in facts)
+        return f"<remembered_facts>\n{lines}\n</remembered_facts>"
+
+    @hook
+    async def _on_before_invocation(self, event: BeforeInvocationEvent) -> None:
+        """Inject remembered facts into the system prompt before each invocation.
+
+        Removes the previously injected block (if any) via exact match and
+        appends a fresh one, so re-invocation never duplicates facts. Uses
+        agent state to track the injected text, mirroring the approach used by
+        the ``AgentSkills`` plugin for its own system-prompt injection. Leaves
+        the prompt and state untouched when there are no facts and nothing
+        previously injected to remove.
+
+        Args:
+            event: The before-invocation event containing the agent reference.
+        """
+        agent = event.agent
+        facts = await self._load_facts()
+        facts_text = self._format_facts(facts)
+
+        state_data = self._get_state(agent)
+        last_injected = state_data.get("last_injected_text")
+
+        if not facts_text and last_injected is None:
+            return
+
+        content = agent.system_prompt_content
+        if content is not None:
+            blocks: list[SystemContentBlock] = list(content)
+            if last_injected is not None:
+                injected_block: SystemContentBlock = {"text": last_injected}
+                if injected_block in blocks:
+                    blocks.remove(injected_block)
+                else:
+                    logger.warning("unable to find previously injected memory block in system prompt, re-appending")
+            if facts_text:
+                blocks.append({"text": facts_text})
+            agent.system_prompt = blocks
+        else:
+            current_prompt = agent.system_prompt or ""
+            if last_injected and last_injected in current_prompt:
+                current_prompt = current_prompt.replace(last_injected, "")
+            injection = f"\n\n{facts_text}" if current_prompt and facts_text else facts_text
+            agent.system_prompt = f"{current_prompt}{injection}" if current_prompt else injection
+            facts_text = injection
+
+        state_data["last_injected_text"] = facts_text or None
+        agent.state.set(_DEFAULT_STATE_KEY, state_data)

--- a/strands-py/tests/strands/vended_plugins/actor_memory/__init__.py
+++ b/strands-py/tests/strands/vended_plugins/actor_memory/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the ActorMemory plugin."""

--- a/strands-py/tests/strands/vended_plugins/actor_memory/test_actor_memory.py
+++ b/strands-py/tests/strands/vended_plugins/actor_memory/test_actor_memory.py
@@ -1,0 +1,317 @@
+"""Tests for the ActorMemory plugin."""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from strands.hooks.events import BeforeInvocationEvent
+from strands.hooks.registry import HookRegistry
+from strands.storage import InMemoryStorage, S3Storage, Storage
+from strands.vended_plugins.actor_memory import ActorMemory
+
+
+@pytest.fixture
+def s3_bucket():
+    """Create a moto-mocked S3 bucket."""
+    import boto3
+    from moto import mock_aws
+
+    with mock_aws():
+        session = boto3.Session(region_name="us-east-1")
+        client = session.client("s3")
+        client.create_bucket(Bucket="test-bucket")
+        yield session
+
+
+def _mock_agent(system_prompt: str | list | None = "You are an agent."):
+    """Create a mock agent exposing the properties/state ActorMemory depends on."""
+    agent = MagicMock()
+    _set_system_prompt(agent, system_prompt)
+
+    type(agent).system_prompt = property(
+        lambda self: self._system_prompt,
+        lambda self, value: _set_system_prompt(self, value),
+    )
+    type(agent).system_prompt_content = property(lambda self: self._system_prompt_content)
+
+    agent.hooks = HookRegistry()
+    agent.add_hook = MagicMock(
+        side_effect=lambda callback, event_type=None: agent.hooks.add_callback(event_type, callback)
+    )
+    agent.tool_registry = MagicMock()
+    agent.tool_registry.process_tools = MagicMock(return_value=["remember"])
+
+    state_store: dict[str, object] = {}
+    agent.state = MagicMock()
+    agent.state.get = MagicMock(side_effect=lambda key: state_store.get(key))
+    agent.state.set = MagicMock(side_effect=lambda key, value: state_store.__setitem__(key, value))
+    return agent
+
+
+def _set_system_prompt(agent: MagicMock, value: str | list | None) -> None:
+    """Simulate the Agent.system_prompt setter (string or content-block list)."""
+    if isinstance(value, str):
+        agent._system_prompt = value
+        agent._system_prompt_content = [{"text": value}]
+    elif isinstance(value, list):
+        text_parts = [block["text"] for block in value if "text" in block]
+        agent._system_prompt = "\n".join(text_parts) if text_parts else None
+        agent._system_prompt_content = value
+    else:
+        agent._system_prompt = None
+        agent._system_prompt_content = None
+
+
+async def _read_facts(storage: Storage, actor_id: str) -> list[str]:
+    """Read facts straight from storage, using the documented actor_memory/<actor_id>/facts.json key."""
+    raw = await storage.read(f"actor_memory/{actor_id}/facts.json")
+    return json.loads(raw) if raw else []
+
+
+async def _attach(plugin: ActorMemory, agent: MagicMock) -> None:
+    """Attach a plugin to a mock agent, registering its hooks the way the plugin registry does."""
+    await plugin.init_agent(agent)
+    for callback in plugin.hooks:
+        agent.add_hook(callback)
+
+
+async def _run_before_invocation(agent: MagicMock) -> None:
+    """Dispatch a BeforeInvocationEvent through the agent's public hook registry."""
+    await agent.hooks.invoke_callbacks_async(BeforeInvocationEvent(agent=agent))
+
+
+class TestActorMemoryInit:
+    """Tests for ActorMemory initialization."""
+
+    def test_rejects_empty_actor_id(self):
+        with pytest.raises(ValueError, match="actor_id is not a valid actor identifier"):
+            ActorMemory(actor_id="")
+
+    def test_rejects_actor_id_with_path_separator(self):
+        with pytest.raises(ValueError, match="cannot contain path separators"):
+            ActorMemory(actor_id="a/b")
+
+    @pytest.mark.parametrize("bad_id", [".", "..", "   "])
+    def test_rejects_relative_or_blank_actor_id(self, bad_id):
+        with pytest.raises(ValueError, match="actor_id is not a valid actor identifier"):
+            ActorMemory(actor_id=bad_id)
+
+    @pytest.mark.asyncio
+    async def test_default_storage_is_local_file_storage(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        plugin = ActorMemory(actor_id="actor-1")
+        agent = _mock_agent()
+        agent.storage = None
+        await plugin.init_agent(agent)
+
+        await plugin.remember(fact="prefers Spanish")
+
+        # A default-configured LocalFileStorage, read directly, should see the same fact,
+        # proving init_agent fell back to a local file backend rather than erroring or
+        # keeping facts only in memory.
+        from strands.storage import LocalFileStorage
+
+        assert await _read_facts(LocalFileStorage(), "actor-1") == ["prefers Spanish"]
+
+    @pytest.mark.asyncio
+    async def test_init_agent_uses_agent_storage_when_not_explicit(self):
+        storage = InMemoryStorage()
+        plugin = ActorMemory(actor_id="actor-1")
+        agent = _mock_agent()
+        agent.storage = storage
+        await plugin.init_agent(agent)
+
+        await plugin.remember(fact="prefers Spanish")
+
+        assert await _read_facts(storage, "actor-1") == ["prefers Spanish"]
+
+    @pytest.mark.asyncio
+    async def test_custom_storage_is_used(self):
+        storage = InMemoryStorage()
+        plugin = ActorMemory(actor_id="actor-1", storage=storage)
+
+        await plugin.remember(fact="prefers Spanish")
+
+        assert await _read_facts(storage, "actor-1") == ["prefers Spanish"]
+
+    @pytest.mark.asyncio
+    async def test_explicit_storage_takes_precedence_over_agent_storage(self):
+        explicit_storage = InMemoryStorage()
+        agent_storage = InMemoryStorage()
+        plugin = ActorMemory(actor_id="actor-1", storage=explicit_storage)
+        agent = _mock_agent()
+        agent.storage = agent_storage
+        await plugin.init_agent(agent)
+
+        await plugin.remember(fact="prefers Spanish")
+
+        assert await _read_facts(explicit_storage, "actor-1") == ["prefers Spanish"]
+        assert await _read_facts(agent_storage, "actor-1") == []
+
+    @pytest.mark.asyncio
+    async def test_remember_before_init_agent_raises(self):
+        plugin = ActorMemory(actor_id="actor-1")
+        with pytest.raises(RuntimeError, match="requires a storage backend"):
+            await plugin.remember(fact="prefers Spanish")
+
+
+class TestActorMemoryRemember:
+    """Tests for the remember tool."""
+
+    @pytest.mark.asyncio
+    async def test_remember_persists_a_fact(self):
+        storage = InMemoryStorage()
+        plugin = ActorMemory(actor_id="actor-1", storage=storage)
+
+        await plugin.remember(fact="prefers Spanish")
+
+        assert await _read_facts(storage, "actor-1") == ["prefers Spanish"]
+
+    @pytest.mark.asyncio
+    async def test_remember_is_idempotent(self):
+        storage = InMemoryStorage()
+        plugin = ActorMemory(actor_id="actor-1", storage=storage)
+
+        await plugin.remember(fact="prefers Spanish")
+        await plugin.remember(fact="prefers Spanish")
+
+        assert await _read_facts(storage, "actor-1") == ["prefers Spanish"]
+
+    @pytest.mark.asyncio
+    async def test_repeated_reads_hit_storage_once(self):
+        """After the first load, remember() and the before-invocation hook reuse the in-process cache."""
+        storage = InMemoryStorage()
+        plugin = ActorMemory(actor_id="actor-1", storage=storage)
+        real_read = storage.read
+        read_calls = 0
+
+        async def counting_read(key):
+            nonlocal read_calls
+            read_calls += 1
+            return await real_read(key)
+
+        storage.read = counting_read
+
+        await plugin.remember(fact="prefers Spanish")
+        await plugin.remember(fact="likes coffee")
+        agent = _mock_agent()
+        await _attach(plugin, agent)
+        await _run_before_invocation(agent)
+        await _run_before_invocation(agent)
+
+        assert read_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_remember_trims_to_max_facts(self):
+        storage = InMemoryStorage()
+        plugin = ActorMemory(actor_id="actor-1", storage=storage, max_facts=2)
+
+        await plugin.remember(fact="fact-1")
+        await plugin.remember(fact="fact-2")
+        await plugin.remember(fact="fact-3")
+
+        assert await _read_facts(storage, "actor-1") == ["fact-2", "fact-3"]
+
+    @pytest.mark.asyncio
+    async def test_facts_persist_across_plugin_instances(self):
+        """Different ActorMemory instances sharing storage + actor_id see the same facts."""
+        storage = InMemoryStorage()
+        first = ActorMemory(actor_id="actor-1", storage=storage)
+        await first.remember(fact="prefers Spanish")
+
+        # A second instance, with no in-process cache of its own, must load the existing
+        # fact from storage first -- otherwise remembering it again here would duplicate it.
+        second = ActorMemory(actor_id="actor-1", storage=storage)
+        await second.remember(fact="prefers Spanish")
+
+        assert await _read_facts(storage, "actor-1") == ["prefers Spanish"]
+
+    @pytest.mark.asyncio
+    async def test_different_actors_do_not_share_facts(self):
+        storage = InMemoryStorage()
+        actor_one = ActorMemory(actor_id="actor-1", storage=storage)
+        _ = ActorMemory(actor_id="actor-2", storage=storage)
+
+        await actor_one.remember(fact="prefers Spanish")
+
+        assert await _read_facts(storage, "actor-1") == ["prefers Spanish"]
+        assert await _read_facts(storage, "actor-2") == []
+
+    @pytest.mark.asyncio
+    async def test_remember_persists_to_s3(self, s3_bucket):
+        storage = S3Storage("test-bucket", prefix="agents/", boto_session=s3_bucket)
+        plugin = ActorMemory(actor_id="juan", storage=storage)
+
+        await plugin.remember(fact="prefers Spanish")
+
+        # Read back through a fresh plugin instance to prove it round-tripped through S3,
+        # not just the in-process cache.
+        reloaded = ActorMemory(actor_id="juan", storage=storage)
+        await reloaded.remember(fact="prefers Spanish")
+
+        assert await _read_facts(storage, "juan") == ["prefers Spanish"]
+
+
+class TestActorMemoryInjection:
+    """Tests for system-prompt injection before each invocation."""
+
+    @pytest.mark.asyncio
+    async def test_injects_remembered_facts_into_string_prompt(self):
+        plugin = ActorMemory(actor_id="actor-1", storage=InMemoryStorage())
+        await plugin.remember(fact="prefers Spanish")
+        agent = _mock_agent(system_prompt="You are an agent.")
+        await _attach(plugin, agent)
+
+        await _run_before_invocation(agent)
+
+        assert "You are an agent." in agent.system_prompt
+        assert "prefers Spanish" in agent.system_prompt
+
+    @pytest.mark.asyncio
+    async def test_injects_remembered_facts_into_content_block_prompt(self):
+        plugin = ActorMemory(actor_id="actor-1", storage=InMemoryStorage())
+        await plugin.remember(fact="prefers Spanish")
+        agent = _mock_agent(system_prompt=[{"text": "You are an agent."}])
+        await _attach(plugin, agent)
+
+        await _run_before_invocation(agent)
+
+        blocks = agent.system_prompt_content
+        assert {"text": "You are an agent."} in blocks
+        assert any("prefers Spanish" in block.get("text", "") for block in blocks)
+
+    @pytest.mark.asyncio
+    async def test_no_injection_when_no_facts_remembered(self):
+        plugin = ActorMemory(actor_id="actor-1", storage=InMemoryStorage())
+        agent = _mock_agent(system_prompt="You are an agent.")
+        await _attach(plugin, agent)
+
+        await _run_before_invocation(agent)
+
+        assert agent.system_prompt == "You are an agent."
+
+    @pytest.mark.asyncio
+    async def test_reinjection_does_not_duplicate_facts(self):
+        plugin = ActorMemory(actor_id="actor-1", storage=InMemoryStorage())
+        await plugin.remember(fact="prefers Spanish")
+        agent = _mock_agent(system_prompt="You are an agent.")
+        await _attach(plugin, agent)
+
+        await _run_before_invocation(agent)
+        await _run_before_invocation(agent)
+
+        assert agent.system_prompt.count("prefers Spanish") == 1
+
+    @pytest.mark.asyncio
+    async def test_reinjection_picks_up_newly_remembered_facts(self):
+        plugin = ActorMemory(actor_id="actor-1", storage=InMemoryStorage())
+        agent = _mock_agent(system_prompt="You are an agent.")
+        await _attach(plugin, agent)
+
+        await _run_before_invocation(agent)
+        await plugin.remember(fact="prefers Spanish")
+        await _run_before_invocation(agent)
+
+        assert "prefers Spanish" in agent.system_prompt
+        assert agent.system_prompt.count("You are an agent.") == 1


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

Hello! Thanks for this amazing project.

I'm using this framework in my work and there is a need to maintain knowledge by actor (in this case by developer). I decided to create a PR with a new plugin, `ActorMemory`. This plugin takes an actor and saves the important information in storage to be re injected before each call, similar to Skills (I used that plugin as a reference). 

```python
from strands import Agent
from strands.storage import S3Storage
from strands.vended_plugins.actor_memory import ActorMemory

# actor_id identifies the user  not this conversation's session_id.
agent = Agent(
    plugins=[
        ActorMemory(
            actor_id="user-123",
            storage=S3Storage("my-bucket", prefix="agents/"),
        )
    ],
)

# Session 1
agent("Always answer me in Spanish, and call me 'Andrés'.")
# The model, seeing the `remember` tool, decides to call it because it detects a durable preference:
#   remember(fact="The user prefers responses in Spanish")
#   remember(fact="The user wants to be called 'Andrés'")
# This persists to storage under the key actor_memory/user-123/facts.json

#  Session 2 (new Agent, new session_id, maybe a different process)
agent2 = Agent(plugins=[ActorMemory(actor_id="user-123", storage=S3Storage("my-bucket", prefix="agents/"))])
agent2("What's the weather like today?")
# Before invoking the model, the `_on_before_invocation` hook injects into the system prompt:
#
#   <remembered_facts>
#   - The user prefers responses in Spanish
#   - The user wants to be called 'Andrés'
#   </remembered_facts>
#
# The model responds in Spanish and using "Andrés", without the user having to repeat it.

```

I think there might be a small issue with this implementation tho, I added a sort of cache. 

```python
async def _load_facts(self) -> list[str]:
    """Load facts, from cache after the first read."""
    if self._facts_cache is not None:
        return list(self._facts_cache)

    data = await self._resolved_storage.read(_facts_key(self._actor_id))
    facts: list[str] = json.loads(data) if data else []
    self._facts_cache = facts
    return list(facts)
```

I noticed that the `Storage` write method is an override, so, If there are more than a single process using this `actor_id` some preferences might be lost. Is there any recommendation about it?

If you consider this PR useful I'm really interested on completing it.

## Related Issues

I took this issue as reference #3547

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

New feature

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [ ] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
