### PR TITLE
fix(bedrock): handle missing reasoningText in non-streaming conversion

### DIFF
--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -1601,21 +1601,29 @@ class BedrockModel(Model):
                     }
                 }
             elif "reasoningContent" in content:
-                # Then yield the reasoning content as a delta
-                yield {
-                    "contentBlockDelta": {
-                        "delta": {"reasoningContent": {"text": content["reasoningContent"]["reasoningText"]["text"]}}
-                    }
-                }
-
-                if "signature" in content["reasoningContent"]["reasoningText"]:
-                    yield {
-                        "contentBlockDelta": {
-                            "delta": {
-                                "reasoningContent": {
-                                    "signature": content["reasoningContent"]["reasoningText"]["signature"]
+                reasoning = content["reasoningContent"]
+                if "reasoningText" in reasoning:
+                    reasoning_text = reasoning["reasoningText"]
+                    if "text" in reasoning_text:
+                        yield {
+                            "contentBlockDelta": {
+                                "delta": {"reasoningContent": {"text": reasoning_text["text"]}}
+                            }
+                        }
+                    if reasoning_text.get("signature"):
+                        yield {
+                            "contentBlockDelta": {
+                                "delta": {
+                                    "reasoningContent": {
+                                        "signature": reasoning_text["signature"]
+                                    }
                                 }
                             }
+                        }
+                if "redactedContent" in reasoning:
+                    yield {
+                        "contentBlockDelta": {
+                            "delta": {"reasoningContent": {"redactedContent": reasoning["redactedContent"]}}
                         }
                     }
             elif "citationsContent" in content:

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -4642,8 +4642,7 @@ async def test_non_streaming_citations_with_only_location(bedrock_client, model,
     assert "sourceContent" not in citation
 
 
-@pytest.mark.asyncio
-async def test_non_streaming_reasoning_content_with_reasoning_text(bedrock_client, model, alist):
+def test_non_streaming_reasoning_content_with_reasoning_text(bedrock_client, model):
     """Test that convert_non_streaming_to_streaming handles reasoningContent with reasoningText."""
     non_streaming_response = {
         "output": {
@@ -4680,8 +4679,7 @@ async def test_non_streaming_reasoning_content_with_reasoning_text(bedrock_clien
     assert reasoning_deltas[1]["contentBlockDelta"]["delta"]["reasoningContent"] == {"signature": "sig-abc123"}
 
 
-@pytest.mark.asyncio
-async def test_non_streaming_reasoning_content_without_signature(bedrock_client, model, alist):
+def test_non_streaming_reasoning_content_without_signature(bedrock_client, model):
     """Test that convert_non_streaming_to_streaming handles reasoningContent without a signature."""
     non_streaming_response = {
         "output": {
@@ -4715,8 +4713,36 @@ async def test_non_streaming_reasoning_content_without_signature(bedrock_client,
     }
 
 
-@pytest.mark.asyncio
-async def test_non_streaming_reasoning_content_with_redacted_content(bedrock_client, model, alist):
+def test_non_streaming_reasoning_content_with_empty_reasoning_text(bedrock_client, model):
+    """Test that convert_non_streaming_to_streaming handles reasoningText without text or signature."""
+    non_streaming_response = {
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "reasoningContent": {
+                            "reasoningText": {}
+                        }
+                    }
+                ],
+            }
+        },
+        "stopReason": "end_turn",
+        "usage": {"inputTokens": 5, "outputTokens": 10},
+    }
+
+    events = list(model.convert_non_streaming_to_streaming(non_streaming_response))
+
+    reasoning_deltas = [
+        event
+        for event in events
+        if "contentBlockDelta" in event and "reasoningContent" in event.get("contentBlockDelta", {}).get("delta", {})
+    ]
+    assert len(reasoning_deltas) == 0
+
+
+def test_non_streaming_reasoning_content_with_redacted_content(bedrock_client, model):
     """Test that convert_non_streaming_to_streaming handles reasoningContent with redactedContent."""
     non_streaming_response = {
         "output": {

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -4642,6 +4642,77 @@ async def test_non_streaming_citations_with_only_location(bedrock_client, model,
     assert "sourceContent" not in citation
 
 
+@pytest.mark.asyncio
+async def test_non_streaming_reasoning_content_with_reasoning_text(bedrock_client, model, alist):
+    """Test that convert_non_streaming_to_streaming handles reasoningContent with reasoningText."""
+    non_streaming_response = {
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "reasoningContent": {
+                            "reasoningText": {
+                                "text": "Let me think about this...",
+                                "signature": "sig-abc123",
+                            }
+                        }
+                    }
+                ],
+            }
+        },
+        "stopReason": "end_turn",
+        "usage": {"inputTokens": 10, "outputTokens": 20},
+    }
+
+    events = list(model.convert_non_streaming_to_streaming(non_streaming_response))
+
+    reasoning_deltas = [
+        event
+        for event in events
+        if "contentBlockDelta" in event and "reasoningContent" in event.get("contentBlockDelta", {}).get("delta", {})
+    ]
+    assert len(reasoning_deltas) == 2
+
+    assert reasoning_deltas[0]["contentBlockDelta"]["delta"]["reasoningContent"] == {
+        "text": "Let me think about this..."
+    }
+    assert reasoning_deltas[1]["contentBlockDelta"]["delta"]["reasoningContent"] == {"signature": "sig-abc123"}
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_reasoning_content_with_redacted_content(bedrock_client, model, alist):
+    """Test that convert_non_streaming_to_streaming handles reasoningContent with redactedContent."""
+    non_streaming_response = {
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "reasoningContent": {
+                            "redactedContent": b"redacted-bytes",
+                        }
+                    }
+                ],
+            }
+        },
+        "stopReason": "end_turn",
+        "usage": {"inputTokens": 5, "outputTokens": 10},
+    }
+
+    events = list(model.convert_non_streaming_to_streaming(non_streaming_response))
+
+    reasoning_deltas = [
+        event
+        for event in events
+        if "contentBlockDelta" in event and "reasoningContent" in event.get("contentBlockDelta", {}).get("delta", {})
+    ]
+    assert len(reasoning_deltas) == 1
+    assert reasoning_deltas[0]["contentBlockDelta"]["delta"]["reasoningContent"] == {
+        "redactedContent": b"redacted-bytes"
+    }
+
+
 class TestCountTokens:
     """Tests for BedrockModel.count_tokens native token counting."""
 

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -4681,6 +4681,41 @@ async def test_non_streaming_reasoning_content_with_reasoning_text(bedrock_clien
 
 
 @pytest.mark.asyncio
+async def test_non_streaming_reasoning_content_without_signature(bedrock_client, model, alist):
+    """Test that convert_non_streaming_to_streaming handles reasoningContent without a signature."""
+    non_streaming_response = {
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "reasoningContent": {
+                            "reasoningText": {
+                                "text": "Let me think about this...",
+                            }
+                        }
+                    }
+                ],
+            }
+        },
+        "stopReason": "end_turn",
+        "usage": {"inputTokens": 10, "outputTokens": 20},
+    }
+
+    events = list(model.convert_non_streaming_to_streaming(non_streaming_response))
+
+    reasoning_deltas = [
+        event
+        for event in events
+        if "contentBlockDelta" in event and "reasoningContent" in event.get("contentBlockDelta", {}).get("delta", {})
+    ]
+    assert len(reasoning_deltas) == 1
+    assert reasoning_deltas[0]["contentBlockDelta"]["delta"]["reasoningContent"] == {
+        "text": "Let me think about this..."
+    }
+
+
+@pytest.mark.asyncio
 async def test_non_streaming_reasoning_content_with_redacted_content(bedrock_client, model, alist):
     """Test that convert_non_streaming_to_streaming handles reasoningContent with redactedContent."""
     non_streaming_response = {


### PR DESCRIPTION
## Description

`convert_non_streaming_to_streaming` crashes with a `KeyError` when a model returns `reasoningContent` without the `reasoningText` wrapper (e.g. `redactedContent` only). Replaced unsafe direct indexing with safe conditional access, matching the pattern in `_format_request_message_content`. Also added `redactedContent` handling that the streaming path already supported.

## Related Issues

Related to #243, #245

## Type of Change

Bug fix

## Testing

- [x] I ran `hatch run prepare`
- [x] Validated end-to-end against real Bedrock models (Claude Sonnet 4, Opus 4.8, Opus 5) with `streaming=False` and thinking enabled

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.