### PR TITLE
fix(bidi): internal renames for bidi constants and private class

### DIFF
--- a/strands-py/src/strands/experimental/bidi/agent/_reconnect_timer.py
+++ b/strands-py/src/strands/experimental/bidi/agent/_reconnect_timer.py
@@ -1,6 +1,6 @@
 """Proactive reconnect timer for bidirectional streaming.
 
-``_BidiReconnectTimer`` fires a warning then a deadline callback at caller-supplied offsets;
+``BidiReconnectTimer`` fires a warning then a deadline callback at caller-supplied offsets;
 it holds no reconnect policy. ``resolve_deadline_s`` reads the deadline from a provider's
 declared ``BidiConnectionConfig``.
 """
@@ -14,7 +14,7 @@ from ..types.model import BidiConnectionConfig
 logger = logging.getLogger(__name__)
 
 
-def resolve_deadline_s(connection_config: BidiConnectionConfig) -> float | None:
+def resolve_deadline_s(connection_config: BidiConnectionConfig) -> int | None:
     """Resolve the proactive reconnect deadline in seconds from a connection config.
 
     Args:
@@ -29,20 +29,17 @@ def resolve_deadline_s(connection_config: BidiConnectionConfig) -> float | None:
     return restart_after_s
 
 
-class _BidiReconnectTimer:
+class BidiReconnectTimer:
     """Fire a warning then a deadline callback ahead of a provider's connection limit.
 
     The clock is injectable so tests can drive timing without wall time.
-
-    Attributes:
-        _sleep: Injectable async sleep, defaults to ``asyncio.sleep``.
     """
 
     def __init__(
         self,
-        on_warning: Callable[[float], Awaitable[None]],
+        on_warning: Callable[[int], Awaitable[None]],
         on_deadline: Callable[[], Awaitable[None]],
-        sleep: Callable[[float], Awaitable[None]] | None = None,
+        sleep: Callable[[int], Awaitable[None]] | None = None,
     ) -> None:
         """Initialize the timer.
 
@@ -56,7 +53,7 @@ class _BidiReconnectTimer:
         self._sleep = sleep or asyncio.sleep
         self._task: asyncio.Task | None = None
 
-    def arm(self, deadline_s: float, warning_lead_s: float) -> None:
+    def arm(self, deadline_s: int, warning_lead_s: int) -> None:
         """Arm the warning and deadline timers, cancelling any previously armed cycle.
 
         Args:
@@ -77,14 +74,14 @@ class _BidiReconnectTimer:
             self._task.cancel()
             self._task = None
 
-    async def _run(self, deadline_s: float, warning_lead_s: float) -> None:
+    async def _run(self, deadline_s: int, warning_lead_s: int) -> None:
         """Sleep until the warning lead, fire the warning, then fire the deadline.
 
         The warning fires ``warning_lead_s`` before the deadline. When the lead is zero
         or exceeds the deadline, the warning is emitted immediately and the remaining
         wait runs down to the deadline.
         """
-        warning_at_s = max(deadline_s - warning_lead_s, 0.0)
+        warning_at_s = max(deadline_s - warning_lead_s, 0)
 
         await self._sleep(warning_at_s)
         time_left_s = deadline_s - warning_at_s

--- a/strands-py/src/strands/experimental/bidi/agent/loop.py
+++ b/strands-py/src/strands/experimental/bidi/agent/loop.py
@@ -44,7 +44,7 @@ from ..types.events import (
     BidiUsageEvent,
 )
 from ..types.model import BidiConnectionConfig
-from ._reconnect_timer import _BidiReconnectTimer, resolve_deadline_s
+from ._reconnect_timer import BidiReconnectTimer, resolve_deadline_s
 
 if TYPE_CHECKING:
     from .agent import BidiAgent
@@ -52,13 +52,13 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Bound on awaiting a superseded reader after its stream is closed before cancelling it.
-_READER_REAP_TIMEOUT_S = 2.0
+_MODEL_RESTART_STOP_TIMEOUT_S = 2
 
 # Fixed advance notice, in seconds before a scheduled reconnect, for the warning event.
-_WARNING_LEAD_S = 10.0
+_MODEL_RESTART_WARNING_S = 10
 
 # Max seconds a proactive reconnect waits for a turn boundary before forcing the swap.
-_TURN_ALIGN_WAIT_S = 10.0
+_MODEL_RESTART_TURN_TIMEOUT_S = 10
 
 
 @dataclass(frozen=True)
@@ -123,7 +123,7 @@ class _BidiAgentLoop:
         self._baseline_total_tokens = 0
         self._baseline_cache_read_tokens = 0
 
-        self._reconnect_timer = _BidiReconnectTimer(
+        self._reconnect_timer = BidiReconnectTimer(
             on_warning=self._on_reconnect_warning,
             on_deadline=self._on_reconnect_deadline,
         )
@@ -367,9 +367,9 @@ class _BidiAgentLoop:
         deadline_s = resolve_deadline_s(self._connection_config())
         if deadline_s is None:
             return
-        self._reconnect_timer.arm(deadline_s, _WARNING_LEAD_S)
+        self._reconnect_timer.arm(deadline_s, _MODEL_RESTART_WARNING_S)
 
-    async def _on_reconnect_warning(self, time_left_s: float) -> None:
+    async def _on_reconnect_warning(self, time_left_s: int) -> None:
         """Timer callback: surface an approaching-reconnect warning to the receiver.
 
         Emitted on the lifecycle queue: non-blocking (so it never stalls the timer's run to the
@@ -408,15 +408,18 @@ class _BidiAgentLoop:
         """Wait for the current turn to finish, bounded so the reconnect beats the limit.
 
         Returns immediately at a turn boundary (including for a provider that emits no turn
-        events). Otherwise waits up to ``_TURN_ALIGN_WAIT_S`` for the turn to complete, then
+        events). Otherwise waits up to ``_MODEL_RESTART_TURN_TIMEOUT_S`` for the turn to complete, then
         proceeds so the swap does not overrun the headroom below the provider limit.
         """
         if self._turn_complete.is_set():
             return
         try:
-            await asyncio.wait_for(self._turn_complete.wait(), timeout=_TURN_ALIGN_WAIT_S)
+            await asyncio.wait_for(self._turn_complete.wait(), timeout=_MODEL_RESTART_TURN_TIMEOUT_S)
         except asyncio.TimeoutError:
-            logger.debug("no turn boundary within %.1fs | forcing reconnect", _TURN_ALIGN_WAIT_S)
+            logger.debug(
+                "no turn boundary within %.1fs | forcing reconnect",
+                _MODEL_RESTART_TURN_TIMEOUT_S,
+            )
 
     def _reset_turn_state(self) -> None:
         """Reset turn tracking to the idle boundary state."""
@@ -505,7 +508,7 @@ class _BidiAgentLoop:
             previous_reader = self._model_task
             self._generation += 1
             await self._reconnect_model(restart_kwargs)
-            await self._await_superseded_reader(previous_reader)
+            await self._wait_for_model_task(previous_reader)
             self._model_task = self._task_pool.create(self._run_model(self._generation))
         except Exception as exception:
             restart_exception = exception
@@ -539,7 +542,7 @@ class _BidiAgentLoop:
 
         await model.reconnect(system_prompt, tools, messages, **restart_kwargs)
 
-    async def _await_superseded_reader(self, task: asyncio.Task | None) -> None:
+    async def _wait_for_model_task(self, task: asyncio.Task | None) -> None:
         """Await a superseded reader after its stream is closed; cancel only as a backstop.
 
         The reader is expected to fall out of receive() when its connection is closed. It is
@@ -549,7 +552,7 @@ class _BidiAgentLoop:
         if task is None or task.done():
             return
         try:
-            await asyncio.wait_for(task, timeout=_READER_REAP_TIMEOUT_S)
+            await asyncio.wait_for(task, timeout=_MODEL_RESTART_STOP_TIMEOUT_S)
         except Exception as error:
             # Expected: the reader's stream-close error, or the reap timeout. Logged, not
             # forwarded — the current reader is the only one that surfaces errors to the consumer.

--- a/strands-py/tests/strands/experimental/bidi/agent/test_loop.py
+++ b/strands-py/tests/strands/experimental/bidi/agent/test_loop.py
@@ -642,7 +642,7 @@ async def test_forced_swap_flags_interrupted_turn(agent, agenerator):
     loop._update_turn_state()
 
     # Force the turn-alignment wait to time out immediately (no wall-clock wait).
-    with unittest.mock.patch("strands.experimental.bidi.agent.loop._TURN_ALIGN_WAIT_S", 0.0):
+    with unittest.mock.patch("strands.experimental.bidi.agent.loop._MODEL_RESTART_TURN_TIMEOUT_S", 0):
         await loop._on_reconnect_deadline()
 
     restart = await loop._lifecycle_queue.get()
@@ -656,7 +656,7 @@ async def test_forced_swap_flags_interrupted_turn(agent, agenerator):
 async def test_proactive_reconnect_waits_for_turn_boundary(loop, agent, agenerator):
     """A proactive reconnect defers until the in-progress turn completes (turn alignment)."""
     # The real timer is cancelled so the deadline is driven manually; the turn state is set
-    # directly, and _await_turn_boundary waits up to _TURN_ALIGN_WAIT_S for the boundary.
+    # directly, and _await_turn_boundary waits up to _MODEL_RESTART_TURN_TIMEOUT_S for the boundary.
     agent.model.connection_config = {"restart_after_s": 60}
     agent.model.receive = unittest.mock.Mock(return_value=agenerator([]))
     await loop.start()

--- a/strands-py/tests/strands/experimental/bidi/agent/test_reconnect_timer.py
+++ b/strands-py/tests/strands/experimental/bidi/agent/test_reconnect_timer.py
@@ -8,7 +8,7 @@ import asyncio
 
 import pytest
 
-from strands.experimental.bidi.agent._reconnect_timer import _BidiReconnectTimer, resolve_deadline_s
+from strands.experimental.bidi.agent._reconnect_timer import BidiReconnectTimer, resolve_deadline_s
 
 # resolve_deadline_s
 
@@ -30,7 +30,7 @@ def test_resolve_deadline_none_when_not_positive():
     assert resolve_deadline_s({"restart_after_s": -5}) is None
 
 
-# _BidiReconnectTimer
+# BidiReconnectTimer
 
 
 @pytest.mark.asyncio
@@ -42,26 +42,26 @@ async def test_timer_fires_warning_then_deadline():
     async def fake_sleep(seconds):
         sleeps.append(seconds)
 
-    timer = _BidiReconnectTimer(
+    timer = BidiReconnectTimer(
         on_warning=lambda t: _record(warnings, t),
         on_deadline=lambda: _record(deadlines, None),
         sleep=fake_sleep,
     )
 
     # deadline 420, warning 30 before it => sleep 390 then 30.
-    timer.arm(deadline_s=420.0, warning_lead_s=30.0)
+    timer.arm(deadline_s=420, warning_lead_s=30)
 
     await timer._task
 
-    assert sleeps == [390.0, 30.0]
-    assert warnings == [30.0]  # time_left_s at warning == warning_lead_s
+    assert sleeps == [390, 30]
+    assert warnings == [30]  # time_left_s at warning == warning_lead_s
     assert deadlines == [None]
 
 
 @pytest.mark.asyncio
 async def test_timer_cancel_is_safe_when_idle():
     """cancel() before arming does not raise."""
-    timer = _BidiReconnectTimer(on_warning=_noop_arg, on_deadline=_noop)
+    timer = BidiReconnectTimer(on_warning=_noop_arg, on_deadline=_noop)
     timer.cancel()  # should not raise
 
 
@@ -76,17 +76,17 @@ async def test_timer_rearm_cancels_previous():
         started.set()
         await asyncio.sleep(3600)
 
-    timer = _BidiReconnectTimer(
+    timer = BidiReconnectTimer(
         on_warning=_noop_arg,
         on_deadline=lambda: _record(deadlines, None),
         sleep=slow_sleep,
     )
 
-    timer.arm(deadline_s=420.0, warning_lead_s=30.0)
+    timer.arm(deadline_s=420, warning_lead_s=30)
     await started.wait()
     first_task = timer._task
 
-    timer.arm(deadline_s=420.0, warning_lead_s=30.0)
+    timer.arm(deadline_s=420, warning_lead_s=30)
 
     await asyncio.sleep(0)
     assert first_task.cancelled() or first_task.done()

--- a/strands-py/tests/strands/experimental/bidi/models/test_google.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_google.py
@@ -483,7 +483,7 @@ async def test_proactive_reconnect_end_to_end_through_agent(mock_genai_client, m
 
     mock_live_session.receive = unittest.mock.Mock(side_effect=blocking_receive)
     # Reap the parked superseded reader promptly instead of waiting the full backstop.
-    monkeypatch.setattr(loop_module, "_READER_REAP_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(loop_module, "_MODEL_RESTART_STOP_TIMEOUT_S", 0.05)
 
     model = GoogleGeminiLiveModel(model_id=model_id, client_config={"api_key": api_key})
     # A small deadline; the injected clock below fires it without wall time.


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

Clarifies the bidi reconnect implementation by using restart-oriented names for internal constants and helpers. The reconnect timer now uses integer-second values consistently with `BidiConnectionConfig` and no longer documents private implementation attributes. Follow-up to #3874.

No behavior or public API changes.
## Related Issues

<!-- Link to related issues using #issue-number format -->
https://github.com/strands-agents/harness-sdk/issues/3721

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Other (please describe): renames based on follow-up in https://github.com/strands-agents/harness-sdk/pull/3874

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [ ] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
