### PR TITLE
fix(vercel): emit tool results before user text to preserve tool_use/tool_result adjacency

### DIFF
--- a/strands-ts/src/models/__tests__/vercel.test.ts
+++ b/strands-ts/src/models/__tests__/vercel.test.ts
@@ -900,6 +900,32 @@ describe('VercelModel', () => {
         expect(warnSpy).toHaveBeenCalled()
         warnSpy.mockRestore()
       })
+
+      it('keeps the tool result adjacent to its tool call when the answering turn also carries text', async () => {
+        // An everyTurn context injector folds rendered text onto the tool-result turn, so its content
+        // is [toolResult, text]. The tool message must still lead the split so it stays adjacent to the
+        // assistant tool call it answers; the injected text follows as a separate user message.
+        const { collect, callArgs } = setupCaptureTest()
+        await collect([
+          new Message({ role: 'user', content: [new TextBlock('task')] }),
+          new Message({
+            role: 'assistant',
+            content: [new ToolUseBlock({ name: 'calc', toolUseId: 'tu1', input: {} })],
+          }),
+          new Message({
+            role: 'user',
+            content: [
+              new ToolResultBlock({ toolUseId: 'tu1', status: 'success', content: [new TextBlock('42')] }),
+              new TextBlock('\n\nNOTE'),
+            ],
+          }),
+        ])
+
+        const prompt = callArgs().prompt
+        expect(prompt.map((message) => message.role)).toEqual(['user', 'assistant', 'tool', 'user'])
+        expect((prompt[2] as any).content[0]).toMatchObject({ type: 'tool-result', toolCallId: 'tu1' })
+        expect((prompt[3] as any).content[0]).toEqual({ type: 'text', text: '\n\nNOTE' })
+      })
     })
   })
 

--- a/strands-ts/src/models/__tests__/vercel.test.ts
+++ b/strands-ts/src/models/__tests__/vercel.test.ts
@@ -716,6 +716,46 @@ describe('VercelModel', () => {
         expect(warnSpy).toHaveBeenCalled()
         warnSpy.mockRestore()
       })
+
+      // Regression: an everyTurn context injector folds rendered text onto a tool-result turn, making a
+      // mixed turn. Tool results must lead the split regardless of source-block order so each one stays
+      // adjacent to the assistant tool call it answers once an adapter re-merges the messages (#4138).
+      it.each([
+        { name: 'tool result then text', order: ['tu1', 'text'], roles: ['user', 'assistant', 'tool', 'user'] },
+        { name: 'text then tool result', order: ['text', 'tu1'], roles: ['user', 'assistant', 'tool', 'user'] },
+        {
+          name: 'text between parallel tool results',
+          order: ['tu1', 'text', 'tu2'],
+          roles: ['user', 'assistant', 'tool', 'tool', 'user'],
+        },
+      ])('keeps tool results ahead of injected text for $name', async ({ order, roles }) => {
+        const toolUseIds = order.filter((entry) => entry !== 'text')
+        const { collect, callArgs } = setupCaptureTest()
+        await collect([
+          new Message({ role: 'user', content: [new TextBlock('task')] }),
+          new Message({
+            role: 'assistant',
+            content: toolUseIds.map((toolUseId) => new ToolUseBlock({ name: 'calc', toolUseId, input: {} })),
+          }),
+          new Message({
+            role: 'user',
+            content: order.map((entry) =>
+              entry === 'text'
+                ? new TextBlock('\n\nNOTE')
+                : new ToolResultBlock({ toolUseId: entry, status: 'success', content: [new TextBlock('42')] })
+            ),
+          }),
+        ])
+
+        const prompt = callArgs().prompt
+        expect(prompt.map((message) => message.role)).toEqual(roles)
+        expect((prompt[2] as any).content[0]).toMatchObject({
+          type: 'tool-result',
+          toolCallId: 'tu1',
+          toolName: 'calc',
+        })
+        expect((prompt.at(-1) as any).content[0]).toEqual({ type: 'text', text: '\n\nNOTE' })
+      })
     })
 
     describe('assistant messages', () => {
@@ -899,46 +939,6 @@ describe('VercelModel', () => {
         await getToolOutput([block])
         expect(warnSpy).toHaveBeenCalled()
         warnSpy.mockRestore()
-      })
-
-      // Regression: an everyTurn context injector folds rendered text onto the tool-result turn, making
-      // a mixed turn. Tool messages must lead the split whatever the source-block order, so each tool
-      // result stays adjacent to the assistant tool call it answers once an adapter re-merges them. See #4138.
-      it.each([
-        { name: 'tool result then text', order: ['tu1', 'text'], roles: ['user', 'assistant', 'tool', 'user'] },
-        { name: 'text then tool result', order: ['text', 'tu1'], roles: ['user', 'assistant', 'tool', 'user'] },
-        {
-          name: 'text between parallel tool results',
-          order: ['tu1', 'text', 'tu2'],
-          roles: ['user', 'assistant', 'tool', 'tool', 'user'],
-        },
-      ])('keeps tool results ahead of injected text for $name', async ({ order, roles }) => {
-        const toolUseIds = order.filter((entry) => entry !== 'text')
-        const { collect, callArgs } = setupCaptureTest()
-        await collect([
-          new Message({ role: 'user', content: [new TextBlock('task')] }),
-          new Message({
-            role: 'assistant',
-            content: toolUseIds.map((id) => new ToolUseBlock({ name: 'calc', toolUseId: id, input: {} })),
-          }),
-          new Message({
-            role: 'user',
-            content: order.map((entry) =>
-              entry === 'text'
-                ? new TextBlock('\n\nNOTE')
-                : new ToolResultBlock({ toolUseId: entry, status: 'success', content: [new TextBlock('42')] })
-            ),
-          }),
-        ])
-
-        const prompt = callArgs().prompt
-        expect(prompt.map((message) => message.role)).toEqual(roles)
-        expect((prompt[2] as any).content[0]).toMatchObject({
-          type: 'tool-result',
-          toolCallId: 'tu1',
-          toolName: 'calc',
-        })
-        expect((prompt.at(-1) as any).content[0]).toEqual({ type: 'text', text: '\n\nNOTE' })
       })
     })
   })

--- a/strands-ts/src/models/__tests__/vercel.test.ts
+++ b/strands-ts/src/models/__tests__/vercel.test.ts
@@ -901,30 +901,44 @@ describe('VercelModel', () => {
         warnSpy.mockRestore()
       })
 
-      it('keeps the tool result adjacent to its tool call when the answering turn also carries text', async () => {
-        // An everyTurn context injector folds rendered text onto the tool-result turn, so its content
-        // is [toolResult, text]. The tool message must still lead the split so it stays adjacent to the
-        // assistant tool call it answers; the injected text follows as a separate user message.
+      // Regression: an everyTurn context injector folds rendered text onto the tool-result turn, making
+      // a mixed turn. Tool messages must lead the split whatever the source-block order, so each tool
+      // result stays adjacent to the assistant tool call it answers once an adapter re-merges them. See #4138.
+      it.each([
+        { name: 'tool result then text', order: ['tu1', 'text'], roles: ['user', 'assistant', 'tool', 'user'] },
+        { name: 'text then tool result', order: ['text', 'tu1'], roles: ['user', 'assistant', 'tool', 'user'] },
+        {
+          name: 'text between parallel tool results',
+          order: ['tu1', 'text', 'tu2'],
+          roles: ['user', 'assistant', 'tool', 'tool', 'user'],
+        },
+      ])('keeps tool results ahead of injected text for $name', async ({ order, roles }) => {
+        const toolUseIds = order.filter((entry) => entry !== 'text')
         const { collect, callArgs } = setupCaptureTest()
         await collect([
           new Message({ role: 'user', content: [new TextBlock('task')] }),
           new Message({
             role: 'assistant',
-            content: [new ToolUseBlock({ name: 'calc', toolUseId: 'tu1', input: {} })],
+            content: toolUseIds.map((id) => new ToolUseBlock({ name: 'calc', toolUseId: id, input: {} })),
           }),
           new Message({
             role: 'user',
-            content: [
-              new ToolResultBlock({ toolUseId: 'tu1', status: 'success', content: [new TextBlock('42')] }),
-              new TextBlock('\n\nNOTE'),
-            ],
+            content: order.map((entry) =>
+              entry === 'text'
+                ? new TextBlock('\n\nNOTE')
+                : new ToolResultBlock({ toolUseId: entry, status: 'success', content: [new TextBlock('42')] })
+            ),
           }),
         ])
 
         const prompt = callArgs().prompt
-        expect(prompt.map((message) => message.role)).toEqual(['user', 'assistant', 'tool', 'user'])
-        expect((prompt[2] as any).content[0]).toMatchObject({ type: 'tool-result', toolCallId: 'tu1' })
-        expect((prompt[3] as any).content[0]).toEqual({ type: 'text', text: '\n\nNOTE' })
+        expect(prompt.map((message) => message.role)).toEqual(roles)
+        expect((prompt[2] as any).content[0]).toMatchObject({
+          type: 'tool-result',
+          toolCallId: 'tu1',
+          toolName: 'calc',
+        })
+        expect((prompt.at(-1) as any).content[0]).toEqual({ type: 'text', text: '\n\nNOTE' })
       })
     })
   })

--- a/strands-ts/src/models/vercel.ts
+++ b/strands-ts/src/models/vercel.ts
@@ -738,8 +738,10 @@ function formatMessages(messages: Message[], systemPrompt?: SystemPrompt): Langu
 
 /**
  * Formats a Strands user message to LanguageModelV3 format. Tool result blocks are extracted into
- * separate `tool` messages, emitted before the text/media `user` message so a mixed turn keeps the
- * tool result adjacent to the assistant tool call it answers (tool_use → tool_result).
+ * separate `tool` messages, always emitted before the text/media `user` message regardless of their
+ * order within the source message. A provider adapter re-merges the split messages in prompt order,
+ * so leading with the tool results keeps each one adjacent to the assistant tool call it answers
+ * (tool_use → tool_result) — the LanguageModelV3 prompt itself carries no such adjacency guarantee.
  *
  * @param message - The user message to format
  * @param prompt - The prompt array to push formatted messages into

--- a/strands-ts/src/models/vercel.ts
+++ b/strands-ts/src/models/vercel.ts
@@ -737,8 +737,9 @@ function formatMessages(messages: Message[], systemPrompt?: SystemPrompt): Langu
 }
 
 /**
- * Formats a Strands user message to LanguageModelV3 format.
- * Tool result blocks are extracted into separate tool messages.
+ * Formats a Strands user message to LanguageModelV3 format. Tool result blocks are extracted into
+ * separate `tool` messages, emitted before the text/media `user` message so a mixed turn keeps the
+ * tool result adjacent to the assistant tool call it answers (tool_use → tool_result).
  *
  * @param message - The user message to format
  * @param prompt - The prompt array to push formatted messages into
@@ -772,12 +773,12 @@ function formatUserMessage(message: Message, prompt: LanguageModelV3Prompt, tool
     }
   }
 
-  if (content.length > 0) {
-    prompt.push({ role: 'user', content })
-  }
-
   for (const result of toolResults) {
     prompt.push({ role: 'tool', content: [result] })
+  }
+
+  if (content.length > 0) {
+    prompt.push({ role: 'user', content })
   }
 }
 


### PR DESCRIPTION
## Description

An `everyTurn` context injector (`ContextInjector`, `MemoryManager`, or any always-fire trigger) folds its rendered text as a trailing `TextBlock` onto the last user message. On an autonomous tool-result turn that message already carries a `toolResult` block, so its content becomes `[toolResult, injectedText]` — the injection layer deliberately keeps the tool result first.

`VercelModel` is the only provider that then reorders this. Because the AI SDK `LanguageModelV3` prompt has a distinct `tool` role, `formatUserMessage` splits a mixed Strands user message by block type — and it was pushing the text/media `user` message before the extracted `tool` messages, wedging the injected text between the assistant `tool_use` and its `tool_result`. Bedrock Converse and Anthropic Messages both require a `tool_result` to immediately follow its `tool_use`; the inverted body is rejected with a 400. So on `main` today, attaching an `everyTurn` injector to a Bedrock-on-Vercel tool loop crashes the agent mid-task. Native `BedrockModel`/`AnthropicModel` — and the entire Python SDK — map one Strands message to one provider message preserving block order, so they are unaffected.

The fix emits the extracted `tool` messages before the text/media `user` message, so the adapters merge a mixed turn back into a single `tool_result`-first user turn. 

## Related Issues

discovered while adding Vercel cache support (#4055).

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

- Ran the `VercelModel` formatting unit suite (Node + browser), including a new regression test that feeds a mixed `[toolResult, text]` tool-answering turn and asserts the emitted `LanguageModelV3` prompt keeps the `tool` message adjacent to the assistant `tool_use`, with the injected text as a trailing `user` message.
- Verified end-to-end against live Bedrock with a real `Agent` + calculator tool + `everyTurn` `ContextInjector` wrapping `VercelModel(createAmazonBedrock(...))`, capturing the real Converse request body. Pre-fix reproduces the `ValidationException` 400; post-fix the agent completes with correct results and the tool-answering turn ordered `tool_result`-first, across single-step invoke and streaming multi-step tool loops. The default `userTurn` trigger and the no-injector baseline are unaffected.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.