### PR TITLE
feat(bidi): add reconnect() for openai

### DIFF
--- a/strands-py/src/strands/experimental/bidi/models/openai.py
+++ b/strands-py/src/strands/experimental/bidi/models/openai.py
@@ -38,7 +38,7 @@ from ..types.events import (
     Role,
     StopReason,
 )
-from ..types.model import AudioConfig
+from ..types.model import AudioConfig, BidiConnectionConfig
 from .model import BidiModel, BidiModelTimeoutError
 
 logger = logging.getLogger(__name__)
@@ -77,6 +77,14 @@ DEFAULT_SESSION_CONFIG = {
     },
 }
 
+# Sent as a system message after a reconnect. Replay restores the conversation text but not the
+# live audio state, so the fresh session can drift language or re-introduce itself; this steers it
+# to continue seamlessly.
+_RECONNECT_INSTRUCTION = (
+    "The connection was re-established mid-conversation. Continue seamlessly from the prior "
+    "context: do not greet or re-introduce yourself, and keep replying in the language already in use."
+)
+
 
 class OpenAIRealtimeModel(BidiModel):
     """OpenAI Realtime API implementation for bidirectional streaming.
@@ -108,6 +116,17 @@ class OpenAIRealtimeModel(BidiModel):
         """
         # Store model ID
         self.model_id = model_id
+
+        # OpenAI caps a realtime session at 60 min and emits no approaching-limit warning, so
+        # reconnect proactively with headroom below the cap; the client-side timeout in receive()
+        # (OPENAI_MAX_TIMEOUT_S) remains the reactive backstop. Tunable via
+        # provider_config["connection"], e.g. to lower restart_after_s for tests.
+        default_connection: BidiConnectionConfig = {"restart_after_s": OPENAI_MAX_TIMEOUT_S}
+        self.connection_config = cast(
+            BidiConnectionConfig, {**default_connection, **(provider_config or {}).get("connection", {})}
+        )
+        # OpenAI reports per-response token usage on response.done, not cumulative session totals.
+        self.usage_is_cumulative = False
 
         # Resolve client config with defaults and env vars
         self._client_config = self._resolve_client_config(client_config or {})
@@ -424,13 +443,19 @@ class OpenAIRealtimeModel(BidiModel):
 
         yield BidiConnectionStartEvent(connection_id=self._connection_id, model=self.model_id)
 
+        # Bind this reader to the connection it started on. After a reconnect swaps self._websocket,
+        # a still-draining superseded reader keeps reading its own (now-closed) socket rather than
+        # stealing messages from the connection that replaced it.
+        websocket = self._websocket
+        start_time = self._start_time
+
         while True:
-            duration = time.time() - self._start_time
+            duration = time.time() - start_time
             if duration >= self.timeout_s:
                 raise BidiModelTimeoutError(f"timeout_s=<{self.timeout_s}>")
 
             try:
-                message = await asyncio.wait_for(self._websocket.recv(), timeout=10)
+                message = await asyncio.wait_for(websocket.recv(), timeout=10)
             except asyncio.TimeoutError:
                 continue
 
@@ -795,6 +820,41 @@ class OpenAIRealtimeModel(BidiModel):
         await stop_all(stop_websocket, stop_connection)
 
         logger.debug("openai realtime connection closed")
+
+    async def reconnect(
+        self,
+        system_prompt: str | None = None,
+        tools: list[ToolSpec] | None = None,
+        messages: Messages | None = None,
+        **restart_kwargs: Any,
+    ) -> None:
+        """Reconnect by closing the connection and starting a new one, replaying history.
+
+        OpenAI's Realtime API exposes no server-side resume handle, so a reconnect re-establishes
+        the session and replays the accumulated conversation history to preserve context across the
+        swap.
+
+        Args:
+            system_prompt: System instructions for the new connection.
+            tools: Tool specifications for the new connection.
+            messages: Conversation history to replay into the new connection.
+            **restart_kwargs: Reserved for provider-specific restart options.
+        """
+        logger.debug("openai realtime reconnect starting")
+        await self.stop()
+        await self.start(system_prompt, tools, messages, **restart_kwargs)
+        # Re-anchor the fresh session so it continues the conversation rather than drifting.
+        await self._send_event(
+            {
+                "type": "conversation.item.create",
+                "item": {
+                    "type": "message",
+                    "role": "system",
+                    "content": [{"type": "input_text", "text": _RECONNECT_INSTRUCTION}],
+                },
+            }
+        )
+        logger.debug("connection_id=<%s> | openai realtime reconnect complete", self._connection_id)
 
     async def _send_event(self, event: dict[str, Any]) -> None:
         """Send event to OpenAI via WebSocket."""

--- a/strands-py/src/strands/experimental/bidi/models/openai.py
+++ b/strands-py/src/strands/experimental/bidi/models/openai.py
@@ -54,6 +54,10 @@ OpenAI documents a 60 minute limit on realtime sessions
 not emit any warnings when approaching the limit. As a workaround, we configure a max timeout client side to gracefully
 handle the connection closure. We set the max to 50 minutes to provide enough buffer before hitting the real limit.
 """
+# Proactive reconnect fires this many seconds below the reader's reactive timeout, leaving room for
+# the turn-boundary alignment wait so a mid-turn swap stays graceful instead of being preempted by
+# the reactive timeout firing at the same instant.
+OPENAI_PROACTIVE_RECONNECT_MARGIN_S = 300
 OPENAI_REALTIME_URL = "wss://api.openai.com/v1/realtime"
 DEFAULT_MODEL = "gpt-realtime"
 DEFAULT_SAMPLE_RATE = 24000
@@ -117,14 +121,6 @@ class OpenAIRealtimeModel(BidiModel):
         # Store model ID
         self.model_id = model_id
 
-        # OpenAI caps a realtime session at 60 min and emits no approaching-limit warning, so
-        # reconnect proactively with headroom below the cap; the client-side timeout in receive()
-        # (OPENAI_MAX_TIMEOUT_S) remains the reactive backstop. Tunable via
-        # provider_config["connection"], e.g. to lower restart_after_s for tests.
-        default_connection: BidiConnectionConfig = {"restart_after_s": OPENAI_MAX_TIMEOUT_S}
-        self.connection_config = cast(
-            BidiConnectionConfig, {**default_connection, **(provider_config or {}).get("connection", {})}
-        )
         # OpenAI reports per-response token usage on response.done, not cumulative session totals.
         self.usage_is_cumulative = False
 
@@ -144,6 +140,17 @@ class OpenAIRealtimeModel(BidiModel):
             raise ValueError(
                 f"timeout_s=<{self.timeout_s}>, max_timeout_s=<{OPENAI_MAX_TIMEOUT_S}> | timeout exceeds max limit"
             )
+
+        # OpenAI emits no approaching-limit warning, so reconnect proactively a margin below the
+        # reader's reactive timeout: the swap can then align to a turn boundary before the reactive
+        # path fires. Deriving from timeout_s keeps that headroom even when a caller lowers it.
+        # Tunable via provider_config["connection"], e.g. to lower restart_after_s for tests.
+        default_connection: BidiConnectionConfig = {
+            "restart_after_s": self.timeout_s - OPENAI_PROACTIVE_RECONNECT_MARGIN_S
+        }
+        self.connection_config = cast(
+            BidiConnectionConfig, {**default_connection, **(provider_config or {}).get("connection", {})}
+        )
 
         # Connection state (initialized in start())
         self._connection_id: str | None = None
@@ -843,17 +850,22 @@ class OpenAIRealtimeModel(BidiModel):
         logger.debug("openai realtime reconnect starting")
         await self.stop()
         await self.start(system_prompt, tools, messages, **restart_kwargs)
-        # Re-anchor the fresh session so it continues the conversation rather than drifting.
-        await self._send_event(
-            {
-                "type": "conversation.item.create",
-                "item": {
-                    "type": "message",
-                    "role": "system",
-                    "content": [{"type": "input_text", "text": _RECONNECT_INSTRUCTION}],
-                },
-            }
-        )
+        # Re-anchor the fresh session so it continues the conversation rather than drifting. This is
+        # a best-effort nudge: if the send fails, the connection is still healthy, so log and move on
+        # rather than let a failed nudge tear down the session.
+        try:
+            await self._send_event(
+                {
+                    "type": "conversation.item.create",
+                    "item": {
+                        "type": "message",
+                        "role": "system",
+                        "content": [{"type": "input_text", "text": _RECONNECT_INSTRUCTION}],
+                    },
+                }
+            )
+        except Exception as error:
+            logger.warning("error=<%s> | failed to send reconnect re-anchor message | continuing", error)
         logger.debug("connection_id=<%s> | openai realtime reconnect complete", self._connection_id)
 
     async def _send_event(self, event: dict[str, Any]) -> None:

--- a/strands-py/tests/strands/experimental/bidi/models/test_openai.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_openai.py
@@ -20,6 +20,7 @@ from strands.experimental.bidi.models.model import BidiModelTimeoutError
 from strands.experimental.bidi.models.openai import (
     _RECONNECT_INSTRUCTION,
     OPENAI_MAX_TIMEOUT_S,
+    OPENAI_PROACTIVE_RECONNECT_MARGIN_S,
     OpenAIRealtimeModel,
 )
 from strands.experimental.bidi.types.events import (
@@ -952,11 +953,19 @@ async def test_tool_result_document_content_raises_error(mock_websockets_connect
 
 
 def test_connection_config_defaults_and_override(api_key, mock_websockets_connect):
-    """Reconnect timing is declared for the proactive timer and is overridable."""
+    """Proactive reconnect fires a margin below the reactive timeout, and is overridable."""
     default_model = OpenAIRealtimeModel(client_config={"api_key": api_key})
-    assert default_model.connection_config == {"restart_after_s": OPENAI_MAX_TIMEOUT_S}
+    # Deadline sits below the reactive timeout so a mid-turn swap is not preempted by it.
+    assert default_model.connection_config == {
+        "restart_after_s": OPENAI_MAX_TIMEOUT_S - OPENAI_PROACTIVE_RECONNECT_MARGIN_S
+    }
+    assert default_model.connection_config["restart_after_s"] < default_model.timeout_s
     # OpenAI reports per-response usage, so it must not be treated as cumulative.
     assert default_model.usage_is_cumulative is False
+
+    # Lowering timeout_s keeps the headroom rather than recreating the tie.
+    lowered_model = OpenAIRealtimeModel(client_config={"api_key": api_key, "timeout_s": 1000})
+    assert lowered_model.connection_config["restart_after_s"] == 1000 - OPENAI_PROACTIVE_RECONNECT_MARGIN_S
 
     tuned_model = OpenAIRealtimeModel(
         client_config={"api_key": api_key},
@@ -982,14 +991,60 @@ async def test_reconnect_reestablishes_and_replays_history(mock_websockets_conne
     assert model._connection_id is not None
     assert model._connection_id != first_connection_id
 
-    # History was replayed into the new connection.
-    item_creates = [
-        json.loads(call[0][0])
+    # Real history replay: the user turn is recreated on the new connection. Filtering on the user
+    # role ensures the re-anchor system message (also an item.create) cannot satisfy this alone.
+    user_items = [
+        json.loads(call[0][0])["item"]
         for call in mock_ws.send.call_args_list
         if json.loads(call[0][0]).get("type") == "conversation.item.create"
+        and json.loads(call[0][0])["item"].get("role") == "user"
     ]
-    assert len(item_creates) > 0
+    assert user_items == [{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "Hello"}]}]
 
+    await model.stop()
+
+
+@pytest.mark.asyncio
+async def test_reconnect_forwards_tools(mock_websockets_connect, model, tool_spec):
+    """Tools are re-sent on reconnect so the new session can still call them."""
+    _, mock_ws = mock_websockets_connect
+
+    await model.start()
+    mock_ws.send.reset_mock()
+
+    await model.reconnect(tools=[tool_spec])
+
+    tool_names = [
+        tool["name"]
+        for call in mock_ws.send.call_args_list
+        if json.loads(call[0][0]).get("type") == "session.update"
+        for tool in json.loads(call[0][0])["session"].get("tools", [])
+    ]
+    assert tool_spec["name"] in tool_names
+
+    await model.stop()
+
+
+@pytest.mark.asyncio
+async def test_reconnect_survives_reanchor_send_failure(mock_websockets_connect, model):
+    """A failed re-anchor send is logged, not fatal: the reconnected session stays healthy."""
+    _, mock_ws = mock_websockets_connect
+
+    await model.start()
+
+    async def fail_on_anchor(message):
+        payload = json.loads(message)
+        if payload.get("type") == "conversation.item.create" and payload.get("item", {}).get("role") == "system":
+            raise RuntimeError("re-anchor send failed")
+
+    mock_ws.send.side_effect = fail_on_anchor
+
+    # Must not raise even though the re-anchor send fails.
+    await model.reconnect()
+
+    assert model._connection_id is not None
+
+    mock_ws.send.side_effect = None
     await model.stop()
 
 

--- a/strands-py/tests/strands/experimental/bidi/models/test_openai.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_openai.py
@@ -8,6 +8,7 @@ Tests the unified OpenAIRealtimeModel interface including:
 - Connection lifecycle management
 """
 
+import asyncio
 import base64
 import itertools
 import json
@@ -16,7 +17,11 @@ import unittest.mock
 import pytest
 
 from strands.experimental.bidi.models.model import BidiModelTimeoutError
-from strands.experimental.bidi.models.openai import OpenAIRealtimeModel
+from strands.experimental.bidi.models.openai import (
+    _RECONNECT_INSTRUCTION,
+    OPENAI_MAX_TIMEOUT_S,
+    OpenAIRealtimeModel,
+)
 from strands.experimental.bidi.types.events import (
     BidiAudioInputEvent,
     BidiAudioStreamEvent,
@@ -941,3 +946,116 @@ async def test_tool_result_document_content_raises_error(mock_websockets_connect
         await model.send(ToolResultEvent(tool_result))
 
     await model.stop()
+
+
+# Reconnect Tests
+
+
+def test_connection_config_defaults_and_override(api_key, mock_websockets_connect):
+    """Reconnect timing is declared for the proactive timer and is overridable."""
+    default_model = OpenAIRealtimeModel(client_config={"api_key": api_key})
+    assert default_model.connection_config == {"restart_after_s": OPENAI_MAX_TIMEOUT_S}
+    # OpenAI reports per-response usage, so it must not be treated as cumulative.
+    assert default_model.usage_is_cumulative is False
+
+    tuned_model = OpenAIRealtimeModel(
+        client_config={"api_key": api_key},
+        provider_config={"connection": {"restart_after_s": 25}},
+    )
+    assert tuned_model.connection_config["restart_after_s"] == 25
+
+
+@pytest.mark.asyncio
+async def test_reconnect_reestablishes_and_replays_history(mock_websockets_connect, model, system_prompt, messages):
+    """reconnect() closes the old socket, opens a new one, and replays conversation history."""
+    mock_connect, mock_ws = mock_websockets_connect
+
+    await model.start()
+    first_connection_id = model._connection_id
+    mock_ws.send.reset_mock()
+
+    await model.reconnect(system_prompt=system_prompt, messages=messages)
+
+    # Old socket closed, a new connection opened, and the connection identity advanced.
+    mock_ws.close.assert_called_once()
+    assert mock_connect.call_count == 2
+    assert model._connection_id is not None
+    assert model._connection_id != first_connection_id
+
+    # History was replayed into the new connection.
+    item_creates = [
+        json.loads(call[0][0])
+        for call in mock_ws.send.call_args_list
+        if json.loads(call[0][0]).get("type") == "conversation.item.create"
+    ]
+    assert len(item_creates) > 0
+
+    await model.stop()
+
+
+@pytest.mark.asyncio
+async def test_reconnect_sends_reanchor_system_message(mock_websockets_connect, model):
+    """reconnect() injects a system message so the fresh session continues rather than drifting."""
+    _, mock_ws = mock_websockets_connect
+
+    await model.start()
+    mock_ws.send.reset_mock()
+
+    await model.reconnect()
+
+    system_items = [
+        json.loads(call[0][0])["item"]
+        for call in mock_ws.send.call_args_list
+        if json.loads(call[0][0]).get("type") == "conversation.item.create"
+        and json.loads(call[0][0])["item"].get("role") == "system"
+    ]
+    assert system_items == [
+        {"type": "message", "role": "system", "content": [{"type": "input_text", "text": _RECONNECT_INSTRUCTION}]}
+    ]
+
+    await model.stop()
+
+
+@pytest.mark.asyncio
+async def test_receive_binds_websocket_per_reader(mock_websockets_connect, model):
+    """A superseded reader keeps reading its own socket after self._websocket is swapped.
+
+    Guards against a still-draining reader stealing messages from the connection that replaced it
+    on reconnect.
+    """
+    _, ws1 = mock_websockets_connect
+    await model.start()
+
+    audio_from_ws1 = json.dumps({"type": "response.output_audio.delta", "delta": "FROM_WS1"})
+    blocker = asyncio.Event()
+    call_count = itertools.count()
+
+    async def ws1_recv(*args, **kwargs):
+        # First read yields one audio delta; subsequent reads park so the reader stays on ws1.
+        if next(call_count) == 0:
+            return audio_from_ws1
+        await blocker.wait()
+        return audio_from_ws1
+
+    ws1.recv = unittest.mock.AsyncMock(side_effect=ws1_recv)
+
+    reader = model.receive()
+    await reader.__anext__()  # BidiConnectionStartEvent (reader not yet bound to a socket)
+    first = await reader.__anext__()  # binds to ws1, reads its message
+    assert isinstance(first, BidiAudioStreamEvent)
+    assert first.audio == "FROM_WS1"
+
+    # Swap in a replacement socket, as a reconnect would.
+    ws2 = unittest.mock.AsyncMock()
+    ws2.recv = unittest.mock.AsyncMock(
+        return_value=json.dumps({"type": "response.output_audio.delta", "delta": "FROM_WS2"})
+    )
+    model._websocket = ws2
+
+    # The bound reader stays parked on ws1 and never touches the replacement socket.
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(reader.__anext__(), timeout=0.2)
+    ws2.recv.assert_not_called()
+
+    blocker.set()
+    await reader.aclose()


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

Adds reconnect support to the OpenAI Realtime bidi provider.

## What this adds

  - **`connection_config` + `usage_is_cumulative`** — declares `restart_after_s` so the loop arms
    its proactive reconnect timer, and flags per-response token usage (not cumulative). The existing
    client-side `receive()` timeout stays as the reactive backstop.
  - **`reconnect()`** — OpenAI exposes no server-side session resume, so it closes the connection and
    starts a new one, replaying conversation history (including tool `function_call` /
    `function_call_output` items) to preserve context across the swap.
  - **Per-reader websocket binding in `receive()`** — a reader is bound to the socket it started on,
    so a superseded reader drains its own (now-closed) socket instead of stealing messages from the
    connection that replaced it.
  - **Post-reconnect re-anchor** — after reconnecting, a `system` message conversation item
    (`conversation.item.create` with a `RealtimeConversationItemSystemMessage`) is added to steer the
    fresh session to continue the existing conversation. Replay restores the text but not the live
    audio state, so without it the model can drift language or re-introduce itself on the first
    post-swap turn. This reduces, not eliminates, that drift.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

New feature

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [ ] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
