### PR TITLE
feat(bidi): add run_audio convenience

### DIFF
--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/agent.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/agent.mdx
@@ -285,10 +285,13 @@ await agent.start(invocation_state={...})
 #### 3. Running
 
 ```python
-# Option A: Using run()
+# Option A: Using local microphone and speakers
+await agent.run_audio()
+
+# Option B: Using custom I/O
 await agent.run(inputs=[...], outputs=[...])
 
-# Option B: Manual send/receive
+# Option C: Manual send/receive
 await agent.send("Hello")
 async for event in agent.receive():
     # Process events - events streaming, tools executing, messages accumulating
@@ -304,6 +307,16 @@ await agent.stop()
 
 ### Lifecycle Patterns
 
+#### Using run_audio()
+
+```python
+agent = BidiAgent(model=model)
+
+await agent.run_audio(audio_processor=True)
+```
+
+Simplest for local voice conversations. Creates `BidiAudioIO` internally and handles start/stop automatically.
+
 #### Using run()
 
 ```python
@@ -316,7 +329,7 @@ await agent.run(
 )
 ```
 
-Simplest for I/O-based applications - handles start/stop automatically.
+Use for custom or additional I/O channels. Handles start/stop automatically.
 
 #### Context Manager
 

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/quickstart.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/quickstart.mdx
@@ -146,7 +146,7 @@ Now let's create a simple voice-enabled agent that can have real-time conversati
 
 ```python
 import asyncio
-from strands.experimental.bidi import BidiAgent, BidiAudioIO
+from strands.experimental.bidi import BidiAgent
 from strands.experimental.bidi.models import BedrockNovaSonicModel
 
 # Create a bidirectional streaming model
@@ -158,15 +158,9 @@ agent = BidiAgent(
     system_prompt="You are a helpful voice assistant. Keep responses concise and natural."
 )
 
-# Setup audio I/O for microphone and speakers
-audio_io = BidiAudioIO()
-
 # Run the conversation
 async def main():
-    await agent.run(
-        inputs=[audio_io.input()],
-        outputs=[audio_io.output()]
-    )
+    await agent.run_audio()
 
 asyncio.run(main())
 ```
@@ -316,7 +310,7 @@ Customize audio configuration for both the model and I/O:
 ```python
 import asyncio
 
-from strands.experimental.bidi import BidiAgent, BidiAudioIO
+from strands.experimental.bidi import BidiAgent
 from strands.experimental.bidi.models import GoogleGeminiLiveModel
 
 # Configure model audio settings
@@ -330,20 +324,14 @@ model = GoogleGeminiLiveModel(
     }
 )
 
-# Configure I/O buffer settings
-audio_io = BidiAudioIO(
-    input_buffer_size=10,           # Max input queue size
-    output_buffer_size=20,          # Max output queue size
-    input_frames_per_buffer=512,   # Input chunk size
-    output_frames_per_buffer=512   # Output chunk size
-)
-
 agent = BidiAgent(model=model)
 
 async def main():
-    await agent.run(
-        inputs=[audio_io.input()],
-        outputs=[audio_io.output()]
+    await agent.run_audio(
+        input_buffer_size=10,           # Max input queue size
+        output_buffer_size=20,          # Max output queue size
+        input_frames_per_buffer=512,   # Input chunk size
+        output_frames_per_buffer=512,  # Output chunk size
     )
 
 asyncio.run(main())

--- a/strands-py/src/strands/experimental/bidi/agent/agent.py
+++ b/strands-py/src/strands/experimental/bidi/agent/agent.py
@@ -18,6 +18,8 @@ import logging
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any
 
+from typing_extensions import Unpack
+
 from .... import _identifier
 from ...._middleware import MiddlewareRegistry
 from ....agent.state import AgentState
@@ -47,6 +49,7 @@ from .loop import _BidiAgentLoop
 
 if TYPE_CHECKING:
     from ....session.session_manager import SessionManager
+    from ..io.audio import BidiAudioIOConfig
 
 logger = logging.getLogger(__name__)
 
@@ -226,11 +229,13 @@ class BidiAgent:
 
         Example:
             ```python
-            await agent.start(invocation_state={
-                "user_id": "user_123",
-                "session_id": "session_456",
-                "database": db_connection,
-            })
+            await agent.start(
+                invocation_state={
+                    "user_id": "user_123",
+                    "session_id": "session_456",
+                    "database": db_connection,
+                }
+            )
             ```
         """
         if self._started:
@@ -364,7 +369,7 @@ class BidiAgent:
             await agent.run(
                 inputs=[audio_io.input()],
                 outputs=[audio_io.output(), text_io.output()],
-                invocation_state={"user_id": "user_123"}
+                invocation_state={"user_id": "user_123"},
             )
 
             # Using custom audio config:
@@ -411,6 +416,36 @@ class BidiAgent:
             output_stops = [output.stop for output in outputs if isinstance(output, BidiOutput)]
 
             await stop_all(*input_stops, *output_stops, self.stop)
+
+    async def run_audio(
+        self,
+        *,
+        invocation_state: dict[str, Any] | None = None,
+        **audio_config: Unpack["BidiAudioIOConfig"],
+    ) -> None:
+        """Run the agent using the local microphone and speakers.
+
+        Args:
+            invocation_state: Optional context to pass to tools during execution.
+            **audio_config: Configuration passed to ``BidiAudioIO``.
+
+        Example:
+            ```python
+            await agent.run_audio(
+                audio_processor=True,
+                input_device_index=1,
+                invocation_state={"user_id": "user_123"},
+            )
+            ```
+        """
+        from ..io.audio import BidiAudioIO
+
+        audio_io = BidiAudioIO(**audio_config)
+        await self.run(
+            inputs=[audio_io.input()],
+            outputs=[audio_io.output()],
+            invocation_state=invocation_state,
+        )
 
     async def _append_messages(self, *messages: Message) -> None:
         """Append messages to history in sequence without interference.

--- a/strands-py/tests/strands/experimental/bidi/agent/test_agent.py
+++ b/strands-py/tests/strands/experimental/bidi/agent/test_agent.py
@@ -3,6 +3,7 @@
 import asyncio
 import sys
 import unittest.mock
+from types import ModuleType
 from uuid import uuid4
 
 import pytest
@@ -363,3 +364,27 @@ async def test_bidi_agent_state_consistency(agent):
     await agent.stop()
     assert not agent._started
     assert agent.model._connection_id is None
+
+
+@pytest.mark.asyncio
+async def test_bidi_agent_run_audio_delegates_to_run(agent, monkeypatch):
+    audio_io = unittest.mock.Mock()
+    audio_io_class = unittest.mock.Mock(return_value=audio_io)
+    audio_module = ModuleType("strands.experimental.bidi.io.audio")
+    audio_module.BidiAudioIO = audio_io_class
+    monkeypatch.setitem(sys.modules, "strands.experimental.bidi.io.audio", audio_module)
+    agent.run = unittest.mock.AsyncMock()
+    invocation_state = {"user_id": "user_123"}
+
+    await agent.run_audio(
+        audio_processor=True,
+        input_device_index=1,
+        invocation_state=invocation_state,
+    )
+
+    audio_io_class.assert_called_once_with(audio_processor=True, input_device_index=1)
+    agent.run.assert_awaited_once_with(
+        inputs=[audio_io.input.return_value],
+        outputs=[audio_io.output.return_value],
+        invocation_state=invocation_state,
+    )


### PR DESCRIPTION
## Description

Add `BidiAgent.run_audio()` as a convenience for local voice conversations.

The method:

- Configures local microphone input and speaker output through `BidiAudioIO`.
- Accepts the same typed keyword configuration as `BidiAudioIO`.
- Preserves `invocation_state` support for tool execution.
- Keeps the PyAudio-dependent audio implementation lazily imported.

## Related Issues

None.

## Documentation PR

Updated the bidirectional streaming quickstart and agent lifecycle guide to use `run_audio()` for local voice conversations and demonstrate audio configuration.

## Type of Change

New feature

## Testing

- `hatch run prepare`
- `npm run build --prefix site`
- Repository pre-commit checks

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.