### PR TITLE
feat(mcp): read llms.txt sources, timeout and user agent from the environment

### DIFF
--- a/strands-mcp/README.md
+++ b/strands-mcp/README.md
@@ -56,6 +56,14 @@ This MCP server provides curated documentation access to your GenAI tools via ll
 
 - `STRANDS_MCP_PREFETCH_ALL`: when set to a truthy value (`1`, `true`, `yes`), the server prefetches and indexes all pages in the background at startup, so body-term search works immediately instead of only after a page has been hydrated by a prior query. Defaults to off. Prefetch is best-effort and eventually consistent: results may be title-only until background hydration completes.
 
+- `STRANDS_MCP_LLMS_TXT`: comma-separated list of `llms.txt` URLs to index. Defaults to `https://strandsagents.com/llms.txt`. A value with no usable URLs falls back to the default.
+- `STRANDS_MCP_TIMEOUT`: HTTP request timeout in seconds. Defaults to `30`. A value that is not a positive number is ignored, with a warning, so a typo cannot stop the server from starting.
+- `STRANDS_MCP_USER_AGENT`: `User-Agent` header for outbound requests. Defaults to `strands-mcp-docs/1.0`.
+
+Configuration is read from the environment at import time.
+
+> **Note:** `fetch_doc` currently accepts only `https://strandsagents.com` URLs. Documents from other configured sources are indexed and searchable through `search_docs` (including their body text, which is hydrated during search), but cannot be read directly with `fetch_doc` yet.
+
 ## Prerequisites
 
 The usage methods below require [uv](https://github.com/astral-sh/uv) to be installed on your system. You can install it by following the [official installation instructions](https://github.com/astral-sh/uv#installation).

--- a/strands-mcp/src/strands_mcp_server/config.py
+++ b/strands-mcp/src/strands_mcp_server/config.py
@@ -1,9 +1,73 @@
+import logging
+import os
 from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+ENV_LLMS_TXT = "STRANDS_MCP_LLMS_TXT"  # comma-separated llms.txt URLs
+ENV_TIMEOUT = "STRANDS_MCP_TIMEOUT"  # HTTP timeout in seconds
+ENV_USER_AGENT = "STRANDS_MCP_USER_AGENT"  # User-Agent header
+
+DEFAULT_LLMS_TXT_URLS = ["https://strandsagents.com/llms.txt"]
+DEFAULT_TIMEOUT = 30.0
+DEFAULT_USER_AGENT = "strands-mcp-docs/1.0"
+
+
+def _env_llms_txt_urls() -> list[str]:
+    """Read the llms.txt source list from the environment.
+
+    Returns:
+        URLs from ENV_LLMS_TXT split on commas, or the default list when the
+        variable is unset, empty, or contains only separators.
+    """
+    raw = os.environ.get(ENV_LLMS_TXT, "").strip()
+    if not raw:
+        return list(DEFAULT_LLMS_TXT_URLS)
+    urls = [url.strip() for url in raw.split(",") if url.strip()]
+    if not urls:
+        logger.warning("%s contained no usable URLs; using defaults", ENV_LLMS_TXT)
+        return list(DEFAULT_LLMS_TXT_URLS)
+    return urls
+
+
+def _env_timeout() -> float:
+    """Read the HTTP timeout from the environment.
+
+    An unparseable or non-positive value falls back to the default rather than
+    raising, so a typo cannot stop the server from starting.
+
+    Returns:
+        Timeout in seconds.
+    """
+    raw = os.environ.get(ENV_TIMEOUT, "").strip()
+    if not raw:
+        return DEFAULT_TIMEOUT
+    try:
+        timeout = float(raw)
+    except ValueError:
+        logger.warning("%s=%r is not a number; using %s", ENV_TIMEOUT, raw, DEFAULT_TIMEOUT)
+        return DEFAULT_TIMEOUT
+    if timeout <= 0:
+        logger.warning("%s=%r must be positive; using %s", ENV_TIMEOUT, raw, DEFAULT_TIMEOUT)
+        return DEFAULT_TIMEOUT
+    return timeout
+
+
+def _env_user_agent() -> str:
+    """Read the User-Agent header from the environment.
+
+    Returns:
+        ENV_USER_AGENT if set and non-empty, otherwise the default.
+    """
+    return os.environ.get(ENV_USER_AGENT, "").strip() or DEFAULT_USER_AGENT
 
 
 @dataclass
 class Config:
     """Configuration settings for the MCP server.
+
+    Values are read from the environment when the instance is constructed, so
+    the module-level ``doc_config`` reflects the environment at import time.
 
     Attributes:
         llm_texts_url: List of llms.txt URLs to index for documentation
@@ -11,11 +75,9 @@ class Config:
         user_agent: User agent string for HTTP requests
     """
 
-    llm_texts_url: list[str] = field(
-        default_factory=lambda: ["https://strandsagents.com/llms.txt"]
-    )  # Curated list of llms.txt files to index at startup
-    timeout: float = 30.0  # HTTP request timeout in seconds
-    user_agent: str = "strands-mcp-docs/1.0"  # User agent for HTTP requests
+    llm_texts_url: list[str] = field(default_factory=_env_llms_txt_urls)
+    timeout: float = field(default_factory=_env_timeout)
+    user_agent: str = field(default_factory=_env_user_agent)
 
 
 # Global configuration instance

--- a/strands-mcp/tests/test_config.py
+++ b/strands-mcp/tests/test_config.py
@@ -1,0 +1,98 @@
+"""Tests for environment-driven configuration (#3330)."""
+
+import logging
+
+import pytest
+
+from strands_mcp_server import config
+from strands_mcp_server.config import Config
+
+
+@pytest.fixture(autouse=True)
+def clear_config_env(monkeypatch):
+    """Start every test from an unset environment."""
+    for var in (config.ENV_LLMS_TXT, config.ENV_TIMEOUT, config.ENV_USER_AGENT):
+        monkeypatch.delenv(var, raising=False)
+
+
+class TestDefaults:
+    def test_unset_environment_uses_defaults(self):
+        cfg = Config()
+
+        assert cfg.llm_texts_url == config.DEFAULT_LLMS_TXT_URLS
+        assert cfg.timeout == config.DEFAULT_TIMEOUT
+        assert cfg.user_agent == config.DEFAULT_USER_AGENT
+
+    def test_default_url_list_is_not_shared_between_instances(self):
+        first = Config()
+        first.llm_texts_url.append("https://example.com/llms.txt")
+
+        assert Config().llm_texts_url == config.DEFAULT_LLMS_TXT_URLS
+
+
+class TestLlmsTxtUrls:
+    def test_single_url(self, monkeypatch):
+        monkeypatch.setenv(config.ENV_LLMS_TXT, "https://example.com/llms.txt")
+
+        assert Config().llm_texts_url == ["https://example.com/llms.txt"]
+
+    def test_comma_separated_list_is_split_and_stripped(self, monkeypatch):
+        monkeypatch.setenv(config.ENV_LLMS_TXT, " https://a.com/llms.txt , https://b.com/llms.txt ")
+
+        assert Config().llm_texts_url == ["https://a.com/llms.txt", "https://b.com/llms.txt"]
+
+    def test_empty_entries_are_dropped(self, monkeypatch):
+        monkeypatch.setenv(config.ENV_LLMS_TXT, "https://a.com/llms.txt,,  ,")
+
+        assert Config().llm_texts_url == ["https://a.com/llms.txt"]
+
+    @pytest.mark.parametrize("value", ["", "   ", ",", " , "])
+    def test_blank_value_falls_back_to_defaults(self, monkeypatch, value):
+        monkeypatch.setenv(config.ENV_LLMS_TXT, value)
+
+        assert Config().llm_texts_url == config.DEFAULT_LLMS_TXT_URLS
+
+
+class TestTimeout:
+    def test_valid_value_is_used(self, monkeypatch):
+        monkeypatch.setenv(config.ENV_TIMEOUT, "5.5")
+
+        assert Config().timeout == 5.5
+
+    @pytest.mark.parametrize("value", ["abc", "", "  ", "1,5"])
+    def test_unparseable_value_falls_back_to_default(self, monkeypatch, value):
+        monkeypatch.setenv(config.ENV_TIMEOUT, value)
+
+        assert Config().timeout == config.DEFAULT_TIMEOUT
+
+    @pytest.mark.parametrize("value", ["0", "-1", "-0.5"])
+    def test_non_positive_value_falls_back_to_default(self, monkeypatch, value):
+        monkeypatch.setenv(config.ENV_TIMEOUT, value)
+
+        assert Config().timeout == config.DEFAULT_TIMEOUT
+
+    def test_bad_value_is_logged(self, monkeypatch, caplog):
+        monkeypatch.setenv(config.ENV_TIMEOUT, "abc")
+
+        with caplog.at_level(logging.WARNING, logger="strands_mcp_server.config"):
+            Config()
+
+        assert config.ENV_TIMEOUT in caplog.text
+
+    def test_bad_value_does_not_raise(self, monkeypatch):
+        monkeypatch.setenv(config.ENV_TIMEOUT, "not-a-number")
+
+        assert Config().timeout > 0
+
+
+class TestUserAgent:
+    def test_custom_value_is_used(self, monkeypatch):
+        monkeypatch.setenv(config.ENV_USER_AGENT, "acme-docs/2.0")
+
+        assert Config().user_agent == "acme-docs/2.0"
+
+    @pytest.mark.parametrize("value", ["", "   "])
+    def test_blank_value_falls_back_to_default(self, monkeypatch, value):
+        monkeypatch.setenv(config.ENV_USER_AGENT, value)
+
+        assert Config().user_agent == config.DEFAULT_USER_AGENT


### PR DESCRIPTION
Fixes #3330

## Why

`Config` was a dataclass with no way to set it. The llms.txt source list, timeout, and user agent were hardcoded, so the README's framing ("indexes documentation from llms.txt files") was not something a team could actually act on without forking.

## What changed

Three environment variables, read through dataclass `default_factory` so `Config()` reflects the environment at construction and defaults are unchanged when nothing is set:

| Variable | Default | Notes |
|---|---|---|
| `STRANDS_MCP_LLMS_TXT` | `https://strandsagents.com/llms.txt` | Comma-separated. Blank entries dropped. |
| `STRANDS_MCP_TIMEOUT` | `30` | Seconds. |
| `STRANDS_MCP_USER_AGENT` | `strands-mcp-docs/1.0` | |

**Bad input degrades rather than raises.** A non-numeric or non-positive timeout logs a warning and keeps the default; a source list with no usable URLs falls back to the default. These variables are set in client `mcp.json` env blocks, where a typo is easy and a server that refuses to start is a bad failure mode. `test_bad_value_does_not_raise` pins this.

Also documented all three in the README's Configuration section, alongside the existing `STRANDS_MCP_PREFETCH_ALL`.

## Something worth flagging

**This does not fully deliver the issue's use case on its own,** and I would rather say so than let it look complete.

`_is_valid_doc_url` in `server.py` hardcodes `strandsagents.com`. So for a team pointing at their own docs:

- `search_docs` **works** — custom sources are parsed, indexed, and hydrated. `cache.ensure_page` has no host check, so body terms become searchable as normal.
- `fetch_doc` **refuses** them with `"only https://strandsagents.com URLs allowed"`.

I deliberately did not widen that check here. It is the SSRF guard, it has dedicated tests (`test_ssrf_bypass_vectors_rejected`), and changing a security boundary belongs in its own reviewed change rather than riding along with a config PR.

The natural follow-up is to derive the allowed host set from the configured llms.txt URLs, keeping https-only and exact-host matching so every current SSRF test still passes. Happy to open that as a separate PR, or fold it into this one if you would rather have the feature land whole. I have noted the limitation in the README in the meantime.

## Verification

- `pytest tests` — **109 passed** (was 87; 22 new in `tests/test_config.py`).
- `ruff check` and `ruff format --check` clean.
- Mutation-checked: making `_env_llms_txt_urls` ignore the variable fails exactly the three parsing tests.
- Covered: defaults, single and comma-separated URLs, whitespace stripping, empty entries, blank and separator-only values, unparseable and non-positive timeouts, warning emission, and that the default URL list is not shared between instances (a mutable-default regression guard).

AI assistance was used for this change; I have reviewed every line and can walk through the design choices above.