### PR TITLE
fix(http_request): strip non-standard headers on cross-origin redirects

### DIFF
--- a/strands-py/src/strands/vended_tools/http_request/http_request.py
+++ b/strands-py/src/strands/vended_tools/http_request/http_request.py
@@ -9,9 +9,9 @@ control over transport configuration, authentication, proxies, timeouts,
 redirects, and connection pooling.
 
 When redirects are enabled on the client, the tool follows them manually
-so that credential headers can be stripped on cross-origin hops. Only
+so that credential headers can be stripped on cross-host hops. Only
 standard transport headers (``accept``, ``user-agent``, etc.) survive a
-redirect to a different origin; operator-configured credentials and
+redirect to a different host; operator-configured credentials and
 model-supplied auth tokens are dropped.
 
 The parent agent's cancel signal (``Agent._cancel_signal``) is propagated so
@@ -34,18 +34,8 @@ from .types import DEFAULT_HTTP_REQUEST_DESCRIPTION, HttpMethod, HttpRequestOutp
 if TYPE_CHECKING:
     from ...tools.decorator import DecoratedFunctionTool
 
-_SAFE_REDIRECT_HEADERS: frozenset[str] = frozenset(
-    {
-        "accept",
-        "accept-encoding",
-        "connection",
-        "host",
-        "user-agent",
-    }
-)
-"""Header names safe to forward on a cross-origin redirect."""
-
-_DEFAULT_SCHEME_PORTS: dict[str, int] = {"http": 80, "https": 443}
+_SAFE_REDIRECT_HEADERS: frozenset[str] = frozenset({"accept", "accept-encoding", "connection", "host", "user-agent"})
+"""Header names safe to forward on a cross-host redirect."""
 
 
 class HttpRequestError(RuntimeError):
@@ -121,47 +111,9 @@ http_request = make_http_request()
 # ---- Internals ----
 
 
-def _port_or_default(url: httpx.URL) -> int:
-    """Return the explicit port, or the default for the URL's scheme."""
-    if url.port is not None:
-        return url.port
-    return _DEFAULT_SCHEME_PORTS.get(url.scheme, 0)
-
-
-def _is_safe_redirect(original: httpx.URL, target: httpx.URL) -> bool:
-    """Return True if credentials may be forwarded to the redirect target.
-
-    Same-origin redirects and HTTP-to-HTTPS upgrades on the same host are
-    considered safe.  An upgrade from ``http://h/`` to ``https://h/`` (both
-    using their scheme's default port) is safe because no explicit port
-    changed.
-    """
-    if (
-        original.scheme == target.scheme
-        and original.host == target.host
-        and _port_or_default(original) == _port_or_default(target)
-    ):
-        return True
-
-    if (
-        original.host == target.host
-        and original.port == target.port
-        and original.scheme == "http"
-        and target.scheme == "https"
-    ):
-        return True
-
-    return False
-
-
-def _safe_redirect_headers(headers: httpx.Headers) -> httpx.Headers:
-    """Strip all non-default headers for a cross-origin redirect.
-
-    Only httpx's standard transport headers (accept, user-agent, etc.) are
-    retained.  Everything else — operator credentials, model-supplied auth
-    tokens, custom API keys — is stripped to prevent credential leakage.
-    """
-    return httpx.Headers({key: value for key, value in headers.items() if key.lower() in _SAFE_REDIRECT_HEADERS})
+def _strip_headers_for_cross_host(headers: httpx.Headers) -> httpx.Headers:
+    """Keep only safe transport headers, dropping everything else."""
+    return httpx.Headers({k: v for k, v in headers.items() if k.lower() in _SAFE_REDIRECT_HEADERS})
 
 
 def _resolve_timeout(
@@ -210,7 +162,7 @@ async def _perform_request(
     """Perform the HTTP request, following redirects with credential safety.
 
     When the client has ``follow_redirects=True``, redirects are followed
-    manually so that credential headers can be stripped on cross-origin hops.
+    manually so that credential headers can be stripped on cross-host hops.
     The response body is streamed so the cancel signal can be checked between
     chunks.
     """
@@ -267,8 +219,8 @@ async def _perform_request(
                 if next_request is None:
                     break
 
-                if not _is_safe_redirect(request.url, next_request.url):
-                    next_request.headers = _safe_redirect_headers(next_request.headers)
+                if request.url.host != next_request.url.host:
+                    next_request.headers = _strip_headers_for_cross_host(next_request.headers)
 
                 request = next_request
 

--- a/strands-py/src/strands/vended_tools/http_request/http_request.py
+++ b/strands-py/src/strands/vended_tools/http_request/http_request.py
@@ -8,6 +8,12 @@ networking to the client instance provided by the operator, giving full
 control over transport configuration, authentication, proxies, timeouts,
 redirects, and connection pooling.
 
+When redirects are enabled on the client, the tool follows them manually
+so that credential headers can be stripped on cross-origin hops. Only
+standard transport headers (``accept``, ``user-agent``, etc.) survive a
+redirect to a different origin; operator-configured credentials and
+model-supplied auth tokens are dropped.
+
 The parent agent's cancel signal (``Agent._cancel_signal``) is propagated so
 an in-flight fetch aborts when the agent is cancelled. Cancellation is
 signalled with :class:`asyncio.CancelledError`.
@@ -27,6 +33,19 @@ from .types import DEFAULT_HTTP_REQUEST_DESCRIPTION, HttpMethod, HttpRequestOutp
 
 if TYPE_CHECKING:
     from ...tools.decorator import DecoratedFunctionTool
+
+_SAFE_REDIRECT_HEADERS: frozenset[str] = frozenset(
+    {
+        "accept",
+        "accept-encoding",
+        "connection",
+        "host",
+        "user-agent",
+    }
+)
+"""Header names safe to forward on a cross-origin redirect."""
+
+_DEFAULT_SCHEME_PORTS: dict[str, int] = {"http": 80, "https": 443}
 
 
 class HttpRequestError(RuntimeError):
@@ -102,6 +121,49 @@ http_request = make_http_request()
 # ---- Internals ----
 
 
+def _port_or_default(url: httpx.URL) -> int:
+    """Return the explicit port, or the default for the URL's scheme."""
+    if url.port is not None:
+        return url.port
+    return _DEFAULT_SCHEME_PORTS.get(url.scheme, 0)
+
+
+def _is_safe_redirect(original: httpx.URL, target: httpx.URL) -> bool:
+    """Return True if credentials may be forwarded to the redirect target.
+
+    Same-origin redirects and HTTP-to-HTTPS upgrades on the same host are
+    considered safe.  An upgrade from ``http://h/`` to ``https://h/`` (both
+    using their scheme's default port) is safe because no explicit port
+    changed.
+    """
+    if (
+        original.scheme == target.scheme
+        and original.host == target.host
+        and _port_or_default(original) == _port_or_default(target)
+    ):
+        return True
+
+    if (
+        original.host == target.host
+        and original.port == target.port
+        and original.scheme == "http"
+        and target.scheme == "https"
+    ):
+        return True
+
+    return False
+
+
+def _safe_redirect_headers(headers: httpx.Headers) -> httpx.Headers:
+    """Strip all non-default headers for a cross-origin redirect.
+
+    Only httpx's standard transport headers (accept, user-agent, etc.) are
+    retained.  Everything else — operator credentials, model-supplied auth
+    tokens, custom API keys — is stripped to prevent credential leakage.
+    """
+    return httpx.Headers({key: value for key, value in headers.items() if key.lower() in _SAFE_REDIRECT_HEADERS})
+
+
 def _resolve_timeout(
     model_timeout: float | None,
     client: httpx.AsyncClient | None,
@@ -145,10 +207,12 @@ async def _perform_request(
     client: httpx.AsyncClient | None,
     cancel_signal: threading.Event | None = None,
 ) -> HttpRequestOutput:
-    """Perform the HTTP request, delegating all behavior to the client.
+    """Perform the HTTP request, following redirects with credential safety.
 
+    When the client has ``follow_redirects=True``, redirects are followed
+    manually so that credential headers can be stripped on cross-origin hops.
     The response body is streamed so the cancel signal can be checked between
-    chunks, giving mid-flight abort granularity similar to AbortSignal in fetch.
+    chunks.
     """
     owns_client = client is None
 
@@ -157,6 +221,9 @@ async def _perform_request(
         active_client = client
     else:
         active_client = httpx.AsyncClient()
+
+    should_follow = active_client.follow_redirects
+    max_redirects = active_client.max_redirects if should_follow else 0
 
     try:
         _check_cancelled(cancel_signal)
@@ -176,7 +243,35 @@ async def _perform_request(
                 content=body,
                 extensions=extensions,
             )
-            response = await active_client.send(request, stream=True)
+
+            redirect_count = 0
+            while True:
+                _check_cancelled(cancel_signal)
+                response = await active_client.send(request, stream=True, follow_redirects=False)
+
+                if not should_follow or not response.has_redirect_location:
+                    break
+
+                redirect_count += 1
+                if redirect_count > max_redirects:
+                    await response.aclose()
+                    raise httpx.TooManyRedirects(
+                        "Exceeded maximum allowed redirects.",
+                        request=request,
+                    )
+
+                await response.aread()
+                next_request = response.next_request
+                await response.aclose()
+
+                if next_request is None:
+                    break
+
+                if not _is_safe_redirect(request.url, next_request.url):
+                    next_request.headers = _safe_redirect_headers(next_request.headers)
+
+                request = next_request
+
         except httpx.TimeoutException as error:
             raise HttpRequestError(f"Request timed out: {error}") from error
         except httpx.TooManyRedirects as error:

--- a/strands-py/src/strands/vended_tools/http_request/http_request.py
+++ b/strands-py/src/strands/vended_tools/http_request/http_request.py
@@ -9,7 +9,7 @@ control over transport configuration, authentication, proxies, timeouts,
 redirects, and connection pooling.
 
 When redirects are enabled, the tool follows them manually and strips
-non-standard headers on cross-host hops to prevent credential leakage.
+non-standard headers on cross-origin hops to prevent credential leakage.
 
 The parent agent's cancel signal (``Agent._cancel_signal``) is propagated so
 an in-flight fetch aborts when the agent is cancelled.
@@ -30,7 +30,15 @@ from .types import DEFAULT_HTTP_REQUEST_DESCRIPTION, HttpMethod, HttpRequestOutp
 if TYPE_CHECKING:
     from ...tools.decorator import DecoratedFunctionTool
 
-_SAFE_REDIRECT_HEADERS: frozenset[str] = frozenset({"accept", "accept-encoding", "connection", "host", "user-agent"})
+_SAFE_REDIRECT_HEADERS: frozenset[str] = frozenset({
+    "accept",
+    "accept-encoding",
+    "connection",
+    "content-length",
+    "content-type",
+    "host",
+    "user-agent",
+})
 
 
 class HttpRequestError(RuntimeError):
@@ -106,7 +114,17 @@ http_request = make_http_request()
 # ---- Internals ----
 
 
-def _strip_headers_for_cross_host(headers: httpx.Headers) -> httpx.Headers:
+def _is_cross_origin(src: httpx.URL, dst: httpx.URL) -> bool:
+    """Return True when a redirect crosses an origin boundary.
+
+    Same-host http-to-https upgrades are treated as same-origin.
+    """
+    if (src.scheme, src.host, src.port) == (dst.scheme, dst.host, dst.port):
+        return False
+    return not (src.host == dst.host and src.scheme == "http" and dst.scheme == "https")
+
+
+def _strip_credential_headers(headers: httpx.Headers) -> httpx.Headers:
     """Keep only safe transport headers, dropping everything else."""
     return httpx.Headers({k: v for k, v in headers.items() if k.lower() in _SAFE_REDIRECT_HEADERS})
 
@@ -154,7 +172,7 @@ async def _perform_request(
     client: httpx.AsyncClient | None,
     cancel_signal: threading.Event | None = None,
 ) -> HttpRequestOutput:
-    """Perform the HTTP request, stripping non-standard headers on cross-host redirects."""
+    """Perform the HTTP request, stripping non-standard headers on cross-origin redirects."""
     owns_client = client is None
 
     active_client: httpx.AsyncClient
@@ -208,8 +226,8 @@ async def _perform_request(
                 if next_request is None:
                     break
 
-                if request.url.host != next_request.url.host:
-                    next_request.headers = _strip_headers_for_cross_host(next_request.headers)
+                if _is_cross_origin(request.url, next_request.url):
+                    next_request.headers = _strip_credential_headers(next_request.headers)
 
                 request = next_request
 

--- a/strands-py/src/strands/vended_tools/http_request/http_request.py
+++ b/strands-py/src/strands/vended_tools/http_request/http_request.py
@@ -8,15 +8,11 @@ networking to the client instance provided by the operator, giving full
 control over transport configuration, authentication, proxies, timeouts,
 redirects, and connection pooling.
 
-When redirects are enabled on the client, the tool follows them manually
-so that credential headers can be stripped on cross-host hops. Only
-standard transport headers (``accept``, ``user-agent``, etc.) survive a
-redirect to a different host; operator-configured credentials and
-model-supplied auth tokens are dropped.
+When redirects are enabled, the tool follows them manually and strips
+non-standard headers on cross-host hops to prevent credential leakage.
 
 The parent agent's cancel signal (``Agent._cancel_signal``) is propagated so
-an in-flight fetch aborts when the agent is cancelled. Cancellation is
-signalled with :class:`asyncio.CancelledError`.
+an in-flight fetch aborts when the agent is cancelled.
 """
 
 from __future__ import annotations
@@ -35,7 +31,6 @@ if TYPE_CHECKING:
     from ...tools.decorator import DecoratedFunctionTool
 
 _SAFE_REDIRECT_HEADERS: frozenset[str] = frozenset({"accept", "accept-encoding", "connection", "host", "user-agent"})
-"""Header names safe to forward on a cross-host redirect."""
 
 
 class HttpRequestError(RuntimeError):
@@ -159,13 +154,7 @@ async def _perform_request(
     client: httpx.AsyncClient | None,
     cancel_signal: threading.Event | None = None,
 ) -> HttpRequestOutput:
-    """Perform the HTTP request, following redirects with credential safety.
-
-    When the client has ``follow_redirects=True``, redirects are followed
-    manually so that credential headers can be stripped on cross-host hops.
-    The response body is streamed so the cancel signal can be checked between
-    chunks.
-    """
+    """Perform the HTTP request, stripping non-standard headers on cross-host redirects."""
     owns_client = client is None
 
     active_client: httpx.AsyncClient

--- a/strands-py/tests/strands/vended_tools/test_http_request.py
+++ b/strands-py/tests/strands/vended_tools/test_http_request.py
@@ -441,6 +441,174 @@ class TestRequestError:
             await tool(method="GET", url="https://example.com/")
 
 
+class TestRedirectCredentialSafety:
+    """Cross-origin redirects strip credential headers to prevent leakage."""
+
+    @pytest.mark.asyncio
+    async def test_cross_origin_strips_custom_headers(self):
+        captured: dict[str, dict[str, str]] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured[str(request.url)] = dict(request.headers)
+            if request.url.host == "api.example.com":
+                return httpx.Response(302, headers={"location": "https://attacker.com/steal"})
+            return httpx.Response(200, text="ok")
+
+        client = httpx.AsyncClient(
+            transport=_make_transport(handler),
+            headers={"X-API-Key": "secret", "Authorization": "Bearer tok"},
+            follow_redirects=True,
+        )
+        tool = make_http_request(client=client)
+        result = await tool(method="GET", url="https://api.example.com/start")
+
+        assert result["status"] == 200
+        redirected = captured["https://attacker.com/steal"]
+        assert "x-api-key" not in redirected
+        assert "authorization" not in redirected
+
+    @pytest.mark.asyncio
+    async def test_same_origin_preserves_all_headers(self):
+        captured: dict[str, dict[str, str]] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured[str(request.url)] = dict(request.headers)
+            if request.url.path == "/start":
+                return httpx.Response(302, headers={"location": "/final"})
+            return httpx.Response(200, text="ok")
+
+        client = httpx.AsyncClient(
+            transport=_make_transport(handler),
+            headers={"X-API-Key": "secret", "Authorization": "Bearer tok"},
+            follow_redirects=True,
+        )
+        tool = make_http_request(client=client)
+        result = await tool(method="GET", url="https://api.example.com/start")
+
+        assert result["status"] == 200
+        redirected = captured["https://api.example.com/final"]
+        assert redirected["x-api-key"] == "secret"
+        assert redirected["authorization"] == "Bearer tok"
+
+    @pytest.mark.asyncio
+    async def test_cross_origin_preserves_default_headers(self):
+        captured: dict[str, dict[str, str]] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured[str(request.url)] = dict(request.headers)
+            if request.url.host == "example.com":
+                return httpx.Response(302, headers={"location": "https://other.com/page"})
+            return httpx.Response(200, text="ok")
+
+        client = httpx.AsyncClient(
+            transport=_make_transport(handler),
+            headers={"X-API-Key": "secret"},
+            follow_redirects=True,
+        )
+        tool = make_http_request(client=client)
+        await tool(method="GET", url="https://example.com/start")
+
+        redirected = captured["https://other.com/page"]
+        assert "user-agent" in redirected
+        assert "accept" in redirected
+
+    @pytest.mark.asyncio
+    async def test_cross_origin_strips_model_supplied_headers(self):
+        captured: dict[str, dict[str, str]] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured[str(request.url)] = dict(request.headers)
+            if request.url.host == "example.com":
+                return httpx.Response(302, headers={"location": "https://other.com/page"})
+            return httpx.Response(200, text="ok")
+
+        client = httpx.AsyncClient(
+            transport=_make_transport(handler),
+            follow_redirects=True,
+        )
+        tool = make_http_request(client=client)
+        await tool(method="GET", url="https://example.com/start", headers={"X-Custom-Auth": "secret"})
+
+        redirected = captured["https://other.com/page"]
+        assert "x-custom-auth" not in redirected
+
+    @pytest.mark.asyncio
+    async def test_multi_hop_strips_on_cross_origin_hop(self):
+        captured: dict[str, dict[str, str]] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured[str(request.url)] = dict(request.headers)
+            if request.url.path == "/start":
+                return httpx.Response(302, headers={"location": "https://a.com/mid"})
+            if request.url.path == "/mid":
+                return httpx.Response(302, headers={"location": "https://b.com/final"})
+            return httpx.Response(200, text="ok")
+
+        client = httpx.AsyncClient(
+            transport=_make_transport(handler),
+            headers={"X-API-Key": "secret"},
+            follow_redirects=True,
+        )
+        tool = make_http_request(client=client)
+        result = await tool(method="GET", url="https://a.com/start")
+
+        assert result["status"] == 200
+        assert captured["https://a.com/mid"]["x-api-key"] == "secret"
+        assert "x-api-key" not in captured["https://b.com/final"]
+
+    @pytest.mark.asyncio
+    async def test_no_redirect_follow_when_client_disabled(self):
+        call_count = {"n": 0}
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            call_count["n"] += 1
+            return httpx.Response(302, headers={"location": "https://other.com/page"}, text="redirecting")
+
+        client = httpx.AsyncClient(transport=_make_transport(handler))
+        tool = make_http_request(client=client)
+        result = await tool(method="GET", url="https://example.com/start")
+
+        assert result["status"] == 302
+        assert call_count["n"] == 1
+
+    @pytest.mark.asyncio
+    async def test_max_redirects_respected(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            next_path = "/next" + request.url.path
+            return httpx.Response(302, headers={"location": next_path})
+
+        client = httpx.AsyncClient(
+            transport=_make_transport(handler),
+            follow_redirects=True,
+            max_redirects=3,
+        )
+        tool = make_http_request(client=client)
+        with pytest.raises(HttpRequestError, match="Too many redirects"):
+            await tool(method="GET", url="https://example.com/start")
+
+    @pytest.mark.asyncio
+    async def test_https_upgrade_preserves_headers(self):
+        captured: dict[str, dict[str, str]] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured[str(request.url)] = dict(request.headers)
+            if request.url.scheme == "http":
+                return httpx.Response(302, headers={"location": "https://example.com/page"})
+            return httpx.Response(200, text="ok")
+
+        client = httpx.AsyncClient(
+            transport=_make_transport(handler),
+            headers={"X-API-Key": "secret"},
+            follow_redirects=True,
+        )
+        tool = make_http_request(client=client)
+        result = await tool(method="GET", url="http://example.com/page")
+
+        assert result["status"] == 200
+        redirected = captured["https://example.com/page"]
+        assert redirected["x-api-key"] == "secret"
+
+
 class TestEncodingFallback:
     """Response body decoding falls back to UTF-8 on unknown encodings."""
 

--- a/strands-py/tests/strands/vended_tools/test_http_request.py
+++ b/strands-py/tests/strands/vended_tools/test_http_request.py
@@ -587,6 +587,29 @@ class TestRedirectCredentialSafety:
             await tool(method="GET", url="https://example.com/start")
 
     @pytest.mark.asyncio
+    async def test_redirect_stops_when_next_request_is_none(self):
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(302, headers={"location": "https://other.com/page"}, text="redirecting")
+
+        client = httpx.AsyncClient(
+            transport=_make_transport(handler),
+            follow_redirects=True,
+        )
+        original_send = client.send
+
+        async def send_nulling_next_request(*args, **kwargs):
+            response = await original_send(*args, **kwargs)
+            response.next_request = None
+            return response
+
+        client.send = send_nulling_next_request  # type: ignore[assignment]
+        tool = make_http_request(client=client)
+        result = await tool(method="GET", url="https://example.com/start")
+
+        assert result["status"] == 302
+        assert result["body"] == "redirecting"
+
+    @pytest.mark.asyncio
     async def test_https_upgrade_preserves_headers(self):
         captured: dict[str, dict[str, str]] = {}
 

--- a/strands-py/tests/strands/vended_tools/test_http_request.py
+++ b/strands-py/tests/strands/vended_tools/test_http_request.py
@@ -631,6 +631,72 @@ class TestRedirectCredentialSafety:
         redirected = captured["https://example.com/page"]
         assert redirected["x-api-key"] == "secret"
 
+    @pytest.mark.asyncio
+    async def test_https_downgrade_strips_headers(self):
+        captured: dict[str, dict[str, str]] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured[str(request.url)] = dict(request.headers)
+            if request.url.scheme == "https":
+                return httpx.Response(302, headers={"location": "http://example.com/page"})
+            return httpx.Response(200, text="ok")
+
+        client = httpx.AsyncClient(
+            transport=_make_transport(handler),
+            headers={"X-API-Key": "secret"},
+            follow_redirects=True,
+        )
+        tool = make_http_request(client=client)
+        result = await tool(method="GET", url="https://example.com/page")
+
+        assert result["status"] == 200
+        redirected = captured["http://example.com/page"]
+        assert "x-api-key" not in redirected
+
+    @pytest.mark.asyncio
+    async def test_port_change_strips_headers(self):
+        captured: dict[str, dict[str, str]] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured[str(request.url)] = dict(request.headers)
+            if request.url.port is None or request.url.port == 443:
+                return httpx.Response(302, headers={"location": "https://example.com:8443/page"})
+            return httpx.Response(200, text="ok")
+
+        client = httpx.AsyncClient(
+            transport=_make_transport(handler),
+            headers={"X-API-Key": "secret"},
+            follow_redirects=True,
+        )
+        tool = make_http_request(client=client)
+        result = await tool(method="GET", url="https://example.com/page")
+
+        assert result["status"] == 200
+        redirected = captured["https://example.com:8443/page"]
+        assert "x-api-key" not in redirected
+
+    @pytest.mark.asyncio
+    async def test_cross_origin_preserves_body_headers(self):
+        captured: dict[str, dict[str, str]] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured[str(request.url)] = dict(request.headers)
+            if request.url.host == "example.com":
+                return httpx.Response(307, headers={"location": "https://other.com/page"})
+            return httpx.Response(200, text="ok")
+
+        client = httpx.AsyncClient(
+            transport=_make_transport(handler),
+            headers={"X-API-Key": "secret"},
+            follow_redirects=True,
+        )
+        tool = make_http_request(client=client)
+        await tool(method="POST", url="https://example.com/start", body="payload")
+
+        redirected = captured["https://other.com/page"]
+        assert "x-api-key" not in redirected
+        assert "content-length" in redirected
+
 
 class TestEncodingFallback:
     """Response body decoding falls back to UTF-8 on unknown encodings."""


### PR DESCRIPTION
## Description

When an operator configures custom headers on the httpx client (e.g. `httpx.AsyncClient(headers={"X-API-Key": "secret"}, follow_redirects=True)`), httpx's built-in redirect handling strips `Authorization` on cross-origin hops but forwards all other headers unchanged. This means custom credential headers like `X-API-Key` survive redirects to different origins.

This PR switches to manual redirect following so that all non-standard headers are stripped when a redirect crosses an origin boundary (different scheme, host, or port). Same-origin redirects and same-host http-to-https upgrades preserve all headers. `follow_redirects=False` (the default) is unaffected.

## Related Issues

N/A

## Documentation PR

N/A — no new public API.

## Type of Change

Bug fix

## Testing

- [ ] I ran `hatch run prepare`

12 tests in `TestRedirectCredentialSafety` covering cross-origin stripping, same-origin preservation, multi-hop chains, HTTPS upgrades, HTTPS downgrades, port changes, body-header preservation on 307, max_redirects, and disabled redirects. All 40 tests pass with 100% coverage on the changed file.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.