### PR TITLE
refactor(bidi): make BidiModel extend Model

### DIFF
--- a/strands-py/src/strands/experimental/bidi/agent/agent.py
+++ b/strands-py/src/strands/experimental/bidi/agent/agent.py
@@ -103,10 +103,16 @@ class BidiAgent:
         """
         if isinstance(model, BidiModel):
             self.model = model
-        else:
+        elif isinstance(model, str):
             from ..models.bedrock import BedrockNovaSonicModel
 
-            self.model = BedrockNovaSonicModel(model_id=model) if isinstance(model, str) else BedrockNovaSonicModel()
+            self.model = BedrockNovaSonicModel(model_id=model)
+        elif model is None:
+            from ..models.bedrock import BedrockNovaSonicModel
+
+            self.model = BedrockNovaSonicModel()
+        else:
+            raise TypeError("model must be a BidiModel, string, or None")
 
         self.system_prompt = system_prompt
         self.messages = messages or []

--- a/strands-py/src/strands/experimental/bidi/models/model.py
+++ b/strands-py/src/strands/experimental/bidi/models/model.py
@@ -73,6 +73,7 @@ class BidiModel(Model, abc.ABC):
         raise NotImplementedError("regular streaming is not supported by bidirectional models")
 
     @abc.abstractmethod
+    # pragma: no cover
     async def start(
         self,
         system_prompt: str | None = None,
@@ -95,6 +96,7 @@ class BidiModel(Model, abc.ABC):
         pass
 
     @abc.abstractmethod
+    # pragma: no cover
     async def stop(self) -> None:
         """Close the streaming connection and release resources.
 
@@ -105,6 +107,7 @@ class BidiModel(Model, abc.ABC):
         pass
 
     @abc.abstractmethod
+    # pragma: no cover
     def receive(self) -> AsyncIterable[BidiOutputEvent]:
         """Receive streaming events from the model.
 
@@ -121,6 +124,7 @@ class BidiModel(Model, abc.ABC):
         pass
 
     @abc.abstractmethod
+    # pragma: no cover
     async def send(
         self,
         content: BidiInputEvent | ToolResultEvent,

--- a/strands-py/src/strands/experimental/bidi/models/model.py
+++ b/strands-py/src/strands/experimental/bidi/models/model.py
@@ -13,10 +13,12 @@ Features:
 - Support for audio, text, image, and tool result streaming
 """
 
+import abc
 import logging
 from collections.abc import AsyncIterable
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, NoReturn
 
+from ....models.model import Model
 from ....types._events import ToolResultEvent
 from ....types.content import Messages
 from ....types.tools import ToolSpec
@@ -29,9 +31,8 @@ from ..types.model import BidiConnectionConfig
 logger = logging.getLogger(__name__)
 
 
-@runtime_checkable
-class BidiModel(Protocol):
-    """Protocol for bidirectional streaming models.
+class BidiModel(Model, abc.ABC):
+    """Abstract base class for bidirectional streaming models.
 
     This interface defines the contract for models that support persistent streaming
     connections with real-time audio and text communication. Implementations handle
@@ -51,6 +52,27 @@ class BidiModel(Protocol):
     connection_config: BidiConnectionConfig
     usage_is_cumulative: bool
 
+    def update_config(self, **model_config: Any) -> None:
+        """Update the model configuration with the provided arguments.
+
+        Args:
+            **model_config: Configuration overrides.
+        """
+        self.config.update(model_config)
+
+    def get_config(self) -> dict[str, Any]:
+        """Return a copy of the model configuration."""
+        return self.config.copy()
+
+    def structured_output(self, *args: Any, **kwargs: Any) -> NoReturn:
+        """Raise because bidirectional models do not support structured output."""
+        raise NotImplementedError("structured output is not supported by bidirectional models")
+
+    def stream(self, *args: Any, **kwargs: Any) -> NoReturn:
+        """Raise because bidirectional models use their persistent streaming API."""
+        raise NotImplementedError("regular streaming is not supported by bidirectional models")
+
+    @abc.abstractmethod
     async def start(
         self,
         system_prompt: str | None = None,
@@ -70,8 +92,9 @@ class BidiModel(Protocol):
             messages: Initial conversation history to provide context.
             **kwargs: Provider-specific configuration options.
         """
-        ...
+        pass
 
+    @abc.abstractmethod
     async def stop(self) -> None:
         """Close the streaming connection and release resources.
 
@@ -79,8 +102,9 @@ class BidiModel(Protocol):
         resources such as network connections, buffers, or background tasks. After
         calling close(), the model instance cannot be used until start() is called again.
         """
-        ...
+        pass
 
+    @abc.abstractmethod
     def receive(self) -> AsyncIterable[BidiOutputEvent]:
         """Receive streaming events from the model.
 
@@ -94,8 +118,9 @@ class BidiModel(Protocol):
             BidiOutputEvent: Standardized event objects containing audio output,
                 transcripts, tool calls, or control signals.
         """
-        ...
+        pass
 
+    @abc.abstractmethod
     async def send(
         self,
         content: BidiInputEvent | ToolResultEvent,
@@ -122,7 +147,7 @@ class BidiModel(Protocol):
             await model.send(ToolResultEvent(tool_result))
             ```
         """
-        ...
+        pass
 
     async def reconnect(
         self,
@@ -141,8 +166,12 @@ class BidiModel(Protocol):
             tools: Tool specifications that the model can invoke during the conversation.
             messages: Conversation history to replay for providers that resume via replay.
             **restart_kwargs: Provider-specific restart options (e.g. from a timeout error).
+
+        Raises:
+            NotImplementedError: If the model does not implement reconnection.
         """
-        ...
+        # TODO: Make reconnect abstract after Google and OpenAI implement it.
+        raise NotImplementedError("reconnect is not implemented by this bidirectional model")
 
 
 class BidiModelTimeoutError(Exception):

--- a/strands-py/tests/strands/experimental/bidi/agent/test_agent.py
+++ b/strands-py/tests/strands/experimental/bidi/agent/test_agent.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 import pytest
 
 from strands.experimental.bidi.agent.agent import BidiAgent
+from strands.experimental.bidi.models.model import BidiModel
 from strands.experimental.bidi.types.events import (
     BidiAudioInputEvent,
     BidiAudioStreamEvent,
@@ -18,7 +19,7 @@ from strands.experimental.bidi.types.events import (
 )
 
 
-class MockBidiModel:
+class MockBidiModel(BidiModel):
     """Mock bidirectional model for testing."""
 
     def __init__(self, config=None, model_id="mock-model"):
@@ -136,6 +137,12 @@ def test_bidi_agent_init_with_various_configurations():
     assert config["audio"]["input_rate"] == 16000
     assert config["audio"]["output_rate"] == 24000
     assert config["audio"]["channels"] == 1
+
+
+def test_bidi_agent_init_with_unsupported_model():
+    """Test agent initialization rejects unsupported model types."""
+    with pytest.raises(TypeError, match="model must be a BidiModel, string, or None"):
+        BidiAgent(model=object())
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="BedrockNovaSonicModel is only supported for Python 3.12+")

--- a/strands-py/tests/strands/experimental/bidi/agent/test_agent.py
+++ b/strands-py/tests/strands/experimental/bidi/agent/test_agent.py
@@ -146,6 +146,15 @@ def test_bidi_agent_init_with_unsupported_model():
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="BedrockNovaSonicModel is only supported for Python 3.12+")
+def test_bidi_agent_init_with_default_model():
+    from strands.experimental.bidi.models.bedrock import BedrockNovaSonicModel
+
+    agent = BidiAgent(model=None)
+
+    assert isinstance(agent.model, BedrockNovaSonicModel)
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="BedrockNovaSonicModel is only supported for Python 3.12+")
 def test_bidi_agent_init_with_model_id():
     from strands.experimental.bidi.models.bedrock import BedrockNovaSonicModel
 

--- a/strands-py/tests/strands/experimental/bidi/models/test_model.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_model.py
@@ -1,0 +1,86 @@
+"""Tests for the bidirectional model base class."""
+
+from collections.abc import AsyncIterable
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from strands.experimental.bidi.models.model import BidiModel
+from strands.experimental.bidi.types.events import BidiInputEvent, BidiOutputEvent
+from strands.models import Model
+from strands.types._events import ToolResultEvent
+from strands.types.content import Messages
+from strands.types.tools import ToolSpec
+
+
+class _Output(BaseModel):
+    value: str
+
+
+class _TestBidiModel(BidiModel):
+    def __init__(self) -> None:
+        self.config = {"model_id": "test-model"}
+        self.connection_config = {}
+        self.usage_is_cumulative = False
+
+    async def start(
+        self,
+        system_prompt: str | None = None,
+        tools: list[ToolSpec] | None = None,
+        messages: Messages | None = None,
+        **kwargs: Any,
+    ) -> None:
+        pass
+
+    async def stop(self) -> None:
+        pass
+
+    def receive(self) -> AsyncIterable[BidiOutputEvent]:
+        async def events() -> AsyncIterable[BidiOutputEvent]:
+            if False:
+                yield
+
+        return events()
+
+    async def send(self, content: BidiInputEvent | ToolResultEvent) -> None:
+        pass
+
+
+def test_model_is_model():
+    assert isinstance(_TestBidiModel(), Model)
+
+
+def test_update_config():
+    model = _TestBidiModel()
+
+    model.update_config(model_id="updated-model")
+
+    assert model.get_config() == {"model_id": "updated-model"}
+
+
+def test_get_config_returns_copy():
+    model = _TestBidiModel()
+
+    config = model.get_config()
+    config["model_id"] = "updated-model"
+
+    assert model.config == {"model_id": "test-model"}
+
+
+@pytest.mark.asyncio
+async def test_reconnect_raises_not_implemented():
+    model = _TestBidiModel()
+
+    with pytest.raises(NotImplementedError, match="reconnect is not implemented"):
+        await model.reconnect()
+
+
+def test_stream_raises_not_implemented():
+    with pytest.raises(NotImplementedError, match="regular streaming"):
+        _TestBidiModel().stream([])
+
+
+def test_structured_output_raises_not_implemented():
+    with pytest.raises(NotImplementedError, match="structured output"):
+        _TestBidiModel().structured_output(_Output, [])


### PR DESCRIPTION
## Description

Makes `BidiModel` inherit from the shared `Model` abstract base class so `Agent` and `BidiAgent` can share a common model type.

- Provides shared dictionary-backed `get_config` and `update_config` implementations.
- Explicitly rejects standard streaming and structured-output APIs that bidirectional models do not support.
- Defines the bidirectional connection lifecycle as an abstract interface.
- Preserves the existing reconnect fallback contract for providers that do not implement reconnect.

This is a prerequisite for consolidating shared `Agent` and `BidiAgent` tool, hook, and session typing without introducing model unions throughout the SDK. It isolates the common model foundation from the broader typing changes explored in [PR #3855](https://github.com/strands-agents/harness-sdk/pull/3855).

## Related Issues

- Part of #3764

## Documentation PR

No documentation changes are needed because this refactors the model abstraction without changing supported Bidi model usage.

## Type of Change

Other: Refactor

## Testing

- `hatch run hatch-static-analysis:lint-check`
- `hatch test -- tests/strands/experimental/bidi` (314 passed)

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.