### PR TITLE
feat(bidi): expose nova sonic server-assigned session id

### DIFF
--- a/strands-py/src/strands/experimental/bidi/models/bedrock.py
+++ b/strands-py/src/strands/experimental/bidi/models/bedrock.py
@@ -105,6 +105,10 @@ _MAX_HISTORY_TOTAL_BYTES = 200 * 1024  # 200KB total history
 
 _STRANDS_USER_AGENT_EXTRA = "strands-agents"
 
+# Nova reports its server-assigned sessionId on more than one event type; read it from
+# whichever of these arrives first.
+_SESSION_ID_EVENT_NAMES = ("completionStart", "usageEvent")
+
 
 class BedrockNovaSonicModel(BidiModel):
     """Amazon Bedrock Nova Sonic implementation for bidirectional streaming.
@@ -192,6 +196,7 @@ class BedrockNovaSonicModel(BidiModel):
         self._connection_id: str | None = None
         self._audio_content_name: str | None = None
         self._current_completion_id: str | None = None
+        self._session_id: str | None = None
 
         # Indicates if model is done generating transcript
         self._generation_stage: str | None = None
@@ -200,6 +205,21 @@ class BedrockNovaSonicModel(BidiModel):
         self._send_lock = asyncio.Lock()
 
         logger.debug("model_id=<%s> | nova sonic model initialized", model_id)
+
+    @property
+    def session_id(self) -> str | None:
+        """Nova Sonic's server-assigned session ID for the current connection.
+
+        This is the identifier Bedrock uses for the connection on its side. Reference it in AWS
+        support cases or to correlate client-side logs with Bedrock-side telemetry. It is unrelated
+        to Strands session management, which identifies a persisted conversation.
+
+        `None` until Nova reports it, which happens on the first model response of a connection. It
+        is cleared by `start` (and therefore by `reconnect`) so the value always belongs to the
+        current connection, and retained after `stop` so it stays readable for post-mortem
+        debugging.
+        """
+        return self._session_id
 
     def _resolve_client_config(self, config: dict[str, Any]) -> dict[str, Any]:
         """Resolve AWS client config (creates boto session if needed)."""
@@ -265,6 +285,7 @@ class BedrockNovaSonicModel(BidiModel):
         logger.debug("nova connection starting")
 
         self._connection_id = str(uuid.uuid4())
+        self._session_id = None
 
         # Get credentials from boto3 session (full credential chain)
         credentials = self._session.get_credentials()
@@ -378,6 +399,18 @@ class BedrockNovaSonicModel(BidiModel):
             else:
                 logger.debug("event_payload=<%s> | nova sonic event details", json.dumps(nova_event, indent=2)[:500])
 
+    def _track_session_id(self, nova_event: dict[str, Any]) -> None:
+        """Record Nova's server-assigned session ID the first time an event carries it."""
+        if self._session_id:
+            return
+
+        for event_name in _SESSION_ID_EVENT_NAMES:
+            session_id = nova_event.get(event_name, {}).get("sessionId")
+            if session_id:
+                self._session_id = session_id
+                logger.info("session_id=<%s> | nova sonic session id received", session_id)
+                return
+
     async def receive(self) -> AsyncGenerator[BidiOutputEvent, None]:
         """Receive Nova Sonic events and convert to provider-agnostic format.
 
@@ -418,6 +451,7 @@ class BedrockNovaSonicModel(BidiModel):
 
             nova_event = json.loads(raw_bytes)["event"]
             self._log_event_type(nova_event)
+            self._track_session_id(nova_event)
 
             model_event = self._convert_nova_event(nova_event)
             if model_event:

--- a/strands-py/tests/strands/experimental/bidi/models/test_bedrock.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_bedrock.py
@@ -1027,6 +1027,73 @@ async def test_receive_ends_when_stream_closed(nova_model, mock_stream):
     assert [type(event).__name__ for event in events] == ["BidiConnectionStartEvent"]
 
 
+# Session ID Tests
+
+
+def _mock_event_receiver(*nova_events):
+    """Build an event receiver that emits the given Nova events, then end-of-stream."""
+    payloads = [
+        Mock(value=Mock(bytes_=json.dumps({"event": nova_event}).encode("utf-8"))) for nova_event in nova_events
+    ]
+    output = AsyncMock()
+    output.receive = AsyncMock(side_effect=[*payloads, None])
+    return output
+
+
+@pytest.mark.asyncio
+async def test_session_id_none_until_nova_reports_it(nova_model, mock_stream):
+    """session_id stays None while no received event has carried Nova's sessionId."""
+    assert nova_model.session_id is None
+
+    mock_stream.await_output.return_value = (None, _mock_event_receiver({"contentEnd": {"type": "AUDIO"}}))
+    await nova_model.start()
+
+    async for _ in nova_model.receive():
+        pass
+
+    assert nova_model.session_id is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "nova_event",
+    [
+        {"completionStart": {"sessionId": "session-abc", "completionId": "completion-1"}},
+        {"usageEvent": {"sessionId": "session-abc", "totalInputTokens": 4, "totalOutputTokens": 8}},
+    ],
+)
+async def test_session_id_captured_from_nova_event(nova_model, mock_stream, nova_event):
+    """Nova carries sessionId on both completionStart and usageEvent; either one populates it."""
+    mock_stream.await_output.return_value = (None, _mock_event_receiver(nova_event))
+    await nova_model.start()
+
+    async for _ in nova_model.receive():
+        pass
+
+    tru_session_id = nova_model.session_id
+    exp_session_id = "session-abc"
+    assert tru_session_id == exp_session_id
+
+
+@pytest.mark.asyncio
+async def test_session_id_retained_after_stop_and_cleared_on_start(nova_model, mock_stream):
+    """The ID outlives stop() for post-mortem debugging but never carries into a new connection."""
+    mock_stream.await_output.return_value = (
+        None,
+        _mock_event_receiver({"completionStart": {"sessionId": "session-abc"}}),
+    )
+    await nova_model.start()
+
+    async for _ in nova_model.receive():
+        pass
+
+    await nova_model.stop()
+    assert nova_model.session_id == "session-abc"
+
+    await nova_model.start()
+    assert nova_model.session_id is None
+
+
 @pytest.mark.asyncio
 async def test_error_handling(nova_model, mock_stream):
     """Test error handling in various scenarios."""


### PR DESCRIPTION
## Description

Nova Sonic assigns a server-side `sessionId` to every connection and reports it on both the `completionStart` and `usageEvent` payloads, but `BedrockNovaSonicModel` reads only `completionId` off `completionStart` for internal response tracking and discards the rest. The ID never reaches a `BidiOutputEvent` and there is no attribute to read it from, so it is unavailable to anyone running Nova Sonic in production — it is the identifier you reference when opening an AWS support case, and the only way to correlate client-side logs with Bedrock-side telemetry for a given connection.

Today the sole workaround is subclassing the provider and overriding the private `_convert_nova_event` hook, which is fragile against internal changes (and broke on the `nova_sonic.py` → `bedrock.py` rename).

This exposes it as a read-only property on the provider. A property rather than a new field on `BidiConnectionStartEvent`, because that event is yielded at the top of `receive()` before any bytes come back from Nova — the `sessionId` does not exist yet at that point.

## Public API Changes

`BedrockNovaSonicModel` gains a `session_id` property:

```python
# Before: only reachable by overriding a private hook
class _SessionIdModel(BedrockNovaSonicModel):
    def _convert_nova_event(self, nova_event):
        session_id = (nova_event.get("completionStart") or {}).get("sessionId")
        ...
        return super()._convert_nova_event(nova_event)

# After
model = BedrockNovaSonicModel(client_config={"region": "us-east-1"})
agent = BidiAgent(model=model)
...
logger.info("nova_session_id=<%s>", model.session_id)
```

`None` until Nova reports it, which happens on the first model response of a connection. Cleared by `start` — and therefore by `reconnect`, which assigns a new session on the Bedrock side — so the value always belongs to the current connection. Retained after `stop` so it stays readable for post-mortem debugging. Also logged once at INFO when first observed.

Purely additive; no existing behavior changes.

## Related Issues

None — filing this directly as a small, self-contained addition.

## Documentation PR

Not included. Happy to add a section to `site/.../bidirectional-streaming/models/bedrock.mdx` in this PR or a follow-up, whichever you prefer.

## Type of Change

New feature

## Testing

Four unit tests in `test_bedrock.py` covering the property's contract: `None` before Nova reports it, populated from either carrying event type, retained across `stop`, and cleared by a subsequent `start`.

- [ ] I ran `hatch run prepare`

Ran the equivalent checks individually rather than through hatch: `ruff format --check`, `ruff check`, and `mypy` clean on both touched files, and the full `tests/strands/experimental/bidi/` suite passing (`test_bedrock.py` 51/51).

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
