### PR TITLE
fix: [BUG] Cross-provider document-source gate from #1572 doesn't cover tool results — KeyError: 'bytes' on location-source documents in toolResult (#4018)

### DIFF
--- a/strands-py/src/strands/models/anthropic.py
+++ b/strands-py/src/strands/models/anthropic.py
@@ -200,15 +200,26 @@ class AnthropicModel(Model):
             }
 
         if "toolResult" in content:
-            return {
-                "content": [
+            # Mirror the message-path gate at anthropic.py:211 — toolResult content
+            # nesting location-source documents/images would otherwise crash with
+            # KeyError: 'bytes' when recursively formatting each entry below.
+            # See https://github.com/strands-agents/harness-sdk/issues/4018
+            formatted_inner: list[dict[str, Any]] = []
+            for tool_result_content in content["toolResult"]["content"]:
+                if _has_location_source(cast(ContentBlock, tool_result_content)):
+                    logger.warning(
+                        "Location sources are not supported by Anthropic | skipping toolResult content block"
+                    )
+                    continue
+                formatted_inner.append(
                     self._format_request_message_content(
                         {"text": json.dumps(tool_result_content["json"], ensure_ascii=False)}
                         if "json" in tool_result_content
                         else cast(ContentBlock, tool_result_content)
                     )
-                    for tool_result_content in content["toolResult"]["content"]
-                ],
+                )
+            return {
+                "content": formatted_inner,
                 "is_error": content["toolResult"]["status"] == "error",
                 "tool_use_id": content["toolResult"]["toolUseId"],
                 "type": "tool_result",

--- a/strands-py/src/strands/models/openai.py
+++ b/strands-py/src/strands/models/openai.py
@@ -254,6 +254,13 @@ class OpenAIModel(Model):
                 else:
                     merged.append({"type": "text", "text": content_block["text"]})
             elif "image" in content_block or "document" in content_block:
+                if _has_location_source(content_block):
+                    # Mirror the message-path gate at openai.py:412 — location-source
+                    # documents/images cannot be inlined as base64 (no `bytes` key),
+                    # so warn and skip rather than crash with KeyError: 'bytes'.
+                    # See https://github.com/strands-agents/harness-sdk/issues/4018
+                    logger.warning("Location sources are not supported by OpenAI | skipping toolResult content block")
+                    continue
                 has_non_text = True
                 merged.append(cls.format_request_message_content(content_block))
 

--- a/strands-py/tests/strands/models/test_anthropic.py
+++ b/strands-py/tests/strands/models/test_anthropic.py
@@ -12,6 +12,7 @@ import pytest
 import strands
 from strands.models.anthropic import AnthropicModel
 from strands.models.model import CacheConfig, CacheToolsConfig
+from strands.types.content import Messages
 from strands.types.exceptions import ContextWindowOverflowException, ModelThrottledException
 
 
@@ -1206,6 +1207,70 @@ def test_format_request_filters_location_source_document(model, model_id, max_to
     ]
     assert tru_request["messages"] == exp_messages
     assert "Location sources are not supported by Anthropic" in caplog.text
+
+
+def test_format_request_filters_location_source_document_in_tool_result(model, model_id, max_tokens, caplog):
+    """Regression for https://github.com/strands-agents/harness-sdk/issues/4018.
+
+    A location-source document nested inside a toolResult must be warn-and-skipped
+    rather than crashing with KeyError: 'bytes' when the Anthropic provider
+    recursively formats each entry of the toolResult content list.
+    """
+    caplog.set_level(logging.WARNING, logger="strands.models.anthropic")
+
+    messages: Messages = [
+        {"role": "user", "content": [{"text": "fetch the report"}]},
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "toolUse": {
+                        "input": {"path": "report.pdf"},
+                        "name": "fetch_doc",
+                        "toolUseId": "t1",
+                    },
+                },
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "toolUseId": "t1",
+                        "status": "success",
+                        "content": [
+                            {
+                                "document": {
+                                    "format": "pdf",
+                                    "name": "report.pdf",
+                                    "source": {
+                                        "location": {"type": "s3", "uri": "s3://bucket/report.pdf"},
+                                    },
+                                },
+                            },
+                            {"text": "fallback summary"},
+                        ],
+                    },
+                },
+            ],
+        },
+    ]
+
+    tru_request = model.format_request(messages)
+    # No exception is the headline assertion; toolResult preserves the text
+    # block but drops the location-source document and emits the warn+skip log.
+    last = tru_request["messages"][-1]
+    assert last["role"] == "user"
+    assert last["content"] == [
+        {
+            "content": [{"text": "fallback summary", "type": "text"}],
+            "is_error": False,
+            "tool_use_id": "t1",
+            "type": "tool_result",
+        },
+    ]
+    assert "Location sources are not supported by Anthropic | skipping toolResult content block" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests/strands/models/test_openai.py
+++ b/strands-py/tests/strands/models/test_openai.py
@@ -10,6 +10,7 @@ import pytest
 import strands
 from strands.models import CacheConfig
 from strands.models.openai import OpenAIModel
+from strands.types.content import Messages
 from strands.types.exceptions import ContextWindowOverflowException, ModelThrottledException
 
 
@@ -390,6 +391,120 @@ def test_format_request_tool_message_empty_content():
     assert tru_result["content"] == ""
     assert tru_result["role"] == "tool"
     assert tru_result["tool_call_id"] == "c1"
+
+
+def test_format_request_tool_message_skips_location_source_document(caplog):
+    """Regression for https://github.com/strands-agents/harness-sdk/issues/4018.
+
+    A location-source document nested inside a toolResult must not crash with
+    KeyError: 'bytes'; it is warn-and-skipped instead (mirrors the message-
+    path gate at openai.py for user messages containing location-source docs).
+    """
+    caplog.set_level(logging.WARNING, logger="strands.models.openai")
+
+    tool_result = {
+        "content": [
+            {"text": "analyze this report"},
+            {
+                "document": {
+                    "format": "pdf",
+                    "name": "report.pdf",
+                    "source": {"location": {"type": "s3", "uri": "s3://bucket/report.pdf"}},
+                },
+            },
+        ],
+        "status": "success",
+        "toolUseId": "c1",
+    }
+
+    tru_result = OpenAIModel.format_request_tool_message(tool_result)
+    content = tru_result["content"]
+
+    # Location-source document skipped; surviving text returns as a joined string
+    # (no non-text content remains, so has_non_text is False — same path as the
+    # all-text case in format_request_tool_message).
+    assert content == "analyze this report"
+    assert "Location sources are not supported by OpenAI | skipping toolResult content block" in caplog.text
+
+
+def test_format_request_tool_message_skips_location_source_image(caplog):
+    """Regression for https://github.com/strands-agents/harness-sdk/issues/4018.
+
+    Same gate for image blocks whose source is a location rather than bytes.
+    """
+    caplog.set_level(logging.WARNING, logger="strands.models.openai")
+
+    tool_result = {
+        "content": [
+            {
+                "image": {
+                    "format": "png",
+                    "source": {"location": {"type": "s3", "uri": "s3://bucket/img.png"}},
+                },
+            },
+        ],
+        "status": "success",
+        "toolUseId": "c1",
+    }
+
+    tru_result = OpenAIModel.format_request_tool_message(tool_result)
+    # Image-only result becomes empty string (no surviving text or non-text).
+    assert tru_result["content"] == ""
+    assert "Location sources are not supported by OpenAI | skipping toolResult content block" in caplog.text
+
+
+def test_format_request_messages_tool_result_with_location_source_document(model, caplog):
+    """Regression for https://github.com/strands-agents/harness-sdk/issues/4018.
+
+    End-to-end: build an assistant→toolResult pair where the tool result carries
+    a location-source document and confirm model.format_request does not raise.
+    """
+    caplog.set_level(logging.WARNING, logger="strands.models.openai")
+
+    messages: Messages = [
+        {"role": "user", "content": [{"text": "fetch the report"}]},
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "toolUse": {
+                        "input": {"path": "report.pdf"},
+                        "name": "fetch_doc",
+                        "toolUseId": "t1",
+                    },
+                },
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "toolUseId": "t1",
+                        "status": "success",
+                        "content": [
+                            {
+                                "document": {
+                                    "format": "pdf",
+                                    "name": "report.pdf",
+                                    "source": {
+                                        "location": {"type": "s3", "uri": "s3://bucket/report.pdf"},
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                },
+            ],
+        },
+    ]
+
+    request = model.format_request(messages)
+    # No exception is the headline assertion; the document is dropped, the
+    # tool-message comes back with empty content.
+    assert request["messages"][-1]["role"] == "tool"
+    assert request["messages"][-1]["tool_call_id"] == "t1"
+    assert "skipping toolResult content block" in caplog.text
 
 
 def test_split_tool_message_images_with_image():


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

## Related Issues

Closes #4018

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [ ] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

