### PR TITLE
feat: add cache config to llama.cpp

### DIFF
--- a/strands-py/src/strands/models/llamacpp.py
+++ b/strands-py/src/strands/models/llamacpp.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel
 from typing_extensions import Unpack, override
 
 from ..types.content import ContentBlock, Messages, SystemContentBlock
+from ..types.event_loop import Usage
 from ..types.exceptions import ContextWindowOverflowException, ModelThrottledException
 from ..types.streaming import StreamEvent
 from ..types.tools import ToolChoice, ToolSpec
@@ -57,6 +58,28 @@ def _apply_cache_config(request: dict[str, Any], cache_config: CacheConfig | Non
     if "cache_prompt" not in request:
         request["cache_prompt"] = True
     warn_on_cache_config_not_supported(cache_config, "llama.cpp", supported=set())
+
+
+def _format_usage(data: Any) -> Usage:
+    """Build a Usage from a llama.cpp usage payload.
+
+    llama.cpp reports KV-prefix reuse as cached prompt tokens; surface it as a cache read like the
+    other providers so it flows into usage metrics and telemetry.
+
+    Args:
+        data: The usage payload from the server's final stream chunk.
+
+    Returns:
+        The standardized token usage.
+    """
+    usage: Usage = {
+        "inputTokens": data.prompt_tokens,
+        "outputTokens": data.completion_tokens,
+        "totalTokens": data.total_tokens,
+    }
+    if cached_tokens := getattr(data, "cached_tokens", 0):
+        usage["cacheReadInputTokens"] = cached_tokens
+    return usage
 
 
 class LlamaCppModel(Model):
@@ -521,11 +544,7 @@ class LlamaCppModel(Model):
             case "metadata":
                 return {
                     "metadata": {
-                        "usage": {
-                            "inputTokens": event["data"].prompt_tokens,
-                            "outputTokens": event["data"].completion_tokens,
-                            "totalTokens": event["data"].total_tokens,
-                        },
+                        "usage": _format_usage(event["data"]),
                         "metrics": {
                             "latencyMs": event.get("latency_ms", 0),
                         },
@@ -752,6 +771,8 @@ class LlamaCppModel(Model):
             if usage_data:
                 # Calculate latency
                 latency_ms = int((time.perf_counter() - start_time) * 1000)
+                # cached_tokens is the length of the prompt prefix llama.cpp reused from its KV cache.
+                cached_tokens = (usage_data.get("prompt_tokens_details") or {}).get("cached_tokens", 0)
                 yield self._format_chunk(
                     {
                         "chunk_type": "metadata",
@@ -762,6 +783,7 @@ class LlamaCppModel(Model):
                                 "prompt_tokens": usage_data.get("prompt_tokens", 0),
                                 "completion_tokens": usage_data.get("completion_tokens", 0),
                                 "total_tokens": usage_data.get("total_tokens", 0),
+                                "cached_tokens": cached_tokens,
                             },
                         )(),
                         "latency_ms": latency_ms,

--- a/strands-py/src/strands/models/llamacpp.py
+++ b/strands-py/src/strands/models/llamacpp.py
@@ -170,10 +170,10 @@ class LlamaCppModel(Model):
             use_native_token_count: Whether to use the native llama.cpp /tokenize endpoint.
                 When True, count_tokens() calls the server's tokenize endpoint for accurate counts.
                 When False (default), skips the API call and uses the local estimator.
-            cache_config: Prompt-caching configuration. llama.cpp uses the shared prompt prefix server-side 
-                by default. A CacheConfig pins ``cache_prompt: true`` on each request. An explicit 
-                ``params["cache_prompt"]`` takes precedence. llama.cpp has no per-field cache controls, so 
-                every other CacheConfig field is ignored.
+            cache_config: Prompt-caching configuration. llama.cpp reuses the shared prompt prefix
+                server-side by default. A CacheConfig pins ``cache_prompt: true`` on each request. An
+                explicit ``params["cache_prompt"]`` takes precedence. llama.cpp has no per-field cache
+                controls, so every other CacheConfig field is ignored.
         """
 
         model_id: str

--- a/strands-py/src/strands/models/llamacpp.py
+++ b/strands-py/src/strands/models/llamacpp.py
@@ -29,12 +29,34 @@ from ..types.content import ContentBlock, Messages, SystemContentBlock
 from ..types.exceptions import ContextWindowOverflowException, ModelThrottledException
 from ..types.streaming import StreamEvent
 from ..types.tools import ToolChoice, ToolSpec
-from ._validation import _has_location_source, validate_config_keys, warn_on_tool_choice_not_supported
-from .model import BaseModelConfig, Model
+from ._validation import (
+    _has_location_source,
+    validate_config_keys,
+    warn_on_cache_config_not_supported,
+    warn_on_tool_choice_not_supported,
+)
+from .model import BaseModelConfig, CacheConfig, Model
 
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=BaseModel)
+
+
+def _apply_cache_config(request: dict[str, Any], cache_config: CacheConfig | None) -> None:
+    """Enable llama.cpp server-side prompt caching from a CacheConfig.
+
+    llama.cpp handles caching server side via ``cache_prompt``. It has no per-field cache
+    controls, so a ``CacheConfig`` only turns caching on and every other field is a no-op.
+
+    Args:
+        request: The llama.cpp request dict to mutate.
+        cache_config: The provider's configured cache settings, if any.
+    """
+    if cache_config is None:
+        return
+    if "cache_prompt" not in request:
+        request["cache_prompt"] = True
+    warn_on_cache_config_not_supported(cache_config, "llama.cpp", supported=set())
 
 
 class LlamaCppModel(Model):
@@ -128,11 +150,16 @@ class LlamaCppModel(Model):
             use_native_token_count: Whether to use the native llama.cpp /tokenize endpoint.
                 When True, count_tokens() calls the server's tokenize endpoint for accurate counts.
                 When False (default), skips the API call and uses the local estimator.
+            cache_config: Enables llama.cpp's server-side caching. llama.cpp reuses the shared
+                prompt prefix across requests via a coarse ``cache_prompt`` boolean. Setting a CacheConfig
+                turns it on unless ``params["cache_prompt"]`` is set explicitly. llama.cpp has no per-field
+                cache controls, so every other CacheConfig field (ttl, cache_key, strategy, ...) is ignored.
         """
 
         model_id: str
         params: dict[str, Any] | None
         use_native_token_count: bool
+        cache_config: CacheConfig | None
 
     def __init__(
         self,
@@ -437,6 +464,7 @@ class LlamaCppModel(Model):
                 if param in llamacpp_specific_params:
                     request[param] = value
 
+        _apply_cache_config(request, cast(CacheConfig | None, self.config.get("cache_config")))
         return request
 
     def _format_chunk(self, event: dict[str, Any]) -> StreamEvent:

--- a/strands-py/src/strands/models/llamacpp.py
+++ b/strands-py/src/strands/models/llamacpp.py
@@ -44,10 +44,10 @@ T = TypeVar("T", bound=BaseModel)
 
 
 def _apply_cache_config(request: dict[str, Any], cache_config: CacheConfig | None) -> None:
-    """Enable llama.cpp server-side prompt caching from a CacheConfig.
+    """Pin llama.cpp's server-side prompt caching on from a CacheConfig.
 
-    llama.cpp handles caching server side via ``cache_prompt``. It has no per-field cache
-    controls, so a ``CacheConfig`` only turns caching on and every other field is a no-op.
+    llama.cpp uses the shared prompt prefix server-side by default; setting ``cache_prompt`` keeps
+    caching on. It has no per-field cache controls, so every other CacheConfig field is ignored.
 
     Args:
         request: The llama.cpp request dict to mutate.
@@ -62,9 +62,6 @@ def _apply_cache_config(request: dict[str, Any], cache_config: CacheConfig | Non
 
 def _format_usage(data: Any) -> Usage:
     """Build a Usage from a llama.cpp usage payload.
-
-    llama.cpp reports KV-prefix reuse as cached prompt tokens; surface it as a cache read like the
-    other providers so it flows into usage metrics and telemetry.
 
     Args:
         data: The usage payload from the server's final stream chunk.
@@ -173,10 +170,10 @@ class LlamaCppModel(Model):
             use_native_token_count: Whether to use the native llama.cpp /tokenize endpoint.
                 When True, count_tokens() calls the server's tokenize endpoint for accurate counts.
                 When False (default), skips the API call and uses the local estimator.
-            cache_config: Enables llama.cpp's server-side caching. llama.cpp reuses the shared
-                prompt prefix across requests via a coarse ``cache_prompt`` boolean. Setting a CacheConfig
-                turns it on unless ``params["cache_prompt"]`` is set explicitly. llama.cpp has no per-field
-                cache controls, so every other CacheConfig field (ttl, cache_key, strategy, ...) is ignored.
+            cache_config: Prompt-caching configuration. llama.cpp uses the shared prompt prefix server-side 
+                by default. A CacheConfig pins ``cache_prompt: true`` on each request. An explicit 
+                ``params["cache_prompt"]`` takes precedence. llama.cpp has no per-field cache controls, so 
+                every other CacheConfig field is ignored.
         """
 
         model_id: str

--- a/strands-py/tests/strands/models/test_llamacpp.py
+++ b/strands-py/tests/strands/models/test_llamacpp.py
@@ -309,14 +309,32 @@ def test_cache_config_enables_cache_prompt_alongside_other_params(captured_warni
     assert not any("have no effect" in str(warning.message) for warning in captured_warnings)
 
 
-def test_cache_config_strategy_auto_enables_without_warning(captured_warnings) -> None:
-    """strategy="auto" is the default: it enables caching and warns about nothing, like a bare CacheConfig."""
+def test_cache_config_default_enables_without_warning(captured_warnings) -> None:
+    """A CacheConfig whose fields are all default (strategy="auto" is the default) warns about nothing."""
     model = LlamaCppModel(cache_config=CacheConfig(strategy="auto"))
 
     request = model._format_request([{"role": "user", "content": [{"text": "Test"}]}])
 
     assert request["cache_prompt"] is True
     assert not any("have no effect" in str(warning.message) for warning in captured_warnings)
+
+
+@pytest.mark.parametrize(
+    ("cache_config", "field"),
+    [
+        (CacheConfig(strategy="anthropic"), "strategy"),
+        (CacheConfig(system_prompt_ttl="1h"), "system_prompt_ttl"),
+        (CacheConfig(tools_ttl=True), "tools_ttl"),
+    ],
+)
+def test_cache_config_unsupported_field_warns_and_still_enables(cache_config, field) -> None:
+    """A non-default field llama.cpp cannot honor warns (naming the provider) and still enables caching."""
+    model = LlamaCppModel(cache_config=cache_config)
+
+    with pytest.warns(UserWarning, match=rf"fields \['{field}'\] have no effect on llama\.cpp"):
+        request = model._format_request([{"role": "user", "content": [{"text": "Test"}]}])
+
+    assert request["cache_prompt"] is True
 
 
 def test_explicit_cache_prompt_false_preserved() -> None:
@@ -355,7 +373,7 @@ def test_cache_config_unsupported_ttl_warns_and_still_enables() -> None:
     """llama.cpp has no retention control: ttl is a no-op that warns, and caching is still enabled."""
     model = LlamaCppModel(cache_config=CacheConfig(ttl="1h"))
 
-    with pytest.warns(UserWarning, match=r"fields \['ttl'\] have no effect"):
+    with pytest.warns(UserWarning, match=r"fields \['ttl'\] have no effect on llama\.cpp"):
         request = model._format_request([{"role": "user", "content": [{"text": "Test"}]}])
 
     assert request["cache_prompt"] is True
@@ -365,7 +383,7 @@ def test_cache_config_cache_key_warns_and_is_not_routed() -> None:
     """llama.cpp has no key-based cache routing: cache_key warns and is never placed on the request."""
     model = LlamaCppModel(cache_config=CacheConfig(cache_key="tenant-42"))
 
-    with pytest.warns(UserWarning, match=r"fields \['cache_key'\] have no effect"):
+    with pytest.warns(UserWarning, match=r"fields \['cache_key'\] have no effect on llama\.cpp"):
         request = model._format_request([{"role": "user", "content": [{"text": "Test"}]}])
 
     assert request["cache_prompt"] is True
@@ -448,19 +466,33 @@ async def test_stream_surfaces_cache_read_tokens() -> None:
             chunks.append(chunk)
 
     usage = next(chunk["metadata"]["usage"] for chunk in chunks if "metadata" in chunk)
-    assert usage["cacheReadInputTokens"] == 91
-    assert usage["inputTokens"] == 100
+    assert usage == {"inputTokens": 100, "outputTokens": 5, "totalTokens": 105, "cacheReadInputTokens": 91}
 
 
+_NO_REUSE_TOKENS = {"prompt_tokens": 100, "completion_tokens": 5, "total_tokens": 105}
+
+
+@pytest.mark.parametrize(
+    "usage_payload",
+    [
+        {**_NO_REUSE_TOKENS, "prompt_tokens_details": {"cached_tokens": 0}},
+        {**_NO_REUSE_TOKENS, "prompt_tokens_details": None},
+        _NO_REUSE_TOKENS,
+    ],
+    ids=["cached_zero", "details_null", "details_absent"],
+)
 @pytest.mark.asyncio
-async def test_stream_omits_cache_read_tokens_when_prefix_not_reused() -> None:
-    """With no cached prefix, cacheReadInputTokens is left absent rather than reported as zero."""
+async def test_stream_omits_cache_read_tokens_when_prefix_not_reused(usage_payload) -> None:
+    """No reuse — cached zero, a null details object, or the field absent — yields usage with no cache-read key.
+
+    The whole-dict assertion pins the ``or {}`` guard in stream() and the ``getattr(..., 0)`` default in
+    _format_usage: a fabricated non-zero default would add a phantom cacheReadInputTokens and fail here.
+    """
     model = LlamaCppModel()
 
     mock_response_lines = [
         'data: {"choices": [{"delta": {"content": "Hi"}, "finish_reason": "stop"}]}',
-        'data: {"usage": {"prompt_tokens": 100, "completion_tokens": 5, "total_tokens": 105, '
-        '"prompt_tokens_details": {"cached_tokens": 0}}}',
+        "data: " + json.dumps({"usage": usage_payload}),
         "data: [DONE]",
     ]
 
@@ -478,7 +510,7 @@ async def test_stream_omits_cache_read_tokens_when_prefix_not_reused() -> None:
             chunks.append(chunk)
 
     usage = next(chunk["metadata"]["usage"] for chunk in chunks if "metadata" in chunk)
-    assert "cacheReadInputTokens" not in usage
+    assert usage == {"inputTokens": 100, "outputTokens": 5, "totalTokens": 105}
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests/strands/models/test_llamacpp.py
+++ b/strands-py/tests/strands/models/test_llamacpp.py
@@ -420,6 +420,68 @@ async def test_stream_basic() -> None:
 
 
 @pytest.mark.asyncio
+async def test_stream_surfaces_cache_read_tokens() -> None:
+    """A reused KV prefix is surfaced as cacheReadInputTokens, like the other cache-aware providers.
+
+    llama.cpp reports the reused prefix length in usage.prompt_tokens_details.cached_tokens.
+    """
+    model = LlamaCppModel()
+
+    mock_response_lines = [
+        'data: {"choices": [{"delta": {"content": "Hi"}, "finish_reason": "stop"}]}',
+        'data: {"usage": {"prompt_tokens": 100, "completion_tokens": 5, "total_tokens": 105, '
+        '"prompt_tokens_details": {"cached_tokens": 91}}}',
+        "data: [DONE]",
+    ]
+
+    async def mock_aiter_lines():
+        for line in mock_response_lines:
+            yield line
+
+    mock_response = AsyncMock()
+    mock_response.aiter_lines = mock_aiter_lines
+    mock_response.raise_for_status = MagicMock()
+
+    with patch.object(model.client, "post", return_value=mock_response):
+        chunks = []
+        async for chunk in model.stream([{"role": "user", "content": [{"text": "Hi"}]}]):
+            chunks.append(chunk)
+
+    usage = next(chunk["metadata"]["usage"] for chunk in chunks if "metadata" in chunk)
+    assert usage["cacheReadInputTokens"] == 91
+    assert usage["inputTokens"] == 100
+
+
+@pytest.mark.asyncio
+async def test_stream_omits_cache_read_tokens_when_prefix_not_reused() -> None:
+    """With no cached prefix, cacheReadInputTokens is left absent rather than reported as zero."""
+    model = LlamaCppModel()
+
+    mock_response_lines = [
+        'data: {"choices": [{"delta": {"content": "Hi"}, "finish_reason": "stop"}]}',
+        'data: {"usage": {"prompt_tokens": 100, "completion_tokens": 5, "total_tokens": 105, '
+        '"prompt_tokens_details": {"cached_tokens": 0}}}',
+        "data: [DONE]",
+    ]
+
+    async def mock_aiter_lines():
+        for line in mock_response_lines:
+            yield line
+
+    mock_response = AsyncMock()
+    mock_response.aiter_lines = mock_aiter_lines
+    mock_response.raise_for_status = MagicMock()
+
+    with patch.object(model.client, "post", return_value=mock_response):
+        chunks = []
+        async for chunk in model.stream([{"role": "user", "content": [{"text": "Hi"}]}]):
+            chunks.append(chunk)
+
+    usage = next(chunk["metadata"]["usage"] for chunk in chunks if "metadata" in chunk)
+    assert "cacheReadInputTokens" not in usage
+
+
+@pytest.mark.asyncio
 async def test_structured_output() -> None:
     """Test structured output functionality."""
 

--- a/strands-py/tests/strands/models/test_llamacpp.py
+++ b/strands-py/tests/strands/models/test_llamacpp.py
@@ -10,6 +10,7 @@ import pytest
 from pydantic import BaseModel
 
 from strands.models.llamacpp import LlamaCppModel
+from strands.models.model import CacheConfig
 from strands.types.exceptions import (
     ContextWindowOverflowException,
     ModelThrottledException,
@@ -285,6 +286,93 @@ def test_get_config() -> None:
 
     assert retrieved_config["model_id"] == "test-model"
     assert retrieved_config["params"]["temperature"] == 0.9
+
+
+def test_cache_config_enables_cache_prompt_when_params_absent(captured_warnings) -> None:
+    """A CacheConfig turns on server-side prompt caching even when no params are configured."""
+    model = LlamaCppModel(cache_config=CacheConfig())
+
+    request = model._format_request([{"role": "user", "content": [{"text": "Test"}]}])
+
+    assert request["cache_prompt"] is True
+    assert not any("have no effect" in str(warning.message) for warning in captured_warnings)
+
+
+def test_cache_config_enables_cache_prompt_alongside_other_params(captured_warnings) -> None:
+    """Enabling caching does not clobber other configured params."""
+    model = LlamaCppModel(params={"temperature": 0.7}, cache_config=CacheConfig())
+
+    request = model._format_request([{"role": "user", "content": [{"text": "Test"}]}])
+
+    assert request["cache_prompt"] is True
+    assert request["temperature"] == 0.7
+    assert not any("have no effect" in str(warning.message) for warning in captured_warnings)
+
+
+def test_cache_config_strategy_auto_enables_without_warning(captured_warnings) -> None:
+    """strategy="auto" is the default: it enables caching and warns about nothing, like a bare CacheConfig."""
+    model = LlamaCppModel(cache_config=CacheConfig(strategy="auto"))
+
+    request = model._format_request([{"role": "user", "content": [{"text": "Test"}]}])
+
+    assert request["cache_prompt"] is True
+    assert not any("have no effect" in str(warning.message) for warning in captured_warnings)
+
+
+def test_explicit_cache_prompt_false_preserved() -> None:
+    """An explicit params["cache_prompt"] wins over the CacheConfig enable signal."""
+    model = LlamaCppModel(params={"cache_prompt": False}, cache_config=CacheConfig())
+
+    request = model._format_request([{"role": "user", "content": [{"text": "Test"}]}])
+
+    assert request["cache_prompt"] is False
+
+
+def test_cache_prompt_absent_without_cache_config() -> None:
+    """Without a CacheConfig, cache_prompt is left unset so the server default applies."""
+    model = LlamaCppModel()
+
+    request = model._format_request([{"role": "user", "content": [{"text": "Test"}]}])
+
+    assert "cache_prompt" not in request
+
+
+def test_cache_config_round_trips(captured_warnings) -> None:
+    """cache_config is a valid config field and survives get_config/update_config unchanged."""
+    cache_config = CacheConfig()
+    model = LlamaCppModel(cache_config=cache_config)
+
+    assert model.get_config()["cache_config"] is cache_config
+
+    updated = CacheConfig()
+    model.update_config(cache_config=updated)
+    assert model.get_config()["cache_config"] is updated
+
+    assert not any("Invalid configuration parameters" in str(warning.message) for warning in captured_warnings)
+
+
+def test_cache_config_unsupported_ttl_warns_and_still_enables() -> None:
+    """llama.cpp has no retention control: ttl is a no-op that warns, and caching is still enabled."""
+    model = LlamaCppModel(cache_config=CacheConfig(ttl="1h"))
+
+    with pytest.warns(UserWarning, match=r"fields \['ttl'\] have no effect"):
+        request = model._format_request([{"role": "user", "content": [{"text": "Test"}]}])
+
+    assert request["cache_prompt"] is True
+
+
+def test_cache_config_cache_key_warns_and_is_not_routed() -> None:
+    """llama.cpp has no key-based cache routing: cache_key warns and is never placed on the request."""
+    model = LlamaCppModel(cache_config=CacheConfig(cache_key="tenant-42"))
+
+    with pytest.warns(UserWarning, match=r"fields \['cache_key'\] have no effect"):
+        request = model._format_request([{"role": "user", "content": [{"text": "Test"}]}])
+
+    assert request["cache_prompt"] is True
+    assert "prompt_cache_key" not in request
+    assert "cache_key" not in request
+    assert "slot_id" not in request
+    assert "id_slot" not in request
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests_integ/models/test_model_llamacpp.py
+++ b/strands-py/tests_integ/models/test_model_llamacpp.py
@@ -9,6 +9,7 @@ Set LLAMACPP_TEST_URL environment variable to use a different server URL.
 """
 
 import os
+import uuid
 
 import pytest
 from pydantic import BaseModel
@@ -408,38 +409,34 @@ async def test_cache_prompt(llamacpp_model: LlamaCppModel) -> None:
 
 @pytest.mark.asyncio
 async def test_cache_config_enables_prompt_cache() -> None:
-    """A CacheConfig enables llama.cpp's server-side KV-prefix caching end to end.
+    """A CacheConfig makes llama.cpp reuse a shared prompt prefix, surfaced as cacheReadInputTokens.
 
-    Two requests sharing a long system prefix reuse the cached prefix on the server; observe the reuse
-    via the server log (``kv cache rm [p0, end)`` with p0 > 0 on the second request) rather than asserting
-    on latency, which is inherently flaky.
+    The first request over a unique long prefix populates the server KV cache (nothing to read back yet);
+    a second request over the same prefix reads it, so its cacheReadInputTokens is positive and larger
+    than the first request's. Asserting on the cache-read token count avoids the flakiness of timing.
     """
     model = LlamaCppModel(base_url=LLAMACPP_URL, cache_config=CacheConfig())
 
-    system_prompt = "You are a helpful assistant. Always be concise. " * 20
-    messages1: list[Message] = [
-        {"role": "system", "content": [{"text": system_prompt}]},
-        {"role": "user", "content": [{"text": "What is 2+2?"}]},
-    ]
-    messages2: list[Message] = [
-        {"role": "system", "content": [{"text": system_prompt}]},
-        {"role": "user", "content": [{"text": "What is 3+3?"}]},
-    ]
+    # Unique so a rerun cannot read a prior run's cache entry; long enough to exceed the server's
+    # minimum cacheable prefix length.
+    system_prompt = f"Session {uuid.uuid4()}. " + ("You are a helpful assistant. Always be concise. " * 40)
 
-    async def _collect(messages: list[Message]) -> str:
-        text = ""
+    async def cache_read_tokens(user_text: str) -> int:
+        messages: list[Message] = [
+            {"role": "system", "content": [{"text": system_prompt}]},
+            {"role": "user", "content": [{"text": user_text}]},
+        ]
+        reads = 0
         async for event in model.stream(messages):
-            if "contentBlockDelta" in event:
-                delta = event["contentBlockDelta"]["delta"]
-                if "text" in delta:
-                    text += delta["text"]
-        return text
+            if "metadata" in event:
+                reads = event["metadata"]["usage"].get("cacheReadInputTokens", 0)
+        return reads
 
-    response1 = await _collect(messages1)
-    response2 = await _collect(messages2)
+    cold_reads = await cache_read_tokens("What is 2+2?")
+    warm_reads = await cache_read_tokens("What is 3+3?")
 
-    assert "4" in response1
-    assert "6" in response2
+    assert warm_reads > 0, "second request should reuse the cached prefix (cacheReadInputTokens > 0)"
+    assert warm_reads > cold_reads, "second request should reuse more of the prefix than the first"
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests_integ/models/test_model_llamacpp.py
+++ b/strands-py/tests_integ/models/test_model_llamacpp.py
@@ -408,35 +408,36 @@ async def test_cache_prompt(llamacpp_model: LlamaCppModel) -> None:
 
 
 @pytest.mark.asyncio
-async def test_cache_config_enables_prompt_cache() -> None:
-    """A CacheConfig makes llama.cpp reuse a shared prompt prefix, surfaced as cacheReadInputTokens.
+async def test_cache_read_tokens_are_surfaced() -> None:
+    """llama.cpp's reused prompt prefix is surfaced end to end as cacheReadInputTokens.
 
-    The first request over a unique long prefix populates the server KV cache (nothing to read back yet);
-    a second request over the same prefix reads it, so its cacheReadInputTokens is positive and larger
-    than the first request's. Asserting on the cache-read token count avoids the flakiness of timing.
+    A first request over a unique long prefix has nothing to read back; a second request over the same
+    prefix reuses it, so its cacheReadInputTokens is positive and larger. A control model that forces
+    ``cache_prompt=False`` reuses nothing — proving the flag, not just the server's default, drives reuse.
     """
-    model = LlamaCppModel(base_url=LLAMACPP_URL, cache_config=CacheConfig())
-
-    # Unique so a rerun cannot read a prior run's cache entry; long enough to exceed the server's
-    # minimum cacheable prefix length.
+    # Unique so a rerun cannot read a prior run's cache entry; long enough that the reused count clearly
+    # exceeds the chat-template prefix.
     system_prompt = f"Session {uuid.uuid4()}. " + ("You are a helpful assistant. Always be concise. " * 40)
 
-    async def cache_read_tokens(user_text: str) -> int:
-        messages: list[Message] = [
-            {"role": "system", "content": [{"text": system_prompt}]},
-            {"role": "user", "content": [{"text": user_text}]},
-        ]
+    async def cache_read_tokens(model: LlamaCppModel, user_text: str) -> int:
+        messages: list[Message] = [{"role": "user", "content": [{"text": user_text}]}]
         reads = 0
-        async for event in model.stream(messages):
+        async for event in model.stream(messages, system_prompt=system_prompt):
             if "metadata" in event:
                 reads = event["metadata"]["usage"].get("cacheReadInputTokens", 0)
         return reads
 
-    cold_reads = await cache_read_tokens("What is 2+2?")
-    warm_reads = await cache_read_tokens("What is 3+3?")
+    cached = LlamaCppModel(base_url=LLAMACPP_URL, cache_config=CacheConfig())
+    cold_reads = await cache_read_tokens(cached, "What is 2+2?")
+    warm_reads = await cache_read_tokens(cached, "What is 3+3?")
 
     assert warm_reads > 0, "second request should reuse the cached prefix (cacheReadInputTokens > 0)"
     assert warm_reads > cold_reads, "second request should reuse more of the prefix than the first"
+
+    # Control: cache_prompt=False suppresses reuse, so the feature — not the server default — is what gates it.
+    uncached = LlamaCppModel(base_url=LLAMACPP_URL, params={"cache_prompt": False})
+    await cache_read_tokens(uncached, "What is 2+2?")
+    assert await cache_read_tokens(uncached, "What is 3+3?") == 0, "cache_prompt=False should reuse nothing"
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests_integ/models/test_model_llamacpp.py
+++ b/strands-py/tests_integ/models/test_model_llamacpp.py
@@ -14,6 +14,7 @@ import pytest
 from pydantic import BaseModel
 
 from strands.models.llamacpp import LlamaCppModel
+from strands.models.model import CacheConfig
 from strands.types.content import Message
 
 # Get server URL from environment or use default
@@ -401,6 +402,42 @@ async def test_cache_prompt(llamacpp_model: LlamaCppModel) -> None:
                 response2 += delta["text"]
 
     # Both should give valid responses
+    assert "4" in response1
+    assert "6" in response2
+
+
+@pytest.mark.asyncio
+async def test_cache_config_enables_prompt_cache() -> None:
+    """A CacheConfig enables llama.cpp's server-side KV-prefix caching end to end.
+
+    Two requests sharing a long system prefix reuse the cached prefix on the server; observe the reuse
+    via the server log (``kv cache rm [p0, end)`` with p0 > 0 on the second request) rather than asserting
+    on latency, which is inherently flaky.
+    """
+    model = LlamaCppModel(base_url=LLAMACPP_URL, cache_config=CacheConfig())
+
+    system_prompt = "You are a helpful assistant. Always be concise. " * 20
+    messages1: list[Message] = [
+        {"role": "system", "content": [{"text": system_prompt}]},
+        {"role": "user", "content": [{"text": "What is 2+2?"}]},
+    ]
+    messages2: list[Message] = [
+        {"role": "system", "content": [{"text": system_prompt}]},
+        {"role": "user", "content": [{"text": "What is 3+3?"}]},
+    ]
+
+    async def _collect(messages: list[Message]) -> str:
+        text = ""
+        async for event in model.stream(messages):
+            if "contentBlockDelta" in event:
+                delta = event["contentBlockDelta"]["delta"]
+                if "text" in delta:
+                    text += delta["text"]
+        return text
+
+    response1 = await _collect(messages1)
+    response2 = await _collect(messages2)
+
     assert "4" in response1
     assert "6" in response2
 


### PR DESCRIPTION
## Description

Every other model provider (Anthropic, Bedrock, OpenAI, LiteLLM, Mistral) honors the cross-provider `CacheConfig`, but `LlamaCppModel` did not — passing `cache_config=...` was silently dropped as an unknown config key. Meanwhile llama.cpp already exposes exactly the right optimization: server-side KV-cache prefix reuse via the `cache_prompt` request flag, so a shared prompt prefix is not re-processed across requests. Until now that was only reachable by hand-placing `cache_prompt` inside `params`. This makes `CacheConfig` the first-class, provider-agnostic way to turn it on.

llama.cpp's caching is a coarse whole-prefix boolean — it has no retention (`ttl`) and no key-based routing (there is no `prompt_cache_key`; the only slot knob is an integer index, not a cache identity). So a `CacheConfig` acts purely as an *enable signal*: when set, `cache_prompt` defaults to `True`; every granular field is a no-op that warns once (`supported=set()`); and an explicit `params["cache_prompt"]` always wins, including an explicit `False`.

Enabling caching is only half the story if you can't tell it worked. llama.cpp reports the reused-prefix length in `usage.prompt_tokens_details.cached_tokens`, which the provider previously discarded — cold and warm requests looked identical in usage metadata. This surfaces it as the SDK's canonical `cacheReadInputTokens`, exactly as OpenAI and LiteLLM do (read-only; llama.cpp has no separate cache-write phase). That routes the reused-prefix count into usage metrics and OpenTelemetry with no provider-specific telemetry code — the central tracer already maps `cacheReadInputTokens` to the GenAI-semconv attribute `gen_ai.usage.cache_read.input_tokens`. Since llama.cpp reports `prompt_tokens` inclusive of the cached prefix, the value is a subset of `inputTokens` rather than additive, which the SDK's prompt-token totaling already accounts for.

## Public API Changes

`LlamaCppModel` accepts a `cache_config` field that enables llama.cpp's server-side prompt-prefix reuse:

```python
from strands.models.llamacpp import LlamaCppModel
from strands.models.model import CacheConfig

# Before: cache_config was rejected as an unknown key (warned, then dropped);
# prefix reuse was only reachable by hand-placing cache_prompt in params.
model = LlamaCppModel(params={"cache_prompt": True})

# After: the cross-provider CacheConfig turns on KV-prefix reuse.
model = LlamaCppModel(cache_config=CacheConfig())
```

Fields llama.cpp cannot honor (`ttl`, `cache_key`, `tools_ttl`, ...) are ignored and warn once per call site; `strategy="auto"` is the default and warns about nothing. An explicit `params["cache_prompt"]` takes precedence over the enable signal.

Streamed usage metadata now reports the reused-prefix length as `cacheReadInputTokens` on a cache hit (absent when nothing was reused), matching the other cache-aware providers:

```python
async for event in model.stream(messages):
    if "metadata" in event:
        # Populated on a cache hit; flows into usage metrics and OTel telemetry.
        event["metadata"]["usage"].get("cacheReadInputTokens")
```

## Related Issues

None.

## Documentation PR

One big docs update for all caching changes once done

## Type of Change

New feature

## Testing

Ran the llama.cpp unit suite (`hatch test tests/strands/models/test_llamacpp.py`), which pins the enable-signal wiring on `_format_request` (config set + no param → `cache_prompt` True; explicit `params={"cache_prompt": False}` preserved; neither → key absent; `strategy="auto"` enables and warns about nothing), the warn-and-still-enable path for unsupported fields, that `cache_key` is never routed onto the request, and that a reused prefix surfaces as `cacheReadInputTokens` (present on a hit, absent when nothing was reused).

Verified end to end against a real `llama-server` (Qwen2.5-0.5B-Instruct): two requests sharing a long unique system prefix. The first reused nothing; the second reported `cacheReadInputTokens` of 448 — confirming the flag reaches the server, drives reuse, and the count is surfaced. Driving the same two calls through the tracer with an in-memory span exporter produced `gen_ai.usage.cache_read.input_tokens = 448` on the warm span and no cache attribute on the cold one, with `gen_ai.usage.input_tokens` unchanged — confirming semconv-compliant telemetry with the cached count reported as a subset of input, not added on top. The gated integration test (`test_cache_config_enables_prompt_cache`, `LLAMACPP_SKIP_TESTS`) asserts the warm request's `cacheReadInputTokens` is positive and exceeds the cold request's.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.