### PR TITLE
feat(mcp): added call_tool support for 2.x

### DIFF
--- a/strands-py/src/strands/tools/mcp/_compat.py
+++ b/strands-py/src/strands/tools/mcp/_compat.py
@@ -15,6 +15,7 @@ ignores the installed line doesn't need.
 
 from collections.abc import AsyncIterator
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
+from datetime import timedelta
 from typing import Any
 
 import httpx
@@ -25,10 +26,16 @@ __all__ = [
     "MCP_V2",
     "GetSessionIdCallback",
     "MCPError",
+    "input_schema",
+    "is_error",
+    "mime_type",
     "negotiate_session",
     "next_cursor",
+    "output_schema",
+    "read_timeout",
     "resource_templates",
     "streamable_http_transport",
+    "structured_content",
     "task_support",
 ]
 
@@ -53,6 +60,54 @@ except ImportError:
     GetSessionIdCallback = Callable[[], str | None]  # type: ignore[misc, assignment]
 
 
+def input_schema(tool: Any) -> dict[str, Any]:
+    """Read a tool's input schema, on either `mcp` major line.
+
+    `mcp` 2.x renamed the pydantic model fields to snake_case, so the field
+    is `input_schema` there and `inputSchema` on 1.x.
+
+    Args:
+        tool: A `Tool` from a list tools result.
+
+    Returns:
+        The tool's JSON input schema.
+    """
+    schema: dict[str, Any] = tool.input_schema if MCP_V2 else tool.inputSchema
+    return schema
+
+
+def is_error(call_tool_result: Any) -> bool | None:
+    """Read a tool call result's error flag, on either `mcp` major line.
+
+    `mcp` 2.x renamed the pydantic result models' camelCase fields to
+    snake_case, so the field is `is_error` there and `isError` on 1.x.
+
+    Args:
+        call_tool_result: A `CallToolResult` returned by the session.
+
+    Returns:
+        The tool's application-level error flag.
+    """
+    error: bool | None = call_tool_result.is_error if MCP_V2 else call_tool_result.isError
+    return error
+
+
+def mime_type(content: Any) -> str | None:
+    """Read a content or resource block's MIME type, on either `mcp` major line.
+
+    `mcp` 2.x renamed the pydantic model fields to snake_case, so the field
+    is `mime_type` there and `mimeType` on 1.x.
+
+    Args:
+        content: An `ImageContent`, `AudioContent`, or `*ResourceContents` model.
+
+    Returns:
+        The block's MIME type, or None when the model leaves it unset.
+    """
+    mime: str | None = content.mime_type if MCP_V2 else content.mimeType
+    return mime
+
+
 def next_cursor(list_result: Any) -> str | None:
     """Read a paginated list result's continuation cursor, on either `mcp` major line.
 
@@ -67,6 +122,39 @@ def next_cursor(list_result: Any) -> str | None:
     """
     cursor: str | None = list_result.next_cursor if MCP_V2 else list_result.nextCursor
     return cursor
+
+
+def output_schema(tool: Any) -> dict[str, Any] | None:
+    """Read a tool's output schema, on either `mcp` major line.
+
+    `mcp` 2.x renamed the pydantic model fields to snake_case, so the field
+    is `output_schema` there and `outputSchema` on 1.x.
+
+    Args:
+        tool: A `Tool` from a list tools result.
+
+    Returns:
+        The tool's JSON output schema, or None when the tool declares none.
+    """
+    schema: dict[str, Any] | None = tool.output_schema if MCP_V2 else tool.outputSchema
+    return schema
+
+
+def read_timeout(timeout: timedelta | None) -> Any:
+    """Convert a tool call read timeout to the form the installed `mcp` line takes.
+
+    The session `call_tool` takes `read_timeout_seconds` as a `timedelta` on
+    1.x and as a `float` of seconds on 2.x.
+
+    Args:
+        timeout: The timeout from the `MCPClient` public API, if any.
+
+    Returns:
+        The value to pass as the session's `read_timeout_seconds`.
+    """
+    if timeout is None:
+        return None
+    return timeout.total_seconds() if MCP_V2 else timeout
 
 
 def resource_templates(list_result: Any) -> list[Any]:
@@ -84,6 +172,27 @@ def resource_templates(list_result: Any) -> list[Any]:
     """
     templates: list[Any] = list_result.resource_templates if MCP_V2 else list_result.resourceTemplates
     return templates
+
+
+def structured_content(call_tool_result: Any) -> Any:
+    """Read a tool call result's structured content, on either `mcp` major line.
+
+    `mcp` 2.x renamed the pydantic result models' camelCase fields to
+    snake_case, so the field is `structured_content` there and
+    `structuredContent` on 1.x.
+
+    The return is `Any` because the lines type the field differently: 1.x
+    validates it to `dict[str, Any] | None`, while 2.x allows any JSON value
+    (the 2026-07-28 spec lifted the JSON-object restriction). Non-dict values
+    pass through unchanged; callers decide how to surface them.
+
+    Args:
+        call_tool_result: A `CallToolResult` returned by the session.
+
+    Returns:
+        The structured JSON payload, or None when the tool returned none.
+    """
+    return call_tool_result.structured_content if MCP_V2 else call_tool_result.structuredContent
 
 
 def task_support(tool: Any) -> str | None:

--- a/strands-py/src/strands/tools/mcp/mcp_agent_tool.py
+++ b/strands-py/src/strands/tools/mcp/mcp_agent_tool.py
@@ -14,6 +14,7 @@ from typing_extensions import override
 
 from ...types._events import ToolResultEvent
 from ...types.tools import AgentTool, ToolGenerator, ToolSpec, ToolUse
+from ._compat import input_schema, output_schema
 
 if TYPE_CHECKING:
     from .mcp_client import MCPClient
@@ -75,19 +76,22 @@ class MCPAgentTool(AgentTool):
         description: str = self.mcp_tool.description or f"Tool which performs {self.mcp_tool.name}"
 
         spec: ToolSpec = {
-            "inputSchema": {"json": self.mcp_tool.inputSchema},
+            "inputSchema": {"json": input_schema(self.mcp_tool)},
             "name": self.tool_name,  # Use agent-facing name in spec
             "description": description,
         }
 
-        if self.mcp_tool.outputSchema:
-            spec["outputSchema"] = {"json": self.mcp_tool.outputSchema}
+        tool_output_schema = output_schema(self.mcp_tool)
+        if tool_output_schema:
+            spec["outputSchema"] = {"json": tool_output_schema}
 
         # Pass annotations through opaquely: per MCP spec they are untrusted hints,
         # and the annotation vocabulary is still evolving (SEP-1984, SEP-1913).
         # An annotations object with no set fields is treated the same as no annotations.
+        # Dump by alias so the keys are the camelCase wire names on both `mcp`
+        # lines: 2.x fields are snake_case with camelCase aliases; 1.x has no aliases.
         if self.mcp_tool.annotations:
-            annotations = self.mcp_tool.annotations.model_dump(exclude_none=True)
+            annotations = self.mcp_tool.annotations.model_dump(by_alias=True, exclude_none=True)
             if annotations:
                 spec["annotations"] = annotations
 

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -64,10 +64,14 @@ from ...types.tools import AgentTool, ToolResultContent, ToolResultStatus
 from ..tool_provider import ToolProvider
 from ._compat import (
     MCPError,
+    is_error,
+    mime_type,
     negotiate_session,
     next_cursor,
+    read_timeout,
     resource_templates,
     streamable_http_transport,
+    structured_content,
     task_support,
 )
 from .mcp_agent_tool import MCPAgentTool
@@ -874,7 +878,11 @@ class MCPClient(ToolProvider):
                     if isinstance(request_id, int):
                         cancellation_state["request_id"] = request_id
                 return await session.call_tool(
-                    name, arguments, read_timeout_seconds, progress_callback=effective_callback, meta=meta
+                    name,
+                    arguments,
+                    read_timeout(read_timeout_seconds),
+                    progress_callback=effective_callback,
+                    meta=meta,
                 )
 
             return _call_tool_direct()
@@ -1057,7 +1065,8 @@ class MCPClient(ToolProvider):
             if (mc := self.map_mcp_content_to_tool_result_content(content)) is not None
         ]
 
-        status: ToolResultStatus = "error" if call_tool_result.isError else "success"
+        tool_error = is_error(call_tool_result)
+        status: ToolResultStatus = "error" if tool_error else "success"
         self._log_debug_with_thread("tool execution completed with status: %s", status)
         result = MCPToolResult(
             status=status,
@@ -1065,12 +1074,13 @@ class MCPClient(ToolProvider):
             content=mapped_contents,
         )
 
-        if call_tool_result.structuredContent:
-            result["structuredContent"] = call_tool_result.structuredContent
+        structured_payload = structured_content(call_tool_result)
+        if structured_payload:
+            result["structuredContent"] = structured_payload
         if call_tool_result.meta:
             result["metadata"] = call_tool_result.meta
-        if call_tool_result.isError is not None:
-            result["isError"] = call_tool_result.isError
+        if tool_error is not None:
+            result["isError"] = tool_error
 
         return result
 
@@ -1197,10 +1207,11 @@ class MCPClient(ToolProvider):
             self._log_debug_with_thread("mapping MCP text content")
             return {"text": content.text}
         elif isinstance(content, MCPImageContent):
-            self._log_debug_with_thread("mapping MCP image content with mime type: %s", content.mimeType)
+            image_mime = cast(str, mime_type(content))
+            self._log_debug_with_thread("mapping MCP image content with mime type: %s", image_mime)
             return {
                 "image": {
-                    "format": MIME_TO_FORMAT[content.mimeType],
+                    "format": MIME_TO_FORMAT[image_mime],
                     "source": {"bytes": base64.b64decode(content.data)},
                 }
             }
@@ -1227,9 +1238,10 @@ class MCPClient(ToolProvider):
                     self._log_debug_with_thread("embedded resource blob could not be decoded - dropping")
                     return None
 
-                if resource.mimeType and (
-                    resource.mimeType.startswith("text/")
-                    or resource.mimeType
+                resource_mime = mime_type(resource)
+                if resource_mime and (
+                    resource_mime.startswith("text/")
+                    or resource_mime
                     in (
                         "application/json",
                         "application/xml",
@@ -1237,17 +1249,17 @@ class MCPClient(ToolProvider):
                         "application/yaml",
                         "application/x-yaml",
                     )
-                    or resource.mimeType.endswith(("+json", "+xml"))
+                    or resource_mime.endswith(("+json", "+xml"))
                 ):
                     try:
                         return {"text": raw_bytes.decode("utf-8", errors="replace")}
                     except Exception:
                         pass
 
-                if resource.mimeType in MIME_TO_FORMAT:
+                if resource_mime in MIME_TO_FORMAT:
                     return {
                         "image": {
-                            "format": MIME_TO_FORMAT[resource.mimeType],
+                            "format": MIME_TO_FORMAT[resource_mime],
                             "source": {"bytes": raw_bytes},
                         }
                     }

--- a/strands-py/tests/strands/tools/mcp/test__compat.py
+++ b/strands-py/tests/strands/tools/mcp/test__compat.py
@@ -13,6 +13,7 @@ import inspect
 import sys
 from collections.abc import Callable
 from contextlib import asynccontextmanager
+from datetime import timedelta
 from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -62,16 +63,58 @@ def test_installed_line_list_methods_accept_params():
 
 def test_installed_line_spells_the_accessor_read_fields_as_expected():
     """Test that every model field a `_compat` accessor reads exists on the installed line's models."""
-    from mcp.types import ListResourceTemplatesResult, ListToolsResult, ToolExecution
+    from mcp.types import (
+        BlobResourceContents,
+        CallToolResult,
+        ImageContent,
+        ListResourceTemplatesResult,
+        ListToolsResult,
+        Tool,
+        ToolExecution,
+    )
 
     if _compat.MCP_V2:
         assert "next_cursor" in ListToolsResult.model_fields
         assert "resource_templates" in ListResourceTemplatesResult.model_fields
         assert "task_support" in ToolExecution.model_fields
+        assert "is_error" in CallToolResult.model_fields
+        assert "structured_content" in CallToolResult.model_fields
+        assert "input_schema" in Tool.model_fields
+        assert "output_schema" in Tool.model_fields
+        assert "mime_type" in ImageContent.model_fields
+        assert "mime_type" in BlobResourceContents.model_fields
     else:
         assert "nextCursor" in ListToolsResult.model_fields
         assert "resourceTemplates" in ListResourceTemplatesResult.model_fields
         assert "taskSupport" in ToolExecution.model_fields
+        assert "isError" in CallToolResult.model_fields
+        assert "structuredContent" in CallToolResult.model_fields
+        assert "inputSchema" in Tool.model_fields
+        assert "outputSchema" in Tool.model_fields
+        assert "mimeType" in ImageContent.model_fields
+        assert "mimeType" in BlobResourceContents.model_fields
+
+
+def test_installed_line_call_tool_takes_the_arguments_mcp_client_passes():
+    """Test that the session `call_tool` takes what `MCPClient` passes on the installed line.
+
+    `MCPClient` passes the first three arguments positionally and the timeout
+    type differs between the lines, so position, kind, and annotation are
+    pinned along with the `read_timeout` conversion that must match it.
+    """
+    from mcp import ClientSession
+
+    call_tool_parameters = inspect.signature(ClientSession.call_tool).parameters
+    for parameter_name in ("progress_callback", "meta"):
+        assert parameter_name in call_tool_parameters, parameter_name
+
+    positional = list(call_tool_parameters.values())[1:4]
+    assert [parameter.name for parameter in positional] == ["name", "arguments", "read_timeout_seconds"]
+    assert all(parameter.kind is inspect.Parameter.POSITIONAL_OR_KEYWORD for parameter in positional)
+
+    expected_timeout_type = float if _compat.MCP_V2 else timedelta
+    assert expected_timeout_type.__name__ in str(positional[2].annotation)
+    assert isinstance(_compat.read_timeout(timedelta(seconds=30)), expected_timeout_type)
 
 
 def test_next_cursor_v1_reads_the_camel_case_field(monkeypatch):
@@ -119,6 +162,96 @@ def test_task_support_v2_reads_the_snake_case_field(monkeypatch):
 def test_task_support_returns_none_for_a_tool_without_execution():
     """Test that a tool with no execution block declares no task support level."""
     assert _compat.task_support(SimpleNamespace(execution=None)) is None
+
+
+def test_is_error_v1_reads_the_camel_case_field(monkeypatch):
+    """Test that the 1.x branch reads the result's `isError` field."""
+    monkeypatch.setattr(_compat, "MCP_V2", False)
+
+    assert _compat.is_error(SimpleNamespace(isError=True)) is True
+
+
+def test_is_error_v2_reads_the_snake_case_field(monkeypatch):
+    """Test that the 2.x branch reads the result's `is_error` field."""
+    monkeypatch.setattr(_compat, "MCP_V2", True)
+
+    assert _compat.is_error(SimpleNamespace(is_error=True)) is True
+
+
+def test_structured_content_v1_reads_the_camel_case_field(monkeypatch):
+    """Test that the 1.x branch reads the result's `structuredContent` field."""
+    monkeypatch.setattr(_compat, "MCP_V2", False)
+
+    assert _compat.structured_content(SimpleNamespace(structuredContent={"answer": 42})) == {"answer": 42}
+
+
+def test_structured_content_v2_reads_the_snake_case_field(monkeypatch):
+    """Test that the 2.x branch reads the result's `structured_content` field."""
+    monkeypatch.setattr(_compat, "MCP_V2", True)
+
+    assert _compat.structured_content(SimpleNamespace(structured_content={"answer": 42})) == {"answer": 42}
+
+
+def test_mime_type_v1_reads_the_camel_case_field(monkeypatch):
+    """Test that the 1.x branch reads the content's `mimeType` field."""
+    monkeypatch.setattr(_compat, "MCP_V2", False)
+
+    assert _compat.mime_type(SimpleNamespace(mimeType="image/png")) == "image/png"
+
+
+def test_mime_type_v2_reads_the_snake_case_field(monkeypatch):
+    """Test that the 2.x branch reads the content's `mime_type` field."""
+    monkeypatch.setattr(_compat, "MCP_V2", True)
+
+    assert _compat.mime_type(SimpleNamespace(mime_type="image/png")) == "image/png"
+
+
+def test_input_schema_v1_reads_the_camel_case_field(monkeypatch):
+    """Test that the 1.x branch reads the tool's `inputSchema` field."""
+    monkeypatch.setattr(_compat, "MCP_V2", False)
+
+    assert _compat.input_schema(SimpleNamespace(inputSchema={"type": "object"})) == {"type": "object"}
+
+
+def test_input_schema_v2_reads_the_snake_case_field(monkeypatch):
+    """Test that the 2.x branch reads the tool's `input_schema` field."""
+    monkeypatch.setattr(_compat, "MCP_V2", True)
+
+    assert _compat.input_schema(SimpleNamespace(input_schema={"type": "object"})) == {"type": "object"}
+
+
+def test_output_schema_v1_reads_the_camel_case_field(monkeypatch):
+    """Test that the 1.x branch reads the tool's `outputSchema` field."""
+    monkeypatch.setattr(_compat, "MCP_V2", False)
+
+    assert _compat.output_schema(SimpleNamespace(outputSchema={"type": "object"})) == {"type": "object"}
+
+
+def test_output_schema_v2_reads_the_snake_case_field(monkeypatch):
+    """Test that the 2.x branch reads the tool's `output_schema` field."""
+    monkeypatch.setattr(_compat, "MCP_V2", True)
+
+    assert _compat.output_schema(SimpleNamespace(output_schema={"type": "object"})) == {"type": "object"}
+
+
+def test_read_timeout_v1_passes_the_timedelta_through(monkeypatch):
+    """Test that the 1.x branch keeps the timeout as the `timedelta` the session takes."""
+    monkeypatch.setattr(_compat, "MCP_V2", False)
+    timeout = timedelta(seconds=30)
+
+    assert _compat.read_timeout(timeout) is timeout
+
+
+def test_read_timeout_v2_converts_to_seconds(monkeypatch):
+    """Test that the 2.x branch converts the timeout to the float of seconds the session takes."""
+    monkeypatch.setattr(_compat, "MCP_V2", True)
+
+    assert _compat.read_timeout(timedelta(seconds=30)) == 30.0
+
+
+def test_read_timeout_passes_none_through():
+    """Test that an absent timeout stays absent on either line."""
+    assert _compat.read_timeout(None) is None
 
 
 def test_mcp_error_resolves_to_installed_exception():

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client.py
@@ -20,6 +20,7 @@ from mcp.types import (
     ResourceTemplate,
     TextResourceContents,
 )
+from mcp.types import ImageContent as MCPImageContent
 from mcp.types import TextContent as MCPTextContent
 from mcp.types import Tool as MCPTool
 from pydantic import AnyUrl
@@ -141,6 +142,23 @@ def test_call_tool_sync_status(mock_transport, mock_session, is_error, expected_
         assert result.get("structuredContent") is None
         # isError mirrors the MCP server's explicit value; absent only for protocol/client exceptions
         assert result.get("isError") is is_error
+
+
+def test_call_tool_sync_without_error_flag(mock_transport, mock_session):
+    """A result whose error flag is unset maps to success without an isError key.
+
+    mcp 2.x models the flag as `bool | None` defaulting to None; the 1.x model
+    validates it to a bool, so the unset shape is built with `model_construct`.
+    """
+    mock_content = MCPTextContent(type="text", text="Test message")
+    mock_session.call_tool.return_value = MCPCallToolResult.model_construct(isError=None, content=[mock_content])
+
+    with MCPClient(mock_transport["transport_callable"]) as client:
+        result = client.call_tool_sync(tool_use_id="test-123", name="test_tool", arguments={"param": "value"})
+
+        assert result["status"] == "success"
+        assert result["content"][0]["text"] == "Test message"
+        assert "isError" not in result
 
 
 def test_call_tool_sync_session_not_active():
@@ -1042,6 +1060,23 @@ def test_mcp_client_state_reset_after_timeout():
     assert client._background_thread_session is None
     assert client._background_thread_event_loop is None
     assert not client._init_future.done()  # New future created
+
+
+def test_call_tool_sync_image_content(mock_transport, mock_session):
+    """A top-level ImageContent block should map to image content with decoded bytes."""
+    with open("tests_integ/resources/yellow.png", "rb") as image_file:
+        png_data = image_file.read()
+
+    image_content = MCPImageContent(type="image", data=base64.b64encode(png_data).decode(), mimeType="image/png")
+    mock_session.call_tool.return_value = MCPCallToolResult(isError=False, content=[image_content])
+
+    with MCPClient(mock_transport["transport_callable"]) as client:
+        result = client.call_tool_sync(tool_use_id="img-1", name="get_image", arguments={})
+
+        assert result["status"] == "success"
+        assert len(result["content"]) == 1
+        assert result["content"][0]["image"]["format"] == "png"
+        assert result["content"][0]["image"]["source"]["bytes"] == png_data
 
 
 def test_call_tool_sync_embedded_nested_text(mock_transport, mock_session):


### PR DESCRIPTION
## Description
Follow-up in the `mcp` 2.x series. Nothing changes for current installs while the pin holds `<2`.

`mcp` 2.x renamed the camelCase pydantic model fields that tool calling reads to snake_case, and changed the `call_tool` timeout type. `MCPClient` and `MCPAgentTool` used the 1.x spellings, so on 2.x a tool call breaks in four places: building `ToolSpec` reads `Tool.inputSchema` / `Tool.outputSchema` (now `input_schema` / `output_schema`), result handling reads `CallToolResult.isError` and `structuredContent` (now `is_error` / `structured_content`), the content mapper reads `mimeType` on image and resource blocks (now `mime_type`), and `read_timeout_seconds` is passed as a `timedelta` where 2.x takes a `float` of seconds.

Each rename resolves through a new `_compat` accessor (`input_schema`, `output_schema`, `is_error`, `structured_content`, `mime_type`), and `_compat.read_timeout` converts the public `timedelta` API to whatever the installed line's `call_tool` takes. This follows the `_compat` rule from #3708 that version differences resolve in one place and call sites stay version-blind.

The installed-line tests now assert the accessor-read fields exist on the real `CallToolResult`, `Tool`, `ImageContent`, and `BlobResourceContents` models, and that `call_tool` still takes `read_timeout_seconds`, `progress_callback`, and `meta`, so a rename on either line fails the suite.

## Related Issues

#1659

## Documentation PR

No documentation changes needed; the compat module is internal and the public `MCPClient` API is unchanged.

## Type of Change

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`
- Full MCP unit suite passes on `mcp` 1.x; the compat tests pass against `mcp==2.0.*` in the `unit-test-mcp-v2` CI job.
- Exercised end to end on `mcp` 2.0.x against an in-process 2026-07-28 server: plain text, error results, structured content, image content, and the read timeout path.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
