### PR TITLE
adds exports to simplify extending strands for openai compatable APIs

### DIFF
--- a/strands-ts/src/models/openai/chat-adapter.ts
+++ b/strands-ts/src/models/openai/chat-adapter.ts
@@ -1,7 +1,6 @@
 /**
  * Chat Completions API adapter for the OpenAI model provider.
  *
- * @internal
  */
 
 import OpenAI from 'openai'
@@ -52,7 +51,6 @@ type OpenAIChatChoice = {
 /**
  * Builds a Chat Completions streaming request body.
  *
- * @internal
  */
 export function formatChatRequest(
   config: OpenAIChatConfig,
@@ -368,7 +366,6 @@ function splitToolResultMedia(
  * Maps a Chat Completions streaming chunk to one or more SDK events. Mutates
  * `state` and `activeToolCalls` as a side effect.
  *
- * @internal
  */
 export function mapChatChunkToEvents(
   chunk: { choices: unknown[] },

--- a/strands-ts/src/models/openai/index.ts
+++ b/strands-ts/src/models/openai/index.ts
@@ -24,3 +24,4 @@ export type {
   OpenAIResponsesConfig,
 } from './types.js'
 export type { BedrockMantleConfig } from './mantle.js'
+export { formatChatRequest, mapChatChunkToEvents } from './chat-adapter.js'


### PR DESCRIPTION
## Description
OpenAI compatible APIs such as Llamacpp often have additional types/keys on messages such as `reasoning_content`.  The base OpenAI provider does not accommodate additional message types.  However, Strands itself allows for custom providers: https://strandsagents.com/docs/user-guide/concepts/model-providers/custom_model_provider/.  An extension to the OpenAI provider to accommodate these additional message types is straightforward to write as long as the "parsing" logic is exported.  

## Related Issues

N/A

## Documentation PR

N/A
## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

New feature

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `npm test`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
