### PR TITLE
feat(agent): add LocalAgent protocol

### DIFF
--- a/strands-py/pyproject.toml
+++ b/strands-py/pyproject.toml
@@ -150,7 +150,7 @@ format-fix = [
 ]
 lint-check = [
     "ruff check",
-    "mypy ./src"
+    "mypy ./src ./tests_typing"
 ]
 lint-fix = [
     "ruff check --fix"
@@ -251,7 +251,7 @@ warn_unused_ignores = false
 
 [tool.ruff]
 line-length = 120
-include = ["examples/**/*.py", "src/**/*.py", "tests/**/*.py", "tests_integ/**/*.py"]
+include = ["examples/**/*.py", "src/**/*.py", "tests/**/*.py", "tests_integ/**/*.py", "tests_typing/**/*.py"]
 
 [tool.ruff.lint]
 select = [

--- a/strands-py/src/strands/__init__.py
+++ b/strands-py/src/strands/__init__.py
@@ -13,6 +13,7 @@ from .sandbox import (
 from .sandbox.errors import SandboxPathNotFoundError, SandboxTimeoutError
 from .tools.decorator import tool
 from .types._snapshot import Snapshot
+from .types.agent import LocalAgent
 from .types.tools import ToolContext
 from .vended_plugins.skills import AgentSkills, Skill
 
@@ -21,6 +22,7 @@ __all__ = [
     "AgentBase",
     "AgentSkills",
     "InterventionHandler",
+    "LocalAgent",
     "agent",
     "models",
     "ModelRetryStrategy",

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
+    ClassVar,
     Literal,
     TypeVar,
     Union,
@@ -83,7 +84,7 @@ from ..tools.registry import ToolRegistry
 from ..tools.structured_output._structured_output_context import StructuredOutputContext
 from ..tools.watcher import ToolWatcher
 from ..types._events import AgentResultEvent, EventLoopStopEvent, InitEventLoopEvent, ModelStreamChunkEvent, TypedEvent
-from ..types.agent import AgentInput, ConcurrentInvocationMode, Limits
+from ..types.agent import AgentInput, ConcurrentInvocationMode, Limits, LocalAgent
 from ..types.content import (
     ContentBlock,
     Message,
@@ -187,7 +188,7 @@ class _PassProgress:
     event_loop_produced_result: bool = False
 
 
-class Agent(AgentBase):
+class Agent(AgentBase, LocalAgent):
     """Core Agent implementation.
 
     An agent orchestrates the following workflow:
@@ -199,6 +200,8 @@ class Agent(AgentBase):
     5. Continues reasoning with the new information
     6. Produces a final response
     """
+
+    _is_strands_local_agent: ClassVar[Literal[True]] = True
 
     # For backwards compatibility
     ToolCaller = _ToolCaller

--- a/strands-py/src/strands/hooks/_type_inference.py
+++ b/strands-py/src/strands/hooks/_type_inference.py
@@ -11,10 +11,17 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _normalize_event_type(type_hint: object) -> type | None:
+    """Normalize a plain or parameterized annotation to its event type."""
+    origin = get_origin(type_hint)
+    candidate = origin or type_hint
+    return candidate if isinstance(candidate, type) else None
+
+
 def infer_event_types(callback: "HookCallback[TEvent]") -> "list[type[TEvent]]":
     """Infer the event type(s) from a callback's type hints.
 
-    Supports both single types and union types (A | B or Union[A, B]).
+    Supports plain or parameterized event types and unions (A | B or Union[A, B]).
 
     Args:
         callback: The callback function to inspect.
@@ -64,14 +71,16 @@ def infer_event_types(callback: "HookCallback[TEvent]") -> "list[type[TEvent]]":
         for arg in get_args(type_hint):
             if arg is type(None):
                 raise ValueError("None is not a valid event type in union")
-            if not (isinstance(arg, type) and issubclass(arg, BaseHookEvent)):
+            event_type = _normalize_event_type(arg)
+            if event_type is None or not issubclass(event_type, BaseHookEvent):
                 raise ValueError(f"Invalid type in union: {arg} | must be a subclass of BaseHookEvent")
-            event_types.append(cast("type[TEvent]", arg))
+            event_types.append(cast("type[TEvent]", event_type))
         return event_types
 
     # Handle single type
-    if isinstance(type_hint, type) and issubclass(type_hint, BaseHookEvent):
-        return [cast("type[TEvent]", type_hint)]
+    event_type = _normalize_event_type(type_hint)
+    if event_type is not None and issubclass(event_type, BaseHookEvent):
+        return [cast("type[TEvent]", event_type)]
 
     raise ValueError(
         f"parameter=<{first_param.name}>, type=<{type_hint}> | type hint must be a subclass of BaseHookEvent"

--- a/strands-py/src/strands/hooks/events.py
+++ b/strands-py/src/strands/hooks/events.py
@@ -17,7 +17,7 @@ from ..types.content import ContentBlock, Message, Messages
 from ..types.interrupt import _Interruptible
 from ..types.streaming import StopReason
 from ..types.tools import AgentTool, ToolResult, ToolUse
-from .registry import BaseHookEvent, HookEvent
+from .registry import BaseHookEvent, HookEvent, _LocalAgentT
 
 if TYPE_CHECKING:
     from ..multiagent.base import MultiAgentBase
@@ -205,7 +205,7 @@ class AfterToolsEvent(HookEvent):
 
 
 @dataclass
-class BeforeToolCallEvent(HookEvent, _Interruptible):
+class BeforeToolCallEvent(HookEvent[_LocalAgentT], _Interruptible):
     """Event triggered before a tool is invoked.
 
     This event is fired just before the agent executes a tool, allowing hook
@@ -245,7 +245,7 @@ class BeforeToolCallEvent(HookEvent, _Interruptible):
 
 
 @dataclass
-class AfterToolCallEvent(HookEvent):
+class AfterToolCallEvent(HookEvent[_LocalAgentT]):
     """Event triggered after a tool invocation completes.
 
     This event is fired after the agent has finished executing a tool,

--- a/strands-py/src/strands/hooks/registry.py
+++ b/strands-py/src/strands/hooks/registry.py
@@ -13,13 +13,16 @@ import logging
 from collections.abc import Awaitable, Generator
 from dataclasses import dataclass
 from itertools import groupby
-from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar, runtime_checkable
+from typing import TYPE_CHECKING, Any, Generic, Protocol, runtime_checkable
+
+from typing_extensions import TypeVar
 
 from ..interrupt import Interrupt, InterruptException
 from ._type_inference import infer_event_types
 
 if TYPE_CHECKING:
     from ..agent import Agent
+    from ..types.agent import LocalAgent
 
 logger = logging.getLogger(__name__)
 
@@ -92,15 +95,19 @@ class BaseHookEvent:
         raise AttributeError(f"Property {name} is not writable")
 
 
+_LocalAgentT = TypeVar("_LocalAgentT", bound="LocalAgent", default="Agent", covariant=True)
+"""Agent type carried by hook events."""
+
+
 @dataclass
-class HookEvent(BaseHookEvent):
+class HookEvent(BaseHookEvent, Generic[_LocalAgentT]):
     """Base class for single agent hook events.
 
     Attributes:
         agent: The agent instance that triggered this event.
     """
 
-    agent: "Agent"
+    agent: _LocalAgentT
 
 
 TEvent = TypeVar("TEvent", bound=BaseHookEvent, contravariant=True)

--- a/strands-py/src/strands/tools/decorator.py
+++ b/strands-py/src/strands/tools/decorator.py
@@ -177,7 +177,8 @@ class FunctionToolMetadata:
     def _validate_signature(self) -> None:
         """Verify that ToolContext is used correctly in the function signature."""
         for param in self.signature.parameters.values():
-            if param.annotation is ToolContext:
+            annotation = self.type_hints.get(param.name)
+            if annotation is ToolContext or get_origin(annotation) is ToolContext:
                 if self._context_param is None:
                     raise ValueError("@tool(context) must be set if passing in ToolContext param")
 

--- a/strands-py/src/strands/types/agent.py
+++ b/strands-py/src/strands/types/agent.py
@@ -3,15 +3,88 @@
 This module defines the types used for an Agent.
 """
 
+from __future__ import annotations
+
 from enum import Enum
-from typing import TypeAlias
+from typing import TYPE_CHECKING, ClassVar, Literal, Protocol, TypeAlias, TypeVar
 
 from typing_extensions import TypedDict
 
-from .content import ContentBlock, Messages
+from .content import ContentBlock, Messages, SystemContentBlock
 from .interrupt import InterruptResponseContent
 
+if TYPE_CHECKING:
+    from ..agent.state import AgentState
+    from ..hooks.registry import BaseHookEvent, HookCallback, HookRegistry
+    from ..models.model import Model
+    from ..tools._caller import _ToolCaller
+    from ..tools.registry import ToolRegistry
+
 AgentInput: TypeAlias = str | list[ContentBlock] | list[InterruptResponseContent] | Messages | None
+
+_TEvent = TypeVar("_TEvent", bound="BaseHookEvent")
+"""Hook event type registered by LocalAgent.add_hook."""
+
+
+class LocalAgent(Protocol):
+    """Interface for SDK-provided agents with locally accessible capabilities.
+
+    This protocol is exported for type annotations and is not intended for external implementation.
+
+    Attributes:
+        agent_id: Unique identifier for the agent.
+        name: Display name for the agent.
+        description: Optional description of the agent.
+        messages: Conversation history maintained by the agent.
+        state: Application state associated with the agent.
+        hooks: Registry containing the agent's hook callbacks.
+        model: Model used by the agent.
+        system_prompt: String representation of the agent's system prompt.
+        tool_registry: Registry containing tools available to the agent.
+    """
+
+    _is_strands_local_agent: ClassVar[Literal[True]]
+    """Internal type-level marker for SDK-provided LocalAgent implementations."""
+
+    agent_id: str
+    name: str
+    description: str | None
+    messages: Messages
+    state: AgentState
+    hooks: HookRegistry
+    model: Model
+    system_prompt: str | None
+    tool_registry: ToolRegistry
+
+    @property
+    def tool(self) -> _ToolCaller:
+        """Caller for invoking registered tools directly."""
+        ...
+
+    @property
+    def tool_names(self) -> list[str]:
+        """Names of tools registered with the agent."""
+        ...
+
+    @property
+    def system_prompt_content(self) -> list[SystemContentBlock] | None:
+        """Structured system prompt content used by the agent."""
+        ...
+
+    @property
+    def session_id(self) -> str:
+        """Identifier for the current conversation session."""
+        ...
+
+    def add_hook(
+        self,
+        callback: HookCallback[_TEvent],
+        event_type: type[_TEvent] | list[type[_TEvent]] | None = None,
+        *,
+        order: float = ...,
+    ) -> None:
+        """Register a hook callback."""
+        ...
 
 
 class Limits(TypedDict, total=False):

--- a/strands-py/src/strands/types/tools.py
+++ b/strands-py/src/strands/types/tools.py
@@ -10,15 +10,21 @@ import uuid
 from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import Any, Literal, Protocol
+from typing import TYPE_CHECKING, Any, Generic, Literal, Protocol
 
-from typing_extensions import NotRequired, TypedDict
+from typing_extensions import NotRequired, TypedDict, TypeVar
 
 from .interrupt import _Interruptible
 from .media import DocumentContent, ImageContent
 
+if TYPE_CHECKING:
+    from .agent import LocalAgent
+
 JSONSchema = dict
 """Type alias for JSON Schema dictionaries."""
+
+_LocalAgentT = TypeVar("_LocalAgentT", bound="LocalAgent", default=Any)
+"""Local agent type exposed through ToolContext."""
 
 
 class ToolSpec(TypedDict):
@@ -140,7 +146,7 @@ class ToolChoiceTool(TypedDict):
 
 
 @dataclass
-class ToolContext(_Interruptible):
+class ToolContext(_Interruptible, Generic[_LocalAgentT]):
     """Context object containing framework-provided data for decorated tools.
 
     This object provides access to framework-level information that may be useful
@@ -164,7 +170,7 @@ class ToolContext(_Interruptible):
     """
 
     tool_use: ToolUse
-    agent: Any  # Agent or BidiAgent - using Any for backwards compatibility
+    agent: _LocalAgentT
     invocation_state: dict[str, Any]
     # Defaulted so a directly-constructed context stays valid; the SDK always supplies the
     # invoking agent's signal. Kept out of repr and equality: an Event carries no useful text

--- a/strands-py/tests/strands/hooks/test_registry.py
+++ b/strands-py/tests/strands/hooks/test_registry.py
@@ -3,6 +3,7 @@ from typing import Union
 
 import pytest
 
+from strands import LocalAgent
 from strands.hooks import (
     AfterModelCallEvent,
     AgentInitializedEvent,
@@ -115,6 +116,15 @@ def test_hook_registry_add_callback_infers_event_type(registry):
     # Verify callback was registered
     assert BeforeInvocationEvent in registry._registered_callbacks
     assert _has_callback(registry, BeforeInvocationEvent, typed_callback)
+
+
+def test_hook_registry_add_callback_infers_parameterized_event_type(registry):
+    def typed_callback(event: BeforeToolCallEvent[LocalAgent]) -> None:
+        pass
+
+    registry.add_callback(None, typed_callback)
+
+    assert _has_callback(registry, BeforeToolCallEvent, typed_callback)
 
 
 def test_hook_registry_add_callback_raises_error_no_type_hint(registry):

--- a/strands-py/tests/strands/tools/test_decorator.py
+++ b/strands-py/tests/strands/tools/test_decorator.py
@@ -12,7 +12,7 @@ import pytest
 from pydantic import BaseModel, Field
 
 import strands
-from strands import Agent
+from strands import Agent, LocalAgent
 from strands.interrupt import Interrupt, _InterruptState
 from strands.types._events import ToolInterruptEvent, ToolResultEvent, ToolStreamEvent
 from strands.types.tools import AgentTool, ToolContext, ToolUse
@@ -1507,6 +1507,28 @@ async def test_tool_context_injection_default():
             "test_reference": value_to_pass,
         },
     )
+
+
+@pytest.mark.asyncio
+async def test_tool_context_injection_parameterized():
+    """Test that parameterized ToolContext annotations are injected."""
+
+    @strands.tool(context=True)
+    def context_tool(tool_context: ToolContext[LocalAgent]) -> str:
+        return tool_context.agent.name
+
+    agent = Agent(name="test_agent")
+    events = [
+        event
+        async for event in context_tool.stream(
+            tool_use={"toolUseId": "test-id", "name": "context_tool", "input": {}},
+            invocation_state={"agent": agent},
+        )
+    ]
+
+    assert events == [
+        ToolResultEvent({"toolUseId": "test-id", "status": "success", "content": [{"text": "test_agent"}]})
+    ]
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests_typing/test_local_agent.py
+++ b/strands-py/tests_typing/test_local_agent.py
@@ -1,0 +1,61 @@
+from typing import Any
+
+from typing_extensions import assert_type
+
+from strands import Agent, LocalAgent, ToolContext, tool
+from strands.hooks import AfterToolCallEvent, BeforeToolCallEvent
+
+
+@tool(context=True)
+def unparameterized_tool(tool_context: ToolContext) -> str:
+    assert_type(tool_context.agent, Any)
+    return "unparameterized"
+
+
+@tool(context=True)
+def agent_tool(tool_context: ToolContext[Agent]) -> str:
+    assert_type(tool_context.agent, Agent)
+    return tool_context.agent.name
+
+
+@tool(context=True)
+def local_agent_tool(tool_context: ToolContext[LocalAgent]) -> str:
+    assert_type(tool_context.agent, LocalAgent)
+    return tool_context.agent.name
+
+
+def before_tool_call(event: BeforeToolCallEvent) -> None:
+    assert_type(event.agent, Agent)
+
+
+def before_local_tool_call(event: BeforeToolCallEvent[LocalAgent]) -> None:
+    assert_type(event.agent, LocalAgent)
+
+
+async def after_local_tool_call(event: AfterToolCallEvent[LocalAgent]) -> None:
+    assert_type(event.agent, LocalAgent)
+
+
+def local_tool_call(event: BeforeToolCallEvent[LocalAgent] | AfterToolCallEvent[LocalAgent]) -> None:
+    assert_type(event.agent, LocalAgent)
+
+
+def register_hooks(agent: Agent, local_agent: LocalAgent) -> None:
+    shared_agent: LocalAgent = agent
+    assert_type(shared_agent, LocalAgent)
+
+    agent.add_hook(before_tool_call)
+    agent.add_hook(before_local_tool_call)
+    agent.add_hook(after_local_tool_call)
+    agent.add_hook(local_tool_call)
+
+    local_agent.add_hook(before_local_tool_call)
+    local_agent.add_hook(after_local_tool_call)
+    local_agent.add_hook(local_tool_call)
+
+    local_agent.add_hook(before_local_tool_call, BeforeToolCallEvent)
+    local_agent.add_hook(local_tool_call, [BeforeToolCallEvent, AfterToolCallEvent])
+
+
+def local_agent_excludes_agent_only_members(local_agent: LocalAgent) -> None:
+    local_agent.cleanup()  # type: ignore[attr-defined]


### PR DESCRIPTION
## Description

Introduces a public `LocalAgent` protocol for SDK-provided agents with locally accessible state, messages, tools, and
hooks. `Agent` now implements this protocol, providing the shared type boundary needed for a follow-up `BidiAgent`
change.

This is, in essence, a Python port of the `LocalAgent` interface already used by the TypeScript SDK, adapted to the
current Python Agent surface. The protocol is exported for type annotations, but its private brand marks it as an
SDK-internal implementation contract. External implementations are not supported, allowing the SDK to add fields and
properties as the shared Agent and BidiAgent surface evolves.

This also makes `ToolContext` and tool-call hook events generic over their agent type:

- `ToolContext` continues to default to `Any` for backwards compatibility.
- `BeforeToolCallEvent` and `AfterToolCallEvent` continue to default to `Agent`.
- Shared tools and hooks can opt into `LocalAgent`.

Runtime annotation handling now recognizes parameterized `ToolContext` and hook event annotations. A dedicated
`tests_typing` suite verifies both the existing defaults and the new opt-in forms.

The shared typing work is intentionally iterative. This PR starts with the tool-call events needed by shared tool
execution; additional events can adopt `LocalAgent` in follow-up changes as their Agent and BidiAgent behavior is
consolidated.

This implements the Agent portion of the shared typing direction proposed in #3855.

## Usage

Use `LocalAgent` when a tool or hook is intended to work with any SDK-provided local agent:

```python
from strands import LocalAgent, ToolContext, tool


@tool(context=True)
def describe_agent(tool_context: ToolContext[LocalAgent]) -> str:
    return f"{tool_context.agent.name} has {len(tool_context.agent.messages)} messages"
```

Tool-call hooks can use the same shared agent type:

```python
from strands import LocalAgent
from strands.hooks import BeforeToolCallEvent


def log_tool_call(event: BeforeToolCallEvent[LocalAgent]) -> None:
    print(f"{event.agent.name} is calling {event.tool_use['name']}")


def register_hooks(agent: LocalAgent) -> None:
    agent.add_hook(log_tool_call)
```

## Related Issues

Related to #3764

Parent issue #1722

## Documentation PR

N/A. This introduces a typing boundary for follow-up SDK work without changing runtime usage. `LocalAgent`
documentation will be added once the shared contract is fully fleshed out with `BidiAgent`.

## Type of Change

New feature

## Testing

- `hatch fmt --linter --check`
- `hatch test --all tests/strands/hooks/test_registry.py tests/strands/tools/test_decorator.py -q`
- `hatch run prepare`
- Repository pre-commit checks, including build, tests, lint, formatting, and type checks

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
