### PR TITLE
feat(python): add internal in-process task engine / manager

### DIFF
--- a/strands-py/src/strands/_async.py
+++ b/strands-py/src/strands/_async.py
@@ -8,6 +8,13 @@ from typing import TypeVar
 
 T = TypeVar("T")
 
+_RUN_ASYNC_BRIDGE = contextvars.ContextVar("strands_run_async_bridge", default=False)
+
+
+def is_run_async_bridge() -> bool:
+    """Return whether execution is inside the temporary sync bridge loop."""
+    return _RUN_ASYNC_BRIDGE.get()
+
 
 def run_async(async_func: Callable[[], Awaitable[T]]) -> T:
     """Run an async function in a separate thread to avoid event loop conflicts.
@@ -26,7 +33,11 @@ def run_async(async_func: Callable[[], Awaitable[T]]) -> T:
         return await async_func()
 
     def execute() -> T:
-        return asyncio.run(execute_async())
+        token = _RUN_ASYNC_BRIDGE.set(True)
+        try:
+            return asyncio.run(execute_async())
+        finally:
+            _RUN_ASYNC_BRIDGE.reset(token)
 
     with ThreadPoolExecutor() as executor:
         context = contextvars.copy_context()

--- a/strands-py/src/strands/background_tasks/__init__.py
+++ b/strands-py/src/strands/background_tasks/__init__.py
@@ -1,0 +1,1 @@
+"""Internal background task execution primitives."""

--- a/strands-py/src/strands/background_tasks/_errors.py
+++ b/strands-py/src/strands/background_tasks/_errors.py
@@ -1,0 +1,25 @@
+"""Internal background task exceptions."""
+
+
+class BackgroundTaskNotFoundError(LookupError):
+    """Raised when a background task ID is not found."""
+
+    def __init__(self, task_id: str) -> None:
+        """Initialize the error.
+
+        Args:
+            task_id: Task ID that could not be found.
+        """
+        super().__init__(f"Background task '{task_id}' was not found")
+
+
+class BackgroundTaskTimeoutError(TimeoutError):
+    """Raised when waiting for background tasks times out."""
+
+    def __init__(self, timeout: float) -> None:
+        """Initialize the error.
+
+        Args:
+            timeout: Wait timeout in seconds.
+        """
+        super().__init__(f"Timed out waiting for background tasks after {timeout}s")

--- a/strands-py/src/strands/background_tasks/_runtime.py
+++ b/strands-py/src/strands/background_tasks/_runtime.py
@@ -1,0 +1,68 @@
+"""Process-lifetime event loop for detached background work."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import threading
+from collections.abc import Awaitable, Callable
+from typing import TypeVar, cast
+
+_T = TypeVar("_T")
+
+
+class _BackgroundTaskRuntime:
+    """Own a daemon event loop shared by in-process task managers."""
+
+    def __init__(self) -> None:
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
+        self._ready = threading.Event()
+        self._start_lock = threading.Lock()
+
+    async def run(self, operation: Callable[[], _T | Awaitable[_T]]) -> _T:
+        """Run an operation on the persistent loop."""
+        loop = self._ensure_started()
+        if threading.current_thread() is self._thread:
+            return await self._invoke(operation)
+        future = asyncio.run_coroutine_threadsafe(self._invoke(operation), loop)
+        return await asyncio.wrap_future(future)
+
+    def _ensure_started(self) -> asyncio.AbstractEventLoop:
+        existing_loop = self._loop
+        if existing_loop is not None:
+            return existing_loop
+        with self._start_lock:
+            if self._loop is None:
+                self._thread = threading.Thread(
+                    target=self._run_loop,
+                    name="strands-background-tasks",
+                    daemon=True,
+                )
+                self._thread.start()
+                self._ready.wait()
+        loop = self._loop
+        if loop is None:
+            raise RuntimeError("Background task runtime failed to start")
+        return loop
+
+    def _run_loop(self) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        self._loop = loop
+        self._ready.set()
+        loop.run_forever()
+
+    async def _invoke(self, operation: Callable[[], _T | Awaitable[_T]]) -> _T:
+        result = operation()
+        if inspect.isawaitable(result):
+            return await cast(Awaitable[_T], result)
+        return result
+
+
+_RUNTIME = _BackgroundTaskRuntime()
+
+
+def get_background_task_runtime() -> _BackgroundTaskRuntime:
+    """Return the shared process-lifetime runtime."""
+    return _RUNTIME

--- a/strands-py/src/strands/background_tasks/_types.py
+++ b/strands-py/src/strands/background_tasks/_types.py
@@ -1,0 +1,60 @@
+"""Internal background task snapshots."""
+
+from __future__ import annotations
+
+from typing import Literal, TypeAlias
+
+from typing_extensions import NotRequired, TypedDict
+
+from strands.types.tools import ToolResultContent
+
+BackgroundTaskStatus: TypeAlias = Literal[
+    "queued",
+    "working",
+    "input_required",
+    "completed",
+    "failed",
+    "cancelled",
+]
+BackgroundTaskFailureType: TypeAlias = Literal["tool_error", "execution_error", "timeout"]
+
+
+class BackgroundTaskResult(TypedDict):
+    """Visible background task result."""
+
+    content: list[ToolResultContent]
+
+
+class BackgroundTaskError(TypedDict):
+    """Background task failure details."""
+
+    type: BackgroundTaskFailureType
+    message: str
+
+
+class BackgroundTaskInterrupt(TypedDict):
+    """Visible unanswered background task interrupt."""
+
+    id: str
+    name: str
+    reason: object
+    source: Literal["middleware", "tool"]
+
+
+class BackgroundTask(TypedDict):
+    """Snapshot of one background task."""
+
+    task_id: str
+    tool_use_id: str
+    tool_name: str
+    status: BackgroundTaskStatus
+    created_at: str
+    last_updated_at: str
+    result: NotRequired[BackgroundTaskResult]
+    error: NotRequired[BackgroundTaskError]
+    interrupts: NotRequired[list[BackgroundTaskInterrupt]]
+
+
+def is_task_status_terminal(status: BackgroundTaskStatus) -> bool:
+    """Return whether a task status is terminal."""
+    return status in {"completed", "failed", "cancelled"}

--- a/strands-py/src/strands/background_tasks/in_process/__init__.py
+++ b/strands-py/src/strands/background_tasks/in_process/__init__.py
@@ -1,0 +1,1 @@
+"""Internal in-process background task implementation."""

--- a/strands-py/src/strands/background_tasks/in_process/_engine.py
+++ b/strands-py/src/strands/background_tasks/in_process/_engine.py
@@ -1,0 +1,367 @@
+"""Bounded in-process background task execution."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import math
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from functools import partial
+from uuid import uuid4
+
+from strands.background_tasks._errors import BackgroundTaskNotFoundError
+from strands.background_tasks._types import is_task_status_terminal
+
+from ._types import (
+    CancelSignal,
+    CompletedTaskExecutionOutcome,
+    FailedTaskExecutionOutcome,
+    InProcessTaskExecutionContext,
+    InProcessTaskExecutionOutcome,
+    InProcessTaskRecord,
+    InterruptStateData,
+)
+
+_DEFAULT_EXECUTION_FAILURE_MESSAGE = "Background task execution failed"
+
+
+@dataclass
+class _ActiveExecution:
+    cancel_signal: CancelSignal
+    timeout_handle: asyncio.TimerHandle | None = None
+
+
+class InProcessTaskEngine:
+    """Run and track bounded in-process tasks."""
+
+    def __init__(
+        self,
+        *,
+        max_concurrency: int,
+        timeout: float,
+        execute: Callable[[InProcessTaskExecutionContext], Awaitable[InProcessTaskExecutionOutcome]],
+        on_task_updated: Callable[[InProcessTaskRecord], None],
+    ) -> None:
+        """Initialize the engine.
+
+        Args:
+            max_concurrency: Maximum concurrent physical executions.
+            timeout: Per-execution timeout in seconds, or infinity.
+            execute: Callback that executes one task.
+            on_task_updated: Best-effort committed-update callback.
+
+        Raises:
+            TypeError: If execution configuration is invalid.
+        """
+        if isinstance(max_concurrency, bool) or not isinstance(max_concurrency, int) or max_concurrency <= 0:
+            raise TypeError(f"max_concurrency must be a positive finite integer, got {max_concurrency}")
+        if isinstance(timeout, bool) or not isinstance(timeout, (int, float)) or math.isnan(timeout) or timeout <= 0:
+            raise TypeError(f"timeout must be a positive number or infinity, got {timeout}")
+        self._max_concurrency = max_concurrency
+        self._timeout = timeout
+        self._execute_callback = execute
+        self._on_task_updated = on_task_updated
+        self._tasks: dict[str, InProcessTaskRecord] = {}
+        self._queue: dict[str, None] = {}
+        self._active_executions: dict[str, _ActiveExecution] = {}
+        self._idle_waiters: set[asyncio.Future[None]] = set()
+        self._spawned_tasks: set[asyncio.Task[None]] = set()
+
+    def submit(self, *, tool_use_id: str, tool_name: str, invocation_state_id: str) -> InProcessTaskRecord:
+        """Submit a task for execution."""
+        now = _timestamp()
+        stored = InProcessTaskRecord(
+            task_id=str(uuid4()),
+            tool_use_id=tool_use_id,
+            tool_name=tool_name,
+            invocation_state_id=invocation_state_id,
+            status="queued",
+            created_at=now,
+            last_updated_at=now,
+        )
+        self._tasks[stored["task_id"]] = stored
+        self._notify_task_updated(stored)
+        self._schedule_task(stored["task_id"])
+        return _snapshot(stored)
+
+    def get(self, task_id: str) -> InProcessTaskRecord | None:
+        """Return a task snapshot if it exists."""
+        task = self._tasks.get(task_id)
+        return _snapshot(task) if task is not None else None
+
+    def list(self) -> list[InProcessTaskRecord]:
+        """Return all task snapshots."""
+        return [_snapshot(task) for task in self._tasks.values()]
+
+    def remove(self, task_id: str) -> None:
+        """Remove a terminal task."""
+        task = self._require_task(task_id)
+        if not is_task_status_terminal(task["status"]):
+            raise RuntimeError(f"Background task '{task_id}' cannot be removed before reaching a terminal status")
+        del self._tasks[task_id]
+
+    def cancel(self, task_id: str, *, reason: str) -> InProcessTaskRecord:
+        """Cancel a non-terminal task."""
+        current = self._require_task(task_id)
+        if is_task_status_terminal(current["status"]):
+            return _snapshot(current)
+        task = self._update_task(task_id, _cancel_task)
+        assert task is not None
+        self._queue.pop(task_id, None)
+        active_execution = self._active_executions.get(task_id)
+        if active_execution is not None:
+            if active_execution.timeout_handle is not None:
+                active_execution.timeout_handle.cancel()
+                active_execution.timeout_handle = None
+            active_execution.cancel_signal.abort(reason)
+        self._wake_idle_waiters()
+        return task
+
+    async def wait_for_idle(self, *, cancel_signal: CancelSignal | None = None) -> None:
+        """Wait until no task is queued or physically executing."""
+        while self._queue or self._active_executions:
+            if cancel_signal is not None and cancel_signal.aborted:
+                raise _exception_from_reason(cancel_signal.reason)
+            await self._wait_for_idle_change(cancel_signal)
+
+    async def _wait_for_idle_change(self, cancel_signal: CancelSignal | None) -> None:
+        waiter = asyncio.get_running_loop().create_future()
+        self._idle_waiters.add(waiter)
+        try:
+            while not waiter.done():
+                if cancel_signal is not None and cancel_signal.aborted:
+                    raise _exception_from_reason(cancel_signal.reason)
+                try:
+                    # Cancellation may arrive from another thread, so periodically recheck the thread-safe signal.
+                    await asyncio.wait_for(asyncio.shield(waiter), timeout=0.01)
+                except asyncio.TimeoutError:
+                    pass
+        finally:
+            self._idle_waiters.discard(waiter)
+            if not waiter.done():
+                waiter.cancel()
+
+    def resume(
+        self,
+        task_id: str,
+        update: Callable[[InterruptStateData], tuple[InterruptStateData, bool]],
+    ) -> InProcessTaskRecord:
+        """Apply input to a task that requires it."""
+
+        def resume_task(record: InProcessTaskRecord) -> bool:
+            if record["status"] != "input_required":
+                raise RuntimeError(
+                    f"Background task '{task_id}' cannot be resumed: "
+                    f"status is '{record['status']}', not 'input_required'"
+                )
+            if "state" not in record:
+                raise RuntimeError(f"Background task '{task_id}' cannot be resumed: interrupt state is missing")
+            state, ready = update(record["state"])
+            record["state"] = state
+            if ready:
+                record["status"] = "queued"
+            return True
+
+        task = self._update_task(task_id, resume_task)
+        assert task is not None
+        if task["status"] == "queued":
+            self._schedule_task(task_id)
+        return task
+
+    def _schedule_task(self, task_id: str) -> None:
+        if task_id in self._active_executions:
+            return
+        self._queue[task_id] = None
+        self._start_queued_tasks()
+
+    def _start_queued_tasks(self) -> None:
+        while len(self._active_executions) < self._max_concurrency and self._queue:
+            task_id = next(iter(self._queue))
+            del self._queue[task_id]
+            active_execution = _ActiveExecution(cancel_signal=CancelSignal())
+            self._active_executions[task_id] = active_execution
+            task = asyncio.create_task(self._execute(task_id, active_execution))
+            self._spawned_tasks.add(task)
+            task.add_done_callback(partial(self._finish_execution, task_id, active_execution))
+            task.add_done_callback(self._spawned_tasks.discard)
+
+    async def _execute(self, task_id: str, active_execution: _ActiveExecution) -> None:
+        working = self._update_task(task_id, _mark_working)
+        if working is None:
+            return
+        if math.isfinite(self._timeout):
+            active_execution.timeout_handle = asyncio.get_running_loop().call_later(
+                self._timeout,
+                self._timeout_task,
+                task_id,
+                active_execution,
+            )
+        try:
+            outcome = await self._execute_callback(
+                InProcessTaskExecutionContext(
+                    task_id=task_id,
+                    tool_use_id=working["tool_use_id"],
+                    tool_name=working["tool_name"],
+                    invocation_state_id=working["invocation_state_id"],
+                    state=working.get("state"),
+                    cancel_signal=active_execution.cancel_signal,
+                )
+            )
+        except Exception as error:
+            outcome = FailedTaskExecutionOutcome(
+                status="failed",
+                failure={"type": "execution_error", "message": _execution_failure_message(error)},
+            )
+        try:
+            self._finish_outcome(task_id, outcome)
+        except Exception as error:
+            self._finish_outcome(
+                task_id,
+                FailedTaskExecutionOutcome(
+                    status="failed",
+                    failure={"type": "execution_error", "message": _execution_failure_message(error)},
+                ),
+            )
+
+    def _finish_execution(
+        self,
+        task_id: str,
+        active_execution: _ActiveExecution,
+        completed: asyncio.Task[None],
+    ) -> None:
+        if active_execution.timeout_handle is not None:
+            active_execution.timeout_handle.cancel()
+        self._active_executions.pop(task_id, None)
+        current = self._tasks.get(task_id)
+        if current is not None and current["status"] == "queued":
+            self._queue[task_id] = None
+        self._wake_idle_waiters()
+        self._start_queued_tasks()
+        try:
+            completed.result()
+        except asyncio.CancelledError:
+            pass
+
+    def _finish_outcome(self, task_id: str, outcome: InProcessTaskExecutionOutcome) -> None:
+        if outcome["status"] == "input_required":
+            self._update_task(task_id, partial(_require_input, state=outcome["state"]))
+            return
+        self._update_task(task_id, partial(_finish_terminal_outcome, outcome=outcome))
+
+    def _timeout_task(self, task_id: str, active_execution: _ActiveExecution) -> None:
+        active_execution.timeout_handle = None
+        reason = f"Timed out after {self._timeout}s"
+
+        def time_out(record: InProcessTaskRecord) -> bool:
+            if record["status"] != "working":
+                return False
+            record["status"] = "failed"
+            record.pop("state", None)
+            record["failure"] = {"type": "timeout", "message": reason}
+            return True
+
+        task = self._update_task(task_id, time_out)
+        if task is not None:
+            active_execution.cancel_signal.abort(reason)
+
+    def _update_task(
+        self,
+        task_id: str,
+        update: Callable[[InProcessTaskRecord], bool],
+    ) -> InProcessTaskRecord | None:
+        current = self._require_task(task_id)
+        next_task = _snapshot(current)
+        if not update(next_task):
+            return None
+        next_task["last_updated_at"] = _timestamp()
+        stored = _snapshot(next_task)
+        self._tasks[task_id] = stored
+        self._notify_task_updated(stored)
+        return _snapshot(stored)
+
+    def _require_task(self, task_id: str) -> InProcessTaskRecord:
+        task = self._tasks.get(task_id)
+        if task is None:
+            raise BackgroundTaskNotFoundError(task_id)
+        return task
+
+    def _notify_task_updated(self, task: InProcessTaskRecord) -> None:
+        asyncio.get_running_loop().call_soon(self._run_notification, _snapshot(task))
+
+    def _run_notification(self, task: InProcessTaskRecord) -> None:
+        try:
+            self._on_task_updated(task)
+        except Exception:
+            pass
+
+    def _wake_idle_waiters(self) -> None:
+        for waiter in self._idle_waiters:
+            if not waiter.done():
+                waiter.set_result(None)
+        self._idle_waiters.clear()
+
+
+def _cancel_task(record: InProcessTaskRecord) -> bool:
+    record["status"] = "cancelled"
+    record.pop("state", None)
+    return True
+
+
+def _mark_working(record: InProcessTaskRecord) -> bool:
+    if record["status"] != "queued":
+        return False
+    record["status"] = "working"
+    return True
+
+
+def _require_input(record: InProcessTaskRecord, *, state: InterruptStateData) -> bool:
+    if record["status"] != "working":
+        return False
+    record["status"] = "input_required"
+    record["state"] = state
+    return True
+
+
+def _finish_terminal_outcome(
+    record: InProcessTaskRecord,
+    *,
+    outcome: CompletedTaskExecutionOutcome | FailedTaskExecutionOutcome,
+) -> bool:
+    if record["status"] != "working":
+        return False
+    record.pop("state", None)
+    if outcome["status"] == "failed":
+        record["status"] = "failed"
+        record["failure"] = {
+            "type": outcome["failure"]["type"],
+            "message": outcome["failure"]["message"] or _DEFAULT_EXECUTION_FAILURE_MESSAGE,
+        }
+        if "result" in outcome:
+            record["result"] = outcome["result"]
+        return True
+    record["status"] = "completed"
+    record["result"] = outcome["result"]
+    return True
+
+
+def _execution_failure_message(error: Exception) -> str:
+    try:
+        return str(error) or _DEFAULT_EXECUTION_FAILURE_MESSAGE
+    except Exception:
+        return _DEFAULT_EXECUTION_FAILURE_MESSAGE
+
+
+def _exception_from_reason(reason: object | None) -> BaseException:
+    if isinstance(reason, BaseException):
+        return reason
+    return RuntimeError(str(reason) if reason is not None else "Operation cancelled")
+
+
+def _snapshot(task: InProcessTaskRecord) -> InProcessTaskRecord:
+    return copy.deepcopy(task)
+
+
+def _timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/strands-py/src/strands/background_tasks/in_process/_engine.py
+++ b/strands-py/src/strands/background_tasks/in_process/_engine.py
@@ -84,16 +84,16 @@ class InProcessTaskEngine:
         self._tasks[stored["task_id"]] = stored
         self._notify_task_updated(stored)
         self._schedule_task(stored["task_id"])
-        return _snapshot(stored)
+        return copy.deepcopy(stored)
 
     def get(self, task_id: str) -> InProcessTaskRecord | None:
         """Return a task snapshot if it exists."""
         task = self._tasks.get(task_id)
-        return _snapshot(task) if task is not None else None
+        return copy.deepcopy(task) if task is not None else None
 
     def list(self) -> list[InProcessTaskRecord]:
         """Return all task snapshots."""
-        return [_snapshot(task) for task in self._tasks.values()]
+        return [copy.deepcopy(task) for task in self._tasks.values()]
 
     def remove(self, task_id: str) -> None:
         """Remove a terminal task."""
@@ -106,7 +106,7 @@ class InProcessTaskEngine:
         """Cancel a non-terminal task."""
         current = self._require_task(task_id)
         if is_task_status_terminal(current["status"]):
-            return _snapshot(current)
+            return copy.deepcopy(current)
         task = self._update_task(task_id, _cancel_task)
         assert task is not None
         self._queue.pop(task_id, None)
@@ -127,18 +127,28 @@ class InProcessTaskEngine:
             await self._wait_for_idle_change(cancel_signal)
 
     async def _wait_for_idle_change(self, cancel_signal: CancelSignal | None) -> None:
-        waiter = asyncio.get_running_loop().create_future()
+        loop = asyncio.get_running_loop()
+        waiter = loop.create_future()
         self._idle_waiters.add(waiter)
+
+        def wake_waiter() -> None:
+            if not waiter.done():
+                waiter.set_result(None)
+
+        def on_abort() -> None:
+            # Abort may arrive from another thread, and possibly after the loop closed.
+            try:
+                loop.call_soon_threadsafe(wake_waiter)
+            except RuntimeError:
+                pass
+
+        if cancel_signal is not None:
+            cancel_signal.add_abort_callback(on_abort)
         try:
-            while not waiter.done():
-                if cancel_signal is not None and cancel_signal.aborted:
-                    raise _exception_from_reason(cancel_signal.reason)
-                try:
-                    # Cancellation may arrive from another thread, so periodically recheck the thread-safe signal.
-                    await asyncio.wait_for(asyncio.shield(waiter), timeout=0.01)
-                except asyncio.TimeoutError:
-                    pass
+            await waiter
         finally:
+            if cancel_signal is not None:
+                cancel_signal.remove_abort_callback(on_abort)
             self._idle_waiters.discard(waiter)
             if not waiter.done():
                 waiter.cancel()
@@ -272,14 +282,14 @@ class InProcessTaskEngine:
         update: Callable[[InProcessTaskRecord], bool],
     ) -> InProcessTaskRecord | None:
         current = self._require_task(task_id)
-        next_task = _snapshot(current)
+        next_task = copy.deepcopy(current)
         if not update(next_task):
             return None
         next_task["last_updated_at"] = _timestamp()
-        stored = _snapshot(next_task)
+        stored = copy.deepcopy(next_task)
         self._tasks[task_id] = stored
         self._notify_task_updated(stored)
-        return _snapshot(stored)
+        return copy.deepcopy(stored)
 
     def _require_task(self, task_id: str) -> InProcessTaskRecord:
         task = self._tasks.get(task_id)
@@ -288,7 +298,7 @@ class InProcessTaskEngine:
         return task
 
     def _notify_task_updated(self, task: InProcessTaskRecord) -> None:
-        asyncio.get_running_loop().call_soon(self._run_notification, _snapshot(task))
+        asyncio.get_running_loop().call_soon(self._run_notification, copy.deepcopy(task))
 
     def _run_notification(self, task: InProcessTaskRecord) -> None:
         try:
@@ -357,10 +367,6 @@ def _exception_from_reason(reason: object | None) -> BaseException:
     if isinstance(reason, BaseException):
         return reason
     return RuntimeError(str(reason) if reason is not None else "Operation cancelled")
-
-
-def _snapshot(task: InProcessTaskRecord) -> InProcessTaskRecord:
-    return copy.deepcopy(task)
 
 
 def _timestamp() -> str:

--- a/strands-py/src/strands/background_tasks/in_process/_manager.py
+++ b/strands-py/src/strands/background_tasks/in_process/_manager.py
@@ -327,18 +327,35 @@ async def _await_origin_result(
     future: concurrent.futures.Future[ToolResult],
     cancel_signal: CancelSignal,
 ) -> ToolResult:
+    loop = asyncio.get_running_loop()
     wrapped = asyncio.wrap_future(future)
+    aborted: asyncio.Future[None] = loop.create_future()
+
+    def wake_aborted() -> None:
+        if not aborted.done():
+            aborted.set_result(None)
+
+    def on_abort() -> None:
+        # Abort may arrive from another thread, and possibly after the loop closed.
+        try:
+            loop.call_soon_threadsafe(wake_aborted)
+        except RuntimeError:
+            pass
+
+    cancel_signal.add_abort_callback(on_abort)
     try:
-        while True:
-            if cancel_signal.aborted:
-                raise asyncio.CancelledError
-            try:
-                return await asyncio.wait_for(asyncio.shield(wrapped), timeout=0.01)
-            except asyncio.TimeoutError:
-                pass
+        pending: set[asyncio.Future[Any]] = {wrapped, aborted}
+        await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
+        if wrapped.done():
+            return wrapped.result()
+        raise asyncio.CancelledError
     except BaseException:
         future.cancel()
         raise
+    finally:
+        cancel_signal.remove_abort_callback(on_abort)
+        if not aborted.done():
+            aborted.cancel()
 
 
 def _request_interrupt(

--- a/strands-py/src/strands/background_tasks/in_process/_manager.py
+++ b/strands-py/src/strands/background_tasks/in_process/_manager.py
@@ -1,0 +1,400 @@
+"""Agent-owned in-process background task manager."""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import copy
+import math
+import threading
+import uuid
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
+from typing import Any, Literal, Protocol
+
+from strands._async import is_run_async_bridge
+from strands._middleware import MiddlewareInterruptResult
+from strands.background_tasks._errors import (
+    BackgroundTaskNotFoundError,
+    BackgroundTaskTimeoutError,
+)
+from strands.background_tasks._runtime import get_background_task_runtime
+from strands.background_tasks._types import BackgroundTask, BackgroundTaskInterrupt, is_task_status_terminal
+from strands.interrupt import Interrupt, InterruptException, _InterruptState
+from strands.types.agent import LocalAgent
+from strands.types.interrupt import InterruptResponse, InterruptResponseContent
+from strands.types.tools import AgentTool, ToolContext, ToolResult, ToolUse
+
+from ._engine import InProcessTaskEngine
+from ._types import (
+    CancelSignal,
+    InProcessTaskExecutionContext,
+    InProcessTaskExecutionOutcome,
+    InProcessTaskRecord,
+    InterruptStateData,
+)
+
+
+class _MiddlewareInterrupt(Protocol):
+    def __call__(
+        self,
+        name: str,
+        *,
+        reason: Any = None,
+        response: Any = None,
+    ) -> MiddlewareInterruptResult:
+        """Request middleware input."""
+        ...
+
+
+@dataclass(frozen=True)
+class _LiveToolExecution:
+    tool_use: ToolUse
+    invocation_state: dict[str, Any]
+    tool: AgentTool
+    origin_loop: asyncio.AbstractEventLoop | None
+
+
+class _BackgroundToolContext(ToolContext[LocalAgent]):
+    def __init__(
+        self,
+        *,
+        task_id: str,
+        tool_use: ToolUse,
+        agent: LocalAgent,
+        invocation_state: dict[str, Any],
+        cancel_signal: threading.Event,
+        interrupt_state: _InterruptState,
+    ) -> None:
+        ToolContext.__init__(self, tool_use, agent, invocation_state)
+        self._task_id = task_id
+        self.cancel_signal = cancel_signal
+        self._task_interrupt_state = interrupt_state
+
+    def _interrupt_id(self, name: str) -> str:
+        return f"v1:tool_call:{self._task_id}:{uuid.uuid5(uuid.NAMESPACE_OID, name)}"
+
+    def interrupt(self, name: str, reason: Any = None, response: Any = None) -> Any:
+        """Request task-local tool input."""
+        return _request_interrupt(
+            self._task_interrupt_state,
+            self._interrupt_id(name),
+            name,
+            reason,
+            response,
+        )
+
+
+class InProcessTaskManager:
+    """Execute approved tool calls on the process-lifetime background loop."""
+
+    def __init__(
+        self,
+        agent: LocalAgent,
+        execute_tool: Callable[[AgentTool, ToolContext[LocalAgent], _MiddlewareInterrupt], Awaitable[ToolResult]],
+        *,
+        max_concurrency: int = 4,
+        timeout: float = math.inf,
+        on_task_updated: Callable[[BackgroundTask], None] | None = None,
+    ) -> None:
+        """Initialize the task manager."""
+        self._agent = agent
+        self._execute_tool = execute_tool
+        self._on_task_updated = on_task_updated
+        self._runtime = get_background_task_runtime()
+        self._has_tasks = threading.Event()
+        self._engine = InProcessTaskEngine(
+            max_concurrency=max_concurrency,
+            timeout=timeout,
+            execute=self._execute_tool_task,
+            on_task_updated=self._handle_task_updated,
+        )
+        self._executions: dict[str, _LiveToolExecution] = {}
+        self._task_id_by_submission: dict[tuple[str, str], str] = {}
+        self._task_events: dict[str, asyncio.Event] = {}
+
+    async def submit(
+        self,
+        tool_use: ToolUse,
+        invocation_state: dict[str, Any],
+        pass_id: str,
+        tool: AgentTool,
+    ) -> BackgroundTask:
+        """Submit one approved tool call."""
+        origin_loop = None if is_run_async_bridge() else asyncio.get_running_loop()
+
+        def submit() -> BackgroundTask:
+            submission_key = (pass_id, tool_use["toolUseId"])
+            existing_task_id = self._task_id_by_submission.get(submission_key)
+            if existing_task_id is not None:
+                existing = self._engine.get(existing_task_id)
+                if existing is not None:
+                    return _to_background_task(existing)
+
+            invocation_state_id = str(uuid.uuid4())
+            self._executions[invocation_state_id] = _LiveToolExecution(
+                tool_use=copy.deepcopy(tool_use),
+                invocation_state=invocation_state,
+                tool=tool,
+                origin_loop=origin_loop,
+            )
+            record = self._engine.submit(
+                tool_use_id=tool_use["toolUseId"],
+                tool_name=tool_use["name"],
+                invocation_state_id=invocation_state_id,
+            )
+            self._task_id_by_submission[submission_key] = record["task_id"]
+            self._has_tasks.set()
+            return _to_background_task(record)
+
+        return await self._runtime.run(submit)
+
+    async def get(self, task_id: str) -> BackgroundTask | None:
+        """Get one task."""
+        return await self._runtime.run(
+            lambda: _to_background_task(record) if (record := self._engine.get(task_id)) is not None else None
+        )
+
+    async def list(self) -> list[BackgroundTask]:
+        """List tracked tasks."""
+        return await self._runtime.run(lambda: [_to_background_task(record) for record in self._engine.list()])
+
+    def has_tasks(self) -> bool:
+        """Return whether any tasks remain tracked."""
+        return self._has_tasks.is_set()
+
+    async def cancel(self, task_id: str) -> BackgroundTask:
+        """Cancel one task."""
+        return await self._runtime.run(
+            lambda: _to_background_task(self._engine.cancel(task_id, reason="Cancellation requested"))
+        )
+
+    async def wait(self, task_id: str) -> BackgroundTask:
+        """Wait until one task requires input or becomes terminal."""
+        return await self._runtime.run(lambda: self._wait(task_id))
+
+    async def _wait(self, task_id: str) -> BackgroundTask:
+        while True:
+            record = self._engine.get(task_id)
+            if record is None:
+                raise BackgroundTaskNotFoundError(task_id)
+            if record["status"] == "input_required" or is_task_status_terminal(record["status"]):
+                return _to_background_task(record)
+            changed = self._task_events.setdefault(task_id, asyncio.Event())
+            await changed.wait()
+            changed.clear()
+
+    async def wait_for_idle(self, *, timeout: float | None = None) -> None:
+        """Wait until no task is queued or physically executing."""
+        if timeout is not None and (
+            isinstance(timeout, bool)
+            or not isinstance(timeout, (int, float))
+            or not math.isfinite(timeout)
+            or timeout <= 0
+        ):
+            raise TypeError(f"wait timeout must be a positive finite number, got {timeout!r}")
+        if timeout is None:
+            idle_wait: Awaitable[None] = self._runtime.run(self._engine.wait_for_idle)
+            await idle_wait
+            return
+        cancel_signal = CancelSignal()
+
+        def wait_for_idle() -> Awaitable[None]:
+            return self._engine.wait_for_idle(cancel_signal=cancel_signal)
+
+        idle_wait = self._runtime.run(wait_for_idle)
+        operation = asyncio.ensure_future(idle_wait)
+        try:
+            await asyncio.wait_for(asyncio.shield(operation), timeout=float(timeout))
+        except asyncio.TimeoutError as error:
+            cancel_signal.abort(error)
+            try:
+                await operation
+            except asyncio.TimeoutError:
+                pass
+            raise BackgroundTaskTimeoutError(float(timeout)) from error
+
+    async def resume(self, task_id: str, responses: Sequence[InterruptResponse]) -> BackgroundTask:
+        """Apply interrupt responses to one task."""
+
+        def resume() -> BackgroundTask:
+            def update(state_data: InterruptStateData) -> tuple[InterruptStateData, bool]:
+                state = _InterruptState.from_dict(state_data)
+                response_contents: list[InterruptResponseContent] = [
+                    {
+                        "interruptResponse": {
+                            "interruptId": response["interruptId"],
+                            "response": response["response"],
+                        }
+                    }
+                    for response in responses
+                ]
+                state.resume(response_contents)
+                return (
+                    state.to_dict(),
+                    all(interrupt.response is not None for interrupt in state.interrupts.values()),
+                )
+
+            return _to_background_task(self._engine.resume(task_id, update))
+
+        return await self._runtime.run(resume)
+
+    async def remove(self, task_ids: Sequence[str]) -> None:
+        """Remove terminal tasks atomically."""
+
+        def remove() -> None:
+            unique_task_ids = list(dict.fromkeys(task_ids))
+            for task_id in unique_task_ids:
+                record = self._engine.get(task_id)
+                if record is None:
+                    raise BackgroundTaskNotFoundError(task_id)
+                if not is_task_status_terminal(record["status"]):
+                    raise RuntimeError(
+                        f"Background task '{task_id}' cannot be removed before reaching a terminal status"
+                    )
+            for task_id in unique_task_ids:
+                self._engine.remove(task_id)
+                self._task_events.pop(task_id, None)
+            removed = set(unique_task_ids)
+            self._task_id_by_submission = {
+                key: task_id for key, task_id in self._task_id_by_submission.items() if task_id not in removed
+            }
+            if not self._task_id_by_submission:
+                self._has_tasks.clear()
+
+        await self._runtime.run(remove)
+
+    async def _execute_tool_task(self, context: InProcessTaskExecutionContext) -> InProcessTaskExecutionOutcome:
+        execution = self._executions.get(context.invocation_state_id)
+        if execution is None:
+            raise RuntimeError("Background task live execution state is unavailable")
+        interrupt_state = _InterruptState.from_dict(context.state) if context.state is not None else _InterruptState()
+        tool_context = _BackgroundToolContext(
+            task_id=context.task_id,
+            tool_use=execution.tool_use,
+            agent=self._agent,
+            invocation_state=execution.invocation_state,
+            cancel_signal=context.cancel_signal,
+            interrupt_state=interrupt_state,
+        )
+
+        def middleware_interrupt(
+            name: str,
+            *,
+            reason: Any = None,
+            response: Any = None,
+        ) -> MiddlewareInterruptResult:
+            interrupt_id = f"v1:middleware_execute_tool:{context.task_id}:{uuid.uuid5(uuid.NAMESPACE_OID, name)}"
+            return MiddlewareInterruptResult(
+                response=_request_interrupt(interrupt_state, interrupt_id, name, reason, response)
+            )
+
+        async def execute_tool() -> ToolResult:
+            return await self._execute_tool(execution.tool, tool_context, middleware_interrupt)
+
+        try:
+            if execution.origin_loop is None or execution.origin_loop.is_closed():
+                result = await execute_tool()
+            else:
+                future = asyncio.run_coroutine_threadsafe(execute_tool(), execution.origin_loop)
+                result = await _await_origin_result(future, context.cancel_signal)
+        except InterruptException as error:
+            if error.interrupt.id not in interrupt_state.interrupts:
+                raise RuntimeError(f"Interrupt raised: {error.interrupt.name}") from error
+            interrupt_state.activate()
+            return {"status": "input_required", "state": interrupt_state.to_dict()}
+
+        if result["status"] == "success":
+            return {"status": "completed", "result": result}
+        return {
+            "status": "failed",
+            "failure": {"type": "tool_error", "message": _tool_error_message(result)},
+            "result": result,
+        }
+
+    def _handle_task_updated(self, record: InProcessTaskRecord) -> None:
+        if record["status"] == "input_required" or is_task_status_terminal(record["status"]):
+            changed = self._task_events.get(record["task_id"])
+            if changed is not None:
+                changed.set()
+        if is_task_status_terminal(record["status"]):
+            self._executions.pop(record["invocation_state_id"], None)
+        if self._on_task_updated is not None:
+            self._on_task_updated(_to_background_task(record))
+
+
+async def _await_origin_result(
+    future: concurrent.futures.Future[ToolResult],
+    cancel_signal: CancelSignal,
+) -> ToolResult:
+    wrapped = asyncio.wrap_future(future)
+    try:
+        while True:
+            if cancel_signal.aborted:
+                raise asyncio.CancelledError
+            try:
+                return await asyncio.wait_for(asyncio.shield(wrapped), timeout=0.01)
+            except asyncio.TimeoutError:
+                pass
+    except BaseException:
+        future.cancel()
+        raise
+
+
+def _request_interrupt(
+    state: _InterruptState,
+    interrupt_id: str,
+    name: str,
+    reason: Any,
+    response: Any,
+) -> Any:
+    interrupt = state.interrupts.setdefault(
+        interrupt_id,
+        Interrupt(id=interrupt_id, name=name, reason=reason, response=response),
+    )
+    if interrupt.response is not None:
+        return interrupt.response
+    raise InterruptException(interrupt)
+
+
+def _tool_error_message(result: ToolResult) -> str:
+    for content in result.get("content", []):
+        text = content.get("text")
+        if text:
+            return text.removeprefix("Error: ")
+    return "Tool returned an error without a message"
+
+
+def _to_background_task(record: InProcessTaskRecord) -> BackgroundTask:
+    task = BackgroundTask(
+        task_id=record["task_id"],
+        tool_use_id=record["tool_use_id"],
+        tool_name=record["tool_name"],
+        status=record["status"],
+        created_at=record["created_at"],
+        last_updated_at=record["last_updated_at"],
+    )
+    if "result" in record:
+        task["result"] = {"content": copy.deepcopy(record["result"]["content"])}
+    if "failure" in record:
+        task["error"] = copy.deepcopy(record["failure"])
+    if "state" in record:
+        state = _InterruptState.from_dict(record["state"])
+        interrupts = [
+            _to_background_interrupt(interrupt) for interrupt in state.interrupts.values() if interrupt.response is None
+        ]
+        if interrupts:
+            task["interrupts"] = interrupts
+    return task
+
+
+def _to_background_interrupt(interrupt: Interrupt) -> BackgroundTaskInterrupt:
+    source: Literal["middleware", "tool"] = (
+        "middleware" if interrupt.id.startswith("v1:middleware_execute_tool:") else "tool"
+    )
+    return {
+        "id": interrupt.id,
+        "name": interrupt.name,
+        "reason": interrupt.reason,
+        "source": source,
+    }

--- a/strands-py/src/strands/background_tasks/in_process/_types.py
+++ b/strands-py/src/strands/background_tasks/in_process/_types.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Literal, TypeAlias
 
@@ -36,6 +37,8 @@ class CancelSignal(threading.Event):
         """Initialize an unset signal."""
         super().__init__()
         self.reason: object | None = None
+        self._abort_callbacks: list[Callable[[], None]] = []
+        self._callback_lock = threading.Lock()
 
     @property
     def aborted(self) -> bool:
@@ -44,10 +47,32 @@ class CancelSignal(threading.Event):
 
     def abort(self, reason: object | None = None) -> None:
         """Request cancellation once."""
-        if self.is_set():
-            return
-        self.reason = reason
-        self.set()
+        with self._callback_lock:
+            if self.is_set():
+                return
+            self.reason = reason
+            self.set()
+            callbacks = self._abort_callbacks
+            self._abort_callbacks = []
+        for callback in callbacks:
+            callback()
+
+    def add_abort_callback(self, callback: Callable[[], None]) -> None:
+        """Invoke callback on abort, immediately if already aborted.
+
+        The callback runs on the aborting thread and must be thread-safe.
+        """
+        with self._callback_lock:
+            if not self.is_set():
+                self._abort_callbacks.append(callback)
+                return
+        callback()
+
+    def remove_abort_callback(self, callback: Callable[[], None]) -> None:
+        """Unregister a previously added callback."""
+        with self._callback_lock:
+            if callback in self._abort_callbacks:
+                self._abort_callbacks.remove(callback)
 
 
 @dataclass(frozen=True)

--- a/strands-py/src/strands/background_tasks/in_process/_types.py
+++ b/strands-py/src/strands/background_tasks/in_process/_types.py
@@ -1,0 +1,89 @@
+"""Internal types for in-process background task execution."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from typing import Any, Literal, TypeAlias
+
+from typing_extensions import NotRequired, TypedDict
+
+from strands.background_tasks._types import BackgroundTaskError, BackgroundTaskStatus
+from strands.types.tools import ToolResult
+
+InterruptStateData: TypeAlias = dict[str, Any]
+
+
+class InProcessTaskRecord(TypedDict):
+    """State tracked for one in-process task."""
+
+    task_id: str
+    tool_use_id: str
+    tool_name: str
+    invocation_state_id: str
+    status: BackgroundTaskStatus
+    created_at: str
+    last_updated_at: str
+    state: NotRequired[InterruptStateData]
+    result: NotRequired[ToolResult]
+    failure: NotRequired[BackgroundTaskError]
+
+
+class CancelSignal(threading.Event):
+    """Thread-compatible cancellation signal with an abort reason."""
+
+    def __init__(self) -> None:
+        """Initialize an unset signal."""
+        super().__init__()
+        self.reason: object | None = None
+
+    @property
+    def aborted(self) -> bool:
+        """Return whether cancellation was requested."""
+        return self.is_set()
+
+    def abort(self, reason: object | None = None) -> None:
+        """Request cancellation once."""
+        if self.is_set():
+            return
+        self.reason = reason
+        self.set()
+
+
+@dataclass(frozen=True)
+class InProcessTaskExecutionContext:
+    """Context supplied to one task execution."""
+
+    task_id: str
+    tool_use_id: str
+    tool_name: str
+    invocation_state_id: str
+    cancel_signal: CancelSignal
+    state: InterruptStateData | None = None
+
+
+class CompletedTaskExecutionOutcome(TypedDict):
+    """Successful task outcome."""
+
+    status: Literal["completed"]
+    result: ToolResult
+
+
+class InputRequiredTaskExecutionOutcome(TypedDict):
+    """Task outcome requiring input."""
+
+    status: Literal["input_required"]
+    state: InterruptStateData
+
+
+class FailedTaskExecutionOutcome(TypedDict):
+    """Failed task outcome."""
+
+    status: Literal["failed"]
+    failure: BackgroundTaskError
+    result: NotRequired[ToolResult]
+
+
+InProcessTaskExecutionOutcome: TypeAlias = (
+    CompletedTaskExecutionOutcome | InputRequiredTaskExecutionOutcome | FailedTaskExecutionOutcome
+)

--- a/strands-py/tests/strands/background_tasks/__init__.py
+++ b/strands-py/tests/strands/background_tasks/__init__.py
@@ -1,0 +1,1 @@
+"""Background Tasks tests."""

--- a/strands-py/tests/strands/background_tasks/in_process/__init__.py
+++ b/strands-py/tests/strands/background_tasks/in_process/__init__.py
@@ -1,0 +1,1 @@
+"""In-process Background Tasks tests."""

--- a/strands-py/tests/strands/background_tasks/in_process/_engine_test_helpers.py
+++ b/strands-py/tests/strands/background_tasks/in_process/_engine_test_helpers.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import Any
+from unittest.mock import ANY
+
+from strands.background_tasks.in_process._engine import InProcessTaskEngine
+from strands.background_tasks.in_process._types import (
+    InProcessTaskExecutionContext,
+    InProcessTaskExecutionOutcome,
+    InProcessTaskRecord,
+)
+from strands.types.tools import ToolResult
+
+
+def create_engine(
+    execute: Callable[[InProcessTaskExecutionContext], Awaitable[InProcessTaskExecutionOutcome]],
+    *,
+    max_concurrency: int = 2,
+    timeout: float = 1.0,
+    on_task_updated: Callable[[InProcessTaskRecord], None] | None = None,
+) -> InProcessTaskEngine:
+    return InProcessTaskEngine(
+        max_concurrency=max_concurrency,
+        timeout=timeout,
+        execute=execute,
+        on_task_updated=on_task_updated or (lambda _: None),
+    )
+
+
+def create_admission(value: str) -> dict[str, str]:
+    return {
+        "tool_use_id": value,
+        "tool_name": value,
+        "invocation_state_id": value,
+    }
+
+
+def create_result(value: str) -> ToolResult:
+    return {
+        "toolUseId": value,
+        "status": "success",
+        "content": [{"text": value}],
+    }
+
+
+def create_state(value: str) -> dict[str, Any]:
+    return {
+        "interrupts": {
+            value: {
+                "id": value,
+                "name": value,
+            }
+        },
+        "activated": True,
+    }
+
+
+def get_state_value(state: dict[str, Any]) -> str:
+    return next(iter(state["interrupts"]))
+
+
+def assert_task(
+    actual: InProcessTaskRecord | None,
+    task: InProcessTaskRecord,
+    fields: dict[str, Any],
+) -> None:
+    exp_task = {
+        "task_id": task["task_id"],
+        "tool_use_id": task["tool_use_id"],
+        "tool_name": task["tool_name"],
+        "invocation_state_id": task["invocation_state_id"],
+        **fields,
+        "created_at": task["created_at"],
+        "last_updated_at": ANY,
+    }
+    assert actual == exp_task
+
+
+def deferred() -> tuple[
+    asyncio.Future[InProcessTaskExecutionOutcome],
+    Callable[[InProcessTaskExecutionOutcome], None],
+]:
+    future = asyncio.get_running_loop().create_future()
+    return future, future.set_result

--- a/strands-py/tests/strands/background_tasks/in_process/test_engine_execution.py
+++ b/strands-py/tests/strands/background_tasks/in_process/test_engine_execution.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import asyncio
+import math
+import threading
+from unittest.mock import ANY
+
+import pytest
+
+from strands.background_tasks.in_process._types import (
+    CancelSignal,
+    InProcessTaskExecutionContext,
+    InProcessTaskExecutionOutcome,
+    InProcessTaskRecord,
+)
+
+from ._engine_test_helpers import (
+    assert_task,
+    create_admission,
+    create_engine,
+    create_result,
+    deferred,
+)
+
+
+@pytest.mark.asyncio
+async def test_admission_and_updates_prevent_callbacks_from_mutating_engine_state() -> None:
+    statuses: list[str] = []
+
+    async def execute(context: InProcessTaskExecutionContext) -> InProcessTaskExecutionOutcome:
+        return {"status": "completed", "result": create_result(context.tool_name.upper())}
+
+    def on_task_updated(task: InProcessTaskRecord) -> None:
+        statuses.append(task["status"])
+        if task["status"] == "working":
+            task["status"] = "cancelled"
+        if task["status"] == "completed":
+            raise RuntimeError("notification failed")
+
+    engine = create_engine(execute, on_task_updated=on_task_updated)
+    admitted = engine.submit(**create_admission("hello"))
+
+    admitted["status"] = "cancelled"
+    await engine.wait_for_idle()
+    completed = engine.get(admitted["task_id"])
+    assert_task(completed, admitted, {"status": "completed", "result": create_result("HELLO")})
+
+    tru_tasks = engine.list()
+    exp_tasks = [completed]
+    assert tru_tasks == exp_tasks
+
+    tru_statuses = statuses
+    exp_statuses = ["queued", "working", "completed"]
+    assert tru_statuses == exp_statuses
+
+    assert completed is not None
+    completed["status"] = "cancelled"
+    engine.list()[0]["status"] = "failed"
+    assert_task(
+        engine.get(admitted["task_id"]),
+        admitted,
+        {"status": "completed", "result": create_result("HELLO")},
+    )
+
+    engine.remove(admitted["task_id"])
+    tru_tasks = engine.list()
+    exp_tasks = []
+    assert tru_tasks == exp_tasks
+
+
+@pytest.mark.asyncio
+async def test_execution_bounds_concurrency() -> None:
+    releases = [deferred(), deferred(), deferred()]
+    started = [asyncio.Event(), asyncio.Event(), asyncio.Event()]
+
+    async def execute(context: InProcessTaskExecutionContext) -> InProcessTaskExecutionOutcome:
+        index = int(context.tool_name)
+        started[index].set()
+        return await releases[index][0]
+
+    engine = create_engine(execute, max_concurrency=2)
+    tasks = [engine.submit(**create_admission(str(index))) for index in range(3)]
+    await asyncio.gather(started[0].wait(), started[1].wait())
+    assert_task(engine.get(tasks[2]["task_id"]), tasks[2], {"status": "queued"})
+
+    releases[0][1]({"status": "completed", "result": create_result("0")})
+    await started[2].wait()
+    releases[1][1]({"status": "completed", "result": create_result("1")})
+    releases[2][1]({"status": "completed", "result": create_result("2")})
+    await engine.wait_for_idle()
+
+
+@pytest.mark.asyncio
+async def test_execution_propagates_asyncio_cancellation() -> None:
+    started = asyncio.Event()
+    execution_task: asyncio.Task[None] | None = None
+
+    async def execute(_: InProcessTaskExecutionContext) -> InProcessTaskExecutionOutcome:
+        nonlocal execution_task
+        execution_task = asyncio.current_task()
+        started.set()
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    engine = create_engine(execute)
+    task = engine.submit(**create_admission("cancel"))
+    await started.wait()
+    assert execution_task is not None
+
+    engine.cancel(task["task_id"], reason="Stop work")
+    execution_task.cancel()
+    await engine.wait_for_idle()
+
+    assert execution_task.cancelled()
+    assert_task(engine.get(task["task_id"]), task, {"status": "cancelled"})
+
+
+@pytest.mark.asyncio
+async def test_execution_records_classified_failures() -> None:
+    async def throw_error(_: InProcessTaskExecutionContext) -> InProcessTaskExecutionOutcome:
+        raise TypeError("Execution exploded")
+
+    thrown_engine = create_engine(throw_error)
+    thrown = thrown_engine.submit(**create_admission("throw"))
+    await thrown_engine.wait_for_idle()
+    assert_task(
+        thrown_engine.get(thrown["task_id"]),
+        thrown,
+        {"status": "failed", "failure": {"type": "execution_error", "message": "Execution exploded"}},
+    )
+
+    class OpaqueError(Exception):
+        def __str__(self) -> str:
+            raise RuntimeError("cannot stringify")
+
+    async def throw_opaque(_: InProcessTaskExecutionContext) -> InProcessTaskExecutionOutcome:
+        raise OpaqueError
+
+    opaque_engine = create_engine(throw_opaque)
+    opaque = opaque_engine.submit(**create_admission("opaque"))
+    await opaque_engine.wait_for_idle()
+    assert_task(
+        opaque_engine.get(opaque["task_id"]),
+        opaque,
+        {
+            "status": "failed",
+            "failure": {"type": "execution_error", "message": "Background task execution failed"},
+        },
+    )
+
+    async def return_failure(_: InProcessTaskExecutionContext) -> InProcessTaskExecutionOutcome:
+        return {
+            "status": "failed",
+            "failure": {"type": "tool_error", "message": "Tool failed"},
+            "result": create_result("tool detail"),
+        }
+
+    returned_engine = create_engine(return_failure)
+    returned = returned_engine.submit(**create_admission("return"))
+    await returned_engine.wait_for_idle()
+    assert_task(
+        returned_engine.get(returned["task_id"]),
+        returned,
+        {
+            "status": "failed",
+            "failure": {"type": "tool_error", "message": "Tool failed"},
+            "result": create_result("tool detail"),
+        },
+    )
+
+    async def return_uncopyable(_: InProcessTaskExecutionContext) -> InProcessTaskExecutionOutcome:
+        return {
+            "status": "completed",
+            "result": {
+                "toolUseId": "uncopyable",
+                "status": "success",
+                "content": [{"json": {"handle": threading.Lock()}}],
+            },
+        }
+
+    uncopyable_engine = create_engine(return_uncopyable)
+    uncopyable = uncopyable_engine.submit(**create_admission("uncopyable"))
+    await uncopyable_engine.wait_for_idle()
+    assert_task(
+        uncopyable_engine.get(uncopyable["task_id"]),
+        uncopyable,
+        {
+            "status": "failed",
+            "failure": {"type": "execution_error", "message": ANY},
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_execution_timeout_retains_capacity_until_execution_settles() -> None:
+    release, resolve = deferred()
+    timed_out = asyncio.Event()
+    hung_signal: CancelSignal | None = None
+
+    async def execute(context: InProcessTaskExecutionContext) -> InProcessTaskExecutionOutcome:
+        nonlocal hung_signal
+        if context.tool_name == "hang":
+            hung_signal = context.cancel_signal
+            while not context.cancel_signal.aborted:
+                await asyncio.sleep(0)
+            timed_out.set()
+            return await release
+        return {"status": "completed", "result": create_result("next")}
+
+    engine = create_engine(execute, max_concurrency=1, timeout=0.01)
+    hung = engine.submit(**create_admission("hang"))
+    next_task = engine.submit(**create_admission("next"))
+    await timed_out.wait()
+    try:
+        tru_aborted = hung_signal is not None and hung_signal.aborted
+        exp_aborted = True
+        assert tru_aborted == exp_aborted
+        assert_task(engine.get(next_task["task_id"]), next_task, {"status": "queued"})
+    finally:
+        resolve({"status": "completed", "result": create_result("late")})
+
+    await engine.wait_for_idle()
+    assert_task(
+        engine.get(next_task["task_id"]),
+        next_task,
+        {"status": "completed", "result": create_result("next")},
+    )
+    assert_task(
+        engine.get(hung["task_id"]),
+        hung,
+        {"status": "failed", "failure": {"type": "timeout", "message": "Timed out after 0.01s"}},
+    )
+
+
+@pytest.mark.asyncio
+async def test_execution_infinity_disables_timeouts(monkeypatch: pytest.MonkeyPatch) -> None:
+    finish, resolve = deferred()
+
+    async def execute(_: InProcessTaskExecutionContext) -> InProcessTaskExecutionOutcome:
+        return await finish
+
+    loop = asyncio.get_running_loop()
+    call_later = loop.call_later
+
+    def fail_call_later(*_: object) -> None:
+        raise AssertionError("timeout scheduled")
+
+    monkeypatch.setattr(loop, "call_later", fail_call_later)
+    engine = create_engine(execute, timeout=math.inf)
+    task = engine.submit(**create_admission("work"))
+    await asyncio.sleep(0)
+    monkeypatch.setattr(loop, "call_later", call_later)
+
+    resolve({"status": "completed", "result": create_result("done")})
+    await engine.wait_for_idle()
+    assert_task(engine.get(task["task_id"]), task, {"status": "completed", "result": create_result("done")})

--- a/strands-py/tests/strands/background_tasks/in_process/test_engine_transitions.py
+++ b/strands-py/tests/strands/background_tasks/in_process/test_engine_transitions.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from strands.background_tasks._errors import BackgroundTaskNotFoundError
+from strands.background_tasks.in_process._engine import InProcessTaskEngine
+from strands.background_tasks.in_process._types import (
+    CancelSignal,
+    InProcessTaskExecutionContext,
+    InProcessTaskExecutionOutcome,
+    InProcessTaskRecord,
+)
+
+from ._engine_test_helpers import (
+    assert_task,
+    create_admission,
+    create_engine,
+    create_result,
+    create_state,
+    deferred,
+    get_state_value,
+)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_idle_cancels_observation_without_cancelling_work() -> None:
+    finish, resolve = deferred()
+
+    async def execute(_: InProcessTaskExecutionContext) -> InProcessTaskExecutionOutcome:
+        return await finish
+
+    engine = create_engine(execute)
+    task = engine.submit(**create_admission("work"))
+    idle_signal = CancelSignal()
+    idle_waiting = asyncio.create_task(engine.wait_for_idle(cancel_signal=idle_signal))
+
+    idle_signal.abort(RuntimeError("stop idle observation"))
+    with pytest.raises(RuntimeError, match="stop idle observation"):
+        await idle_waiting
+    assert_task(engine.get(task["task_id"]), task, {"status": "working"})
+
+    resolve({"status": "completed", "result": create_result("done")})
+    await engine.wait_for_idle()
+
+
+@pytest.mark.asyncio
+async def test_resume_updates_state_and_restarts_execution() -> None:
+    async def execute(context: InProcessTaskExecutionContext) -> InProcessTaskExecutionOutcome:
+        if context.state is not None:
+            return {"status": "completed", "result": create_result(get_state_value(context.state))}
+        return {"status": "input_required", "state": create_state("waiting")}
+
+    engine = create_engine(execute)
+    task = engine.submit(**create_admission("work"))
+    await engine.wait_for_idle()
+    assert_task(
+        engine.get(task["task_id"]),
+        task,
+        {"status": "input_required", "state": create_state("waiting")},
+    )
+    assert_task(
+        engine.resume(
+            task["task_id"],
+            lambda _: (create_state("still waiting"), False),
+        ),
+        task,
+        {"status": "input_required", "state": create_state("still waiting")},
+    )
+    engine.resume(task["task_id"], lambda state: (state, True))
+    await engine.wait_for_idle()
+    assert_task(
+        engine.get(task["task_id"]),
+        task,
+        {"status": "completed", "result": create_result("still waiting")},
+    )
+
+
+@pytest.mark.asyncio
+async def test_resume_restarts_execution_while_previous_execution_settles() -> None:
+    executions = 0
+    engine: InProcessTaskEngine
+
+    async def execute(context: InProcessTaskExecutionContext) -> InProcessTaskExecutionOutcome:
+        nonlocal executions
+        executions += 1
+        if context.state is None:
+            return {"status": "input_required", "state": create_state("waiting")}
+        return {"status": "completed", "result": create_result("done")}
+
+    def on_task_updated(task: InProcessTaskRecord) -> None:
+        if task["status"] == "input_required":
+            engine.resume(task["task_id"], lambda state: (state, True))
+
+    engine = create_engine(execute, on_task_updated=on_task_updated)
+    task = engine.submit(**create_admission("work"))
+    await engine.wait_for_idle()
+
+    tru_executions = executions
+    exp_executions = 2
+    assert tru_executions == exp_executions
+    assert_task(engine.get(task["task_id"]), task, {"status": "completed", "result": create_result("done")})
+
+
+@pytest.mark.asyncio
+async def test_cancel_running_work_and_remove_before_execution_settles() -> None:
+    finish, resolve = deferred()
+    execution_signal: CancelSignal | None = None
+
+    async def execute(context: InProcessTaskExecutionContext) -> InProcessTaskExecutionOutcome:
+        nonlocal execution_signal
+        execution_signal = context.cancel_signal
+        return await finish
+
+    engine = create_engine(execute)
+    task = engine.submit(**create_admission("work"))
+    await asyncio.sleep(0)
+
+    assert_task(engine.cancel(task["task_id"], reason="Stop work"), task, {"status": "cancelled"})
+    assert execution_signal is not None
+    tru_reason = execution_signal.reason
+    exp_reason = "Stop work"
+    assert tru_reason == exp_reason
+
+    engine.remove(task["task_id"])
+    tru_task = engine.get(task["task_id"])
+    exp_task = None
+    assert tru_task == exp_task
+    with pytest.raises(BackgroundTaskNotFoundError, match="was not found"):
+        engine.cancel(task["task_id"], reason="Again")
+
+    resolve({"status": "completed", "result": create_result("late")})
+    await engine.wait_for_idle()
+
+
+@pytest.mark.asyncio
+async def test_cancel_scheduled_work_without_executing_it() -> None:
+    executed = False
+
+    async def execute(_: InProcessTaskExecutionContext) -> InProcessTaskExecutionOutcome:
+        nonlocal executed
+        executed = True
+        return {"status": "completed", "result": create_result("late")}
+
+    engine = create_engine(execute)
+    task = engine.submit(**create_admission("work"))
+
+    assert_task(engine.cancel(task["task_id"], reason="Stop work"), task, {"status": "cancelled"})
+    await engine.wait_for_idle()
+
+    assert not executed
+    assert_task(engine.get(task["task_id"]), task, {"status": "cancelled"})
+
+
+@pytest.mark.asyncio
+async def test_cancel_queued_work_without_executing_it() -> None:
+    finish, resolve = deferred()
+    executions: list[str] = []
+
+    async def execute(context: InProcessTaskExecutionContext) -> InProcessTaskExecutionOutcome:
+        executions.append(context.tool_name)
+        return await finish
+
+    engine = create_engine(execute, max_concurrency=1)
+    engine.submit(**create_admission("running"))
+    queued = engine.submit(**create_admission("queued"))
+
+    assert_task(engine.cancel(queued["task_id"], reason="No longer needed"), queued, {"status": "cancelled"})
+    resolve({"status": "completed", "result": create_result("done")})
+    await engine.wait_for_idle()
+
+    tru_executions = executions
+    exp_executions = ["running"]
+    assert tru_executions == exp_executions
+
+
+def test_init_rejects_invalid_execution_configuration() -> None:
+    async def complete(_: InProcessTaskExecutionContext) -> InProcessTaskExecutionOutcome:
+        return {"status": "completed", "result": create_result("done")}
+
+    with pytest.raises(TypeError, match="max_concurrency must be a positive"):
+        create_engine(complete, max_concurrency=0)
+    with pytest.raises(TypeError, match="timeout must be a positive"):
+        create_engine(complete, timeout=0)
+    create_engine(complete, timeout=2**31)

--- a/strands-py/tests/strands/background_tasks/in_process/test_manager.py
+++ b/strands-py/tests/strands/background_tasks/in_process/test_manager.py
@@ -1,0 +1,468 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+import threading
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import ANY
+
+import pytest
+
+from strands import Agent, tool
+from strands._async import run_async
+from strands.background_tasks._errors import BackgroundTaskTimeoutError
+from strands.background_tasks.in_process._manager import InProcessTaskManager
+from strands.interrupt import Interrupt, InterruptException
+from strands.types.tools import AgentTool, ToolContext, ToolResult
+from tests.fixtures.mocked_model_provider import MockedModelProvider
+
+_Callback = Callable[[dict[str, str], ToolContext], str | Awaitable[str]]
+
+
+@dataclass(frozen=True)
+class _Fixture:
+    manager: InProcessTaskManager
+    work: AgentTool
+
+
+def _create_fixture(callback: _Callback, *, max_concurrency: int = 4) -> _Fixture:
+    @tool(name="work")
+    def work(value: str) -> str:
+        """Perform controlled test work."""
+        return value
+
+    agent = Agent(model=MockedModelProvider([]), callback_handler=None)
+
+    async def execute_tool(
+        selected_tool: AgentTool,
+        context: ToolContext,
+        _middleware_interrupt: Callable[..., Any],
+    ) -> ToolResult:
+        assert selected_tool is work
+        try:
+            result = callback(context.tool_use["input"], context)
+            if inspect.isawaitable(result):
+                result = await result
+            return {
+                "toolUseId": context.tool_use["toolUseId"],
+                "status": "success",
+                "content": [{"text": result}],
+            }
+        except InterruptException:
+            raise
+        except Exception as error:
+            return {
+                "toolUseId": context.tool_use["toolUseId"],
+                "status": "error",
+                "content": [{"text": f"Error: {error}"}],
+            }
+
+    return _Fixture(InProcessTaskManager(agent, execute_tool, max_concurrency=max_concurrency), work)
+
+
+async def _submit(
+    manager: InProcessTaskManager,
+    work: AgentTool,
+    value: str,
+    tool_use_id: str | None = None,
+    pass_id: str | None = None,
+) -> dict[str, Any]:
+    return await manager.submit(
+        {
+            "name": "work",
+            "toolUseId": tool_use_id or f"tool-use-{value}",
+            "input": {"value": value},
+        },
+        {},
+        pass_id or f"pass-{value}",
+        work,
+    )
+
+
+@pytest.mark.asyncio
+async def test_submit_executes_selected_tool_with_transient_invocation_state() -> None:
+    invocation_state = {
+        "request_id": "request-1",
+        "callback": lambda: "not serializable",
+    }
+
+    async def callback(input_data: dict[str, str], context: ToolContext) -> str:
+        assert context.invocation_state is invocation_state
+        tru_tool_name = context.tool_use["name"]
+        exp_tool_name = "hook-alias"
+        assert tru_tool_name == exp_tool_name
+        return input_data["value"].upper()
+
+    fixture = _create_fixture(callback)
+    admitted = await fixture.manager.submit(
+        {
+            "name": "hook-alias",
+            "toolUseId": "tool-use-1",
+            "input": {"value": "hello"},
+        },
+        invocation_state,
+        "pass-1",
+        fixture.work,
+    )
+
+    await fixture.manager.wait_for_idle()
+    exp_completed = {
+        "task_id": admitted["task_id"],
+        "tool_use_id": "tool-use-1",
+        "tool_name": "hook-alias",
+        "status": "completed",
+        "created_at": ANY,
+        "last_updated_at": ANY,
+        "result": {"content": [{"text": "HELLO"}]},
+    }
+    tru_completed = await fixture.manager.get(admitted["task_id"])
+    assert tru_completed == exp_completed
+
+    tru_tasks = await fixture.manager.list()
+    exp_tasks = [exp_completed]
+    assert tru_tasks == exp_tasks
+
+    await fixture.manager.remove([admitted["task_id"]])
+    tru_removed = await fixture.manager.get(admitted["task_id"])
+    exp_removed = None
+    assert tru_removed == exp_removed
+
+
+def test_submit_from_sync_bridge_survives_temporary_event_loop() -> None:
+    release = threading.Event()
+
+    async def callback(input_data: dict[str, str], _: ToolContext) -> str:
+        while not release.is_set():
+            await asyncio.sleep(0)
+        return input_data["value"].upper()
+
+    fixture = _create_fixture(callback)
+    admitted = run_async(lambda: _submit(fixture.manager, fixture.work, "detached"))
+
+    release.set()
+    tru_completed = run_async(lambda: fixture.manager.wait(admitted["task_id"]))
+    exp_completed = {
+        **admitted,
+        "status": "completed",
+        "last_updated_at": ANY,
+        "result": {"content": [{"text": "DETACHED"}]},
+    }
+    assert tru_completed == exp_completed
+
+
+@pytest.mark.asyncio
+async def test_submit_deduplicates_repeated_submissions_within_one_pass() -> None:
+    execution_count = 0
+
+    def callback(input_data: dict[str, str], _: ToolContext) -> str:
+        nonlocal execution_count
+        execution_count += 1
+        return input_data["value"]
+
+    fixture = _create_fixture(callback)
+    first = await _submit(fixture.manager, fixture.work, "same", "tool-use-1", "pass-1")
+    duplicate = await _submit(fixture.manager, fixture.work, "same", "tool-use-1", "pass-1")
+    later_pass = await _submit(fixture.manager, fixture.work, "same", "tool-use-1", "pass-2")
+
+    tru_duplicate_id = duplicate["task_id"]
+    exp_duplicate_id = first["task_id"]
+    assert tru_duplicate_id == exp_duplicate_id
+    assert later_pass["task_id"] != first["task_id"]
+
+    await fixture.manager.wait_for_idle()
+    tru_execution_count = execution_count
+    exp_execution_count = 2
+    assert tru_execution_count == exp_execution_count
+
+
+@pytest.mark.asyncio
+async def test_wait_projects_tool_errors() -> None:
+    def callback(_: dict[str, str], __: ToolContext) -> str:
+        raise RuntimeError("tool failed")
+
+    fixture = _create_fixture(callback)
+    failed = await _submit(fixture.manager, fixture.work, "failed")
+
+    tru_failed = await fixture.manager.wait(failed["task_id"])
+    exp_failed = {
+        **failed,
+        "status": "failed",
+        "last_updated_at": ANY,
+        "result": {"content": [{"text": "Error: tool failed"}]},
+        "error": {"type": "tool_error", "message": "tool failed"},
+    }
+    assert tru_failed == exp_failed
+
+
+@pytest.mark.asyncio
+async def test_cancel_stops_tool_execution() -> None:
+    started = asyncio.Event()
+    cancel_signal: Any = None
+
+    async def callback(_: dict[str, str], context: ToolContext) -> str:
+        nonlocal cancel_signal
+        cancel_signal = context.cancel_signal
+        started.set()
+        while not cancel_signal.is_set():
+            await asyncio.sleep(0)
+        return "late"
+
+    fixture = _create_fixture(callback)
+    admitted = await _submit(fixture.manager, fixture.work, "cancel")
+    await started.wait()
+    waiting = asyncio.create_task(fixture.manager.wait(admitted["task_id"]))
+
+    exp_cancelled = {
+        **admitted,
+        "status": "cancelled",
+        "last_updated_at": ANY,
+    }
+    tru_cancelled = await fixture.manager.cancel(admitted["task_id"])
+    assert tru_cancelled == exp_cancelled
+
+    tru_waited = await waiting
+    assert tru_waited == exp_cancelled
+    tru_signal = {
+        "aborted": cancel_signal.is_set(),
+        "reason": cancel_signal.reason,
+    }
+    exp_signal = {
+        "aborted": True,
+        "reason": "Cancellation requested",
+    }
+    assert tru_signal == exp_signal
+    await fixture.manager.wait_for_idle()
+
+
+@pytest.mark.asyncio
+async def test_wait_for_idle_rejects_invalid_timeout() -> None:
+    fixture = _create_fixture(lambda input_data, _: input_data["value"])
+
+    with pytest.raises(TypeError):
+        await fixture.manager.wait_for_idle(timeout=0)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_idle_raises_timeout_error() -> None:
+    async def callback(_: dict[str, str], context: ToolContext) -> str:
+        while not context.cancel_signal.is_set():
+            await asyncio.sleep(0)
+        return "cancelled"
+
+    fixture = _create_fixture(callback)
+    admitted = await _submit(fixture.manager, fixture.work, "slow")
+
+    with pytest.raises(BackgroundTaskTimeoutError):
+        await fixture.manager.wait_for_idle(timeout=0.01)
+
+    tru_idle_waiters = await fixture.manager._runtime.run(lambda: len(fixture.manager._engine._idle_waiters))
+    exp_idle_waiters = 0
+    assert tru_idle_waiters == exp_idle_waiters
+
+    await fixture.manager.cancel(admitted["task_id"])
+    await fixture.manager.wait_for_idle()
+
+
+@pytest.mark.asyncio
+async def test_resume_applies_input_to_tool_interrupts() -> None:
+    def callback(input_data: dict[str, str], context: ToolContext) -> str:
+        if input_data["value"] == "complete":
+            return "complete"
+        response = context.interrupt("approve_work", reason="Approve work?")
+        return f"approved:{response}"
+
+    fixture = _create_fixture(callback)
+    completed = await _submit(fixture.manager, fixture.work, "complete")
+    await fixture.manager.wait(completed["task_id"])
+    admitted = await _submit(fixture.manager, fixture.work, "interrupt", "tool-use-1")
+    tru_input_required = await fixture.manager.wait(admitted["task_id"])
+    exp_input_required = {
+        **admitted,
+        "status": "input_required",
+        "last_updated_at": ANY,
+        "interrupts": [
+            {
+                "id": ANY,
+                "name": "approve_work",
+                "reason": "Approve work?",
+                "source": "tool",
+            },
+        ],
+    }
+    assert tru_input_required == exp_input_required
+    interrupt = tru_input_required["interrupts"][0]
+
+    with pytest.raises(RuntimeError, match="cannot be removed before reaching a terminal status"):
+        await fixture.manager.remove([completed["task_id"], admitted["task_id"]])
+    tru_completed = await fixture.manager.get(completed["task_id"])
+    assert tru_completed is not None
+
+    tru_queued = await fixture.manager.resume(
+        admitted["task_id"],
+        [{"interruptId": interrupt["id"], "response": "yes"}],
+    )
+    exp_queued = {
+        **admitted,
+        "status": "queued",
+        "last_updated_at": ANY,
+    }
+    assert tru_queued == exp_queued
+
+    tru_resumed = await fixture.manager.wait(admitted["task_id"])
+    exp_resumed = {
+        **admitted,
+        "status": "completed",
+        "last_updated_at": ANY,
+        "result": {"content": [{"text": "approved:yes"}]},
+    }
+    assert tru_resumed == exp_resumed
+
+
+def test_resume_after_origin_event_loop_closes() -> None:
+    def callback(input_data: dict[str, str], context: ToolContext) -> str:
+        response = context.interrupt("approve_work", reason="Approve work?")
+        return f"{input_data['value']}:{response}"
+
+    fixture = _create_fixture(callback)
+
+    async def submit_and_wait() -> tuple[dict[str, Any], dict[str, Any]]:
+        admitted = await _submit(fixture.manager, fixture.work, "interrupt")
+        return admitted, await fixture.manager.wait(admitted["task_id"])
+
+    admitted, input_required = asyncio.run(submit_and_wait())
+    interrupt = input_required["interrupts"][0]
+
+    async def resume_and_wait() -> dict[str, Any]:
+        await fixture.manager.resume(
+            admitted["task_id"],
+            [{"interruptId": interrupt["id"], "response": "yes"}],
+        )
+        return await fixture.manager.wait(admitted["task_id"])
+
+    resumed = asyncio.run(resume_and_wait())
+
+    assert resumed == {
+        **admitted,
+        "status": "completed",
+        "last_updated_at": ANY,
+        "result": {"content": [{"text": "interrupt:yes"}]},
+    }
+
+
+def test_cancel_reclaims_execution_from_stopped_origin_event_loop() -> None:
+    started = threading.Event()
+
+    async def callback(input_data: dict[str, str], context: ToolContext) -> str:
+        if input_data["value"] != "stopped":
+            return input_data["value"]
+        started.set()
+        while not context.cancel_signal.is_set():
+            await asyncio.sleep(0)
+        return input_data["value"]
+
+    fixture = _create_fixture(callback, max_concurrency=1)
+    origin_loop = asyncio.new_event_loop()
+
+    async def submit_from_origin() -> dict[str, Any]:
+        admitted = await _submit(fixture.manager, fixture.work, "stopped")
+        while not started.is_set():
+            await asyncio.sleep(0)
+        return admitted
+
+    admitted = origin_loop.run_until_complete(submit_from_origin())
+
+    async def cancel_and_run_next() -> dict[str, Any]:
+        await fixture.manager.cancel(admitted["task_id"])
+        next_task = await _submit(fixture.manager, fixture.work, "next")
+        return await asyncio.wait_for(fixture.manager.wait(next_task["task_id"]), timeout=1)
+
+    try:
+        completed = asyncio.run(cancel_and_run_next())
+        assert completed == {
+            "task_id": ANY,
+            "tool_use_id": "tool-use-next",
+            "tool_name": "work",
+            "status": "completed",
+            "created_at": ANY,
+            "last_updated_at": ANY,
+            "result": {"content": [{"text": "next"}]},
+        }
+    finally:
+        pending = asyncio.all_tasks(origin_loop)
+        for task in pending:
+            task.cancel()
+        origin_loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+        origin_loop.close()
+
+
+@pytest.mark.asyncio
+async def test_resume_applies_input_to_middleware_interrupts() -> None:
+    agent = Agent(model=MockedModelProvider([]), callback_handler=None)
+
+    @tool(name="work")
+    def work(value: str) -> str:
+        """Perform controlled test work."""
+        return value
+
+    async def execute_tool(
+        selected_tool: AgentTool,
+        context: ToolContext,
+        middleware_interrupt: Callable[..., Any],
+    ) -> ToolResult:
+        assert selected_tool is work
+        response = middleware_interrupt("approve_work", reason="Approve work?").response
+        return {
+            "toolUseId": context.tool_use["toolUseId"],
+            "status": "success",
+            "content": [{"text": f"approved:{response}"}],
+        }
+
+    manager = InProcessTaskManager(agent, execute_tool)
+    admitted = await _submit(manager, work, "interrupt", "tool-use-1")
+    input_required = await manager.wait(admitted["task_id"])
+    interrupt = input_required["interrupts"][0]
+
+    assert interrupt == {
+        "id": ANY,
+        "name": "approve_work",
+        "reason": "Approve work?",
+        "source": "middleware",
+    }
+
+    await manager.resume(
+        admitted["task_id"],
+        [{"interruptId": interrupt["id"], "response": "yes"}],
+    )
+    resumed = await manager.wait(admitted["task_id"])
+
+    assert resumed == {
+        **admitted,
+        "status": "completed",
+        "last_updated_at": ANY,
+        "result": {"content": [{"text": "approved:yes"}]},
+    }
+
+
+@pytest.mark.asyncio
+async def test_wait_fails_interrupts_outside_the_tool_context() -> None:
+    def callback(_: dict[str, str], __: ToolContext) -> str:
+        raise InterruptException(
+            Interrupt(
+                id="v1:before_tool_call:tool-use-1:approve_hook",
+                name="approve_hook",
+            )
+        )
+
+    fixture = _create_fixture(callback)
+    admitted = await _submit(fixture.manager, fixture.work, "hook-interrupt", "tool-use-1")
+
+    tru_failed = await fixture.manager.wait(admitted["task_id"])
+    exp_failed = {
+        **admitted,
+        "status": "failed",
+        "last_updated_at": ANY,
+        "error": {"type": "execution_error", "message": "Interrupt raised: approve_hook"},
+    }
+    assert tru_failed == exp_failed


### PR DESCRIPTION
## Description

Ports the internal in-process Background Tasks foundation from TypeScript to Python:

- `InProcessTaskEngine` provides bounded execution, cancellation, timeouts, interrupt-driven pause/resume, idle waiting, and task update notifications.
- `InProcessTaskManager` provides task submission and lifecycle operations while executing tools through the Agent's middleware path.

The public Agent integration corresponding to #4026 will follow separately.

```mermaid
flowchart LR
    A["Agent"] -->|"tool call"| P["BackgroundTasks"]

    P -->|"foreground"| X["ToolExecutor"]
    P -->|"background"| M["InProcessTaskManager"]
    M -->|"schedule / manage"| E["InProcessTaskEngine"]
    E -->|"execute via callback"| X

    M -->|"completed results"| P
    P -.->|"deliver via hooks"| A

    classDef focus fill:#2da44e,stroke:#116329,color:#fff,stroke-width:3px
    class M,E focus
```

## Related Issues

Part of #2496

Design: #3531

TypeScript parity: #3838 and #3876

Python continuation prerequisite: #3953 (port of #3837)

## Documentation PR

Not applicable. This change is internal.

## Type of Change

New feature

## Testing

- [x] Full Python suite: 5,966 passed, 11 skipped
- [x] Ruff and mypy

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
