### PR TITLE
feat(bidi): implement LocalAgent

### DIFF
--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/hooks.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/hooks.mdx
@@ -7,6 +7,8 @@ experimental: true
 tags: [bidi-streaming, hooks]
 sourceLinks:
   - path: strands-py/src/strands/experimental/hooks/events.py
+  - path: strands-py/src/strands/hooks/events.py
+  - path: strands-py/src/strands/types/agent.py
 ---
 
 
@@ -86,6 +88,41 @@ async def log_message(event: BidiMessageAddedEvent):
 agent.hooks.add_callback(BidiMessageAddedEvent, log_message)
 ```
 
+### Shared Tool Call Hooks
+
+`BidiAgent` uses the same `BeforeToolCallEvent` and `AfterToolCallEvent` types as
+`Agent`. Callbacks and tools that support both agent types can use `LocalAgent`
+for their agent type:
+
+```python
+from strands import LocalAgent, ToolContext, tool
+from strands.experimental.bidi import BidiAgent
+from strands.hooks import AfterToolCallEvent, BeforeToolCallEvent
+
+
+@tool(context=True)
+def inspect_agent(tool_context: ToolContext[LocalAgent]) -> str:
+    return tool_context.agent.name
+
+
+def log_tool_call(event: BeforeToolCallEvent[LocalAgent]) -> None:
+    print(f"Calling {event.tool_use['name']} on {event.agent.name}")
+
+
+def retry_failed_tool(event: AfterToolCallEvent[LocalAgent]) -> None:
+    if event.exception is not None:
+        event.retry = True
+
+
+agent = BidiAgent(model=model, tools=[inspect_agent])
+agent.add_hook(log_tool_call)
+agent.add_hook(retry_failed_tool)
+```
+
+`add_hook()` infers the event type from the callback annotation. You can also
+pass an event type, or a list of event types, explicitly. For more registration
+patterns and retry guidance, see the [Hooks documentation](../agents/hooks.md).
+
 ## Hook Event Lifecycle
 
 The following diagram shows when hook events are emitted during a bidirectional streaming session:
@@ -140,6 +177,8 @@ The bidirectional streaming hooks system provides events for different stages of
 | `BidiBeforeInvocationEvent` | Triggered when the agent connection starts (before `model.start()`) |
 | `BidiAfterInvocationEvent` | Triggered when the agent connection ends (after `model.stop()`), regardless of success or failure |
 | `BidiMessageAddedEvent` | Triggered when a message is added to the agent's conversation history |
+| `BeforeToolCallEvent` | Triggered before a tool is invoked |
+| `AfterToolCallEvent` | Triggered after tool invocation completes. Uses reverse callback ordering |
 | `BidiInterruptionEvent` | Triggered when the model's response is interrupted by user speech |
 | `BidiBeforeConnectionRestartEvent` | Triggered before the model connection is restarted due to timeout |
 | `BidiAfterConnectionRestartEvent` | Triggered after the model connection has been restarted |

--- a/strands-py/src/strands/experimental/bidi/agent/agent.py
+++ b/strands-py/src/strands/experimental/bidi/agent/agent.py
@@ -70,7 +70,7 @@ class BidiAgent(LocalAgent):
         self,
         model: BidiModel | str | None = None,
         tools: list[str | AgentTool | ToolProvider] | None = None,
-        system_prompt: str | None = None,
+        system_prompt: str | list[SystemContentBlock] | None = None,
         messages: Messages | None = None,
         record_direct_tool_call: bool = True,
         load_tools_from_directory: bool = False,
@@ -88,7 +88,8 @@ class BidiAgent(LocalAgent):
         Args:
             model: BidiModel instance, string model_id, or None for default detection.
             tools: Optional list of tools with flexible format support.
-            system_prompt: Optional system prompt for conversations.
+            system_prompt: System prompt for conversations as a string or structured content blocks.
+                Structured blocks are retained, while their text is passed to Bidi models as a string.
             messages: Optional conversation history to initialize with.
             record_direct_tool_call: Whether to record direct tool calls in message history.
             load_tools_from_directory: Whether to load and automatically reload tools in the `./tools/` directory.
@@ -223,8 +224,8 @@ class BidiAgent(LocalAgent):
         return self._system_prompt
 
     @system_prompt.setter
-    def system_prompt(self, value: str | None) -> None:
-        """Set the system prompt and its structured content representation."""
+    def system_prompt(self, value: str | list[SystemContentBlock] | None) -> None:
+        """Set the system prompt and retain its structured content representation."""
         self._system_prompt, self._system_prompt_content = split_system_prompt(value)
 
     @property

--- a/strands-py/src/strands/experimental/bidi/agent/agent.py
+++ b/strands-py/src/strands/experimental/bidi/agent/agent.py
@@ -245,12 +245,31 @@ class BidiAgent(LocalAgent):
         *,
         order: float = HookOrder.DEFAULT,
     ) -> None:
-        """Register a callback function for one or more event types.
+        """Register a callback function for a specific event type.
+
+        This method supports multiple call patterns:
+        1. ``add_hook(callback)`` - Event type inferred from callback's type hint
+        2. ``add_hook(callback, event_type)`` - Event type specified explicitly
+        3. ``add_hook(callback, [TypeA, TypeB])`` - Register for multiple event types
+
+        When the callback's type hint is a union type (``A | B`` or ``Union[A, B]``),
+        the callback is automatically registered for each event type in the union.
+
+        Callbacks can be either synchronous or asynchronous functions.
 
         Args:
-            callback: The callback function to invoke.
-            event_type: The event type or types to handle. If omitted, the type is inferred from the callback.
+            callback: The callback function to invoke when events of this type occur.
+            event_type: The class type(s) of events this callback should handle.
+                Can be a single type, a list of types, or None to infer from
+                the callback's first parameter type hint. If a list is provided,
+                the callback is registered for each type in the list.
             order: Execution priority. Lower values execute first.
+                Use a HookOrder constant such as SDK_FIRST (-100), DEFAULT (0),
+                MODEL_ROUTING (50), or SDK_LAST (100).
+
+        Raises:
+            ValueError: If event_type is not provided and cannot be inferred from
+                the callback's type hints, or if the event_type list is empty.
         """
         self.hooks.add_callback(event_type, callback, order=order)
 

--- a/strands-py/src/strands/experimental/bidi/agent/agent.py
+++ b/strands-py/src/strands/experimental/bidi/agent/agent.py
@@ -15,13 +15,15 @@ Key capabilities:
 
 import asyncio
 import logging
+import uuid
 from collections.abc import AsyncGenerator
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 from .... import _identifier
 from ...._middleware import MiddlewareRegistry
 from ....agent.state import AgentState
-from ....hooks import HookProvider, HookRegistry
+from ....hooks import HookCallback, HookOrder, HookProvider, HookRegistry
+from ....hooks.registry import TEvent
 from ....interrupt import _InterruptState
 from ....tools._caller import _ToolCaller
 from ....tools.executors import ConcurrentToolExecutor
@@ -29,7 +31,8 @@ from ....tools.executors._executor import ToolExecutor
 from ....tools.registry import ToolRegistry
 from ....tools.tool_provider import ToolProvider
 from ....tools.watcher import ToolWatcher
-from ....types.content import Message, Messages, _ensure_tracking_id
+from ....types.agent import LocalAgent
+from ....types.content import Message, Messages, SystemContentBlock, _ensure_tracking_id, split_system_prompt
 from ....types.tools import AgentTool
 from ...hooks.events import BidiAgentInitializedEvent, BidiMessageAddedEvent
 from .._async import _TaskGroup, stop_all
@@ -54,12 +57,14 @@ _DEFAULT_AGENT_NAME = "Strands Agents"
 _DEFAULT_AGENT_ID = "default"
 
 
-class BidiAgent:
+class BidiAgent(LocalAgent):
     """Agent for bidirectional streaming conversations.
 
     Enables real-time audio and text interaction with AI models through persistent
     connections. Supports concurrent tool execution and interruption handling.
     """
+
+    _is_strands_local_agent: ClassVar[Literal[True]] = True
 
     def __init__(
         self,
@@ -114,7 +119,7 @@ class BidiAgent:
         else:
             raise TypeError("model must be a BidiModel, string, or None")
 
-        self.system_prompt = system_prompt
+        self._system_prompt, self._system_prompt_content = split_system_prompt(system_prompt)
         self.messages = messages or []
 
         # Agent identification
@@ -164,7 +169,10 @@ class BidiAgent:
         # Initialize session management functionality
         self._session_manager = session_manager
         if self._session_manager:
+            self._session_id: str = getattr(self._session_manager, "session_id", None) or uuid.uuid4().hex[:8]
             self.hooks.add_hook(self._session_manager)
+        else:
+            self._session_id = uuid.uuid4().hex[:8]
 
         self._loop = _BidiAgentLoop(self)
 
@@ -208,6 +216,42 @@ class BidiAgent:
         """
         all_tools = self.tool_registry.get_all_tools_config()
         return list(all_tools.keys())
+
+    @property
+    def system_prompt(self) -> str | None:
+        """Get the system prompt as a string."""
+        return self._system_prompt
+
+    @system_prompt.setter
+    def system_prompt(self, value: str | None) -> None:
+        """Set the system prompt and its structured content representation."""
+        self._system_prompt, self._system_prompt_content = split_system_prompt(value)
+
+    @property
+    def system_prompt_content(self) -> list[SystemContentBlock] | None:
+        """Get the system prompt as structured content blocks."""
+        return list(self._system_prompt_content) if self._system_prompt_content is not None else None
+
+    @property
+    def session_id(self) -> str:
+        """Get the conversation session identifier."""
+        return self._session_id
+
+    def add_hook(
+        self,
+        callback: HookCallback[TEvent],
+        event_type: type[TEvent] | list[type[TEvent]] | None = None,
+        *,
+        order: float = HookOrder.DEFAULT,
+    ) -> None:
+        """Register a callback function for one or more event types.
+
+        Args:
+            callback: The callback function to invoke.
+            event_type: The event type or types to handle. If omitted, the type is inferred from the callback.
+            order: Execution priority. Lower values execute first.
+        """
+        self.hooks.add_callback(event_type, callback, order=order)
 
     async def start(self, invocation_state: dict[str, Any] | None = None) -> None:
         """Start a persistent bidirectional conversation connection.

--- a/strands-py/src/strands/experimental/hooks/__init__.py
+++ b/strands-py/src/strands/experimental/hooks/__init__.py
@@ -5,11 +5,9 @@ from typing import Any
 from .events import (
     BidiAfterConnectionRestartEvent,
     BidiAfterInvocationEvent,
-    BidiAfterToolCallEvent,
     BidiAgentInitializedEvent,
     BidiBeforeConnectionRestartEvent,
     BidiBeforeInvocationEvent,
-    BidiBeforeToolCallEvent,
     BidiInterruptionEvent,
     BidiMessageAddedEvent,
 )
@@ -33,8 +31,6 @@ __all__ = [
     "BidiBeforeInvocationEvent",
     "BidiAfterInvocationEvent",
     "BidiMessageAddedEvent",
-    "BidiBeforeToolCallEvent",
-    "BidiAfterToolCallEvent",
     "BidiInterruptionEvent",
     "BidiBeforeConnectionRestartEvent",
     "BidiAfterConnectionRestartEvent",

--- a/strands-py/src/strands/experimental/hooks/events.py
+++ b/strands-py/src/strands/experimental/hooks/events.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, Any, Literal
 from ...hooks.events import AfterModelCallEvent, AfterToolCallEvent, BeforeModelCallEvent, BeforeToolCallEvent
 from ...hooks.registry import BaseHookEvent
 from ...types.content import Message
-from ...types.tools import AgentTool, ToolResult, ToolUse
 
 if TYPE_CHECKING:
     from ..bidi.agent.agent import BidiAgent
@@ -114,77 +113,6 @@ class BidiMessageAddedEvent(BidiHookEvent):
     """
 
     message: Message
-
-
-@dataclass
-class BidiBeforeToolCallEvent(BidiHookEvent):
-    """Event triggered before BidiAgent executes a tool.
-
-    This event is fired just before the BidiAgent executes a tool during a streaming
-    session, allowing hook providers to inspect, modify, or replace the tool that
-    will be executed. The selected_tool can be modified by hook callbacks to change
-    which tool gets executed.
-
-    Attributes:
-        selected_tool: The tool that will be invoked. Can be modified by hooks
-            to change which tool gets executed. This may be None if tool lookup failed.
-        tool_use: The tool parameters that will be passed to selected_tool.
-        invocation_state: Keyword arguments that will be passed to the tool.
-        cancel_tool: A user defined message that when set, will cancel the tool call.
-            The message will be placed into a tool result with an error status. If set to `True`, Strands will cancel
-            the tool call and use a default cancel message.
-    """
-
-    selected_tool: AgentTool | None
-    tool_use: ToolUse
-    invocation_state: dict[str, Any]
-    cancel_tool: bool | str = False
-
-    def _can_write(self, name: str) -> bool:
-        return name in ["cancel_tool", "selected_tool", "tool_use"]
-
-
-@dataclass
-class BidiAfterToolCallEvent(BidiHookEvent):
-    """Event triggered after BidiAgent executes a tool.
-
-    This event is fired after the BidiAgent has finished executing a tool during
-    a streaming session, regardless of whether the execution was successful or
-    resulted in an error. Hook providers can use this event for cleanup, logging,
-    or post-processing.
-
-    Note: This event uses reverse callback ordering, meaning callbacks registered
-    later will be invoked first during cleanup.
-
-    Attributes:
-        selected_tool: The tool that was invoked. It may be None if tool lookup failed.
-        tool_use: The tool parameters that were passed to the tool invoked.
-        invocation_state: Keyword arguments that were passed to the tool.
-        result: The result of the tool invocation. Either a ToolResult on success
-            or an Exception if the tool execution failed.
-        exception: Exception if the tool execution failed, None if successful.
-        cancel_message: The cancellation message if the user cancelled the tool call.
-        duration: Elapsed time in seconds spent executing the tool. Starts after
-            BeforeToolCallEvent returns and stops before AfterToolCallEvent is constructed.
-            None when the tool call was cancelled by a BeforeToolCallEvent hook
-            before execution.
-    """
-
-    selected_tool: AgentTool | None
-    tool_use: ToolUse
-    invocation_state: dict[str, Any]
-    result: ToolResult
-    exception: Exception | None = None
-    cancel_message: str | None = None
-    duration: float | None = None
-
-    def _can_write(self, name: str) -> bool:
-        return name == "result"
-
-    @property
-    def should_reverse_callbacks(self) -> bool:
-        """True to invoke callbacks in reverse order."""
-        return True
 
 
 @dataclass

--- a/strands-py/src/strands/tools/executors/_executor.py
+++ b/strands-py/src/strands/tools/executors/_executor.py
@@ -14,14 +14,13 @@ from typing import TYPE_CHECKING, Any, cast
 from opentelemetry import trace as trace_api
 
 from ..._middleware.stages import ExecuteToolContext, ExecuteToolStage
-from ...experimental.hooks.events import BidiAfterToolCallEvent, BidiBeforeToolCallEvent
 from ...hooks import AfterToolCallEvent, BeforeToolCallEvent
 from ...interrupt import InterruptException
 from ...telemetry.metrics import Trace
 from ...telemetry.tracer import get_tracer, serialize
 from ...types._events import ToolCancelEvent, ToolInterruptEvent, ToolResultEvent, ToolStreamEvent, TypedEvent
+from ...types.agent import LocalAgent
 from ...types.content import Message
-from ...types.interrupt import Interrupt
 from ...types.tools import ToolChoice, ToolChoiceAuto, ToolConfig, ToolResult, ToolUse
 from ..structured_output._structured_output_context import StructuredOutputContext
 
@@ -36,8 +35,8 @@ class ToolExecutor(abc.ABC):
     """Abstract base class for tool executors."""
 
     @staticmethod
-    def _is_agent(agent: "Agent | BidiAgent") -> bool:
-        """Check if the agent is an Agent instance, otherwise we assume BidiAgent.
+    def _is_agent(agent: LocalAgent) -> bool:
+        """Check if the local agent is a standard Agent instance.
 
         Note, we use a runtime import to avoid a circular dependency error.
         """
@@ -46,63 +45,13 @@ class ToolExecutor(abc.ABC):
         return isinstance(agent, Agent)
 
     @staticmethod
-    async def _invoke_before_tool_call_hook(
-        agent: "Agent | BidiAgent",
-        tool_func: Any,
-        tool_use: ToolUse,
-        invocation_state: dict[str, Any],
-    ) -> tuple[BeforeToolCallEvent | BidiBeforeToolCallEvent, list[Interrupt]]:
-        """Invoke the appropriate before tool call hook based on agent type."""
-        kwargs = {
-            "selected_tool": tool_func,
-            "tool_use": tool_use,
-            "invocation_state": invocation_state,
-        }
-        event = (
-            BeforeToolCallEvent(agent=cast("Agent", agent), **kwargs)
-            if ToolExecutor._is_agent(agent)
-            else BidiBeforeToolCallEvent(agent=cast("BidiAgent", agent), **kwargs)
-        )
-
-        return await agent.hooks.invoke_callbacks_async(event)
-
-    @staticmethod
-    async def _invoke_after_tool_call_hook(
-        agent: "Agent | BidiAgent",
-        selected_tool: Any,
-        tool_use: ToolUse,
-        invocation_state: dict[str, Any],
-        result: ToolResult,
-        exception: Exception | None = None,
-        cancel_message: str | None = None,
-        duration: float | None = None,
-    ) -> tuple[AfterToolCallEvent | BidiAfterToolCallEvent, list[Interrupt]]:
-        """Invoke the appropriate after tool call hook based on agent type."""
-        kwargs = {
-            "selected_tool": selected_tool,
-            "tool_use": tool_use,
-            "invocation_state": invocation_state,
-            "result": result,
-            "exception": exception,
-            "cancel_message": cancel_message,
-            "duration": duration,
-        }
-        event = (
-            AfterToolCallEvent(agent=cast("Agent", agent), **kwargs)
-            if ToolExecutor._is_agent(agent)
-            else BidiAfterToolCallEvent(agent=cast("BidiAgent", agent), **kwargs)
-        )
-
-        return await agent.hooks.invoke_callbacks_async(event)
-
-    @staticmethod
-    def _should_retry(agent: "Agent | BidiAgent", after_event: AfterToolCallEvent | BidiAfterToolCallEvent) -> bool:
+    def _should_retry(agent: LocalAgent, after_event: AfterToolCallEvent[LocalAgent]) -> bool:
         """Return whether a hook-requested retry should run.
 
         Cancellation is terminal: retrying a locally cancelled tool can spin indefinitely
         while delaying the caller's requested agent stop.
         """
-        if not getattr(after_event, "retry", False):
+        if not after_event.retry:
             return False
         if cast(dict[str, Any], after_event.result).get("cancelled") is True:
             return False
@@ -174,8 +123,13 @@ class ToolExecutor(abc.ABC):
 
         # Retry loop for tool execution - hooks can set after_event.retry = True to retry
         while True:
-            before_event, interrupts = await ToolExecutor._invoke_before_tool_call_hook(
-                agent, tool_func, tool_use, invocation_state
+            before_event, interrupts = await agent.hooks.invoke_callbacks_async(
+                BeforeToolCallEvent[LocalAgent](
+                    agent=agent,
+                    selected_tool=tool_func,
+                    tool_use=tool_use,
+                    invocation_state=invocation_state,
+                )
             )
 
             if interrupts:
@@ -194,13 +148,15 @@ class ToolExecutor(abc.ABC):
                     "content": [{"text": cancel_message}],
                 }
 
-                after_event, _ = await ToolExecutor._invoke_after_tool_call_hook(
-                    agent,
-                    None,
-                    tool_use,
-                    invocation_state,
-                    cancel_result,
-                    cancel_message=cancel_message,
+                after_event, _ = await agent.hooks.invoke_callbacks_async(
+                    AfterToolCallEvent[LocalAgent](
+                        agent=agent,
+                        selected_tool=None,
+                        tool_use=tool_use,
+                        invocation_state=invocation_state,
+                        result=cancel_result,
+                        cancel_message=cancel_message,
+                    )
                 )
                 yield ToolResultEvent(after_event.result)
                 tool_results.append(after_event.result)
@@ -286,14 +242,16 @@ class ToolExecutor(abc.ABC):
                 exception = result_event.exception
 
                 tool_duration = time.monotonic() - tool_start_time
-                after_event, _ = await ToolExecutor._invoke_after_tool_call_hook(
-                    agent,
-                    selected_tool,
-                    tool_use,
-                    invocation_state,
-                    result,
-                    exception=exception,
-                    duration=tool_duration,
+                after_event, _ = await agent.hooks.invoke_callbacks_async(
+                    AfterToolCallEvent[LocalAgent](
+                        agent=agent,
+                        selected_tool=selected_tool,
+                        tool_use=tool_use,
+                        invocation_state=invocation_state,
+                        result=result,
+                        exception=exception,
+                        duration=tool_duration,
+                    )
                 )
 
                 if ToolExecutor._should_retry(agent, after_event):
@@ -324,8 +282,16 @@ class ToolExecutor(abc.ABC):
                     "content": [{"text": f"Error: {str(e)}"}],
                 }
 
-                after_event, _ = await ToolExecutor._invoke_after_tool_call_hook(
-                    agent, selected_tool, tool_use, invocation_state, error_result, exception=e, duration=tool_duration
+                after_event, _ = await agent.hooks.invoke_callbacks_async(
+                    AfterToolCallEvent[LocalAgent](
+                        agent=agent,
+                        selected_tool=selected_tool,
+                        tool_use=tool_use,
+                        invocation_state=invocation_state,
+                        result=error_result,
+                        exception=e,
+                        duration=tool_duration,
+                    )
                 )
                 if ToolExecutor._should_retry(agent, after_event):
                     logger.debug("tool_name=<%s> | retry requested after exception, retrying tool call", tool_name)

--- a/strands-py/tests/strands/experimental/bidi/agent/test_agent.py
+++ b/strands-py/tests/strands/experimental/bidi/agent/test_agent.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 
 import pytest
 
+from strands import LocalAgent, ToolContext, tool
 from strands.experimental.bidi.agent.agent import BidiAgent
 from strands.experimental.bidi.models.model import BidiModel
 from strands.experimental.bidi.types.events import (
@@ -17,6 +18,7 @@ from strands.experimental.bidi.types.events import (
     BidiTextInputEvent,
     BidiTranscriptStreamEvent,
 )
+from strands.hooks import AfterToolCallEvent, BeforeToolCallEvent
 
 
 class MockBidiModel(BidiModel):
@@ -122,6 +124,7 @@ def test_bidi_agent_init_with_various_configurations():
 
     assert agent.model == mock_model
     assert agent.system_prompt is None
+    assert agent.system_prompt_content is None
     assert not agent._started
     assert agent.model._connection_id is None
 
@@ -130,6 +133,7 @@ def test_bidi_agent_init_with_various_configurations():
     agent_with_config = BidiAgent(model=mock_model, system_prompt=system_prompt, agent_id="test_agent")
 
     assert agent_with_config.system_prompt == system_prompt
+    assert agent_with_config.system_prompt_content == [{"text": system_prompt}]
     assert agent_with_config.agent_id == "test_agent"
 
     # Test model config access
@@ -139,10 +143,82 @@ def test_bidi_agent_init_with_various_configurations():
     assert config["audio"]["channels"] == 1
 
 
+def test_bidi_agent_tool_emits_shared_hook_events_and_retries(mock_model):
+    """Test BidiAgent emits shared tool hook events and honors retry requests."""
+    call_count = 0
+    hook_events: list[BeforeToolCallEvent[LocalAgent] | AfterToolCallEvent[LocalAgent]] = []
+
+    @tool
+    def counting_tool() -> str:
+        nonlocal call_count
+        call_count += 1
+        return f"attempt_{call_count}"
+
+    agent = BidiAgent(model=mock_model, tools=[counting_tool])
+
+    def record_before(event: BeforeToolCallEvent[LocalAgent]) -> None:
+        hook_events.append(event)
+
+    def retry_once(event: AfterToolCallEvent[LocalAgent]) -> None:
+        hook_events.append(event)
+        event.retry = call_count == 1
+
+    agent.add_hook(record_before)
+    agent.add_hook(retry_once)
+
+    result = agent.tool.counting_tool(record_direct_tool_call=False)
+
+    assert call_count == 2
+    assert [type(event) for event in hook_events] == [
+        BeforeToolCallEvent,
+        AfterToolCallEvent,
+        BeforeToolCallEvent,
+        AfterToolCallEvent,
+    ]
+    assert all(event.agent is agent for event in hook_events)
+    assert result["content"] == [{"text": "attempt_2"}]
+
+
+def test_bidi_agent_tool_injects_local_agent(mock_model):
+    """Test context-aware tools receive BidiAgent through LocalAgent."""
+
+    @tool(context=True)
+    def context_tool(tool_context: ToolContext[LocalAgent]) -> str:
+        assert tool_context.agent is agent
+        return tool_context.agent.name
+
+    agent = BidiAgent(model=mock_model, tools=[context_tool], name="test_agent")
+
+    result = agent.tool.context_tool(record_direct_tool_call=False)
+
+    assert result["content"] == [{"text": "test_agent"}]
+
+
 def test_bidi_agent_init_with_unsupported_model():
     """Test agent initialization rejects unsupported model types."""
     with pytest.raises(TypeError, match="model must be a BidiModel, string, or None"):
         BidiAgent(model=object())
+
+
+def test_bidi_agent_session_id_without_session_manager(mock_model):
+    """Test the generated session identifier remains stable."""
+    agent = BidiAgent(model=mock_model)
+
+    first = agent.session_id
+    second = agent.session_id
+
+    assert first == second
+    assert len(first) == 8
+
+
+def test_bidi_agent_session_id_delegates_to_session_manager(mock_model):
+    """Test the session manager's persistent identifier is exposed."""
+    session_manager = unittest.mock.Mock()
+    session_manager.session_id = "test-session"
+
+    agent = BidiAgent(model=mock_model, session_manager=session_manager)
+
+    assert agent.session_id == "test-session"
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="BedrockNovaSonicModel is only supported for Python 3.12+")

--- a/strands-py/tests/strands/experimental/bidi/agent/test_agent.py
+++ b/strands-py/tests/strands/experimental/bidi/agent/test_agent.py
@@ -19,6 +19,7 @@ from strands.experimental.bidi.types.events import (
     BidiTranscriptStreamEvent,
 )
 from strands.hooks import AfterToolCallEvent, BeforeToolCallEvent
+from strands.types.content import SystemContentBlock
 
 
 class MockBidiModel(BidiModel):
@@ -146,11 +147,16 @@ def test_bidi_agent_init_with_various_configurations():
 def test_bidi_agent_system_prompt_setter(mock_model):
     """Test setting the system prompt updates its content blocks."""
     agent = BidiAgent(model=mock_model, system_prompt="initial prompt")
+    content_blocks: list[SystemContentBlock] = [
+        {"text": "updated prompt"},
+        {"cachePoint": {"type": "default"}},
+        {"text": "additional instructions"},
+    ]
 
-    agent.system_prompt = "updated prompt"
+    agent.system_prompt = content_blocks
 
-    assert agent.system_prompt == "updated prompt"
-    assert agent.system_prompt_content == [{"text": "updated prompt"}]
+    assert agent.system_prompt == "updated prompt\nadditional instructions"
+    assert agent.system_prompt_content == content_blocks
 
 
 def test_bidi_agent_tool_emits_shared_hook_events_and_retries(mock_model):

--- a/strands-py/tests/strands/experimental/bidi/agent/test_agent.py
+++ b/strands-py/tests/strands/experimental/bidi/agent/test_agent.py
@@ -143,6 +143,16 @@ def test_bidi_agent_init_with_various_configurations():
     assert config["audio"]["channels"] == 1
 
 
+def test_bidi_agent_system_prompt_setter(mock_model):
+    """Test setting the system prompt updates its content blocks."""
+    agent = BidiAgent(model=mock_model, system_prompt="initial prompt")
+
+    agent.system_prompt = "updated prompt"
+
+    assert agent.system_prompt == "updated prompt"
+    assert agent.system_prompt_content == [{"text": "updated prompt"}]
+
+
 def test_bidi_agent_tool_emits_shared_hook_events_and_retries(mock_model):
     """Test BidiAgent emits shared tool hook events and honors retry requests."""
     call_count = 0

--- a/strands-py/tests/strands/experimental/hooks/test_bidi_hook_events.py
+++ b/strands-py/tests/strands/experimental/hooks/test_bidi_hook_events.py
@@ -6,41 +6,16 @@ import pytest
 
 from strands.experimental.hooks import (
     BidiAfterInvocationEvent,
-    BidiAfterToolCallEvent,
     BidiAgentInitializedEvent,
     BidiBeforeInvocationEvent,
-    BidiBeforeToolCallEvent,
     BidiInterruptionEvent,
     BidiMessageAddedEvent,
 )
-from strands.types.tools import ToolResult, ToolUse
 
 
 @pytest.fixture
 def agent():
     return Mock()
-
-
-@pytest.fixture
-def tool():
-    tool = Mock()
-    tool.tool_name = "test_tool"
-    return tool
-
-
-@pytest.fixture
-def tool_use():
-    return ToolUse(name="test_tool", toolUseId="123", input={"param": "value"})
-
-
-@pytest.fixture
-def tool_invocation_state():
-    return {"param": "value"}
-
-
-@pytest.fixture
-def tool_result():
-    return ToolResult(content=[{"text": "result"}], status="success", toolUseId="123")
 
 
 @pytest.fixture
@@ -69,27 +44,6 @@ def message_added_event(agent, message):
 
 
 @pytest.fixture
-def before_tool_event(agent, tool, tool_use, tool_invocation_state):
-    return BidiBeforeToolCallEvent(
-        agent=agent,
-        selected_tool=tool,
-        tool_use=tool_use,
-        invocation_state=tool_invocation_state,
-    )
-
-
-@pytest.fixture
-def after_tool_event(agent, tool, tool_use, tool_invocation_state, tool_result):
-    return BidiAfterToolCallEvent(
-        agent=agent,
-        selected_tool=tool,
-        tool_use=tool_use,
-        invocation_state=tool_invocation_state,
-        result=tool_result,
-    )
-
-
-@pytest.fixture
 def interruption_event(agent):
     return BidiInterruptionEvent(agent=agent, reason="user_speech")
 
@@ -99,8 +53,6 @@ def test_event_should_reverse_callbacks(
     before_invocation_event,
     after_invocation_event,
     message_added_event,
-    before_tool_event,
-    after_tool_event,
     interruption_event,
 ):
     """Verify which events use reverse callback ordering."""
@@ -112,9 +64,6 @@ def test_event_should_reverse_callbacks(
 
     assert before_invocation_event.should_reverse_callbacks == False  # noqa: E712
     assert after_invocation_event.should_reverse_callbacks == True  # noqa: E712
-
-    assert before_tool_event.should_reverse_callbacks == False  # noqa: E712
-    assert after_tool_event.should_reverse_callbacks == True  # noqa: E712
 
 
 def test_interruption_event_with_response_id(agent):
@@ -131,39 +80,3 @@ def test_message_added_event_cannot_write_properties(message_added_event):
         message_added_event.agent = Mock()
     with pytest.raises(AttributeError, match="Property message is not writable"):
         message_added_event.message = {}
-
-
-def test_before_tool_call_event_can_write_properties(before_tool_event):
-    """Verify BidiBeforeToolCallEvent allows writing specific properties."""
-    new_tool_use = ToolUse(name="new_tool", toolUseId="456", input={})
-    before_tool_event.selected_tool = None  # Should not raise
-    before_tool_event.tool_use = new_tool_use  # Should not raise
-    before_tool_event.cancel_tool = "Cancelled by user"  # Should not raise
-
-
-def test_before_tool_call_event_cannot_write_properties(before_tool_event):
-    """Verify BidiBeforeToolCallEvent protects certain properties."""
-    with pytest.raises(AttributeError, match="Property agent is not writable"):
-        before_tool_event.agent = Mock()
-    with pytest.raises(AttributeError, match="Property invocation_state is not writable"):
-        before_tool_event.invocation_state = {}
-
-
-def test_after_tool_call_event_can_write_properties(after_tool_event):
-    """Verify BidiAfterToolCallEvent allows writing result property."""
-    new_result = ToolResult(content=[{"text": "new result"}], status="success", toolUseId="456")
-    after_tool_event.result = new_result  # Should not raise
-
-
-def test_after_tool_call_event_cannot_write_properties(after_tool_event):
-    """Verify BidiAfterToolCallEvent protects certain properties."""
-    with pytest.raises(AttributeError, match="Property agent is not writable"):
-        after_tool_event.agent = Mock()
-    with pytest.raises(AttributeError, match="Property selected_tool is not writable"):
-        after_tool_event.selected_tool = None
-    with pytest.raises(AttributeError, match="Property tool_use is not writable"):
-        after_tool_event.tool_use = ToolUse(name="new", toolUseId="456", input={})
-    with pytest.raises(AttributeError, match="Property invocation_state is not writable"):
-        after_tool_event.invocation_state = {}
-    with pytest.raises(AttributeError, match="Property exception is not writable"):
-        after_tool_event.exception = Exception("test")

--- a/strands-py/tests/strands/tools/executors/test_executor.py
+++ b/strands-py/tests/strands/tools/executors/test_executor.py
@@ -4,7 +4,6 @@ from unittest.mock import ANY, MagicMock
 import pytest
 
 import strands
-from strands.experimental.hooks.events import BidiAfterToolCallEvent
 from strands.hooks import AfterToolCallEvent, BeforeToolCallEvent
 from strands.interrupt import Interrupt
 from strands.telemetry.metrics import Trace
@@ -859,52 +858,6 @@ async def test_executor_stream_retry_false(executor, agent, tool_results, invoca
     # tool_results should contain the result
     assert len(tool_results) == 1
     assert tool_results[0] == {"toolUseId": "1", "status": "success", "content": [{"text": "attempt_1"}]}
-
-
-@pytest.mark.asyncio
-async def test_executor_stream_bidi_event_no_retry_attribute(executor, agent, tool_results, invocation_state, alist):
-    """Test that BidiAfterToolCallEvent (which lacks retry attribute) doesn't cause retry.
-
-    This tests the getattr(after_event, "retry", False) fallback for events without retry.
-    """
-    call_count = {"count": 0}
-
-    @strands.tool(name="counting_tool")
-    def counting_tool():
-        call_count["count"] += 1
-        return f"attempt_{call_count['count']}"
-
-    agent.tool_registry.register_tool(counting_tool)
-
-    tool_use: ToolUse = {"name": "counting_tool", "toolUseId": "1", "input": {}}
-    result: strands.types.tools.ToolResult = {
-        "toolUseId": "1",
-        "status": "success",
-        "content": [{"text": "attempt_1"}],
-    }
-
-    # Create a BidiAfterToolCallEvent (which has no retry attribute)
-    bidi_event = BidiAfterToolCallEvent(
-        agent=agent,
-        selected_tool=counting_tool,
-        tool_use=tool_use,
-        invocation_state=invocation_state,
-        result=result,
-    )
-
-    # Patch _invoke_after_tool_call_hook to return BidiAfterToolCallEvent
-    async def mock_after_hook(*args, **kwargs):
-        return bidi_event, []
-
-    with unittest.mock.patch.object(ToolExecutor, "_invoke_after_tool_call_hook", mock_after_hook):
-        stream = executor._stream(agent, tool_use, tool_results, invocation_state)
-        tru_events = await alist(stream)
-
-    # Tool should be called once - no retry since BidiAfterToolCallEvent has no retry attr
-    assert call_count["count"] == 1
-
-    # Result should be returned
-    assert len(tru_events) == 1
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests_integ/bidi/hook_utils.py
+++ b/strands-py/tests_integ/bidi/hook_utils.py
@@ -1,15 +1,14 @@
 """Shared utilities for testing BidiAgent hooks."""
 
+from strands import LocalAgent
 from strands.experimental.hooks.events import (
     BidiAfterInvocationEvent,
-    BidiAfterToolCallEvent,
     BidiAgentInitializedEvent,
     BidiBeforeInvocationEvent,
-    BidiBeforeToolCallEvent,
     BidiInterruptionEvent,
     BidiMessageAddedEvent,
 )
-from strands.hooks import HookProvider
+from strands.hooks import AfterToolCallEvent, BeforeToolCallEvent, HookProvider
 
 
 class HookEventCollector(HookProvider):
@@ -22,8 +21,8 @@ class HookEventCollector(HookProvider):
         registry.add_callback(BidiAgentInitializedEvent, self.on_initialized)
         registry.add_callback(BidiBeforeInvocationEvent, self.on_before_invocation)
         registry.add_callback(BidiAfterInvocationEvent, self.on_after_invocation)
-        registry.add_callback(BidiBeforeToolCallEvent, self.on_before_tool_call)
-        registry.add_callback(BidiAfterToolCallEvent, self.on_after_tool_call)
+        registry.add_callback(BeforeToolCallEvent, self.on_before_tool_call)
+        registry.add_callback(AfterToolCallEvent, self.on_after_tool_call)
         registry.add_callback(BidiMessageAddedEvent, self.on_message_added)
         registry.add_callback(BidiInterruptionEvent, self.on_interruption)
 
@@ -36,10 +35,10 @@ class HookEventCollector(HookProvider):
     def on_after_invocation(self, event: BidiAfterInvocationEvent):
         self.events.append(("after_invocation", event))
 
-    def on_before_tool_call(self, event: BidiBeforeToolCallEvent):
+    def on_before_tool_call(self, event: BeforeToolCallEvent[LocalAgent]):
         self.events.append(("before_tool_call", event))
 
-    def on_after_tool_call(self, event: BidiAfterToolCallEvent):
+    def on_after_tool_call(self, event: AfterToolCallEvent[LocalAgent]):
         self.events.append(("after_tool_call", event))
 
     def on_message_added(self, event: BidiMessageAddedEvent):

--- a/strands-py/tests_typing/test_local_agent.py
+++ b/strands-py/tests_typing/test_local_agent.py
@@ -3,6 +3,7 @@ from typing import Any
 from typing_extensions import assert_type
 
 from strands import Agent, LocalAgent, ToolContext, tool
+from strands.experimental.bidi import BidiAgent
 from strands.hooks import AfterToolCallEvent, BeforeToolCallEvent
 
 
@@ -40,14 +41,20 @@ def local_tool_call(event: BeforeToolCallEvent[LocalAgent] | AfterToolCallEvent[
     assert_type(event.agent, LocalAgent)
 
 
-def register_hooks(agent: Agent, local_agent: LocalAgent) -> None:
+def register_hooks(agent: Agent, bidi_agent: BidiAgent, local_agent: LocalAgent) -> None:
     shared_agent: LocalAgent = agent
     assert_type(shared_agent, LocalAgent)
+    shared_bidi_agent: LocalAgent = bidi_agent
+    assert_type(shared_bidi_agent, LocalAgent)
 
     agent.add_hook(before_tool_call)
     agent.add_hook(before_local_tool_call)
     agent.add_hook(after_local_tool_call)
     agent.add_hook(local_tool_call)
+
+    bidi_agent.add_hook(before_local_tool_call)
+    bidi_agent.add_hook(after_local_tool_call)
+    bidi_agent.add_hook(local_tool_call)
 
     local_agent.add_hook(before_local_tool_call)
     local_agent.add_hook(after_local_tool_call)


### PR DESCRIPTION
## Description

Make `BidiAgent` implement the shared `LocalAgent` protocol introduced in #4091.

This PR keeps the initial adoption focused on tool call extension points:

- Emit shared `BeforeToolCallEvent[LocalAgent]` and `AfterToolCallEvent[LocalAgent]` events for `BidiAgent`.
- Support `ToolContext[LocalAgent]` in Bidi tool definitions.
- Remove the duplicate Bidi-specific tool call events.
- Allow Bidi tool calls to honor `AfterToolCallEvent.retry`.
- Add the `LocalAgent` members needed by `BidiAgent`, including `add_hook`, `session_id`, and `system_prompt_content`.

We will follow up on the other event types to determine whether they should also use `LocalAgent`. Tool call events are the only events converted here to keep this change focused.

## Usage

Tools and tool call hooks can now use `LocalAgent` when they need to support both `Agent` and `BidiAgent`:

```python
from strands import LocalAgent, ToolContext, tool
from strands.experimental.bidi import BidiAgent
from strands.hooks import AfterToolCallEvent, BeforeToolCallEvent


@tool(context=True)
def inspect_agent(tool_context: ToolContext[LocalAgent]) -> str:
    return tool_context.agent.name


def before_tool_call(event: BeforeToolCallEvent[LocalAgent]) -> None:
    print(f"Calling {event.tool_use['name']} on {event.agent.name}")


def retry_failed_tool(event: AfterToolCallEvent[LocalAgent]) -> None:
    if event.exception is not None:
        event.retry = True


agent = BidiAgent(tools=[inspect_agent])
agent.add_hook(before_tool_call)
agent.add_hook(retry_failed_tool)
```


`BidiAgent` now preserves structured system prompt blocks, but current Bidi model interfaces still consume the backwards-compatible string representation. We will follow up by updating Bidi models to consume `system_prompt_content` directly.

## Related Issues

- Design: [Shared Agent and Model Types](https://github.com/strands-agents/harness-sdk/blob/main/team/designs/0017-shared-agent-model-types.md)
- Builds on: #4091

## Documentation PR

Updated the bidirectional streaming hooks guide to document shared tool call events, `LocalAgent` typing, `BidiAgent.add_hook()`, and hook-requested retries. General `LocalAgent` documentation is still required and will be added in a follow-up once its `BidiAgent` support is more fully fleshed out.

## Type of Change

Breaking change

## Testing

- `hatch run test-lint`
- `hatch test --all tests/strands/experimental/bidi/agent/test_agent.py tests/strands/experimental/hooks/test_bidi_hook_events.py tests/strands/tools/executors/test_executor.py`
- `hatch run prepare`
- Repository pre-commit checks

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.