### PR TITLE
fix(models): skip location-source content in OpenAI Responses instead of raising KeyError

### DIFF
--- a/strands-py/src/strands/models/openai_responses.py
+++ b/strands-py/src/strands/models/openai_responses.py
@@ -63,7 +63,7 @@ from ._defaults import resolve_config_metadata  # noqa: E402
 from ._openai_bedrock import BedrockMantleConfig, resolve_bedrock_client_args  # noqa: E402
 from ._openai_cache import apply_cache_config  # noqa: E402
 from ._openai_errors import classify_openai_error  # noqa: E402
-from ._validation import validate_config_keys  # noqa: E402
+from ._validation import _has_location_source, validate_config_keys  # noqa: E402
 from .model import BaseModelConfig, CacheConfig, Model  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -648,12 +648,16 @@ class OpenAIResponsesModel(Model):
             if any("cachePoint" in content for content in contents):
                 logger.warning("cachePoint content block is not supported by OpenAI Responses | skipping")
 
+            if any(_has_location_source(content) for content in contents):
+                logger.warning("Location sources are not supported by OpenAI Responses | skipping content block")
+
             formatted_contents = [
                 cls._format_request_message_content(content, role=role)
                 for content in contents
                 if not any(
                     block_type in content for block_type in ["toolResult", "toolUse", "reasoningContent", "cachePoint"]
                 )
+                and not _has_location_source(content)
             ]
 
             formatted_tool_calls = [
@@ -782,6 +786,11 @@ class OpenAIResponsesModel(Model):
         has_media = False
 
         for content in tool_result["content"]:
+            if _has_location_source(cast(ContentBlock, content)):
+                logger.warning(
+                    "Location sources are not supported by OpenAI Responses | skipping toolResult content block"
+                )
+                continue
             if "json" in content:
                 output_parts.append({"type": "input_text", "text": json.dumps(content["json"], ensure_ascii=False)})
             elif "text" in content:

--- a/strands-py/tests/strands/models/test_openai_responses.py
+++ b/strands-py/tests/strands/models/test_openai_responses.py
@@ -2068,3 +2068,94 @@ class TestOpenAIResponsesModelBedrockMantleConfig:
         model = OpenAIResponsesModel(model_id="openai.gpt-oss-120b", bedrock_mantle_config={"region": "us-east-1"})
         with pytest.raises(RuntimeError, match="Bedrock Mantle bearer token.*us-east-1"):
             model._resolve_client_args()
+
+
+def test_format_request_filters_location_source_document(model, caplog):
+    """Location-source documents are skipped with a warning instead of raising KeyError."""
+    caplog.set_level(logging.WARNING, logger="strands.models.openai_responses")
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"text": "summarize this"},
+                {
+                    "document": {
+                        "format": "pdf",
+                        "name": "spec",
+                        "source": {"location": {"type": "s3", "uri": "s3://my-bucket/spec.pdf"}},
+                    },
+                },
+            ],
+        },
+    ]
+
+    request = model._format_request(messages)
+
+    formatted_content = request["input"][0]["content"]
+    assert len(formatted_content) == 1
+    assert formatted_content[0]["type"] == "input_text"
+    assert "Location sources are not supported by OpenAI Responses" in caplog.text
+
+
+def test_format_request_filters_location_source_image(model, caplog):
+    """Location-source images are skipped with a warning instead of raising KeyError."""
+    caplog.set_level(logging.WARNING, logger="strands.models.openai_responses")
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"text": "look at this image"},
+                {
+                    "image": {
+                        "format": "png",
+                        "source": {"location": {"type": "s3", "uri": "s3://my-bucket/image.png"}},
+                    },
+                },
+            ],
+        },
+    ]
+
+    request = model._format_request(messages)
+
+    formatted_content = request["input"][0]["content"]
+    assert len(formatted_content) == 1
+    assert formatted_content[0]["type"] == "input_text"
+    assert "Location sources are not supported by OpenAI Responses" in caplog.text
+
+
+def test_format_request_filters_location_source_in_tool_result(model, caplog):
+    """Location-source blocks nested in a toolResult are skipped, not crashed on."""
+    caplog.set_level(logging.WARNING, logger="strands.models.openai_responses")
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "toolUseId": "tool-1",
+                        "status": "success",
+                        "content": [
+                            {"text": "fetched the file"},
+                            {
+                                "document": {
+                                    "format": "pdf",
+                                    "name": "report",
+                                    "source": {"location": {"type": "s3", "uri": "s3://my-bucket/report.pdf"}},
+                                },
+                            },
+                        ],
+                    },
+                },
+            ],
+        },
+    ]
+
+    request = model._format_request(messages)
+
+    tool_output = request["input"][0]["output"]
+    assert "fetched the file" in str(tool_output)
+    assert "report.pdf" not in str(tool_output)
+    assert "skipping toolResult content block" in caplog.text


### PR DESCRIPTION
## Description

`OpenAIResponsesModel` is the only model provider that never got the location-source gate from #1572. Every other provider checks `_has_location_source` before trying to inline content as base64; this one does not, so a document or image whose source is a location (an S3 URI, say) falls straight through to the inlining code and dies on a missing key:

```
KeyError: 'bytes'
```

Both spots the issue points at read `source["bytes"]` with nothing in front of them:

- `_format_request_message_content`, the message path
- `_format_request_tool_message`, the toolResult path

This adds the same gate to both. A location-source block now logs a warning and gets skipped, and the rest of the message goes through untouched. That is exactly what `openai.py`, `anthropic.py`, `gemini.py`, `mistral.py`, `ollama.py`, `writer.py` and `llamaapi.py` already do. Each of them has the check in two places, and `openai_responses.py` had it in zero.

Nothing else changes. Content without a location source takes the same path it always did.

## Related Issues

Fixes #4016

## Documentation PR

None needed. This brings one provider in line with the documented behaviour of all the others, it doesn't change it.

## Type of Change

Bug fix

## Testing

Three regression tests in `tests/strands/models/test_openai_responses.py`, one per case in the issue: a location-source document in a message, a location-source image in a message, and a location-source document nested inside a toolResult. Each one asserts the surrounding text survives, the location-source block is gone, and the warning was logged.

I checked they actually catch the bug rather than just passing. With the fix stashed, all three fail on `main` with the error from the issue:

```
E       KeyError: 'bytes'
src/strands/models/openai_responses.py:797: KeyError

FAILED test_format_request_filters_location_source_document
FAILED test_format_request_filters_location_source_image
FAILED test_format_request_filters_location_source_in_tool_result
3 failed
```

Put the fix back and they pass.

- `hatch test`: 5837 passed, 2 skipped
- `hatch run test-lint`: all checks passed, mypy clean on 274 files
- `hatch run test-format`: my two files are clean. The check does report 4 files under `vended_memory_stores/` and `tests/strands/storage/`, but those are already unformatted on `main` and I left them alone rather than mix an unrelated reformat into this PR.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
