### PR TITLE
fix(bidi): bedrock nova sonic reconnect

### DIFF
--- a/strands-py/src/strands/experimental/bidi/models/bedrock.py
+++ b/strands-py/src/strands/experimental/bidi/models/bedrock.py
@@ -404,9 +404,13 @@ class BedrockNovaSonicModel(BidiModel):
             except ModelTimeoutException as error:
                 raise BidiModelTimeoutError(error.message) from error
 
-            if not event_data:
-                logger.debug("received empty event data, continuing")
-                continue
+            # Per the smithy EventReceiver contract, receive() returns None only at
+            # end-of-stream (e.g. the connection closed during reconnect). A closed receiver
+            # returns None without suspending, so continuing here busy-loops and starves the
+            # event loop; end the generator so the reader exits cleanly and the swap proceeds.
+            if event_data is None:
+                logger.debug("event stream closed by service | ending nova receive loop")
+                break
 
             # Decode and parse the event
             raw_bytes = event_data.value.bytes_.decode("utf-8")

--- a/strands-py/tests/strands/experimental/bidi/models/test_bedrock.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_bedrock.py
@@ -1003,6 +1003,31 @@ async def test_bidi_nova_sonic_model_receive_timeout_validation(nova_model, mock
 
 
 @pytest.mark.asyncio
+async def test_receive_ends_when_stream_closed(nova_model, mock_stream):
+    """A None from the event receiver marks end-of-stream; the receive loop must terminate.
+
+    Per the smithy EventReceiver contract, receive() returns None only at end-of-stream (e.g.
+    the connection closed on reconnect), and a closed receiver returns it without suspending.
+    Treating that as a transient empty event and continuing busy-loops the reader, starving the
+    event loop and hanging the reconnect swap. The generator must instead finish.
+    """
+    mock_output = AsyncMock()
+    mock_output.receive = AsyncMock(return_value=None)
+    mock_stream.await_output.return_value = (None, mock_output)
+
+    await nova_model.start()
+
+    async def collect():
+        return [event async for event in nova_model.receive()]
+
+    # Bounded so a regression (busy-loop) fails fast instead of hanging the suite.
+    events = await asyncio.wait_for(collect(), timeout=5.0)
+
+    # Only the initial connection-start event precedes the end-of-stream.
+    assert [type(event).__name__ for event in events] == ["BidiConnectionStartEvent"]
+
+
+@pytest.mark.asyncio
 async def test_error_handling(nova_model, mock_stream):
     """Test error handling in various scenarios."""
 


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

The Nova Sonic receive() loop treated a `None` from the smithy event receiver as a transient empty event and continued, but per the `EventReceiver` contract `None` signals end-of-stream and a closed receiver returns it immediately without suspending, so on reconnect the old reader spun in a non-yielding loop that starved the event loop and hung the connection swap. This was a latent bug exposed by the dependency bump in #3997 (aws_sdk_bedrock_runtime / smithy-aws-core 0.9.x → 0.11.x): the newer stack signals end-of-stream by returning `None` where the older versions raised/closed the generator, so the reader no longer exited on its own. This fix breaks out of the loop when receive() returns None so the reader exits cleanly and the reconnect proceeds, and adds a timeout-bounded regression test that models real end-of-stream behavior and asserts the generator terminates instead of hanging.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [ ] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
