### PR TITLE
feat(mcp-py): refresh tools on list-changed notifications for 2.x

### DIFF
--- a/.github/workflows/python-test-lint.yml
+++ b/.github/workflows/python-test-lint.yml
@@ -132,7 +132,9 @@ jobs:
       # With coverage: the 2.x branches of `_compat` execute only in this job,
       # so without this upload they always show as uncovered on the patch.
       - name: Run compat tests
-        run: pytest tests/strands/tools/mcp/test__compat.py -vv --cov=src/strands --cov-report=xml
+        run: |
+          pytest tests/strands/tools/mcp/test__compat.py -vv --cov=src/strands --cov-report=xml
+          pytest tests/strands/tools/mcp/test_mcp_client.py -k 'tools_changed or session_message' -vv --cov=src/strands --cov-append --cov-report=xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7

--- a/strands-py/docs/MCP_CLIENT_ARCHITECTURE.md
+++ b/strands-py/docs/MCP_CLIENT_ARCHITECTURE.md
@@ -29,7 +29,7 @@ sequenceDiagram
         BG-->>Main: tool response via Future.set_result()
         Main-->>Dev: return tool result
     else Fatal error in tool response
-        BG->>BG: _handle_error_message() - raise exception
+        BG->>BG: _handle_session_message() - raise exception
         BG->>BG: Background thread exits
         Note over BG: Connection collapses
         BG-->>Main: exception via Future.set_exception()
@@ -38,7 +38,7 @@ sequenceDiagram
     
     Note over MCP,BG: Separate flow - server can send unexpected messages anytime
     MCP-->>BG: orphaned response (unknown request id)
-    BG->>BG: _handle_error_message() - log & continue
+    BG->>BG: _handle_session_message() - log & continue
     Note over BG: Connection stays alive (non-fatal error)
     
     Dev->>Main: exit context manager
@@ -74,12 +74,12 @@ Once the background thread's event loop is running, we can create `asyncio.Futur
 
 *Problem*: MCP SDK silently swallows server exceptions (HTTP timeouts, connection errors) without a message handler. Tool calls timeout on server side but client waits indefinitely for responses that never arrive.
 
-*Defense*: `message_handler=self._handle_error_message` in ClientSession
+*Defense*: `message_handler=self._handle_session_message` in ClientSession
 ```python
 async with ClientSession(
     read_stream,
     write_stream,
-    message_handler=self._handle_error_message,  # Prevents hanging
+    message_handler=self._handle_session_message,  # Prevents hanging
     elicitation_callback=self._elicitation_callback,
 ) as session:
 ```
@@ -91,7 +91,7 @@ async with ClientSession(
 3. **Server times out** and sends an exception message back to the MCP client
 4. **Without message handler**: MCP SDK silently ignores the exception, never calls `Future.set_result()` or `Future.set_exception()`
 5. **Main thread hangs forever** waiting for `invoke_future.result()` that will never complete
-6. **With `_handle_error_message`**: Exception is raised in background thread, propagates to `Future.set_exception()`, unblocks main thread
+6. **With `_handle_session_message`**: Exception is raised in background thread, propagates to `Future.set_exception()`, unblocks main thread
 
 The threading architecture makes this particularly problematic because the main thread has no way to detect that the background thread received an error - it can only wait for the Future to complete. Without the message handler, that Future never gets resolved.
 
@@ -116,7 +116,7 @@ async def run_async() -> T:
 
 ### Defense Against Premature Connection Collapse
 
-Before [PR #922](https://github.com/strands-agents/harness-sdk/pull/922), the MCP client would never collapse connections because exceptions were silently ignored. After adding `_handle_error_message`, we introduced the risk of collapsing connections on client-side errors that should be recoverable. The challenge is ensuring we:
+Before [PR #922](https://github.com/strands-agents/harness-sdk/pull/922), the MCP client would never collapse connections because exceptions were silently ignored. After adding `_handle_session_message`, we introduced the risk of collapsing connections on client-side errors that should be recoverable. The challenge is ensuring we:
 
 1. **DO collapse** when we want to (fatal server errors)
 2. **DO NOT collapse** when we don't want to (client-side errors, orphaned responses)
@@ -133,7 +133,7 @@ Client receives a response from server with an ID it doesn't recognize (orphaned
 
 **Connection Decision Flow**:
 1. MCP server sends error message to client
-2. `ClientSession` calls `message_handler=self._handle_error_message`
+2. `ClientSession` calls `message_handler=self._handle_session_message`
 3. **Decision point**: Is error in `_NON_FATAL_ERROR_PATTERNS`?
    - **Yes**: Log and continue (connection stays alive)
    - **No**: Raise exception (connection collapses)

--- a/strands-py/src/strands/tools/mcp/__init__.py
+++ b/strands-py/src/strands/tools/mcp/__init__.py
@@ -9,7 +9,7 @@ servers.
 from .mcp_agent_tool import MCPAgentTool
 from .mcp_client import MCPClient, MCPServerConfig, ToolFilters
 from .mcp_tasks import TasksConfig
-from .mcp_types import MCPClientCredentials, MCPTransport
+from .mcp_types import MCPClientCredentials, MCPTransport, ToolsChanged, ToolsChangedCallback
 
 __all__ = [
     "MCPAgentTool",
@@ -19,4 +19,6 @@ __all__ = [
     "MCPTransport",
     "TasksConfig",
     "ToolFilters",
+    "ToolsChanged",
+    "ToolsChangedCallback",
 ]

--- a/strands-py/src/strands/tools/mcp/_compat.py
+++ b/strands-py/src/strands/tools/mcp/_compat.py
@@ -15,13 +15,13 @@ ignores the installed line doesn't need.
 
 import asyncio
 from collections.abc import AsyncIterator
-from contextlib import AbstractAsyncContextManager, asynccontextmanager
+from contextlib import AbstractAsyncContextManager, AsyncExitStack, asynccontextmanager
 from datetime import timedelta
 from typing import Any
 
 import httpx
 from mcp import ClientSession
-from mcp.types import ServerCapabilities
+from mcp.types import ServerCapabilities, ToolListChangedNotification
 
 __all__ = [
     "MCP_V2",
@@ -30,6 +30,7 @@ __all__ = [
     "call_tool",
     "input_schema",
     "is_error",
+    "is_tools_list_changed",
     "mime_type",
     "negotiate_session",
     "next_cursor",
@@ -39,6 +40,7 @@ __all__ = [
     "streamable_http_transport",
     "structured_content",
     "task_support",
+    "tools_changed_subscription",
 ]
 
 # Feature-probed rather than version-parsed so pre-releases and backports
@@ -189,6 +191,26 @@ def is_error(call_tool_result: Any) -> bool | None:
     return error
 
 
+def is_tools_list_changed(message: Any) -> bool:
+    """Return whether a message-handler message is a tools list-changed notification.
+
+    The 1.x session hands the message handler a `ServerNotification` wrapper
+    whose `root` holds the notification; the 2.x session hands it the
+    notification itself, including events it tees from a
+    `subscriptions/listen` stream on a 2026-07-28 connection. Both shapes are
+    accepted unconditionally, so no version branch is needed.
+
+    Args:
+        message: A message delivered to the session's `message_handler`.
+
+    Returns:
+        Whether the message announces a change to the server's tool list.
+    """
+    if isinstance(message, ToolListChangedNotification):
+        return True
+    return isinstance(getattr(message, "root", None), ToolListChangedNotification)
+
+
 def mime_type(content: Any) -> str | None:
     """Read a content or resource block's MIME type, on either `mcp` major line.
 
@@ -337,6 +359,42 @@ async def negotiate_session(session: ClientSession) -> tuple[str | None, ServerC
 
     init_result = await session.initialize()
     return init_result.instructions, session.get_server_capabilities()  # type: ignore[attr-defined]
+
+
+@asynccontextmanager
+async def tools_changed_subscription(session: ClientSession) -> AsyncIterator[Any]:
+    """Hold open the subscription that makes a 2026-07-28 server publish tools list changes.
+
+    The 2026-07-28 spec (SEP-2575) consolidated server notifications into an
+    opt-in `subscriptions/listen` stream: a modern server emits a tools
+    list-changed event only while a subscriber holds the stream open. The 2.x
+    session tees each event to the `message_handler` as a
+    `ToolListChangedNotification`, so holding the stream open is all the
+    intake requires. The 1.x line and legacy-negotiated 2.x connections push
+    the notification without any subscription; those yield None and hold
+    nothing.
+
+    Args:
+        session: An active, negotiated `ClientSession`.
+
+    Yields:
+        The subscription handle, or None when the connection has no
+        subscription to hold.
+    """
+    if not MCP_V2:
+        yield None
+        return
+
+    from mcp.client.subscriptions import ListenNotSupportedError, listen  # type: ignore[import-not-found]
+
+    async with AsyncExitStack() as subscription_scope:
+        try:
+            subscription = await subscription_scope.enter_async_context(listen(session, tools_list_changed=True))
+        except ListenNotSupportedError:
+            # The connection negotiated a legacy protocol version, so the
+            # server pushes list-changed notifications unprompted.
+            subscription = None
+        yield subscription
 
 
 def streamable_http_transport(

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -80,7 +80,7 @@ from ._compat import call_tool as compat_call_tool
 from .mcp_agent_tool import MCPAgentTool
 from .mcp_instrumentation import inject_trace_context, mcp_instrumentation
 from .mcp_tasks import DEFAULT_TASK_CONFIG, DEFAULT_TASK_POLL_TIMEOUT, DEFAULT_TASK_TTL, TasksConfig
-from .mcp_types import MCPClientCredentials, MCPToolResult, MCPTransport
+from .mcp_types import MCPClientCredentials, MCPToolResult, MCPTransport, ToolsChanged
 
 if TYPE_CHECKING:
     # Only the mcp 1.x line spells this name; the runtime import stays inside
@@ -186,8 +186,6 @@ _NON_FATAL_ERROR_PATTERNS = [
     "unknown request id",
 ]
 
-# Matches the TypeScript SDK's tools listChanged debounce, so a burst of
-# notifications folds into one refresh in both SDKs.
 _TOOLS_CHANGED_DEBOUNCE_SECONDS = 0.3
 
 
@@ -276,7 +274,7 @@ class MCPClient(ToolProvider):
         elicitation_callback: ElicitationFnT | None = None,
         progress_callback: ProgressFnT | None = None,
         tasks_config: TasksConfig | None = None,
-        on_tools_changed: Callable[[list[str], list[MCPAgentTool]], None] | None = None,
+        on_tools_changed: ToolsChanged | None = None,
     ) -> None:
         """Initialize a new MCP Server connection.
 
@@ -313,9 +311,13 @@ class MCPClient(ToolProvider):
             on_tools_changed: Optional callback invoked after the server announces a change to its
                 tool list and the client refreshes it. Called with the previous tool names and the
                 refreshed tool instances. Registering it turns on the refresh: the client listens
-                for the server's tools list-changed notifications, re-lists the tools (applying the
-                constructor's prefix and filters), and updates the cached tools that `load_tools`
-                returns.
+                for the server's tools list-changed notifications, re-lists the tools (applying
+                the constructor's prefix and filters), and updates the cached tools that
+                `load_tools` returns. On a connection that negotiated MCP 2026-07-28, registering
+                it also makes `start()` failable: the client must open the server's
+                `subscriptions/listen` stream to receive the notifications, and a failure to open
+                it (other than the server lacking support) raises `MCPClientInitializationError`
+                from `start()`.
 
         Raises:
             ValueError: If neither or both of `transport_callable` and `url` are provided, if
@@ -447,6 +449,24 @@ class MCPClient(ToolProvider):
         """
         return self._connection_failed
 
+    @property
+    def on_tools_changed(self) -> ToolsChanged | None:
+        """The registered tools-changed callback, if any (see `__init__`)."""
+        return self._on_tools_changed
+
+    @on_tools_changed.setter
+    def on_tools_changed(self, callback: ToolsChanged | None) -> None:
+        """Register or remove the tools-changed callback.
+
+        On a connection that negotiated MCP 2026-07-28, the `subscriptions/listen`
+        stream that makes the server publish list-changed notifications is opened
+        at session start only when a callback is registered, so a callback set
+        after `start()` receives nothing from such a server until the client is
+        restarted. Servers on earlier protocol versions push the notification
+        unprompted, so a late-set callback works there immediately.
+        """
+        self._on_tools_changed = callback
+
     # ToolProvider interface methods
     async def load_tools(self, **kwargs: Any) -> Sequence[AgentTool]:
         """Load and return tools from the MCP server.
@@ -489,7 +509,11 @@ class MCPClient(ToolProvider):
 
         if self._loaded_tools is None:
             logger.debug("loading tools from MCP server")
-            self._loaded_tools = self._list_all_tools_sync()
+            initial_tools = self._list_all_tools_sync()
+            # A refresh may have replaced the cache while this listing ran;
+            # the refreshed list is newer, so it wins over the initial load.
+            if self._loaded_tools is None:
+                self._loaded_tools = initial_tools
             logger.debug("final_tools=<%d> | loading complete", len(self._loaded_tools))
 
         return self._loaded_tools
@@ -631,6 +655,11 @@ class MCPClient(ToolProvider):
         self._background_cleanup_tasks.clear()
         self._server_task_capable = None
         self._tool_task_support_cache = {}
+        # A refresh task destroyed with the loop never ran its finally, so
+        # without this reset a restarted client would skip every refresh.
+        self._tools_refresh_in_progress = False
+        self._tools_refresh_pending = False
+        self._tools_refresh_tasks.clear()
 
         if self._close_exception:
             exception = self._close_exception
@@ -1162,9 +1191,19 @@ class MCPClient(ToolProvider):
 
                     async with AsyncExitStack() as session_scope:
                         if self._on_tools_changed is not None:
-                            subscription = await session_scope.enter_async_context(tools_changed_subscription(session))
+                            # Bounded so a server that accepts the listen request but never
+                            # acknowledges it cannot hold start() past its startup timeout.
+                            try:
+                                subscription = await asyncio.wait_for(
+                                    session_scope.enter_async_context(tools_changed_subscription(session)),
+                                    timeout=self._startup_timeout,
+                                )
+                            except asyncio.TimeoutError as timeout_error:
+                                raise MCPClientInitializationError(
+                                    "timed out opening the tools list-changed subscription"
+                                ) from timeout_error
                             self._log_debug_with_thread(
-                                "subscribed=<%s> | tools list-changed intake ready", subscription is not None
+                                "subscribed=<%s> | tools list-changed notifications ready", subscription is not None
                             )
 
                         # Signal that the session has been created and is ready for use
@@ -1176,6 +1215,7 @@ class MCPClient(ToolProvider):
                         await self._close_future
 
                         self._log_debug_with_thread("close signal received")
+                        await self._drain_tools_refresh_tasks()
                         await self._drain_background_cleanup_tasks()
         except Exception as e:
             # If we encounter an exception and the future is still running,
@@ -1213,9 +1253,9 @@ class MCPClient(ToolProvider):
         """Refresh the tool list after a list-changed notification.
 
         Runs on the background event loop. One refresh runs at a time;
-        notifications that arrive mid-refresh fold into a single trailing
-        rerun, and the debounce folds a burst of notifications into one
-        refresh.
+        notifications that arrive while a round is sleeping or refreshing
+        fold into a single trailing rerun, so a burst costs at most two
+        refreshes.
         """
         if self._tools_refresh_in_progress:
             self._tools_refresh_pending = True
@@ -1225,11 +1265,13 @@ class MCPClient(ToolProvider):
             while True:
                 self._tools_refresh_pending = False
                 await asyncio.sleep(_TOOLS_CHANGED_DEBOUNCE_SECONDS)
-                await asyncio.to_thread(self._refresh_loaded_tools)
+                try:
+                    await asyncio.to_thread(self._refresh_loaded_tools)
+                except Exception as error:
+                    # One failed round must not discard a queued trailing rerun.
+                    logger.warning("error=<%s> | failed to refresh tools after list-changed notification", error)
                 if not self._tools_refresh_pending:
                     return
-        except Exception as error:
-            logger.warning("error=<%s> | failed to refresh tools after list-changed notification", error)
         finally:
             self._tools_refresh_in_progress = False
 
@@ -1242,9 +1284,16 @@ class MCPClient(ToolProvider):
         previous_names = [tool.tool_name for tool in self._loaded_tools or []]
         refreshed_tools = self._list_all_tools_sync()
         self._loaded_tools = refreshed_tools
+        self._log_debug_with_thread("refreshed_tools=<%d> | tools refresh complete", len(refreshed_tools))
         callback = self._on_tools_changed
-        if callback is not None:
+        if callback is None:
+            return
+        try:
             callback(previous_names, refreshed_tools)
+        except Exception:
+            # The cache is already refreshed; only the notification to the
+            # consumer failed, so name the callback rather than the refresh.
+            logger.warning("the on_tools_changed callback raised", exc_info=True)
 
     def _background_task(self) -> None:
         """Sets up and runs the event loop in the background thread.
@@ -1363,6 +1412,24 @@ class MCPClient(ToolProvider):
             return
         self._background_cleanup_tasks.add(task)
         task.add_done_callback(self._background_cleanup_tasks.discard)
+
+    async def _drain_tools_refresh_tasks(self) -> None:
+        """Let in-flight tool refreshes unwind before the background loop stops.
+
+        A refresh worker thread blocks on a future served by this loop; once
+        the close signal has fired, that future resolves promptly, so waiting
+        here keeps the worker from being stranded on a future a stopped loop
+        can never resolve (a stranded worker is a non-daemon thread that
+        hangs interpreter exit).
+        """
+        if not self._tools_refresh_tasks:
+            return
+        pending_refreshes = set(self._tools_refresh_tasks)
+        _, still_pending = await asyncio.wait(pending_refreshes, timeout=1)
+        for task in still_pending:
+            task.cancel()
+        if still_pending:
+            await asyncio.wait(still_pending, timeout=1)
 
     async def _drain_background_cleanup_tasks(self) -> None:
         """Give detached MCP cancellation cleanup a bounded window before session shutdown."""

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -20,6 +20,7 @@ import uuid
 from asyncio import AbstractEventLoop
 from collections.abc import Callable, Coroutine, Sequence
 from concurrent import futures
+from contextlib import AsyncExitStack
 from datetime import timedelta
 from importlib.metadata import version as pkg_version
 from pathlib import Path
@@ -65,6 +66,7 @@ from ..tool_provider import ToolProvider
 from ._compat import (
     MCPError,
     is_error,
+    is_tools_list_changed,
     mime_type,
     negotiate_session,
     next_cursor,
@@ -72,6 +74,7 @@ from ._compat import (
     streamable_http_transport,
     structured_content,
     task_support,
+    tools_changed_subscription,
 )
 from ._compat import call_tool as compat_call_tool
 from .mcp_agent_tool import MCPAgentTool
@@ -183,6 +186,10 @@ _NON_FATAL_ERROR_PATTERNS = [
     "unknown request id",
 ]
 
+# Matches the TypeScript SDK's tools listChanged debounce, so a burst of
+# notifications folds into one refresh in both SDKs.
+_TOOLS_CHANGED_DEBOUNCE_SECONDS = 0.3
+
 
 class MCPClient(ToolProvider):
     """Represents a connection to a Model Context Protocol (MCP) server.
@@ -269,6 +276,7 @@ class MCPClient(ToolProvider):
         elicitation_callback: ElicitationFnT | None = None,
         progress_callback: ProgressFnT | None = None,
         tasks_config: TasksConfig | None = None,
+        on_tools_changed: Callable[[list[str], list[MCPAgentTool]], None] | None = None,
     ) -> None:
         """Initialize a new MCP Server connection.
 
@@ -302,6 +310,12 @@ class MCPClient(ToolProvider):
             tasks_config: Configuration for MCP task-augmented execution for long-running tools.
                 If provided (not None), enables task-augmented execution for tools that support it.
                 See TasksConfig for details. This feature is experimental and subject to change.
+            on_tools_changed: Optional callback invoked after the server announces a change to its
+                tool list and the client refreshes it. Called with the previous tool names and the
+                refreshed tool instances. Registering it turns on the refresh: the client listens
+                for the server's tools list-changed notifications, re-lists the tools (applying the
+                constructor's prefix and filters), and updates the cached tools that `load_tools`
+                returns.
 
         Raises:
             ValueError: If neither or both of `transport_callable` and `url` are provided, if
@@ -319,6 +333,11 @@ class MCPClient(ToolProvider):
         self._connection_failed = False
         self._elicitation_callback = elicitation_callback
         self._progress_callback = progress_callback
+        self._on_tools_changed = on_tools_changed
+        self._tools_refresh_in_progress = False
+        self._tools_refresh_pending = False
+        # Keep refresh tasks alive until they finish; asyncio only retains weak references.
+        self._tools_refresh_tasks: set[asyncio.Task[None]] = set()
 
         mcp_instrumentation()
         self._session_id = uuid.uuid4()
@@ -470,37 +489,38 @@ class MCPClient(ToolProvider):
 
         if self._loaded_tools is None:
             logger.debug("loading tools from MCP server")
-            self._loaded_tools = []
-            pagination_token = None
-            page_count = 0
-
-            while True:
-                logger.debug("page=<%d>, token=<%s> | fetching tools page", page_count, pagination_token)
-                # Use constructor defaults for prefix and filters in load_tools
-                paginated_tools = self.list_tools_sync(
-                    pagination_token, prefix=self._prefix, tool_filters=self._tool_filters
-                )
-
-                # Tools are already filtered by list_tools_sync, so add them all
-                for tool in paginated_tools:
-                    self._loaded_tools.append(tool)
-
-                logger.debug(
-                    "page=<%d>, page_tools=<%d>, total_filtered=<%d> | processed page",
-                    page_count,
-                    len(paginated_tools),
-                    len(self._loaded_tools),
-                )
-
-                pagination_token = paginated_tools.pagination_token
-                page_count += 1
-
-                if pagination_token is None:
-                    break
-
+            self._loaded_tools = self._list_all_tools_sync()
             logger.debug("final_tools=<%d> | loading complete", len(self._loaded_tools))
 
         return self._loaded_tools
+
+    def _list_all_tools_sync(self) -> list[MCPAgentTool]:
+        """List every tool page with the constructor's prefix and filters applied."""
+        all_tools: list[MCPAgentTool] = []
+        pagination_token = None
+        page_count = 0
+
+        while True:
+            logger.debug("page=<%d>, token=<%s> | fetching tools page", page_count, pagination_token)
+            paginated_tools = self.list_tools_sync(
+                pagination_token, prefix=self._prefix, tool_filters=self._tool_filters
+            )
+
+            # Tools are already filtered by list_tools_sync, so add them all
+            all_tools.extend(paginated_tools)
+
+            logger.debug(
+                "page=<%d>, page_tools=<%d>, total_filtered=<%d> | processed page",
+                page_count,
+                len(paginated_tools),
+                len(all_tools),
+            )
+
+            pagination_token = paginated_tools.pagination_token
+            page_count += 1
+
+            if pagination_token is None:
+                return all_tools
 
     def add_consumer(self, consumer_id: Any, **kwargs: Any) -> None:
         """Add a consumer to this tool provider.
@@ -1108,7 +1128,7 @@ class MCPClient(ToolProvider):
                 async with ClientSession(
                     read_stream,
                     write_stream,
-                    message_handler=self._handle_error_message,
+                    message_handler=self._handle_session_message,
                     elicitation_callback=self._elicitation_callback,
                     client_info=(
                         Implementation(
@@ -1140,16 +1160,23 @@ class MCPClient(ToolProvider):
                         "server_task_capable=<%s> | cached server task capability", self._server_task_capable
                     )
 
-                    # Signal that the session has been created and is ready for use
-                    self._init_future.set_result(None)
+                    async with AsyncExitStack() as session_scope:
+                        if self._on_tools_changed is not None:
+                            subscription = await session_scope.enter_async_context(tools_changed_subscription(session))
+                            self._log_debug_with_thread(
+                                "subscribed=<%s> | tools list-changed intake ready", subscription is not None
+                            )
 
-                    self._log_debug_with_thread("waiting for close signal")
-                    # Keep background thread running until signaled to close.
-                    # Thread is not blocked as this a future
-                    await self._close_future
+                        # Signal that the session has been created and is ready for use
+                        self._init_future.set_result(None)
 
-                    self._log_debug_with_thread("close signal received")
-                    await self._drain_background_cleanup_tasks()
+                        self._log_debug_with_thread("waiting for close signal")
+                        # Keep background thread running until signaled to close.
+                        # Thread is not blocked as this a future
+                        await self._close_future
+
+                        self._log_debug_with_thread("close signal received")
+                        await self._drain_background_cleanup_tasks()
         except Exception as e:
             # If we encounter an exception and the future is still running,
             # it means it was encountered during the initialization phase.
@@ -1168,14 +1195,56 @@ class MCPClient(ToolProvider):
 
     # Raise an exception if the underlying client raises an exception in a message
     # This happens when the underlying client has an http timeout error
-    async def _handle_error_message(self, message: Exception | Any) -> None:
+    async def _handle_session_message(self, message: Exception | Any) -> None:
         if isinstance(message, Exception):
             error_msg = str(message).lower()
             if any(pattern in error_msg for pattern in _NON_FATAL_ERROR_PATTERNS):
                 self._log_debug_with_thread("ignoring non-fatal MCP session error: %s", message)
             else:
                 raise message
+        elif is_tools_list_changed(message) and self._on_tools_changed is not None:
+            self._log_debug_with_thread("received tools list-changed notification")
+            refresh_task = asyncio.create_task(self._handle_tools_changed())
+            self._tools_refresh_tasks.add(refresh_task)
+            refresh_task.add_done_callback(self._tools_refresh_tasks.discard)
         await anyio.lowlevel.checkpoint()
+
+    async def _handle_tools_changed(self) -> None:
+        """Refresh the tool list after a list-changed notification.
+
+        Runs on the background event loop. One refresh runs at a time;
+        notifications that arrive mid-refresh fold into a single trailing
+        rerun, and the debounce folds a burst of notifications into one
+        refresh.
+        """
+        if self._tools_refresh_in_progress:
+            self._tools_refresh_pending = True
+            return
+        self._tools_refresh_in_progress = True
+        try:
+            while True:
+                self._tools_refresh_pending = False
+                await asyncio.sleep(_TOOLS_CHANGED_DEBOUNCE_SECONDS)
+                await asyncio.to_thread(self._refresh_loaded_tools)
+                if not self._tools_refresh_pending:
+                    return
+        except Exception as error:
+            logger.warning("error=<%s> | failed to refresh tools after list-changed notification", error)
+        finally:
+            self._tools_refresh_in_progress = False
+
+    def _refresh_loaded_tools(self) -> None:
+        """Re-list every tool and invoke the change callback.
+
+        Runs off the event loop thread because `list_tools_sync` blocks on
+        work it submits back to the background loop.
+        """
+        previous_names = [tool.tool_name for tool in self._loaded_tools or []]
+        refreshed_tools = self._list_all_tools_sync()
+        self._loaded_tools = refreshed_tools
+        callback = self._on_tools_changed
+        if callback is not None:
+            callback(previous_names, refreshed_tools)
 
     def _background_task(self) -> None:
         """Sets up and runs the event loop in the background thread.

--- a/strands-py/src/strands/tools/mcp/mcp_types.py
+++ b/strands-py/src/strands/tools/mcp/mcp_types.py
@@ -1,15 +1,35 @@
 """Type definitions for MCP integration."""
 
+from collections.abc import Callable
 from contextlib import AbstractAsyncContextManager
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from mcp.shared.memory import MessageStream
 from mcp.shared.message import SessionMessage
-from typing_extensions import NotRequired, TypedDict
+from typing_extensions import NotRequired, Protocol, TypedDict
 
 from ...types.tools import ToolResult
 from ._compat import GetSessionIdCallback
+
+if TYPE_CHECKING:
+    from .mcp_agent_tool import MCPAgentTool
+
+
+class ToolsChangedCallback(Protocol):
+    """Called after the server announces a tool list change and the client refreshes it.
+
+    Implemented by a plain function as well — the `**kwargs` tail lets the calling
+    convention grow new keyword arguments without breaking existing callbacks.
+    """
+
+    def __call__(self, previous_names: list[str], refreshed_tools: list["MCPAgentTool"], **kwargs: Any) -> None:
+        """Handle a refresh, given the previous tool names and the refreshed tool instances."""
+        ...
+
+
+ToolsChanged = Callable[[list[str], "list[MCPAgentTool]"], None] | ToolsChangedCallback
+"""A tools-changed handler: the `**kwargs`-ready protocol or a plain two-argument callable."""
 
 
 class MCPClientCredentials(TypedDict):

--- a/strands-py/src/strands/vended_memory_stores/file_memory_store/store.py
+++ b/strands-py/src/strands/vended_memory_stores/file_memory_store/store.py
@@ -120,9 +120,7 @@ class FileMemoryStore(MemoryStore):
         self.extraction: ExtractionConfig | bool | None = self._resolve_extraction(config)
         self._write_lock = asyncio.Lock()
 
-    def _resolve_extraction(
-        self, config: FileMemoryStoreConfig
-    ) -> ExtractionConfig | bool | None:
+    def _resolve_extraction(self, config: FileMemoryStoreConfig) -> ExtractionConfig | bool | None:
         extraction: ExtractionConfig | bool | None = config.get("extraction")
         if extraction is None or extraction is False:
             return extraction
@@ -151,8 +149,10 @@ class FileMemoryStore(MemoryStore):
         if option_max is not None and option_max < 1:
             raise ValueError("max_search_results must be >= 1")
         max_results = (
-            option_max if option_max is not None
-            else self.max_search_results if self.max_search_results is not None
+            option_max
+            if option_max is not None
+            else self.max_search_results
+            if self.max_search_results is not None
             else _DEFAULT_MAX_SEARCH_RESULTS
         )
 

--- a/strands-py/src/strands/vended_memory_stores/test_memory_store/store.py
+++ b/strands-py/src/strands/vended_memory_stores/test_memory_store/store.py
@@ -53,8 +53,6 @@ def _sanitize_name(name: str) -> str:
     return re.sub(r"[^\w\-.]", "_", sanitized, flags=re.ASCII)
 
 
-
-
 class TestMemoryStore(MemoryStore):
     """A :class:`~strands.memory.types.MemoryStore` backed by a local JSON file.
 

--- a/strands-py/tests/strands/storage/test_storage.py
+++ b/strands-py/tests/strands/storage/test_storage.py
@@ -126,7 +126,6 @@ class TestNamespacedStorage:
         keys = await ns.list("")
         assert keys == ["key1"]
 
-
     @pytest.mark.asyncio
     async def test_search_scopes_to_prefix(self, storage):
         await storage.write("scope/a.md", b"dark mode toggle")

--- a/strands-py/tests/strands/tools/mcp/test__compat.py
+++ b/strands-py/tests/strands/tools/mcp/test__compat.py
@@ -722,11 +722,14 @@ def test_is_tools_list_changed_rejects_other_messages():
 @requires_mcp_v2
 def test_installed_v2_line_exposes_the_subscriptions_names():
     """Test that the names the 2.x subscription branch imports exist on the installed line."""
+    from contextlib import AbstractAsyncContextManager
+
     from mcp.client.subscriptions import ListenNotSupportedError, listen
 
-    assert callable(listen)
     assert issubclass(ListenNotSupportedError, Exception)
     assert "tools_list_changed" in inspect.signature(listen).parameters
+    # Creating the context manager defers the body, so no session traffic happens here.
+    assert isinstance(listen(MagicMock(), tools_list_changed=True), AbstractAsyncContextManager)
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests/strands/tools/mcp/test__compat.py
+++ b/strands-py/tests/strands/tools/mcp/test__compat.py
@@ -688,3 +688,102 @@ async def test_streamable_http_transport_v2_owns_client_lifecycle(monkeypatch):
         ("transport_exit", "https://example.com/mcp"),
         ("client_exit", headers, auth),
     ]
+
+
+def test_is_tools_list_changed_accepts_both_delivery_shapes():
+    """Test that both message-handler delivery shapes are recognized.
+
+    The 1.x session wraps the notification in `ServerNotification`; the 2.x
+    session delivers it bare, including events teed from a
+    `subscriptions/listen` stream. The wrapper is constructible only on the
+    1.x line (2.x spells `ServerNotification` as a plain union), so the real
+    wrapped shape is asserted there and a stand-in with the same `root`
+    attribute everywhere.
+    """
+    from mcp.types import ToolListChangedNotification
+
+    notification = ToolListChangedNotification(method="notifications/tools/list_changed")
+
+    assert _compat.is_tools_list_changed(notification)
+    assert _compat.is_tools_list_changed(SimpleNamespace(root=notification))
+    if not _compat.MCP_V2:
+        from mcp.types import ServerNotification
+
+        assert _compat.is_tools_list_changed(ServerNotification(notification))
+
+
+def test_is_tools_list_changed_rejects_other_messages():
+    """Test that unrelated messages and exceptions are not treated as tool list changes."""
+    assert not _compat.is_tools_list_changed("normal message")
+    assert not _compat.is_tools_list_changed(Exception("boom"))
+    assert not _compat.is_tools_list_changed(SimpleNamespace(root="not a notification"))
+
+
+@requires_mcp_v2
+def test_installed_v2_line_exposes_the_subscriptions_names():
+    """Test that the names the 2.x subscription branch imports exist on the installed line."""
+    from mcp.client.subscriptions import ListenNotSupportedError, listen
+
+    assert callable(listen)
+    assert issubclass(ListenNotSupportedError, Exception)
+    assert "tools_list_changed" in inspect.signature(listen).parameters
+
+
+@pytest.mark.asyncio
+async def test_tools_changed_subscription_v1_yields_none(monkeypatch):
+    """Test that the 1.x branch holds no subscription: the server pushes notifications unprompted."""
+    monkeypatch.setattr(_compat, "MCP_V2", False)
+
+    async with _compat.tools_changed_subscription(MagicMock()) as subscription:
+        assert subscription is None
+
+
+@pytest.mark.asyncio
+async def test_tools_changed_subscription_v2_holds_the_listen_stream(monkeypatch):
+    """Test that the 2.x branch opens `subscriptions/listen` for tool changes and closes it on exit.
+
+    The `mcp.client.subscriptions` module exists only on the 2.x line, so a
+    stub module stands in for it to exercise this branch under the 1.x pin.
+    """
+    monkeypatch.setattr(_compat, "MCP_V2", True)
+    lifecycle_events = []
+    stream = MagicMock()
+    session = MagicMock()
+
+    @asynccontextmanager
+    async def fake_listen(listen_session, *, tools_list_changed):
+        lifecycle_events.append(("enter", listen_session, tools_list_changed))
+        yield stream
+        lifecycle_events.append(("exit",))
+
+    subscriptions_module = ModuleType("mcp.client.subscriptions")
+    subscriptions_module.listen = fake_listen  # type: ignore[attr-defined]
+    subscriptions_module.ListenNotSupportedError = type("ListenNotSupportedError", (RuntimeError,), {})  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "mcp.client.subscriptions", subscriptions_module)
+
+    async with _compat.tools_changed_subscription(session) as subscription:
+        assert subscription is stream
+        assert lifecycle_events == [("enter", session, True)]
+
+    assert lifecycle_events == [("enter", session, True), ("exit",)]
+
+
+@pytest.mark.asyncio
+async def test_tools_changed_subscription_v2_degrades_on_a_legacy_connection(monkeypatch):
+    """Test that a connection whose negotiated version predates `subscriptions/listen` yields None."""
+    monkeypatch.setattr(_compat, "MCP_V2", True)
+
+    listen_not_supported = type("ListenNotSupportedError", (RuntimeError,), {})
+
+    @asynccontextmanager
+    async def fake_listen(listen_session, *, tools_list_changed):
+        raise listen_not_supported("negotiated version predates 2026-07-28")
+        yield
+
+    subscriptions_module = ModuleType("mcp.client.subscriptions")
+    subscriptions_module.listen = fake_listen  # type: ignore[attr-defined]
+    subscriptions_module.ListenNotSupportedError = listen_not_supported  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "mcp.client.subscriptions", subscriptions_module)
+
+    async with _compat.tools_changed_subscription(MagicMock()) as subscription:
+        assert subscription is None

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 import threading
 import time
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -19,12 +20,14 @@ from mcp.types import (
     Resource,
     ResourceTemplate,
     TextResourceContents,
+    ToolListChangedNotification,
 )
 from mcp.types import ImageContent as MCPImageContent
 from mcp.types import TextContent as MCPTextContent
 from mcp.types import Tool as MCPTool
 from pydantic import AnyUrl
 
+import strands.tools.mcp.mcp_client as mcp_client_module
 from strands.tools.mcp import MCPClient
 from strands.tools.mcp.mcp_types import MCPToolResult
 from strands.types.exceptions import MCPClientInitializationError
@@ -1300,8 +1303,6 @@ async def test_handle_session_message_non_exception():
 @pytest.mark.asyncio
 async def test_handle_session_message_tools_changed_schedules_a_refresh():
     """Test that a tools list-changed notification schedules a refresh when the callback is set."""
-    from mcp.types import ToolListChangedNotification
-
     client = MCPClient(MagicMock(), on_tools_changed=MagicMock())
     notification = ToolListChangedNotification(method="notifications/tools/list_changed")
 
@@ -1319,8 +1320,6 @@ async def test_handle_session_message_tools_changed_schedules_a_refresh():
 @pytest.mark.asyncio
 async def test_handle_session_message_tools_changed_ignored_without_callback():
     """Test that a tools list-changed notification is a no-op when no callback is registered."""
-    from mcp.types import ToolListChangedNotification
-
     client = MCPClient(MagicMock())
     notification = ToolListChangedNotification(method="notifications/tools/list_changed")
 
@@ -1332,8 +1331,6 @@ async def test_handle_session_message_tools_changed_ignored_without_callback():
 @pytest.mark.asyncio
 async def test_handle_tools_changed_coalesces_overlapping_notifications(monkeypatch):
     """Test that a notification arriving mid-refresh folds into one trailing rerun."""
-    import strands.tools.mcp.mcp_client as mcp_client_module
-
     monkeypatch.setattr(mcp_client_module, "_TOOLS_CHANGED_DEBOUNCE_SECONDS", 0)
     client = MCPClient(MagicMock(), on_tools_changed=MagicMock())
     refresh_calls = []
@@ -1344,12 +1341,14 @@ async def test_handle_tools_changed_coalesces_overlapping_notifications(monkeypa
         refresh_calls.append(len(refresh_calls))
         if len(refresh_calls) == 1:
             first_refresh_started.set()
-            assert release_first_refresh.wait(timeout=5)
+            release_first_refresh.wait(timeout=5)
 
     monkeypatch.setattr(client, "_refresh_loaded_tools", blocking_refresh)
 
     first_notification = asyncio.create_task(client._handle_tools_changed())
+    deadline = time.time() + 5
     while not first_refresh_started.is_set():
+        assert time.time() < deadline, "first refresh never started"
         await asyncio.sleep(0.01)
 
     await client._handle_tools_changed()
@@ -1365,8 +1364,6 @@ async def test_handle_tools_changed_coalesces_overlapping_notifications(monkeypa
 @pytest.mark.asyncio
 async def test_handle_tools_changed_logs_and_recovers_when_the_refresh_raises(monkeypatch, caplog):
     """Test that a failing refresh is logged as a warning and leaves the client ready for the next one."""
-    import strands.tools.mcp.mcp_client as mcp_client_module
-
     monkeypatch.setattr(mcp_client_module, "_TOOLS_CHANGED_DEBOUNCE_SECONDS", 0)
     client = MCPClient(MagicMock(), on_tools_changed=MagicMock())
     monkeypatch.setattr(client, "_refresh_loaded_tools", MagicMock(side_effect=RuntimeError("listing failed")))
@@ -1375,6 +1372,30 @@ async def test_handle_tools_changed_logs_and_recovers_when_the_refresh_raises(mo
 
     assert "failed to refresh tools after list-changed notification" in caplog.text
     assert not client._tools_refresh_in_progress
+
+
+@pytest.mark.asyncio
+async def test_handle_tools_changed_failed_round_keeps_the_queued_rerun(monkeypatch, caplog):
+    """Test that a round that raises does not discard a rerun queued by a mid-refresh notification."""
+    monkeypatch.setattr(mcp_client_module, "_TOOLS_CHANGED_DEBOUNCE_SECONDS", 0)
+    client = MCPClient(MagicMock(), on_tools_changed=MagicMock())
+    refresh_calls = []
+
+    def failing_first_refresh():
+        refresh_calls.append(len(refresh_calls))
+        if len(refresh_calls) == 1:
+            # A notification landing mid-refresh queues the trailing rerun.
+            client._tools_refresh_pending = True
+            raise RuntimeError("listing failed")
+
+    monkeypatch.setattr(client, "_refresh_loaded_tools", failing_first_refresh)
+
+    await client._handle_tools_changed()
+
+    assert refresh_calls == [0, 1]
+    assert "failed to refresh tools after list-changed notification" in caplog.text
+    assert not client._tools_refresh_in_progress
+    assert not client._tools_refresh_pending
 
 
 def test_refresh_loaded_tools_updates_the_cache_and_invokes_the_callback():
@@ -1393,10 +1414,162 @@ def test_refresh_loaded_tools_updates_the_cache_and_invokes_the_callback():
     on_tools_changed.assert_called_once_with(["previous_tool"], refreshed_tools)
 
 
-def test_client_with_on_tools_changed_starts_and_stops(mock_transport, mock_session):
-    """Test that registering the callback leaves the connection lifecycle working."""
-    with MCPClient(mock_transport["transport_callable"], on_tools_changed=MagicMock()) as client:
-        assert client._init_future.done()
+def test_refresh_loaded_tools_raising_callback_keeps_the_refreshed_cache(caplog):
+    """Test that a raising callback is logged with its own message and the cache stays refreshed."""
+    on_tools_changed = MagicMock(side_effect=RuntimeError("consumer broke"))
+    client = MCPClient(MagicMock(), on_tools_changed=on_tools_changed)
+    refreshed_tools = [MagicMock()]
+
+    with patch.object(client, "_list_all_tools_sync", return_value=refreshed_tools):
+        client._refresh_loaded_tools()
+
+    assert client._loaded_tools is refreshed_tools
+    assert "on_tools_changed callback raised" in caplog.text
+    assert "failed to refresh tools" not in caplog.text
+
+
+def test_on_tools_changed_is_settable_after_construction():
+    """Test that the callback can be registered and removed through the property."""
+    client = MCPClient(MagicMock())
+    assert client.on_tools_changed is None
+
+    callback = MagicMock()
+    client.on_tools_changed = callback
+
+    assert client.on_tools_changed is callback
+
+
+def test_subscription_entered_before_ready_and_exited_on_stop(mock_transport, mock_session):
+    """Test that the tools list-changed subscription wraps the session lifetime when a callback is set."""
+    lifecycle_events = []
+
+    @asynccontextmanager
+    async def recording_subscription(session):
+        lifecycle_events.append("enter")
+        try:
+            yield None
+        finally:
+            lifecycle_events.append("exit")
+
+    with patch("strands.tools.mcp.mcp_client.tools_changed_subscription", new=recording_subscription):
+        client = MCPClient(mock_transport["transport_callable"], on_tools_changed=MagicMock())
+        with client:
+            assert lifecycle_events == ["enter"]
+        assert lifecycle_events == ["enter", "exit"]
+
+
+def test_subscription_not_entered_without_callback(mock_transport, mock_session):
+    """Test that no subscription is held when no callback is registered."""
+    lifecycle_events = []
+
+    @asynccontextmanager
+    async def recording_subscription(session):
+        lifecycle_events.append("enter")
+        yield None
+
+    with patch("strands.tools.mcp.mcp_client.tools_changed_subscription", new=recording_subscription):
+        with MCPClient(mock_transport["transport_callable"]):
+            pass
+
+    assert lifecycle_events == []
+
+
+def test_start_raises_when_the_subscription_never_acknowledges(mock_transport, mock_session):
+    """Test that a subscription the server never acknowledges bounds start() instead of hanging it."""
+
+    @asynccontextmanager
+    async def never_acknowledging_subscription(session):
+        await asyncio.Event().wait()
+        yield None
+
+    with patch("strands.tools.mcp.mcp_client.tools_changed_subscription", new=never_acknowledging_subscription):
+        client = MCPClient(mock_transport["transport_callable"], on_tools_changed=MagicMock(), startup_timeout=1)
+        started = time.time()
+        with pytest.raises(MCPClientInitializationError):
+            client.start()
+
+    assert time.time() - started < 10
+
+
+def test_stop_resets_tools_refresh_state_for_restart(mock_transport, mock_session):
+    """Test that a restarted client refreshes again after a stop that interrupted a refresh.
+
+    A refresh task destroyed with its event loop never runs the finally block
+    that clears the in-progress flag, so stop() must reset the refresh state
+    itself for the next start() to work.
+    """
+    client = MCPClient(mock_transport["transport_callable"], on_tools_changed=MagicMock())
+    with client:
+        client._tools_refresh_in_progress = True
+        client._tools_refresh_pending = True
+
+        # The stale entry must be a real future: stop() drains this set with
+        # asyncio.wait, which on Python 3.10 rejects a non-awaitable stand-in.
+        async def _seed_stale_refresh_task() -> None:
+            stale_refresh_task: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+            stale_refresh_task.set_result(None)
+            client._tools_refresh_tasks.add(stale_refresh_task)
+
+        asyncio.run_coroutine_threadsafe(_seed_stale_refresh_task(), client._background_thread_event_loop).result(
+            timeout=5
+        )
+
+    with client:
+        assert not client._tools_refresh_in_progress
+        assert not client._tools_refresh_pending
+        assert not client._tools_refresh_tasks
+
+
+def test_tools_changed_notification_end_to_end_refreshes_and_notifies(mock_transport, mock_session, monkeypatch):
+    """Test the composed chain: notification, refresh off the loop thread, callback with real tools."""
+    monkeypatch.setattr(mcp_client_module, "_TOOLS_CHANGED_DEBOUNCE_SECONDS", 0)
+    callback_called = threading.Event()
+    callback_args = {}
+
+    def on_tools_changed(previous_names, refreshed_tools):
+        callback_args["previous_names"] = previous_names
+        callback_args["refreshed_tools"] = refreshed_tools
+        callback_called.set()
+
+    refreshed_tool = MCPTool(name="echo", description="test tool", inputSchema={"type": "object", "properties": {}})
+    mock_session.list_tools.return_value = ListToolsResult(tools=[refreshed_tool])
+    notification = ToolListChangedNotification(method="notifications/tools/list_changed")
+
+    client = MCPClient(mock_transport["transport_callable"], on_tools_changed=on_tools_changed)
+    with client:
+        asyncio.run_coroutine_threadsafe(
+            client._handle_session_message(notification), client._background_thread_event_loop
+        ).result(timeout=5)
+        assert callback_called.wait(timeout=5)
+
+        assert callback_args["previous_names"] == []
+        assert [tool.tool_name for tool in callback_args["refreshed_tools"]] == ["echo"]
+        assert client._loaded_tools == callback_args["refreshed_tools"]
+
+
+def test_stop_with_refresh_in_flight_unwinds_the_worker(mock_transport, mock_session, monkeypatch):
+    """Test that stop() lets an in-flight refresh unwind instead of stranding its worker thread."""
+    monkeypatch.setattr(mcp_client_module, "_TOOLS_CHANGED_DEBOUNCE_SECONDS", 0)
+    refresh_started = threading.Event()
+
+    async def hanging_list_tools(*args, **kwargs):
+        refresh_started.set()
+        await asyncio.Event().wait()
+
+    mock_session.list_tools.side_effect = hanging_list_tools
+    notification = ToolListChangedNotification(method="notifications/tools/list_changed")
+
+    client = MCPClient(mock_transport["transport_callable"], on_tools_changed=MagicMock())
+    with client:
+        asyncio.run_coroutine_threadsafe(
+            client._handle_session_message(notification), client._background_thread_event_loop
+        ).result(timeout=5)
+        assert refresh_started.wait(timeout=5)
+
+    # Exiting the block proves stop() drained the refresh; a restart proves nothing leaked.
+    mock_session.list_tools.side_effect = None
+    with client:
+        assert not client._tools_refresh_tasks
 
 
 def test_call_tool_sync_with_meta_and_structured_content(mock_transport, mock_session):

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client.py
@@ -1362,6 +1362,21 @@ async def test_handle_tools_changed_coalesces_overlapping_notifications(monkeypa
     assert not client._tools_refresh_in_progress
 
 
+@pytest.mark.asyncio
+async def test_handle_tools_changed_logs_and_recovers_when_the_refresh_raises(monkeypatch, caplog):
+    """Test that a failing refresh is logged as a warning and leaves the client ready for the next one."""
+    import strands.tools.mcp.mcp_client as mcp_client_module
+
+    monkeypatch.setattr(mcp_client_module, "_TOOLS_CHANGED_DEBOUNCE_SECONDS", 0)
+    client = MCPClient(MagicMock(), on_tools_changed=MagicMock())
+    monkeypatch.setattr(client, "_refresh_loaded_tools", MagicMock(side_effect=RuntimeError("listing failed")))
+
+    await client._handle_tools_changed()
+
+    assert "failed to refresh tools after list-changed notification" in caplog.text
+    assert not client._tools_refresh_in_progress
+
+
 def test_refresh_loaded_tools_updates_the_cache_and_invokes_the_callback():
     """Test that a refresh replaces the cached tools and reports the change to the callback."""
     on_tools_changed = MagicMock()

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client.py
@@ -1263,14 +1263,14 @@ def test_call_tool_sync_embedded_unknown_resource_type_dropped(mock_transport, m
 
 
 @pytest.mark.asyncio
-async def test_handle_error_message_non_fatal_error():
-    """Test that _handle_error_message ignores non-fatal errors and logs them."""
+async def test_handle_session_message_non_fatal_error():
+    """Test that _handle_session_message ignores non-fatal errors and logs them."""
     client = MCPClient(MagicMock())
 
     # Test the message handler directly with a non-fatal error
     with patch.object(client, "_log_debug_with_thread") as mock_log:
         # This should not raise an exception
-        await client._handle_error_message(Exception("unknown request id: abc123"))
+        await client._handle_session_message(Exception("unknown request id: abc123"))
 
         # Verify the non-fatal error was logged as ignored
         assert mock_log.called
@@ -1279,22 +1279,109 @@ async def test_handle_error_message_non_fatal_error():
 
 
 @pytest.mark.asyncio
-async def test_handle_error_message_fatal_error():
-    """Test that _handle_error_message raises fatal errors."""
+async def test_handle_session_message_fatal_error():
+    """Test that _handle_session_message raises fatal errors."""
     client = MCPClient(MagicMock())
 
     # This should raise the exception
     with pytest.raises(Exception, match="connection timeout"):
-        await client._handle_error_message(Exception("connection timeout"))
+        await client._handle_session_message(Exception("connection timeout"))
 
 
 @pytest.mark.asyncio
-async def test_handle_error_message_non_exception():
-    """Test that _handle_error_message handles non-exception messages."""
+async def test_handle_session_message_non_exception():
+    """Test that _handle_session_message handles non-exception messages."""
     client = MCPClient(MagicMock())
 
     # This should not raise an exception
-    await client._handle_error_message("normal message")
+    await client._handle_session_message("normal message")
+
+
+@pytest.mark.asyncio
+async def test_handle_session_message_tools_changed_schedules_a_refresh():
+    """Test that a tools list-changed notification schedules a refresh when the callback is set."""
+    from mcp.types import ToolListChangedNotification
+
+    client = MCPClient(MagicMock(), on_tools_changed=MagicMock())
+    notification = ToolListChangedNotification(method="notifications/tools/list_changed")
+
+    with patch.object(client, "_handle_tools_changed", new=AsyncMock()) as mock_refresh:
+        await client._handle_session_message(notification)
+        assert client._tools_refresh_tasks
+        await asyncio.gather(*client._tools_refresh_tasks)
+        # One more loop tick so the done-callback that discards the task runs.
+        await asyncio.sleep(0)
+
+    mock_refresh.assert_awaited_once()
+    assert not client._tools_refresh_tasks
+
+
+@pytest.mark.asyncio
+async def test_handle_session_message_tools_changed_ignored_without_callback():
+    """Test that a tools list-changed notification is a no-op when no callback is registered."""
+    from mcp.types import ToolListChangedNotification
+
+    client = MCPClient(MagicMock())
+    notification = ToolListChangedNotification(method="notifications/tools/list_changed")
+
+    await client._handle_session_message(notification)
+
+    assert not client._tools_refresh_tasks
+
+
+@pytest.mark.asyncio
+async def test_handle_tools_changed_coalesces_overlapping_notifications(monkeypatch):
+    """Test that a notification arriving mid-refresh folds into one trailing rerun."""
+    import strands.tools.mcp.mcp_client as mcp_client_module
+
+    monkeypatch.setattr(mcp_client_module, "_TOOLS_CHANGED_DEBOUNCE_SECONDS", 0)
+    client = MCPClient(MagicMock(), on_tools_changed=MagicMock())
+    refresh_calls = []
+    first_refresh_started = threading.Event()
+    release_first_refresh = threading.Event()
+
+    def blocking_refresh():
+        refresh_calls.append(len(refresh_calls))
+        if len(refresh_calls) == 1:
+            first_refresh_started.set()
+            assert release_first_refresh.wait(timeout=5)
+
+    monkeypatch.setattr(client, "_refresh_loaded_tools", blocking_refresh)
+
+    first_notification = asyncio.create_task(client._handle_tools_changed())
+    while not first_refresh_started.is_set():
+        await asyncio.sleep(0.01)
+
+    await client._handle_tools_changed()
+    assert client._tools_refresh_pending
+
+    release_first_refresh.set()
+    await first_notification
+
+    assert refresh_calls == [0, 1]
+    assert not client._tools_refresh_in_progress
+
+
+def test_refresh_loaded_tools_updates_the_cache_and_invokes_the_callback():
+    """Test that a refresh replaces the cached tools and reports the change to the callback."""
+    on_tools_changed = MagicMock()
+    client = MCPClient(MagicMock(), on_tools_changed=on_tools_changed)
+    previous_tool = MagicMock()
+    previous_tool.tool_name = "previous_tool"
+    client._loaded_tools = [previous_tool]
+    refreshed_tools = [MagicMock()]
+
+    with patch.object(client, "_list_all_tools_sync", return_value=refreshed_tools):
+        client._refresh_loaded_tools()
+
+    assert client._loaded_tools is refreshed_tools
+    on_tools_changed.assert_called_once_with(["previous_tool"], refreshed_tools)
+
+
+def test_client_with_on_tools_changed_starts_and_stops(mock_transport, mock_session):
+    """Test that registering the callback leaves the connection lifecycle working."""
+    with MCPClient(mock_transport["transport_callable"], on_tools_changed=MagicMock()) as client:
+        assert client._init_future.done()
 
 
 def test_call_tool_sync_with_meta_and_structured_content(mock_transport, mock_session):
@@ -1464,8 +1551,8 @@ def test_list_resource_templates_sync_session_not_active():
 
 
 @pytest.mark.asyncio
-async def test_handle_error_message_with_percent_in_message():
-    """Test that _handle_error_message handles messages containing % characters without string formatting errors.
+async def test_handle_session_message_with_percent_in_message():
+    """Test that _handle_session_message handles messages containing % characters without string formatting errors.
 
     This is a regression test for issue #1244 where MCP error messages containing '%' characters
     (e.g., from URLs like "https://example.com/path?param=value%20encoded") would cause a
@@ -1478,7 +1565,7 @@ async def test_handle_error_message_with_percent_in_message():
     error_with_percent = Exception("unknown request id: abc%20123%30def")
 
     # This should not raise TypeError and should not raise the exception (since it's non-fatal)
-    await client._handle_error_message(error_with_percent)
+    await client._handle_session_message(error_with_percent)
 
 
 def test_call_tool_sync_elicitation_error(mock_transport, mock_session):

--- a/strands-py/tests/strands/vended_memory_stores/file_memory_store/test_store.py
+++ b/strands-py/tests/strands/vended_memory_stores/file_memory_store/test_store.py
@@ -87,9 +87,7 @@ class TestAdd:
 
     @pytest.mark.asyncio
     async def test_truncates_slug_at_50_chars(self, store, storage):
-        long_content = (
-            "this is a very long sentence that should be truncated when used as a filename slug for storage"
-        )
+        long_content = "this is a very long sentence that should be truncated when used as a filename slug for storage"
         await store.add(long_content)
         scoped = storage.namespace("memory/test-store")
         keys = await scoped.list("")
@@ -276,7 +274,6 @@ class TestExtraction:
         store = FileMemoryStore(name="ext-test", storage=storage)
         assert store.extraction is None
 
-
     @pytest.mark.asyncio
     async def test_key_aware_extractor_includes_headings_in_prompt(self, storage):
         store = FileMemoryStore(name="ext-test", storage=storage, extraction=True)
@@ -285,9 +282,7 @@ class TestExtraction:
 
         extractor = store.extraction["extractor"]
 
-        with patch(
-            "strands.vended_memory_stores.file_memory_store.store.ModelExtractor"
-        ) as mock_model_extractor_cls:
+        with patch("strands.vended_memory_stores.file_memory_store.store.ModelExtractor") as mock_model_extractor_cls:
             mock_instance = AsyncMock()
             mock_instance.extract = AsyncMock(return_value=[])
             mock_model_extractor_cls.return_value = mock_instance


### PR DESCRIPTION
## Description
**Problem.** MCP servers can add or remove tools at runtime and announce it with a `tools/list_changed` notification. `MCPClient` ignores that notification today: `load_tools` caches the first listing for the life of the client, so an agent keeps seeing a stale tool set. 

The 2026-07-28 spec (SEP-2575) also made the notification opt-in: a modern server publishes list-changed events only to clients that hold a `subscriptions/listen` stream open, so a client that merely watched for the notification would hear nothing from a modern server.

**Change.** `MCPClient` takes an optional `on_tools_changed` callback. Registering it turns on the refresh:

```python
def tools_changed(previous_names: list[str], refreshed_tools: list[MCPAgentTool]) -> None:
    ...

client = MCPClient(transport, on_tools_changed=tools_changed)
```

- The session's message handler recognizes the notification on both versions: `mcp` 1.x wraps it in `ServerNotification`, 2.x delivers it bare.
- On a 2026-07-28 connection the client holds a `subscriptions/listen` stream open for tool changes, which is what makes a modern server publish them. On 1.x, and on 2.x connections that negotiated a legacy protocol version, servers push the notification unprompted and nothing extra is held.
- A refresh re-lists every page with the constructor's prefix and filters, replaces the cached tools that `load_tools` returns, then invokes the callback with the previous tool names and the refreshed tools. A 300ms debounce folds a burst of notifications into one refresh, matching the TypeScript SDK, and a notification arriving mid-refresh folds into a single trailing rerun.
- Without the callback, behavior is unchanged. Internal rename: `_handle_error_message` became `_handle_session_message`, since it now dispatches more than errors.

### Known limitations

1. **Only an unsupported connection degrades gracefully. Other subscription failures fail startup.** When `listen()` raises `ListenNotSupportedError` because the negotiated protocol version predates 2026-07-28, the client continues without a subscription and relies on unprompted notifications. Any other failure to open the subscription, such as a modern server rejecting the request or the acknowledgment timing out, propagates and fails client startup. This is deliberate: the caller explicitly asked for tool-change notifications, and a client that starts but can never deliver them would fail silently.
2. **No re-listen.** The subscription is opened once and held for the life of the session. The spec has no replay: if the stream drops mid-session, notifications from a modern server stop and the client does not currently re-subscribe. A re-listen loop that refetches on reconnect is a candidate follow-up.

## Notes for review

- The 2.x branch imports from `mcp.client.subscriptions`, a public module that declares `listen` and `ListenNotSupportedError` in its `__all__`. A compat test runs in the `unit-test-mcp-v2` CI job and fails if the 2.x package moves or renames those names.
- The held stream is intentionally never iterated. This is safe: the 2.x session also delivers each subscription event to the message handler, so one dispatch point serves both paths, and the SDK deduplicates identical pending events, so a tools-only subscription queues at most one unconsumed event.

## API bar-raising

A new parameter and property on `MCPClient` and two newly exported types. The shape ports the TypeScript SDK's existing `onToolsChanged`, so the design has precedent.

New public surface, all in `strands.tools.mcp`:

```python
class MCPClient(ToolProvider):
    def __init__(self, ..., on_tools_changed: ToolsChanged | None = None) -> None: ...

    on_tools_changed: ToolsChanged | None  # read/write property. A callback set after start()
                                           # hears nothing from a 2026-07-28 server until restart

class ToolsChangedCallback(Protocol):  # exported
    def __call__(self, previous_names: list[str], refreshed_tools: list[MCPAgentTool], **kwargs: Any) -> None: ...

ToolsChanged = Callable[[list[str], list[MCPAgentTool]], None] | ToolsChangedCallback  # exported
```

The default is `None`. Registering a callback turns on the refresh and, on the 2.x connection, makes `start()` failable with `MCPClientInitializationError` when the `listen` subscription cannot be opened. The callback runs on a worker thread after the cached tools are replaced, the exception it raises will be logged, not propagated.

**Deviations from the TypeScript API, made knowingly**: Python also accepts the callback in the constructor because the subscription opens at session start. The arguments are named `previous_names` / `refreshed_tools` rather than `oldTools` / `newTools`, since the first value is a list of name strings. The callback type is a named `Protocol` with a `**kwargs` tail (style guide rule) rather than an inline function type.

## Related Issues

#1659

Relates to #3272: this delivers the notification handling and the cache refresh. Wiring a refresh into a live agent's tool registry is the remaining piece and stays a follow-up.

## Documentation PR

No documentation changes needed. The TypeScript `onToolsChanged` has no site/ page either, and a shared docs pass for the mcp 2.x work can cover both SDKs later.

## Type of Change

New feature

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`
- Full unit suite passes on `mcp` 1.x (`hatch fmt --linter` and `hatch test` on the rebased branch). Compat tests pass against `mcp==2.0.*` in a fresh venv replicating the `unit-test-mcp-v2` CI job.
- 
## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.



