### PR TITLE
ci: use strands-agents 4-core runner pool

### DIFF
--- a/.github/workflows/api-review-label.yml
+++ b/.github/workflows/api-review-label.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check-api-review-label:
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     permissions:
       pull-requests: read
     steps:

--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   auto-close:
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     strategy:
       matrix:
         include:

--- a/.github/workflows/auto-strands-review.yml
+++ b/.github/workflows/auto-strands-review.yml
@@ -17,7 +17,7 @@ jobs:
     name: Check access
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     outputs:
       approval-env: ${{ steps.auth.outputs.approval-env }}
     steps:
@@ -38,7 +38,7 @@ jobs:
     permissions:
       actions: write
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     steps:
       - name: Trigger Strands Command Workflow
         uses: actions/github-script@v9

--- a/.github/workflows/bot-pr-review-gate.yml
+++ b/.github/workflows/bot-pr-review-gate.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   check-bot-reviews:
     name: 2 Approvers for Bots
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     steps:
       - name: Enforce maintainer reviews for bot/agent PRs
         uses: actions/github-script@v9

--- a/.github/workflows/catalog-editorial-review.yml
+++ b/.github/workflows/catalog-editorial-review.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   flag-editorial-fields:
     name: Flag editorial catalog fields
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     steps:
       # The review script parses entry YAML with js-yaml, which github-script
       # doesn't bundle. Installed from the registry into the (empty) workspace

--- a/.github/workflows/catalog-stats.yml
+++ b/.github/workflows/catalog-stats.yml
@@ -12,7 +12,7 @@ jobs:
   refresh:
     # Upstream only: the bot fork mirrors main and lacks the bot token secret.
     if: github.repository == 'strands-agents/harness-sdk'
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     concurrency:
       group: catalog-stats
       cancel-in-progress: false

--- a/.github/workflows/changelog-sync.yml
+++ b/.github/workflows/changelog-sync.yml
@@ -34,7 +34,7 @@ jobs:
       startsWith(github.event.release.tag_name, 'python/v') ||
       startsWith(github.event.release.tag_name, 'typescript/v') ||
       startsWith(github.event.release.tag_name, 'v'))
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     # De-dupes runs of the same event type + tag. Deliberately does NOT
     # serialize release vs. cron: a cross-event duplicate PR has identical
     # content and is closed manually. In-flight syncs finish (no cancel).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   detect-changes:
     name: Detect Changes
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     permissions:
       pull-requests: read
       contents: read
@@ -64,7 +64,7 @@ jobs:
     # to a vulnerable version); pre-existing advisories do not block.
     # PR-only: it needs a base ref to diff, so it is skipped on dispatch.
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     permissions:
       contents: read
     steps:
@@ -115,7 +115,7 @@ jobs:
     name: PR Metrics Scripts
     needs: detect-changes
     if: needs.detect-changes.outputs.pr-metrics == 'true'
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     permissions:
       contents: read
     steps:
@@ -138,7 +138,7 @@ jobs:
     name: CI Gate
     if: always()
     needs: [detect-changes, dependency-review, python, typescript, docs, mcp, pr-metrics]
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     permissions: {}
     steps:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -14,7 +14,7 @@ defaults:
 jobs:
   ci:
     name: CI
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/docs-deploy-github-pages.yml
+++ b/.github/workflows/docs-deploy-github-pages.yml
@@ -12,7 +12,7 @@ defaults:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
 
     steps:
       - name: Checkout

--- a/.github/workflows/docs-deploy-preview.yml
+++ b/.github/workflows/docs-deploy-preview.yml
@@ -15,7 +15,7 @@ jobs:
   authorization-check:
     name: Authorization Check
     permissions: read-all
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     outputs:
       approval-env: ${{ steps.auth.outputs.approval-env }}
     steps:
@@ -28,7 +28,7 @@ jobs:
 
   build-and-deploy:
     name: Build and Deploy Preview
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     needs: authorization-check
     environment: ${{ needs.authorization-check.outputs.approval-env }}
 

--- a/.github/workflows/docs-strands-command.yml
+++ b/.github/workflows/docs-strands-command.yml
@@ -25,7 +25,7 @@ jobs:
     if: startsWith(github.event.comment.body, '/strands') || github.event_name == 'workflow_dispatch'
     name: Check access
     permissions: read-all
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     outputs:
       approval-env: ${{ steps.auth.outputs.approval-env }}
     steps:
@@ -46,7 +46,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     steps:
       - name: Parse input
         id: parse
@@ -63,7 +63,7 @@ jobs:
       issues: read
       pull-requests: read
       id-token: write # Required for OIDC
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     timeout-minutes: 60
     steps:
       - name: Setup Node.js
@@ -90,7 +90,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     timeout-minutes: 30
     steps:
       - name: Execute write operations

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   label-area:
     name: "Label: Area"
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     timeout-minutes: 2
     steps:
       - uses: actions/checkout@v7
@@ -30,7 +30,7 @@ jobs:
 
   label-type:
     name: "Label: Type"
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     timeout-minutes: 2
     steps:
       - uses: actions/checkout@v7
@@ -45,7 +45,7 @@ jobs:
 
   label-language:
     name: "Label: Language"
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     timeout-minutes: 2
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/issue-responder.yml
+++ b/.github/workflows/issue-responder.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   respond-to-issue:
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     # Only run for repository-affiliated authors. This is intentional: the job
     # assumes an AWS role via OIDC and forwards issue text to a Bedrock AgentCore
     # runtime, so an arbitrary account opening an issue must not be able to drive

--- a/.github/workflows/mcp-security-audit.yml
+++ b/.github/workflows/mcp-security-audit.yml
@@ -12,7 +12,7 @@ jobs:
     name: pip-audit
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     defaults:
       run:
         working-directory: strands-mcp

--- a/.github/workflows/mcp-test-lint.yml
+++ b/.github/workflows/mcp-test-lint.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   test-lint:
     name: Test and Lint
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     permissions:
       contents: read
     defaults:

--- a/.github/workflows/mcp-test-package-build.yml
+++ b/.github/workflows/mcp-test-package-build.yml
@@ -22,7 +22,7 @@ jobs:
     name: Wheel install
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
 
     steps:
       - name: Checkout code

--- a/.github/workflows/pr-metrics-analyze.yml
+++ b/.github/workflows/pr-metrics-analyze.yml
@@ -27,7 +27,7 @@ permissions: {}
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     timeout-minutes: 10
     steps:
       # The base revision supplies the analysis scripts and pinned tool

--- a/.github/workflows/pr-metrics-label.yml
+++ b/.github/workflows/pr-metrics-label.yml
@@ -33,7 +33,7 @@ jobs:
     name: Label
     # A failed analysis has nothing trustworthy to label with.
     if: github.event.workflow_run.conclusion == 'success'
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     timeout-minutes: 5
     permissions:
       pull-requests: write

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   validate-pr-title:
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     permissions:
       pull-requests: read
     steps:

--- a/.github/workflows/python-check-markdown-links.yml
+++ b/.github/workflows/python-check-markdown-links.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check-links:
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/python-integration-test.yml
+++ b/.github/workflows/python-integration-test.yml
@@ -37,7 +37,7 @@ jobs:
   validate-call-ref:
     name: Validate workflow_call ref
     if: inputs.ref != ''
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     permissions:
       contents: read
     # Reject ref shapes that could check out untrusted code:
@@ -75,7 +75,7 @@ jobs:
       (needs.validate-call-ref.result == 'success' || needs.validate-call-ref.result == 'skipped')
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     outputs:
       approval-env: ${{ steps.auth.outputs.approval-env }}
     steps:
@@ -97,7 +97,7 @@ jobs:
 
   check-access-and-checkout:
     name: Run integration tests - Python ${{ matrix.python-version }} - ${{ matrix.scope }}
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     needs: authorization-check
     if: always() && needs.authorization-check.result == 'success'
     strategy:
@@ -160,7 +160,7 @@ jobs:
           path: strands-py/build/test-results.xml
 
   upload-metrics:
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     needs: check-access-and-checkout
     # Publishes to the team's CloudWatch via STRANDS_INTEG_TEST_ROLE. Only run
     # when the integration-test job actually executed; on fork PRs the auth

--- a/.github/workflows/python-pr-and-push.yml
+++ b/.github/workflows/python-pr-and-push.yml
@@ -22,7 +22,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   check-api:
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     permissions:
       contents: read
     steps:

--- a/.github/workflows/python-publish-lambda-layer.yml
+++ b/.github/workflows/python-publish-lambda-layer.yml
@@ -37,7 +37,7 @@ on:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     permissions: {}
     steps:
       - name: Validate confirmation
@@ -52,7 +52,7 @@ jobs:
 
   package-and-upload:
     needs: validate
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     strategy:
       matrix:
         python-version: ${{ inputs.python_version == 'ALL' && fromJson('["3.10", "3.11", "3.12", "3.13"]') || fromJson(format('["{0}"]', inputs.python_version)) }}
@@ -106,7 +106,7 @@ jobs:
 
   publish-layer:
     needs: package-and-upload
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     strategy:
       matrix:
         python-version: ${{ inputs.python_version == 'ALL' && fromJson('["3.10", "3.11", "3.12", "3.13"]') || fromJson(format('["{0}"]', inputs.python_version)) }}

--- a/.github/workflows/python-security-audit.yml
+++ b/.github/workflows/python-security-audit.yml
@@ -12,7 +12,7 @@ jobs:
     name: pip-audit
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     defaults:
       run:
         working-directory: strands-py

--- a/.github/workflows/python-test-lint.yml
+++ b/.github/workflows/python-test-lint.yml
@@ -19,35 +19,35 @@ jobs:
       matrix:
        include:
         # Linux
-        - os: ubuntu-latest
+        - os: strands-agents_ubuntu-latest_4-core
           os-name: 'linux'
           python-version: "3.10"
-        - os: ubuntu-latest
+        - os: strands-agents_ubuntu-latest_4-core
           os-name: 'linux'
           python-version: "3.11"
-        - os: ubuntu-latest
+        - os: strands-agents_ubuntu-latest_4-core
           os-name: 'linux'
           python-version: "3.12"
-        - os: ubuntu-latest
+        - os: strands-agents_ubuntu-latest_4-core
           os-name: 'linux'
           python-version: "3.13"
-        - os: ubuntu-latest
+        - os: strands-agents_ubuntu-latest_4-core
           os-name: 'linux'
           python-version: "3.14"
         # Windows
-        - os: windows-latest
+        - os: strands-agents_windows-latest_4-core
           os-name: 'windows'
           python-version: "3.10"
-        - os: windows-latest
+        - os: strands-agents_windows-latest_4-core
           os-name: 'windows'
           python-version: "3.11"
-        - os: windows-latest
+        - os: strands-agents_windows-latest_4-core
           os-name: 'windows'
           python-version: "3.12"
-        - os: windows-latest
+        - os: strands-agents_windows-latest_4-core
           os-name: 'windows'
           python-version: "3.13"
-        - os: windows-latest
+        - os: strands-agents_windows-latest_4-core
           os-name: 'windows'
           python-version: "3.14"
         # MacOS - latest only; not enough runners for macOS
@@ -97,7 +97,7 @@ jobs:
     # layer resolves the 2.x names. Scoped to the compat tests; the full suite
     # is not expected to pass on 2.x while the pin holds. Pinned to `2.0.*` so
     # upstream 2.x releases cannot break unrelated PRs; bump deliberately.
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     timeout-minutes: 10
     permissions:
       contents: read
@@ -143,7 +143,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     # Lint typically runs in ~2 min; 20 min caps a hung step instead of
     # letting it run to the 6-hour default.
     timeout-minutes: 20

--- a/.github/workflows/python-test-package-build.yml
+++ b/.github/workflows/python-test-package-build.yml
@@ -28,7 +28,7 @@ jobs:
     name: Wheel install
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -34,7 +34,7 @@ concurrency:
 jobs:
   scan-commits:
     name: Resolve SHA and validate version
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     permissions:
       contents: read
     outputs:
@@ -164,7 +164,7 @@ jobs:
   inspect:
     name: Inspect MCP dists
     needs: package-build
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     permissions:
       contents: read
     steps:
@@ -254,7 +254,7 @@ jobs:
       needs.security-audit.result == 'success' &&
       needs.package-build.result == 'success' &&
       needs.inspect.result == 'success'
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     permissions:
       contents: read
     steps:
@@ -316,7 +316,7 @@ jobs:
     name: Wait for reviewer approvals
     needs: [scan-commits, draft-notes]
     if: inputs.dry_run != true
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     environment:
       # Shared with release-python.yml and release-typescript.yml. Configure
       # reviewers + main-only deployment branches in repo settings.
@@ -341,7 +341,7 @@ jobs:
     name: Create GitHub release
     needs: [scan-commits, draft-notes, approve-release]
     if: inputs.dry_run != true
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     permissions:
       contents: write
       # discussions: write lets the announcement step below create the
@@ -436,7 +436,7 @@ jobs:
     name: Publish to PyPI
     needs: [inspect, approve-release, create-gh-release]
     if: inputs.dry_run != true
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     environment:
       name: pypi
       url: https://pypi.org/p/strands-agents-mcp-server

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -39,7 +39,7 @@ concurrency:
 jobs:
   scan-commits:
     name: Resolve SHA and validate version
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     permissions:
       contents: read
     outputs:
@@ -204,7 +204,7 @@ jobs:
   inspect:
     name: Inspect Python dists
     needs: package-build
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     permissions:
       contents: read
     steps:
@@ -299,7 +299,7 @@ jobs:
       needs.security-audit.result == 'success' &&
       needs.package-build.result == 'success' &&
       needs.inspect.result == 'success'
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     permissions:
       contents: read
     steps:
@@ -361,7 +361,7 @@ jobs:
     name: Wait for reviewer approvals
     needs: [scan-commits, draft-notes]
     if: inputs.dry_run != true
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     environment:
       # Shared with release-typescript.yml. Configure reviewers + main-only
       # deployment branches in repo settings.
@@ -386,7 +386,7 @@ jobs:
     name: Create GitHub release
     needs: [scan-commits, draft-notes, approve-release]
     if: inputs.dry_run != true
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     permissions:
       contents: write
       # discussions: write lets the announcement step below create the
@@ -481,7 +481,7 @@ jobs:
     name: Publish to PyPI
     needs: [inspect, approve-release, create-gh-release]
     if: inputs.dry_run != true
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     environment:
       name: pypi
       url: https://pypi.org/p/strands-agents
@@ -506,7 +506,7 @@ jobs:
     name: Verify version on PyPI
     needs: [publish-pypi]
     if: inputs.dry_run != true
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     permissions: {}
     steps:
       - name: Poll PyPI for the new version

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -39,7 +39,7 @@ concurrency:
 jobs:
   scan-commits:
     name: Resolve SHA and validate version
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     permissions:
       contents: read
     outputs:
@@ -212,7 +212,7 @@ jobs:
   inspect:
     name: Inspect npm tarball
     needs: package-pack
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     permissions:
       contents: read
     steps:
@@ -286,7 +286,7 @@ jobs:
       needs.security-audit.result == 'success' &&
       needs.package-pack.result == 'success' &&
       needs.inspect.result == 'success'
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     permissions:
       contents: read
     steps:
@@ -348,7 +348,7 @@ jobs:
     name: Wait for reviewer approvals
     needs: [scan-commits, draft-notes]
     if: inputs.dry_run != true
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     environment:
       # Shared with release-python.yml. Configure reviewers + main-only
       # deployment branches in repo settings.
@@ -370,7 +370,7 @@ jobs:
     name: Create GitHub release
     needs: [scan-commits, draft-notes, approve-release]
     if: inputs.dry_run != true
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     permissions:
       contents: write
       # discussions: write lets the announcement step below create the
@@ -465,7 +465,7 @@ jobs:
     name: Publish to npm
     needs: [inspect, approve-release, create-gh-release]
     if: inputs.dry_run != true
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     environment:
       name: npm
       url: https://www.npmjs.com/package/@strands-agents/sdk
@@ -509,7 +509,7 @@ jobs:
     name: Verify version on npm
     needs: [publish-npm]
     if: inputs.dry_run != true
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     permissions: {}
     steps:
       - name: Poll npm for the new version

--- a/.github/workflows/strands-command.yml
+++ b/.github/workflows/strands-command.yml
@@ -26,7 +26,7 @@ jobs:
     name: Check access
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     outputs:
       approval-env: ${{ steps.auth.outputs.approval-env }}
     steps:
@@ -49,7 +49,7 @@ jobs:
       # These both are needed to add the `strands-running` label to issues and prs
       issues: write
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     steps:
       - name: Parse input
         id: parse
@@ -66,7 +66,7 @@ jobs:
       issues: read
       pull-requests: read
       id-token: write # Required for OIDC
-    runs-on: ubuntu-latest 
+    runs-on: strands-agents_ubuntu-latest_4-core 
     timeout-minutes: 60
     steps:
       
@@ -88,7 +88,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
-    runs-on: ubuntu-latest 
+    runs-on: strands-agents_ubuntu-latest_4-core 
     timeout-minutes: 30
     steps:
       - name: Execute write operations

--- a/.github/workflows/typescript-integration-test.yml
+++ b/.github/workflows/typescript-integration-test.yml
@@ -44,7 +44,7 @@ jobs:
   validate-call-ref:
     name: Validate workflow_call ref
     if: inputs.ref != ''
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     permissions:
       contents: read
     # Reject ref shapes that could check out untrusted code:
@@ -82,7 +82,7 @@ jobs:
       (needs.validate-call-ref.result == 'success' || needs.validate-call-ref.result == 'skipped')
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     outputs:
       approval-env: ${{ steps.auth.outputs.approval-env }}
     steps:
@@ -103,7 +103,7 @@ jobs:
 
   run-integration-tests:
     name: Run integration tests
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     needs: authorization-check
     if: always() && needs.authorization-check.result == 'success'
     environment:
@@ -176,7 +176,7 @@ jobs:
           if-no-files-found: ignore
 
   upload-metrics:
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
     needs: run-integration-tests
     # Publishes to the team's CloudWatch via STRANDS_INTEG_TEST_ROLE. Only run
     # when the integration-test job actually executed; on fork PRs the auth

--- a/.github/workflows/typescript-security-audit.yml
+++ b/.github/workflows/typescript-security-audit.yml
@@ -12,7 +12,7 @@ jobs:
     name: NPM Security Audit
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
 
     steps:
       - name: Checkout code

--- a/.github/workflows/typescript-test-package-pack.yml
+++ b/.github/workflows/typescript-test-package-pack.yml
@@ -31,7 +31,7 @@ jobs:
     name: Pack Install
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
 
     steps:
       - name: Checkout code

--- a/.github/workflows/typescript-ts-check.yml
+++ b/.github/workflows/typescript-ts-check.yml
@@ -12,7 +12,7 @@ jobs:
     name: Code Quality
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: strands-agents_ubuntu-latest_4-core
 
     steps:
       - name: Checkout code

--- a/.github/workflows/typescript-ts-test.yml
+++ b/.github/workflows/typescript-ts-test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [20, 22, 24]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [strands-agents_ubuntu-latest_4-core, strands-agents_windows-latest_4-core, macos-latest]
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Human summary
We were facing long wait times to be allocated github hosted runners for our github actions due to all of amazon sharing the same concurrency. To help address this, we were provisioned a self-hosted runner group with capacity allocated to the strands team. Updating runners to use this newly allocated capacity.

## Summary
- Switch all GitHub Actions workflows from `ubuntu-latest` / `windows-latest` to the dedicated `strands-agents_ubuntu-latest_4-core` / `strands-agents_windows-latest_4-core` runner pool.
- Motivation: the shared GitHub-hosted runners have been queueing under concurrency pressure; the dedicated pool gives us headroom and reduces flaky/slow CI runs.
- `macos-latest` is intentionally left unchanged (no custom mac pool).

## Test plan
- [ ] CI runs schedule on the new pool and complete successfully across all workflows (unit, lint, integ, docs, release dry-runs).
- [ ] Windows-matrix jobs (`typescript-ts-test`, `python-test-lint`) still pass on `strands-agents_windows-latest_4-core`.