### PR TITLE
fix(ts-telemetry): close cycle telemetry when the stream iterator exits early

### DIFF
--- a/strands-ts/src/agent/__tests__/agent.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.test.ts
@@ -419,6 +419,72 @@ describe('Agent', () => {
 
         expect(agent.metrics.cycleCount).toBe(1)
       })
+
+      it('includes the completed cycle duration in the returned result metrics', async () => {
+        vi.useFakeTimers()
+        vi.setSystemTime(0)
+
+        try {
+          const model = new MockMessageModel().addTurn(
+            { type: 'toolUseBlock', name: 'slowTool', toolUseId: 'tool-1', input: {} },
+            { usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } }
+          )
+
+          const tool = createMockTool(
+            'slowTool',
+            (context) =>
+              new ToolResultBlock({
+                toolUseId: context.toolUse.toolUseId,
+                status: 'success' as const,
+                content: [new TextBlock('Done')],
+              })
+          )
+
+          const agent = new Agent({ model, tools: [tool] })
+          agent.addHook(BeforeToolsEvent, () => {
+            vi.setSystemTime(60)
+          })
+          agent.addHook(AfterToolsEvent, (event: AfterToolsEvent) => {
+            event.endTurn = true
+          })
+
+          const result = await agent.invoke('Test')
+
+          expect(result.stopReason).toBe('endTurn')
+          expect(result.metrics).toMatchObject({
+            cycleCount: 1,
+            totalDuration: 60,
+            averageCycleTime: 60,
+            latestAgentInvocation: { cycles: [{ duration: 60 }] },
+          })
+        } finally {
+          vi.useRealTimers()
+        }
+      })
+
+      it('includes the cycle duration when the model ends the turn without tools', async () => {
+        vi.useFakeTimers()
+        vi.setSystemTime(0)
+
+        try {
+          const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Hello' })
+          const agent = new Agent({ model })
+          agent.addHook(BeforeModelCallEvent, () => {
+            vi.setSystemTime(60)
+          })
+
+          const result = await agent.invoke('Test')
+
+          expect(result.metrics).toMatchObject({
+            cycleCount: 1,
+            totalDuration: 60,
+            averageCycleTime: 60,
+            latestAgentInvocation: { cycles: [{ duration: 60 }] },
+          })
+        } finally {
+          vi.useRealTimers()
+        }
+      })
     })
 
     describe('metrics on errors', () => {

--- a/strands-ts/src/agent/__tests__/agent.tracer.test.node.ts
+++ b/strands-ts/src/agent/__tests__/agent.tracer.test.node.ts
@@ -2,7 +2,15 @@ import { describe, expect, it, vi, beforeEach, type MockInstance } from 'vitest'
 import { Agent } from '../agent.js'
 import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
 import { createMockTool } from '../../__fixtures__/tool-helpers.js'
-import { TextBlock, ToolUseBlock, ToolResultBlock, MaxTokensError, StructuredOutputError } from '../../index.js'
+import {
+  TextBlock,
+  ToolUseBlock,
+  ToolResultBlock,
+  MaxTokensError,
+  StructuredOutputError,
+  Message,
+} from '../../index.js'
+import { AfterToolsEvent, BeforeToolsEvent } from '../../hooks/events.js'
 import { InvokeModelStage } from '../../middleware/stages.js'
 import { Tracer } from '../../telemetry/tracer.js'
 import { z } from 'zod'
@@ -195,6 +203,136 @@ describe('Agent tracer integration', () => {
   })
 
   describe('agent loop span lifecycle', () => {
+    // Guards https://github.com/strands-agents/harness-sdk/issues/3800: breaking out of the
+    // public stream closes the generator mid-cycle and must still end the loop span
+    // and record the meter cycle.
+    it('ends the loop span once when the public stream iterator is closed mid-cycle', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(0)
+
+      try {
+        const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Done' })
+        const agent = new Agent({ model })
+        const tracer = getLatestTracer()
+
+        for await (const event of agent.stream('Hi')) {
+          if (event.type === 'messageAddedEvent') {
+            vi.setSystemTime(60)
+            break
+          }
+        }
+
+        // The first messageAddedEvent is the user-message append, so the break
+        // lands before the model call.
+        expect(tracer.startModelInvokeSpan).not.toHaveBeenCalled()
+        expect(tracer.startAgentLoopSpan).toHaveBeenCalledTimes(1)
+        expect(tracer.endAgentLoopSpan).toHaveBeenCalledTimes(1)
+        expect(tracer.endAgentLoopSpan).toHaveBeenCalledWith({ mock: 'loopSpan' })
+        expect(agent.metrics.totalDuration).toBe(60)
+        expect(agent.metrics.latestAgentInvocation?.cycles).toEqual([expect.objectContaining({ duration: 60 })])
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    // Guards https://github.com/strands-agents/harness-sdk/issues/3800: the issue's
+    // reported scenario is cancel() plus break while the model is streaming.
+    it('ends the loop span once when the consumer cancels and breaks during model streaming', async () => {
+      const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Done' })
+      const agent = new Agent({ model })
+      const tracer = getLatestTracer()
+
+      for await (const event of agent.stream('Hi')) {
+        if (event.type === 'modelStreamUpdateEvent') {
+          agent.cancel()
+          break
+        }
+      }
+
+      expect(tracer.startAgentLoopSpan).toHaveBeenCalledTimes(1)
+      expect(tracer.endAgentLoopSpan).toHaveBeenCalledTimes(1)
+      expect(tracer.endAgentLoopSpan).toHaveBeenCalledWith({ mock: 'loopSpan' })
+    })
+
+    it('closes cycle telemetry for every started cycle when the consumer breaks during tool execution', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'testTool', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+      const tool = createMockTool(
+        'testTool',
+        () =>
+          new ToolResultBlock({
+            toolUseId: 'tool-1',
+            status: 'success',
+            content: [new TextBlock('Result')],
+          })
+      )
+      const agent = new Agent({ model, tools: [tool] })
+      const tracer = getLatestTracer()
+
+      for await (const event of agent.stream('Hi')) {
+        if (event.type === 'toolResultEvent') break
+      }
+
+      // _streamCore's drain loop resumes the agent loop after the break, so the
+      // invocation runs to completion; every started cycle must also close.
+      expect(tracer.startAgentLoopSpan).toHaveBeenCalledTimes(2)
+      expect(tracer.endAgentLoopSpan).toHaveBeenCalledTimes(2)
+    })
+
+    it('closes cycle telemetry once when an error is thrown after the cycle already closed', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(0)
+
+      try {
+        const model = new MockMessageModel().addTurn({
+          type: 'toolUseBlock',
+          name: 'testTool',
+          toolUseId: 'tool-1',
+          input: {},
+        })
+        const tool = createMockTool(
+          'testTool',
+          () =>
+            new ToolResultBlock({
+              toolUseId: 'tool-1',
+              status: 'success',
+              content: [new TextBlock('Result')],
+            })
+        )
+        const agent = new Agent({ model, tools: [tool] })
+        const tracer = getLatestTracer()
+
+        agent.addHook(BeforeToolsEvent, () => {
+          vi.setSystemTime(60)
+        })
+        agent.addHook(AfterToolsEvent, (event: AfterToolsEvent) => {
+          event.endTurn = true
+        })
+
+        // Cycle telemetry closes after tool execution; the endTurn message append
+        // then throws, exercising the error-after-clean-close path.
+        const push = agent.messages.push.bind(agent.messages)
+        vi.spyOn(agent.messages, 'push').mockImplementation((...items: Message[]): number => {
+          const isEndTurnMessage = items.some((message) =>
+            message.content.some((block) => block.type === 'textBlock' && block.text.includes('Turn ended early'))
+          )
+          if (isEndTurnMessage) {
+            throw new Error('append failed after cycle close')
+          }
+          return push(...items)
+        })
+
+        await expect(agent.invoke('Hi')).rejects.toThrow('append failed after cycle close')
+
+        expect(tracer.endAgentLoopSpan).toHaveBeenCalledTimes(1)
+        expect(tracer.endAgentLoopSpan).toHaveBeenCalledWith({ mock: 'loopSpan' })
+        expect(agent.metrics.totalDuration).toBe(60)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
     it('starts and ends loop span for each cycle', async () => {
       const model = new MockMessageModel().addTurn({ type: 'textBlock', text: 'Done' })
       const agent = new Agent({ model })
@@ -241,6 +379,7 @@ describe('Agent tracer integration', () => {
 
       await expect(agent.invoke('Hi')).rejects.toThrow(MaxTokensError)
 
+      expect(tracer.endAgentLoopSpan).toHaveBeenCalledTimes(1)
       expect(tracer.endAgentLoopSpan).toHaveBeenCalledWith(
         { mock: 'loopSpan' },
         expect.objectContaining({ error: expect.any(MaxTokensError) })

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -1602,6 +1602,24 @@ export class Agent implements LocalAgent, InvokableAgent {
           messages: this.messages,
         })
 
+        // Closes cycle telemetry exactly once, however the cycle exits: return,
+        // continue, throw, or the consumer closing the public iterator (which
+        // resumes the generator at the suspended yield and runs the finally).
+        // Called before building an AgentResult so its metrics include this cycle.
+        let cycleClosed = false
+        const closeCycle = (error?: Error): void => {
+          if (cycleClosed) {
+            return
+          }
+          cycleClosed = true
+          this._meter.endCycle(cycleStartTime)
+          if (error) {
+            this._tracer.endAgentLoopSpan(cycleSpan, { error })
+          } else {
+            this._tracer.endAgentLoopSpan(cycleSpan)
+          }
+        }
+
         try {
           // Normalize input and append user messages on first invocation only
           if (currentArgs !== undefined) {
@@ -1637,8 +1655,7 @@ export class Agent implements LocalAgent, InvokableAgent {
                 )
               }
 
-              this._meter.endCycle(cycleStartTime)
-              this._tracer.endAgentLoopSpan(cycleSpan)
+              closeCycle()
 
               // Schema set, model ignored the tool — drop the response and force the tool next cycle.
               // Appending the plain-text turn here would leave the conversation ending on an
@@ -1681,8 +1698,7 @@ export class Agent implements LocalAgent, InvokableAgent {
               yield this._appendMessage(modelResult.message, invocationState)
               yield this._appendMessage(toolResultMessage, invocationState)
 
-              this._meter.endCycle(cycleStartTime)
-              this._tracer.endAgentLoopSpan(cycleSpan)
+              closeCycle()
 
               result = new AgentResult({
                 stopReason: 'cancelled',
@@ -1704,8 +1720,7 @@ export class Agent implements LocalAgent, InvokableAgent {
               const priorResumePosition = resumePosition
               resumePosition = undefined
               if (priorResumePosition !== 'afterModel') {
-                this._meter.endCycle(cycleStartTime)
-                this._tracer.endAgentLoopSpan(cycleSpan)
+                closeCycle()
                 result = new AgentResult({
                   stopReason: 'checkpoint',
                   lastMessage: modelResult.message,
@@ -1724,11 +1739,12 @@ export class Agent implements LocalAgent, InvokableAgent {
           // Execute tools
           const toolsResult = yield* this.executeTools(assistantMessage, invocationState, completedToolResults)
 
-          // When the consumer breaks the stream (e.g. agent.cancel() + break),
-          // yield* returns undefined because the inner generator was closed.
+          // Reached when the consumer breaks the stream during tool execution.
+          // _streamCore's drain loop calls .return(), which runs the finally in
+          // executeTools and yields its AfterToolsEvent, and the drain's next()
+          // then completes the closed generator, so this yield* evaluates to
+          // undefined instead of unwinding.
           if (!toolsResult) {
-            this._meter.endCycle(cycleStartTime)
-            this._tracer.endAgentLoopSpan(cycleSpan)
             continue
           }
           const toolResultMessage = toolsResult.message
@@ -1736,8 +1752,6 @@ export class Agent implements LocalAgent, InvokableAgent {
           // Tools were skipped (not executed) — preserve pending state so the next resume
           // can run them.
           if (this.isCancelled && toolsResult.toolsSkipped && this._interruptState.pendingToolExecution) {
-            this._meter.endCycle(cycleStartTime)
-            this._tracer.endAgentLoopSpan(cycleSpan)
             continue
           }
 
@@ -1759,8 +1773,7 @@ export class Agent implements LocalAgent, InvokableAgent {
             this._interruptState.deactivate()
           }
 
-          this._meter.endCycle(cycleStartTime)
-          this._tracer.endAgentLoopSpan(cycleSpan)
+          closeCycle()
 
           // Hook requested halt with content: exit without calling the model again.
           const { afterToolsEvent } = toolsResult
@@ -1818,9 +1831,10 @@ export class Agent implements LocalAgent, InvokableAgent {
             return result
           }
         } catch (error) {
-          this._meter.endCycle(cycleStartTime)
-          this._tracer.endAgentLoopSpan(cycleSpan, { error: error as Error })
+          closeCycle(error as Error)
           throw error
+        } finally {
+          closeCycle()
         }
       }
     } catch (error) {


### PR DESCRIPTION
## Description

Breaking out of `for await` on the public stream closes the generator at the suspended yield. This skipped the inline `endCycle`/`endAgentLoopSpan` calls in the agent loop and left the cycle span and meter cycle open.

This change adds a small idempotent `closeCycle()` helper for each cycle and runs it from a `finally` on the cycle body, so every exit path (return, continue, throw, consumer close) closes telemetry exactly once. The early returns still call it explicitly before building the `AgentResult`, so the result metrics include the finished cycle's duration. The two `continue` sites drop their inline cleanup entirely and rely on the `finally`.

This also fixes a double count in the original code. An error thrown after the cycle had already closed re-ran `endCycle` in the catch block, which inflated `totalDuration` and emitted a duplicate OTel duration sample. `Meter.endCycle` is not idempotent, so the guard in `closeCycle()` is what prevents this.

One behavior note for reviewers: an error thrown after the cycle already closed cleanly (for example while appending the endTurn message) is no longer attributed to the cycle span. The original code did not meaningfully attribute it either, because OTel ignores operations on an already-ended span. Nothing is lost, and the duplicate meter count and OTel warnings go away.

This is a simpler alternative to the approach in #3812, which restructured the loop body around `shouldReturnCycleResult`/`cycleResultData` flags. This version keeps the existing control flow intact (the touched function scores 105 on the cognitive complexity check versus 125 for #3812).

## Related Issues

Resolves #3800

## Documentation PR

No documentation changes are needed; this fixes internal telemetry lifecycle behavior without changing the public API.

## Type of Change

Bug fix

## Testing
- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
