### PR TITLE
fix(mcp): negatively cache failed doc fetches and report their cause

### DIFF
--- a/strands-mcp/src/strands_mcp_server/server.py
+++ b/strands-mcp/src/strands_mcp_server/server.py
@@ -127,7 +127,9 @@ def fetch_doc(uri: str = "", section: str = "") -> Dict[str, Any]:
         - error: Error description
         - url: Requested URL
 
-        Errors are returned for unsupported URLs and failed page fetches. For
+        Errors are returned for unsupported URLs and failed page fetches. A
+        failed fetch reports its cause (e.g. "fetch failed: HTTPError: 404") when
+        one is known. For
         sectioned documents, unknown section IDs also return an error; `section`
         is ignored when the full document is returned automatically.
 
@@ -143,7 +145,8 @@ def fetch_doc(uri: str = "", section: str = "") -> Dict[str, Any]:
 
     page = cache.ensure_page(uri)
     if page is None:
-        return {"error": "fetch failed", "url": uri}
+        reason = cache.get_failure_reason(uri)
+        return {"error": f"fetch failed: {reason}" if reason else "fetch failed", "url": uri}
 
     # Small doc: return full content directly
     if len(page.content.encode("utf-8")) <= text_processor.SMALL_DOC_THRESHOLD:

--- a/strands-mcp/src/strands_mcp_server/utils/cache.py
+++ b/strands-mcp/src/strands_mcp_server/utils/cache.py
@@ -1,7 +1,8 @@
 import logging
 import os
 import threading
-from typing import Dict
+import time
+from typing import Dict, Tuple
 
 from ..config import doc_config
 from . import doc_fetcher, indexer, text_processor
@@ -12,6 +13,7 @@ logger = logging.getLogger(__name__)
 _INDEX: indexer.IndexSearch | None = None
 _URL_CACHE: Dict[str, doc_fetcher.Page | None] = {}  # url -> Page (None if not fetched yet)
 _URL_TITLES: Dict[str, str] = {}  # url -> curated title from llms.txt
+_FAILED_URLS: Dict[str, Tuple[float, str]] = {}  # url -> (monotonic time of failure, reason)
 _LINKS_LOADED = False
 _PREFETCH_STARTED = False
 
@@ -22,6 +24,7 @@ _CACHE_LOCK = threading.Lock()
 _PREFETCH_LOCK = threading.Lock()
 
 SNIPPET_HYDRATE_MAX = 5  # how many top results to hydrate with content
+FAILED_FETCH_TTL = 300.0  # seconds a failed fetch is remembered before it is retried
 
 # Environment variable to enable background prefetch (default: OFF)
 PREFETCH_ENV_VAR = "STRANDS_MCP_PREFETCH_ALL"
@@ -133,6 +136,30 @@ def ensure_ready() -> None:
         load_links_only()
 
 
+def get_failure_reason(url: str) -> str | None:
+    """Return why the most recent fetch of ``url`` failed, if still remembered.
+
+    Entries older than ``FAILED_FETCH_TTL`` are treated as expired and dropped,
+    which is what allows a transiently broken URL to be retried later.
+
+    Args:
+        url: The URL to look up
+
+    Returns:
+        A short "ExceptionType: message" string, or None if the URL has no
+        remembered failure.
+    """
+    with _CACHE_LOCK:
+        entry = _FAILED_URLS.get(url)
+        if entry is None:
+            return None
+        failed_at, reason = entry
+        if time.monotonic() - failed_at >= FAILED_FETCH_TTL:
+            del _FAILED_URLS[url]
+            return None
+        return reason
+
+
 def ensure_page(url: str) -> doc_fetcher.Page | None:
     """Ensure a page is cached, fetching it if necessary.
 
@@ -147,6 +174,13 @@ def ensure_page(url: str) -> doc_fetcher.Page | None:
         re-indexes it. Body terms therefore become searchable even after a
         transient indexing failure.
 
+        A failed *fetch* is remembered for ``FAILED_FETCH_TTL`` seconds and the
+        cause is logged. Within that window this returns None without another
+        network attempt, so one unreachable URL in a search result set costs a
+        single timeout rather than one per call. ``get_failure_reason`` exposes
+        the cause to callers. Indexing failures are deliberately not remembered,
+        so they retry on the very next call.
+
     Args:
         url: The URL of the page to ensure is cached
 
@@ -157,8 +191,21 @@ def ensure_page(url: str) -> doc_fetcher.Page | None:
     page = _URL_CACHE.get(url)
     if page is not None:
         return page
+    if get_failure_reason(url) is not None:
+        return None
+
+    # Only the network fetch is negatively cached. A failure after this point is
+    # an indexing failure, which must stay immediately retryable so body terms
+    # can still become searchable (see update_content's failure contract).
     try:
         raw = doc_fetcher.fetch_and_clean(url)
+    except Exception as exc:
+        logger.warning("Fetch failed for %s: %s: %s", url, type(exc).__name__, exc)
+        with _CACHE_LOCK:
+            _FAILED_URLS[url] = (time.monotonic(), f"{type(exc).__name__}: {exc}")
+        return None
+
+    try:
         display_title = text_processor.format_display_title(url, raw.title, _URL_TITLES)
         page = doc_fetcher.Page(url=url, title=display_title, content=raw.content)
 
@@ -180,6 +227,7 @@ def ensure_page(url: str) -> doc_fetcher.Page | None:
 
             # Only cache after indexing succeeds
             _URL_CACHE[url] = page
+            _FAILED_URLS.pop(url, None)
 
         return page
     except Exception:

--- a/strands-mcp/tests/test_cache.py
+++ b/strands-mcp/tests/test_cache.py
@@ -1,5 +1,6 @@
 """Tests for cache module hydration and prefetch functionality."""
 
+import logging
 import os
 from unittest.mock import MagicMock, patch
 
@@ -17,12 +18,14 @@ def reset_cache_state():
     cache._URL_TITLES = {}
     cache._LINKS_LOADED = False
     cache._PREFETCH_STARTED = False
+    cache._FAILED_URLS = {}
     yield
     cache._INDEX = None
     cache._URL_CACHE = {}
     cache._URL_TITLES = {}
     cache._LINKS_LOADED = False
     cache._PREFETCH_STARTED = False
+    cache._FAILED_URLS = {}
 
 
 class TestEnsurePageIndexUpdate:
@@ -154,3 +157,117 @@ class TestBackgroundPrefetch:
                         cache.load_links_only()
 
                         mock_thread.assert_called_once()
+
+
+class TestFailedFetchNegativeCache:
+    """Tests for negative caching of failed fetches (#3328)."""
+
+    URL = "https://strandsagents.com/broken.md"
+
+    @pytest.fixture
+    def clock(self):
+        """Controllable monotonic clock so TTL expiry is deterministic."""
+        current = {"now": 1000.0}
+        with patch(
+            "strands_mcp_server.utils.cache.time.monotonic",
+            side_effect=lambda: current["now"],
+        ):
+            yield current
+
+    def _failing_fetch(self, exc=None):
+        return patch(
+            "strands_mcp_server.utils.cache.doc_fetcher.fetch_and_clean",
+            side_effect=exc or TimeoutError("timed out"),
+        )
+
+    def test_failure_is_not_retried_within_ttl(self, clock):
+        with self._failing_fetch() as mock_fetch:
+            assert cache.ensure_page(self.URL) is None
+            clock["now"] += cache.FAILED_FETCH_TTL - 1
+            assert cache.ensure_page(self.URL) is None
+            assert cache.ensure_page(self.URL) is None
+
+        assert mock_fetch.call_count == 1
+
+    def test_failure_is_retried_after_ttl_expires(self, clock):
+        with self._failing_fetch() as mock_fetch:
+            assert cache.ensure_page(self.URL) is None
+            clock["now"] += cache.FAILED_FETCH_TTL
+            assert cache.ensure_page(self.URL) is None
+
+        assert mock_fetch.call_count == 2
+
+    def test_failure_reason_reports_exception_type_and_message(self, clock):
+        with self._failing_fetch():
+            cache.ensure_page(self.URL)
+
+        assert cache.get_failure_reason(self.URL) == "TimeoutError: timed out"
+
+    def test_failure_reason_is_none_for_unknown_url(self):
+        assert cache.get_failure_reason("https://strandsagents.com/never-fetched.md") is None
+
+    def test_failure_reason_expires_with_ttl(self, clock):
+        with self._failing_fetch():
+            cache.ensure_page(self.URL)
+
+        clock["now"] += cache.FAILED_FETCH_TTL
+        assert cache.get_failure_reason(self.URL) is None
+
+    def test_successful_retry_clears_remembered_failure(self, clock):
+        cache._INDEX = indexer.IndexSearch()
+
+        with self._failing_fetch():
+            assert cache.ensure_page(self.URL) is None
+        assert cache.get_failure_reason(self.URL) == "TimeoutError: timed out"
+
+        clock["now"] += cache.FAILED_FETCH_TTL
+        mock_raw = MagicMock()
+        mock_raw.title = "Recovered"
+        mock_raw.content = "The page came back."
+
+        with patch("strands_mcp_server.utils.cache.doc_fetcher.fetch_and_clean", return_value=mock_raw):
+            with patch(
+                "strands_mcp_server.utils.cache.text_processor.format_display_title",
+                return_value="Recovered",
+            ):
+                page = cache.ensure_page(self.URL)
+
+        assert page is not None
+        assert cache.get_failure_reason(self.URL) is None
+
+    def test_failure_is_logged(self, clock, caplog):
+        with self._failing_fetch():
+            with caplog.at_level(logging.WARNING, logger="strands_mcp_server.utils.cache"):
+                cache.ensure_page(self.URL)
+
+        assert self.URL in caplog.text
+        assert "TimeoutError" in caplog.text
+
+    def test_prefetch_does_not_retry_failed_pages(self, clock):
+        cache._URL_CACHE = {self.URL: None}
+
+        with self._failing_fetch() as mock_fetch:
+            cache._background_prefetch()
+            cache._background_prefetch()
+
+        assert mock_fetch.call_count == 1
+
+    def test_indexing_failure_is_not_negatively_cached(self, clock):
+        """Only fetch failures are remembered; indexing must stay retryable."""
+        cache._INDEX = indexer.IndexSearch()
+        cache._INDEX.add(indexer.Doc(uri=self.URL, display_title="Broken", content="", index_title="broken"))
+        mock_raw = MagicMock()
+        mock_raw.title = "Broken"
+        mock_raw.content = "body with specialterm"
+
+        with patch("strands_mcp_server.utils.cache.doc_fetcher.fetch_and_clean", return_value=mock_raw) as mock_fetch:
+            with patch(
+                "strands_mcp_server.utils.cache.text_processor.format_display_title",
+                return_value="Broken",
+            ):
+                with patch.object(cache._INDEX, "update_content", side_effect=RuntimeError("index down")):
+                    assert cache.ensure_page(self.URL) is None
+                assert cache.get_failure_reason(self.URL) is None
+                assert cache.ensure_page(self.URL) is not None
+
+        assert mock_fetch.call_count == 2

--- a/strands-mcp/tests/test_indexer_concurrency.py
+++ b/strands-mcp/tests/test_indexer_concurrency.py
@@ -411,6 +411,7 @@ class TestBlocker2CacheBeforeIndexing:
         cache._URL_TITLES = {}
         cache._LINKS_LOADED = False
         cache._PREFETCH_STARTED = False
+        cache._FAILED_URLS = {}
         yield
         cache._INDEX = None
         cache._URL_CACHE = {}
@@ -504,18 +505,23 @@ class TestBlocker2CacheBeforeIndexing:
             mock_raw.content = "flakyterm content here"
             return mock_raw
 
+        now = [1000.0]
         with patch("strands_mcp_server.utils.cache.doc_fetcher.fetch_and_clean", side_effect=flaky_fetch):
             with patch("strands_mcp_server.utils.cache.text_processor.format_display_title", return_value="Flaky Doc"):
-                # First call: fetch fails
-                page1 = cache.ensure_page(url)
-                assert page1 is None
+                with patch("strands_mcp_server.utils.cache.time.monotonic", side_effect=lambda: now[0]):
+                    # First call: fetch fails
+                    page1 = cache.ensure_page(url)
+                    assert page1 is None
 
-                # Cache should still be None so retry is possible
-                assert cache._URL_CACHE.get(url) is None, "Failed fetch should not populate cache"
+                    # Cache should still be None so retry is possible
+                    assert cache._URL_CACHE.get(url) is None, "Failed fetch should not populate cache"
 
-                # Second call: fetch succeeds
-                page2 = cache.ensure_page(url)
-                assert page2 is not None
+                    # The failure is negatively cached (#3328), so step past its TTL
+                    now[0] += cache.FAILED_FETCH_TTL
+
+                    # Second call: fetch succeeds
+                    page2 = cache.ensure_page(url)
+                    assert page2 is not None
 
         # Term should be searchable
         results = cache._INDEX.search("flakyterm")
@@ -534,6 +540,7 @@ class TestUpdateContentAtomicity:
         cache._URL_TITLES = {}
         cache._LINKS_LOADED = False
         cache._PREFETCH_STARTED = False
+        cache._FAILED_URLS = {}
         yield
         cache._INDEX = None
         cache._URL_CACHE = {}

--- a/strands-mcp/tests/test_server.py
+++ b/strands-mcp/tests/test_server.py
@@ -186,7 +186,17 @@ class TestFetchDocErrors:
 
     def test_fetch_failure_returns_error(self, mock_cache):
         mock_cache.ensure_page.return_value = None
+        mock_cache.get_failure_reason.return_value = None
 
         tru_result = fetch_doc(uri="https://strandsagents.com/missing.md")
 
         assert tru_result["error"] == "fetch failed"
+
+    def test_fetch_failure_reports_known_cause(self, mock_cache):
+        """A remembered fetch failure names its cause instead of "fetch failed" (#3328)."""
+        mock_cache.ensure_page.return_value = None
+        mock_cache.get_failure_reason.return_value = "HTTPError: HTTP Error 404: Not Found"
+
+        tru_result = fetch_doc(uri="https://strandsagents.com/missing.md")
+
+        assert tru_result["error"] == "fetch failed: HTTPError: HTTP Error 404: Not Found"


### PR DESCRIPTION
Fixes #3328

## Why

`cache.ensure_page` wrapped the whole fetch-and-index path in `except Exception: return None`. Two consequences, both called out in the issue:

- **No negative caching.** A broken URL that ranks into the top 5 results re-attempted its fetch on *every* `search_docs` call. With `timeout = 30.0`, one dead link adds up to 30s to each affected search, repeatedly and forever.
- **The cause was discarded.** DNS failure, 404, and timeout were indistinguishable. `fetch_doc` reported a bare `"fetch failed"`, so neither the operator (no log) nor the consuming model (no detail) could tell what went wrong.

## What changed

- Remember a failed fetch in `_FAILED_URLS` as `(monotonic time, "ExceptionType: message")` for `FAILED_FETCH_TTL` (300s). Within that window `ensure_page` returns `None` without touching the network, so one broken URL costs a single timeout instead of one per call.
- Log the exception at `WARNING` with the URL and exception type.
- Add `get_failure_reason(url)`, which drops expired entries as it reads. `fetch_doc` uses it to return `"fetch failed: HTTPError: HTTP Error 404: Not Found"`, falling back to the old bare message when no cause is known.
- A successful fetch clears any remembered failure.

## The one judgement call

**Only the network fetch is negatively cached.** The fetch is split out of the indexing `try` block so that an *indexing* failure is not remembered and retries on the very next call.

That is deliberate: `update_content`'s failure contract (and `TestBlocker2CacheBeforeIndexing`) exists so body terms still become searchable after a transient index error. Negatively caching that path would have silently weakened it. `test_indexing_failure_is_not_negatively_cached` pins the distinction.

## One existing test changed

`test_fetch_failure_does_not_cache_none` retried in the same instant, which the TTL now correctly suppresses. It advances the clock past `FAILED_FETCH_TTL` before retrying and still asserts the invariant it was written for: a failed fetch never poisons `_URL_CACHE` with `None`, and the retry re-indexes the body. No assertion was removed.

## Verification

- `pytest tests` — **97 passed** (was 87; 10 new).
- `ruff check` and `ruff format --check` clean.
- Mutation-checked: disabling the negative-cache guard fails exactly `test_failure_is_not_retried_within_ttl` and `test_prefetch_does_not_retry_failed_pages`.
- New tests use an injected monotonic clock, so TTL expiry is deterministic and no test sleeps.

Interacts with the serial-hydration item in #3317: this removes the repeated-timeout half of that cost, not the hydration half.

AI assistance was used for this change; I have reviewed every line and can walk through the design choices above.