### PR TITLE
feat(mcp-py): added MRTR input-required support for 2.x

### DIFF
--- a/.github/workflows/python-test-lint.yml
+++ b/.github/workflows/python-test-lint.yml
@@ -122,14 +122,22 @@ jobs:
             "pytest>=9.0.0,<10.0.0" \
             "pytest-asyncio>=1.0.0,<1.5.0" \
             "pytest-timeout>=2.0.0,<3.0.0" \
+            "pytest-cov>=6.0.0,<8.0.0" \
             "moto>=5.1.0,<6.0.0"
           pip install --no-cache-dir "mcp==2.0.*"
 
       - name: Verify import and version flag
         run: python -c "import strands; from strands.tools.mcp import _compat; assert _compat.MCP_V2"
 
+      # With coverage: the 2.x branches of `_compat` execute only in this job,
+      # so without this upload they always show as uncovered on the patch.
       - name: Run compat tests
-        run: pytest tests/strands/tools/mcp/test__compat.py -vv
+        run: pytest tests/strands/tools/mcp/test__compat.py -vv --cov=src/strands --cov-report=xml
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   lint:
     name: Lint

--- a/strands-py/src/strands/tools/mcp/_compat.py
+++ b/strands-py/src/strands/tools/mcp/_compat.py
@@ -26,6 +26,7 @@ __all__ = [
     "MCP_V2",
     "GetSessionIdCallback",
     "MCPError",
+    "call_tool",
     "input_schema",
     "is_error",
     "mime_type",
@@ -58,6 +59,82 @@ except ImportError:
     from collections.abc import Callable
 
     GetSessionIdCallback = Callable[[], str | None]  # type: ignore[misc, assignment]
+
+
+async def call_tool(
+    session: ClientSession,
+    name: str,
+    arguments: dict[str, Any] | None,
+    read_timeout_seconds: timedelta | None,
+    progress_callback: Any,
+    meta: Any,
+) -> Any:
+    """Call a tool on an active session, on either `mcp` major line.
+
+    The 2026-07-28 spec (SEP-2322) replaced server-initiated requests with
+    multi round-trip requests: instead of sending `elicitation/create` back
+    to the client mid-call, the server returns an `InputRequiredResult`, and
+    the client resolves the embedded input requests and retries the call
+    carrying the responses and the echoed opaque `request_state`. The 2.x
+    branch resolves each embedded request through
+    `session.dispatch_input_request`, the same callback table that serves
+    1.x server-initiated requests, so an `elicitation_callback` passed to
+    `ClientSession` behaves the same on both lines.
+
+    The retry loop is `mcp.client._input_required.run_input_required_driver`,
+    which the 2.x line's own high-level client uses but does not re-export
+    from a public module, so the forced-2.x CI job is what catches a
+    relocation.
+
+    Args:
+        session: An active, negotiated `ClientSession`.
+        name: The tool name as the server knows it.
+        arguments: Arguments to pass to the tool.
+        read_timeout_seconds: Timeout for each request round, if any.
+        progress_callback: Callback for progress notifications, if any.
+        meta: Request metadata (`_meta`) to send with the call, if any.
+
+    Returns:
+        The terminal `CallToolResult`.
+
+    Raises:
+        MCPError: An embedded input request's callback declined it.
+        InputRequiredRoundsExceededError: The server kept returning
+            `InputRequiredResult` past the driver's round cap.
+    """
+    if not MCP_V2:
+        return await session.call_tool(
+            name, arguments, read_timeout_seconds, progress_callback=progress_callback, meta=meta
+        )
+
+    from mcp.client._input_required import run_input_required_driver  # type: ignore[import-not-found]
+    from mcp.client.session import ClientRequestContext  # type: ignore[attr-defined]
+    from mcp.types import InputRequiredResult  # type: ignore[attr-defined]
+
+    timeout = read_timeout(read_timeout_seconds)
+
+    async def retry(input_responses: Any, request_state: str | None) -> Any:
+        return await session.call_tool(  # type: ignore[call-arg]
+            name,
+            arguments,
+            timeout,  # type: ignore[arg-type]
+            progress_callback=progress_callback,
+            meta=meta,
+            input_responses=input_responses,
+            request_state=request_state,
+            allow_input_required=True,
+        )
+
+    async def dispatch(key: str, request: Any) -> Any:
+        context = ClientRequestContext(
+            session=session, request_id=key, meta=request.params.meta if request.params else None
+        )
+        return await session.dispatch_input_request(context, request)  # type: ignore[attr-defined]
+
+    result = await retry(None, None)
+    if not isinstance(result, InputRequiredResult):
+        return result
+    return await run_input_required_driver(result, dispatch=dispatch, retry=retry)
 
 
 def input_schema(tool: Any) -> dict[str, Any]:
@@ -140,7 +217,7 @@ def output_schema(tool: Any) -> dict[str, Any] | None:
     return schema
 
 
-def read_timeout(timeout: timedelta | None) -> Any:
+def read_timeout(timeout: timedelta | None) -> float | timedelta | None:
     """Convert a tool call read timeout to the form the installed `mcp` line takes.
 
     The session `call_tool` takes `read_timeout_seconds` as a `timedelta` on

--- a/strands-py/src/strands/tools/mcp/_compat.py
+++ b/strands-py/src/strands/tools/mcp/_compat.py
@@ -84,7 +84,10 @@ async def call_tool(
     The retry loop is `mcp.client._input_required.run_input_required_driver`,
     which the 2.x line's own high-level client uses but does not re-export
     from a public module, so the forced-2.x CI job is what catches a
-    relocation.
+    relocation. It is used over the alternatives deliberately: the public
+    `mcp.client.Client` owns connection lifecycle that `MCPClient` manages
+    itself, and a hand-written loop would duplicate the driver's concurrent
+    dispatch, state-only backoff, and round-cap semantics.
 
     Args:
         session: An active, negotiated `ClientSession`.

--- a/strands-py/src/strands/tools/mcp/_compat.py
+++ b/strands-py/src/strands/tools/mcp/_compat.py
@@ -13,6 +13,7 @@ per-module `warn_unused_ignores` override in pyproject.toml silences the
 ignores the installed line doesn't need.
 """
 
+import asyncio
 from collections.abc import AsyncIterator
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from datetime import timedelta
@@ -44,6 +45,11 @@ __all__ = [
 # resolve by capability: `ClientSession.discover` is the 2.x replacement for
 # the removed initialize handshake.
 MCP_V2: bool = hasattr(ClientSession, "discover")
+
+# The official SDKs' shared default for SEP-2322 multi round-trip retries.
+_INPUT_REQUIRED_MAX_ROUNDS = 10
+
+_STATE_ONLY_RETRY_DELAY_SECONDS = 0.05
 
 try:
     from mcp.shared.exceptions import MCPError  # type: ignore[attr-defined]
@@ -81,13 +87,14 @@ async def call_tool(
     1.x server-initiated requests, so an `elicitation_callback` passed to
     `ClientSession` behaves the same on both lines.
 
-    The retry loop is `mcp.client._input_required.run_input_required_driver`,
-    which the 2.x line's own high-level client uses but does not re-export
-    from a public module, so the forced-2.x CI job is what catches a
-    relocation. It is used over the alternatives deliberately: the public
-    `mcp.client.Client` owns connection lifecycle that `MCPClient` manages
-    itself, and a hand-written loop would duplicate the driver's concurrent
-    dispatch, state-only backoff, and round-cap semantics.
+    The retry loop below stands on public 2.x API only: the `call_tool`
+    keywords, `dispatch_input_request` (whose docstring names exactly this
+    use), and `ClientRequestContext` / `InputRequiredRoundsExceededError`
+    from `mcp.client`. The `mcp` package ships its own loop, but only inside
+    the high-level `mcp.client.Client` (which owns connection lifecycle that
+    `MCPClient` manages itself) and a private module. Embedded requests are
+    dispatched one at a time, so a callback's exception propagates as
+    itself.
 
     Args:
         session: An active, negotiated `ClientSession`.
@@ -103,20 +110,19 @@ async def call_tool(
     Raises:
         MCPError: An embedded input request's callback declined it.
         InputRequiredRoundsExceededError: The server kept returning
-            `InputRequiredResult` past the driver's round cap.
+            `InputRequiredResult` past the round cap.
     """
     if not MCP_V2:
         return await session.call_tool(
             name, arguments, read_timeout_seconds, progress_callback=progress_callback, meta=meta
         )
 
-    from mcp.client._input_required import run_input_required_driver  # type: ignore[import-not-found]
-    from mcp.client.session import ClientRequestContext  # type: ignore[attr-defined]
-    from mcp.types import InputRequiredResult  # type: ignore[attr-defined]
+    from mcp.client import ClientRequestContext, InputRequiredRoundsExceededError  # type: ignore[attr-defined]
+    from mcp.types import ErrorData, InputRequiredResult  # type: ignore[attr-defined]
 
     timeout = read_timeout(read_timeout_seconds)
 
-    async def retry(input_responses: Any, request_state: str | None) -> Any:
+    async def call_once(input_responses: Any, request_state: str | None) -> Any:
         return await session.call_tool(  # type: ignore[call-arg]
             name,
             arguments,
@@ -128,16 +134,27 @@ async def call_tool(
             allow_input_required=True,
         )
 
-    async def dispatch(key: str, request: Any) -> Any:
-        context = ClientRequestContext(
-            session=session, request_id=key, meta=request.params.meta if request.params else None
-        )
-        return await session.dispatch_input_request(context, request)  # type: ignore[attr-defined]
-
-    result = await retry(None, None)
-    if not isinstance(result, InputRequiredResult):
-        return result
-    return await run_input_required_driver(result, dispatch=dispatch, retry=retry)
+    result = await call_once(None, None)
+    for _ in range(_INPUT_REQUIRED_MAX_ROUNDS):
+        if not isinstance(result, InputRequiredResult):
+            return result
+        responses: dict[str, Any] = {}
+        for key, request in (result.input_requests or {}).items():
+            context = ClientRequestContext(
+                session=session, request_id=key, meta=request.params.meta if request.params else None
+            )
+            response = await session.dispatch_input_request(context, request)  # type: ignore[attr-defined]
+            if isinstance(response, ErrorData):
+                raise MCPError(code=response.code, message=response.message, data=response.data)
+            responses[key] = response
+        if not responses:
+            # A state-only result asks the client to poll: wait a beat so the
+            # retry loop cannot hammer the server.
+            await asyncio.sleep(_STATE_ONLY_RETRY_DELAY_SECONDS)
+        result = await call_once(responses or None, result.request_state)
+    if isinstance(result, InputRequiredResult):
+        raise InputRequiredRoundsExceededError(_INPUT_REQUIRED_MAX_ROUNDS)
+    return result
 
 
 def input_schema(tool: Any) -> dict[str, Any]:

--- a/strands-py/src/strands/tools/mcp/mcp_agent_tool.py
+++ b/strands-py/src/strands/tools/mcp/mcp_agent_tool.py
@@ -44,7 +44,8 @@ class MCPAgentTool(AgentTool):
             mcp_client: The MCP server connection to use for tool invocation
             name_override: Optional name to use for the agent tool (for disambiguation)
                            If None, uses the original MCP tool name
-            timeout: Optional timeout duration for tool execution
+            timeout: Optional timeout duration for tool execution. On the mcp 2.x line, the timeout
+                     bounds each request round of a multi round-trip tool call rather than the call as a whole.
         """
         super().__init__()
         logger.debug("tool_name=<%s> | creating mcp agent tool", mcp_tool.name)

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -68,12 +68,12 @@ from ._compat import (
     mime_type,
     negotiate_session,
     next_cursor,
-    read_timeout,
     resource_templates,
     streamable_http_transport,
     structured_content,
     task_support,
 )
+from ._compat import call_tool as compat_call_tool
 from .mcp_agent_tool import MCPAgentTool
 from .mcp_instrumentation import inject_trace_context, mcp_instrumentation
 from .mcp_tasks import DEFAULT_TASK_CONFIG, DEFAULT_TASK_POLL_TIMEOUT, DEFAULT_TASK_TTL, TasksConfig
@@ -877,13 +877,15 @@ class MCPClient(ToolProvider):
                     request_id = getattr(session, "_request_id", None)
                     if isinstance(request_id, int):
                         cancellation_state["request_id"] = request_id
-                return await session.call_tool(
+                result = await compat_call_tool(
+                    session,
                     name,
                     arguments,
-                    read_timeout(read_timeout_seconds),
-                    progress_callback=effective_callback,
-                    meta=meta,
+                    read_timeout_seconds,
+                    effective_callback,
+                    meta,
                 )
+                return cast(MCPCallToolResult, result)
 
             return _call_tool_direct()
 
@@ -1074,8 +1076,10 @@ class MCPClient(ToolProvider):
             content=mapped_contents,
         )
 
+        # `is not None`, not truthiness: the 2026-07-28 spec allows any JSON
+        # value here, so 0, False, "", [], and {} are all valid payloads.
         structured_payload = structured_content(call_tool_result)
-        if structured_payload:
+        if structured_payload is not None:
             result["structuredContent"] = structured_payload
         if call_tool_result.meta:
             result["metadata"] = call_tool_result.meta

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -819,7 +819,8 @@ class MCPClient(ToolProvider):
         Args:
             name: Name of the tool to call.
             arguments: Optional arguments to pass to the tool.
-            read_timeout_seconds: Optional timeout for the tool call.
+            read_timeout_seconds: Optional timeout for the tool call. On the mcp 2.x line, the timeout
+                bounds each request round of a multi round-trip tool call rather than the call as a whole.
             meta: Optional metadata to pass to the tool call per MCP spec (_meta).
             progress_callback: Optional callback to receive progress notifications.
                 If None, falls back to the instance-level callback set at construction time.
@@ -909,7 +910,8 @@ class MCPClient(ToolProvider):
             tool_use_id: Unique identifier for this tool use
             name: Name of the tool to call
             arguments: Optional arguments to pass to the tool
-            read_timeout_seconds: Optional timeout for the tool call
+            read_timeout_seconds: Optional timeout for the tool call. On the mcp 2.x line, the timeout
+                bounds each request round of a multi round-trip tool call rather than the call as a whole.
             meta: Optional metadata to pass to the tool call per MCP spec (_meta)
             progress_callback: Optional callback to receive progress notifications for this
                 call. Overrides the instance-level callback set at construction time.
@@ -966,7 +968,8 @@ class MCPClient(ToolProvider):
             tool_use_id: Unique identifier for this tool use
             name: Name of the tool to call
             arguments: Optional arguments to pass to the tool
-            read_timeout_seconds: Optional timeout for the tool call
+            read_timeout_seconds: Optional timeout for the tool call. On the mcp 2.x line, the timeout
+                bounds each request round of a multi round-trip tool call rather than the call as a whole.
             meta: Optional metadata to pass to the tool call per MCP spec (_meta)
             progress_callback: Optional callback to receive progress notifications for this
                 call. Overrides the instance-level callback set at construction time.

--- a/strands-py/tests/strands/tools/mcp/test__compat.py
+++ b/strands-py/tests/strands/tools/mcp/test__compat.py
@@ -117,6 +117,23 @@ def test_installed_line_call_tool_takes_the_arguments_mcp_client_passes():
     assert isinstance(_compat.read_timeout(timedelta(seconds=30)), expected_timeout_type)
 
 
+@requires_mcp_v2
+def test_installed_v2_line_exposes_the_input_required_names():
+    """Test that the names the 2.x `call_tool` branch imports exist on the installed line."""
+    from mcp import ClientSession
+    from mcp.client._input_required import run_input_required_driver
+    from mcp.client.session import ClientRequestContext
+    from mcp.types import InputRequiredResult
+
+    assert callable(run_input_required_driver)
+    assert callable(ClientSession.dispatch_input_request)
+    assert {"session", "request_id", "meta"} <= set(inspect.signature(ClientRequestContext).parameters)
+    assert "input_requests" in InputRequiredResult.model_fields
+    call_tool_parameters = inspect.signature(ClientSession.call_tool).parameters
+    for parameter_name in ("input_responses", "request_state", "allow_input_required"):
+        assert parameter_name in call_tool_parameters, parameter_name
+
+
 def test_next_cursor_v1_reads_the_camel_case_field(monkeypatch):
     """Test that the 1.x branch reads the result's `nextCursor` field."""
     monkeypatch.setattr(_compat, "MCP_V2", False)
@@ -252,6 +269,123 @@ def test_read_timeout_v2_converts_to_seconds(monkeypatch):
 def test_read_timeout_passes_none_through():
     """Test that an absent timeout stays absent on either line."""
     assert _compat.read_timeout(None) is None
+
+
+@pytest.mark.asyncio
+async def test_call_tool_v1_sends_a_single_request(monkeypatch):
+    """Test that the 1.x branch calls the session once, with the timeout as a `timedelta`."""
+    monkeypatch.setattr(_compat, "MCP_V2", False)
+    terminal_result = MagicMock()
+    session = MagicMock()
+    session.call_tool = AsyncMock(return_value=terminal_result)
+    progress_callback = MagicMock()
+    timeout = timedelta(seconds=30)
+
+    result = await _compat.call_tool(session, "echo", {"to_echo": "x"}, timeout, progress_callback, {"trace": "id"})
+
+    assert result is terminal_result
+    session.call_tool.assert_awaited_once_with(
+        "echo", {"to_echo": "x"}, timeout, progress_callback=progress_callback, meta={"trace": "id"}
+    )
+
+
+@requires_mcp_v2
+@pytest.mark.asyncio
+async def test_call_tool_v2_returns_a_terminal_result_without_retrying():
+    """Test that the 2.x branch opts into input-required results and returns a terminal result as-is."""
+    from mcp.types import CallToolResult, TextContent
+
+    terminal_result = CallToolResult(content=[TextContent(type="text", text="done")])
+    session = MagicMock()
+    session.call_tool = AsyncMock(return_value=terminal_result)
+
+    result = await _compat.call_tool(session, "echo", {"to_echo": "x"}, timedelta(seconds=30), None, None)
+
+    assert result is terminal_result
+    session.call_tool.assert_awaited_once()
+    assert session.call_tool.await_args.args[2] == 30.0
+    assert session.call_tool.await_args.kwargs["allow_input_required"] is True
+
+
+@requires_mcp_v2
+@pytest.mark.asyncio
+async def test_call_tool_v2_resolves_input_required_through_the_callback_table():
+    """Test that the 2.x branch resolves an `InputRequiredResult` and retries with the responses.
+
+    The embedded elicit request must reach `dispatch_input_request` (the same
+    callback table that serves 1.x server-initiated requests), and the retry
+    must carry the collected responses and the echoed `request_state`.
+    """
+    from mcp.types import (
+        CallToolResult,
+        ElicitRequest,
+        ElicitRequestFormParams,
+        ElicitResult,
+        InputRequiredResult,
+        TextContent,
+    )
+
+    elicit_request = ElicitRequest(
+        method="elicitation/create",
+        params=ElicitRequestFormParams(
+            mode="form",
+            message="need a value",
+            requested_schema={"type": "object", "properties": {"value": {"type": "string"}}},
+        ),
+    )
+    input_required = InputRequiredResult(input_requests={"q1": elicit_request}, request_state="state-1")
+    terminal_result = CallToolResult(content=[TextContent(type="text", text="done")])
+    elicit_result = ElicitResult(action="accept", content={"value": "x"})
+    session = MagicMock()
+    session.call_tool = AsyncMock(side_effect=[input_required, terminal_result])
+    session.dispatch_input_request = AsyncMock(return_value=elicit_result)
+
+    result = await _compat.call_tool(session, "ask", None, None, None, None)
+
+    assert result is terminal_result
+    dispatched_request = session.dispatch_input_request.await_args.args[1]
+    assert dispatched_request is elicit_request
+    retry_kwargs = session.call_tool.await_args_list[1].kwargs
+    assert retry_kwargs["input_responses"] == {"q1": elicit_result}
+    assert retry_kwargs["request_state"] == "state-1"
+
+
+@requires_mcp_v2
+@pytest.mark.asyncio
+async def test_call_tool_v2_retries_without_request_state_when_the_server_sent_none():
+    """Test that a retry carries no `request_state` when the `InputRequiredResult` had none.
+
+    The MRTR spec: "If the `InputRequiredResult` does not contain a
+    `requestState` field, the client MUST NOT include one in the retry."
+    """
+    from mcp.types import (
+        CallToolResult,
+        ElicitRequest,
+        ElicitRequestFormParams,
+        ElicitResult,
+        InputRequiredResult,
+        TextContent,
+    )
+
+    elicit_request = ElicitRequest(
+        method="elicitation/create",
+        params=ElicitRequestFormParams(
+            mode="form",
+            message="need a value",
+            requested_schema={"type": "object", "properties": {"value": {"type": "string"}}},
+        ),
+    )
+    input_required = InputRequiredResult(input_requests={"q1": elicit_request})
+    terminal_result = CallToolResult(content=[TextContent(type="text", text="done")])
+    session = MagicMock()
+    session.call_tool = AsyncMock(side_effect=[input_required, terminal_result])
+    session.dispatch_input_request = AsyncMock(return_value=ElicitResult(action="accept", content={"value": "x"}))
+
+    result = await _compat.call_tool(session, "ask", None, None, None, None)
+
+    assert result is terminal_result
+    retry_kwargs = session.call_tool.await_args_list[1].kwargs
+    assert retry_kwargs["request_state"] is None
 
 
 def test_mcp_error_resolves_to_installed_exception():

--- a/strands-py/tests/strands/tools/mcp/test__compat.py
+++ b/strands-py/tests/strands/tools/mcp/test__compat.py
@@ -121,11 +121,10 @@ def test_installed_line_call_tool_takes_the_arguments_mcp_client_passes():
 def test_installed_v2_line_exposes_the_input_required_names():
     """Test that the names the 2.x `call_tool` branch imports exist on the installed line."""
     from mcp import ClientSession
-    from mcp.client._input_required import run_input_required_driver
-    from mcp.client.session import ClientRequestContext
+    from mcp.client import ClientRequestContext, InputRequiredRoundsExceededError
     from mcp.types import InputRequiredResult
 
-    assert callable(run_input_required_driver)
+    assert issubclass(InputRequiredRoundsExceededError, Exception)
     assert callable(ClientSession.dispatch_input_request)
     assert {"session", "request_id", "meta"} <= set(inspect.signature(ClientRequestContext).parameters)
     assert "input_requests" in InputRequiredResult.model_fields
@@ -400,6 +399,34 @@ async def test_call_tool_v2_retries_without_request_state_when_the_server_sent_n
 
 @requires_mcp_v2
 @pytest.mark.asyncio
+async def test_call_tool_v2_polls_after_a_state_only_result(monkeypatch):
+    """Test that a result with only a `request_state` waits, then retries carrying no responses.
+
+    A state-only `InputRequiredResult` asks the client to poll: there is nothing
+    to dispatch, so the retry must send `input_responses=None` rather than an
+    empty map, and must not hammer the server.
+    """
+    from mcp.types import CallToolResult, InputRequiredResult, TextContent
+
+    terminal_result = CallToolResult(content=[TextContent(type="text", text="done")])
+    session = MagicMock()
+    session.call_tool = AsyncMock(side_effect=[InputRequiredResult(request_state="state-1"), terminal_result])
+    session.dispatch_input_request = AsyncMock()
+    sleep = AsyncMock()
+    monkeypatch.setattr("asyncio.sleep", sleep)
+
+    result = await _compat.call_tool(session, "ask", None, None, None, None)
+
+    assert result is terminal_result
+    session.dispatch_input_request.assert_not_awaited()
+    sleep.assert_awaited_once_with(_compat._STATE_ONLY_RETRY_DELAY_SECONDS)
+    retry_kwargs = session.call_tool.await_args_list[1].kwargs
+    assert retry_kwargs["input_responses"] is None
+    assert retry_kwargs["request_state"] == "state-1"
+
+
+@requires_mcp_v2
+@pytest.mark.asyncio
 async def test_call_tool_v2_dispatches_each_request_under_its_own_key():
     """Test that each embedded request dispatches with its server key and its own `_meta`, if any."""
     from mcp.types import (
@@ -442,6 +469,88 @@ async def test_call_tool_v2_dispatches_each_request_under_its_own_key():
     assert dispatched.keys() == {"q1", "r1"}
     assert dispatched["q1"].meta == {"traceparent": "tp"}
     assert dispatched["r1"].meta is None
+
+
+@requires_mcp_v2
+@pytest.mark.asyncio
+async def test_call_tool_v2_raises_when_a_callback_declines_an_input_request():
+    """Test that a declined embedded request aborts the call as an `MCPError`."""
+    from mcp.types import ElicitRequest, ElicitRequestFormParams, ErrorData, InputRequiredResult
+
+    elicit_request = ElicitRequest(
+        method="elicitation/create",
+        params=ElicitRequestFormParams(
+            mode="form",
+            message="need a value",
+            requested_schema={"type": "object", "properties": {}},
+        ),
+    )
+    session = MagicMock()
+    session.call_tool = AsyncMock(return_value=InputRequiredResult(input_requests={"q1": elicit_request}))
+    session.dispatch_input_request = AsyncMock(return_value=ErrorData(code=-32601, message="Elicitation not supported"))
+
+    with pytest.raises(MCPError, match="Elicitation not supported"):
+        await _compat.call_tool(session, "ask", None, None, None, None)
+
+    session.call_tool.assert_awaited_once()
+
+
+@requires_mcp_v2
+@pytest.mark.asyncio
+async def test_call_tool_v2_stops_after_the_round_cap():
+    """Test that a server returning `InputRequiredResult` forever fails instead of looping."""
+    from mcp.client import InputRequiredRoundsExceededError
+    from mcp.types import ElicitRequest, ElicitRequestFormParams, ElicitResult, InputRequiredResult
+
+    elicit_request = ElicitRequest(
+        method="elicitation/create",
+        params=ElicitRequestFormParams(
+            mode="form",
+            message="need a value",
+            requested_schema={"type": "object", "properties": {}},
+        ),
+    )
+    session = MagicMock()
+    session.call_tool = AsyncMock(return_value=InputRequiredResult(input_requests={"q1": elicit_request}))
+    session.dispatch_input_request = AsyncMock(return_value=ElicitResult(action="accept", content={}))
+
+    with pytest.raises(InputRequiredRoundsExceededError):
+        await _compat.call_tool(session, "ask", None, None, None, None)
+
+    # The initial call plus one retry for each allowed round.
+    assert session.call_tool.await_count == 11
+
+
+@requires_mcp_v2
+@pytest.mark.asyncio
+async def test_call_tool_v2_returns_a_terminal_result_from_the_last_allowed_round():
+    """Test that a terminal result on the last allowed retry is returned, not read as an overrun."""
+    from mcp.types import (
+        CallToolResult,
+        ElicitRequest,
+        ElicitRequestFormParams,
+        ElicitResult,
+        InputRequiredResult,
+        TextContent,
+    )
+
+    elicit_request = ElicitRequest(
+        method="elicitation/create",
+        params=ElicitRequestFormParams(
+            mode="form", message="need a value", requested_schema={"type": "object", "properties": {}}
+        ),
+    )
+    input_required = InputRequiredResult(input_requests={"q1": elicit_request})
+    terminal_result = CallToolResult(content=[TextContent(type="text", text="done")])
+    session = MagicMock()
+    # Input-required for every allowed round, terminal on the last retry.
+    session.call_tool = AsyncMock(side_effect=[input_required] * 10 + [terminal_result])
+    session.dispatch_input_request = AsyncMock(return_value=ElicitResult(action="accept", content={}))
+
+    result = await _compat.call_tool(session, "ask", None, None, None, None)
+
+    assert result is terminal_result
+    assert session.call_tool.await_count == 11
 
 
 def test_mcp_error_resolves_to_installed_exception():

--- a/strands-py/tests/strands/tools/mcp/test__compat.py
+++ b/strands-py/tests/strands/tools/mcp/test__compat.py
@@ -298,13 +298,23 @@ async def test_call_tool_v2_returns_a_terminal_result_without_retrying():
     terminal_result = CallToolResult(content=[TextContent(type="text", text="done")])
     session = MagicMock()
     session.call_tool = AsyncMock(return_value=terminal_result)
+    progress_callback = MagicMock()
 
-    result = await _compat.call_tool(session, "echo", {"to_echo": "x"}, timedelta(seconds=30), None, None)
+    result = await _compat.call_tool(
+        session, "echo", {"to_echo": "x"}, timedelta(seconds=30), progress_callback, {"trace": "id"}
+    )
 
     assert result is terminal_result
-    session.call_tool.assert_awaited_once()
-    assert session.call_tool.await_args.args[2] == 30.0
-    assert session.call_tool.await_args.kwargs["allow_input_required"] is True
+    session.call_tool.assert_awaited_once_with(
+        "echo",
+        {"to_echo": "x"},
+        30.0,
+        progress_callback=progress_callback,
+        meta={"trace": "id"},
+        input_responses=None,
+        request_state=None,
+        allow_input_required=True,
+    )
 
 
 @requires_mcp_v2
@@ -386,6 +396,52 @@ async def test_call_tool_v2_retries_without_request_state_when_the_server_sent_n
     assert result is terminal_result
     retry_kwargs = session.call_tool.await_args_list[1].kwargs
     assert retry_kwargs["request_state"] is None
+
+
+@requires_mcp_v2
+@pytest.mark.asyncio
+async def test_call_tool_v2_dispatches_each_request_under_its_own_key():
+    """Test that each embedded request dispatches with its server key and its own `_meta`, if any."""
+    from mcp.types import (
+        CallToolResult,
+        ElicitRequest,
+        ElicitRequestFormParams,
+        ElicitResult,
+        InputRequiredResult,
+        ListRootsRequest,
+        ListRootsResult,
+        TextContent,
+    )
+
+    elicit_request = ElicitRequest(
+        method="elicitation/create",
+        params=ElicitRequestFormParams(
+            mode="form",
+            message="need a value",
+            requested_schema={"type": "object", "properties": {}},
+            _meta={"traceparent": "tp"},
+        ),
+    )
+    roots_request = ListRootsRequest(method="roots/list")
+    input_required = InputRequiredResult(input_requests={"q1": elicit_request, "r1": roots_request})
+    terminal_result = CallToolResult(content=[TextContent(type="text", text="done")])
+    session = MagicMock()
+    session.call_tool = AsyncMock(side_effect=[input_required, terminal_result])
+    session.dispatch_input_request = AsyncMock(
+        side_effect=lambda context, request: (
+            ElicitResult(action="accept", content={"value": "x"})
+            if isinstance(request, ElicitRequest)
+            else ListRootsResult(roots=[])
+        )
+    )
+
+    result = await _compat.call_tool(session, "ask", None, None, None, None)
+
+    assert result is terminal_result
+    dispatched = {call.args[0].request_id: call.args[0] for call in session.dispatch_input_request.await_args_list}
+    assert dispatched.keys() == {"q1", "r1"}
+    assert dispatched["q1"].meta == {"traceparent": "tp"}
+    assert dispatched["r1"].meta is None
 
 
 def test_mcp_error_resolves_to_installed_exception():

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client.py
@@ -156,9 +156,11 @@ def test_call_tool_sync_without_error_flag(mock_transport, mock_session):
     with MCPClient(mock_transport["transport_callable"]) as client:
         result = client.call_tool_sync(tool_use_id="test-123", name="test_tool", arguments={"param": "value"})
 
-        assert result["status"] == "success"
-        assert result["content"][0]["text"] == "Test message"
-        assert "isError" not in result
+        assert result == {
+            "status": "success",
+            "toolUseId": "test-123",
+            "content": [{"text": "Test message"}],
+        }
 
 
 def test_call_tool_sync_session_not_active():
@@ -1073,10 +1075,12 @@ def test_call_tool_sync_image_content(mock_transport, mock_session):
     with MCPClient(mock_transport["transport_callable"]) as client:
         result = client.call_tool_sync(tool_use_id="img-1", name="get_image", arguments={})
 
-        assert result["status"] == "success"
-        assert len(result["content"]) == 1
-        assert result["content"][0]["image"]["format"] == "png"
-        assert result["content"][0]["image"]["source"]["bytes"] == png_data
+        assert result == {
+            "status": "success",
+            "toolUseId": "img-1",
+            "content": [{"image": {"format": "png", "source": {"bytes": png_data}}}],
+            "isError": False,
+        }
 
 
 def test_call_tool_sync_embedded_nested_text(mock_transport, mock_session):

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client.py
@@ -163,6 +163,39 @@ def test_call_tool_sync_without_error_flag(mock_transport, mock_session):
         }
 
 
+def test_call_tool_sync_with_falsy_structured_content(mock_transport, mock_session):
+    """Test that an empty structured payload is forwarded, not dropped as falsy.
+
+    The 2026-07-28 spec allows any JSON value in `structuredContent`, so `0`,
+    `False`, `""`, `[]`, and `{}` are all valid payloads.
+    """
+    mock_content = MCPTextContent(type="text", text="Test message")
+    mock_session.call_tool.return_value = MCPCallToolResult(isError=False, content=[mock_content], structuredContent={})
+
+    with MCPClient(mock_transport["transport_callable"]) as client:
+        result = client.call_tool_sync(tool_use_id="test-123", name="test_tool", arguments={"param": "value"})
+
+        assert result == {
+            "status": "success",
+            "toolUseId": "test-123",
+            "content": [{"text": "Test message"}],
+            "structuredContent": {},
+            "isError": False,
+        }
+
+
+def test_call_tool_sync_calls_the_tool_through_the_compat_shim(mock_transport, mock_session):
+    """Test that the direct tool-call path calls the tool through the version shim."""
+    mock_content = MCPTextContent(type="text", text="Test message")
+    shim = AsyncMock(return_value=MCPCallToolResult(isError=False, content=[mock_content]))
+
+    with patch("strands.tools.mcp.mcp_client.compat_call_tool", shim):
+        with MCPClient(mock_transport["transport_callable"]) as client:
+            client.call_tool_sync(tool_use_id="test-123", name="test_tool", arguments={"param": "value"})
+
+    shim.assert_awaited_once_with(mock_session, "test_tool", {"param": "value"}, None, None, None)
+
+
 def test_call_tool_sync_session_not_active():
     """Test that call_tool_sync raises an error when session is not active."""
     client = MCPClient(MagicMock())


### PR DESCRIPTION
## Description
*Follow-up in the `mcp` 2.x upgrade. One behavior change is reachable on current installs (the `structuredContent` gate, below); the MRTR loop itself is inert while the pin holds `<2`.*

**Problem.** The 2026-07-28 spec (SEP-2322) removed server-initiated requests. A server that needs mid-call input no longer sends `elicitation/create` back over the connection; it returns an `InputRequiredResult` from `tools/call`, and the client must answer the embedded requests and retry the call. The 2.x `ClientSession` does not drive that loop itself, so on the 2.x line any tool that elicits mid-call fails with `RuntimeError` today.

**Change.** `_compat.call_tool` now owns the session tool call, and `MCPClient` calls it instead of `session.call_tool`:

- On 1.x: one request, exactly as before.
- On 2.x: the call opts into `allow_input_required=True`. When the server returns `InputRequiredResult`, the `mcp` package's own retry driver runs, answering each embedded request through `session.dispatch_input_request` and retrying with the responses and the echoed `request_state`.
- `dispatch_input_request` is the same callback table that serves 1.x server-initiated requests, so an `elicitation_callback` passed to `MCPClient` works identically on both versions. No public API change.
- A client with no callback fails the tool cleanly with an "Elicitation not supported" error result.

**Also in this PR** (small riders, called out so nothing is undisclosed):

- `structuredContent` is forwarded when it is not `None` instead of when truthy, the fix #4090's review asked for. This is reachable on the current pin: a tool returning `structuredContent: {}` now reaches the model where it was silently dropped before. The spec allows any JSON value there, so falsy payloads are valid.
- Timeout semantics documented: on the 2.x line, `read_timeout_seconds` bounds each request round of a multi round-trip call rather than the call as a whole (docstrings on `call_tool_sync`, `call_tool_async`, and `MCPAgentTool`).
- `read_timeout` returns `float | timedelta | None` instead of `Any`, and the 1.x branch passes the `timedelta` straight through.
- The two call_tool_sync tests from #4090 now assert the whole result object, following `docs/TESTING.md`.
- The `unit-test-mcp-v2` CI job now uploads coverage, so the 2.x-only lines of `_compat` stop showing as uncovered on the codecov patch check (they only ever execute in that job).

**Notes for review:**

- Behavior follows the [MRTR spec's client requirements](https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr): `request_state` is echoed untouched and omitted when the server sent none (a test quotes that requirement), every retry is a fresh JSON-RPC id, and retries cap at 10 rounds, the official SDKs' default.
- The retry loop uses public 2.x API only: the `call_tool` keywords, `session.dispatch_input_request` (whose docstring names exactly this use), and `ClientRequestContext` / `InputRequiredRoundsExceededError` from `mcp.client`. The `mcp` package ships its own loop, but only inside the high-level `Client` (which owns connection lifecycle that `MCPClient` manages itself) and a private module, so a ~20-line loop here beat depending on either. Embedded requests dispatch one at a time, so a callback's own exception propagates instead of an `ExceptionGroup`.
- Follow-up, out of scope: the spec also allows `InputRequiredResult` on `prompts/get` and `resources/read`; those paths get the same treatment in a later PR.

## Related Issues

#1659

## Documentation PR

No documentation changes needed; the compat module is internal and the public `MCPClient` API is unchanged.

## Type of Change

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`
- Full unit suite passes on `mcp` 1.x; compat tests pass against `mcp==2.0.*` (the `unit-test-mcp-v2` CI job).
- The new pinning tests were each verified to fail against the mutation they guard: reverting the `structuredContent` gate to truthiness, bypassing the compat call in `MCPClient`, dropping retry kwargs, and changing the dispatch context construction.
- End to end on `mcp` 2.0.x against an in-process 2026-07-28 server whose tool returns `InputRequiredResult`: the elicitation reached the registered callback, the retry carried the responses and `request_state`, and the terminal result came back. A client with no callback returned a clean error result.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

