### PR TITLE
ci: cancel superseded PR runs to reduce runner concurrency

### DIFF
--- a/.github/workflows/auto-strands-review.yml
+++ b/.github/workflows/auto-strands-review.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+
 jobs:
   authorization-check:
     # Authors who opt out of auto-review. They can still trigger it manually

--- a/.github/workflows/bot-pr-review-gate.yml
+++ b/.github/workflows/bot-pr-review-gate.yml
@@ -7,6 +7,10 @@ on:
   pull_request_review:
     types: [submitted, dismissed]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review' }}
+
 # pull_request_target runs in the base-repo context. This job only reads PR
 # metadata and reviews and sets the check status — it never checks out or
 # executes PR head code, and needs no write scope.

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
     types: [opened, edited, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   validate-pr-title:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-integration-test.yml
+++ b/.github/workflows/python-integration-test.yml
@@ -29,6 +29,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: python-integration-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ inputs.ref == '' && github.event_name == 'pull_request_target' }}
+
 jobs:
   validate-call-ref:
     name: Validate workflow_call ref

--- a/.github/workflows/typescript-integration-test.yml
+++ b/.github/workflows/typescript-integration-test.yml
@@ -36,6 +36,10 @@ on:
         default: false
         type: boolean
 
+concurrency:
+  group: typescript-integration-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ inputs.ref == '' && github.event_name == 'pull_request_target' }}
+
 jobs:
   validate-call-ref:
     name: Validate workflow_call ref


### PR DESCRIPTION
## Description

Cost-and-latency cleanup for C with a coupled Node 20 support drop to reduce runner concurrency, with the aim to speed up GitHub Action Workflows.

Today a second push to a PR leaves the prior run queued instead of cancelling it, so stale runs pile up and compete for runners. This adds workflow-level `concurrency` to the PR workflows that lacked it so a newer event (push) supersedes the older run. `cancel-in-progress` is written as a condition keyed to each workflow's own event name. 

## Related Issues

None.

## Documentation PR

Included in this PR under `site/` (and the two SDK docs) — the Node.js prerequisite is updated to 22+ to match the new engines floor.

## Type of Change

Breaking change

## Testing

`actionlint` isn't available locally, so I confirmed all six edited workflows parse as valid YAML and reasoned each `cancel-in-progress` condition against the GitHub Actions docs across every trigger path (PR push → cancels; `merge_group` → survives; release `workflow_call`, where `github.event_name` reports the caller's event → survives). The definitive live check — push twice to a PR and confirm the earlier run cancels while a queued merge-group run does not — runs in CI.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
