### PR TITLE
test(bedrock): stabilize the cache-point-after-document integ test

### DIFF
--- a/strands-py/tests_integ/models/test_model_bedrock.py
+++ b/strands-py/tests_integ/models/test_model_bedrock.py
@@ -860,6 +860,8 @@ def test_a_caller_ttl_does_not_conflict_with_the_tools_ttl(quiet_strands_logging
     assert result.metrics.latest_agent_invocation.usage.get("cacheWriteInputTokens", 0) > 0
 
 
+# A ~100 KB PDF plus the SDK's throttling backoff can outlast the global 90s timeout.
+@pytest.mark.timeout(300)
 @pytest.mark.parametrize("document_format", ["csv", "pdf"])
 def test_a_cache_point_after_a_document_is_accepted(quiet_strands_logging, letter_pdf, document_format):
     """Bedrock refuses a cache point directly after a non-PDF document but allows one after a PDF.
@@ -878,6 +880,6 @@ def test_a_cache_point_after_a_document_is_accepted(quiet_strands_logging, lette
     model = BedrockModel(model_id=_CACHE_TTL_MODEL_ID, cache_config=CacheConfig(strategy="auto"))
     agent = Agent(model=model, load_tools_from_directory=False, callback_handler=None)
 
-    result = agent([{"text": _durable_prefix()}, document, {"cachePoint": {"type": "default"}}, {"text": "Summarize."}])
+    result = agent([{"text": _durable_prefix()}, document, {"cachePoint": {"type": "default"}}, {"text": "Reply OK."}])
 
     assert result.stop_reason == "end_turn"


### PR DESCRIPTION
## Description

The `test_a_cache_point_after_a_document_is_accepted[pdf]` integration test intermittently failed with `Timeout (>90.0s)`. The global pytest ceiling is 90s, but the SDK's default throttle-retry backoff can reach ~124s on its own (`4→8→16→32→64`), and the `[pdf]` case compounds it by sending a ~100 KB document and asking the model to `Summarize.` — a slow generation. A throttled or slow run therefore outlasts the 90s ceiling before the SDK's own retry can finish.

Two changes address both causes: a per-test `@pytest.mark.timeout(300)` gives the throttle backoff room (matching other retry-heavy Bedrock tests in the suite), and the trailing instruction becomes `Reply OK.` so the common path returns in seconds. The test only asserts the request is accepted (`stop_reason == "end_turn"`) — it verifies the `auto` cache strategy places a cache point around a document in a shape Bedrock accepts — so the terse prompt keeps coverage identical while cutting generation time.

## Related Issues

None — surfaced by a flaky CI integration-test run.

## Documentation PR

None — test-only change.

## Type of Change

Bug fix

## Testing

Ran the target test against real Bedrock in `us-east-1`, both `csv` and `pdf` parameters, four times: consistently passes in 5–11s (previously timing out at >90s), reaching `stop_reason == "end_turn"`. `ruff` and `mypy` clean.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
