### PR TITLE
feat(mcp): paginate fetch_doc catalog mode

### DIFF
--- a/strands-mcp/src/strands_mcp_server/server.py
+++ b/strands-mcp/src/strands_mcp_server/server.py
@@ -8,6 +8,9 @@ from .utils import cache, text_processor
 
 APP_NAME = "strands-agents-mcp-server"
 
+CATALOG_PAGE_SIZE = 100  # default catalog entries per fetch_doc call
+CATALOG_PAGE_MAX = 500  # ceiling on a caller-supplied catalog limit
+
 
 def _is_valid_doc_url(uri: str) -> bool:
     """Validate that a URI points to strandsagents.com over HTTPS."""
@@ -81,7 +84,7 @@ def search_docs(query: str, k: int = 5) -> List[Dict[str, Any]]:
 
 
 @mcp.tool()
-def fetch_doc(uri: str = "", section: str = "") -> Dict[str, Any]:
+def fetch_doc(uri: str = "", section: str = "", offset: int = 0, limit: int = CATALOG_PAGE_SIZE) -> Dict[str, Any]:
     """Read documentation pages with smart sectioning for token efficiency.
 
     Two modes of operation:
@@ -102,11 +105,19 @@ def fetch_doc(uri: str = "", section: str = "") -> Dict[str, Any]:
 
     Args:
         uri: Document URL (must be under https://strandsagents.com/).
-            If empty, returns a catalog of all available document URLs with titles.
+            If empty, returns one page of the catalog of available document URLs.
         section: Section ID from the TOC (e.g., "3" or "3.2").
             Omit to get the table of contents.
+        offset: Catalog mode only. Index of the first entry to return (default: 0).
+        limit: Catalog mode only. Maximum entries to return (default: 100, max: 500).
 
     Returns:
+        When uri is omitted (catalog mode):
+        - urls: One page of {url, title} entries, in llms.txt order
+        - total: Total number of catalogued documents
+        - offset, limit: The slice that was applied
+        - next_offset: Offset of the next page, absent on the last page
+
         When section is omitted (TOC mode):
         - url, title: Document metadata
         - preamble: Introductory text between page title and first section
@@ -136,7 +147,19 @@ def fetch_doc(uri: str = "", section: str = "") -> Dict[str, Any]:
 
     if not uri:
         url_titles = cache.get_url_titles()
-        return {"urls": [{"url": url, "title": title} for url, title in url_titles.items()]}
+        total = len(url_titles)
+        start = max(offset, 0)
+        page_size = min(max(limit, 1), CATALOG_PAGE_MAX)
+        page = list(url_titles.items())[start : start + page_size]
+        result: Dict[str, Any] = {
+            "urls": [{"url": url, "title": title} for url, title in page],
+            "total": total,
+            "offset": start,
+            "limit": page_size,
+        }
+        if start + page_size < total:
+            result["next_offset"] = start + page_size
+        return result
 
     if not _is_valid_doc_url(uri):
         return {"error": "only https://strandsagents.com URLs allowed", "url": uri}

--- a/strands-mcp/tests/test_server.py
+++ b/strands-mcp/tests/test_server.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
+from strands_mcp_server import server
 from strands_mcp_server.server import fetch_doc, search_docs
 from strands_mcp_server.utils.doc_fetcher import Page
 from strands_mcp_server.utils.indexer import Doc
@@ -132,7 +133,88 @@ class TestFetchDocTocMode:
 
         tru_result = fetch_doc(**kwargs)
 
-        assert tru_result == {"urls": [{"url": "https://strandsagents.com/a.md", "title": "Doc A"}]}
+        assert tru_result == {
+            "urls": [{"url": "https://strandsagents.com/a.md", "title": "Doc A"}],
+            "total": 1,
+            "offset": 0,
+            "limit": server.CATALOG_PAGE_SIZE,
+        }
+
+
+@patch("strands_mcp_server.server.cache")
+class TestFetchDocCatalogPagination:
+    """Catalog mode returns a bounded page instead of every URL (#3326)."""
+
+    @staticmethod
+    def _catalog(size):
+        return {f"https://strandsagents.com/{i:04d}.md": f"Doc {i}" for i in range(size)}
+
+    def test_large_catalog_is_capped_at_default_page_size(self, mock_cache):
+        mock_cache.get_url_titles.return_value = self._catalog(763)
+
+        tru_result = fetch_doc()
+
+        assert len(tru_result["urls"]) == server.CATALOG_PAGE_SIZE
+        assert tru_result["total"] == 763
+        assert tru_result["next_offset"] == server.CATALOG_PAGE_SIZE
+
+    def test_offset_and_limit_select_a_slice(self, mock_cache):
+        mock_cache.get_url_titles.return_value = self._catalog(50)
+
+        tru_result = fetch_doc(offset=10, limit=5)
+
+        assert [entry["title"] for entry in tru_result["urls"]] == [f"Doc {i}" for i in range(10, 15)]
+        assert tru_result["offset"] == 10
+        assert tru_result["limit"] == 5
+        assert tru_result["next_offset"] == 15
+
+    def test_last_page_omits_next_offset(self, mock_cache):
+        mock_cache.get_url_titles.return_value = self._catalog(10)
+
+        tru_result = fetch_doc(offset=5, limit=5)
+
+        assert len(tru_result["urls"]) == 5
+        assert "next_offset" not in tru_result
+
+    def test_offset_past_the_end_returns_empty_page(self, mock_cache):
+        mock_cache.get_url_titles.return_value = self._catalog(10)
+
+        tru_result = fetch_doc(offset=999)
+
+        assert tru_result["urls"] == []
+        assert tru_result["total"] == 10
+        assert "next_offset" not in tru_result
+
+    def test_paging_covers_every_entry_exactly_once(self, mock_cache):
+        catalog = self._catalog(25)
+        mock_cache.get_url_titles.return_value = catalog
+
+        seen, offset = [], 0
+        while True:
+            page = fetch_doc(offset=offset, limit=7)
+            seen.extend(entry["url"] for entry in page["urls"])
+            if "next_offset" not in page:
+                break
+            offset = page["next_offset"]
+
+        assert seen == list(catalog)
+
+    @pytest.mark.parametrize("limit,expected", [(0, 1), (-5, 1), (10_000, 500)])
+    def test_limit_is_clamped_to_a_usable_range(self, mock_cache, limit, expected):
+        mock_cache.get_url_titles.return_value = self._catalog(600)
+
+        tru_result = fetch_doc(limit=limit)
+
+        assert tru_result["limit"] == expected
+        assert len(tru_result["urls"]) == expected
+
+    def test_negative_offset_is_treated_as_zero(self, mock_cache):
+        mock_cache.get_url_titles.return_value = self._catalog(10)
+
+        tru_result = fetch_doc(offset=-5, limit=3)
+
+        assert tru_result["offset"] == 0
+        assert [entry["title"] for entry in tru_result["urls"]] == ["Doc 0", "Doc 1", "Doc 2"]
 
 
 @patch("strands_mcp_server.server.cache")


### PR DESCRIPTION
Fixes #3326

## Why

`fetch_doc(uri="")` returned every catalogued URL and title in a single response, 763 entries today and growing. That is a large, fixed token cost for a call whose whole purpose is orientation, paid before the agent knows whether the catalog was even the right move.

## What changed

Catalog mode now returns one bounded page:

```json
{
  "urls": [{"url": "...", "title": "..."}],
  "total": 763,
  "offset": 0,
  "limit": 100,
  "next_offset": 100
}
```

- `offset` and `limit` parameters, default page size 100.
- `total` so the agent knows the size of the corpus without fetching it.
- `next_offset` **omitted on the last page**, which gives the model an unambiguous stop condition rather than requiring it to compare `offset + limit` against `total`.
- `limit` clamped to `1..500`, negative `offset` treated as `0`. A model passing `limit=0` or `limit=99999` gets a usable page instead of an empty response or the unbounded dump this PR is removing.

Entries keep `llms.txt` order, which is stable across calls, so paging visits every entry exactly once. `test_paging_covers_every_entry_exactly_once` walks a 25-entry catalog at `limit=7` and asserts the concatenated result equals the full ordered list.

## Design choices worth naming

**No `filter` parameter.** The issue offers pagination, grouping, or a filter string. `search_docs` already answers "find the page about X", and the issue itself notes it should be the entry point for that, so a filter here would be a second, worse search. Pagination is the part that catalog mode uniquely needs.

**Grouping by llms.txt section was the other candidate.** It would give nicer browsing, but it changes the response shape from a flat list to a nested one and makes "page through everything" harder to express. Pagination is the smaller change and directly answers the token-cost problem. Happy to revisit grouping if you would prefer it.

## One existing test changed

`test_omitted_uri_returns_url_catalog` asserted exact equality against `{"urls": [...]}`. It now asserts the full new shape including `total`, `offset`, and `limit`. It still uses a single-entry catalog, so it also serves as the "no `next_offset` when everything fits" case.

## Verification

- `pytest tests` — **96 passed** (was 87; 9 new).
- `ruff check` and `ruff format --check` clean.
- Mutation-checked: returning the unsliced list fails 9 tests, including the round-trip paging test.
- Covered: default cap on a 763-entry catalog, arbitrary slices, last page, offset past the end, full round-trip paging, limit clamping at both ends, and negative offset.

AI assistance was used for this change; I have reviewed every line and can walk through the design choices above.