### PR TITLE
fix(storage): reject backslashes in storage keys

### DIFF
--- a/strands-py/src/strands/storage/storage.py
+++ b/strands-py/src/strands/storage/storage.py
@@ -43,7 +43,7 @@ def _normalize_key(key: str) -> str:
     """Validate and normalize a storage key for path-based backends.
 
     Collapses runs of '/', strips leading and trailing '/', rejects empty
-    keys, and rejects any '..' segment.
+    keys, rejects backslashes, and rejects any '..' segment.
 
     Used by the shipped path-based backends (InMemoryStorage, LocalFileStorage,
     S3Storage), not required by the Storage protocol itself.
@@ -55,8 +55,10 @@ def _normalize_key(key: str) -> str:
         The normalized key.
 
     Raises:
-        StorageError: If the key is empty or contains a '..' segment.
+        StorageError: If the key is empty, contains backslashes, or contains a '..' segment.
     """
+    if "\\" in key:
+        raise StorageError(f"Invalid storage key '{key}': backslashes are not allowed")
     normalized = re.sub(r"/+", "/", key).strip("/")
     if not normalized:
         raise StorageError("Storage key must not be empty")
@@ -81,8 +83,10 @@ def _normalize_prefix(prefix: str) -> str:
         The normalized prefix.
 
     Raises:
-        StorageError: If the prefix contains a '..' segment.
+        StorageError: If the prefix contains backslashes or a '..' segment.
     """
+    if "\\" in prefix:
+        raise StorageError(f"Invalid storage prefix '{prefix}': backslashes are not allowed")
     normalized = re.sub(r"/+", "/", prefix).lstrip("/")
     if ".." in normalized.split("/"):
         raise StorageError(f"Invalid storage prefix '{prefix}': '..' path segments are not allowed")

--- a/strands-py/tests/strands/storage/test_storage.py
+++ b/strands-py/tests/strands/storage/test_storage.py
@@ -48,6 +48,14 @@ class TestNormalizeKey:
         assert _normalize_key("foo/bar.txt") == "foo/bar.txt"
         assert _normalize_key("foo/...bar") == "foo/...bar"
 
+    def test_rejects_backslash(self):
+        with pytest.raises(StorageError, match="backslashes are not allowed"):
+            _normalize_key("foo\\bar")
+
+    def test_rejects_backslash_traversal(self):
+        with pytest.raises(StorageError, match="backslashes are not allowed"):
+            _normalize_key("foo\\..\\..\\secret")
+
 
 class TestNormalizePrefix:
     def test_simple_prefix(self):
@@ -68,6 +76,10 @@ class TestNormalizePrefix:
     def test_rejects_dot_dot(self):
         with pytest.raises(StorageError, match="path segments are not allowed"):
             _normalize_prefix("foo/../bar")
+
+    def test_rejects_backslash(self):
+        with pytest.raises(StorageError, match="backslashes are not allowed"):
+            _normalize_prefix("foo\\bar/")
 
 
 class TestNamespacedStorage:

--- a/strands-ts/src/session/__tests__/snapshot-storage-adapter.test.ts
+++ b/strands-ts/src/session/__tests__/snapshot-storage-adapter.test.ts
@@ -241,6 +241,27 @@ describe('SnapshotStorageAdapter', () => {
     })
   })
 
+  describe('path traversal protection', () => {
+    it('rejects snapshotId with path traversal characters', async () => {
+      const location = createLocation()
+
+      await expect(
+        adapter.saveSnapshot({
+          location,
+          snapshotId: '..\\..\\other-session\\snapshots\\snapshot_latest',
+          isLatest: false,
+          snapshot: createTestSnapshot(),
+        })
+      ).rejects.toThrow()
+    })
+
+    it('rejects snapshotId with forward-slash traversal', async () => {
+      const location = createLocation()
+
+      await expect(adapter.loadSnapshot({ location, snapshotId: '../../other-session' })).rejects.toThrow()
+    })
+  })
+
   describe('custom namespace', () => {
     it('uses the namespace provided to the adapter', async () => {
       const customAdapter = new SnapshotStorageAdapter(namespace(backend, 'custom/prefix'))

--- a/strands-ts/src/session/snapshot-storage-adapter.ts
+++ b/strands-ts/src/session/snapshot-storage-adapter.ts
@@ -151,6 +151,7 @@ export class SnapshotStorageAdapter implements SnapshotStorage {
   }
 
   private _historyKey(location: SnapshotLocation, snapshotId: string): string {
+    validateIdentifier(snapshotId)
     return `${this._scopePrefix(location)}/immutable_history/snapshot_${snapshotId}.json`
   }
 

--- a/strands-ts/src/storage/__tests__/local-file-storage.test.node.ts
+++ b/strands-ts/src/storage/__tests__/local-file-storage.test.node.ts
@@ -70,6 +70,16 @@ describe('LocalFileStorage', () => {
     })
   })
 
+  describe('key validation', () => {
+    it('rejects keys containing backslashes', async () => {
+      await expect(storage.write('foo\\bar', new Uint8Array([1]))).rejects.toThrow('backslashes are not allowed')
+    })
+
+    it('rejects backslash path traversal', async () => {
+      await expect(storage.read('foo\\..\\..\\etc\\passwd')).rejects.toThrow('backslashes are not allowed')
+    })
+  })
+
   describe('delete', () => {
     it('removes an existing key', async () => {
       await storage.write('deleteme', new Uint8Array([1]))

--- a/strands-ts/src/storage/storage.ts
+++ b/strands-ts/src/storage/storage.ts
@@ -22,6 +22,9 @@ export const NAMESPACED: unique symbol = Symbol.for('strands.storage.namespaced'
  * @throws {@link StorageError} if the key is empty or contains a `..` segment
  */
 export function normalizeKey(key: string): string {
+  if (key.includes('\\')) {
+    throw new StorageError(`Invalid storage key '${key}': backslashes are not allowed`)
+  }
   const segments = key.split('/').filter(Boolean)
   if (segments.length === 0) {
     throw new StorageError('Storage key must not be empty')
@@ -44,6 +47,9 @@ export function normalizeKey(key: string): string {
  * @throws {@link StorageError} if the prefix contains a `..` segment
  */
 export function normalizePrefix(prefix: string): string {
+  if (prefix.includes('\\')) {
+    throw new StorageError(`Invalid storage prefix '${prefix}': backslashes are not allowed`)
+  }
   const parts = prefix.split('/')
   const segments = parts.filter(Boolean)
   if (segments.includes('..')) {


### PR DESCRIPTION


## Description
reject backslashes in storage + snapshot keys

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [ ] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
