### PR TITLE
fix(mcp): cap the no_sections fallback at the small-doc threshold

### DIFF
--- a/strands-mcp/src/strands_mcp_server/server.py
+++ b/strands-mcp/src/strands_mcp_server/server.py
@@ -123,6 +123,14 @@ def fetch_doc(uri: str = "", section: str = "") -> Dict[str, Any]:
         - document_small: true
         - content: Full document content (returned automatically)
 
+        For documents with no parseable sections that exceed ~8KB:
+        - url, title: Document metadata
+        - reason: "no_sections"
+        - truncated: true
+        - returned_bytes, total_bytes: Size of the returned slice and of the
+          whole document, so the caller can tell how much was withheld
+        - content: Leading slice of the document, capped at ~8KB
+
         On error:
         - error: Error description
         - url: Requested URL
@@ -157,14 +165,23 @@ def fetch_doc(uri: str = "", section: str = "") -> Dict[str, Any]:
 
     sections = text_processor.parse_sections(page.content)
 
-    # No parseable sections: treat as small doc regardless of size
+    # No parseable sections: there is nothing to build a TOC from, so return the
+    # content directly - but keep the size gate, or a large structureless page
+    # (any HTML page, since _html_to_text strips markdown structure) would dump
+    # its full body into the model context.
+    # Reaching here means the size gate above already passed, so the document is
+    # always larger than SMALL_DOC_THRESHOLD.
     if not sections:
+        total_bytes = len(page.content.encode("utf-8"))
+        content = text_processor.truncate_utf8(page.content, text_processor.SMALL_DOC_THRESHOLD)
         return {
             "url": uri,
             "title": page.title,
-            "document_small": True,
             "reason": "no_sections",
-            "content": page.content,
+            "truncated": True,
+            "returned_bytes": len(content.encode("utf-8")),
+            "total_bytes": total_bytes,
+            "content": content,
         }
 
     # Section mode: extract specific section

--- a/strands-mcp/src/strands_mcp_server/utils/text_processor.py
+++ b/strands-mcp/src/strands_mcp_server/utils/text_processor.py
@@ -132,6 +132,30 @@ def _truncate(text: str, max_chars: int) -> str:
     return text[: max_chars - 1].rstrip() + "\u2026"
 
 
+def truncate_utf8(text: str, max_bytes: int) -> str:
+    """Clip text to at most max_bytes of UTF-8 without splitting a character.
+
+    Prefers the last line break in the clipped region so the tail is not a
+    half-written line, but only when that keeps more than half the budget.
+
+    Args:
+        text: Text to clip
+        max_bytes: Maximum size of the result when UTF-8 encoded
+
+    Returns:
+        The original text when it already fits, otherwise a clipped copy.
+    """
+    encoded = text.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return text
+
+    clipped = encoded[:max_bytes].decode("utf-8", errors="ignore")
+    boundary = clipped.rfind("\n")
+    if boundary > max_bytes // 2:
+        clipped = clipped[:boundary]
+    return clipped
+
+
 def make_snippet(page: Page | None, display_title: str, max_chars: int = 300) -> str:
     """Create a contextual snippet from page content.
 

--- a/strands-mcp/tests/test_server.py
+++ b/strands-mcp/tests/test_server.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from strands_mcp_server.server import fetch_doc, search_docs
+from strands_mcp_server.utils import text_processor
 from strands_mcp_server.utils.doc_fetcher import Page
 from strands_mcp_server.utils.indexer import Doc
 
@@ -111,7 +112,8 @@ class TestFetchDocTocMode:
         assert "preamble" in tru_result
         assert "Experimental hook events" in tru_result["preamble"]
 
-    def test_no_h2_headers_returns_full_content(self, mock_cache, no_h2_doc):
+    def test_no_h2_headers_large_doc_is_capped(self, mock_cache, no_h2_doc):
+        """A structureless doc over the threshold is capped, not dumped whole (#3327)."""
         mock_cache.ensure_page.return_value = Page(
             url="https://strandsagents.com/no-h2.md",
             title="No H2 Doc",
@@ -120,11 +122,14 @@ class TestFetchDocTocMode:
 
         tru_result = fetch_doc(uri="https://strandsagents.com/no-h2.md")
 
-        # No ## sections means fallback to full content
-        assert tru_result["document_small"] is True
         assert tru_result["reason"] == "no_sections"
-        assert "content" in tru_result
+        assert tru_result["truncated"] is True
+        assert "document_small" not in tru_result
         assert "sections" not in tru_result
+        assert tru_result["returned_bytes"] <= text_processor.SMALL_DOC_THRESHOLD
+        assert tru_result["total_bytes"] == len(no_h2_doc.encode("utf-8"))
+        assert tru_result["total_bytes"] > tru_result["returned_bytes"]
+        assert no_h2_doc.startswith(tru_result["content"])
 
     @pytest.mark.parametrize("kwargs", [{}, {"uri": ""}], ids=["no-args", "empty-uri"])
     def test_omitted_uri_returns_url_catalog(self, mock_cache, kwargs):

--- a/strands-mcp/tests/test_text_processor.py
+++ b/strands-mcp/tests/test_text_processor.py
@@ -7,6 +7,7 @@ from strands_mcp_server.utils.text_processor import (
     extract_section,
     make_section_summary,
     parse_sections,
+    truncate_utf8,
 )
 
 
@@ -246,3 +247,38 @@ class TestExtractPreamble:
         tru_preamble = extract_preamble(content)
 
         assert "Some intro without title" in tru_preamble
+
+
+class TestTruncateUtf8:
+    """Tests for the byte-budget clipper behind the no_sections cap (#3327)."""
+
+    def test_short_text_returned_unchanged(self):
+        assert truncate_utf8("hello", 100) == "hello"
+
+    def test_exact_fit_returned_unchanged(self):
+        text = "a" * 50
+        assert truncate_utf8(text, 50) == text
+
+    def test_result_never_exceeds_budget(self):
+        text = "line of text\n" * 500
+        clipped = truncate_utf8(text, 200)
+        assert len(clipped.encode("utf-8")) <= 200
+        assert text.startswith(clipped)
+
+    def test_multibyte_characters_are_not_split(self):
+        text = "é" * 500  # 2 bytes each
+        clipped = truncate_utf8(text, 101)
+        assert len(clipped.encode("utf-8")) <= 101
+        assert clipped == "é" * 50  # decodes cleanly, no replacement char
+        assert "�" not in clipped
+
+    def test_prefers_line_boundary(self):
+        text = "aaaa\n" * 100
+        clipped = truncate_utf8(text, 22)
+        assert clipped == "aaaa\naaaa\naaaa\naaaa"
+
+    def test_keeps_budget_when_line_boundary_is_too_early(self):
+        text = "a\n" + "b" * 500
+        clipped = truncate_utf8(text, 100)
+        assert len(clipped.encode("utf-8")) == 100
+        assert clipped.startswith("a\nbbb")


### PR DESCRIPTION
Fixes #3327

## Why

`fetch_doc` puts large documents behind a TOC so the consuming agent pays a predictable token cost. When `parse_sections` returned nothing, that gate was skipped entirely:

```python
if not sections:
    return {..., "document_small": True, "reason": "no_sections", "content": page.content}
```

The document was returned whole, at any size, labelled `document_small: true`.

This is not a rare path. As the issue notes, `_html_to_text` in `doc_fetcher.py` is regex-based and strips markdown structure, so **any large HTML page** lands here and dumps its full body into the model context.

## What changed

- Clip the fallback to `SMALL_DOC_THRESHOLD` and return `truncated: true`, plus `returned_bytes` and `total_bytes` so the caller can see how much was withheld rather than silently receiving a prefix.
- Drop `document_small: true` from this path. It was actively misleading: it only ever fired for documents *over* the threshold. `reason: "no_sections"` still distinguishes it from the `reason: "size"` path.
- Add `text_processor.truncate_utf8`, which clips on a character boundary so multi-byte text is never split into a replacement character, and prefers the last line break when that keeps more than half the budget.

## A note on the shape of the fix

The issue offered two options: cap with a truncation notice, or fixed-size chunking with an `offset` parameter. I took the cap, because it is the smaller change and does not add a parameter to a tool signature that models already have to reason about. The trade-off is that content past the cap is currently unreachable for structureless documents; `total_bytes` at least makes that visible. Happy to follow up with `offset` if you would rather have paging.

I also removed a size check I had initially written inside this branch. The gate above it already returns for anything under the threshold, so `if not sections` is only reachable for a document that exceeds it, and the second check was dead code.

## One existing test changed

`test_no_h2_headers_returns_full_content` asserted the old behavior directly, using the `no_h2_doc` fixture that conftest deliberately pads above the threshold. It is renamed to `test_no_h2_headers_large_doc_is_capped` and now asserts the cap, that `content` is a true prefix of the document, and that `total_bytes > returned_bytes`.

## Verification

- `pytest tests` — **93 passed** (was 87).
- `ruff check` and `ruff format --check` clean.
- Mutation-checked: restoring `content = page.content` fails `test_no_h2_headers_large_doc_is_capped`.
- `truncate_utf8` covered for exact fit, budget ceiling, multi-byte safety (asserts no `U+FFFD`), line-boundary preference, and the case where the only line break is too early to use.

AI assistance was used for this change; I have reviewed every line and can walk through the design choices above.