### PR TITLE
fix(interrupts): guard Interrupt restore against TypeError on session restore

### DIFF
--- a/strands-py/src/strands/interrupt.py
+++ b/strands-py/src/strands/interrupt.py
@@ -227,13 +227,21 @@ class _InterruptState:
         else:
             pending_tool_execution = None
 
+        interrupts: dict[str, Interrupt] = {}
+        for interrupt_id, interrupt_data in data["interrupts"].items():
+            # Mirror to_dict's filter — don't revive a stale response as a standing approval.
+            if not activated and interrupt_id.startswith(_AGENT_STREAM_INTERRUPT_ID_PREFIX):
+                continue
+            try:
+                interrupts[interrupt_id] = Interrupt(**interrupt_data)
+            except TypeError as error:
+                # Avoid importing the types package while this module is still initializing.
+                from .types.exceptions import SessionException
+
+                raise SessionException(f"Failed to restore interrupt state for {interrupt_id}: {error}") from error
+
         return cls(
-            interrupts={
-                interrupt_id: Interrupt(**interrupt_data)
-                for interrupt_id, interrupt_data in data["interrupts"].items()
-                # Mirror to_dict's filter — don't revive a stale response as a standing approval.
-                if activated or not interrupt_id.startswith(_AGENT_STREAM_INTERRUPT_ID_PREFIX)
-            },
+            interrupts=interrupts,
             context=context,
             activated=activated,
             pending_tool_execution=pending_tool_execution,

--- a/strands-py/tests/strands/test_interrupt.py
+++ b/strands-py/tests/strands/test_interrupt.py
@@ -197,6 +197,19 @@ def test_interrupt_state_from_dict_wraps_invalid_pending_tool_execution():
     assert isinstance(error_info.value.__cause__, TypeError)
 
 
+def test_interrupt_state_from_dict_wraps_invalid_interrupt():
+    data = {
+        "interrupts": {"test_id": {"id": "test_id", "name": "test_name", "unexpected_field": "boom"}},
+        "context": {},
+        "activated": True,
+    }
+
+    with pytest.raises(SessionException, match="Failed to restore interrupt state") as error_info:
+        _InterruptState.from_dict(data)
+
+    assert isinstance(error_info.value.__cause__, TypeError)
+
+
 def test_interrupt_state_resume():
     interrupt_state = _InterruptState(
         interrupts={"test_id": Interrupt(id="test_id", name="test_name", reason="test reason")},


### PR DESCRIPTION
## Description

When an agent restores interrupt state from a persisted session, `_InterruptState.from_dict` reconstructs each persisted `Interrupt` via an unguarded `Interrupt(**interrupt_data)` call. If the persisted interrupt dict carries a field that no longer matches the `Interrupt` dataclass — for example a field renamed or removed after an upgrade, or otherwise corrupted state — the dataclass constructor raises a bare `TypeError` that propagates out of `Agent.__init__`, crashing the agent on session restore with an uninformative traceback rather than the graceful `SessionException` the restore path already uses elsewhere.

The sibling `PendingToolExecution(**pending_tool_execution_data)` construction in the same `from_dict` is already guarded this way (landed in #3894). This change mirrors that guard — wrapping the `Interrupt(**interrupt_data)` construction in `try/except TypeError` and re-raising as `SessionException("Failed to restore interrupt state for …")` with the original error chained as the cause — so a malformed persisted interrupt surfaces as a clear, actionable session error instead of crashing construction.

## Related Issues

Resolves: #4009

## Type of Change

Bug fix

## Testing

The new `test_interrupt_state_from_dict_wraps_invalid_interrupt` feeds `from_dict` a persisted interrupt dict with an unexpected field and asserts a `SessionException` (chained from the underlying `TypeError`) is raised. It is red on `main` (the bare `TypeError` escapes `pytest.raises(SessionException)`) and green on this branch. The full `tests/strands/test_interrupt.py` suite passes with no new warnings.

- [x] I ran `hatch run prepare`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR and can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly *(n/a — internal restore guard, no doc surface)*
- [x] I have added an appropriate example to the documentation, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published