### PR TITLE
feat(context-manager): add session support for L1

### DIFF
--- a/.agents/references/terminology.md
+++ b/.agents/references/terminology.md
@@ -26,6 +26,7 @@ One concept, one term. Never vary for stylistic reasons. This file is the canoni
 | Pausing agent execution for human input | interrupts | human-in-the-loop, breakpoints, pause points |
 | Agent output with enforced schema | structured output | typed output, schema-validated output, Pydantic output |
 | Watching agent execution | observability | monitoring, telemetry, instrumentation |
+| Durable storage for offloaded context content | stash | L1 stash, L1, stash layer, context cache |
 | Checking agent quality | evaluation | testing, benchmarking, assessment |
 | Running agents in production | deployment | hosting, serving, shipping |
 | The decorator for making Python functions into tools | @tool decorator | tool annotation, tool wrapper |

--- a/strands-ts/src/context-manager/context-manager.ts
+++ b/strands-ts/src/context-manager/context-manager.ts
@@ -35,7 +35,7 @@ export class ContextManager implements Plugin {
   readonly name = 'strands:context-manager'
 
   private readonly _strategies: ContextStrategy[]
-  private readonly _stashStorage: Storage | false
+  private readonly _stashStorage: Storage | false | undefined
   private readonly _enableRetrievalTool: boolean
   private readonly _retrievalToolUseIds = new Set<string>()
   private _stash: Stash | undefined
@@ -51,7 +51,7 @@ export class ContextManager implements Plugin {
     ]
     const stashConfig = config?.stash
     const stashObj = typeof stashConfig === 'object' ? stashConfig : undefined
-    this._stashStorage = stashConfig === false ? false : (stashObj?.storage ?? new InMemoryStorage())
+    this._stashStorage = stashConfig === false ? false : stashObj?.storage
     this._enableRetrievalTool = stashConfig !== false && stashObj?.retrievalTool !== false
   }
 
@@ -66,7 +66,8 @@ export class ContextManager implements Plugin {
 
   initAgent(agent: LocalAgent): void {
     if (this._stashStorage !== false) {
-      this._stash = new Stash(this._stashStorage, agent.sessionId, agent.id)
+      const storage = this._stashStorage ?? agent.storage ?? new InMemoryStorage()
+      this._stash = new Stash(storage, agent.sessionId, agent.id)
     }
 
     if (this._stash) {
@@ -109,6 +110,10 @@ export class ContextManager implements Plugin {
       overflowRetries++
       event.retry = true
     })
+  }
+
+  get stash(): Stash | undefined {
+    return this._stash
   }
 
   private async _runStrategies(agent: LocalAgent, precomputedInputTokens?: number): Promise<boolean> {

--- a/strands-ts/src/context-manager/context-manager.ts
+++ b/strands-ts/src/context-manager/context-manager.ts
@@ -41,7 +41,6 @@ export class ContextManager implements Plugin {
   private readonly _retrievalToolUseIds = new Set<string>()
   private _stash: Stash | undefined
   private _stashIsDurable = false
-  private _resolvedStashStorage: Storage | undefined
   private _retrievalTool: Tool | undefined
 
   constructor(config?: ContextManagerConfig) {
@@ -70,7 +69,6 @@ export class ContextManager implements Plugin {
   initAgent(agent: LocalAgent): void {
     if (this._stashStorage !== false) {
       const storage = this._stashStorage ?? agent.storage ?? new InMemoryStorage()
-      this._resolvedStashStorage = storage
       this._stashIsDurable = !(EPHEMERAL in storage)
       this._stash = new Stash(storage, agent.sessionId, agent.id)
     }
@@ -136,15 +134,6 @@ export class ContextManager implements Plugin {
     return this._stashIsDurable
   }
 
-  /**
-   * The raw storage backend used by the stash, before namespace scoping.
-   * Used by SessionManager to clean up stash data on session delete.
-   *
-   * @returns The storage instance, or undefined if stash is disabled or not initialized
-   */
-  get stashStorage(): Storage | undefined {
-    return this._resolvedStashStorage
-  }
 
   private async _runStrategies(agent: LocalAgent, precomputedInputTokens?: number): Promise<boolean> {
     const messages = agent.messages

--- a/strands-ts/src/context-manager/context-manager.ts
+++ b/strands-ts/src/context-manager/context-manager.ts
@@ -134,7 +134,6 @@ export class ContextManager implements Plugin {
     return this._stashIsDurable
   }
 
-
   private async _runStrategies(agent: LocalAgent, precomputedInputTokens?: number): Promise<boolean> {
     const messages = agent.messages
     const inputTokens = precomputedInputTokens ?? (await agent.model.countTokens(messages))

--- a/strands-ts/src/context-manager/context-manager.ts
+++ b/strands-ts/src/context-manager/context-manager.ts
@@ -39,6 +39,8 @@ export class ContextManager implements Plugin {
   private readonly _enableRetrievalTool: boolean
   private readonly _retrievalToolUseIds = new Set<string>()
   private _stash: Stash | undefined
+  private _stashIsDurable = false
+  private _resolvedStashStorage: Storage | undefined
   private _retrievalTool: Tool | undefined
 
   constructor(config?: ContextManagerConfig) {
@@ -67,6 +69,8 @@ export class ContextManager implements Plugin {
   initAgent(agent: LocalAgent): void {
     if (this._stashStorage !== false) {
       const storage = this._stashStorage ?? agent.storage ?? new InMemoryStorage()
+      this._resolvedStashStorage = storage
+      this._stashIsDurable = !(storage instanceof InMemoryStorage)
       this._stash = new Stash(storage, agent.sessionId, agent.id)
     }
 
@@ -112,8 +116,33 @@ export class ContextManager implements Plugin {
     })
   }
 
+  /**
+   * The L1 stash instance, if stash is enabled and the agent has been initialized.
+   *
+   * @returns The stash, or undefined if stash is disabled or initAgent has not run
+   */
   get stash(): Stash | undefined {
     return this._stash
+  }
+
+  /**
+   * Whether the stash is backed by durable storage that survives process restarts.
+   * When true, stash data does not need to be embedded in session snapshots.
+   *
+   * @returns true if the stash storage is not InMemoryStorage
+   */
+  get stashIsDurable(): boolean {
+    return this._stashIsDurable
+  }
+
+  /**
+   * The raw storage backend used by the stash, before namespace scoping.
+   * Used by SessionManager to clean up stash data on session delete.
+   *
+   * @returns The storage instance, or undefined if stash is disabled or not initialized
+   */
+  get stashStorage(): Storage | undefined {
+    return this._resolvedStashStorage
   }
 
   private async _runStrategies(agent: LocalAgent, precomputedInputTokens?: number): Promise<boolean> {

--- a/strands-ts/src/context-manager/context-manager.ts
+++ b/strands-ts/src/context-manager/context-manager.ts
@@ -10,6 +10,7 @@ import type { LocalAgent } from '../types/agent.js'
 import { AfterModelCallEvent, BeforeModelCallEvent, MessageAddedEvent } from '../hooks/events.js'
 import { ContextWindowOverflowError } from '../errors.js'
 import { InMemoryStorage } from '../storage/in-memory-storage.js'
+import { EPHEMERAL } from '../storage/storage.js'
 import type { Storage } from '../storage/storage.js'
 import { logger } from '../logging/logger.js'
 import type { ContextManagerConfig, ContextStrategy, ContextState } from './types.js'
@@ -70,7 +71,7 @@ export class ContextManager implements Plugin {
     if (this._stashStorage !== false) {
       const storage = this._stashStorage ?? agent.storage ?? new InMemoryStorage()
       this._resolvedStashStorage = storage
-      this._stashIsDurable = !(storage instanceof InMemoryStorage)
+      this._stashIsDurable = !(EPHEMERAL in storage)
       this._stash = new Stash(storage, agent.sessionId, agent.id)
     }
 
@@ -129,7 +130,7 @@ export class ContextManager implements Plugin {
    * Whether the stash is backed by durable storage that survives process restarts.
    * When true, stash data does not need to be embedded in session snapshots.
    *
-   * @returns true if the stash storage is not InMemoryStorage
+   * @returns true if the stash storage is not ephemeral
    */
   get stashIsDurable(): boolean {
     return this._stashIsDurable

--- a/strands-ts/src/context-manager/stash.ts
+++ b/strands-ts/src/context-manager/stash.ts
@@ -43,10 +43,14 @@ export class Stash {
   private readonly _baseStorage: Storage
   private readonly _sessionId: string
 
+  /** Name of the base storage constructor, for diagnostic logging. */
+  readonly storageTypeName: string
+
   constructor(storage: Storage, sessionId: string, agentId: string) {
     this._baseStorage = storage
     this._sessionId = sessionId
     this._storage = namespaceStorage(storage, `${STASH_PREFIX}/${sessionId}/scopes/agent/${agentId}`)
+    this.storageTypeName = storage.constructor.name || 'unknown'
   }
 
   /**

--- a/strands-ts/src/context-manager/stash.ts
+++ b/strands-ts/src/context-manager/stash.ts
@@ -13,7 +13,8 @@ import { Message, ToolResultBlock, ToolUseBlock, CachePointBlock, ReasoningBlock
 import type { ContentBlock } from '../types/messages.js'
 import { logger } from '../logging/logger.js'
 
-const STASH_PREFIX = 'context'
+/** @internal */
+export const STASH_PREFIX = 'context'
 
 function encode(value: unknown): Uint8Array {
   return new TextEncoder().encode(JSON.stringify(value))
@@ -131,6 +132,34 @@ export class Stash {
   async delete(reference: string): Promise<void> {
     await this._storage.delete(reference)
     logger.debug(`reference=<${reference}> | stash entry deleted`)
+  }
+
+  /**
+   * Serialize all stash entries into a plain object for snapshot persistence.
+   *
+   * @returns Map of reference keys to their stored JSON values
+   */
+  async takeSnapshot(): Promise<Record<string, unknown>> {
+    const keys = await this.list()
+    const entries: Record<string, unknown> = {}
+    for (const key of keys) {
+      const result = await this.retrieve(key)
+      if (result) {
+        entries[key] = result.data
+      }
+    }
+    return entries
+  }
+
+  /**
+   * Restore stash entries from a previously captured snapshot.
+   *
+   * @param entries - Map of reference keys to their JSON values (from {@link takeSnapshot})
+   */
+  async loadSnapshot(entries: Record<string, unknown>): Promise<void> {
+    for (const [key, data] of Object.entries(entries)) {
+      await this._storage.write(key, encode(data))
+    }
   }
 
   private async _storeToolResult(block: ToolResultBlock): Promise<void> {

--- a/strands-ts/src/context-manager/stash.ts
+++ b/strands-ts/src/context-manager/stash.ts
@@ -11,6 +11,7 @@
 import { resolveNamespace, type Storage } from '../storage/storage.js'
 import { Message, ToolResultBlock, ToolUseBlock, CachePointBlock, ReasoningBlock } from '../types/messages.js'
 import type { ContentBlock } from '../types/messages.js'
+import type { JSONValue } from '../types/json.js'
 import { logger } from '../logging/logger.js'
 
 /** @internal */
@@ -139,13 +140,13 @@ export class Stash {
    *
    * @returns Map of reference keys to their stored JSON values
    */
-  async takeSnapshot(): Promise<Record<string, unknown>> {
+  async takeSnapshot(): Promise<Record<string, JSONValue>> {
     const keys = await this.list()
     const results = await Promise.all(keys.map((key) => this.retrieve(key).then((result) => [key, result] as const)))
-    const entries: Record<string, unknown> = {}
+    const entries: Record<string, JSONValue> = {}
     for (const [key, result] of results) {
       if (result) {
-        entries[key] = result.data
+        entries[key] = result.data as JSONValue
       }
     }
     return entries
@@ -156,7 +157,7 @@ export class Stash {
    *
    * @param entries - Map of reference keys to their JSON values (from {@link takeSnapshot})
    */
-  async loadSnapshot(entries: Record<string, unknown>): Promise<void> {
+  async loadSnapshot(entries: Record<string, JSONValue>): Promise<void> {
     await Promise.all(Object.entries(entries).map(([key, data]) => this._storage.write(key, encode(data))))
   }
 

--- a/strands-ts/src/context-manager/stash.ts
+++ b/strands-ts/src/context-manager/stash.ts
@@ -8,7 +8,7 @@
  * @internal
  */
 
-import { resolveNamespace, type Storage } from '../storage/storage.js'
+import { namespace as namespaceStorage, type Storage } from '../storage/storage.js'
 import { Message, ToolResultBlock, ToolUseBlock, CachePointBlock, ReasoningBlock } from '../types/messages.js'
 import type { ContentBlock } from '../types/messages.js'
 import type { JSONValue } from '../types/json.js'
@@ -40,9 +40,13 @@ export function formatStashRefs(refs: string[]): string {
  */
 export class Stash {
   private readonly _storage: Storage
+  private readonly _baseStorage: Storage
+  private readonly _sessionId: string
 
   constructor(storage: Storage, sessionId: string, agentId: string) {
-    this._storage = resolveNamespace(storage, `${STASH_PREFIX}/${sessionId}/scopes/agent/${agentId}`)
+    this._baseStorage = storage
+    this._sessionId = sessionId
+    this._storage = namespaceStorage(storage, `${STASH_PREFIX}/${sessionId}/scopes/agent/${agentId}`)
   }
 
   /**
@@ -133,6 +137,27 @@ export class Stash {
   async delete(reference: string): Promise<void> {
     await this._storage.delete(reference)
     logger.debug(`reference=<${reference}> | stash entry deleted`)
+  }
+
+  /**
+   * Delete all entries in this stash instance.
+   */
+  async clear(): Promise<void> {
+    const keys = await this.list()
+    await Promise.all(keys.map((key) => this.delete(key)))
+  }
+
+  /**
+   * Delete all stash data for this session across all agents.
+   *
+   * Unlike {@link clear}, which is scoped to this agent's namespace,
+   * this scans `context/<sessionId>/` on the base storage to catch data
+   * from every agent that wrote to the session.
+   */
+  async clearSession(): Promise<void> {
+    const prefix = `${STASH_PREFIX}/${this._sessionId}/`
+    const keys = await this._baseStorage.list(prefix)
+    await Promise.all(keys.map((key) => this._baseStorage.delete(key)))
   }
 
   /**

--- a/strands-ts/src/context-manager/stash.ts
+++ b/strands-ts/src/context-manager/stash.ts
@@ -141,9 +141,9 @@ export class Stash {
    */
   async takeSnapshot(): Promise<Record<string, unknown>> {
     const keys = await this.list()
+    const results = await Promise.all(keys.map((key) => this.retrieve(key).then((result) => [key, result] as const)))
     const entries: Record<string, unknown> = {}
-    for (const key of keys) {
-      const result = await this.retrieve(key)
+    for (const [key, result] of results) {
       if (result) {
         entries[key] = result.data
       }
@@ -157,9 +157,7 @@ export class Stash {
    * @param entries - Map of reference keys to their JSON values (from {@link takeSnapshot})
    */
   async loadSnapshot(entries: Record<string, unknown>): Promise<void> {
-    for (const [key, data] of Object.entries(entries)) {
-      await this._storage.write(key, encode(data))
-    }
+    await Promise.all(Object.entries(entries).map(([key, data]) => this._storage.write(key, encode(data))))
   }
 
   private async _storeToolResult(block: ToolResultBlock): Promise<void> {

--- a/strands-ts/src/session/__tests__/session-manager.test.ts
+++ b/strands-ts/src/session/__tests__/session-manager.test.ts
@@ -21,6 +21,10 @@ import {
 import { loadStateFromJSONSymbol, stateToJSONSymbol } from '../../types/serializable.js'
 import { StateStore } from '../../state-store.js'
 import { logger } from '../../logging/logger.js'
+import { InMemoryStorage } from '../../storage/in-memory-storage.js'
+import { ContextManager } from '../../context-manager/context-manager.js'
+import { Stash } from '../../context-manager/stash.js'
+import { STASH_PREFIX } from '../../context-manager/stash.js'
 import {
   AfterMultiAgentInvocationEvent,
   AfterNodeCallEvent,
@@ -731,6 +735,172 @@ describe('SessionManager', () => {
         location: { sessionId: 'test-session', scope: 'agent', scopeId: 'test-agent' },
       })
       expect(snapshot).toBeNull()
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Stash integration tests
+// ---------------------------------------------------------------------------
+
+describe('SessionManager — stash integration', () => {
+  let rootStorage: InMemoryStorage
+  let snapshotStorage: MockSnapshotStorage
+  let sessionManager: SessionManager
+
+  function createAgentWithStash(
+    sessionId: string,
+    agentId = 'agent'
+  ): { agent: Agent; stash: Stash } {
+    const stash = new Stash(rootStorage, sessionId, agentId)
+    const contextManager = { stash } as unknown as ContextManager
+    const agent = {
+      ...createMockAgent(agentId),
+      contextManager,
+    } as unknown as Agent
+    return { agent, stash }
+  }
+
+  beforeEach(() => {
+    rootStorage = new InMemoryStorage()
+    snapshotStorage = new MockSnapshotStorage()
+  })
+
+  describe('saveSnapshot', () => {
+    it('includes stash data in the snapshot', async () => {
+      sessionManager = new SessionManager({
+        sessionId: 'test-session',
+        storage: { snapshot: snapshotStorage },
+      })
+      sessionManager.initAgent(createMockAgentWithHooks())
+
+      const { agent, stash } = createAgentWithStash('test-session')
+      await stash.store('tool-1', 0, new TextEncoder().encode(JSON.stringify({ text: 'hello' })))
+
+      await sessionManager.saveSnapshot({ target: agent, isLatest: true })
+
+      const snapshot = await snapshotStorage.loadSnapshot({
+        location: { sessionId: 'test-session', scope: 'agent', scopeId: 'agent' },
+      })
+      expect(snapshot).not.toBeNull()
+      expect(snapshot!.data.stash).toBeDefined()
+      const stashData = snapshot!.data.stash as Record<string, unknown>
+      expect(stashData['tool-1_0']).toEqual({ text: 'hello' })
+    })
+
+    it('omits stash key when agent has no context manager', async () => {
+      sessionManager = new SessionManager({
+        sessionId: 'test-session',
+        storage: { snapshot: snapshotStorage },
+      })
+      sessionManager.initAgent(createMockAgentWithHooks())
+
+      const agent = createMockAgent('agent')
+      await sessionManager.saveSnapshot({ target: agent, isLatest: true })
+
+      const snapshot = await snapshotStorage.loadSnapshot({
+        location: { sessionId: 'test-session', scope: 'agent', scopeId: 'agent' },
+      })
+      expect(snapshot).not.toBeNull()
+      expect('stash' in snapshot!.data).toBe(false)
+    })
+
+    it('omits stash key when stash is empty', async () => {
+      sessionManager = new SessionManager({
+        sessionId: 'test-session',
+        storage: { snapshot: snapshotStorage },
+      })
+      sessionManager.initAgent(createMockAgentWithHooks())
+
+      const { agent } = createAgentWithStash('test-session')
+      await sessionManager.saveSnapshot({ target: agent, isLatest: true })
+
+      const snapshot = await snapshotStorage.loadSnapshot({
+        location: { sessionId: 'test-session', scope: 'agent', scopeId: 'agent' },
+      })
+      expect(snapshot).not.toBeNull()
+      // Empty stash returns {} which is truthy, so the key is present but empty
+      expect(snapshot!.data.stash).toEqual({})
+    })
+  })
+
+  describe('restoreSnapshot', () => {
+    it('restores stash data from snapshot', async () => {
+      sessionManager = new SessionManager({
+        sessionId: 'test-session',
+        storage: { snapshot: snapshotStorage },
+      })
+      sessionManager.initAgent(createMockAgentWithHooks())
+
+      const { agent, stash } = createAgentWithStash('test-session')
+      await stash.store('tool-1', 0, new TextEncoder().encode(JSON.stringify({ text: 'hello' })))
+      await stash.store('tool-2', 0, new TextEncoder().encode(JSON.stringify({ text: 'world' })))
+
+      await sessionManager.saveSnapshot({ target: agent, isLatest: true })
+
+      // Create a fresh stash and agent to restore into
+      const { agent: freshAgent, stash: freshStash } = createAgentWithStash('test-session')
+      const result = await sessionManager.restoreSnapshot({ target: freshAgent })
+
+      expect(result).toBe(true)
+      const restored1 = await freshStash.retrieve('tool-1_0')
+      const restored2 = await freshStash.retrieve('tool-2_0')
+      expect(restored1?.data).toEqual({ text: 'hello' })
+      expect(restored2?.data).toEqual({ text: 'world' })
+    })
+
+    it('handles snapshot without stash data', async () => {
+      const snapshot = createTestSnapshot()
+      await snapshotStorage.saveSnapshot({
+        location: { sessionId: 'test-session', scope: 'agent', scopeId: 'agent' },
+        snapshotId: 'latest',
+        isLatest: true,
+        snapshot,
+      })
+
+      sessionManager = new SessionManager({
+        sessionId: 'test-session',
+        storage: { snapshot: snapshotStorage },
+      })
+      sessionManager.initAgent(createMockAgentWithHooks())
+
+      const { agent } = createAgentWithStash('test-session')
+      const result = await sessionManager.restoreSnapshot({ target: agent })
+
+      expect(result).toBe(true)
+    })
+  })
+
+  describe('deleteSession', () => {
+    it('deletes stash data from root storage', async () => {
+      sessionManager = new SessionManager({
+        sessionId: 'test-session',
+        storage: rootStorage,
+      })
+      sessionManager.initAgent(createMockAgentWithHooks({ extra: { storage: rootStorage } as Partial<Agent> }))
+
+      // Write stash data directly to root storage under the expected prefix
+      const prefix = `${STASH_PREFIX}/test-session/scopes/agent/agent`
+      await rootStorage.write(`${prefix}/tool-1_0`, new TextEncoder().encode('data1'))
+      await rootStorage.write(`${prefix}/tool-2_0`, new TextEncoder().encode('data2'))
+
+      const keysBefore = await rootStorage.list(`${STASH_PREFIX}/test-session/`)
+      expect(keysBefore).toHaveLength(2)
+
+      await sessionManager.deleteSession()
+
+      const keysAfter = await rootStorage.list(`${STASH_PREFIX}/test-session/`)
+      expect(keysAfter).toHaveLength(0)
+    })
+
+    it('succeeds when no root storage is available', async () => {
+      sessionManager = new SessionManager({
+        sessionId: 'test-session',
+        storage: { snapshot: snapshotStorage },
+      })
+      sessionManager.initAgent(createMockAgentWithHooks())
+
+      await expect(sessionManager.deleteSession()).resolves.not.toThrow()
     })
   })
 })

--- a/strands-ts/src/session/__tests__/session-manager.test.ts
+++ b/strands-ts/src/session/__tests__/session-manager.test.ts
@@ -948,24 +948,29 @@ describe('SessionManager — stash integration', () => {
   })
 
   describe('deleteSession', () => {
-    it('deletes stash data from root storage', async () => {
+    it('deletes stash data via stash reference', async () => {
       sessionManager = new SessionManager({
         sessionId: 'test-session',
         storage: rootStorage,
       })
-      sessionManager.initAgent(createMockAgentWithHooks({ extra: { storage: rootStorage } as Partial<Agent> }))
+      const stash = new Stash(rootStorage, 'test-session', 'agent')
+      const mockAgent = createMockAgentWithHooks({
+        extra: {
+          storage: rootStorage,
+          contextManager: { stash, stashStorage: rootStorage },
+        } as unknown as Partial<Agent>,
+      })
+      sessionManager.initAgent(mockAgent)
 
-      // Write stash data directly to root storage under the expected prefix
-      const prefix = `${STASH_PREFIX}/test-session/scopes/agent/agent`
-      await rootStorage.write(`${prefix}/tool-1_0`, new TextEncoder().encode('data1'))
-      await rootStorage.write(`${prefix}/tool-2_0`, new TextEncoder().encode('data2'))
+      await stash.store('tool-1', 0, new TextEncoder().encode(JSON.stringify('data1')))
+      await stash.store('tool-2', 0, new TextEncoder().encode(JSON.stringify('data2')))
 
-      const keysBefore = await rootStorage.list(`${STASH_PREFIX}/test-session/`)
+      const keysBefore = await stash.list()
       expect(keysBefore).toHaveLength(2)
 
       await sessionManager.deleteSession()
 
-      const keysAfter = await rootStorage.list(`${STASH_PREFIX}/test-session/`)
+      const keysAfter = await stash.list()
       expect(keysAfter).toHaveLength(0)
     })
 
@@ -975,27 +980,54 @@ describe('SessionManager — stash integration', () => {
         sessionId: 'test-session',
         storage: rootStorage,
       })
+      const stash = new Stash(customStashStorage, 'test-session', 'agent')
       const mockAgent = createMockAgentWithHooks({
         extra: {
           storage: rootStorage,
-          contextManager: { stashStorage: customStashStorage },
+          contextManager: { stash, stashStorage: customStashStorage },
         } as unknown as Partial<Agent>,
       })
       sessionManager.initAgent(mockAgent)
 
-      const prefix = `${STASH_PREFIX}/test-session/scopes/agent/agent`
-      await customStashStorage.write(`${prefix}/tool-1_0`, new TextEncoder().encode('data1'))
+      await stash.store('tool-1', 0, new TextEncoder().encode(JSON.stringify('data1')))
 
-      const keysBefore = await customStashStorage.list(`${STASH_PREFIX}/test-session/`)
+      const keysBefore = await stash.list()
       expect(keysBefore).toHaveLength(1)
 
       await sessionManager.deleteSession()
 
-      const keysAfter = await customStashStorage.list(`${STASH_PREFIX}/test-session/`)
+      const keysAfter = await stash.list()
       expect(keysAfter).toHaveLength(0)
     })
 
-    it('succeeds when no root storage is available', async () => {
+    it('deletes stash data when storage is pre-namespaced', async () => {
+      const shared = new InMemoryStorage()
+      const namespacedStorage = shared.namespace('my-prefix')
+      sessionManager = new SessionManager({
+        sessionId: 'test-session',
+        storage: rootStorage,
+      })
+      const stash = new Stash(namespacedStorage, 'test-session', 'agent')
+      const mockAgent = createMockAgentWithHooks({
+        extra: {
+          storage: rootStorage,
+          contextManager: { stash, stashStorage: namespacedStorage },
+        } as unknown as Partial<Agent>,
+      })
+      sessionManager.initAgent(mockAgent)
+
+      await stash.store('tool-1', 0, new TextEncoder().encode(JSON.stringify('data1')))
+
+      const keysBefore = await stash.list()
+      expect(keysBefore).toHaveLength(1)
+
+      await sessionManager.deleteSession()
+
+      const keysAfter = await stash.list()
+      expect(keysAfter).toHaveLength(0)
+    })
+
+    it('succeeds when no stash is available', async () => {
       sessionManager = new SessionManager({
         sessionId: 'test-session',
         storage: { snapshot: snapshotStorage },

--- a/strands-ts/src/session/__tests__/session-manager.test.ts
+++ b/strands-ts/src/session/__tests__/session-manager.test.ts
@@ -1058,6 +1058,32 @@ describe('SessionManager — stash integration', () => {
       expect(preserved).not.toBeNull()
     })
 
+    it('clearSession cleans up stash data from other agents in the session', async () => {
+      sessionManager = new SessionManager({
+        sessionId: 'test-session',
+        storage: rootStorage,
+      })
+      const stashA = new Stash(rootStorage, 'test-session', 'agent-a')
+      const stashB = new Stash(rootStorage, 'test-session', 'agent-b')
+      const mockAgent = createMockAgentWithHooks({
+        extra: {
+          storage: rootStorage,
+          contextManager: { stash: stashA },
+        } as unknown as Partial<Agent>,
+      })
+      sessionManager.initAgent(mockAgent)
+
+      await stashA.store('tool-1', 0, new TextEncoder().encode(JSON.stringify('from-a')))
+      await stashB.store('tool-2', 0, new TextEncoder().encode(JSON.stringify('from-b')))
+
+      await sessionManager.deleteSession()
+
+      const keysA = await stashA.list()
+      const keysB = await stashB.list()
+      expect(keysA).toHaveLength(0)
+      expect(keysB).toHaveLength(0)
+    })
+
     it('succeeds when no stash is available', async () => {
       sessionManager = new SessionManager({
         sessionId: 'test-session',

--- a/strands-ts/src/session/__tests__/session-manager.test.ts
+++ b/strands-ts/src/session/__tests__/session-manager.test.ts
@@ -1027,6 +1027,37 @@ describe('SessionManager — stash integration', () => {
       expect(keysAfter).toHaveLength(0)
     })
 
+    it('does not over-delete when rootStorage is pre-namespaced', async () => {
+      const shared = new InMemoryStorage()
+      const namespacedRoot = shared.namespace('tenant-a')
+      sessionManager = new SessionManager({
+        sessionId: 'test-session',
+        storage: namespacedRoot,
+      })
+      const stash = new Stash(namespacedRoot, 'test-session', 'agent')
+      const mockAgent = createMockAgentWithHooks({
+        extra: {
+          storage: namespacedRoot,
+          contextManager: { stash, stashStorage: namespacedRoot },
+        } as unknown as Partial<Agent>,
+      })
+      sessionManager.initAgent(mockAgent)
+
+      await stash.store('tool-1', 0, new TextEncoder().encode(JSON.stringify('data1')))
+
+      // Write unrelated data under the same namespace but outside the session's stash prefix
+      await namespacedRoot.write('other-data/important', new TextEncoder().encode('keep-me'))
+
+      await sessionManager.deleteSession()
+
+      const stashKeys = await stash.list()
+      expect(stashKeys).toHaveLength(0)
+
+      // Unrelated data must survive
+      const preserved = await namespacedRoot.read('other-data/important')
+      expect(preserved).not.toBeNull()
+    })
+
     it('succeeds when no stash is available', async () => {
       sessionManager = new SessionManager({
         sessionId: 'test-session',

--- a/strands-ts/src/session/__tests__/session-manager.test.ts
+++ b/strands-ts/src/session/__tests__/session-manager.test.ts
@@ -787,7 +787,10 @@ describe('SessionManager — stash integration', () => {
       expect(snapshot).not.toBeNull()
       expect(snapshot!.data.stash).toBeDefined()
       const stashData = snapshot!.data.stash as Record<string, unknown>
-      expect(stashData['tool-1_0']).toEqual({ text: 'hello' })
+      expect(stashData).toEqual({
+        location: 'inline',
+        entries: { 'tool-1_0': { text: 'hello' } },
+      })
     })
 
     it('omits stash key when agent has no context manager', async () => {
@@ -824,7 +827,7 @@ describe('SessionManager — stash integration', () => {
       expect('stash' in snapshot!.data).toBe(false)
     })
 
-    it('skips stash snapshot when storage is durable', async () => {
+    it('writes external ref when storage is durable', async () => {
       sessionManager = new SessionManager({
         sessionId: 'test-session',
         storage: { snapshot: snapshotStorage },
@@ -832,7 +835,7 @@ describe('SessionManager — stash integration', () => {
       sessionManager.initAgent(createMockAgentWithHooks())
 
       const stash = new Stash(rootStorage, 'test-session', 'agent')
-      const contextManager = { stash, stashIsDurable: true } as unknown as ContextManager
+      const contextManager = { stash, stashIsDurable: true, stashStorage: rootStorage } as unknown as ContextManager
       const agent = { ...createMockAgent('agent'), contextManager } as unknown as Agent
       await stash.store('tool-1', 0, new TextEncoder().encode(JSON.stringify({ text: 'hello' })))
 
@@ -842,7 +845,7 @@ describe('SessionManager — stash integration', () => {
         location: { sessionId: 'test-session', scope: 'agent', scopeId: 'agent' },
       })
       expect(snapshot).not.toBeNull()
-      expect('stash' in snapshot!.data).toBe(false)
+      expect(snapshot!.data.stash).toEqual({ location: 'external' })
     })
   })
 
@@ -869,6 +872,30 @@ describe('SessionManager — stash integration', () => {
       const restored2 = await freshStash.retrieve('tool-2_0')
       expect(restored1?.data).toEqual({ text: 'hello' })
       expect(restored2?.data).toEqual({ text: 'world' })
+    })
+
+    it('skips stash restore when location is external', async () => {
+      const snapshot = createTestSnapshot()
+      snapshot.data.stash = { location: 'external' } as unknown as typeof snapshot.data.stash
+      await snapshotStorage.saveSnapshot({
+        location: { sessionId: 'test-session', scope: 'agent', scopeId: 'agent' },
+        snapshotId: 'latest',
+        isLatest: true,
+        snapshot,
+      })
+
+      sessionManager = new SessionManager({
+        sessionId: 'test-session',
+        storage: { snapshot: snapshotStorage },
+      })
+      sessionManager.initAgent(createMockAgentWithHooks())
+
+      const { agent, stash } = createAgentWithStash('test-session')
+      const result = await sessionManager.restoreSnapshot({ target: agent })
+
+      expect(result).toBe(true)
+      const keys = await stash.list()
+      expect(keys).toHaveLength(0)
     })
 
     it('handles snapshot without stash data', async () => {

--- a/strands-ts/src/session/__tests__/session-manager.test.ts
+++ b/strands-ts/src/session/__tests__/session-manager.test.ts
@@ -845,7 +845,7 @@ describe('SessionManager — stash integration', () => {
         location: { sessionId: 'test-session', scope: 'agent', scopeId: 'agent' },
       })
       expect(snapshot).not.toBeNull()
-      expect(snapshot!.data.stash).toEqual({ location: 'external' })
+      expect(snapshot!.data.stash).toEqual({ location: 'external', storageType: 'InMemoryStorage' })
     })
   })
 
@@ -896,6 +896,32 @@ describe('SessionManager — stash integration', () => {
       expect(result).toBe(true)
       const keys = await stash.list()
       expect(keys).toHaveLength(0)
+    })
+
+    it('warns when stash storage type changed since snapshot', async () => {
+      const snapshot = createTestSnapshot()
+      snapshot.data.stash = { location: 'external', storageType: 'S3Storage' } as unknown as typeof snapshot.data.stash
+      await snapshotStorage.saveSnapshot({
+        location: { sessionId: 'test-session', scope: 'agent', scopeId: 'agent' },
+        snapshotId: 'latest',
+        isLatest: true,
+        snapshot,
+      })
+
+      sessionManager = new SessionManager({
+        sessionId: 'test-session',
+        storage: { snapshot: snapshotStorage },
+      })
+      sessionManager.initAgent(createMockAgentWithHooks())
+
+      const { agent } = createAgentWithStash('test-session')
+      const warnSpy = vi.spyOn(logger, 'warn')
+      await sessionManager.restoreSnapshot({ target: agent })
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('stash storage type changed since snapshot was created')
+      )
+      warnSpy.mockRestore()
     })
 
     it('handles snapshot without stash data', async () => {

--- a/strands-ts/src/session/__tests__/session-manager.test.ts
+++ b/strands-ts/src/session/__tests__/session-manager.test.ts
@@ -975,7 +975,12 @@ describe('SessionManager — stash integration', () => {
         sessionId: 'test-session',
         storage: rootStorage,
       })
-      const mockAgent = createMockAgentWithHooks({ extra: { storage: rootStorage, contextManager: { stashStorage: customStashStorage } } as unknown as Partial<Agent> })
+      const mockAgent = createMockAgentWithHooks({
+        extra: {
+          storage: rootStorage,
+          contextManager: { stashStorage: customStashStorage },
+        } as unknown as Partial<Agent>,
+      })
       sessionManager.initAgent(mockAgent)
 
       const prefix = `${STASH_PREFIX}/test-session/scopes/agent/agent`

--- a/strands-ts/src/session/__tests__/session-manager.test.ts
+++ b/strands-ts/src/session/__tests__/session-manager.test.ts
@@ -756,7 +756,7 @@ describe('SessionManager — stash integration', () => {
   ): { agent: Agent; stash: Stash } {
     const storage = stashStorage ?? rootStorage
     const stash = new Stash(storage, sessionId, agentId)
-    const contextManager = { stash, stashStorage: storage } as unknown as ContextManager
+    const contextManager = { stash } as unknown as ContextManager
     const agent = {
       ...createMockAgent(agentId),
       contextManager,
@@ -836,7 +836,7 @@ describe('SessionManager — stash integration', () => {
       sessionManager.initAgent(createMockAgentWithHooks())
 
       const stash = new Stash(rootStorage, 'test-session', 'agent')
-      const contextManager = { stash, stashIsDurable: true, stashStorage: rootStorage } as unknown as ContextManager
+      const contextManager = { stash, stashIsDurable: true } as unknown as ContextManager
       const agent = { ...createMockAgent('agent'), contextManager } as unknown as Agent
       await stash.store('tool-1', 0, new TextEncoder().encode(JSON.stringify({ text: 'hello' })))
 
@@ -957,7 +957,7 @@ describe('SessionManager — stash integration', () => {
       const mockAgent = createMockAgentWithHooks({
         extra: {
           storage: rootStorage,
-          contextManager: { stash, stashStorage: rootStorage },
+          contextManager: { stash },
         } as unknown as Partial<Agent>,
       })
       sessionManager.initAgent(mockAgent)
@@ -984,7 +984,7 @@ describe('SessionManager — stash integration', () => {
       const mockAgent = createMockAgentWithHooks({
         extra: {
           storage: rootStorage,
-          contextManager: { stash, stashStorage: customStashStorage },
+          contextManager: { stash },
         } as unknown as Partial<Agent>,
       })
       sessionManager.initAgent(mockAgent)
@@ -1011,7 +1011,7 @@ describe('SessionManager — stash integration', () => {
       const mockAgent = createMockAgentWithHooks({
         extra: {
           storage: rootStorage,
-          contextManager: { stash, stashStorage: namespacedStorage },
+          contextManager: { stash },
         } as unknown as Partial<Agent>,
       })
       sessionManager.initAgent(mockAgent)
@@ -1038,7 +1038,7 @@ describe('SessionManager — stash integration', () => {
       const mockAgent = createMockAgentWithHooks({
         extra: {
           storage: namespacedRoot,
-          contextManager: { stash, stashStorage: namespacedRoot },
+          contextManager: { stash },
         } as unknown as Partial<Agent>,
       })
       sessionManager.initAgent(mockAgent)

--- a/strands-ts/src/session/__tests__/session-manager.test.ts
+++ b/strands-ts/src/session/__tests__/session-manager.test.ts
@@ -1008,6 +1008,86 @@ describe('SessionManager — stash integration', () => {
 })
 
 // ---------------------------------------------------------------------------
+// Stash integration test — real Agent + ContextManager + SessionManager
+// ---------------------------------------------------------------------------
+
+describe('SessionManager — stash with real Agent wiring', () => {
+  let storage: InMemoryStorage
+  let snapshotStorage: MockSnapshotStorage
+
+  beforeEach(() => {
+    storage = new InMemoryStorage()
+    snapshotStorage = new MockSnapshotStorage()
+  })
+
+  it('round-trips stash data through save and restore with real Agent', async () => {
+    const sessionManager = new SessionManager({
+      sessionId: 'test-session',
+      storage: { snapshot: snapshotStorage },
+    })
+    const agent = new Agent({
+      model: {} as any,
+      storage,
+      contextManager: new ContextManager(),
+      sessionManager,
+      printer: false,
+    })
+    await agent.initialize()
+
+    const stash = agent.contextManager!.stash!
+    await stash.store('tool-1', 0, new TextEncoder().encode(JSON.stringify({ text: 'hello' })))
+    await stash.store('tool-2', 0, new TextEncoder().encode(JSON.stringify({ text: 'world' })))
+
+    await sessionManager.saveSnapshot({ target: agent, isLatest: true })
+
+    const freshSessionManager = new SessionManager({
+      sessionId: 'test-session',
+      storage: { snapshot: snapshotStorage },
+    })
+    const freshAgent = new Agent({
+      model: {} as any,
+      storage,
+      contextManager: new ContextManager(),
+      sessionManager: freshSessionManager,
+      printer: false,
+    })
+    await freshAgent.initialize()
+
+    const freshStash = freshAgent.contextManager!.stash!
+    const restored1 = await freshStash.retrieve('tool-1_0')
+    const restored2 = await freshStash.retrieve('tool-2_0')
+    expect(restored1?.data).toEqual({ text: 'hello' })
+    expect(restored2?.data).toEqual({ text: 'world' })
+  })
+
+  it('deleteSession cleans up stash data with real Agent', async () => {
+    const sessionManager = new SessionManager({
+      sessionId: 'test-session',
+      storage,
+    })
+    const agent = new Agent({
+      model: {} as any,
+      storage,
+      contextManager: new ContextManager(),
+      sessionManager,
+      printer: false,
+    })
+    await agent.initialize()
+
+    const stash = agent.contextManager!.stash!
+    await stash.store('tool-1', 0, new TextEncoder().encode(JSON.stringify({ text: 'hello' })))
+
+    const keysBefore = await storage.list(`${STASH_PREFIX}/`)
+    expect(keysBefore.length).toBeGreaterThan(0)
+
+    await sessionManager.deleteSession()
+
+    const keysAfter = await storage.list(`${STASH_PREFIX}/`)
+    expect(keysAfter).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Multi-agent tests
 // ---------------------------------------------------------------------------
 

--- a/strands-ts/src/session/__tests__/session-manager.test.ts
+++ b/strands-ts/src/session/__tests__/session-manager.test.ts
@@ -750,10 +750,12 @@ describe('SessionManager — stash integration', () => {
 
   function createAgentWithStash(
     sessionId: string,
-    agentId = 'agent'
+    agentId = 'agent',
+    stashStorage?: InMemoryStorage
   ): { agent: Agent; stash: Stash } {
-    const stash = new Stash(rootStorage, sessionId, agentId)
-    const contextManager = { stash } as unknown as ContextManager
+    const storage = stashStorage ?? rootStorage
+    const stash = new Stash(storage, sessionId, agentId)
+    const contextManager = { stash, stashStorage: storage } as unknown as ContextManager
     const agent = {
       ...createMockAgent(agentId),
       contextManager,
@@ -819,8 +821,28 @@ describe('SessionManager — stash integration', () => {
         location: { sessionId: 'test-session', scope: 'agent', scopeId: 'agent' },
       })
       expect(snapshot).not.toBeNull()
-      // Empty stash returns {} which is truthy, so the key is present but empty
-      expect(snapshot!.data.stash).toEqual({})
+      expect('stash' in snapshot!.data).toBe(false)
+    })
+
+    it('skips stash snapshot when storage is durable', async () => {
+      sessionManager = new SessionManager({
+        sessionId: 'test-session',
+        storage: { snapshot: snapshotStorage },
+      })
+      sessionManager.initAgent(createMockAgentWithHooks())
+
+      const stash = new Stash(rootStorage, 'test-session', 'agent')
+      const contextManager = { stash, stashIsDurable: true } as unknown as ContextManager
+      const agent = { ...createMockAgent('agent'), contextManager } as unknown as Agent
+      await stash.store('tool-1', 0, new TextEncoder().encode(JSON.stringify({ text: 'hello' })))
+
+      await sessionManager.saveSnapshot({ target: agent, isLatest: true })
+
+      const snapshot = await snapshotStorage.loadSnapshot({
+        location: { sessionId: 'test-session', scope: 'agent', scopeId: 'agent' },
+      })
+      expect(snapshot).not.toBeNull()
+      expect('stash' in snapshot!.data).toBe(false)
     })
   })
 
@@ -890,6 +912,27 @@ describe('SessionManager — stash integration', () => {
       await sessionManager.deleteSession()
 
       const keysAfter = await rootStorage.list(`${STASH_PREFIX}/test-session/`)
+      expect(keysAfter).toHaveLength(0)
+    })
+
+    it('deletes stash data from custom stash storage', async () => {
+      const customStashStorage = new InMemoryStorage()
+      sessionManager = new SessionManager({
+        sessionId: 'test-session',
+        storage: rootStorage,
+      })
+      const mockAgent = createMockAgentWithHooks({ extra: { storage: rootStorage, contextManager: { stashStorage: customStashStorage } } as Partial<Agent> })
+      sessionManager.initAgent(mockAgent)
+
+      const prefix = `${STASH_PREFIX}/test-session/scopes/agent/agent`
+      await customStashStorage.write(`${prefix}/tool-1_0`, new TextEncoder().encode('data1'))
+
+      const keysBefore = await customStashStorage.list(`${STASH_PREFIX}/test-session/`)
+      expect(keysBefore).toHaveLength(1)
+
+      await sessionManager.deleteSession()
+
+      const keysAfter = await customStashStorage.list(`${STASH_PREFIX}/test-session/`)
       expect(keysAfter).toHaveLength(0)
     })
 

--- a/strands-ts/src/session/__tests__/session-manager.test.ts
+++ b/strands-ts/src/session/__tests__/session-manager.test.ts
@@ -37,6 +37,7 @@ import {
 } from '../../multiagent/index.js'
 import { takeSnapshot, loadSnapshot } from '../../agent/snapshot.js'
 import type { Snapshot } from '../../types/snapshot.js'
+import type { JSONValue } from '../../types/json.js'
 import type { TakeSnapshotOptions } from '../../agent/snapshot.js'
 
 // Test fixtures
@@ -876,7 +877,7 @@ describe('SessionManager — stash integration', () => {
 
     it('skips stash restore when location is external', async () => {
       const snapshot = createTestSnapshot()
-      snapshot.data.stash = { location: 'external' } as unknown as typeof snapshot.data.stash
+      snapshot.data.stash = { location: 'external' } as JSONValue
       await snapshotStorage.saveSnapshot({
         location: { sessionId: 'test-session', scope: 'agent', scopeId: 'agent' },
         snapshotId: 'latest',
@@ -900,7 +901,7 @@ describe('SessionManager — stash integration', () => {
 
     it('warns when stash storage type changed since snapshot', async () => {
       const snapshot = createTestSnapshot()
-      snapshot.data.stash = { location: 'external', storageType: 'S3Storage' } as unknown as typeof snapshot.data.stash
+      snapshot.data.stash = { location: 'external', storageType: 'S3Storage' } as JSONValue
       await snapshotStorage.saveSnapshot({
         location: { sessionId: 'test-session', scope: 'agent', scopeId: 'agent' },
         snapshotId: 'latest',
@@ -974,7 +975,7 @@ describe('SessionManager — stash integration', () => {
         sessionId: 'test-session',
         storage: rootStorage,
       })
-      const mockAgent = createMockAgentWithHooks({ extra: { storage: rootStorage, contextManager: { stashStorage: customStashStorage } } as Partial<Agent> })
+      const mockAgent = createMockAgentWithHooks({ extra: { storage: rootStorage, contextManager: { stashStorage: customStashStorage } } as unknown as Partial<Agent> })
       sessionManager.initAgent(mockAgent)
 
       const prefix = `${STASH_PREFIX}/test-session/scopes/agent/agent`

--- a/strands-ts/src/session/session-manager.ts
+++ b/strands-ts/src/session/session-manager.ts
@@ -86,6 +86,15 @@ export interface SessionManagerConfig {
 }
 
 /**
+ * Stash data envelope stored in snapshot.data.stash.
+ *
+ * @internal
+ */
+type StashSnapshotData =
+  | { location: 'inline'; entries: Record<string, JSONValue> }
+  | { location: 'external'; storageType?: string }
+
+/**
  * Manages session persistence for agents, enabling conversation state
  * to be saved and restored across invocations using pluggable storage backends.
  *
@@ -340,13 +349,18 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
     if (!contextManager?.stash) return
 
     if (contextManager.stashIsDurable) {
-      snapshot.data.stash = { location: 'external' } as unknown as JSONValue
+      const storageType = contextManager.stashStorage?.constructor.name
+      const ref: StashSnapshotData = storageType
+        ? { location: 'external', storageType }
+        : { location: 'external' }
+      snapshot.data.stash = ref as unknown as JSONValue
       return
     }
 
     const entries = await contextManager.stash.takeSnapshot()
     if (Object.keys(entries).length > 0) {
-      snapshot.data.stash = { location: 'inline', entries } as unknown as JSONValue
+      const data: StashSnapshotData = { location: 'inline', entries }
+      snapshot.data.stash = data as unknown as JSONValue
     }
   }
 
@@ -355,10 +369,18 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
     const stash = agent.contextManager?.stash
     if (!stash) return
 
-    const stashData = snapshot.data.stash as unknown as Record<string, unknown>
-    if (stashData.location === 'external') return
+    const stashData = snapshot.data.stash as unknown as StashSnapshotData
+    if (stashData.location === 'external') {
+      const currentType = agent.contextManager?.stashStorage?.constructor.name
+      if (stashData.storageType && currentType && stashData.storageType !== currentType) {
+        logger.warn(
+          `session_id=<${this._sessionId}>, snapshot_storage=<${stashData.storageType}>, current_storage=<${currentType}> | stash storage type changed since snapshot was created, stash data may be inaccessible`
+        )
+      }
+      return
+    }
     if (stashData.location === 'inline') {
-      await stash.loadSnapshot(stashData.entries as Record<string, unknown>)
+      await stash.loadSnapshot(stashData.entries)
     }
   }
 

--- a/strands-ts/src/session/session-manager.ts
+++ b/strands-ts/src/session/session-manager.ts
@@ -8,7 +8,6 @@ import type { Snapshot } from '../types/snapshot.js'
 import type { JSONValue } from '../types/json.js'
 import type { Plugin } from '../plugins/plugin.js'
 import type { LocalAgent } from '../types/agent.js'
-import type { ContextManager } from '../context-manager/context-manager.js'
 import { STASH_PREFIX } from '../context-manager/stash.js'
 import { AfterInvocationEvent, AfterModelCallEvent, InitializedEvent, MessageAddedEvent } from '../hooks/events.js'
 import { v7 as uuidV7 } from 'uuid'
@@ -109,6 +108,7 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
   private _storage!: { snapshot: SnapshotStorage }
   private readonly _configStorage?: Storage | { snapshot: SnapshotStorage } | undefined
   private _rootStorage: Storage | undefined
+  private _stashStorage: Storage | undefined
   private readonly _saveLatestOn: SaveLatestStrategy
   private readonly _snapshotTrigger?: SnapshotTriggerCallback | undefined
   private readonly _multiAgentSaveLatestOn: MultiAgentSaveLatestStrategy
@@ -168,6 +168,7 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
       this._storage = { snapshot: this._resolveSnapshotStorage(agent.storage) }
     }
     this._rootStorage ??= agent.storage
+    this._stashStorage = agent.contextManager?.stashStorage
     agent.addHook(InitializedEvent, async (event) => {
       await this._onAgentInitialized(event)
     })
@@ -333,30 +334,32 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
   // Stash integration
   // ---------------------------------------------------------------------------
 
-  private static _contextManager(agent: LocalAgent): ContextManager | undefined {
-    return (agent as unknown as { contextManager?: ContextManager }).contextManager
-  }
 
   private async _includeStashData(agent: LocalAgent, snapshot: Snapshot): Promise<void> {
-    const stash = SessionManager._contextManager(agent)?.stash
-    if (!stash) return
-    const stashData = await stash.takeSnapshot()
-    snapshot.data.stash = stashData as unknown as JSONValue
+    const contextManager = agent.contextManager
+    if (!contextManager?.stash) return
+    // Durable storage already persists stash entries — no need to duplicate in the snapshot.
+    if (contextManager.stashIsDurable) return
+    const stashData = await contextManager.stash.takeSnapshot()
+    if (Object.keys(stashData).length > 0) {
+      snapshot.data.stash = stashData as unknown as JSONValue
+    }
   }
 
   private async _restoreStashData(agent: LocalAgent, snapshot: Snapshot): Promise<void> {
     if ('stash' in snapshot.data && snapshot.data.stash) {
-      await SessionManager._contextManager(agent)?.stash?.loadSnapshot(
+      await agent.contextManager?.stash?.loadSnapshot(
         snapshot.data.stash as unknown as Record<string, unknown>
       )
     }
   }
 
   private async _deleteStashData(): Promise<void> {
-    if (!this._rootStorage) return
+    const storage = this._stashStorage ?? this._rootStorage
+    if (!storage) return
     const prefix = `${STASH_PREFIX}/${this._sessionId}/`
-    const keys = await this._rootStorage.list(prefix)
-    await Promise.all(keys.map((key) => this._rootStorage!.delete(key)))
+    const keys = await storage.list(prefix)
+    await Promise.all(keys.map((key) => storage.delete(key)))
   }
 
   // ---------------------------------------------------------------------------

--- a/strands-ts/src/session/session-manager.ts
+++ b/strands-ts/src/session/session-manager.ts
@@ -389,16 +389,12 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
   }
 
   private async _deleteStashData(): Promise<void> {
-    // Agent-scoped: delete via the Stash's own namespaced storage, which handles
-    // pre-namespaced backends correctly. Only covers the agent registered with
-    // this SessionManager — orchestrator children with custom stash storage
-    // distinct from rootStorage are not reached here.
+    // Stash handles pre-namespaced storage; only covers this agent's data.
     if (this._stash) {
       const keys = await this._stash.list()
       await Promise.all(keys.map((key) => this._stash!.delete(key)))
     }
-    // Session-scoped: sweep rootStorage for any remaining stash data under this
-    // session (e.g. other agents sharing root storage).
+    // Catch stash data from other agents sharing rootStorage in this session.
     if (!this._rootStorage) return
     const scoped = resolveNamespace(this._rootStorage, `${STASH_PREFIX}/${this._sessionId}`)
     const keys = await scoped.list('')

--- a/strands-ts/src/session/session-manager.ts
+++ b/strands-ts/src/session/session-manager.ts
@@ -1,6 +1,6 @@
 import type { SnapshotStorage, SnapshotLocation } from './storage.js'
 import type { Storage } from '../storage/storage.js'
-import { NAMESPACED, namespace, resolveNamespace } from '../storage/storage.js'
+import { NAMESPACED, namespace } from '../storage/storage.js'
 import { SnapshotStorageAdapter } from './snapshot-storage-adapter.js'
 import { validateIdentifier } from './validation.js'
 import type { SnapshotTriggerCallback } from './types.js'
@@ -8,7 +8,7 @@ import type { Snapshot } from '../types/snapshot.js'
 import type { JSONValue } from '../types/json.js'
 import type { Plugin } from '../plugins/plugin.js'
 import type { LocalAgent } from '../types/agent.js'
-import { STASH_PREFIX, Stash } from '../context-manager/stash.js'
+import { Stash } from '../context-manager/stash.js'
 import { AfterInvocationEvent, AfterModelCallEvent, InitializedEvent, MessageAddedEvent } from '../hooks/events.js'
 import { v7 as uuidV7 } from 'uuid'
 import { logger } from '../logging/logger.js'
@@ -125,8 +125,7 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
   private readonly _sessionId: string
   private _storage!: { snapshot: SnapshotStorage }
   private readonly _configStorage?: Storage | { snapshot: SnapshotStorage } | undefined
-  private _rootStorage: Storage | undefined
-  private _stash: Stash | undefined
+  private _agentStash: Stash | undefined
   private readonly _saveLatestOn: SaveLatestStrategy
   private readonly _snapshotTrigger?: SnapshotTriggerCallback | undefined
   private readonly _multiAgentSaveLatestOn: MultiAgentSaveLatestStrategy
@@ -151,9 +150,6 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
     this._configStorage = config.storage
     if (config.storage) {
       this._storage = { snapshot: this._resolveSnapshotStorage(config.storage) }
-      if (!('snapshot' in config.storage)) {
-        this._rootStorage = config.storage
-      }
     }
     this._saveLatestOn = config.saveLatestOn ?? 'invocation'
     this._multiAgentSaveLatestOn = config.multiAgentSaveLatestOn ?? 'node'
@@ -185,8 +181,7 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
       }
       this._storage = { snapshot: this._resolveSnapshotStorage(agent.storage) }
     }
-    this._rootStorage ??= agent.storage
-    this._stash = agent.contextManager?.stash
+    this._agentStash = agent.contextManager?.stash
     agent.addHook(InitializedEvent, async (event) => {
       await this._onAgentInitialized(event)
     })
@@ -389,16 +384,10 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
   }
 
   private async _deleteStashData(): Promise<void> {
-    // Stash handles pre-namespaced storage; only covers this agent's data.
-    if (this._stash) {
-      const keys = await this._stash.list()
-      await Promise.all(keys.map((key) => this._stash!.delete(key)))
+    if (this._agentStash) {
+      await this._agentStash.clear()
+      await this._agentStash.clearSession()
     }
-    // Catch stash data from other agents sharing rootStorage in this session.
-    if (!this._rootStorage) return
-    const scoped = resolveNamespace(this._rootStorage, `${STASH_PREFIX}/${this._sessionId}`)
-    const keys = await scoped.list('')
-    await Promise.all(keys.map((key) => scoped.delete(key)))
   }
 
   // ---------------------------------------------------------------------------

--- a/strands-ts/src/session/session-manager.ts
+++ b/strands-ts/src/session/session-manager.ts
@@ -127,7 +127,6 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
   private readonly _configStorage?: Storage | { snapshot: SnapshotStorage } | undefined
   private _rootStorage: Storage | undefined
   private _stash: Stash | undefined
-  private _stashStorage: Storage | undefined
   private readonly _saveLatestOn: SaveLatestStrategy
   private readonly _snapshotTrigger?: SnapshotTriggerCallback | undefined
   private readonly _multiAgentSaveLatestOn: MultiAgentSaveLatestStrategy
@@ -188,7 +187,6 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
     }
     this._rootStorage ??= agent.storage
     this._stash = agent.contextManager?.stash
-    this._stashStorage = agent.contextManager?.stashStorage
     agent.addHook(InitializedEvent, async (event) => {
       await this._onAgentInitialized(event)
     })
@@ -395,9 +393,8 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
       const keys = await this._stash.list()
       await Promise.all(keys.map((key) => this._stash!.delete(key)))
     }
-    const storage = this._stashStorage ?? this._rootStorage
-    if (!storage) return
-    const scoped = resolveNamespace(storage, `${STASH_PREFIX}/${this._sessionId}`)
+    if (!this._rootStorage) return
+    const scoped = resolveNamespace(this._rootStorage, `${STASH_PREFIX}/${this._sessionId}`)
     const keys = await scoped.list('')
     await Promise.all(keys.map((key) => scoped.delete(key)))
   }

--- a/strands-ts/src/session/session-manager.ts
+++ b/strands-ts/src/session/session-manager.ts
@@ -88,10 +88,20 @@ export interface SessionManagerConfig {
 /**
  * Stash data envelope stored in snapshot.data.stash.
  *
+ * Extends `Record<string, JSONValue>` so it is directly assignable to
+ * `Snapshot.data` entries without casts.
+ *
  * @internal
  */
-type StashSnapshotData =
-  { location: 'inline'; entries: Record<string, JSONValue> } | { location: 'external'; storageType?: string }
+interface InlineStashSnapshot extends Record<string, JSONValue> {
+  location: 'inline'
+  entries: Record<string, JSONValue>
+}
+interface ExternalStashSnapshot extends Record<string, JSONValue> {
+  location: 'external'
+  storageType: string
+}
+type StashSnapshotData = InlineStashSnapshot | ExternalStashSnapshot
 
 /**
  * Manages session persistence for agents, enabling conversation state
@@ -347,16 +357,14 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
     if (!contextManager?.stash) return
 
     if (contextManager.stashIsDurable) {
-      const storageType = contextManager.stashStorage?.constructor.name
-      const ref: StashSnapshotData = storageType ? { location: 'external', storageType } : { location: 'external' }
-      snapshot.data.stash = ref as unknown as JSONValue
+      const storageType = contextManager.stashStorage?.constructor.name ?? 'unknown'
+      snapshot.data.stash = { location: 'external', storageType } satisfies StashSnapshotData
       return
     }
 
     const entries = await contextManager.stash.takeSnapshot()
     if (Object.keys(entries).length > 0) {
-      const data: StashSnapshotData = { location: 'inline', entries }
-      snapshot.data.stash = data as unknown as JSONValue
+      snapshot.data.stash = { location: 'inline', entries } satisfies StashSnapshotData
     }
   }
 
@@ -365,7 +373,7 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
     const stash = agent.contextManager?.stash
     if (!stash) return
 
-    const stashData = snapshot.data.stash as unknown as StashSnapshotData
+    const stashData = snapshot.data.stash as StashSnapshotData
     if (stashData.location === 'external') {
       const currentType = agent.contextManager?.stashStorage?.constructor.name
       if (stashData.storageType && currentType && stashData.storageType !== currentType) {

--- a/strands-ts/src/session/session-manager.ts
+++ b/strands-ts/src/session/session-manager.ts
@@ -1,6 +1,6 @@
 import type { SnapshotStorage, SnapshotLocation } from './storage.js'
 import type { Storage } from '../storage/storage.js'
-import { NAMESPACED, namespace, resolveNamespace } from '../storage/storage.js'
+import { NAMESPACED, namespace } from '../storage/storage.js'
 import { SnapshotStorageAdapter } from './snapshot-storage-adapter.js'
 import { validateIdentifier } from './validation.js'
 import type { SnapshotTriggerCallback } from './types.js'
@@ -8,7 +8,7 @@ import type { Snapshot } from '../types/snapshot.js'
 import type { JSONValue } from '../types/json.js'
 import type { Plugin } from '../plugins/plugin.js'
 import type { LocalAgent } from '../types/agent.js'
-import { STASH_PREFIX } from '../context-manager/stash.js'
+import type { Stash } from '../context-manager/stash.js'
 import { AfterInvocationEvent, AfterModelCallEvent, InitializedEvent, MessageAddedEvent } from '../hooks/events.js'
 import { v7 as uuidV7 } from 'uuid'
 import { logger } from '../logging/logger.js'
@@ -126,7 +126,7 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
   private _storage!: { snapshot: SnapshotStorage }
   private readonly _configStorage?: Storage | { snapshot: SnapshotStorage } | undefined
   private _rootStorage: Storage | undefined
-  private _stashStorage: Storage | undefined
+  private _stash: Stash | undefined
   private readonly _saveLatestOn: SaveLatestStrategy
   private readonly _snapshotTrigger?: SnapshotTriggerCallback | undefined
   private readonly _multiAgentSaveLatestOn: MultiAgentSaveLatestStrategy
@@ -186,7 +186,7 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
       this._storage = { snapshot: this._resolveSnapshotStorage(agent.storage) }
     }
     this._rootStorage ??= agent.storage
-    this._stashStorage = agent.contextManager?.stashStorage
+    this._stash = agent.contextManager?.stash
     agent.addHook(InitializedEvent, async (event) => {
       await this._onAgentInitialized(event)
     })
@@ -389,11 +389,9 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
   }
 
   private async _deleteStashData(): Promise<void> {
-    const storage = this._stashStorage ?? this._rootStorage
-    if (!storage) return
-    const scoped = resolveNamespace(storage, `${STASH_PREFIX}/${this._sessionId}`)
-    const keys = await scoped.list('')
-    await Promise.all(keys.map((key) => scoped.delete(key)))
+    if (!this._stash) return
+    const keys = await this._stash.list()
+    await Promise.all(keys.map((key) => this._stash!.delete(key)))
   }
 
   // ---------------------------------------------------------------------------

--- a/strands-ts/src/session/session-manager.ts
+++ b/strands-ts/src/session/session-manager.ts
@@ -91,8 +91,7 @@ export interface SessionManagerConfig {
  * @internal
  */
 type StashSnapshotData =
-  | { location: 'inline'; entries: Record<string, JSONValue> }
-  | { location: 'external'; storageType?: string }
+  { location: 'inline'; entries: Record<string, JSONValue> } | { location: 'external'; storageType?: string }
 
 /**
  * Manages session persistence for agents, enabling conversation state
@@ -343,16 +342,13 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
   // Stash integration
   // ---------------------------------------------------------------------------
 
-
   private async _includeStashData(agent: LocalAgent, snapshot: Snapshot): Promise<void> {
     const contextManager = agent.contextManager
     if (!contextManager?.stash) return
 
     if (contextManager.stashIsDurable) {
       const storageType = contextManager.stashStorage?.constructor.name
-      const ref: StashSnapshotData = storageType
-        ? { location: 'external', storageType }
-        : { location: 'external' }
+      const ref: StashSnapshotData = storageType ? { location: 'external', storageType } : { location: 'external' }
       snapshot.data.stash = ref as unknown as JSONValue
       return
     }

--- a/strands-ts/src/session/session-manager.ts
+++ b/strands-ts/src/session/session-manager.ts
@@ -352,7 +352,7 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
     if (!contextManager?.stash) return
 
     if (contextManager.stashIsDurable) {
-      const storageType = contextManager.stashStorage?.constructor.name ?? 'unknown'
+      const storageType = contextManager.stash.storageTypeName
       snapshot.data.stash = { location: 'external', storageType } satisfies StashSnapshotData
       return
     }
@@ -370,7 +370,7 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
 
     const stashData = snapshot.data.stash as StashSnapshotData
     if (stashData.location === 'external') {
-      const currentType = agent.contextManager?.stashStorage?.constructor.name
+      const currentType = stash.storageTypeName
       if (stashData.storageType && currentType && stashData.storageType !== currentType) {
         logger.warn(
           `session_id=<${this._sessionId}>, snapshot_storage=<${stashData.storageType}>, current_storage=<${currentType}> | stash storage type changed since snapshot was created, stash data may be inaccessible`

--- a/strands-ts/src/session/session-manager.ts
+++ b/strands-ts/src/session/session-manager.ts
@@ -4,8 +4,12 @@ import { NAMESPACED, namespace } from '../storage/storage.js'
 import { SnapshotStorageAdapter } from './snapshot-storage-adapter.js'
 import { validateIdentifier } from './validation.js'
 import type { SnapshotTriggerCallback } from './types.js'
+import type { Snapshot } from '../types/snapshot.js'
+import type { JSONValue } from '../types/json.js'
 import type { Plugin } from '../plugins/plugin.js'
 import type { LocalAgent } from '../types/agent.js'
+import type { ContextManager } from '../context-manager/context-manager.js'
+import { STASH_PREFIX } from '../context-manager/stash.js'
 import { AfterInvocationEvent, AfterModelCallEvent, InitializedEvent, MessageAddedEvent } from '../hooks/events.js'
 import { v7 as uuidV7 } from 'uuid'
 import { logger } from '../logging/logger.js'
@@ -104,6 +108,7 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
   private readonly _sessionId: string
   private _storage!: { snapshot: SnapshotStorage }
   private readonly _configStorage?: Storage | { snapshot: SnapshotStorage } | undefined
+  private _rootStorage: Storage | undefined
   private readonly _saveLatestOn: SaveLatestStrategy
   private readonly _snapshotTrigger?: SnapshotTriggerCallback | undefined
   private readonly _multiAgentSaveLatestOn: MultiAgentSaveLatestStrategy
@@ -128,6 +133,9 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
     this._configStorage = config.storage
     if (config.storage) {
       this._storage = { snapshot: this._resolveSnapshotStorage(config.storage) }
+      if (!('snapshot' in config.storage)) {
+        this._rootStorage = config.storage
+      }
     }
     this._saveLatestOn = config.saveLatestOn ?? 'invocation'
     this._multiAgentSaveLatestOn = config.multiAgentSaveLatestOn ?? 'node'
@@ -159,6 +167,7 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
       }
       this._storage = { snapshot: this._resolveSnapshotStorage(agent.storage) }
     }
+    this._rootStorage ??= agent.storage
     agent.addHook(InitializedEvent, async (event) => {
       await this._onAgentInitialized(event)
     })
@@ -197,6 +206,9 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
     const snapshot = isAgent
       ? (params.target as LocalAgent).takeSnapshot({ preset: 'session' })
       : takeMultiAgentSnapshot(params.target as Graph | Swarm, params.state)
+    if (isAgent) {
+      await this._includeStashData(params.target as LocalAgent, snapshot)
+    }
     const snapshotId = params.isLatest ? 'latest' : uuidV7()
     const location = isAgent
       ? this._location(params.target as LocalAgent)
@@ -204,9 +216,10 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
     await this._snapshotStorage.saveSnapshot({ location, snapshotId, isLatest: params.isLatest, snapshot })
   }
 
-  /** Deletes all snapshots and manifests for this session from storage. */
+  /** Deletes all snapshots, manifests, and stash data for this session from storage. */
   async deleteSession(): Promise<void> {
     await this._snapshotStorage.deleteSession({ sessionId: this._sessionId })
+    await this._deleteStashData()
   }
 
   /** Lists all available immutable snapshot IDs for the given agent target. */
@@ -243,6 +256,7 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
 
     if (isAgent) {
       ;(params.target as LocalAgent).loadSnapshot(snapshot)
+      await this._restoreStashData(params.target as LocalAgent, snapshot)
     } else {
       loadMultiAgentSnapshot(params.target as Graph | Swarm, snapshot, params.state)
     }
@@ -302,6 +316,7 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
   /** Captures one snapshot and writes it to both immutable history and snapshot_latest. */
   private async _saveImmutableAndLatest(agent: LocalAgent): Promise<void> {
     const snapshot = agent.takeSnapshot({ preset: 'session' })
+    await this._includeStashData(agent, snapshot)
     const snapshotId = uuidV7()
     await Promise.all([
       this._snapshotStorage.saveSnapshot({ location: this._location(agent), snapshotId, isLatest: false, snapshot }),
@@ -312,6 +327,36 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
         snapshot,
       }),
     ])
+  }
+
+  // ---------------------------------------------------------------------------
+  // Stash integration
+  // ---------------------------------------------------------------------------
+
+  private static _contextManager(agent: LocalAgent): ContextManager | undefined {
+    return (agent as unknown as { contextManager?: ContextManager }).contextManager
+  }
+
+  private async _includeStashData(agent: LocalAgent, snapshot: Snapshot): Promise<void> {
+    const stash = SessionManager._contextManager(agent)?.stash
+    if (!stash) return
+    const stashData = await stash.takeSnapshot()
+    snapshot.data.stash = stashData as unknown as JSONValue
+  }
+
+  private async _restoreStashData(agent: LocalAgent, snapshot: Snapshot): Promise<void> {
+    if ('stash' in snapshot.data && snapshot.data.stash) {
+      await SessionManager._contextManager(agent)?.stash?.loadSnapshot(
+        snapshot.data.stash as unknown as Record<string, unknown>
+      )
+    }
+  }
+
+  private async _deleteStashData(): Promise<void> {
+    if (!this._rootStorage) return
+    const prefix = `${STASH_PREFIX}/${this._sessionId}/`
+    const keys = await this._rootStorage.list(prefix)
+    await Promise.all(keys.map((key) => this._rootStorage!.delete(key)))
   }
 
   // ---------------------------------------------------------------------------

--- a/strands-ts/src/session/session-manager.ts
+++ b/strands-ts/src/session/session-manager.ts
@@ -1,6 +1,6 @@
 import type { SnapshotStorage, SnapshotLocation } from './storage.js'
 import type { Storage } from '../storage/storage.js'
-import { NAMESPACED, namespace } from '../storage/storage.js'
+import { NAMESPACED, namespace, resolveNamespace } from '../storage/storage.js'
 import { SnapshotStorageAdapter } from './snapshot-storage-adapter.js'
 import { validateIdentifier } from './validation.js'
 import type { SnapshotTriggerCallback } from './types.js'
@@ -8,7 +8,7 @@ import type { Snapshot } from '../types/snapshot.js'
 import type { JSONValue } from '../types/json.js'
 import type { Plugin } from '../plugins/plugin.js'
 import type { LocalAgent } from '../types/agent.js'
-import type { Stash } from '../context-manager/stash.js'
+import { STASH_PREFIX, Stash } from '../context-manager/stash.js'
 import { AfterInvocationEvent, AfterModelCallEvent, InitializedEvent, MessageAddedEvent } from '../hooks/events.js'
 import { v7 as uuidV7 } from 'uuid'
 import { logger } from '../logging/logger.js'
@@ -127,6 +127,7 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
   private readonly _configStorage?: Storage | { snapshot: SnapshotStorage } | undefined
   private _rootStorage: Storage | undefined
   private _stash: Stash | undefined
+  private _stashStorage: Storage | undefined
   private readonly _saveLatestOn: SaveLatestStrategy
   private readonly _snapshotTrigger?: SnapshotTriggerCallback | undefined
   private readonly _multiAgentSaveLatestOn: MultiAgentSaveLatestStrategy
@@ -187,6 +188,7 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
     }
     this._rootStorage ??= agent.storage
     this._stash = agent.contextManager?.stash
+    this._stashStorage = agent.contextManager?.stashStorage
     agent.addHook(InitializedEvent, async (event) => {
       await this._onAgentInitialized(event)
     })
@@ -389,9 +391,15 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
   }
 
   private async _deleteStashData(): Promise<void> {
-    if (!this._stash) return
-    const keys = await this._stash.list()
-    await Promise.all(keys.map((key) => this._stash!.delete(key)))
+    if (this._stash) {
+      const keys = await this._stash.list()
+      await Promise.all(keys.map((key) => this._stash!.delete(key)))
+    }
+    const storage = this._stashStorage ?? this._rootStorage
+    if (!storage) return
+    const scoped = resolveNamespace(storage, `${STASH_PREFIX}/${this._sessionId}`)
+    const keys = await scoped.list('')
+    await Promise.all(keys.map((key) => scoped.delete(key)))
   }
 
   // ---------------------------------------------------------------------------

--- a/strands-ts/src/session/session-manager.ts
+++ b/strands-ts/src/session/session-manager.ts
@@ -389,10 +389,16 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
   }
 
   private async _deleteStashData(): Promise<void> {
+    // Agent-scoped: delete via the Stash's own namespaced storage, which handles
+    // pre-namespaced backends correctly. Only covers the agent registered with
+    // this SessionManager — orchestrator children with custom stash storage
+    // distinct from rootStorage are not reached here.
     if (this._stash) {
       const keys = await this._stash.list()
       await Promise.all(keys.map((key) => this._stash!.delete(key)))
     }
+    // Session-scoped: sweep rootStorage for any remaining stash data under this
+    // session (e.g. other agents sharing root storage).
     if (!this._rootStorage) return
     const scoped = resolveNamespace(this._rootStorage, `${STASH_PREFIX}/${this._sessionId}`)
     const keys = await scoped.list('')

--- a/strands-ts/src/session/session-manager.ts
+++ b/strands-ts/src/session/session-manager.ts
@@ -338,19 +338,27 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
   private async _includeStashData(agent: LocalAgent, snapshot: Snapshot): Promise<void> {
     const contextManager = agent.contextManager
     if (!contextManager?.stash) return
-    // Durable storage already persists stash entries — no need to duplicate in the snapshot.
-    if (contextManager.stashIsDurable) return
-    const stashData = await contextManager.stash.takeSnapshot()
-    if (Object.keys(stashData).length > 0) {
-      snapshot.data.stash = stashData as unknown as JSONValue
+
+    if (contextManager.stashIsDurable) {
+      snapshot.data.stash = { location: 'external' } as unknown as JSONValue
+      return
+    }
+
+    const entries = await contextManager.stash.takeSnapshot()
+    if (Object.keys(entries).length > 0) {
+      snapshot.data.stash = { location: 'inline', entries } as unknown as JSONValue
     }
   }
 
   private async _restoreStashData(agent: LocalAgent, snapshot: Snapshot): Promise<void> {
-    if ('stash' in snapshot.data && snapshot.data.stash) {
-      await agent.contextManager?.stash?.loadSnapshot(
-        snapshot.data.stash as unknown as Record<string, unknown>
-      )
+    if (!('stash' in snapshot.data) || !snapshot.data.stash) return
+    const stash = agent.contextManager?.stash
+    if (!stash) return
+
+    const stashData = snapshot.data.stash as unknown as Record<string, unknown>
+    if (stashData.location === 'external') return
+    if (stashData.location === 'inline') {
+      await stash.loadSnapshot(stashData.entries as Record<string, unknown>)
     }
   }
 

--- a/strands-ts/src/session/session-manager.ts
+++ b/strands-ts/src/session/session-manager.ts
@@ -1,6 +1,6 @@
 import type { SnapshotStorage, SnapshotLocation } from './storage.js'
 import type { Storage } from '../storage/storage.js'
-import { NAMESPACED, namespace } from '../storage/storage.js'
+import { NAMESPACED, namespace, resolveNamespace } from '../storage/storage.js'
 import { SnapshotStorageAdapter } from './snapshot-storage-adapter.js'
 import { validateIdentifier } from './validation.js'
 import type { SnapshotTriggerCallback } from './types.js'
@@ -391,9 +391,9 @@ export class SessionManager implements Plugin, MultiAgentPlugin {
   private async _deleteStashData(): Promise<void> {
     const storage = this._stashStorage ?? this._rootStorage
     if (!storage) return
-    const prefix = `${STASH_PREFIX}/${this._sessionId}/`
-    const keys = await storage.list(prefix)
-    await Promise.all(keys.map((key) => storage.delete(key)))
+    const scoped = resolveNamespace(storage, `${STASH_PREFIX}/${this._sessionId}`)
+    const keys = await scoped.list('')
+    await Promise.all(keys.map((key) => scoped.delete(key)))
   }
 
   // ---------------------------------------------------------------------------

--- a/strands-ts/src/storage/in-memory-storage.ts
+++ b/strands-ts/src/storage/in-memory-storage.ts
@@ -1,6 +1,6 @@
 import type { Storage, StorageSearchResult } from './storage.js'
 
-import { namespace, normalizeKey, normalizePrefix } from './storage.js'
+import { EPHEMERAL, namespace, normalizeKey, normalizePrefix } from './storage.js'
 import { KeywordSearchStrategy } from './search/keyword.js'
 
 /**
@@ -25,6 +25,7 @@ import { KeywordSearchStrategy } from './search/keyword.js'
  * ```
  */
 export class InMemoryStorage implements Storage {
+  readonly [EPHEMERAL] = true as const
   private readonly _store = new Map<string, Uint8Array>()
 
   /**

--- a/strands-ts/src/storage/storage.ts
+++ b/strands-ts/src/storage/storage.ts
@@ -10,7 +10,7 @@ export const NAMESPACED: unique symbol = Symbol.for('strands.storage.namespaced'
 
 /**
  * Symbol marking storage backends whose data does not survive process restarts.
- * Propagated through {@link namespace} so namespaced views of ephemeral storage
+ * Propagated through {@link "namespace"} so namespaced views of ephemeral storage
  * remain detectable.
  *
  * @internal

--- a/strands-ts/src/storage/storage.ts
+++ b/strands-ts/src/storage/storage.ts
@@ -9,6 +9,15 @@ import { StorageError } from '../errors.js'
 export const NAMESPACED: unique symbol = Symbol.for('strands.storage.namespaced')
 
 /**
+ * Symbol marking storage backends whose data does not survive process restarts.
+ * Propagated through {@link namespace} so namespaced views of ephemeral storage
+ * remain detectable.
+ *
+ * @internal
+ */
+export const EPHEMERAL: unique symbol = Symbol.for('strands.storage.ephemeral')
+
+/**
  * Validates and normalizes a storage key for path-based backends: collapses
  * runs of `/`, strips leading and trailing `/`, and rejects empty keys and
  * any `..` segment.
@@ -185,6 +194,9 @@ export function namespace(storage: Storage, prefix: string): Storage {
     list: (query) => storage.list(`${p}${query}`).then((keys) => keys.map((key) => key.slice(p.length))),
     namespace: (sub) => namespace(storage, `${p}${sub}`),
     [NAMESPACED]: true,
+  }
+  if (EPHEMERAL in storage) {
+    ;(view as unknown as Record<symbol, boolean>)[EPHEMERAL] = true
   }
   if (storage.search) {
     view.search = (query: string): Promise<StorageSearchResult[]> =>

--- a/strands-ts/src/types/agent.ts
+++ b/strands-ts/src/types/agent.ts
@@ -1,5 +1,6 @@
 import type { Sandbox } from '../sandbox/base.js'
 import type { Storage } from '../storage/storage.js'
+import type { ContextManager } from '../context-manager/context-manager.js'
 import type { StateStore } from '../state-store.js'
 import type { ContentBlock, ContentBlockData, Message, MessageData, StopReason, SystemPrompt } from './messages.js'
 import type { Interrupt } from '../interrupt.js'
@@ -304,6 +305,15 @@ export interface LocalAgent {
    * auto-namespaces under its own prefix to avoid key collisions.
    */
   readonly storage?: Storage | undefined
+
+  /**
+   * The context manager instance, when a {@link ContextManager} was passed to the agent.
+   * Undefined when no context manager is configured or when a string preset
+   * (`'auto'`, `'agentic'`) was used.
+   *
+   * @internal
+   */
+  readonly contextManager?: ContextManager | undefined
 
   /**
    * Aggregated metrics for the agent's loop execution.


### PR DESCRIPTION
## Description

Integrate the ContextManager's L1 stash with SessionManager so stash data is preserved across process restarts.

### Snapshot envelope

Stash data in snapshots uses a typed `StashSnapshotData` envelope with two variants:

- **`{ location: 'inline', entries: {...} }`** — for non-durable stash (InMemoryStorage). Entries are serialized into the snapshot so they survive restarts via session restore.
- **`{ location: 'external', storageType?: '...' }`** — for durable stash (LocalFileStorage, S3, etc.). Data already persists in its own storage backend, so the snapshot only records a reference. `storageType` captures the storage class name for mismatch detection.

### Storage mismatch warning

On restore, if the snapshot's `storageType` differs from the current stash storage type, a warning is logged so the user knows stash data may be inaccessible (e.g., switched from S3 to LocalFileStorage between deploys).

### Session delete

`deleteSession()` cleans up stash keys from the correct storage backend. A `stashStorage` getter on ContextManager exposes the resolved (pre-namespace) storage, and SessionManager captures it during `initAgent`. This handles the case where the stash uses explicit custom storage different from `agent.storage`.

### LocalAgent interface

Added `contextManager` to the `LocalAgent` interface so SessionManager can access stash state without double-casting through `unknown`.

### Changes

- **`context-manager.ts`** — Added `stash`, `stashIsDurable`, and `stashStorage` getters. Durability is determined by `instanceof InMemoryStorage` on the raw storage before namespacing.
- **`stash.ts`** — Added `takeSnapshot()` and `loadSnapshot()` methods with parallelized I/O via `Promise.all`. Return types use `JSONValue` for type safety at the serialization boundary.
- **`session-manager.ts`** — Added `_includeStashData`, `_restoreStashData`, `_deleteStashData` private methods and `StashSnapshotData` discriminated union type.
- **`types/agent.ts`** — Added `contextManager?: ContextManager` to `LocalAgent` interface.
- **`session-manager.test.ts`** — 12 new tests covering inline snapshot, external ref, empty stash, durable skip, round-trip restore, external restore no-op, storage mismatch warning, delete from root/custom storage.

## Related Issues
https://github.com/strands-agents/harness-sdk/issues/1679

## Type of Change

New feature

## Testing

- 62 unit tests pass (12 new stash integration tests)
- Type-check clean (no new errors)
- Lint and prettier clean

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.