### PR TITLE
fix: Text content block is silently dropped when a toolUse is pending in the same content block stop (#4004)

### DIFF
--- a/strands-py/src/strands/event_loop/streaming.py
+++ b/strands-py/src/strands/event_loop/streaming.py
@@ -330,7 +330,14 @@ def handle_content_block_stop(state: dict[str, Any]) -> dict[str, Any]:
         content.append({"toolUse": tool_use})
         state["current_tool_use"] = {}
 
-    elif text:
+    # The remaining branches (text / reasoning / redacted) are independent
+    # siblings of the tool-use branch: a model can stream a short preamble
+    # ("Let me check that for you.") and call a tool in the same assistant
+    # turn, in which case both blocks must land in the assistant message.
+    # Using `elif` here (as before this fix) silently dropped the text and
+    # reasoning when they accompanied a pending toolUse. Same defect class
+    # as #1394, applied to a different branch pair.
+    if text:
         if citations_content:
             citations_block: CitationsContentBlock = {"citations": citations_content, "content": [{"text": text}]}
             content.append({"citationsContent": citations_block})
@@ -339,7 +346,7 @@ def handle_content_block_stop(state: dict[str, Any]) -> dict[str, Any]:
             content.append({"text": text})
         state["text"] = ""
 
-    elif reasoning_text or "signature" in state:
+    if reasoning_text or "signature" in state:
         content_block: ContentBlock = {
             "reasoningContent": {
                 "reasoningText": {
@@ -354,7 +361,7 @@ def handle_content_block_stop(state: dict[str, Any]) -> dict[str, Any]:
 
         content.append(content_block)
         state["reasoningText"] = ""
-    elif redacted_content:
+    if redacted_content:
         content.append({"reasoningContent": {"redactedContent": redacted_content}})
         state["redactedContent"] = b""
 

--- a/strands-py/tests/strands/event_loop/test_streaming.py
+++ b/strands-py/tests/strands/event_loop/test_streaming.py
@@ -590,6 +590,81 @@ def test_handle_content_block_delta(event: ContentBlockDeltaEvent, event_type, s
                 "redactedContent": b"",
             },
         ),
+        # Regression: text + pending tool use — both must land in content (issue #4004)
+        # Previously, the `elif text:` chain silently dropped the text when a toolUse
+        # block had also accumulated. Now both are appended and both state fields cleared.
+        # Append order follows the function: toolUse first (its branch runs first), then text.
+        (
+            {
+                "content": [],
+                "current_tool_use": {"toolUseId": "t1", "name": "read_file", "input": "{}"},
+                "text": "Let me check that for you.",
+                "reasoningText": "",
+                "citationsContent": [],
+                "redactedContent": b"",
+            },
+            {
+                "content": [
+                    {"toolUse": {"toolUseId": "t1", "name": "read_file", "input": {}}},
+                    {"text": "Let me check that for you."},
+                ],
+                "current_tool_use": {},
+                "text": "",
+                "reasoningText": "",
+                "citationsContent": [],
+                "redactedContent": b"",
+            },
+        ),
+        # Regression: reasoning text + pending tool use — both must land (issue #4004)
+        (
+            {
+                "content": [],
+                "current_tool_use": {"toolUseId": "t1", "name": "lookup", "input": '{"k": "v"}'},
+                "text": "",
+                "reasoningText": "thinking...",
+                "signature": "sig-123",
+                "citationsContent": [],
+                "redactedContent": b"",
+            },
+            {
+                "content": [
+                    {"toolUse": {"toolUseId": "t1", "name": "lookup", "input": {"k": "v"}}},
+                    {
+                        "reasoningContent": {
+                            "reasoningText": {"text": "thinking...", "signature": "sig-123"},
+                        },
+                    },
+                ],
+                "current_tool_use": {},
+                "text": "",
+                "reasoningText": "",
+                "citationsContent": [],
+                "redactedContent": b"",
+            },
+        ),
+        # Regression: text + reasoning + pending tool use — all three blocks land (issue #4004)
+        (
+            {
+                "content": [],
+                "current_tool_use": {"toolUseId": "t1", "name": "multi", "input": "{}"},
+                "text": "ok",
+                "reasoningText": "hmm",
+                "citationsContent": [],
+                "redactedContent": b"",
+            },
+            {
+                "content": [
+                    {"toolUse": {"toolUseId": "t1", "name": "multi", "input": {}}},
+                    {"text": "ok"},
+                    {"reasoningContent": {"reasoningText": {"text": "hmm"}}},
+                ],
+                "current_tool_use": {},
+                "text": "",
+                "reasoningText": "",
+                "citationsContent": [],
+                "redactedContent": b"",
+            },
+        ),
     ],
 )
 def test_handle_content_block_stop(state, exp_updated_state):


### PR DESCRIPTION
## Description

Fixes a bug where text content blocks are silently dropped when a `toolUse` is pending in the same `content_block_stop` event.

When a model streams a short preamble ("Let me check that for you.") and then calls a tool in the same assistant turn, both blocks must land in the assistant message. Previously, the `elif text:` chain would only process the toolUse and skip the text entirely because the branches were mutually exclusive.

This fix changes `elif` to `if` for the text, reasoning, and redacted content branches so they process independently of the toolUse branch.

## Related Issues

Closes #4004

## Type of Change

Bug fix

## Testing

- Added 3 regression tests covering:
  - text + pending tool use
  - reasoning text + pending tool use  
  - text + reasoning + pending tool use (all three blocks)

All tests pass (76 passed in test_streaming.py).

```
uv run --extra dev pytest tests/strands/event_loop/test_streaming.py -vv
...
============================== 76 passed in 1.11s ==============================
```

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR
- [x] My change is focused and reasonably small
- [x] I have added necessary tests that prove my fix is effective
- [x] My changes generate no new warnings

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.