### PR TITLE
docs: add OrcaRouter model provider integration

### DIFF
--- a/site/src/config/navigation.yml
+++ b/site/src/config/navigation.yml
@@ -378,6 +378,7 @@ sidebar:
           - docs/integrations/model-providers/nebius-token-factory
           - docs/integrations/model-providers/nvidia-nim
           - docs/integrations/model-providers/openrouter
+          - docs/integrations/model-providers/orcarouter
           - docs/integrations/model-providers/sglang
           - docs/integrations/model-providers/vllm
           - docs/integrations/model-providers/mlx

--- a/site/src/content/catalog/orcarouter.yaml
+++ b/site/src/content/catalog/orcarouter.yaml
@@ -1,7 +1,6 @@
 name: OrcaRouter
 description: OrcaRouter's adaptive routing across many models behind one API key, accessed through the Strands Agents OpenAI-compatibility layer.
 integrationType: model-provider
-maintainedBy: strands
 languages:
   python: {}
   typescript: {}

--- a/site/src/content/catalog/orcarouter.yaml
+++ b/site/src/content/catalog/orcarouter.yaml
@@ -1,0 +1,10 @@
+name: OrcaRouter
+description: OrcaRouter's adaptive routing across many models behind one API key, accessed through the Strands Agents OpenAI-compatibility layer.
+integrationType: model-provider
+maintainedBy: strands
+languages:
+  python: {}
+  typescript: {}
+github: https://github.com/strands-agents/harness-sdk/blob/main/strands-py/src/strands/models/openai.py
+docsPage: docs/integrations/model-providers/orcarouter
+addedDate: 2026-08-29

--- a/site/src/content/docs/integrations/model-providers/orcarouter.mdx
+++ b/site/src/content/docs/integrations/model-providers/orcarouter.mdx
@@ -1,0 +1,93 @@
+---
+title: OrcaRouter
+description: 'Run Strands agents on many models through OrcaRouter, using the SDK''s built-in OpenAI provider against the OpenAI-compatible endpoint.'
+integrationType: model-provider
+---
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for
+both models and agents. Like OpenRouter, it exposes a provider/model namespace across
+many models — but it also combines adaptive routing, automatic failover, zero-markup
+inference, observability, guardrails, and agent-tool governance behind the same
+endpoint.
+
+:::note[OpenAI compatibility]
+This integration works through the SDK's built-in
+[OpenAI provider](../../user-guide/concepts/model-providers/openai.mdx) pointed at
+OrcaRouter's OpenAI-compatible endpoint; there is no separate OrcaRouter integration.
+Compatible endpoints can have quirks that deviate from the exact OpenAI API spec, so
+some features may behave differently than they do against OpenAI itself.
+:::
+
+## Installation
+
+The OpenAI provider is an optional dependency. To install, run:
+
+<Tabs>
+<Tab label="Python">
+
+```bash
+pip install 'strands-agents[openai]'
+```
+</Tab>
+<Tab label="TypeScript">
+
+```bash
+npm install @strands-agents/sdk openai
+```
+</Tab>
+</Tabs>
+
+## Usage
+
+Create an [API key](https://www.orcarouter.ai/keys), export it as
+`ORCAROUTER_API_KEY`, and point the provider at OrcaRouter's endpoint:
+
+<Tabs>
+<Tab label="Python">
+
+```python
+import os
+
+from strands import Agent
+from strands.models.openai import OpenAIModel
+
+model = OpenAIModel(
+    client_args={
+        "api_key": os.environ["ORCAROUTER_API_KEY"],
+        "base_url": "https://api.orcarouter.ai/v1",
+    },
+    model_id="orcarouter/auto",
+)
+
+agent = Agent(model=model)
+response = agent("Explain tool calling in one sentence.")
+print(response)
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "integrations/model-providers/orcarouter_imports.ts:usage_imports"
+
+--8<-- "integrations/model-providers/orcarouter.ts:usage"
+```
+</Tab>
+</Tabs>
+
+## Configuration
+
+Two client settings connect the provider to OrcaRouter:
+
+* **API key**: from your [OrcaRouter dashboard](https://www.orcarouter.ai/keys)
+* **Base URL**: `https://api.orcarouter.ai/v1`
+
+Model IDs come from the [OrcaRouter model catalog](https://www.orcarouter.ai/models) and
+are prefixed with the gateway name, for example `orcarouter/auto` or
+`orcarouter/fusion`. For model parameters and other provider options, see the
+[OpenAI provider](../../user-guide/concepts/model-providers/openai.mdx) guide.
+
+## References
+
+* [OrcaRouter docs](https://docs.orcarouter.ai)
+* [OrcaRouter model catalog](https://www.orcarouter.ai/models)
+* [OpenAI provider](../../user-guide/concepts/model-providers/openai.mdx)

--- a/site/src/content/docs/integrations/model-providers/orcarouter.ts
+++ b/site/src/content/docs/integrations/model-providers/orcarouter.ts
@@ -1,0 +1,19 @@
+import { Agent } from '@strands-agents/sdk'
+import { OpenAIModel } from '@strands-agents/sdk/models/openai'
+
+async function usage() {
+  // --8<-- [start:usage]
+  const model = new OpenAIModel({
+    api: 'chat',
+    apiKey: process.env.ORCAROUTER_API_KEY,
+    clientConfig: {
+      baseURL: 'https://api.orcarouter.ai/v1',
+    },
+    modelId: 'orcarouter/auto',
+  })
+
+  const agent = new Agent({ model })
+  const response = await agent.invoke('Explain tool calling in one sentence.')
+  console.log(response)
+  // --8<-- [end:usage]
+}

--- a/site/src/content/docs/integrations/model-providers/orcarouter_imports.ts
+++ b/site/src/content/docs/integrations/model-providers/orcarouter_imports.ts
@@ -1,0 +1,4 @@
+// --8<-- [start:usage_imports]
+import { Agent } from '@strands-agents/sdk'
+import { OpenAIModel } from '@strands-agents/sdk/models/openai'
+// --8<-- [end:usage_imports]


### PR DESCRIPTION
This adds OrcaRouter as a documented model provider on the integrations page, so
Strands users can point the built-in OpenAI provider at OrcaRouter's
OpenAI-compatible endpoint (`https://api.orcarouter.ai/v1`) and use it as a
first-class provider instead of an anonymous custom base URL.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for
both models and agents. Like OpenRouter, it exposes a provider/model namespace across
many models — but it also combines adaptive routing, automatic failover, zero-markup
inference, observability, guardrails, and agent-tool governance behind the same
endpoint. Adding orcarouter as a first-class provider means this project's users can
use that stack directly, without treating OrcaRouter as an anonymous custom base URL.
It also runs gateway-level, zero-trust security for AI agents on the same endpoint —
screening every prompt/response and governing every tool call on a default-deny basis,
with no application code changes.

The change mirrors the existing OpenRouter integration exactly: an MDX page under
`site/src/content/docs/integrations/model-providers/`, the matching TypeScript
snippet files, a `site/src/content/catalog/orcarouter.yaml` entry, and a sidebar
navigation entry. The examples use the `orcarouter/auto` model ID from the
[OrcaRouter model catalog](https://www.orcarouter.ai/models).

Verified locally from `site/` with Node 22: `npm run build` (including the broken
links checker and pagefind), `npm run typecheck`, `npm run typecheck:snippets`,
`npm test` (613 passed), and `npm run format:check` all pass; the complexity check
reports no SDK source functions touched. I also confirmed the endpoint live with a
real API key — a chat completion against `https://api.orcarouter.ai/v1` returns HTTP
200.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
