### PR TITLE
feat(mcp-py): extend MRTR to prompts and resources, scope hand-sent cancel to 1.x

### DIFF
--- a/strands-py/src/strands/tools/mcp/_compat.py
+++ b/strands-py/src/strands/tools/mcp/_compat.py
@@ -14,7 +14,7 @@ ignores the installed line doesn't need.
 """
 
 import asyncio
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from contextlib import AbstractAsyncContextManager, AsyncExitStack, asynccontextmanager
 from datetime import timedelta
 from typing import Any
@@ -28,6 +28,7 @@ __all__ = [
     "GetSessionIdCallback",
     "MCPError",
     "call_tool",
+    "get_prompt",
     "input_schema",
     "is_error",
     "is_tools_list_changed",
@@ -35,6 +36,7 @@ __all__ = [
     "negotiate_session",
     "next_cursor",
     "output_schema",
+    "read_resource",
     "read_timeout",
     "resource_templates",
     "streamable_http_transport",
@@ -64,77 +66,35 @@ try:
 except ImportError:
     # mcp 2.x removed protocol sessions, so its transports never yield a
     # session-id callback; the alias survives only to type 1.x transports.
-    from collections.abc import Callable
-
     GetSessionIdCallback = Callable[[], str | None]  # type: ignore[misc, assignment]
 
 
-async def call_tool(
-    session: ClientSession,
-    name: str,
-    arguments: dict[str, Any] | None,
-    read_timeout_seconds: timedelta | None,
-    progress_callback: Any,
-    meta: Any,
-) -> Any:
-    """Call a tool on an active session, on either `mcp` major line.
+async def _drive_input_required(session: ClientSession, call_once: Callable[[Any, str | None], Any]) -> Any:
+    """Retry a 2.x request until it stops returning `InputRequiredResult`.
 
-    The 2026-07-28 spec (SEP-2322) replaced server-initiated requests with
-    multi round-trip requests: instead of sending `elicitation/create` back
-    to the client mid-call, the server returns an `InputRequiredResult`, and
-    the client resolves the embedded input requests and retries the call
-    carrying the responses and the echoed opaque `request_state`. The 2.x
-    branch resolves each embedded request through
-    `session.dispatch_input_request`, the same callback table that serves
-    1.x server-initiated requests, so an `elicitation_callback` passed to
-    `ClientSession` behaves the same on both lines.
+    The 2026-07-28 spec (SEP-2322) replaced server-initiated requests with multi round-trip requests: instead of
+    sending `elicitation/create` back to the client mid-call, the server returns an `InputRequiredResult` from
+    `tools/call`, `prompts/get`, or `resources/read`, and the client resolves the embedded input requests and retries
+    the call carrying the responses and the echoed opaque `request_state`. Each round resolves the embedded requests
+    through `session.dispatch_input_request`, the same callback table that serves 1.x server-initiated requests, so an
+    `elicitation_callback` passed to `ClientSession` behaves the same on both lines.
 
-    The retry loop below stands on public 2.x API only: the `call_tool`
-    keywords, `dispatch_input_request` (whose docstring names exactly this
-    use), and `ClientRequestContext` / `InputRequiredRoundsExceededError`
-    from `mcp.client`. The `mcp` package ships its own loop, but only inside
-    the high-level `mcp.client.Client` (which owns connection lifecycle that
-    `MCPClient` manages itself) and a private module. Embedded requests are
-    dispatched one at a time, so a callback's exception propagates as
-    itself.
+    The `mcp` package ships its own retry loop, but only inside the high-level `mcp.client.Client`, which owns
+    connection lifecycle that `MCPClient` manages itself, so the loop is reimplemented here at the session level.
 
     Args:
         session: An active, negotiated `ClientSession`.
-        name: The tool name as the server knows it.
-        arguments: Arguments to pass to the tool.
-        read_timeout_seconds: Timeout for each request round, if any.
-        progress_callback: Callback for progress notifications, if any.
-        meta: Request metadata (`_meta`) to send with the call, if any.
+        call_once: Sends one request round, taking the input responses and the request state to carry.
 
     Returns:
-        The terminal `CallToolResult`.
+        The terminal result.
 
     Raises:
         MCPError: An embedded input request's callback declined it.
-        InputRequiredRoundsExceededError: The server kept returning
-            `InputRequiredResult` past the round cap.
+        InputRequiredRoundsExceededError: The server kept returning `InputRequiredResult` past the round cap.
     """
-    if not MCP_V2:
-        return await session.call_tool(
-            name, arguments, read_timeout_seconds, progress_callback=progress_callback, meta=meta
-        )
-
     from mcp.client import ClientRequestContext, InputRequiredRoundsExceededError  # type: ignore[attr-defined]
     from mcp.types import ErrorData, InputRequiredResult  # type: ignore[attr-defined]
-
-    timeout = read_timeout(read_timeout_seconds)
-
-    async def call_once(input_responses: Any, request_state: str | None) -> Any:
-        return await session.call_tool(  # type: ignore[call-arg]
-            name,
-            arguments,
-            timeout,  # type: ignore[arg-type]
-            progress_callback=progress_callback,
-            meta=meta,
-            input_responses=input_responses,
-            request_state=request_state,
-            allow_input_required=True,
-        )
 
     result = await call_once(None, None)
     for _ in range(_INPUT_REQUIRED_MAX_ROUNDS):
@@ -150,13 +110,127 @@ async def call_tool(
                 raise MCPError(code=response.code, message=response.message, data=response.data)
             responses[key] = response
         if not responses:
-            # A state-only result asks the client to poll: wait a beat so the
-            # retry loop cannot hammer the server.
+            # A state-only result asks the client to poll: wait a beat so the retry loop cannot hammer the server.
             await asyncio.sleep(_STATE_ONLY_RETRY_DELAY_SECONDS)
         result = await call_once(responses or None, result.request_state)
     if isinstance(result, InputRequiredResult):
         raise InputRequiredRoundsExceededError(_INPUT_REQUIRED_MAX_ROUNDS)
     return result
+
+
+async def call_tool(
+    session: ClientSession,
+    name: str,
+    arguments: dict[str, Any] | None,
+    read_timeout_seconds: timedelta | None,
+    progress_callback: Any,
+    meta: Any,
+) -> Any:
+    """Call a tool on an active session, on either `mcp` major line.
+
+    On the 2.x branch the server may answer with an `InputRequiredResult` mid-call. `_drive_input_required`
+    resolves the embedded input requests and retries until the call reaches a terminal result.
+
+    Args:
+        session: An active, negotiated `ClientSession`.
+        name: The tool name as the server knows it.
+        arguments: Arguments to pass to the tool.
+        read_timeout_seconds: Timeout for each request round, if any.
+        progress_callback: Callback for progress notifications, if any.
+        meta: Request metadata (`_meta`) to send with the call, if any.
+
+    Returns:
+        The terminal `CallToolResult`.
+
+    Raises:
+        MCPError: An embedded input request's callback declined it.
+        InputRequiredRoundsExceededError: The server kept returning `InputRequiredResult` past the round cap.
+    """
+    if not MCP_V2:
+        return await session.call_tool(
+            name, arguments, read_timeout_seconds, progress_callback=progress_callback, meta=meta
+        )
+
+    timeout = read_timeout(read_timeout_seconds)
+
+    async def call_once(input_responses: Any, request_state: str | None) -> Any:
+        return await session.call_tool(  # type: ignore[call-arg]
+            name,
+            arguments,
+            timeout,  # type: ignore[arg-type]
+            progress_callback=progress_callback,
+            meta=meta,
+            input_responses=input_responses,
+            request_state=request_state,
+            allow_input_required=True,
+        )
+
+    return await _drive_input_required(session, call_once)
+
+
+async def get_prompt(session: ClientSession, name: str, arguments: dict[str, str] | None) -> Any:
+    """Get a prompt on an active session, on either `mcp` major line.
+
+    On the 2.x branch the server may answer with an `InputRequiredResult` mid-call. `_drive_input_required`
+    resolves the embedded input requests and retries until the call reaches a terminal result.
+
+    Args:
+        session: An active, negotiated `ClientSession`.
+        name: The prompt name as the server knows it.
+        arguments: Arguments to pass to the prompt.
+
+    Returns:
+        The terminal `GetPromptResult`.
+
+    Raises:
+        MCPError: An embedded input request's callback declined it.
+        InputRequiredRoundsExceededError: The server kept returning `InputRequiredResult` past the round cap.
+    """
+    if not MCP_V2:
+        return await session.get_prompt(name, arguments=arguments)
+
+    async def call_once(input_responses: Any, request_state: str | None) -> Any:
+        return await session.get_prompt(  # type: ignore[call-arg]
+            name,
+            arguments=arguments,
+            input_responses=input_responses,
+            request_state=request_state,
+            allow_input_required=True,
+        )
+
+    return await _drive_input_required(session, call_once)
+
+
+async def read_resource(session: ClientSession, uri: Any) -> Any:
+    """Read a resource on an active session, on either `mcp` major line.
+
+    On the 2.x branch the server may answer with an `InputRequiredResult` mid-call. `_drive_input_required`
+    resolves the embedded input requests and retries until the call reaches a terminal result.
+
+    Args:
+        session: An active, negotiated `ClientSession`.
+        uri: The resource URI. 1.x takes the pydantic `AnyUrl` model. 2.x takes a plain string, so anything
+            `str()` accepts works there.
+
+    Returns:
+        The terminal `ReadResourceResult`.
+
+    Raises:
+        MCPError: An embedded input request's callback declined it.
+        InputRequiredRoundsExceededError: The server kept returning `InputRequiredResult` past the round cap.
+    """
+    if not MCP_V2:
+        return await session.read_resource(uri)
+
+    async def call_once(input_responses: Any, request_state: str | None) -> Any:
+        return await session.read_resource(  # type: ignore[call-arg]
+            str(uri),  # type: ignore[arg-type]
+            input_responses=input_responses,
+            request_state=request_state,
+            allow_input_required=True,
+        )
+
+    return await _drive_input_required(session, call_once)
 
 
 def input_schema(tool: Any) -> dict[str, Any]:

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -64,6 +64,7 @@ from ...types.media import ImageFormat
 from ...types.tools import AgentTool, ToolResultContent, ToolResultStatus
 from ..tool_provider import ToolProvider
 from ._compat import (
+    MCP_V2,
     MCPError,
     is_error,
     is_tools_list_changed,
@@ -77,6 +78,8 @@ from ._compat import (
     tools_changed_subscription,
 )
 from ._compat import call_tool as compat_call_tool
+from ._compat import get_prompt as compat_get_prompt
+from ._compat import read_resource as compat_read_resource
 from .mcp_agent_tool import MCPAgentTool
 from .mcp_instrumentation import inject_trace_context, mcp_instrumentation
 from .mcp_tasks import DEFAULT_TASK_CONFIG, DEFAULT_TASK_POLL_TIMEOUT, DEFAULT_TASK_TTL, TasksConfig
@@ -766,7 +769,8 @@ class MCPClient(ToolProvider):
             raise MCPClientInitializationError(CLIENT_SESSION_NOT_RUNNING_ERROR_MESSAGE)
 
         async def _get_prompt_async() -> GetPromptResult:
-            return await cast(ClientSession, self._background_thread_session).get_prompt(prompt_id, arguments=args)
+            session = cast(ClientSession, self._background_thread_session)
+            return cast(GetPromptResult, await compat_get_prompt(session, prompt_id, args))
 
         get_prompt_result: GetPromptResult = self._invoke_on_background_thread(_get_prompt_async()).result()
         self._log_debug_with_thread("received prompt from MCP server")
@@ -815,7 +819,8 @@ class MCPClient(ToolProvider):
         async def _read_resource_async() -> ReadResourceResult:
             # Convert string to AnyUrl if needed
             resource_uri = AnyUrl(uri) if isinstance(uri, str) else uri
-            return await cast(ClientSession, self._background_thread_session).read_resource(resource_uri)
+            session = cast(ClientSession, self._background_thread_session)
+            return cast(ReadResourceResult, await compat_read_resource(session, resource_uri))
 
         read_resource_result: ReadResourceResult = self._invoke_on_background_thread(_read_resource_async()).result()
         self._log_debug_with_thread("received resource content from MCP server")
@@ -921,12 +926,16 @@ class MCPClient(ToolProvider):
                 session = cast(ClientSession, self._background_thread_session)
                 if cancellation_state is not None:
                     cancellation_state["session"] = session
-                    # MCP assigns the captured private ID synchronously at the start of
-                    # send_request(). If that invariant changes, omit remote notification rather
-                    # than risk cancelling a different request; local cancellation still works.
-                    request_id = getattr(session, "_request_id", None)
-                    if isinstance(request_id, int):
-                        cancellation_state["request_id"] = request_id
+                    # Only 1.x needs the request id: the client must hand-send notifications/cancelled itself
+                    # there. The 2.x dispatcher sends the cancel with the right id when the awaiting task is
+                    # cancelled.
+                    if not MCP_V2:
+                        # MCP assigns the captured private ID synchronously at the start of
+                        # send_request(). If that invariant changes, omit remote notification rather
+                        # than risk cancelling a different request; local cancellation still works.
+                        request_id = getattr(session, "_request_id", None)
+                        if isinstance(request_id, int):
+                            cancellation_state["request_id"] = request_id
                 result = await compat_call_tool(
                     session,
                     name,
@@ -1454,7 +1463,12 @@ class MCPClient(ToolProvider):
         self._background_cleanup_tasks.clear()
 
     async def _cancel_tool_call(self, cancellation_state: _CallCancellationState) -> None:
-        """Cancel the exact MCP task or request represented by the per-call state."""
+        """Cancel the exact MCP task or request represented by the per-call state.
+
+        Hand-sending `notifications/cancelled` is 1.x-only work: on 2.x no request id is captured, so this returns
+        without sending, and the dispatcher sends the cancel itself when the task awaiting the request is cancelled
+        (SEP-2575 scopes hand-sent cancellation to STDIO).
+        """
         session = cancellation_state.get("session")
         if session is None or cancellation_state.get("notification_sent"):
             return

--- a/strands-py/tests/strands/tools/mcp/test__compat.py
+++ b/strands-py/tests/strands/tools/mcp/test__compat.py
@@ -553,6 +553,110 @@ async def test_call_tool_v2_returns_a_terminal_result_from_the_last_allowed_roun
     assert session.call_tool.await_count == 11
 
 
+@pytest.mark.asyncio
+async def test_get_prompt_v1_sends_a_single_request(monkeypatch):
+    """Test that the 1.x branch calls the session once, with no retry keywords."""
+    monkeypatch.setattr(_compat, "MCP_V2", False)
+    terminal_result = MagicMock()
+    session = MagicMock()
+    session.get_prompt = AsyncMock(return_value=terminal_result)
+
+    result = await _compat.get_prompt(session, "greet", {"name": "x"})
+
+    assert result is terminal_result
+    session.get_prompt.assert_awaited_once_with("greet", arguments={"name": "x"})
+
+
+@pytest.mark.asyncio
+async def test_read_resource_v1_sends_a_single_request(monkeypatch):
+    """Test that the 1.x branch calls the session once, passing the URI object through untouched."""
+    monkeypatch.setattr(_compat, "MCP_V2", False)
+    terminal_result = MagicMock()
+    session = MagicMock()
+    session.read_resource = AsyncMock(return_value=terminal_result)
+    resource_uri = MagicMock()
+
+    result = await _compat.read_resource(session, resource_uri)
+
+    assert result is terminal_result
+    session.read_resource.assert_awaited_once_with(resource_uri)
+
+
+@requires_mcp_v2
+@pytest.mark.asyncio
+async def test_get_prompt_v2_resolves_input_required_through_the_callback_table():
+    """Test that the 2.x branch resolves an `InputRequiredResult` from `prompts/get` and retries."""
+    from mcp.types import (
+        ElicitRequest,
+        ElicitRequestFormParams,
+        ElicitResult,
+        GetPromptResult,
+        InputRequiredResult,
+    )
+
+    elicit_request = ElicitRequest(
+        method="elicitation/create",
+        params=ElicitRequestFormParams(
+            mode="form",
+            message="need a value",
+            requested_schema={"type": "object", "properties": {"value": {"type": "string"}}},
+        ),
+    )
+    input_required = InputRequiredResult(input_requests={"q1": elicit_request}, request_state="state-1")
+    terminal_result = GetPromptResult(messages=[])
+    elicit_result = ElicitResult(action="accept", content={"value": "x"})
+    session = MagicMock()
+    session.get_prompt = AsyncMock(side_effect=[input_required, terminal_result])
+    session.dispatch_input_request = AsyncMock(return_value=elicit_result)
+
+    result = await _compat.get_prompt(session, "greet", {"name": "x"})
+
+    assert result is terminal_result
+    first_kwargs = session.get_prompt.await_args_list[0].kwargs
+    assert first_kwargs["allow_input_required"] is True
+    retry_kwargs = session.get_prompt.await_args_list[1].kwargs
+    assert retry_kwargs["input_responses"] == {"q1": elicit_result}
+    assert retry_kwargs["request_state"] == "state-1"
+
+
+@requires_mcp_v2
+@pytest.mark.asyncio
+async def test_read_resource_v2_resolves_input_required_and_sends_a_string_uri():
+    """Test that the 2.x branch retries an `InputRequiredResult` from `resources/read` with a plain-string URI."""
+    from mcp.types import (
+        ElicitRequest,
+        ElicitRequestFormParams,
+        ElicitResult,
+        InputRequiredResult,
+        ReadResourceResult,
+    )
+    from pydantic import AnyUrl
+
+    elicit_request = ElicitRequest(
+        method="elicitation/create",
+        params=ElicitRequestFormParams(
+            mode="form", message="need a value", requested_schema={"type": "object", "properties": {}}
+        ),
+    )
+    input_required = InputRequiredResult(input_requests={"q1": elicit_request}, request_state="state-1")
+    terminal_result = ReadResourceResult(contents=[])
+    elicit_result = ElicitResult(action="accept", content={})
+    session = MagicMock()
+    session.read_resource = AsyncMock(side_effect=[input_required, terminal_result])
+    session.dispatch_input_request = AsyncMock(return_value=elicit_result)
+    resource_uri = AnyUrl("resource://server/thing")
+
+    result = await _compat.read_resource(session, resource_uri)
+
+    assert result is terminal_result
+    first_call = session.read_resource.await_args_list[0]
+    assert first_call.args[0] == str(resource_uri)
+    assert first_call.kwargs["allow_input_required"] is True
+    retry_kwargs = session.read_resource.await_args_list[1].kwargs
+    assert retry_kwargs["input_responses"] == {"q1": elicit_result}
+    assert retry_kwargs["request_state"] == "state-1"
+
+
 def test_mcp_error_resolves_to_installed_exception():
     """Test that MCPError is the mcp package's error type regardless of its spelling."""
     import mcp.shared.exceptions as mcp_exceptions

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client.py
@@ -369,6 +369,39 @@ def test_call_tool_sync_cancel_signal_cancels_only_in_flight_call(mock_transport
     assert mock_session.call_tool.call_count == 2
 
 
+def test_call_tool_sync_cancel_on_v2_sends_no_hand_built_notification(mock_transport, mock_session):
+    """Test that cancelling on the 2.x path hand-sends nothing: cancelling the awaiting task is the mechanism."""
+    call_started = threading.Event()
+    call_cancelled = threading.Event()
+    cancel_signal = threading.Event()
+
+    async def call_tool(name, arguments, read_timeout_seconds, progress_callback=None, meta=None):
+        call_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            call_cancelled.set()
+            raise
+
+    mock_session.call_tool.side_effect = call_tool
+    mock_session._request_id = 0
+
+    with (
+        patch("strands.tools.mcp.mcp_client.MCP_V2", True),
+        MCPClient(mock_transport["transport_callable"]) as client,
+    ):
+        cancellation_thread = threading.Thread(target=lambda: (call_started.wait(timeout=1), cancel_signal.set()))
+        cancellation_thread.start()
+        cancelled_result = client.call_tool_sync(
+            tool_use_id="cancelled", name="slow_tool", arguments={}, cancel_signal=cancel_signal
+        )
+        cancellation_thread.join(timeout=1)
+
+    assert cancelled_result["cancelled"] is True
+    assert call_cancelled.wait(timeout=1)
+    mock_session.send_notification.assert_not_awaited()
+
+
 @pytest.mark.asyncio
 async def test_call_tool_async_cancel_signal_cancels_only_matching_call(mock_transport, mock_session):
     """Test each concurrent call observes only its own cancellation signal."""


### PR DESCRIPTION
## Description
https://modelcontextprotocol.io/seps/2575-stateless-mcp
Two changes to the mcp 2.x compat layer:

### Multi round-trip requests now cover prompts and resources.###
The 2026-07-28 spec (SEP-2322) lets a server pause a request to ask the client for input. Instead of sending an `elicitation/create` request back to the client mid-call, the server returns an `InputRequiredResult`, and the client answers the embedded input requests and retries the call carrying the answers and the echoed `request_state`. 
#4094 built that retry loop for `tools/call` only. The spec applies the same mechanism to `prompts/get` and `resources/read`, and without the loop the 2.x `mcp` package raises a `RuntimeError` when a server answers one of those with an `InputRequiredResult`. 

The loop moved out of `call_tool` into a shared `_drive_input_required`, and new compat wrappers `get_prompt` and `read_resource` use it. `MCPClient.get_prompt` and `MCPClient.read_resource` now route through the wrappers. 

One incidental version difference is handled in the same place: `read_resource` on 2.x takes a plain string URI, so the wrapper passes `str(uri)`, while 1.x keeps the `AnyUrl` model.

### The hand-sent cancel notification is now 1.x-only.### 
To cancel an in-flight `tools/call` on 1.x, the client must send `notifications/cancelled` itself, which requires capturing the session's private request id. On 2.x the dispatcher already sends that notification with the correct id when the task awaiting the request is cancelled, and the spec (SEP-2575) narrows hand-sent cancellation to the STDIO transport.
The client now captures the request id only on 1.x. On 2.x it sends nothing and relies on the dispatcher, so the server no longer receives a second notification for the same request. Local cancellation behaves the same on both lines.

## Notes for review

- `_drive_input_required` stands on public 2.x API only: the request methods' keywords, `session.dispatch_input_request`, and `ClientRequestContext` / `InputRequiredRoundsExceededError` from `mcp.client`. The `mcp` package ships its own retry loop, but only inside the high-level `mcp.client.Client`, which owns connection lifecycle that `MCPClient` manages itself.
- An `InputRequiredResult` that carries only state and no input requests asks the client to poll. The loop waits briefly before retrying so it cannot hammer the server, and it gives up after the same round cap the tools path already used.

## Related Issues

#1659

Follows #4094, which added the retry loop for `tools/call`.

## Documentation PR

No documentation changes needed. The public `MCPClient` API is unchanged.

## Type of Change

New feature

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`
- Format, lint, and mypy checks pass. The full unit suite passes on mcp 1.x (5966 passed, 14 skipped).
- Compat tests pass against `mcp==2.0.*` in a fresh venv replicating the `unit-test-mcp-v2` CI job: `test__compat.py` (51 passed, 1 skipped) and the `test_mcp_client.py` subset that job runs (11 passed).

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
