### PR TITLE
fix: [BUG] Python guardrail block detection fails open when Bedrock omits the optional `detected` field — blocked content is never redacted (#3617)

### DIFF
--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -1634,19 +1634,26 @@ class BedrockModel(Model):
             yield metadata
 
     def _find_detected_and_blocked_policy(self, input: Any) -> bool:
-        """Recursively checks if the assessment contains a detected and blocked guardrail.
+        """Recursively checks if the assessment contains a blocked guardrail.
 
         Args:
             input: The assessment to check.
 
         Returns:
-            True if the input contains a detected and blocked guardrail, False otherwise.
+            True if the input contains a blocked guardrail, False otherwise.
 
         """
         # Check if input is a dictionary
         if isinstance(input, dict):
-            # Check if current dictionary has action: BLOCKED and detected: true
-            if input.get("action") == "BLOCKED" and input.get("detected") and isinstance(input.get("detected"), bool):
+            # Per AWS Bedrock Guardrail APIs (e.g. GuardrailTopic, GuardrailContentFilter,
+            # GuardrailCustomWord, GuardrailManagedWord, GuardrailPiiEntityFilter,
+            # GuardrailRegexFilter, GuardrailContextualGroundingFilter), `action` is
+            # Required: Yes and `detected` is Required: No. Real Bedrock Converse traces
+            # for actually-blocked content omit the `detected` field entirely. Treat
+            # action == "BLOCKED" as blocked regardless of `detected`, while keeping
+            # an explicit `detected: False` as not blocked to match documented NONE
+            # semantics.
+            if input.get("action") == "BLOCKED" and input.get("detected") is not False:
                 return True
 
             # Otherwise, recursively check all values in the dictionary

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -1576,6 +1576,157 @@ async def test_stream_output_no_blocked_guardrails_doesnt_redact(
 
 
 @pytest.mark.asyncio
+async def test_stream_input_guardrail_blocks_without_detected_field(
+    bedrock_client, model, messages, tool_spec, model_id, additional_request_fields, alist
+):
+    """Real Bedrock traces omit the optional `detected` field on a BLOCKED policy.
+
+    Per the Bedrock Guardrail API reference (GuardrailTopic, GuardrailContentFilter,
+    GuardrailCustomWord, GuardrailManagedWord, GuardrailPiiEntityFilter, GuardrailRegexFilter,
+    GuardrailContextualGroundingFilter), `action` is Required: Yes and `detected` is Required: No.
+    A trace with `action == "BLOCKED"` and no `detected` key must still redact the input.
+
+    Guards against https://github.com/strands-agents/harness-sdk/issues/3617.
+    """
+    metadata_event = {
+        "metadata": {
+            "usage": {"inputTokens": 0, "outputTokens": 0, "totalTokens": 0},
+            "metrics": {"latencyMs": 245},
+            "trace": {
+                "guardrail": {
+                    "inputAssessment": {
+                        "3e59qlue4hag": {
+                            "topicPolicy": {
+                                "topics": [
+                                    {
+                                        "name": "Heavy metal",
+                                        "type": "DENY",
+                                        # NOTE: no `detected` key at all
+                                        "action": "BLOCKED",
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            },
+        }
+    }
+    bedrock_client.converse_stream.return_value = {"stream": [metadata_event]}
+
+    model.update_config(additional_request_fields=additional_request_fields)
+    response = model.stream(messages, [tool_spec])
+
+    tru_chunks = await alist(response)
+    exp_chunks = [
+        {"redactContent": {"redactUserContentMessage": "[User input redacted.]"}},
+        metadata_event,
+    ]
+
+    assert tru_chunks == exp_chunks
+
+
+@pytest.mark.asyncio
+async def test_stream_output_guardrail_blocks_without_detected_field(
+    bedrock_client, model, messages, tool_spec, model_id, additional_request_fields, alist
+):
+    """Output assessment with BLOCKED + no `detected` field must redact both input and output.
+
+    Same AWS schema rule as test_stream_input_guardrail_blocks_without_detected_field, but on
+    the output side. Verifies the predicate treats action == "BLOCKED" as blocked regardless of
+    whether `detected` is present.
+
+    Guards against https://github.com/strands-agents/harness-sdk/issues/3617.
+    """
+    model.update_config(guardrail_redact_output=True)
+    metadata_event = {
+        "metadata": {
+            "usage": {"inputTokens": 0, "outputTokens": 0, "totalTokens": 0},
+            "metrics": {"latencyMs": 245},
+            "trace": {
+                "guardrail": {
+                    "outputAssessments": {
+                        "3e59qlue4hag": [
+                            {
+                                "wordPolicy": {
+                                    "customWords": [
+                                        {
+                                            "match": "CACTUS",
+                                            # NOTE: no `detected` key at all
+                                            "action": "BLOCKED",
+                                        }
+                                    ]
+                                },
+                            }
+                        ]
+                    },
+                }
+            },
+        }
+    }
+    bedrock_client.converse_stream.return_value = {"stream": [metadata_event]}
+
+    model.update_config(additional_request_fields=additional_request_fields)
+    response = model.stream(messages, [tool_spec])
+
+    tru_chunks = await alist(response)
+    exp_chunks = [
+        {"redactContent": {"redactUserContentMessage": "[User input redacted.]"}},
+        {"redactContent": {"redactAssistantContentMessage": "[Assistant output redacted.]"}},
+        metadata_event,
+    ]
+
+    assert tru_chunks == exp_chunks
+
+
+@pytest.mark.asyncio
+async def test_stream_guardrail_detected_false_with_none_action_does_not_redact(
+    bedrock_client, model, messages, tool_spec, model_id, additional_request_fields, alist
+):
+    """An explicit `detected: False` must not be treated as blocked even when other fields vary.
+
+    The fix relaxed the predicate to `detected is not False` so that an explicit
+    `detected: False` keeps the documented NONE semantics (no redaction). A shape that has
+    `detected: False` and no other BLOCKED action in the tree must produce no redaction events.
+
+    Guards against https://github.com/strands-agents/harness-sdk/issues/3617.
+    """
+    metadata_event = {
+        "metadata": {
+            "usage": {"inputTokens": 0, "outputTokens": 0, "totalTokens": 0},
+            "metrics": {"latencyMs": 245},
+            "trace": {
+                "guardrail": {
+                    "inputAssessment": {
+                        "3e59qlue4hag": {
+                            "contentPolicy": {
+                                "filters": [
+                                    {
+                                        "action": "NONE",
+                                        "confidence": "NONE",
+                                        "detected": False,
+                                        "filterStrength": "HIGH",
+                                        "type": "VIOLENCE",
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            },
+        }
+    }
+    bedrock_client.converse_stream.return_value = {"stream": [metadata_event]}
+
+    model.update_config(additional_request_fields=additional_request_fields)
+    response = model.stream(messages, [tool_spec])
+
+    tru_chunks = await alist(response)
+    assert tru_chunks == [metadata_event]
+    assert not any("redactContent" in chunk for chunk in tru_chunks)
+
+
+@pytest.mark.asyncio
 async def test_stream_stream_guardrails_redacts_without_trace(
     bedrock_client, model, messages, tool_spec, model_id, additional_request_fields, alist
 ):


### PR DESCRIPTION
## Description

Bedrock's guardrail trace omits the optional `detected` field on responses for actually-blocked content. `_find_detected_and_blocked_policy` required **both** `action == "BLOCKED"` and a truthy boolean `detected`, so a genuinely blocked assessment was classified as not blocked: no `redactContent` chunk was emitted and the blocked content was passed through to the caller.

Per the Bedrock Guardrail API reference (`GuardrailTopic`, `GuardrailContentFilter`, `GuardrailCustomWord`, `GuardrailManagedWord`, `GuardrailPiiEntityFilter`, `GuardrailRegexFilter`, `GuardrailContextualGroundingFilter`), `action` is Required: Yes and `detected` is Required: No — so `detected` must not be part of the block predicate.

The predicate is now `action == "BLOCKED" and detected is not False`: a missing `detected` is treated as blocked, while an explicit `detected: false` (the documented `NONE` case) stays not blocked. The docstring is updated to match, and the rationale is recorded as an inline comment.

## Related Issues

Closes #3617

## Documentation PR

No documentation change needed — internal detection predicate, no public API or docs surface changes.

## Type of Change

Bug fix

## Testing

`python -m pytest tests/strands/models/test_bedrock.py -q`
→ **286 passed** with the fix.

Fail-before, verified by running the same test file against unpatched `main` `src/`
→ **2 failed** (`test_stream_input_guardrail_blocks_without_detected_field`, `test_stream_output_guardrail_blocks_without_detected_field`); both pass with the fix.

3 regression tests added:

- `test_stream_input_guardrail_blocks_without_detected_field` — input assessment with `action: "BLOCKED"` and no `detected` key must redact user content.
- `test_stream_output_guardrail_blocks_without_detected_field` — same shape on the output side must redact both user and assistant content.
- `test_stream_guardrail_detected_false_with_none_action_does_not_redact` — guards the inverse: `detected: false` with `action: "NONE"` must not redact.

## Checklist
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] Any dependent changes have been merged and published
- [ ] I have read the CONTRIBUTING document
- [ ] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
