### PR TITLE
fix(openai): report max_tokens when a Responses function call is cut off

### DIFF
--- a/strands-py/src/strands/models/openai_responses.py
+++ b/strands-py/src/strands/models/openai_responses.py
@@ -483,11 +483,13 @@ class OpenAIResponsesModel(Model):
                 yield self._format_chunk({"chunk_type": "content_delta", "data_type": "tool", "data": tool_call})
                 yield self._format_chunk({"chunk_type": "content_stop", "data_type": "tool"})
 
-            # Determine finish reason: tool_calls > max_tokens (length) > normal stop
-            if tool_calls:
-                finish_reason = "tool_calls"
-            elif stop_reason == "length":
+            # Determine finish reason: max_tokens (length) > tool_calls > normal stop.
+            # A function call that is still in flight when the response is cut off has truncated
+            # arguments, so it must surface as max_tokens rather than be executed.
+            if stop_reason == "length":
                 finish_reason = "length"
+            elif tool_calls:
+                finish_reason = "tool_calls"
             else:
                 finish_reason = "stop"
             yield self._format_chunk({"chunk_type": "message_stop", "data": finish_reason})

--- a/strands-py/tests/strands/models/test_openai_responses.py
+++ b/strands-py/tests/strands/models/test_openai_responses.py
@@ -982,6 +982,35 @@ async def test_stream_response_incomplete(openai_client, model, agenerator, alis
 
 
 @pytest.mark.asyncio
+async def test_stream_response_incomplete_with_truncated_tool_call(openai_client, model, agenerator, alist):
+    """Test that max_tokens takes precedence over tool_use when a function call is cut off."""
+    mock_item_added_event = unittest.mock.Mock(
+        type="response.output_item.added",
+        item=unittest.mock.Mock(type="function_call", call_id="call_1", name="write_file", id="fc_1"),
+    )
+    mock_args_event = unittest.mock.Mock(
+        type="response.function_call_arguments.delta", item_id="fc_1", delta='{"path": "notes.md", "content": "Lorem'
+    )
+    mock_incomplete_event = unittest.mock.Mock(
+        type="response.incomplete",
+        response=unittest.mock.Mock(
+            usage=unittest.mock.Mock(input_tokens=10, output_tokens=50, total_tokens=60, input_tokens_details=None),
+            incomplete_details=unittest.mock.Mock(reason="max_output_tokens"),
+        ),
+    )
+
+    openai_client.responses.create = unittest.mock.AsyncMock(
+        return_value=agenerator([mock_item_added_event, mock_args_event, mock_incomplete_event])
+    )
+
+    messages = [{"role": "user", "content": [{"text": "save my notes"}]}]
+    tru_events = await alist(model.stream(messages))
+
+    assert {"messageStop": {"stopReason": "max_tokens"}} in tru_events
+    assert {"messageStop": {"stopReason": "tool_use"}} not in tru_events
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "event_type",
     [


### PR DESCRIPTION
## Description

When the OpenAI Responses API returns `response.incomplete` with `incomplete_details.reason == "max_output_tokens"` after a `function_call` output item has started, `OpenAIResponsesModel` reported `stopReason: "tool_use"` instead of `"max_tokens"`. The event loop then executed the truncated tool call (with `input: {}` because the partial JSON does not parse) instead of running `recover_message_on_max_tokens_reached` and raising `MaxTokensReachedException`.

Root cause: `tool_calls` is populated on `response.output_item.added`, i.e. before any arguments have streamed, and the finish-reason mapping gave `tool_calls` precedence over the `length` stop reason. So any function call in flight when the response was cut off won over `length`.

Changes:
- `openai_responses.py`: check `stop_reason == "length"` before `tool_calls` when computing `finish_reason`. This matches `OpenAIModel` (Chat Completions), which forwards `finish_reason == "length"` regardless of accumulated tool-call deltas.
- `test_openai_responses.py`: add a regression test for a function call cut off by `max_output_tokens`, asserting `max_tokens` is reported and `tool_use` is not.

Note: #3419 contains the same two-line reordering as part of a much larger change. This PR isolates the stop-reason fix so it can land on its own; the resulting code in that block is identical, so there is no conflict in outcome.

The TypeScript Responses adapter has the same precedence (`responses-adapter.ts`, `stopReason = 'toolUse'` after `maxTokens` was set). I left it out to keep this PR focused and can follow up separately.

## Related Issues

Fixes #4135

## Documentation PR

No documentation change needed.

## Type of Change

Bug fix

## Testing

- `pytest tests/strands/models/test_openai_responses.py`: 137 passed (136 existing + 1 new).
- New test fails on `main` without the source change and passes with it.
- `pytest tests/strands/event_loop`: 173 passed.
- `ruff format --check`, `ruff check`, `mypy` on the two changed files: clean.
- Full `tests/` run: 5174 passed; the 2 failures in `test_mcp_client.py::test_mcp_client_client_info_passed` also fail on unmodified `upstream/main` in my environment, and the collection errors are optional-dependency modules (a2a, writer, cedar) not installed in my env.
- Repro from #4135 now prints `messageStop: [{'messageStop': {'stopReason': 'max_tokens'}}]` and the agent raises `MaxTokensReachedException` instead of invoking the tool with empty input.

- [ ] I ran `hatch run prepare` (hatch is not installed locally; I ran the equivalent ruff/mypy/pytest commands above)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
