### PR TITLE
feat(py): add tool_registry vended tool

### DIFF
--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -335,7 +335,7 @@ an existing entry, and remove entries this tool itself added.
 Developer-registered tools are never mutable through the interface, and there
 is no filesystem or inline-code loading surface.
 
-_Supported in: Node.js, modern browsers (TypeScript); all platforms (Python)._
+_Supported in: all platforms (Python)._
 
 The pre-approved MCP client set is fixed when the tool is constructed; the
 model chooses among aliases the developer set, never a raw URL. A configurable

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -354,18 +354,16 @@ from strands import Agent
 from strands.tools.mcp import MCPClient
 from strands.vended_tools import make_tool_registry
 
-weather = MCPClient(lambda: stdio_client(StdioServerParameters(command="uvx", args=["mcp-weather"])))
-weather.start()
-
-registry_tool = make_tool_registry(mcp_clients={"weather": weather})
-agent = Agent(tools=[registry_tool])
-agent("List the tools you have, then add the forecast tool from weather.")
+with MCPClient(lambda: stdio_client(StdioServerParameters(command="uvx", args=["mcp-weather"]))) as weather:
+    registry_tool = make_tool_registry(mcp_clients={"weather": weather})
+    agent = Agent(tools=[registry_tool])
+    agent("List the tools you have, then add the forecast tool from weather.")
 ```
 
 </Tab>
 </Tabs>
 
-**Custom cap:**
+**Custom configuration:**
 
 <Tabs>
 <Tab label="Python">
@@ -377,12 +375,9 @@ from strands import Agent
 from strands.tools.mcp import MCPClient
 from strands.vended_tools import make_tool_registry
 
-weather = MCPClient(lambda: stdio_client(StdioServerParameters(command="uvx", args=["mcp-weather"])))
-weather.start()
-
-# Allow the model to register up to 10 tools instead of the default 32.
-registry_tool = make_tool_registry(mcp_clients={"weather": weather}, max_dynamic_tools=10)
-agent = Agent(tools=[registry_tool])
+with MCPClient(lambda: stdio_client(StdioServerParameters(command="uvx", args=["mcp-weather"]))) as weather:
+    registry_tool = make_tool_registry(mcp_clients={"weather": weather}, max_dynamic_tools=10)
+    agent = Agent(tools=[registry_tool])
 ```
 
 </Tab>

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -339,7 +339,7 @@ _Supported in: all platforms (Python)._
 
 The pre-approved MCP client set is fixed when the tool is constructed; the
 model chooses among aliases the developer set, never a raw URL. A configurable
-cap (default: thirty-two) bounds the number of tools any one instance may add
+cap (default: 32) bounds the number of tools any one instance may add
 to a given agent.
 
 **Example:**
@@ -360,6 +360,29 @@ weather.start()
 registry_tool = make_tool_registry(mcp_clients={"weather": weather})
 agent = Agent(tools=[registry_tool])
 agent("List the tools you have, then add the forecast tool from weather.")
+```
+
+</Tab>
+</Tabs>
+
+**Custom cap:**
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from mcp import StdioServerParameters, stdio_client
+
+from strands import Agent
+from strands.tools.mcp import MCPClient
+from strands.vended_tools import make_tool_registry
+
+weather = MCPClient(lambda: stdio_client(StdioServerParameters(command="uvx", args=["mcp-weather"])))
+weather.start()
+
+# Allow the model to register up to 10 tools instead of the default 32.
+registry_tool = make_tool_registry(mcp_clients={"weather": weather}, max_dynamic_tools=10)
+agent = Agent(tools=[registry_tool])
 ```
 
 </Tab>

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -42,7 +42,7 @@ Each tool is imported from its own subpath under `@strands-agents/sdk/vended-too
 | [Bash](#bash) | Execute shell commands with persistent sessions | Python, TypeScript (Node.js, Unix/Linux/macOS) |
 | [Sleep](#sleep) | Pause execution for a bounded, cancellable duration | Python, TypeScript (Node.js, browsers) |
 | [Stop](#stop-experimental) | Gracefully end the agent loop when the task is complete | Python, TypeScript (Node.js, browsers) |
-| [Tool Registry](#tool-registry) | Let the agent list, add, re-bind, and remove tools on its own registry at runtime | Python |
+| [Tool Registry](#tool-registry) | Let the agent list, create, update, and delete tools on its own registry at runtime | Python |
 
 ### File Editor
 
@@ -330,8 +330,8 @@ result = agent("Summarize the changes in ./CHANGELOG.md")
 Gives the agent runtime CRUD access to its own tool registry, backed
 exclusively by already-connected MCP clients the developer pre-approved at
 construction time. The model can list every tool currently registered, register
-a new tool that binds to a specific remote tool on one of those clients, re-bind
-an existing entry, and remove entries this tool itself added.
+a new tool that binds to a specific remote tool on one of those clients, update
+an existing binding, and delete entries this tool itself added.
 Developer-registered tools are never mutable through the interface, and there
 is no filesystem or inline-code loading surface.
 
@@ -348,11 +348,13 @@ to a given agent.
 <Tab label="Python">
 
 ```python
+from mcp import StdioServerParameters, stdio_client
+
 from strands import Agent
 from strands.tools.mcp import MCPClient
 from strands.vended_tools import make_tool_registry
 
-weather = MCPClient(...)
+weather = MCPClient(lambda: stdio_client(StdioServerParameters(command="uvx", args=["mcp-weather"])))
 weather.start()
 
 registry_tool = make_tool_registry(mcp_clients={"weather": weather})
@@ -363,7 +365,6 @@ agent("List the tools you have, then add the forecast tool from weather.")
 </Tab>
 </Tabs>
 
-📖 [Full API Reference](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/tool-registry/README.md)
 
 ---
 

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -14,6 +14,7 @@ sourceLinks:
   - path: strands-py/src/strands/vended_tools/http_request/http_request.py
   - path: strands-py/src/strands/vended_tools/shell/shell.py
   - path: strands-py/src/strands/vended_tools/sleep/sleep.py
+  - path: strands-py/src/strands/vended_tools/tool_registry/tool_registry.py
   - path: strands-py/src/strands/experimental/tools/stop/stop.py
 ---
 
@@ -41,6 +42,7 @@ Each tool is imported from its own subpath under `@strands-agents/sdk/vended-too
 | [Bash](#bash) | Execute shell commands with persistent sessions | Python, TypeScript (Node.js, Unix/Linux/macOS) |
 | [Sleep](#sleep) | Pause execution for a bounded, cancellable duration | Python, TypeScript (Node.js, browsers) |
 | [Stop](#stop-experimental) | Gracefully end the agent loop when the task is complete | Python, TypeScript (Node.js, browsers) |
+| [Tool Registry](#tool-registry) | Let the agent list, add, re-bind, and remove tools on its own registry at runtime | Python |
 
 ### File Editor
 
@@ -320,6 +322,48 @@ result = agent("Summarize the changes in ./CHANGELOG.md")
 </Tabs>
 
 📖 [Full API Reference](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/experimental/vended-tools/stop/README.md)
+
+---
+
+### Tool Registry
+
+Gives the agent runtime CRUD access to its own tool registry, backed
+exclusively by already-connected MCP clients the developer pre-approved at
+construction time. The model can list every tool currently registered, register
+a new tool that binds to a specific remote tool on one of those clients, re-bind
+an existing entry, and remove entries this tool itself added.
+Developer-registered tools are never mutable through the interface, and there
+is no filesystem or inline-code loading surface.
+
+_Supported in: Node.js, modern browsers (TypeScript); all platforms (Python)._
+
+The pre-approved MCP client set is fixed when the tool is constructed; the
+model chooses among aliases the developer set, never a raw URL. A configurable
+cap (default: thirty-two) bounds the number of tools any one instance may add
+to a given agent.
+
+**Example:**
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.tools.mcp import MCPClient
+from strands.vended_tools import make_tool_registry
+
+weather = MCPClient(...)
+weather.start()
+
+registry_tool = make_tool_registry(mcp_clients={"weather": weather})
+agent = Agent(tools=[registry_tool])
+agent("List the tools you have, then add the forecast tool from weather.")
+```
+
+</Tab>
+</Tabs>
+
+📖 [Full API Reference](https://github.com/strands-agents/harness-sdk/blob/main/strands-ts/src/vended-tools/tool-registry/README.md)
 
 ---
 

--- a/strands-py/src/strands/tools/registry.py
+++ b/strands-py/src/strands/tools/registry.py
@@ -253,20 +253,7 @@ class ToolRegistry:
             )
 
         # Check for normalized name conflicts (- vs _)
-        if self.registry.get(tool.tool_name) is None:
-            normalized_name = tool.tool_name.replace("-", "_")
-
-            matching_tools = [
-                tool_name
-                for (tool_name, tool) in self.registry.items()
-                if tool_name.replace("-", "_") == normalized_name
-            ]
-
-            if matching_tools:
-                raise ValueError(
-                    f"Tool name '{tool.tool_name}' already exists as '{matching_tools[0]}'."
-                    " Cannot add a duplicate tool which differs by a '-' or '_'"
-                )
+        self._check_normalized_name_conflict(tool.tool_name, self.registry)
 
         # Register in main registry
         self.registry[tool.tool_name] = tool
@@ -565,10 +552,15 @@ class ToolRegistry:
             tool: The tool to register dynamically
 
         Raises:
-            ValueError: If a tool with this name already exists
+            ValueError: If a tool with this name already exists, or if a tool whose name
+                differs only by '-' vs '_' is already registered.
         """
         if tool.tool_name in self.registry or tool.tool_name in self.dynamic_tools:
             raise ValueError(f"Tool '{tool.tool_name}' already exists")
+
+        self._check_normalized_name_conflict(
+            tool.tool_name, list(self.registry.keys()) + list(self.dynamic_tools.keys())
+        )
 
         self.dynamic_tools[tool.tool_name] = tool
         logger.debug("Registered dynamic tool: %s", tool.tool_name)
@@ -690,6 +682,24 @@ class ToolRegistry:
                     logger.warning("tool_name=<%s> | failed to create function tool | %s", name, e)
 
         return tools
+
+    def _check_normalized_name_conflict(self, tool_name: str, search_names: Iterable[str]) -> None:
+        """Raise ValueError if any name in search_names differs from tool_name only by ``-`` vs ``_``.
+
+        Args:
+            tool_name: The candidate name being registered.
+            search_names: Existing names to check against.
+
+        Raises:
+            ValueError: If a normalized conflict is found.
+        """
+        normalized = tool_name.replace("-", "_")
+        for existing_name in search_names:
+            if existing_name != tool_name and existing_name.replace("-", "_") == normalized:
+                raise ValueError(
+                    f"Tool name '{tool_name}' already exists as '{existing_name}'."
+                    " Cannot add a duplicate tool which differs by a '-' or '_'"
+                )
 
     def cleanup(self, **kwargs: Any) -> None:
         """Synchronously clean up all tool providers in this registry."""

--- a/strands-py/src/strands/tools/registry.py
+++ b/strands-py/src/strands/tools/registry.py
@@ -253,9 +253,20 @@ class ToolRegistry:
             )
 
         # Check for normalized name conflicts (- vs _)
-        self._check_normalized_name_conflict(
-            tool.tool_name, list(self.registry.keys()) + list(self.dynamic_tools.keys())
-        )
+        if self.registry.get(tool.tool_name) is None:
+            normalized_name = tool.tool_name.replace("-", "_")
+
+            matching_tools = [
+                tool_name
+                for (tool_name, tool) in self.registry.items()
+                if tool_name.replace("-", "_") == normalized_name
+            ]
+
+            if matching_tools:
+                raise ValueError(
+                    f"Tool name '{tool.tool_name}' already exists as '{matching_tools[0]}'."
+                    " Cannot add a duplicate tool which differs by a '-' or '_'"
+                )
 
         # Register in main registry
         self.registry[tool.tool_name] = tool
@@ -554,15 +565,10 @@ class ToolRegistry:
             tool: The tool to register dynamically
 
         Raises:
-            ValueError: If a tool with this name already exists, or if a tool whose name
-                differs only by '-' vs '_' is already registered.
+            ValueError: If a tool with this name already exists
         """
         if tool.tool_name in self.registry or tool.tool_name in self.dynamic_tools:
             raise ValueError(f"Tool '{tool.tool_name}' already exists")
-
-        self._check_normalized_name_conflict(
-            tool.tool_name, list(self.registry.keys()) + list(self.dynamic_tools.keys())
-        )
 
         self.dynamic_tools[tool.tool_name] = tool
         logger.debug("Registered dynamic tool: %s", tool.tool_name)
@@ -684,24 +690,6 @@ class ToolRegistry:
                     logger.warning("tool_name=<%s> | failed to create function tool | %s", name, e)
 
         return tools
-
-    def _check_normalized_name_conflict(self, tool_name: str, search_names: Iterable[str]) -> None:
-        """Raise ValueError if any name in search_names differs from tool_name only by ``-`` vs ``_``.
-
-        Args:
-            tool_name: The candidate name being registered.
-            search_names: Existing names to check against.
-
-        Raises:
-            ValueError: If a normalized conflict is found.
-        """
-        normalized = tool_name.replace("-", "_")
-        for existing_name in search_names:
-            if existing_name != tool_name and existing_name.replace("-", "_") == normalized:
-                raise ValueError(
-                    f"Tool name '{tool_name}' already exists as '{existing_name}'."
-                    " Cannot add a duplicate tool which differs by a '-' or '_'"
-                )
 
     def cleanup(self, **kwargs: Any) -> None:
         """Synchronously clean up all tool providers in this registry."""

--- a/strands-py/src/strands/tools/registry.py
+++ b/strands-py/src/strands/tools/registry.py
@@ -707,3 +707,12 @@ class ToolRegistry:
 
         if exceptions:
             raise exceptions[0]
+
+    def remove(self, tool_name: str) -> None:
+        """Remove a tool from the registry. No-op if the tool does not exist.
+
+        Args:
+            tool_name: Name of the tool to remove.
+        """
+        self.registry.pop(tool_name, None)
+        self.dynamic_tools.pop(tool_name, None)

--- a/strands-py/src/strands/tools/registry.py
+++ b/strands-py/src/strands/tools/registry.py
@@ -253,7 +253,9 @@ class ToolRegistry:
             )
 
         # Check for normalized name conflicts (- vs _)
-        self._check_normalized_name_conflict(tool.tool_name, self.registry)
+        self._check_normalized_name_conflict(
+            tool.tool_name, list(self.registry.keys()) + list(self.dynamic_tools.keys())
+        )
 
         # Register in main registry
         self.registry[tool.tool_name] = tool

--- a/strands-py/src/strands/vended_tools/__init__.py
+++ b/strands-py/src/strands/vended_tools/__init__.py
@@ -1,4 +1,4 @@
-"""Built-in tools for commands, files, HTTP, and pausing.
+"""Built-in tools for commands, files, HTTP, tool registry, and pausing.
 
 The :func:`make_shell` and :func:`make_file_editor` factories produce
 sandbox-routed tools that either bind to a
@@ -10,6 +10,9 @@ calls. The :data:`sleep` tool pauses execution for a bounded, cancellable durati
 The :data:`http_request` tool makes raw HTTP calls; use
 :func:`make_http_request` to supply a pre-configured ``httpx.AsyncClient``
 with custom timeouts, redirects, authentication, or proxies.
+
+The :func:`make_tool_registry` factory produces a tool that lets the agent
+introspect and mutate its own tool registry at runtime.
 
 Example Usage:
     ```python
@@ -28,6 +31,7 @@ from .file_editor import file_editor, make_file_editor
 from .http_request import http_request, make_http_request
 from .shell import make_shell, shell
 from .sleep import make_sleep, sleep
+from .tool_registry import make_tool_registry
 
 
 def __getattr__(name: str) -> Any:
@@ -52,6 +56,7 @@ __all__ = [
     "make_http_request",
     "make_shell",
     "make_sleep",
+    "make_tool_registry",
     "shell",
     "sleep",
 ]

--- a/strands-py/src/strands/vended_tools/tool_registry/__init__.py
+++ b/strands-py/src/strands/vended_tools/tool_registry/__init__.py
@@ -19,9 +19,6 @@ Example Usage:
 
 from .tool_registry import make_tool_registry
 from .types import (
-    MAX_DYNAMIC_TOOLS,
-    TOOL_NAME_PATTERN,
-    TOOL_REGISTRY_DESCRIPTION,
     ListResult,
     MutationResult,
     RegisteredTool,
@@ -29,9 +26,6 @@ from .types import (
 )
 
 __all__ = [
-    "MAX_DYNAMIC_TOOLS",
-    "TOOL_NAME_PATTERN",
-    "TOOL_REGISTRY_DESCRIPTION",
     "ListResult",
     "MutationResult",
     "RegisteredTool",

--- a/strands-py/src/strands/vended_tools/tool_registry/__init__.py
+++ b/strands-py/src/strands/vended_tools/tool_registry/__init__.py
@@ -1,0 +1,40 @@
+"""Runtime tool-registry-management tool (CRUD over the agent's own tools).
+
+Only tools hosted on pre-approved MCP servers may be registered dynamically.
+Loading tools from a file path or inline source is intentionally not supported.
+
+Example Usage:
+    ```python
+    from strands import Agent
+    from strands.tools.mcp import MCPClient
+    from strands.vended_tools.tool_registry import make_tool_registry
+
+    weather = MCPClient(...)
+    weather.start()
+    registry_tool = make_tool_registry(mcp_clients={"weather": weather})
+
+    agent = Agent(tools=[registry_tool])
+    ```
+"""
+
+from .tool_registry import make_tool_registry
+from .types import (
+    MAX_DYNAMIC_TOOLS,
+    TOOL_NAME_PATTERN,
+    TOOL_REGISTRY_DESCRIPTION,
+    ListResult,
+    MutationResult,
+    RegisteredTool,
+    ToolRegistryError,
+)
+
+__all__ = [
+    "MAX_DYNAMIC_TOOLS",
+    "TOOL_NAME_PATTERN",
+    "TOOL_REGISTRY_DESCRIPTION",
+    "ListResult",
+    "MutationResult",
+    "RegisteredTool",
+    "ToolRegistryError",
+    "make_tool_registry",
+]

--- a/strands-py/src/strands/vended_tools/tool_registry/__init__.py
+++ b/strands-py/src/strands/vended_tools/tool_registry/__init__.py
@@ -9,11 +9,9 @@ Example Usage:
     from strands.tools.mcp import MCPClient
     from strands.vended_tools.tool_registry import make_tool_registry
 
-    weather = MCPClient(...)
-    weather.start()
-    registry_tool = make_tool_registry(mcp_clients={"weather": weather})
-
-    agent = Agent(tools=[registry_tool])
+    with MCPClient(...) as weather:
+        registry_tool = make_tool_registry(mcp_clients={"weather": weather})
+        agent = Agent(tools=[registry_tool])
     ```
 """
 

--- a/strands-py/src/strands/vended_tools/tool_registry/tool_registry.py
+++ b/strands-py/src/strands/vended_tools/tool_registry/tool_registry.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import weakref
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, cast
 
 from ...tools.decorator import tool
 from ...tools.mcp import MCPAgentTool, MCPClient
@@ -45,11 +45,14 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Maps tool_name → registered MCPAgentTool, or a cast sentinel while a create is in flight.
+_OwnedTools = dict[str, MCPAgentTool]
 
-def _get_owned_names(
-    ownership: weakref.WeakKeyDictionary[ToolRegistry, dict[str, object]],
+
+def _get_owned_tools(
+    ownership: weakref.WeakKeyDictionary[ToolRegistry, _OwnedTools],
     registry: ToolRegistry,
-) -> dict[str, object]:
+) -> _OwnedTools:
     owned = ownership.get(registry)
     if owned is None:
         owned = {}
@@ -112,6 +115,121 @@ async def _resolve_mcp_tool(
     raise ToolRegistryError(f"tool '{remote_name}' not found on MCP server")
 
 
+def _list_tools(
+    agent_registry: ToolRegistry,
+    owned: _OwnedTools,
+    max_dynamic_tools: int,
+) -> ListResult:
+    tools_out: list[RegisteredTool] = []
+    for spec in agent_registry.get_all_tool_specs():
+        entry: RegisteredTool = {
+            "name": spec["name"],
+            "description": spec.get("description", ""),
+            "registered_by_tool_registry": spec["name"] in owned,
+        }
+        # Omit input_schema only when the key is absent from the underlying tool.
+        # An explicit empty dict is a valid schema and must be preserved.
+        if "inputSchema" in spec:
+            entry["input_schema"] = spec["inputSchema"]["json"]
+        tools_out.append(entry)
+    return ListResult(
+        tools=tools_out,
+        dynamic_count=len(owned),
+        dynamic_limit=max_dynamic_tools,
+    )
+
+
+def _delete_tool(
+    agent_registry: ToolRegistry,
+    owned: _OwnedTools,
+    tool_name: str,
+) -> MutationResult:
+    if tool_name not in owned:
+        raise ToolRegistryError(
+            f"tool '{tool_name}' was not registered via tool_registry; developer-registered tools cannot be removed"
+        )
+    owned_tool = owned[tool_name]
+    # Only remove from registry if it still holds a tool registered by the tool_registry tool
+    if agent_registry.registry.get(tool_name) is owned_tool:
+        agent_registry.remove(tool_name)
+    else:
+        agent_registry.dynamic_tools.pop(tool_name, None)
+    del owned[tool_name]
+    return MutationResult(operation="delete", name=tool_name, dynamic_count=len(owned))
+
+
+async def _create_tool(
+    agent_registry: ToolRegistry,
+    owned: _OwnedTools,
+    client: MCPClient,
+    tool_name: str,
+    effective_remote: str,
+    description_override: str | None,
+    max_dynamic_tools: int,
+) -> MutationResult:
+    if tool_name in agent_registry.registry or tool_name in agent_registry.dynamic_tools or tool_name in owned:
+        raise ToolRegistryError(f"a tool named '{tool_name}' is already registered")
+    conflict = _find_normalized_conflict(agent_registry, tool_name)
+    if conflict is not None:
+        raise ToolRegistryError(
+            f"a tool named '{conflict}' is already registered; tool names cannot differ only by '-' vs '_'"
+        )
+    if len(owned) >= max_dynamic_tools:
+        raise ToolRegistryError(
+            f"dynamic tool cap reached ({max_dynamic_tools}); delete an existing dynamically-registered tool first"
+        )
+    # Reserve the slot with a sentinel while the MCP round-trip is in flight.
+    reservation: MCPAgentTool = cast(MCPAgentTool, object())
+    new_tool: MCPAgentTool = reservation
+    owned[tool_name] = reservation
+    try:
+        new_tool = await _resolve_mcp_tool(client, effective_remote, tool_name, description_override)
+        # Abort if a concurrent delete+recreate invalidated our reservation during the await.
+        if owned.get(tool_name) is not reservation:
+            raise ToolRegistryError(
+                f"create of '{tool_name}' was cancelled by a concurrent delete before the tool could be registered"
+            )
+        owned[tool_name] = new_tool
+        try:
+            agent_registry.register_tool(new_tool)
+        except ValueError as err:
+            # Concurrent registration can still land a duplicate between the checks and write.
+            raise ToolRegistryError(str(err)) from err
+    except BaseException:
+        # Only release the slot if it still belongs to this create, not a concurrent delete+recreate.
+        current = owned.get(tool_name)
+        if current is reservation or current is new_tool:
+            del owned[tool_name]
+        raise
+    return MutationResult(operation="create", name=tool_name, dynamic_count=len(owned))
+
+
+async def _update_tool(
+    agent_registry: ToolRegistry,
+    owned: _OwnedTools,
+    client: MCPClient,
+    tool_name: str,
+    effective_remote: str,
+    description_override: str | None,
+) -> MutationResult:
+    if tool_name not in owned or tool_name not in agent_registry.dynamic_tools:
+        raise ToolRegistryError(
+            f"tool '{tool_name}' was not registered via tool_registry; developer-registered tools cannot be updated"
+        )
+    update_token = owned[tool_name]
+    new_tool = await _resolve_mcp_tool(client, effective_remote, tool_name, description_override)
+    # Abort if the registration was replaced by a delete+recreate during the await.
+    if owned.get(tool_name) is not update_token:
+        raise ToolRegistryError(
+            f"update of '{tool_name}' was cancelled by a concurrent delete before the tool could be re-bound"
+        )
+    try:
+        agent_registry.replace(new_tool)
+    except ValueError as err:
+        raise ToolRegistryError(str(err)) from err
+    return MutationResult(operation="update", name=tool_name, dynamic_count=len(owned))
+
+
 def make_tool_registry(
     *,
     mcp_clients: dict[str, MCPClient] | None = None,
@@ -147,7 +265,7 @@ def make_tool_registry(
     # Ownership map for this factory instance: keyed on ToolRegistry so two factories
     # on one agent track their tools independently. WeakKeyDictionary lets the entry
     # disappear when the registry is garbage-collected.
-    ownership: weakref.WeakKeyDictionary[ToolRegistry, dict[str, object]] = weakref.WeakKeyDictionary()
+    ownership: weakref.WeakKeyDictionary[ToolRegistry, _OwnedTools] = weakref.WeakKeyDictionary()
 
     @tool(name=name, description=description, context="tool_context")
     async def tool_registry_tool(
@@ -187,31 +305,15 @@ def make_tool_registry(
                 ``create``/``update``.
         """
         agent_registry: ToolRegistry = tool_context.agent.tool_registry
-        owned = _get_owned_names(ownership, agent_registry)
+        owned = _get_owned_tools(ownership, agent_registry)
 
-        if operation == "list":
-            tools_out: list[RegisteredTool] = []
-            for spec in agent_registry.get_all_tool_specs():
-                entry: RegisteredTool = {
-                    "name": spec["name"],
-                    "description": spec.get("description", ""),
-                    "registered_by_tool_registry": spec["name"] in owned,
-                }
-                # Omit input_schema only when the key is absent from the underlying tool.
-                # An explicit empty dict is a valid schema and must be preserved.
-                if "inputSchema" in spec:
-                    entry["input_schema"] = spec["inputSchema"]["json"]
-                tools_out.append(entry)
-            return ListResult(
-                tools=tools_out,
-                dynamic_count=len(owned),
-                dynamic_limit=max_dynamic_tools,
-            )
-
-        if operation not in ("create", "update", "delete"):
+        if operation not in ("list", "create", "update", "delete"):
             raise ToolRegistryError(
                 f"invalid operation '{operation}': must be one of 'list', 'create', 'update', 'delete'"
             )
+
+        if operation == "list":
+            return _list_tools(agent_registry, owned, max_dynamic_tools)
 
         if tool_name is None:
             raise ToolRegistryError(f"'tool_name' is required for operation '{operation}'")
@@ -226,16 +328,8 @@ def make_tool_registry(
             raise ToolRegistryError(f"cannot {operation} the tool_registry tool ('{tool_name}') itself")
 
         if operation == "delete":
-            if tool_name not in owned:
-                raise ToolRegistryError(
-                    f"tool '{tool_name}' was not registered via tool_registry; "
-                    "developer-registered tools cannot be removed"
-                )
-            agent_registry.remove(tool_name)
-            del owned[tool_name]
-            return MutationResult(operation="delete", name=tool_name, dynamic_count=len(owned))
+            return _delete_tool(agent_registry, owned, tool_name)
 
-        # create / update below share the source-resolution logic.
         if not source:
             raise ToolRegistryError(f"'source' is required for operation '{operation}'")
         if source not in clients:
@@ -244,58 +338,24 @@ def make_tool_registry(
         effective_remote = remote_name or tool_name
 
         if operation == "create":
-            if tool_name in agent_registry.registry or tool_name in agent_registry.dynamic_tools or tool_name in owned:
-                raise ToolRegistryError(f"a tool named '{tool_name}' is already registered")
-            conflict = _find_normalized_conflict(agent_registry, tool_name)
-            if conflict is not None:
-                raise ToolRegistryError(
-                    f"a tool named '{conflict}' is already registered; tool names cannot differ only by '-' vs '_'"
-                )
-            if len(owned) >= max_dynamic_tools:
-                raise ToolRegistryError(
-                    f"dynamic tool cap reached ({max_dynamic_tools}); "
-                    "delete an existing dynamically-registered tool first"
-                )
-            # Unique token per registration; guards detect a concurrent delete+recreate.
-            token: object = object()
-            owned[tool_name] = token
-            try:
-                new_tool = await _resolve_mcp_tool(clients[source], effective_remote, tool_name, description_override)
-                # Abort if a concurrent delete invalidated our registration during the await.
-                if owned.get(tool_name) is not token:
-                    raise ToolRegistryError(
-                        f"create of '{tool_name}' was cancelled by a concurrent delete "
-                        "before the tool could be registered"
-                    )
-                try:
-                    agent_registry.register_tool(new_tool)
-                except ValueError as err:
-                    # Concurrent registration can still land a duplicate between the checks and write.
-                    raise ToolRegistryError(str(err)) from err
-            except BaseException:
-                # Only release the slot if it still belongs to this create, not a concurrent delete and recreate.
-                if owned.get(tool_name) is token:
-                    del owned[tool_name]
-                raise
-            return MutationResult(operation="create", name=tool_name, dynamic_count=len(owned))
+            return await _create_tool(
+                agent_registry,
+                owned,
+                clients[source],
+                tool_name,
+                effective_remote,
+                description_override,
+                max_dynamic_tools,
+            )
 
         # operation == "update"
-        if tool_name not in owned or tool_name not in agent_registry.dynamic_tools:
-            raise ToolRegistryError(
-                f"tool '{tool_name}' was not registered via tool_registry; developer-registered tools cannot be updated"
-            )
-        update_token = owned[tool_name]
-        new_tool = await _resolve_mcp_tool(clients[source], effective_remote, tool_name, description_override)
-        # Abort if a concurrent delete cleared ownership during the await (mirrors the create guard).
-        if owned.get(tool_name) is not update_token:
-            raise ToolRegistryError(
-                f"update of '{tool_name}' was cancelled by a concurrent delete before the tool could be re-bound"
-            )
-        # Replace under the same name, keeping ownership.
-        try:
-            agent_registry.replace(new_tool)
-        except ValueError as err:
-            raise ToolRegistryError(str(err)) from err
-        return MutationResult(operation="update", name=tool_name, dynamic_count=len(owned))
+        return await _update_tool(
+            agent_registry,
+            owned,
+            clients[source],
+            tool_name,
+            effective_remote,
+            description_override,
+        )
 
     return tool_registry_tool

--- a/strands-py/src/strands/vended_tools/tool_registry/tool_registry.py
+++ b/strands-py/src/strands/vended_tools/tool_registry/tool_registry.py
@@ -1,0 +1,332 @@
+"""Tool for CRUD over the agent's own tool registry.
+
+Provides :func:`make_tool_registry` (a factory that binds the tool to a set of
+already-connected MCP clients from which new tools may be pulled). The tool
+exposes four operations to the model:
+
+- ``list``: enumerate all tools currently on the agent's registry, marking the
+  ones this tool has registered itself.
+- ``create``: register a new tool that is a thin binding to a specific tool
+  hosted on one of the pre-approved MCP clients.
+- ``update``: re-bind a previously registered tool (e.g. to point at a
+  different remote tool, or to change its description). The local name is the
+  lookup key and is not modifiable; delete and re-create to rename.
+- ``delete``: unregister a tool that this same tool_registry instance
+  registered. Developer-registered tools are never removable.
+
+Design decision (see PR body): ``create`` only accepts references to already-
+connected MCP servers pre-provided by the developer via ``mcp_clients``.
+Accepting a filesystem path (loading arbitrary Python from disk) or inline
+source code (executing arbitrary Python or JS) are explicitly out of scope --
+both introduce a filesystem/code-execution attack surface that is
+disproportionate to the value of runtime tool registration for a general-purpose
+agent tool. Consumers that need those flows should build a separate, more
+locked-down tool. This one is a thin shim onto MCPClient, so its blast radius
+is exactly whatever the developer-approved MCP servers already expose.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import weakref
+from typing import TYPE_CHECKING
+
+from ...tools.decorator import tool
+from ...tools.mcp import MCPAgentTool, MCPClient
+from ...types.tools import ToolContext
+from .types import (
+    MAX_DYNAMIC_TOOLS,
+    TOOL_NAME_PATTERN,
+    TOOL_REGISTRY_DESCRIPTION,
+    ListResult,
+    MutationResult,
+    RegisteredTool,
+    ToolRegistryError,
+)
+
+if TYPE_CHECKING:
+    from ...tools.decorator import DecoratedFunctionTool
+    from ...tools.registry import ToolRegistry
+
+logger = logging.getLogger(__name__)
+
+
+def _get_owned_names(
+    ownership: weakref.WeakKeyDictionary[ToolRegistry, set[str]],
+    registry: ToolRegistry,
+) -> set[str]:
+    owned = ownership.get(registry)
+    if owned is None:
+        owned = set()
+        ownership[registry] = owned
+    return owned
+
+
+def _validate_tool_name(name: str) -> None:
+    if not isinstance(name, str) or not TOOL_NAME_PATTERN.match(name):
+        raise ToolRegistryError(f"invalid tool name '{name}': must match {TOOL_NAME_PATTERN.pattern}")
+
+
+def _find_normalized_conflict(registry: ToolRegistry, name: str) -> str | None:
+    """Return an existing registry name that collides with ``name``.
+
+    The SDK's normalized-name rule treats ``-`` and ``_`` as equivalent.
+    ``ToolRegistry.register_tool`` enforces this rule but
+    ``register_dynamic_tool`` does not, so we replicate the check here to keep
+    the tool_registry surface consistent with ``register_tool`` and to fail
+    with a clear ToolRegistryError rather than a bare ValueError from the SDK.
+    """
+    normalized = name.replace("-", "_")
+    for existing in list(registry.registry.keys()) + list(registry.dynamic_tools.keys()):
+        if existing == name:
+            continue
+        if existing.replace("-", "_") == normalized:
+            return existing
+    return None
+
+
+async def _resolve_mcp_tool(
+    client: MCPClient,
+    remote_name: str,
+    local_name: str,
+    description_override: str | None,
+) -> MCPAgentTool:
+    """Look up a specific tool on the MCP client and adapt it to the local name.
+
+    ``list_tools_sync`` is a blocking network call, so it is dispatched to a
+    worker thread with :func:`asyncio.to_thread`; without that the whole event
+    loop would stall on the round-trip. The suspension point is real, which is
+    what makes the reservation and concurrent-delete/update guards reachable in
+    production the same way the tests exercise them.
+
+    Raises:
+        ToolRegistryError: If ``remote_name`` is not exposed by the MCP server.
+    """
+    pagination_token: str | None = None
+    while True:
+        page = await asyncio.to_thread(client.list_tools_sync, pagination_token=pagination_token)
+        for mcp_tool in page:
+            # ``list_tools_sync`` returns MCPAgentTool objects; the underlying
+            # ``mcp_tool.name`` is the remote-side name, unaffected by any
+            # client-level prefix. Match on that.
+            if mcp_tool.mcp_tool.name == remote_name:
+                adapted = MCPAgentTool(
+                    mcp_tool.mcp_tool,
+                    client,
+                    name_override=local_name,
+                )
+                adapted.mark_dynamic()
+                if description_override is not None:
+                    # ``MCPAgentTool.tool_spec`` reads from ``mcp_tool.description``
+                    # each call; override by copying the underlying pydantic model.
+                    adapted.mcp_tool = adapted.mcp_tool.model_copy(update={"description": description_override})
+                return adapted
+        pagination_token = page.pagination_token
+        if pagination_token is None:
+            break
+    raise ToolRegistryError(f"tool '{remote_name}' not found on MCP server")
+
+
+def make_tool_registry(
+    *,
+    mcp_clients: dict[str, MCPClient] | None = None,
+    max_dynamic_tools: int = MAX_DYNAMIC_TOOLS,
+    name: str = "tool_registry",
+    description: str = TOOL_REGISTRY_DESCRIPTION,
+) -> DecoratedFunctionTool:
+    """Create a runtime tool-registry-management tool bound to a set of MCP sources.
+
+    Args:
+        mcp_clients: Mapping from a stable, developer-chosen alias to an
+            already-connected :class:`~strands.tools.mcp.MCPClient`. Only tools
+            hosted on these clients may be registered dynamically. When ``None``
+            or empty, ``create`` and ``update`` always fail; the tool degrades to
+            a read-only view.
+        max_dynamic_tools: Upper bound on the number of tools this instance may
+            add to the agent's registry. Defaults to :data:`.types.MAX_DYNAMIC_TOOLS`.
+        name: Tool name. Defaults to ``"tool_registry"``.
+        description: Tool description shown to the model.
+
+    Returns:
+        A decorated tool that performs the four CRUD operations on the agent's
+        tool registry.
+
+    Raises:
+        ValueError: If ``max_dynamic_tools`` is less than one.
+    """
+    clients: dict[str, MCPClient] = dict(mcp_clients or {})
+
+    if max_dynamic_tools < 1:
+        raise ValueError("max_dynamic_tools must be at least 1")
+
+    # Per-factory ownership map: keyed on the agent's ToolRegistry, closed over
+    # by this factory instance. Two `make_tool_registry` factories on one agent
+    # therefore track their own tools independently. `WeakKeyDictionary` lets
+    # the entry disappear when the registry (and its agent) is garbage-collected.
+    ownership: weakref.WeakKeyDictionary[ToolRegistry, set[str]] = weakref.WeakKeyDictionary()
+
+    @tool(name=name, description=description, context="tool_context")
+    async def tool_registry_tool(
+        operation: str,
+        tool_context: ToolContext,
+        tool_name: str | None = None,
+        source: str | None = None,
+        remote_name: str | None = None,
+        description_override: str | None = None,
+    ) -> ListResult | MutationResult:
+        """Manage the agent's tool registry at runtime (MCP-backed).
+
+        Args:
+            operation: One of ``"list"``, ``"create"``, ``"update"``, ``"delete"``.
+            tool_context: Injected by the framework. Not user-facing.
+            tool_name: Local name for the tool on the agent's registry. Required
+                for ``create``, ``update``, and ``delete``. Must match
+                ``^[a-zA-Z_][a-zA-Z0-9_]{0,63}$``.
+            source: For ``create``/``update``, the alias of an MCP client
+                previously registered with this tool via ``mcp_clients``. The
+                set of valid aliases is fixed at tool construction time.
+            remote_name: For ``create``/``update``, the name of the tool on the
+                MCP server pointed at by ``source``. Defaults to ``tool_name``
+                when omitted.
+            description_override: Optional description to expose to the model in
+                place of the MCP server's advertised description. Useful when the
+                remote description is empty or too generic.
+
+        Raises:
+            ToolRegistryError: For any validation failure surfaced by the tool
+                itself: unknown operation, missing or invalid ``tool_name``,
+                unknown ``source``, unknown remote tool, dynamic-tool cap
+                reached, duplicate registration, self-mutation attempt,
+                deletion or update of a tool this instance did not register,
+                or a concurrent-delete race that cancels an in-flight
+                ``create``/``update``.
+        """
+        agent_registry: ToolRegistry = tool_context.agent.tool_registry
+        owned = _get_owned_names(ownership, agent_registry)
+
+        if operation == "list":
+            tools_out: list[RegisteredTool] = []
+            for spec in agent_registry.get_all_tool_specs():
+                entry: RegisteredTool = {
+                    "name": spec["name"],
+                    "description": spec.get("description", ""),
+                    "registered_by_tool_registry": spec["name"] in owned,
+                }
+                # Omit input_schema only when the underlying tool doesn't
+                # declare the key at all, matching the TypeScript SDK's
+                # optional-field convention. An explicit empty dict is a
+                # valid schema and must be preserved.
+                if "inputSchema" in spec:
+                    entry["input_schema"] = spec["inputSchema"]
+                tools_out.append(entry)
+            return ListResult(
+                tools=tools_out,
+                dynamic_count=len(owned),
+                dynamic_limit=max_dynamic_tools,
+            )
+
+        if operation not in ("create", "update", "delete"):
+            raise ToolRegistryError(
+                f"invalid operation '{operation}': must be one of 'list', 'create', 'update', 'delete'"
+            )
+
+        if tool_name is None:
+            raise ToolRegistryError(f"'tool_name' is required for operation '{operation}'")
+        _validate_tool_name(tool_name)
+
+        # Never allow this tool to remove or replace itself.
+        if tool_name == name:
+            raise ToolRegistryError(f"cannot {operation} the tool_registry tool ('{tool_name}') itself")
+
+        if operation == "delete":
+            if tool_name not in owned:
+                raise ToolRegistryError(
+                    f"tool '{tool_name}' was not registered via tool_registry; "
+                    "developer-registered tools cannot be removed"
+                )
+            # Owned ⇒ present in dynamic_tools; belt-and-braces guard against
+            # external tampering with the registry between calls.
+            agent_registry.dynamic_tools.pop(tool_name, None)
+            agent_registry.registry.pop(tool_name, None)
+            owned.discard(tool_name)
+            return MutationResult(operation="delete", name=tool_name, dynamic_count=len(owned))
+
+        # create / update below share the source-resolution logic.
+        if not source:
+            raise ToolRegistryError(f"'source' is required for operation '{operation}'")
+        if source not in clients:
+            allowed = ", ".join(sorted(clients)) or "<none>"
+            raise ToolRegistryError(f"unknown source '{source}': allowed sources are: {allowed}")
+        effective_remote = remote_name or tool_name
+
+        if operation == "create":
+            if (
+                tool_name in agent_registry.registry
+                or tool_name in agent_registry.dynamic_tools
+                or tool_name in owned
+            ):
+                raise ToolRegistryError(f"a tool named '{tool_name}' is already registered")
+            conflict = _find_normalized_conflict(agent_registry, tool_name)
+            if conflict is not None:
+                raise ToolRegistryError(
+                    f"a tool named '{conflict}' is already registered; "
+                    f"tool names cannot differ only by '-' vs '_'"
+                )
+            if len(owned) >= max_dynamic_tools:
+                raise ToolRegistryError(
+                    f"dynamic tool cap reached ({max_dynamic_tools}); "
+                    "delete an existing dynamically-registered tool first"
+                )
+            # Reserve the slot in the owned set before the MCP lookup so
+            # concurrent `create` calls in the same turn can't all pass the
+            # cap check before any of them registers. On failure, release.
+            owned.add(tool_name)
+            try:
+                new_tool = await _resolve_mcp_tool(
+                    clients[source], effective_remote, tool_name, description_override
+                )
+                # A concurrent `delete` could have observed our reservation,
+                # treated it as if the tool were already registered, and cleared
+                # it while we were awaiting. If so, abort rather than write a
+                # tool this instance can no longer track.
+                if tool_name not in owned:
+                    raise ToolRegistryError(
+                        f"create of '{tool_name}' was cancelled by a concurrent delete "
+                        "before the tool could be registered"
+                    )
+                try:
+                    agent_registry.register_dynamic_tool(new_tool)
+                except ValueError as err:
+                    # A concurrent registration (e.g. another tool_registry
+                    # instance) can still land a duplicate between our checks
+                    # and the write. Surface as ToolRegistryError so callers
+                    # get a single exception type from the tool.
+                    raise ToolRegistryError(str(err)) from err
+            except Exception:
+                owned.discard(tool_name)
+                raise
+            return MutationResult(operation="create", name=tool_name, dynamic_count=len(owned))
+
+        # operation == "update"
+        if tool_name not in owned:
+            raise ToolRegistryError(
+                f"tool '{tool_name}' was not registered via tool_registry; developer-registered tools cannot be updated"
+            )
+        new_tool = await _resolve_mcp_tool(clients[source], effective_remote, tool_name, description_override)
+        # A concurrent `delete` could have run during the await above and
+        # cleared this instance's ownership of the tool. If so, abort rather
+        # than resurrect a tool the model believed deleted (mirrors the
+        # create-during-delete guard).
+        if tool_name not in owned:
+            raise ToolRegistryError(
+                f"update of '{tool_name}' was cancelled by a concurrent delete "
+                "before the tool could be re-bound"
+            )
+        # Replace under the same name, keeping ownership.
+        agent_registry.dynamic_tools[tool_name] = new_tool
+        if tool_name in agent_registry.registry:
+            agent_registry.registry[tool_name] = new_tool
+        return MutationResult(operation="update", name=tool_name, dynamic_count=len(owned))
+
+    return tool_registry_tool

--- a/strands-py/src/strands/vended_tools/tool_registry/tool_registry.py
+++ b/strands-py/src/strands/vended_tools/tool_registry/tool_registry.py
@@ -67,11 +67,8 @@ def _validate_tool_name(name: str) -> None:
 def _find_normalized_conflict(registry: ToolRegistry, name: str) -> str | None:
     """Return an existing registry name that collides with ``name``.
 
-    The SDK's normalized-name rule treats ``-`` and ``_`` as equivalent.
-    ``ToolRegistry.register_tool`` enforces this rule but
-    ``register_dynamic_tool`` does not, so we replicate the check here to keep
-    the tool_registry surface consistent with ``register_tool`` and to fail
-    with a clear ToolRegistryError rather than a bare ValueError from the SDK.
+    The SDK's normalized-name rule treats ``-`` and ``_`` as equivalent. We replicate the
+    check here to fail with a clear ToolRegistryError rather than a bare ValueError from the SDK.
     """
     normalized = name.replace("-", "_")
     for existing in list(registry.registry.keys()) + list(registry.dynamic_tools.keys()):

--- a/strands-py/src/strands/vended_tools/tool_registry/tool_registry.py
+++ b/strands-py/src/strands/vended_tools/tool_registry/tool_registry.py
@@ -16,9 +16,7 @@ exposes four operations to the model:
 
 ``create`` only accepts tools from the pre-connected MCP clients supplied via ``mcp_clients``;
 filesystem paths and inline source code are out of scope because both introduce a
-code-execution attack surface disproportionate to the benefit. The blast radius is
-intentionally bounded to whatever the developer-approved MCP servers already expose.
-Consumers that need those flows should build a separate, more locked-down tool.
+code-execution attack surface disproportionate to the benefit.
 """
 
 from __future__ import annotations
@@ -67,8 +65,10 @@ def _validate_tool_name(name: str) -> None:
 def _find_normalized_conflict(registry: ToolRegistry, name: str) -> str | None:
     """Return an existing registry name that collides with ``name``.
 
-    The SDK's normalized-name rule treats ``-`` and ``_`` as equivalent. We replicate the
-    check here to fail with a clear ToolRegistryError rather than a bare ValueError from the SDK.
+    The SDK's normalized-name rule treats ``-`` and ``_`` as equivalent.
+    ``register_dynamic_tool`` does not, so we replicate the check here to keep
+    the tool_registry surface consistent with ``register_tool`` and to fail
+    with a clear ToolRegistryError rather than a bare ValueError from the SDK.
     """
     normalized = name.replace("-", "_")
     for existing in list(registry.registry.keys()) + list(registry.dynamic_tools.keys()):
@@ -89,9 +89,7 @@ async def _resolve_mcp_tool(
 
     ``list_tools_sync`` is a blocking network call, so it is dispatched to a
     worker thread with :func:`asyncio.to_thread`; without that the whole event
-    loop would stall on the round-trip. The suspension point is real, which is
-    what makes the reservation and concurrent-delete/update guards reachable in
-    production the same way the tests exercise them.
+    loop would stall on the round-trip.
 
     Raises:
         ToolRegistryError: If ``remote_name`` is not exposed by the MCP server.
@@ -224,6 +222,9 @@ def make_tool_registry(
             raise ToolRegistryError(f"'tool_name' is required for operation '{operation}'")
         _validate_tool_name(tool_name)
 
+        if description_override is not None and not description_override.strip():
+            raise ToolRegistryError("description_override must be non-empty; omit it to keep the server's description")
+
         # Never allow this tool to remove or replace itself.
         if tool_name == name:
             raise ToolRegistryError(f"cannot {operation} the tool_registry tool ('{tool_name}') itself")
@@ -236,7 +237,6 @@ def make_tool_registry(
                 )
             # Guard against external tampering removing the tool between calls.
             agent_registry.dynamic_tools.pop(tool_name, None)
-            agent_registry.registry.pop(tool_name, None)
             owned.discard(tool_name)
             return MutationResult(operation="delete", name=tool_name, dynamic_count=len(owned))
 
@@ -276,13 +276,13 @@ def make_tool_registry(
                 except ValueError as err:
                     # Concurrent registration can still land a duplicate between the checks and write.
                     raise ToolRegistryError(str(err)) from err
-            except Exception:
+            except BaseException:
                 owned.discard(tool_name)
                 raise
             return MutationResult(operation="create", name=tool_name, dynamic_count=len(owned))
 
         # operation == "update"
-        if tool_name not in owned:
+        if tool_name not in owned or tool_name not in agent_registry.dynamic_tools:
             raise ToolRegistryError(
                 f"tool '{tool_name}' was not registered via tool_registry; developer-registered tools cannot be updated"
             )
@@ -294,8 +294,6 @@ def make_tool_registry(
             )
         # Replace under the same name, keeping ownership.
         agent_registry.dynamic_tools[tool_name] = new_tool
-        if tool_name in agent_registry.registry:
-            agent_registry.registry[tool_name] = new_tool
         return MutationResult(operation="update", name=tool_name, dynamic_count=len(owned))
 
     return tool_registry_tool

--- a/strands-py/src/strands/vended_tools/tool_registry/tool_registry.py
+++ b/strands-py/src/strands/vended_tools/tool_registry/tool_registry.py
@@ -1,4 +1,4 @@
-"""Tool for CRUD over the agent's own tool registry.
+"""CRUD tool over the agent's own tool registry.
 
 Provides :func:`make_tool_registry` (a factory that binds the tool to a set of
 already-connected MCP clients from which new tools may be pulled). The tool
@@ -14,15 +14,11 @@ exposes four operations to the model:
 - ``delete``: unregister a tool that this same tool_registry instance
   registered. Developer-registered tools are never removable.
 
-Design decision (see PR body): ``create`` only accepts references to already-
-connected MCP servers pre-provided by the developer via ``mcp_clients``.
-Accepting a filesystem path (loading arbitrary Python from disk) or inline
-source code (executing arbitrary Python or JS) are explicitly out of scope --
-both introduce a filesystem/code-execution attack surface that is
-disproportionate to the value of runtime tool registration for a general-purpose
-agent tool. Consumers that need those flows should build a separate, more
-locked-down tool. This one is a thin shim onto MCPClient, so its blast radius
-is exactly whatever the developer-approved MCP servers already expose.
+``create`` only accepts tools from the pre-connected MCP clients supplied via ``mcp_clients``;
+filesystem paths and inline source code are out of scope because both introduce a
+code-execution attack surface disproportionate to the benefit. The blast radius is
+intentionally bounded to whatever the developer-approved MCP servers already expose.
+Consumers that need those flows should build a separate, more locked-down tool.
 """
 
 from __future__ import annotations
@@ -107,9 +103,7 @@ async def _resolve_mcp_tool(
     while True:
         page = await asyncio.to_thread(client.list_tools_sync, pagination_token=pagination_token)
         for mcp_tool in page:
-            # ``list_tools_sync`` returns MCPAgentTool objects; the underlying
-            # ``mcp_tool.name`` is the remote-side name, unaffected by any
-            # client-level prefix. Match on that.
+            # Match on mcp_tool.name — the remote-side name, unaffected by any client-level prefix.
             if mcp_tool.mcp_tool.name == remote_name:
                 adapted = MCPAgentTool(
                     mcp_tool.mcp_tool,
@@ -160,10 +154,9 @@ def make_tool_registry(
     if max_dynamic_tools < 1:
         raise ValueError("max_dynamic_tools must be at least 1")
 
-    # Per-factory ownership map: keyed on the agent's ToolRegistry, closed over
-    # by this factory instance. Two `make_tool_registry` factories on one agent
-    # therefore track their own tools independently. `WeakKeyDictionary` lets
-    # the entry disappear when the registry (and its agent) is garbage-collected.
+    # Ownership map for this factory instance: keyed on ToolRegistry so two factories
+    # on one agent track their tools independently. WeakKeyDictionary lets the entry
+    # disappear when the registry is garbage-collected.
     ownership: weakref.WeakKeyDictionary[ToolRegistry, set[str]] = weakref.WeakKeyDictionary()
 
     @tool(name=name, description=description, context="tool_context")
@@ -180,9 +173,8 @@ def make_tool_registry(
         Args:
             operation: One of ``"list"``, ``"create"``, ``"update"``, ``"delete"``.
             tool_context: Injected by the framework. Not user-facing.
-            tool_name: Local name for the tool on the agent's registry. Required
-                for ``create``, ``update``, and ``delete``. Must match
-                ``^[a-zA-Z_][a-zA-Z0-9_]{0,63}$``.
+            tool_name: Local name for the tool on the agent's registry. Required for
+                ``create``, ``update``, and ``delete``. Must match :data:`.TOOL_NAME_PATTERN`.
             source: For ``create``/``update``, the alias of an MCP client
                 previously registered with this tool via ``mcp_clients``. The
                 set of valid aliases is fixed at tool construction time.
@@ -213,10 +205,8 @@ def make_tool_registry(
                     "description": spec.get("description", ""),
                     "registered_by_tool_registry": spec["name"] in owned,
                 }
-                # Omit input_schema only when the underlying tool doesn't
-                # declare the key at all, matching the TypeScript SDK's
-                # optional-field convention. An explicit empty dict is a
-                # valid schema and must be preserved.
+                # Omit input_schema only when the key is absent from the underlying tool.
+                # An explicit empty dict is a valid schema and must be preserved.
                 if "inputSchema" in spec:
                     entry["input_schema"] = spec["inputSchema"]
                 tools_out.append(entry)
@@ -245,8 +235,7 @@ def make_tool_registry(
                     f"tool '{tool_name}' was not registered via tool_registry; "
                     "developer-registered tools cannot be removed"
                 )
-            # Owned ⇒ present in dynamic_tools; belt-and-braces guard against
-            # external tampering with the registry between calls.
+            # Guard against external tampering removing the tool between calls.
             agent_registry.dynamic_tools.pop(tool_name, None)
             agent_registry.registry.pop(tool_name, None)
             owned.discard(tool_name)
@@ -261,35 +250,23 @@ def make_tool_registry(
         effective_remote = remote_name or tool_name
 
         if operation == "create":
-            if (
-                tool_name in agent_registry.registry
-                or tool_name in agent_registry.dynamic_tools
-                or tool_name in owned
-            ):
+            if tool_name in agent_registry.registry or tool_name in agent_registry.dynamic_tools or tool_name in owned:
                 raise ToolRegistryError(f"a tool named '{tool_name}' is already registered")
             conflict = _find_normalized_conflict(agent_registry, tool_name)
             if conflict is not None:
                 raise ToolRegistryError(
-                    f"a tool named '{conflict}' is already registered; "
-                    f"tool names cannot differ only by '-' vs '_'"
+                    f"a tool named '{conflict}' is already registered; tool names cannot differ only by '-' vs '_'"
                 )
             if len(owned) >= max_dynamic_tools:
                 raise ToolRegistryError(
                     f"dynamic tool cap reached ({max_dynamic_tools}); "
                     "delete an existing dynamically-registered tool first"
                 )
-            # Reserve the slot in the owned set before the MCP lookup so
-            # concurrent `create` calls in the same turn can't all pass the
-            # cap check before any of them registers. On failure, release.
+            # Reserve slot before the async MCP lookup to block concurrent creates from bypassing the cap.
             owned.add(tool_name)
             try:
-                new_tool = await _resolve_mcp_tool(
-                    clients[source], effective_remote, tool_name, description_override
-                )
-                # A concurrent `delete` could have observed our reservation,
-                # treated it as if the tool were already registered, and cleared
-                # it while we were awaiting. If so, abort rather than write a
-                # tool this instance can no longer track.
+                new_tool = await _resolve_mcp_tool(clients[source], effective_remote, tool_name, description_override)
+                # Abort if a concurrent delete cleared our reservation during the await.
                 if tool_name not in owned:
                     raise ToolRegistryError(
                         f"create of '{tool_name}' was cancelled by a concurrent delete "
@@ -298,10 +275,7 @@ def make_tool_registry(
                 try:
                     agent_registry.register_dynamic_tool(new_tool)
                 except ValueError as err:
-                    # A concurrent registration (e.g. another tool_registry
-                    # instance) can still land a duplicate between our checks
-                    # and the write. Surface as ToolRegistryError so callers
-                    # get a single exception type from the tool.
+                    # Concurrent registration can still land a duplicate between the checks and write.
                     raise ToolRegistryError(str(err)) from err
             except Exception:
                 owned.discard(tool_name)
@@ -314,14 +288,10 @@ def make_tool_registry(
                 f"tool '{tool_name}' was not registered via tool_registry; developer-registered tools cannot be updated"
             )
         new_tool = await _resolve_mcp_tool(clients[source], effective_remote, tool_name, description_override)
-        # A concurrent `delete` could have run during the await above and
-        # cleared this instance's ownership of the tool. If so, abort rather
-        # than resurrect a tool the model believed deleted (mirrors the
-        # create-during-delete guard).
+        # Abort if a concurrent delete cleared ownership during the await (mirrors the create guard).
         if tool_name not in owned:
             raise ToolRegistryError(
-                f"update of '{tool_name}' was cancelled by a concurrent delete "
-                "before the tool could be re-bound"
+                f"update of '{tool_name}' was cancelled by a concurrent delete before the tool could be re-bound"
             )
         # Replace under the same name, keeping ownership.
         agent_registry.dynamic_tools[tool_name] = new_tool

--- a/strands-py/src/strands/vended_tools/tool_registry/tool_registry.py
+++ b/strands-py/src/strands/vended_tools/tool_registry/tool_registry.py
@@ -47,19 +47,14 @@ logger = logging.getLogger(__name__)
 
 
 def _get_owned_names(
-    ownership: weakref.WeakKeyDictionary[ToolRegistry, set[str]],
+    ownership: weakref.WeakKeyDictionary[ToolRegistry, dict[str, object]],
     registry: ToolRegistry,
-) -> set[str]:
+) -> dict[str, object]:
     owned = ownership.get(registry)
     if owned is None:
-        owned = set()
+        owned = {}
         ownership[registry] = owned
     return owned
-
-
-def _validate_tool_name(name: str) -> None:
-    if not isinstance(name, str) or not TOOL_NAME_PATTERN.match(name):
-        raise ToolRegistryError(f"invalid tool name '{name}': must match {TOOL_NAME_PATTERN.pattern}")
 
 
 def _find_normalized_conflict(registry: ToolRegistry, name: str) -> str | None:
@@ -152,7 +147,7 @@ def make_tool_registry(
     # Ownership map for this factory instance: keyed on ToolRegistry so two factories
     # on one agent track their tools independently. WeakKeyDictionary lets the entry
     # disappear when the registry is garbage-collected.
-    ownership: weakref.WeakKeyDictionary[ToolRegistry, set[str]] = weakref.WeakKeyDictionary()
+    ownership: weakref.WeakKeyDictionary[ToolRegistry, dict[str, object]] = weakref.WeakKeyDictionary()
 
     @tool(name=name, description=description, context="tool_context")
     async def tool_registry_tool(
@@ -205,7 +200,7 @@ def make_tool_registry(
                 # Omit input_schema only when the key is absent from the underlying tool.
                 # An explicit empty dict is a valid schema and must be preserved.
                 if "inputSchema" in spec:
-                    entry["input_schema"] = spec["inputSchema"]
+                    entry["input_schema"] = spec["inputSchema"]["json"]
                 tools_out.append(entry)
             return ListResult(
                 tools=tools_out,
@@ -220,7 +215,8 @@ def make_tool_registry(
 
         if tool_name is None:
             raise ToolRegistryError(f"'tool_name' is required for operation '{operation}'")
-        _validate_tool_name(tool_name)
+        if not isinstance(tool_name, str) or not TOOL_NAME_PATTERN.match(tool_name):
+            raise ToolRegistryError(f"invalid tool name '{tool_name}': must match {TOOL_NAME_PATTERN.pattern}")
 
         if description_override is not None and not description_override.strip():
             raise ToolRegistryError("description_override must be non-empty; omit it to keep the server's description")
@@ -235,9 +231,8 @@ def make_tool_registry(
                     f"tool '{tool_name}' was not registered via tool_registry; "
                     "developer-registered tools cannot be removed"
                 )
-            # Guard against external tampering removing the tool between calls.
-            agent_registry.dynamic_tools.pop(tool_name, None)
-            owned.discard(tool_name)
+            agent_registry.remove(tool_name)
+            del owned[tool_name]
             return MutationResult(operation="delete", name=tool_name, dynamic_count=len(owned))
 
         # create / update below share the source-resolution logic.
@@ -261,23 +256,26 @@ def make_tool_registry(
                     f"dynamic tool cap reached ({max_dynamic_tools}); "
                     "delete an existing dynamically-registered tool first"
                 )
-            # Reserve slot before the async MCP lookup to block concurrent creates from bypassing the cap.
-            owned.add(tool_name)
+            # Unique token per registration; guards detect a concurrent delete+recreate.
+            token: object = object()
+            owned[tool_name] = token
             try:
                 new_tool = await _resolve_mcp_tool(clients[source], effective_remote, tool_name, description_override)
-                # Abort if a concurrent delete cleared our reservation during the await.
-                if tool_name not in owned:
+                # Abort if a concurrent delete invalidated our registration during the await.
+                if owned.get(tool_name) is not token:
                     raise ToolRegistryError(
                         f"create of '{tool_name}' was cancelled by a concurrent delete "
                         "before the tool could be registered"
                     )
                 try:
-                    agent_registry.register_dynamic_tool(new_tool)
+                    agent_registry.register_tool(new_tool)
                 except ValueError as err:
                     # Concurrent registration can still land a duplicate between the checks and write.
                     raise ToolRegistryError(str(err)) from err
             except BaseException:
-                owned.discard(tool_name)
+                # Only release the slot if it still belongs to this create, not a concurrent delete and recreate.
+                if owned.get(tool_name) is token:
+                    del owned[tool_name]
                 raise
             return MutationResult(operation="create", name=tool_name, dynamic_count=len(owned))
 
@@ -286,14 +284,18 @@ def make_tool_registry(
             raise ToolRegistryError(
                 f"tool '{tool_name}' was not registered via tool_registry; developer-registered tools cannot be updated"
             )
+        update_token = owned[tool_name]
         new_tool = await _resolve_mcp_tool(clients[source], effective_remote, tool_name, description_override)
         # Abort if a concurrent delete cleared ownership during the await (mirrors the create guard).
-        if tool_name not in owned:
+        if owned.get(tool_name) is not update_token:
             raise ToolRegistryError(
                 f"update of '{tool_name}' was cancelled by a concurrent delete before the tool could be re-bound"
             )
         # Replace under the same name, keeping ownership.
-        agent_registry.dynamic_tools[tool_name] = new_tool
+        try:
+            agent_registry.replace(new_tool)
+        except ValueError as err:
+            raise ToolRegistryError(str(err)) from err
         return MutationResult(operation="update", name=tool_name, dynamic_count=len(owned))
 
     return tool_registry_tool

--- a/strands-py/src/strands/vended_tools/tool_registry/tool_registry.py
+++ b/strands-py/src/strands/vended_tools/tool_registry/tool_registry.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import weakref
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from ...tools.decorator import tool
 from ...tools.mcp import MCPAgentTool, MCPClient
@@ -158,7 +158,7 @@ def make_tool_registry(
 
     @tool(name=name, description=description, context="tool_context")
     async def tool_registry_tool(
-        operation: str,
+        operation: Literal["list", "create", "update", "delete"],
         tool_context: ToolContext,
         tool_name: str | None = None,
         source: str | None = None,
@@ -171,7 +171,9 @@ def make_tool_registry(
             operation: One of ``"list"``, ``"create"``, ``"update"``, ``"delete"``.
             tool_context: Injected by the framework. Not user-facing.
             tool_name: Local name for the tool on the agent's registry. Required for
-                ``create``, ``update``, and ``delete``. Must match :data:`.TOOL_NAME_PATTERN`.
+                ``create``, ``update``, and ``delete``. Must start with a letter or
+                underscore, contain only letters, digits, and underscores (hyphens are
+                not allowed), and be at most 64 characters.
             source: For ``create``/``update``, the alias of an MCP client
                 previously registered with this tool via ``mcp_clients``. The
                 set of valid aliases is fixed at tool construction time.

--- a/strands-py/src/strands/vended_tools/tool_registry/tool_registry.py
+++ b/strands-py/src/strands/vended_tools/tool_registry/tool_registry.py
@@ -216,17 +216,22 @@ async def _update_tool(
         raise ToolRegistryError(
             f"tool '{tool_name}' was not registered via tool_registry; developer-registered tools cannot be updated"
         )
-    update_token = owned[tool_name]
+    # Snapshot before the await so concurrent tool registry writes are detectable afterward.
+    old_tool = owned[tool_name]
     new_tool = await _resolve_mcp_tool(client, effective_remote, tool_name, description_override)
     # Abort if the registration was replaced by a delete+recreate during the await.
-    if owned.get(tool_name) is not update_token:
+    if owned.get(tool_name) is not old_tool:
         raise ToolRegistryError(
             f"update of '{tool_name}' was cancelled by a concurrent delete before the tool could be re-bound"
         )
+    # Guard against a developer hot-reloading a same-named tool on top since we last checked.
+    if agent_registry.registry.get(tool_name) is not old_tool:
+        raise ToolRegistryError(f"tool '{tool_name}' is no longer managed by tool_registry; it cannot be updated")
     try:
         agent_registry.replace(new_tool)
     except ValueError as err:
         raise ToolRegistryError(str(err)) from err
+    owned[tool_name] = new_tool
     return MutationResult(operation="update", name=tool_name, dynamic_count=len(owned))
 
 

--- a/strands-py/src/strands/vended_tools/tool_registry/types.py
+++ b/strands-py/src/strands/vended_tools/tool_registry/types.py
@@ -1,0 +1,65 @@
+"""Shared types and constants for the tool_registry tool."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Literal, TypedDict
+
+from typing_extensions import NotRequired
+
+# Provider-accepted tool name: leading letter/underscore, then letters/digits/underscore,
+# capped at 64 characters. Stricter than the underlying registry (which also allows '-')
+# because the dynamically-registered tool name is echoed into user-visible spec strings
+# and log messages; disallowing '-' keeps every generated identifier a legal Python name.
+TOOL_NAME_PATTERN: re.Pattern[str] = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]{0,63}$")
+"""Regex enforced on all dynamically-registered tool names."""
+
+MAX_DYNAMIC_TOOLS: int = 32
+"""Maximum number of tools a single tool_registry instance may register."""
+
+TOOL_REGISTRY_DESCRIPTION: str = (
+    "Manage the agent's tool registry at runtime. Supports operations to `list` "
+    "currently registered tools, `create` a new binding to an already-connected "
+    "MCP server tool, `update` an existing binding, and `delete` a previously "
+    "registered binding. Registration is limited to remote MCP tools; loading "
+    "tools from a file path or inline source is intentionally not supported."
+)
+
+
+class RegisteredTool(TypedDict):
+    """A tool entry in a `list` response.
+
+    Attributes:
+        name: The tool name as visible to the agent.
+        description: The tool description as visible to the model.
+        input_schema: The tool's JSON input schema. Omitted when the tool
+            does not declare one.
+        registered_by_tool_registry: True when this tool was registered via
+            the tool_registry tool (i.e. it can be updated/deleted by this
+            tool). False for developer-registered tools.
+    """
+
+    name: str
+    description: str
+    input_schema: NotRequired[dict[str, Any]]
+    registered_by_tool_registry: bool
+
+
+class ListResult(TypedDict):
+    """Result payload for the `list` operation."""
+
+    tools: list[RegisteredTool]
+    dynamic_count: int
+    dynamic_limit: int
+
+
+class MutationResult(TypedDict):
+    """Result payload for `create`, `update`, and `delete` operations."""
+
+    operation: Literal["create", "update", "delete"]
+    name: str
+    dynamic_count: int
+
+
+class ToolRegistryError(ValueError):
+    """Raised for validation failures inside the tool_registry tool."""

--- a/strands-py/src/strands/vended_tools/tool_registry/types.py
+++ b/strands-py/src/strands/vended_tools/tool_registry/types.py
@@ -46,7 +46,17 @@ class RegisteredTool(TypedDict):
 
 
 class ListResult(TypedDict):
-    """Result payload for the `list` operation."""
+    """Result payload for the `list` operation.
+
+    Attributes:
+        tools: All tools currently on the registry.
+        dynamic_count: Number of tools registered by this tool_registry instance.
+            Tools with ``registered_by_tool_registry=True`` in the ``tools`` list
+            can be updated or deleted via this tool.
+        dynamic_limit: Maximum number of tools this instance may register. When
+            ``dynamic_count == dynamic_limit``, delete an existing tool before
+            creating a new one.
+    """
 
     tools: list[RegisteredTool]
     dynamic_count: int
@@ -54,7 +64,14 @@ class ListResult(TypedDict):
 
 
 class MutationResult(TypedDict):
-    """Result payload for `create`, `update`, and `delete` operations."""
+    """Result payload for `create`, `update`, and `delete` operations.
+
+    Attributes:
+        operation: The operation that was performed.
+        name: The local tool name the operation acted on.
+        dynamic_count: Number of tools registered by this tool_registry instance
+            after the operation completes.
+    """
 
     operation: Literal["create", "update", "delete"]
     name: str

--- a/strands-py/src/strands/vended_tools/tool_registry/types.py
+++ b/strands-py/src/strands/vended_tools/tool_registry/types.py
@@ -11,7 +11,7 @@ from typing_extensions import NotRequired
 # capped at 64 characters. Stricter than the underlying registry (which also allows '-')
 # because the dynamically-registered tool name is echoed into user-visible spec strings
 # and log messages; disallowing '-' keeps every generated identifier a legal Python name.
-TOOL_NAME_PATTERN: re.Pattern[str] = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]{0,63}$")
+TOOL_NAME_PATTERN: re.Pattern[str] = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]{0,63}\Z")
 """Regex enforced on all dynamically-registered tool names."""
 
 MAX_DYNAMIC_TOOLS: int = 32

--- a/strands-py/tests/strands/tools/test_registry.py
+++ b/strands-py/tests/strands/tools/test_registry.py
@@ -77,58 +77,6 @@ def test_register_tool_with_similar_name_raises():
     )
 
 
-def test_register_dynamic_tool_with_similar_name_raises():
-    tool_1 = PythonAgentTool(tool_name="my-tool", tool_spec=MagicMock(), tool_func=lambda: None)
-    tool_1.mark_dynamic()
-    tool_2 = PythonAgentTool(tool_name="my_tool", tool_spec=MagicMock(), tool_func=lambda: None)
-    tool_2.mark_dynamic()
-
-    tool_registry = ToolRegistry()
-    tool_registry.register_dynamic_tool(tool_1)
-
-    with pytest.raises(ValueError) as err:
-        tool_registry.register_dynamic_tool(tool_2)
-
-    assert (
-        str(err.value) == "Tool name 'my_tool' already exists as 'my-tool'. "
-        "Cannot add a duplicate tool which differs by a '-' or '_'"
-    )
-
-
-def test_register_dynamic_tool_with_similar_name_as_static_tool_raises():
-    static_tool = PythonAgentTool(tool_name="my-tool", tool_spec=MagicMock(), tool_func=lambda: None)
-    dynamic_tool = PythonAgentTool(tool_name="my_tool", tool_spec=MagicMock(), tool_func=lambda: None)
-    dynamic_tool.mark_dynamic()
-
-    tool_registry = ToolRegistry()
-    tool_registry.register_tool(static_tool)
-
-    with pytest.raises(ValueError) as err:
-        tool_registry.register_dynamic_tool(dynamic_tool)
-
-    assert (
-        str(err.value) == "Tool name 'my_tool' already exists as 'my-tool'. "
-        "Cannot add a duplicate tool which differs by a '-' or '_'"
-    )
-
-
-def test_register_tool_after_dynamic_tool_with_similar_name_raises():
-    dynamic_tool = PythonAgentTool(tool_name="my_tool", tool_spec=MagicMock(), tool_func=lambda: None)
-    dynamic_tool.mark_dynamic()
-    static_tool = PythonAgentTool(tool_name="my-tool", tool_spec=MagicMock(), tool_func=lambda: None)
-
-    tool_registry = ToolRegistry()
-    tool_registry.register_dynamic_tool(dynamic_tool)
-
-    with pytest.raises(ValueError) as err:
-        tool_registry.register_tool(static_tool)
-
-    assert (
-        str(err.value) == "Tool name 'my-tool' already exists as 'my_tool'. "
-        "Cannot add a duplicate tool which differs by a '-' or '_'"
-    )
-
-
 def test_get_all_tool_specs_returns_right_tool_specs():
     tool_1 = strands.tool(lambda a: a, name="tool_1")
     tool_2 = strands.tool(lambda b: b, name="tool_2")

--- a/strands-py/tests/strands/tools/test_registry.py
+++ b/strands-py/tests/strands/tools/test_registry.py
@@ -112,6 +112,23 @@ def test_register_dynamic_tool_with_similar_name_as_static_tool_raises():
     )
 
 
+def test_register_tool_after_dynamic_tool_with_similar_name_raises():
+    dynamic_tool = PythonAgentTool(tool_name="my_tool", tool_spec=MagicMock(), tool_func=lambda: None)
+    dynamic_tool.mark_dynamic()
+    static_tool = PythonAgentTool(tool_name="my-tool", tool_spec=MagicMock(), tool_func=lambda: None)
+
+    tool_registry = ToolRegistry()
+    tool_registry.register_dynamic_tool(dynamic_tool)
+
+    with pytest.raises(ValueError) as err:
+        tool_registry.register_tool(static_tool)
+
+    assert (
+        str(err.value) == "Tool name 'my-tool' already exists as 'my_tool'. "
+        "Cannot add a duplicate tool which differs by a '-' or '_'"
+    )
+
+
 def test_get_all_tool_specs_returns_right_tool_specs():
     tool_1 = strands.tool(lambda a: a, name="tool_1")
     tool_2 = strands.tool(lambda b: b, name="tool_2")

--- a/strands-py/tests/strands/tools/test_registry.py
+++ b/strands-py/tests/strands/tools/test_registry.py
@@ -60,6 +60,34 @@ def test_process_tools_with_invalid_path():
         tool_registry.process_tools([invalid_path])
 
 
+def test_remove_static_tool():
+    tool_registry = ToolRegistry()
+    static_tool = PythonAgentTool(tool_name="my_tool", tool_spec=MagicMock(), tool_func=lambda: None)
+    tool_registry.register_tool(static_tool)
+
+    tool_registry.remove("my_tool")
+
+    assert "my_tool" not in tool_registry.registry
+    assert "my_tool" not in tool_registry.dynamic_tools
+
+
+def test_remove_dynamic_tool():
+    tool_registry = ToolRegistry()
+    dynamic_tool = PythonAgentTool(tool_name="my_tool", tool_spec=MagicMock(), tool_func=lambda: None)
+    dynamic_tool.mark_dynamic()
+    tool_registry.register_tool(dynamic_tool)
+
+    tool_registry.remove("my_tool")
+
+    assert "my_tool" not in tool_registry.registry
+    assert "my_tool" not in tool_registry.dynamic_tools
+
+
+def test_remove_nonexistent_tool_is_noop():
+    tool_registry = ToolRegistry()
+    tool_registry.remove("does_not_exist")  # must not raise
+
+
 def test_register_tool_with_similar_name_raises():
     tool_1 = PythonAgentTool(tool_name="tool-like-this", tool_spec=MagicMock(), tool_func=lambda: None)
     tool_2 = PythonAgentTool(tool_name="tool_like_this", tool_spec=MagicMock(), tool_func=lambda: None)

--- a/strands-py/tests/strands/tools/test_registry.py
+++ b/strands-py/tests/strands/tools/test_registry.py
@@ -77,6 +77,41 @@ def test_register_tool_with_similar_name_raises():
     )
 
 
+def test_register_dynamic_tool_with_similar_name_raises():
+    tool_1 = PythonAgentTool(tool_name="my-tool", tool_spec=MagicMock(), tool_func=lambda: None)
+    tool_1.mark_dynamic()
+    tool_2 = PythonAgentTool(tool_name="my_tool", tool_spec=MagicMock(), tool_func=lambda: None)
+    tool_2.mark_dynamic()
+
+    tool_registry = ToolRegistry()
+    tool_registry.register_dynamic_tool(tool_1)
+
+    with pytest.raises(ValueError) as err:
+        tool_registry.register_dynamic_tool(tool_2)
+
+    assert (
+        str(err.value) == "Tool name 'my_tool' already exists as 'my-tool'. "
+        "Cannot add a duplicate tool which differs by a '-' or '_'"
+    )
+
+
+def test_register_dynamic_tool_with_similar_name_as_static_tool_raises():
+    static_tool = PythonAgentTool(tool_name="my-tool", tool_spec=MagicMock(), tool_func=lambda: None)
+    dynamic_tool = PythonAgentTool(tool_name="my_tool", tool_spec=MagicMock(), tool_func=lambda: None)
+    dynamic_tool.mark_dynamic()
+
+    tool_registry = ToolRegistry()
+    tool_registry.register_tool(static_tool)
+
+    with pytest.raises(ValueError) as err:
+        tool_registry.register_dynamic_tool(dynamic_tool)
+
+    assert (
+        str(err.value) == "Tool name 'my_tool' already exists as 'my-tool'. "
+        "Cannot add a duplicate tool which differs by a '-' or '_'"
+    )
+
+
 def test_get_all_tool_specs_returns_right_tool_specs():
     tool_1 = strands.tool(lambda a: a, name="tool_1")
     tool_2 = strands.tool(lambda b: b, name="tool_2")

--- a/strands-py/tests/strands/vended_tools/test_tool_registry.py
+++ b/strands-py/tests/strands/vended_tools/test_tool_registry.py
@@ -10,6 +10,7 @@ validation failures surface as raised ``ToolRegistryError``.
 from __future__ import annotations
 
 import asyncio
+import unittest.mock
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any
@@ -102,40 +103,57 @@ def registry_tool(mcp_client: _FakeMCPClient) -> Any:
 class TestListOperation:
     @pytest.mark.asyncio
     async def test_lists_developer_registered_tools_as_not_owned(self, registry_tool, registry: ToolRegistry) -> None:
-        result = await registry_tool(operation="list", tool_context=_tool_context(registry))
-        names = {t["name"]: t for t in result["tools"]}
-        assert "dev_echo" in names
-        assert "dev_ping" in names
-        assert names["dev_echo"]["registered_by_tool_registry"] is False
-        assert names["dev_ping"]["registered_by_tool_registry"] is False
-        assert result["dynamic_count"] == 0
-        assert result["dynamic_limit"] == MAX_DYNAMIC_TOOLS
+        tru_result = await registry_tool(operation="list", tool_context=_tool_context(registry))
+        exp_result = {
+            "tools": [
+                {
+                    "name": "dev_echo",
+                    "description": "developer-registered echo",
+                    "input_schema": {
+                        "json": {
+                            "type": "object",
+                            "properties": {"text": {"description": "Parameter text", "type": "string"}},
+                            "required": ["text"],
+                        }
+                    },
+                    "registered_by_tool_registry": False,
+                },
+                {
+                    "name": "dev_ping",
+                    "description": "developer-registered ping",
+                    "input_schema": {"json": {"type": "object", "properties": {}, "required": []}},
+                    "registered_by_tool_registry": False,
+                },
+            ],
+            "dynamic_count": 0,
+            "dynamic_limit": MAX_DYNAMIC_TOOLS,
+        }
+        assert tru_result == exp_result
 
 
 class TestCreateOperation:
     @pytest.mark.asyncio
     async def test_registers_mcp_tool_and_marks_owned(self, registry_tool, registry: ToolRegistry) -> None:
-        result = await registry_tool(
+        tru_result = await registry_tool(
             operation="create",
             tool_name="alpha",
             source="weather",
             remote_name="remote_alpha",
             tool_context=_tool_context(registry),
         )
-        assert result["operation"] == "create"
-        assert result["name"] == "alpha"
-        assert result["dynamic_count"] == 1
+        exp_result = {"operation": "create", "name": "alpha", "dynamic_count": 1}
+        assert tru_result == exp_result
         assert "alpha" in registry.dynamic_tools
 
     @pytest.mark.asyncio
     async def test_uses_tool_name_as_default_remote_name(self, registry_tool, registry: ToolRegistry) -> None:
-        result = await registry_tool(
+        tru_result = await registry_tool(
             operation="create",
             tool_name="remote_beta",
             source="weather",
             tool_context=_tool_context(registry),
         )
-        assert result["name"] == "remote_beta"
+        assert tru_result == {"operation": "create", "name": "remote_beta", "dynamic_count": 1}
         assert "remote_beta" in registry.dynamic_tools
 
     @pytest.mark.asyncio
@@ -280,24 +298,21 @@ class TestCreateOperation:
                 tool_context=_tool_context(registry),
             )
         # Reservation released on failure.
-        list_result = await registry_tool(
-            operation="list",
-            tool_context=_tool_context(registry),
-        )
-        assert list_result["dynamic_count"] == 0
+        tru_list = await registry_tool(operation="list", tool_context=_tool_context(registry))
+        assert tru_list["dynamic_count"] == 0
 
     @pytest.mark.asyncio
     async def test_accepts_maximum_length_tool_name(self, registry_tool, registry: ToolRegistry) -> None:
         # 64 chars: one leading letter + 63 alphanumeric/underscore characters.
         max_name = "a" * 64
-        result = await registry_tool(
+        tru_result = await registry_tool(
             operation="create",
             tool_name=max_name,
             source="weather",
             remote_name="remote_alpha",
             tool_context=_tool_context(registry),
         )
-        assert result["name"] == max_name
+        assert tru_result == {"operation": "create", "name": max_name, "dynamic_count": 1}
 
     @pytest.mark.asyncio
     async def test_enforces_dynamic_tool_cap(self, mcp_client: _FakeMCPClient, registry: ToolRegistry) -> None:
@@ -409,15 +424,14 @@ class TestCreateOperation:
 
         # Reservation must be released — cap and name are available again.
         monkeypatch.undo()
-        result = await registry_tool(
+        tru_result = await registry_tool(
             operation="create",
             tool_name="alpha",
             source="weather",
             remote_name="remote_alpha",
             tool_context=ctx,
         )
-        assert result["name"] == "alpha"
-        assert result["dynamic_count"] == 1
+        assert tru_result == {"operation": "create", "name": "alpha", "dynamic_count": 1}
 
     @pytest.mark.asyncio
     async def test_concurrent_create_and_update_same_name(
@@ -465,9 +479,8 @@ class TestCreateOperation:
 
         # Release create; it completes normally and alpha is now owned.
         gate.set()
-        result = await create_task
-        assert result["name"] == "alpha"
-        assert result["dynamic_count"] == 1
+        tru_result = await create_task
+        assert tru_result == {"operation": "create", "name": "alpha", "dynamic_count": 1}
         assert "alpha" in registry.dynamic_tools
 
     @pytest.mark.asyncio
@@ -514,7 +527,7 @@ class TestCreateOperation:
             tool_name="alpha",
             tool_context=ctx,
         )
-        assert delete_result["operation"] == "delete"
+        assert delete_result == {"operation": "delete", "name": "alpha", "dynamic_count": 0}
 
         # Release create; it must abort rather than resurrect an orphan.
         gate.set()
@@ -524,8 +537,11 @@ class TestCreateOperation:
         # No orphan in the SDK registry; ownership set is empty.
         assert "alpha" not in registry.dynamic_tools
         assert "alpha" not in registry.registry
-        list_result = await registry_tool(operation="list", tool_context=ctx)
-        assert list_result["dynamic_count"] == 0
+        assert await registry_tool(operation="list", tool_context=ctx) == {
+            "tools": unittest.mock.ANY,
+            "dynamic_count": 0,
+            "dynamic_limit": MAX_DYNAMIC_TOOLS,
+        }
 
 
 class TestUpdateOperation:
@@ -546,9 +562,7 @@ class TestUpdateOperation:
             remote_name="remote_beta",
             tool_context=ctx,
         )
-        assert result["operation"] == "update"
-        assert result["name"] == "alpha"
-        assert result["dynamic_count"] == 1
+        assert result == {"operation": "update", "name": "alpha", "dynamic_count": 1}
         # The adapter points at remote_beta now.
         assert registry.dynamic_tools["alpha"].mcp_tool.name == "remote_beta"
 
@@ -640,7 +654,7 @@ class TestUpdateOperation:
             tool_name="alpha",
             tool_context=ctx,
         )
-        assert delete_result["operation"] == "delete"
+        assert delete_result == {"operation": "delete", "name": "alpha", "dynamic_count": 0}
 
         # Release the update; it must abort rather than resurrect the tool.
         gate.set()
@@ -650,8 +664,11 @@ class TestUpdateOperation:
         # Deletion stuck; no orphan.
         assert "alpha" not in registry.dynamic_tools
         assert "alpha" not in registry.registry
-        list_result = await registry_tool(operation="list", tool_context=ctx)
-        assert list_result["dynamic_count"] == 0
+        assert await registry_tool(operation="list", tool_context=ctx) == {
+            "tools": unittest.mock.ANY,
+            "dynamic_count": 0,
+            "dynamic_limit": MAX_DYNAMIC_TOOLS,
+        }
 
 
 class TestDeleteOperation:
@@ -666,8 +683,7 @@ class TestDeleteOperation:
             tool_context=ctx,
         )
         result = await registry_tool(operation="delete", tool_name="alpha", tool_context=ctx)
-        assert result["operation"] == "delete"
-        assert result["dynamic_count"] == 0
+        assert result == {"operation": "delete", "name": "alpha", "dynamic_count": 0}
         assert "alpha" not in registry.dynamic_tools
 
     @pytest.mark.asyncio
@@ -748,8 +764,8 @@ class TestOperationDispatch:
     async def test_read_only_when_no_mcp_clients_configured(self, registry: ToolRegistry) -> None:
         registry_tool = make_tool_registry()  # empty
         # list still works
-        result = await registry_tool(operation="list", tool_context=_tool_context(registry))
-        assert result["dynamic_limit"] == MAX_DYNAMIC_TOOLS
+        tru_list = await registry_tool(operation="list", tool_context=_tool_context(registry))
+        assert tru_list == {"tools": unittest.mock.ANY, "dynamic_count": 0, "dynamic_limit": MAX_DYNAMIC_TOOLS}
         # create fails
         with pytest.raises(ToolRegistryError, match="unknown source"):
             await registry_tool(

--- a/strands-py/tests/strands/vended_tools/test_tool_registry.py
+++ b/strands-py/tests/strands/vended_tools/test_tool_registry.py
@@ -636,6 +636,41 @@ class TestUpdateOperation:
         assert registry.dynamic_tools["alpha"].tool_spec["description"] == "overridden on update"
 
     @pytest.mark.asyncio
+    async def test_create_update_delete_removes_tool_cleanly(self, registry_tool, registry: ToolRegistry) -> None:
+        """create → update → delete must leave no trace in registry or dynamic_tools."""
+        ctx = _tool_context(registry)
+        await registry_tool(
+            operation="create", tool_name="alpha", source="weather", remote_name="remote_alpha", tool_context=ctx
+        )
+        await registry_tool(
+            operation="update", tool_name="alpha", source="weather", remote_name="remote_beta", tool_context=ctx
+        )
+        await registry_tool(operation="delete", tool_name="alpha", tool_context=ctx)
+        assert "alpha" not in registry.registry
+        assert "alpha" not in registry.dynamic_tools
+
+    @pytest.mark.asyncio
+    async def test_update_rejected_after_developer_hot_reload(self, registry_tool, registry: ToolRegistry) -> None:
+        """update must be rejected if a developer registered a same-named tool on top."""
+        ctx = _tool_context(registry)
+        await registry_tool(
+            operation="create", tool_name="alpha", source="weather", remote_name="remote_alpha", tool_context=ctx
+        )
+
+        @tool_decorator(name="alpha", description="developer alpha tool")
+        def dev_alpha() -> str:
+            return "dev"
+
+        registry.register_tool(dev_alpha)
+
+        with pytest.raises(ToolRegistryError, match="no longer managed"):
+            await registry_tool(
+                operation="update", tool_name="alpha", source="weather", remote_name="remote_beta", tool_context=ctx
+            )
+
+        assert registry.registry.get("alpha") is dev_alpha
+
+    @pytest.mark.asyncio
     async def test_cannot_update_developer_tool(self, registry_tool, registry: ToolRegistry) -> None:
         with pytest.raises(ToolRegistryError, match="developer-registered"):
             await registry_tool(

--- a/strands-py/tests/strands/vended_tools/test_tool_registry.py
+++ b/strands-py/tests/strands/vended_tools/test_tool_registry.py
@@ -110,18 +110,16 @@ class TestListOperation:
                     "name": "dev_echo",
                     "description": "developer-registered echo",
                     "input_schema": {
-                        "json": {
-                            "type": "object",
-                            "properties": {"text": {"description": "Parameter text", "type": "string"}},
-                            "required": ["text"],
-                        }
+                        "type": "object",
+                        "properties": {"text": {"description": "Parameter text", "type": "string"}},
+                        "required": ["text"],
                     },
                     "registered_by_tool_registry": False,
                 },
                 {
                     "name": "dev_ping",
                     "description": "developer-registered ping",
-                    "input_schema": {"json": {"type": "object", "properties": {}, "required": []}},
+                    "input_schema": {"type": "object", "properties": {}, "required": []},
                     "registered_by_tool_registry": False,
                 },
             ],
@@ -269,13 +267,13 @@ class TestCreateOperation:
             )
 
     @pytest.mark.asyncio
-    async def test_wraps_register_dynamic_tool_value_error(
+    async def test_wraps_register_tool_value_error(
         self,
         mcp_client: _FakeMCPClient,
         registry: ToolRegistry,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """A raw `ValueError` from `register_dynamic_tool` is surfaced as `ToolRegistryError`.
+        """A raw `ValueError` from `register_tool` is surfaced as `ToolRegistryError`.
 
         Another `tool_registry` factory could race a duplicate registration
         between our checks and the write; callers should still see a single
@@ -288,7 +286,7 @@ class TestCreateOperation:
         def raise_duplicate(_tool: Any) -> None:
             raise ValueError("Tool 'alpha' already exists")
 
-        monkeypatch.setattr(registry, "register_dynamic_tool", raise_duplicate)
+        monkeypatch.setattr(registry, "register_tool", raise_duplicate)
         with pytest.raises(ToolRegistryError, match="already exists"):
             await registry_tool(
                 operation="create",
@@ -484,64 +482,115 @@ class TestCreateOperation:
         assert "alpha" in registry.dynamic_tools
 
     @pytest.mark.asyncio
-    async def test_does_not_orphan_reservation_on_concurrent_delete(
+    async def test_aba_create_delete_recreate_does_not_orphan(
         self,
         mcp_client: _FakeMCPClient,
         registry: ToolRegistry,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """A `delete` landing between `create`'s reservation and write must not orphan."""
-        registry_tool = make_tool_registry(
-            mcp_clients={"weather": mcp_client},
-        )
+        """A delete+recreate during an in-flight create must not orphan A2's registration.
+
+        Previously, A1's rollback called owned.discard(name) unconditionally, which
+        removed A2's ownership entry too. With token-based ownership, A1's rollback
+        detects that the token changed and leaves A2's entry intact.
+        """
+        registry_tool = make_tool_registry(mcp_clients={"weather": mcp_client})
         ctx = _tool_context(registry)
 
-        real_resolve = trmod._resolve_mcp_tool
         gate = asyncio.Event()
+        real_resolve = trmod._resolve_mcp_tool
 
         async def gated_resolve(*args: Any, **kwargs: Any) -> Any:
-            # Suspend until the test releases us so a concurrent `delete` can
-            # slip between the synchronous reservation and the post-await
-            # registry write.
             await gate.wait()
             return await real_resolve(*args, **kwargs)
 
         monkeypatch.setattr(trmod, "_resolve_mcp_tool", gated_resolve)
 
-        # Task B: start `create` and let it park on the gate.
-        create_task = asyncio.create_task(
+        # A1: create "alpha", parks at gate.
+        a1 = asyncio.create_task(
             registry_tool(
-                operation="create",
-                tool_name="alpha",
-                source="weather",
-                remote_name="remote_alpha",
-                tool_context=ctx,
+                operation="create", tool_name="alpha", source="weather", remote_name="remote_alpha", tool_context=ctx
             )
         )
-        for _ in range(3):
-            await asyncio.sleep(0)
+        await asyncio.sleep(0)
 
-        # Task A: delete the reserved-but-not-yet-registered tool.
-        delete_result = await registry_tool(
-            operation="delete",
-            tool_name="alpha",
-            tool_context=ctx,
+        # Delete the reservation, then A2 re-creates the same name.
+        monkeypatch.undo()
+        await registry_tool(operation="delete", tool_name="alpha", tool_context=ctx)
+        tru_a2 = await registry_tool(
+            operation="create", tool_name="alpha", source="weather", remote_name="remote_alpha", tool_context=ctx
         )
-        assert delete_result == {"operation": "delete", "name": "alpha", "dynamic_count": 0}
+        assert tru_a2 == {"operation": "create", "name": "alpha", "dynamic_count": 1}
 
-        # Release create; it must abort rather than resurrect an orphan.
+        # Release A1; it must abort, not orphan A2's registration.
         gate.set()
+        monkeypatch.setattr(trmod, "_resolve_mcp_tool", gated_resolve)
         with pytest.raises(ToolRegistryError, match="cancelled by a concurrent delete"):
-            await create_task
+            await a1
 
-        # No orphan in the SDK registry; ownership set is empty.
-        assert "alpha" not in registry.dynamic_tools
-        assert "alpha" not in registry.registry
-        assert await registry_tool(operation="list", tool_context=ctx) == {
-            "tools": unittest.mock.ANY,
-            "dynamic_count": 0,
-            "dynamic_limit": MAX_DYNAMIC_TOOLS,
-        }
+        # A2's registration is intact and deletable.
+        monkeypatch.undo()
+        tru_list = await registry_tool(operation="list", tool_context=ctx)
+        alpha_entry = next(t for t in tru_list["tools"] if t["name"] == "alpha")
+        assert alpha_entry["registered_by_tool_registry"] is True
+        assert tru_list["dynamic_count"] == 1
+        tru_delete = await registry_tool(operation="delete", tool_name="alpha", tool_context=ctx)
+        assert tru_delete == {"operation": "delete", "name": "alpha", "dynamic_count": 0}
+
+    @pytest.mark.asyncio
+    async def test_aba_update_aborted_after_delete_recreate(
+        self,
+        mcp_client: _FakeMCPClient,
+        registry: ToolRegistry,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An update that completes after a delete+recreate must be aborted, not applied.
+
+        Previously, the post-await guard only checked `tool_name not in owned`, which
+        passed after the recreate because the name was back in owned. With token-based
+        ownership, the update detects the token changed and aborts.
+        """
+        registry_tool = make_tool_registry(mcp_clients={"weather": mcp_client})
+        ctx = _tool_context(registry)
+
+        # Create x->remote_alpha.
+        await registry_tool(
+            operation="create", tool_name="alpha", source="weather", remote_name="remote_alpha", tool_context=ctx
+        )
+
+        gate = asyncio.Event()
+        real_resolve = trmod._resolve_mcp_tool
+
+        async def gated_resolve(*args: Any, **kwargs: Any) -> Any:
+            await gate.wait()
+            return await real_resolve(*args, **kwargs)
+
+        monkeypatch.setattr(trmod, "_resolve_mcp_tool", gated_resolve)
+
+        # Start update x->remote_beta, parks at gate.
+        update_task = asyncio.create_task(
+            registry_tool(
+                operation="update", tool_name="alpha", source="weather", remote_name="remote_beta", tool_context=ctx
+            )
+        )
+        await asyncio.sleep(0)
+
+        # Delete then re-create x->remote_gamma while update is parked.
+        monkeypatch.undo()
+        await registry_tool(operation="delete", tool_name="alpha", tool_context=ctx)
+        await registry_tool(
+            operation="create", tool_name="alpha", source="weather", remote_name="remote_gamma", tool_context=ctx
+        )
+
+        # Release update; it must abort, not overwrite gamma with beta.
+        gate.set()
+        monkeypatch.setattr(trmod, "_resolve_mcp_tool", gated_resolve)
+        with pytest.raises(ToolRegistryError, match="cancelled by a concurrent delete"):
+            await update_task
+
+        # x still points at gamma.
+        monkeypatch.undo()
+        assert registry.dynamic_tools["alpha"].mcp_tool.name == "remote_gamma"
 
 
 class TestUpdateOperation:

--- a/strands-py/tests/strands/vended_tools/test_tool_registry.py
+++ b/strands-py/tests/strands/vended_tools/test_tool_registry.py
@@ -22,10 +22,10 @@ from strands.tools.registry import ToolRegistry
 from strands.types import PaginatedList
 from strands.types.tools import ToolContext
 from strands.vended_tools.tool_registry import (
-    MAX_DYNAMIC_TOOLS,
     ToolRegistryError,
     make_tool_registry,
 )
+from strands.vended_tools.tool_registry.types import MAX_DYNAMIC_TOOLS
 
 
 @dataclass
@@ -198,7 +198,7 @@ class TestCreateOperation:
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "bad",
-        ["", "1_starts_with_digit", "has-dash", "has space", "toolname!"],
+        ["", "1_starts_with_digit", "has-dash", "has space", "toolname!", "a" * 65],
     )
     async def test_rejects_invalid_tool_name(self, registry_tool, registry: ToolRegistry, bad: str) -> None:
         with pytest.raises(ToolRegistryError, match="invalid tool name"):
@@ -214,9 +214,7 @@ class TestCreateOperation:
     async def test_rejects_normalized_name_conflict(self, registry_tool) -> None:
         """A tool name that only differs by '-' vs '_' from an existing entry is rejected.
 
-        The underlying SDK registry's `register_tool` enforces this rule but
-        `register_dynamic_tool` does not, so the tool has to replicate the check
-        to keep the two surfaces consistent and to fail with a clear error.
+        The tool replicates the check to fail with a clear error.
         """
         reg = ToolRegistry()
 
@@ -277,15 +275,17 @@ class TestCreateOperation:
         assert list_result["dynamic_count"] == 0
 
     @pytest.mark.asyncio
-    async def test_rejects_overly_long_tool_name(self, registry_tool, registry: ToolRegistry) -> None:
-        with pytest.raises(ToolRegistryError, match="invalid tool name"):
-            await registry_tool(
-                operation="create",
-                tool_name="a" * 65,
-                source="weather",
-                remote_name="remote_alpha",
-                tool_context=_tool_context(registry),
-            )
+    async def test_accepts_maximum_length_tool_name(self, registry_tool, registry: ToolRegistry) -> None:
+        # 64 chars: one leading letter + 63 alphanumeric/underscore characters.
+        max_name = "a" * 64
+        result = await registry_tool(
+            operation="create",
+            tool_name=max_name,
+            source="weather",
+            remote_name="remote_alpha",
+            tool_context=_tool_context(registry),
+        )
+        assert result["name"] == max_name
 
     @pytest.mark.asyncio
     async def test_enforces_dynamic_tool_cap(self, mcp_client: _FakeMCPClient, registry: ToolRegistry) -> None:
@@ -440,8 +440,30 @@ class TestUpdateOperation:
             tool_context=ctx,
         )
         assert result["operation"] == "update"
+        assert result["name"] == "alpha"
+        assert result["dynamic_count"] == 1
         # The adapter points at remote_beta now.
         assert registry.dynamic_tools["alpha"].mcp_tool.name == "remote_beta"
+
+    @pytest.mark.asyncio
+    async def test_update_applies_description_override(self, registry_tool, registry: ToolRegistry) -> None:
+        ctx = _tool_context(registry)
+        await registry_tool(
+            operation="create",
+            tool_name="alpha",
+            source="weather",
+            remote_name="remote_alpha",
+            tool_context=ctx,
+        )
+        await registry_tool(
+            operation="update",
+            tool_name="alpha",
+            source="weather",
+            remote_name="remote_alpha",
+            description_override="overridden on update",
+            tool_context=ctx,
+        )
+        assert registry.dynamic_tools["alpha"].tool_spec["description"] == "overridden on update"
 
     @pytest.mark.asyncio
     async def test_cannot_update_developer_tool(self, registry_tool, registry: ToolRegistry) -> None:
@@ -553,15 +575,6 @@ class TestDeleteOperation:
             )
         # Untouched.
         assert "dev_echo" in registry.registry
-
-    @pytest.mark.asyncio
-    async def test_rejects_deleting_unknown_tool(self, registry_tool, registry: ToolRegistry) -> None:
-        with pytest.raises(ToolRegistryError, match="developer-registered"):
-            await registry_tool(
-                operation="delete",
-                tool_name="never_registered",
-                tool_context=_tool_context(registry),
-            )
 
     @pytest.mark.asyncio
     async def test_does_not_leak_ownership_between_registries(self, mcp_client: _FakeMCPClient) -> None:

--- a/strands-py/tests/strands/vended_tools/test_tool_registry.py
+++ b/strands-py/tests/strands/vended_tools/test_tool_registry.py
@@ -18,6 +18,7 @@ import pytest
 from mcp.types import Tool as MCPTool
 
 from strands.tools.decorator import tool as tool_decorator
+from strands.tools.mcp.mcp_agent_tool import MCPAgentTool
 from strands.tools.registry import ToolRegistry
 from strands.types import PaginatedList
 from strands.types.tools import ToolContext
@@ -25,6 +26,7 @@ from strands.vended_tools.tool_registry import (
     ToolRegistryError,
     make_tool_registry,
 )
+from strands.vended_tools.tool_registry import tool_registry as trmod
 from strands.vended_tools.tool_registry.types import MAX_DYNAMIC_TOOLS
 
 
@@ -40,9 +42,6 @@ class _FakeMCPClient:
     tools: list[MCPTool]
 
     def list_tools_sync(self, pagination_token: str | None = None, **kwargs: Any) -> PaginatedList[Any]:
-        # Import here to avoid a cycle when tests are collected before mcp submodule init.
-        from strands.tools.mcp.mcp_agent_tool import MCPAgentTool
-
         adapted = [MCPAgentTool(t, self) for t in self.tools]  # type: ignore[arg-type]
         return PaginatedList(adapted, token=None)
 
@@ -97,7 +96,7 @@ def mcp_client() -> _FakeMCPClient:
 def registry_tool(mcp_client: _FakeMCPClient) -> Any:
     # Cast MCPClient explicitly via typing.Any to sidestep the isinstance check
     # in the tool factory; the factory only requires the ``list_tools_sync`` API.
-    return make_tool_registry(mcp_clients={"weather": mcp_client})  # type: ignore[dict-item]
+    return make_tool_registry(mcp_clients={"weather": mcp_client})
 
 
 class TestListOperation:
@@ -153,6 +152,19 @@ class TestCreateOperation:
         assert spec["description"] == "custom text"
 
     @pytest.mark.asyncio
+    async def test_rejects_empty_description_override(self, registry_tool, registry: ToolRegistry) -> None:
+        for bad_desc in ["", "   "]:
+            with pytest.raises(ToolRegistryError, match="non-empty"):
+                await registry_tool(
+                    operation="create",
+                    tool_name="alpha",
+                    source="weather",
+                    remote_name="remote_alpha",
+                    description_override=bad_desc,
+                    tool_context=_tool_context(registry),
+                )
+
+    @pytest.mark.asyncio
     async def test_rejects_unknown_source(self, registry_tool, registry: ToolRegistry) -> None:
         with pytest.raises(ToolRegistryError, match="unknown source"):
             await registry_tool(
@@ -198,7 +210,7 @@ class TestCreateOperation:
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "bad",
-        ["", "1_starts_with_digit", "has-dash", "has space", "toolname!", "a" * 65],
+        ["", "1_starts_with_digit", "has-dash", "has space", "toolname!", "a" * 65, "weather\n"],
     )
     async def test_rejects_invalid_tool_name(self, registry_tool, registry: ToolRegistry, bad: str) -> None:
         with pytest.raises(ToolRegistryError, match="invalid tool name"):
@@ -252,7 +264,7 @@ class TestCreateOperation:
         exception type from the tool.
         """
         registry_tool = make_tool_registry(
-            mcp_clients={"weather": mcp_client},  # type: ignore[dict-item]
+            mcp_clients={"weather": mcp_client},
         )
 
         def raise_duplicate(_tool: Any) -> None:
@@ -291,7 +303,7 @@ class TestCreateOperation:
     async def test_enforces_dynamic_tool_cap(self, mcp_client: _FakeMCPClient, registry: ToolRegistry) -> None:
         # Cap at 2 so we can exhaust it quickly.
         registry_tool = make_tool_registry(
-            mcp_clients={"weather": mcp_client},  # type: ignore[dict-item]
+            mcp_clients={"weather": mcp_client},
             max_dynamic_tools=2,
         )
         ctx = _tool_context(registry)
@@ -321,18 +333,12 @@ class TestCreateOperation:
     ) -> None:
         cap = 2
         registry_tool = make_tool_registry(
-            mcp_clients={"weather": mcp_client},  # type: ignore[dict-item]
+            mcp_clients={"weather": mcp_client},
             max_dynamic_tools=cap,
         )
         ctx = _tool_context(registry)
 
-        # `_resolve_mcp_tool` in production never yields (list_tools_sync is
-        # sync), so gather-scheduled invocations would serialize and the old
-        # check-then-write ordering would also pass this test. Monkey-patch a
-        # yielding fake so each concurrent create actually suspends between
-        # its cap check and its registry write, exercising the race window.
-        from strands.vended_tools.tool_registry import tool_registry as trmod
-
+        # Replace _resolve_mcp_tool with a version that yields to let concurrent creates overlap.
         real_resolve = trmod._resolve_mcp_tool
 
         async def yielding_resolve(*args: Any, **kwargs: Any) -> Any:
@@ -362,6 +368,109 @@ class TestCreateOperation:
         assert len(failures) == cap
 
     @pytest.mark.asyncio
+    async def test_cancellation_releases_reservation(
+        self,
+        mcp_client: _FakeMCPClient,
+        registry: ToolRegistry,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A task cancelled during the MCP round-trip must not leak its cap slot or name reservation.
+
+        Without the fix (except Exception instead of except BaseException), the
+        CancelledError bypasses the cleanup branch, leaving the name in `owned`
+        permanently — subsequent creates hit "already registered" and the cap
+        error says to delete a tool that doesn't exist.
+        """
+        registry_tool = make_tool_registry(
+            mcp_clients={"weather": mcp_client},
+        )
+        ctx = _tool_context(registry)
+
+        async def hanging_resolve(*args: Any, **kwargs: Any) -> Any:
+            # Park indefinitely so the task can be cancelled mid-await.
+            await asyncio.Event().wait()
+            raise AssertionError("unreachable")  # pragma: no cover
+
+        monkeypatch.setattr(trmod, "_resolve_mcp_tool", hanging_resolve)
+
+        create_task = asyncio.create_task(
+            registry_tool(
+                operation="create",
+                tool_name="alpha",
+                source="weather",
+                remote_name="remote_alpha",
+                tool_context=ctx,
+            )
+        )
+        await asyncio.sleep(0)  # let the task reach the await
+        create_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await create_task
+
+        # Reservation must be released — cap and name are available again.
+        monkeypatch.undo()
+        result = await registry_tool(
+            operation="create",
+            tool_name="alpha",
+            source="weather",
+            remote_name="remote_alpha",
+            tool_context=ctx,
+        )
+        assert result["name"] == "alpha"
+        assert result["dynamic_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_concurrent_create_and_update_same_name(
+        self,
+        mcp_client: _FakeMCPClient,
+        registry: ToolRegistry,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A concurrent update on a name that is only pending (in-flight create) must be rejected."""
+        registry_tool = make_tool_registry(
+            mcp_clients={"weather": mcp_client},
+        )
+        ctx = _tool_context(registry)
+
+        real_resolve = trmod._resolve_mcp_tool
+        gate = asyncio.Event()
+
+        async def gated_resolve(*args: Any, **kwargs: Any) -> Any:
+            await gate.wait()
+            return await real_resolve(*args, **kwargs)
+
+        monkeypatch.setattr(trmod, "_resolve_mcp_tool", gated_resolve)
+
+        # Start create and let it park on the gate (name is now in pending, not owned).
+        create_task = asyncio.create_task(
+            registry_tool(
+                operation="create",
+                tool_name="alpha",
+                source="weather",
+                remote_name="remote_alpha",
+                tool_context=ctx,
+            )
+        )
+        await asyncio.sleep(0)
+
+        # Concurrent update on the same name must be rejected — alpha is only pending.
+        with pytest.raises(ToolRegistryError, match="developer-registered"):
+            await registry_tool(
+                operation="update",
+                tool_name="alpha",
+                source="weather",
+                remote_name="remote_beta",
+                tool_context=ctx,
+            )
+
+        # Release create; it completes normally and alpha is now owned.
+        gate.set()
+        result = await create_task
+        assert result["name"] == "alpha"
+        assert result["dynamic_count"] == 1
+        assert "alpha" in registry.dynamic_tools
+
+    @pytest.mark.asyncio
     async def test_does_not_orphan_reservation_on_concurrent_delete(
         self,
         mcp_client: _FakeMCPClient,
@@ -370,11 +479,9 @@ class TestCreateOperation:
     ) -> None:
         """A `delete` landing between `create`'s reservation and write must not orphan."""
         registry_tool = make_tool_registry(
-            mcp_clients={"weather": mcp_client},  # type: ignore[dict-item]
+            mcp_clients={"weather": mcp_client},
         )
         ctx = _tool_context(registry)
-
-        from strands.vended_tools.tool_registry import tool_registry as trmod
 
         real_resolve = trmod._resolve_mcp_tool
         gate = asyncio.Event()
@@ -491,7 +598,7 @@ class TestUpdateOperation:
         no longer track.
         """
         registry_tool = make_tool_registry(
-            mcp_clients={"weather": mcp_client},  # type: ignore[dict-item]
+            mcp_clients={"weather": mcp_client},
         )
         ctx = _tool_context(registry)
 
@@ -503,8 +610,6 @@ class TestUpdateOperation:
             remote_name="remote_alpha",
             tool_context=ctx,
         )
-
-        from strands.vended_tools.tool_registry import tool_registry as trmod
 
         real_resolve = trmod._resolve_mcp_tool
         gate = asyncio.Event()
@@ -579,9 +684,7 @@ class TestDeleteOperation:
     @pytest.mark.asyncio
     async def test_does_not_leak_ownership_between_registries(self, mcp_client: _FakeMCPClient) -> None:
         """Two agents sharing a factory bind their own ownership sets."""
-        registry_tool_shared = make_tool_registry(
-            mcp_clients={"weather": mcp_client}  # type: ignore[dict-item]
-        )
+        registry_tool_shared = make_tool_registry(mcp_clients={"weather": mcp_client})
         reg_a = ToolRegistry()
         reg_b = ToolRegistry()
 
@@ -605,9 +708,9 @@ class TestDeleteOperation:
     @pytest.mark.asyncio
     async def test_two_factories_on_one_agent_do_not_collide(self, mcp_client: _FakeMCPClient) -> None:
         """Two separate factories on one agent track ownership independently."""
-        factory_a = make_tool_registry(mcp_clients={"weather": mcp_client})  # type: ignore[dict-item]
+        factory_a = make_tool_registry(mcp_clients={"weather": mcp_client})
         factory_b = make_tool_registry(
-            mcp_clients={"weather": mcp_client},  # type: ignore[dict-item]
+            mcp_clients={"weather": mcp_client},
             name="tool_registry_b",
         )
         reg = ToolRegistry()

--- a/strands-py/tests/strands/vended_tools/test_tool_registry.py
+++ b/strands-py/tests/strands/vended_tools/test_tool_registry.py
@@ -1,0 +1,655 @@
+"""Tests for the tool_registry tool.
+
+The tool provides CRUD access to the agent's own tool registry. Only tools
+hosted on a pre-approved MCP client may be registered; developer-registered
+tools are never removable or updatable via the tool. These tests exercise the
+tool as a plain async callable (bypassing the streaming/error-wrapping path);
+validation failures surface as raised ``ToolRegistryError``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from mcp.types import Tool as MCPTool
+
+from strands.tools.decorator import tool as tool_decorator
+from strands.tools.registry import ToolRegistry
+from strands.types import PaginatedList
+from strands.types.tools import ToolContext
+from strands.vended_tools.tool_registry import (
+    MAX_DYNAMIC_TOOLS,
+    ToolRegistryError,
+    make_tool_registry,
+)
+
+
+@dataclass
+class _FakeMCPClient:
+    """Minimal stand-in for ``MCPClient``: pretends to host a fixed set of tools.
+
+    Only the surface the tool_registry tool actually uses is exposed:
+    ``list_tools_sync`` yielding ``MCPAgentTool`` instances (via the real class
+    from the SDK), with the pagination shape the tool expects.
+    """
+
+    tools: list[MCPTool]
+
+    def list_tools_sync(self, pagination_token: str | None = None, **kwargs: Any) -> PaginatedList[Any]:
+        # Import here to avoid a cycle when tests are collected before mcp submodule init.
+        from strands.tools.mcp.mcp_agent_tool import MCPAgentTool
+
+        adapted = [MCPAgentTool(t, self) for t in self.tools]  # type: ignore[arg-type]
+        return PaginatedList(adapted, token=None)
+
+
+def _mcp_tool(name: str, description: str = "a fake tool") -> MCPTool:
+    return MCPTool(
+        name=name,
+        description=description,
+        inputSchema={"type": "object", "properties": {}},
+    )
+
+
+def _tool_context(registry: ToolRegistry) -> ToolContext:
+    agent = SimpleNamespace(tool_registry=registry)
+    return ToolContext(
+        tool_use={"name": "tool_registry", "toolUseId": "id", "input": {}},
+        agent=agent,
+        invocation_state={},
+    )
+
+
+@pytest.fixture
+def registry() -> ToolRegistry:
+    r = ToolRegistry()
+
+    # Two developer-registered tools that must remain untouchable.
+    @tool_decorator(name="dev_echo", description="developer-registered echo")
+    def dev_echo(text: str) -> str:
+        return text
+
+    @tool_decorator(name="dev_ping", description="developer-registered ping")
+    def dev_ping() -> str:
+        return "pong"
+
+    r.register_tool(dev_echo)
+    r.register_tool(dev_ping)
+    return r
+
+
+@pytest.fixture
+def mcp_client() -> _FakeMCPClient:
+    return _FakeMCPClient(
+        tools=[
+            _mcp_tool("remote_alpha"),
+            _mcp_tool("remote_beta"),
+            _mcp_tool("remote_gamma"),
+        ]
+    )
+
+
+@pytest.fixture
+def registry_tool(mcp_client: _FakeMCPClient) -> Any:
+    # Cast MCPClient explicitly via typing.Any to sidestep the isinstance check
+    # in the tool factory; the factory only requires the ``list_tools_sync`` API.
+    return make_tool_registry(mcp_clients={"weather": mcp_client})  # type: ignore[dict-item]
+
+
+class TestListOperation:
+    @pytest.mark.asyncio
+    async def test_lists_developer_registered_tools_as_not_owned(self, registry_tool, registry: ToolRegistry) -> None:
+        result = await registry_tool(operation="list", tool_context=_tool_context(registry))
+        names = {t["name"]: t for t in result["tools"]}
+        assert "dev_echo" in names
+        assert "dev_ping" in names
+        assert names["dev_echo"]["registered_by_tool_registry"] is False
+        assert names["dev_ping"]["registered_by_tool_registry"] is False
+        assert result["dynamic_count"] == 0
+        assert result["dynamic_limit"] == MAX_DYNAMIC_TOOLS
+
+
+class TestCreateOperation:
+    @pytest.mark.asyncio
+    async def test_registers_mcp_tool_and_marks_owned(self, registry_tool, registry: ToolRegistry) -> None:
+        result = await registry_tool(
+            operation="create",
+            tool_name="alpha",
+            source="weather",
+            remote_name="remote_alpha",
+            tool_context=_tool_context(registry),
+        )
+        assert result["operation"] == "create"
+        assert result["name"] == "alpha"
+        assert result["dynamic_count"] == 1
+        assert "alpha" in registry.dynamic_tools
+
+    @pytest.mark.asyncio
+    async def test_uses_tool_name_as_default_remote_name(self, registry_tool, registry: ToolRegistry) -> None:
+        result = await registry_tool(
+            operation="create",
+            tool_name="remote_beta",
+            source="weather",
+            tool_context=_tool_context(registry),
+        )
+        assert result["name"] == "remote_beta"
+        assert "remote_beta" in registry.dynamic_tools
+
+    @pytest.mark.asyncio
+    async def test_description_override_shadowed_on_spec(self, registry_tool, registry: ToolRegistry) -> None:
+        await registry_tool(
+            operation="create",
+            tool_name="alpha",
+            source="weather",
+            remote_name="remote_alpha",
+            description_override="custom text",
+            tool_context=_tool_context(registry),
+        )
+        spec = registry.dynamic_tools["alpha"].tool_spec
+        assert spec["description"] == "custom text"
+
+    @pytest.mark.asyncio
+    async def test_rejects_unknown_source(self, registry_tool, registry: ToolRegistry) -> None:
+        with pytest.raises(ToolRegistryError, match="unknown source"):
+            await registry_tool(
+                operation="create",
+                tool_name="alpha",
+                source="not_a_real_client",
+                tool_context=_tool_context(registry),
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_unknown_remote_tool(self, registry_tool, registry: ToolRegistry) -> None:
+        with pytest.raises(ToolRegistryError, match="not found on MCP server"):
+            await registry_tool(
+                operation="create",
+                tool_name="alpha",
+                source="weather",
+                remote_name="does_not_exist",
+                tool_context=_tool_context(registry),
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_collision_with_developer_tool(self, registry_tool, registry: ToolRegistry) -> None:
+        with pytest.raises(ToolRegistryError, match="already registered"):
+            await registry_tool(
+                operation="create",
+                tool_name="dev_echo",
+                source="weather",
+                remote_name="remote_alpha",
+                tool_context=_tool_context(registry),
+            )
+
+    @pytest.mark.asyncio
+    async def test_cannot_register_over_itself(self, registry_tool, registry: ToolRegistry) -> None:
+        with pytest.raises(ToolRegistryError, match="itself"):
+            await registry_tool(
+                operation="create",
+                tool_name="tool_registry",
+                source="weather",
+                remote_name="remote_alpha",
+                tool_context=_tool_context(registry),
+            )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "bad",
+        ["", "1_starts_with_digit", "has-dash", "has space", "toolname!"],
+    )
+    async def test_rejects_invalid_tool_name(self, registry_tool, registry: ToolRegistry, bad: str) -> None:
+        with pytest.raises(ToolRegistryError, match="invalid tool name"):
+            await registry_tool(
+                operation="create",
+                tool_name=bad,
+                source="weather",
+                remote_name="remote_alpha",
+                tool_context=_tool_context(registry),
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_normalized_name_conflict(self, registry_tool) -> None:
+        """A tool name that only differs by '-' vs '_' from an existing entry is rejected.
+
+        The underlying SDK registry's `register_tool` enforces this rule but
+        `register_dynamic_tool` does not, so the tool has to replicate the check
+        to keep the two surfaces consistent and to fail with a clear error.
+        """
+        reg = ToolRegistry()
+
+        # Insert a developer tool whose name contains a dash. The tool_registry
+        # tool would never allow the model to register such a name (dashes are
+        # rejected by TOOL_NAME_PATTERN), but developer tools can carry them.
+        @tool_decorator(name="my-tool", description="dash-named developer tool")
+        def my_tool() -> str:
+            return "ok"
+
+        reg.register_tool(my_tool)
+
+        # Now the model tries to add `my_tool` — which normalizes to the same
+        # canonical name — and should be rejected before any MCP work happens.
+        with pytest.raises(ToolRegistryError, match="differ only by '-' vs '_'"):
+            await registry_tool(
+                operation="create",
+                tool_name="my_tool",
+                source="weather",
+                remote_name="remote_alpha",
+                tool_context=_tool_context(reg),
+            )
+
+    @pytest.mark.asyncio
+    async def test_wraps_register_dynamic_tool_value_error(
+        self,
+        mcp_client: _FakeMCPClient,
+        registry: ToolRegistry,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A raw `ValueError` from `register_dynamic_tool` is surfaced as `ToolRegistryError`.
+
+        Another `tool_registry` factory could race a duplicate registration
+        between our checks and the write; callers should still see a single
+        exception type from the tool.
+        """
+        registry_tool = make_tool_registry(
+            mcp_clients={"weather": mcp_client},  # type: ignore[dict-item]
+        )
+
+        def raise_duplicate(_tool: Any) -> None:
+            raise ValueError("Tool 'alpha' already exists")
+
+        monkeypatch.setattr(registry, "register_dynamic_tool", raise_duplicate)
+        with pytest.raises(ToolRegistryError, match="already exists"):
+            await registry_tool(
+                operation="create",
+                tool_name="alpha",
+                source="weather",
+                remote_name="remote_alpha",
+                tool_context=_tool_context(registry),
+            )
+        # Reservation released on failure.
+        list_result = await registry_tool(
+            operation="list",
+            tool_context=_tool_context(registry),
+        )
+        assert list_result["dynamic_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_rejects_overly_long_tool_name(self, registry_tool, registry: ToolRegistry) -> None:
+        with pytest.raises(ToolRegistryError, match="invalid tool name"):
+            await registry_tool(
+                operation="create",
+                tool_name="a" * 65,
+                source="weather",
+                remote_name="remote_alpha",
+                tool_context=_tool_context(registry),
+            )
+
+    @pytest.mark.asyncio
+    async def test_enforces_dynamic_tool_cap(self, mcp_client: _FakeMCPClient, registry: ToolRegistry) -> None:
+        # Cap at 2 so we can exhaust it quickly.
+        registry_tool = make_tool_registry(
+            mcp_clients={"weather": mcp_client},  # type: ignore[dict-item]
+            max_dynamic_tools=2,
+        )
+        ctx = _tool_context(registry)
+        for local_name, remote in [("alpha", "remote_alpha"), ("beta", "remote_beta")]:
+            await registry_tool(
+                operation="create",
+                tool_name=local_name,
+                source="weather",
+                remote_name=remote,
+                tool_context=ctx,
+            )
+        with pytest.raises(ToolRegistryError, match="dynamic tool cap reached"):
+            await registry_tool(
+                operation="create",
+                tool_name="gamma",
+                source="weather",
+                remote_name="remote_gamma",
+                tool_context=ctx,
+            )
+
+    @pytest.mark.asyncio
+    async def test_enforces_dynamic_tool_cap_under_concurrent_creates(
+        self,
+        mcp_client: _FakeMCPClient,
+        registry: ToolRegistry,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        cap = 2
+        registry_tool = make_tool_registry(
+            mcp_clients={"weather": mcp_client},  # type: ignore[dict-item]
+            max_dynamic_tools=cap,
+        )
+        ctx = _tool_context(registry)
+
+        # `_resolve_mcp_tool` in production never yields (list_tools_sync is
+        # sync), so gather-scheduled invocations would serialize and the old
+        # check-then-write ordering would also pass this test. Monkey-patch a
+        # yielding fake so each concurrent create actually suspends between
+        # its cap check and its registry write, exercising the race window.
+        from strands.vended_tools.tool_registry import tool_registry as trmod
+
+        real_resolve = trmod._resolve_mcp_tool
+
+        async def yielding_resolve(*args: Any, **kwargs: Any) -> Any:
+            await asyncio.sleep(0)  # force a real suspend point
+            return await real_resolve(*args, **kwargs)
+
+        monkeypatch.setattr(trmod, "_resolve_mcp_tool", yielding_resolve)
+
+        # Fire 2x cap concurrent creates against a shared context. Under a
+        # check-then-await-then-write ordering all N would race past the cap.
+        results = await asyncio.gather(
+            *(
+                registry_tool(
+                    operation="create",
+                    tool_name=f"t{i}",
+                    source="weather",
+                    remote_name="remote_alpha",
+                    tool_context=ctx,
+                )
+                for i in range(cap * 2)
+            ),
+            return_exceptions=True,
+        )
+        successes = [r for r in results if not isinstance(r, BaseException)]
+        failures = [r for r in results if isinstance(r, ToolRegistryError)]
+        assert len(successes) == cap
+        assert len(failures) == cap
+
+    @pytest.mark.asyncio
+    async def test_does_not_orphan_reservation_on_concurrent_delete(
+        self,
+        mcp_client: _FakeMCPClient,
+        registry: ToolRegistry,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A `delete` landing between `create`'s reservation and write must not orphan."""
+        registry_tool = make_tool_registry(
+            mcp_clients={"weather": mcp_client},  # type: ignore[dict-item]
+        )
+        ctx = _tool_context(registry)
+
+        from strands.vended_tools.tool_registry import tool_registry as trmod
+
+        real_resolve = trmod._resolve_mcp_tool
+        gate = asyncio.Event()
+
+        async def gated_resolve(*args: Any, **kwargs: Any) -> Any:
+            # Suspend until the test releases us so a concurrent `delete` can
+            # slip between the synchronous reservation and the post-await
+            # registry write.
+            await gate.wait()
+            return await real_resolve(*args, **kwargs)
+
+        monkeypatch.setattr(trmod, "_resolve_mcp_tool", gated_resolve)
+
+        # Task B: start `create` and let it park on the gate.
+        create_task = asyncio.create_task(
+            registry_tool(
+                operation="create",
+                tool_name="alpha",
+                source="weather",
+                remote_name="remote_alpha",
+                tool_context=ctx,
+            )
+        )
+        for _ in range(3):
+            await asyncio.sleep(0)
+
+        # Task A: delete the reserved-but-not-yet-registered tool.
+        delete_result = await registry_tool(
+            operation="delete",
+            tool_name="alpha",
+            tool_context=ctx,
+        )
+        assert delete_result["operation"] == "delete"
+
+        # Release create; it must abort rather than resurrect an orphan.
+        gate.set()
+        with pytest.raises(ToolRegistryError, match="cancelled by a concurrent delete"):
+            await create_task
+
+        # No orphan in the SDK registry; ownership set is empty.
+        assert "alpha" not in registry.dynamic_tools
+        assert "alpha" not in registry.registry
+        list_result = await registry_tool(operation="list", tool_context=ctx)
+        assert list_result["dynamic_count"] == 0
+
+
+class TestUpdateOperation:
+    @pytest.mark.asyncio
+    async def test_updates_own_tool(self, registry_tool, registry: ToolRegistry) -> None:
+        ctx = _tool_context(registry)
+        await registry_tool(
+            operation="create",
+            tool_name="alpha",
+            source="weather",
+            remote_name="remote_alpha",
+            tool_context=ctx,
+        )
+        result = await registry_tool(
+            operation="update",
+            tool_name="alpha",
+            source="weather",
+            remote_name="remote_beta",
+            tool_context=ctx,
+        )
+        assert result["operation"] == "update"
+        # The adapter points at remote_beta now.
+        assert registry.dynamic_tools["alpha"].mcp_tool.name == "remote_beta"
+
+    @pytest.mark.asyncio
+    async def test_cannot_update_developer_tool(self, registry_tool, registry: ToolRegistry) -> None:
+        with pytest.raises(ToolRegistryError, match="developer-registered"):
+            await registry_tool(
+                operation="update",
+                tool_name="dev_echo",
+                source="weather",
+                remote_name="remote_alpha",
+                tool_context=_tool_context(registry),
+            )
+
+    @pytest.mark.asyncio
+    async def test_does_not_resurrect_on_concurrent_delete(
+        self,
+        mcp_client: _FakeMCPClient,
+        registry: ToolRegistry,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A `delete` landing during `update`'s MCP lookup must not be undone.
+
+        Mirrors the create-during-delete guard: if `update` re-checks ownership
+        only before the await, a delete landing during the await could resurrect
+        a tool the model believed deleted, leaving an orphan this instance can
+        no longer track.
+        """
+        registry_tool = make_tool_registry(
+            mcp_clients={"weather": mcp_client},  # type: ignore[dict-item]
+        )
+        ctx = _tool_context(registry)
+
+        # First register so `update` has something to target.
+        await registry_tool(
+            operation="create",
+            tool_name="alpha",
+            source="weather",
+            remote_name="remote_alpha",
+            tool_context=ctx,
+        )
+
+        from strands.vended_tools.tool_registry import tool_registry as trmod
+
+        real_resolve = trmod._resolve_mcp_tool
+        gate = asyncio.Event()
+
+        async def gated_resolve(*args: Any, **kwargs: Any) -> Any:
+            await gate.wait()
+            return await real_resolve(*args, **kwargs)
+
+        monkeypatch.setattr(trmod, "_resolve_mcp_tool", gated_resolve)
+
+        # Task B: start `update` and let it park on the gate after the
+        # pre-await ownership check.
+        update_task = asyncio.create_task(
+            registry_tool(
+                operation="update",
+                tool_name="alpha",
+                source="weather",
+                remote_name="remote_beta",
+                tool_context=ctx,
+            )
+        )
+        for _ in range(3):
+            await asyncio.sleep(0)
+
+        # Task A: delete the tool while the update is still awaiting.
+        delete_result = await registry_tool(
+            operation="delete",
+            tool_name="alpha",
+            tool_context=ctx,
+        )
+        assert delete_result["operation"] == "delete"
+
+        # Release the update; it must abort rather than resurrect the tool.
+        gate.set()
+        with pytest.raises(ToolRegistryError, match="cancelled by a concurrent delete"):
+            await update_task
+
+        # Deletion stuck; no orphan.
+        assert "alpha" not in registry.dynamic_tools
+        assert "alpha" not in registry.registry
+        list_result = await registry_tool(operation="list", tool_context=ctx)
+        assert list_result["dynamic_count"] == 0
+
+
+class TestDeleteOperation:
+    @pytest.mark.asyncio
+    async def test_deletes_own_tool(self, registry_tool, registry: ToolRegistry) -> None:
+        ctx = _tool_context(registry)
+        await registry_tool(
+            operation="create",
+            tool_name="alpha",
+            source="weather",
+            remote_name="remote_alpha",
+            tool_context=ctx,
+        )
+        result = await registry_tool(operation="delete", tool_name="alpha", tool_context=ctx)
+        assert result["operation"] == "delete"
+        assert result["dynamic_count"] == 0
+        assert "alpha" not in registry.dynamic_tools
+
+    @pytest.mark.asyncio
+    async def test_rejects_deleting_developer_tool(self, registry_tool, registry: ToolRegistry) -> None:
+        with pytest.raises(ToolRegistryError, match="developer-registered"):
+            await registry_tool(
+                operation="delete",
+                tool_name="dev_echo",
+                tool_context=_tool_context(registry),
+            )
+        # Untouched.
+        assert "dev_echo" in registry.registry
+
+    @pytest.mark.asyncio
+    async def test_rejects_deleting_unknown_tool(self, registry_tool, registry: ToolRegistry) -> None:
+        with pytest.raises(ToolRegistryError, match="developer-registered"):
+            await registry_tool(
+                operation="delete",
+                tool_name="never_registered",
+                tool_context=_tool_context(registry),
+            )
+
+    @pytest.mark.asyncio
+    async def test_does_not_leak_ownership_between_registries(self, mcp_client: _FakeMCPClient) -> None:
+        """Two agents sharing a factory bind their own ownership sets."""
+        registry_tool_shared = make_tool_registry(
+            mcp_clients={"weather": mcp_client}  # type: ignore[dict-item]
+        )
+        reg_a = ToolRegistry()
+        reg_b = ToolRegistry()
+
+        await registry_tool_shared(
+            operation="create",
+            tool_name="alpha",
+            source="weather",
+            remote_name="remote_alpha",
+            tool_context=_tool_context(reg_a),
+        )
+
+        # Registry B never registered "alpha", so deletion must be rejected there
+        # even though registry A has it. Ownership is per-registry, not global.
+        with pytest.raises(ToolRegistryError, match="developer-registered"):
+            await registry_tool_shared(
+                operation="delete",
+                tool_name="alpha",
+                tool_context=_tool_context(reg_b),
+            )
+
+    @pytest.mark.asyncio
+    async def test_two_factories_on_one_agent_do_not_collide(self, mcp_client: _FakeMCPClient) -> None:
+        """Two separate factories on one agent track ownership independently."""
+        factory_a = make_tool_registry(mcp_clients={"weather": mcp_client})  # type: ignore[dict-item]
+        factory_b = make_tool_registry(
+            mcp_clients={"weather": mcp_client},  # type: ignore[dict-item]
+            name="tool_registry_b",
+        )
+        reg = ToolRegistry()
+        ctx = _tool_context(reg)
+
+        await factory_a(
+            operation="create",
+            tool_name="alpha",
+            source="weather",
+            remote_name="remote_alpha",
+            tool_context=ctx,
+        )
+        # Factory B never registered "alpha"; it must refuse to delete it,
+        # matching the TS `WeakMap<LocalAgent, Set<string>>` semantics.
+        with pytest.raises(ToolRegistryError, match="developer-registered"):
+            await factory_b(
+                operation="delete",
+                tool_name="alpha",
+                tool_context=ctx,
+            )
+        # Factory A still owns it.
+        assert "alpha" in reg.dynamic_tools
+
+
+class TestOperationDispatch:
+    @pytest.mark.asyncio
+    async def test_rejects_unknown_operation(self, registry_tool, registry: ToolRegistry) -> None:
+        with pytest.raises(ToolRegistryError, match="invalid operation"):
+            await registry_tool(
+                operation="wipe_registry",
+                tool_context=_tool_context(registry),
+            )
+
+    @pytest.mark.asyncio
+    async def test_read_only_when_no_mcp_clients_configured(self, registry: ToolRegistry) -> None:
+        registry_tool = make_tool_registry()  # empty
+        # list still works
+        result = await registry_tool(operation="list", tool_context=_tool_context(registry))
+        assert result["dynamic_limit"] == MAX_DYNAMIC_TOOLS
+        # create fails
+        with pytest.raises(ToolRegistryError, match="unknown source"):
+            await registry_tool(
+                operation="create",
+                tool_name="alpha",
+                source="anything",
+                tool_context=_tool_context(registry),
+            )
+
+
+class TestFactoryValidation:
+    def test_rejects_zero_max_dynamic_tools(self) -> None:
+        with pytest.raises(ValueError, match="at least 1"):
+            make_tool_registry(max_dynamic_tools=0)
+
+    def test_uses_custom_name_and_description(self) -> None:
+        t = make_tool_registry(name="registry_ctl", description="custom desc")
+        assert t.tool_name == "registry_ctl"
+        assert t.tool_spec["description"] == "custom desc"

--- a/strands-py/tests/strands/vended_tools/test_tool_registry.py
+++ b/strands-py/tests/strands/vended_tools/test_tool_registry.py
@@ -722,6 +722,38 @@ class TestUpdateOperation:
 
 class TestDeleteOperation:
     @pytest.mark.asyncio
+    async def test_delete_does_not_clobber_developer_tool_registered_over_model_tool(
+        self, registry_tool, registry: ToolRegistry
+    ) -> None:
+        """A developer tool registered over a model-created name must survive model delete.
+
+        register_tool with supports_hot_reload=True can overwrite registry['name']
+        with a developer tool after the model created a binding. The model's delete
+        must only remove its own entry (dynamic_tools), leaving the developer tool intact.
+        """
+        ctx = _tool_context(registry)
+        await registry_tool(
+            operation="create",
+            tool_name="alpha",
+            source="weather",
+            remote_name="remote_alpha",
+            tool_context=ctx,
+        )
+
+        # Simulate a developer registering a same-named tool on top (hot-reload allows it).
+        @tool_decorator(name="alpha", description="developer alpha tool")
+        def dev_alpha() -> str:
+            return "dev"
+
+        registry.register_tool(dev_alpha)
+        assert registry.registry.get("alpha") is dev_alpha
+
+        # Model deletes its owned binding — must not clobber the developer tool.
+        await registry_tool(operation="delete", tool_name="alpha", tool_context=ctx)
+        assert registry.registry.get("alpha") is dev_alpha
+        assert "alpha" not in registry.dynamic_tools
+
+    @pytest.mark.asyncio
     async def test_deletes_own_tool(self, registry_tool, registry: ToolRegistry) -> None:
         ctx = _tool_context(registry)
         await registry_tool(


### PR DESCRIPTION
## Description

This PR adds `tool_registry` to the Python vended tools — a CRUD interface that lets the model manage its own tool set at runtime, bounded by a developer-approved set of MCP clients. This lets us deprecate the `load_tool` tool from the tools repository. The implementation is based on https://github.com/strands-agents/harness-sdk/pull/3398.

The model can list all registered tools, bind a new tool from a pre-approved MCP server, re-bind an existing entry to a different remote tool or description, and remove entries it previously registered. Developer-registered tools are never mutable through this interface. The blast radius is intentionally scoped to whatever the developer-approved MCP servers already expose — filesystem paths and inline source loading are out of scope.

The `tool_registry` tool is distinct from [tool selection](https://github.com/strands-agents/harness-sdk/pull/4008) because this expands the agent's capabilities over the course of the session rather than optimizing tool context. This is also distinct from the [mcp_client tool](https://github.com/strands-agents/harness-sdk/pull/3376) because this stores the tool in the registry rather than going over the network every time. Furthermore, tool_registry accepts pre-connected MCP clients instead of MCP server URLs, so it keeps the connection lifecycle out of scope and focuses on the tool registry CRUD.

This PR does not replace the existing `ToolRegistry` interface with a [CRUDL interface](https://github.com/strands-agents/harness-sdk/pull/3398#discussion_r3652591651) because the change is large and out-of-scope for simply adding the `tool_registry` tool. It also defers the [fix to register_dynamic_tool](https://github.com/strands-agents/harness-sdk/pull/3398#discussion_r3652606885) for a similar reason; the change would affect `ToolRegistry` and all its callers.

## Public API Changes

`make_tool_registry` is exported from `strands.vended_tools`:

```python
from strands import Agent
from strands.tools.mcp import MCPClient
from strands.vended_tools import make_tool_registry

weather = MCPClient(...)
weather.start()

agent = Agent(tools=[make_tool_registry(mcp_clients={"weather": weather})])
agent("List your tools, then add the forecast tool from weather.")
```

The factory accepts `mcp_clients` (the approved source set), `max_dynamic_tools` (cap, default 32), and overrides for the tool `name` and `description`. When `mcp_clients` is omitted or empty the tool degrades gracefully to a read-only `list` view.

## Related Issues

https://github.com/strands-agents/harness-sdk/issues/3249

## Documentation PR

Documentation added under `site/` in this PR.

## Type of Change

New feature

## Testing

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
