### PR TITLE
fix(bidi): rename reconnect to restart

### DIFF
--- a/strands-py/src/strands/experimental/bidi/__init__.py
+++ b/strands-py/src/strands/experimental/bidi/__init__.py
@@ -12,7 +12,7 @@ from ...types._events import (
 from .agent.agent import BidiAgent
 
 # Model interface (for custom implementations)
-from .models.model import BidiModel
+from .models.model import BidiModel, Restartable
 
 # Built-in tools (deprecated - use strands_tools.stop instead)
 from .tools import stop_conversation
@@ -74,6 +74,7 @@ __all__ = [
     "ToolStreamEvent",
     # Model interface
     "BidiModel",
+    "Restartable",
     # IO channels and configuration
     "BidiAudioProcessorConfig",
     "BidiAudioIOConfig",

--- a/strands-py/src/strands/experimental/bidi/agent/loop.py
+++ b/strands-py/src/strands/experimental/bidi/agent/loop.py
@@ -28,7 +28,7 @@ from ...hooks.events import (
 )
 from .. import _telemetry
 from .._async import _TaskPool, stop_all
-from ..models import BidiModel, BidiModelTimeoutError
+from ..models import BidiModelTimeoutError, Restartable
 from ..types.events import (
     BidiAudioStreamEvent,
     BidiConnectionCloseEvent,
@@ -507,7 +507,7 @@ class _BidiAgentLoop:
         try:
             previous_reader = self._model_task
             self._generation += 1
-            await self._reconnect_model(restart_kwargs)
+            await self._restart_model(restart_kwargs)
             await self._wait_for_model_task(previous_reader)
             self._model_task = self._task_pool.create(self._run_model(self._generation))
         except Exception as exception:
@@ -521,26 +521,19 @@ class _BidiAgentLoop:
         if restart_exception is not None:
             raise restart_exception
 
-    async def _reconnect_model(self, restart_kwargs: dict[str, Any]) -> None:
-        """Reconnect via the provider's ``reconnect()``, or ``stop()`` then ``start()``.
-
-        The fallback is transitional: providers that have not implemented ``reconnect()``
-        inherit the protocol no-op, so route them through stop/start until they adopt it.
-        """
+    async def _restart_model(self, restart_kwargs: dict[str, Any]) -> None:
+        """Restart through the provider when supported, otherwise use ``stop()`` then ``start()``."""
         model = self._agent.model
         system_prompt = self._agent.system_prompt
         tools = self._agent.tool_registry.get_all_tool_specs()
         messages = self._agent.messages
 
-        # "Provider didn't override reconnect()" — it still resolves to the protocol's no-op
-        # default, so fall back to stop/start. getattr on the type (not the instance) tolerates
-        # a model whose class does not expose reconnect at all (e.g. a mock).
-        if getattr(type(model), "reconnect", None) is BidiModel.reconnect:
-            await model.stop()
-            await model.start(system_prompt, tools, messages, **restart_kwargs)
+        if isinstance(model, Restartable):
+            await model.restart(system_prompt, tools, messages, **restart_kwargs)
             return
 
-        await model.reconnect(system_prompt, tools, messages, **restart_kwargs)
+        await model.stop()
+        await model.start(system_prompt, tools, messages, **restart_kwargs)
 
     async def _wait_for_model_task(self, task: asyncio.Task | None) -> None:
         """Await a superseded reader after its stream is closed; cancel only as a backstop.

--- a/strands-py/src/strands/experimental/bidi/models/__init__.py
+++ b/strands-py/src/strands/experimental/bidi/models/__init__.py
@@ -2,11 +2,12 @@
 
 from typing import Any
 
-from .model import BidiModel, BidiModelTimeoutError
+from .model import BidiModel, BidiModelTimeoutError, Restartable
 
 __all__ = [
     "BidiModel",
     "BidiModelTimeoutError",
+    "Restartable",
 ]
 
 

--- a/strands-py/src/strands/experimental/bidi/models/bedrock.py
+++ b/strands-py/src/strands/experimental/bidi/models/bedrock.py
@@ -612,14 +612,14 @@ class BedrockNovaSonicModel(BidiModel):
 
         logger.debug("nova connection closed")
 
-    async def reconnect(
+    async def restart(
         self,
         system_prompt: str | None = None,
         tools: list[ToolSpec] | None = None,
         messages: Messages | None = None,
         **restart_kwargs: Any,
     ) -> None:
-        """Reconnect by closing the connection and starting a new one, replaying messages.
+        """Restart by closing the connection and starting a new one, replaying messages.
 
         Args:
             system_prompt: System instructions for the new connection.
@@ -627,10 +627,10 @@ class BedrockNovaSonicModel(BidiModel):
             messages: Conversation history to replay into the new connection.
             **restart_kwargs: Reserved for provider-specific restart options.
         """
-        logger.debug("nova reconnect starting")
+        logger.debug("nova restart starting")
         await self.stop()
         await self.start(system_prompt, tools, messages, **restart_kwargs)
-        logger.debug("connection_id=<%s> | nova reconnect complete", self._connection_id)
+        logger.debug("connection_id=<%s> | nova restart complete", self._connection_id)
 
     def _convert_nova_event(self, nova_event: dict[str, Any]) -> BidiOutputEvent | None:
         """Convert Nova Sonic events to TypedEvent format."""

--- a/strands-py/src/strands/experimental/bidi/models/google.py
+++ b/strands-py/src/strands/experimental/bidi/models/google.py
@@ -597,7 +597,7 @@ class GoogleGeminiLiveModel(BidiModel):
             try:
                 await self._live_session_context_manager.__aexit__(None, None, None)
             finally:
-                # Clear so a second stop() (e.g. reconnect's routine teardown) does not
+                # Clear so a second stop() during restart does not
                 # re-exit an already-exited context manager.
                 self._live_session_context_manager = None
                 self._live_session = None
@@ -607,14 +607,14 @@ class GoogleGeminiLiveModel(BidiModel):
 
         await stop_all(stop_session, stop_connection)
 
-    async def reconnect(
+    async def restart(
         self,
         system_prompt: str | None = None,
         tools: list[ToolSpec] | None = None,
         messages: Messages | None = None,
         **restart_kwargs: Any,
     ) -> None:
-        """Reconnect by closing the connection and resuming the same session via its handle.
+        """Restart by closing the connection and resuming the same session via its handle.
 
         Resumes the Gemini session using the last resumption handle so server-side context
         carries across the swap without replaying history. The handle is supplied by the reactive
@@ -628,17 +628,17 @@ class GoogleGeminiLiveModel(BidiModel):
             **restart_kwargs: Provider restart options; ``live_session_handle`` resumes the session.
         """
         handle = restart_kwargs.pop("live_session_handle", None) or self._live_session_handle
-        logger.debug("session_handle=<%s> | gemini reconnect starting", handle)
+        logger.debug("session_handle=<%s> | gemini restart starting", handle)
         await self.stop()
 
         if handle is not None and await self._try_resume(system_prompt, tools, handle, **restart_kwargs):
-            logger.debug("connection_id=<%s> | gemini reconnect complete via resume", self._connection_id)
+            logger.debug("connection_id=<%s> | gemini restart complete via resume", self._connection_id)
             return
 
         # No handle, or the server refused it: start fresh and replay history so the conversation
         # continues rather than going silent.
         await self.start(system_prompt, tools, messages, **restart_kwargs)
-        logger.debug("connection_id=<%s> | gemini reconnect complete via fresh session", self._connection_id)
+        logger.debug("connection_id=<%s> | gemini restart complete via fresh session", self._connection_id)
 
     async def _try_resume(
         self, system_prompt: str | None, tools: list[ToolSpec] | None, handle: str, **restart_kwargs: Any

--- a/strands-py/src/strands/experimental/bidi/models/model.py
+++ b/strands-py/src/strands/experimental/bidi/models/model.py
@@ -16,7 +16,7 @@ Features:
 import abc
 import logging
 from collections.abc import AsyncIterable
-from typing import Any, NoReturn
+from typing import Any, NoReturn, Protocol, runtime_checkable
 
 from ....models.model import Model
 from ....types._events import ToolResultEvent
@@ -29,6 +29,28 @@ from ..types.events import (
 from ..types.model import BidiConnectionConfig
 
 logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class Restartable(Protocol):
+    """A bidirectional model that can replace its active connection while preserving context."""
+
+    async def restart(
+        self,
+        system_prompt: str | None = None,
+        tools: list[ToolSpec] | None = None,
+        messages: Messages | None = None,
+        **restart_kwargs: Any,
+    ) -> None:
+        """Replace the active connection while preserving conversation context.
+
+        Args:
+            system_prompt: System instructions for the new connection.
+            tools: Tool specifications for the new connection.
+            messages: Conversation history to replay when required by the provider.
+            **restart_kwargs: Provider-specific restart options.
+        """
+        ...
 
 
 class BidiModel(Model, abc.ABC):
@@ -152,30 +174,6 @@ class BidiModel(Model, abc.ABC):
             ```
         """
         pass
-
-    async def reconnect(
-        self,
-        system_prompt: str | None = None,
-        tools: list[ToolSpec] | None = None,
-        messages: Messages | None = None,
-        **restart_kwargs: Any,
-    ) -> None:
-        """Close the current connection and establish a new one, preserving context.
-
-        Equivalent to ``stop()`` then ``start()``, but implemented by the provider so it
-        can apply its own resume mechanism (e.g. a session handle).
-
-        Args:
-            system_prompt: System instructions to configure model behavior.
-            tools: Tool specifications that the model can invoke during the conversation.
-            messages: Conversation history to replay for providers that resume via replay.
-            **restart_kwargs: Provider-specific restart options (e.g. from a timeout error).
-
-        Raises:
-            NotImplementedError: If the model does not implement reconnection.
-        """
-        # TODO: Make reconnect abstract after Google and OpenAI implement it.
-        raise NotImplementedError("reconnect is not implemented by this bidirectional model")
 
 
 class BidiModelTimeoutError(Exception):

--- a/strands-py/src/strands/experimental/bidi/models/openai.py
+++ b/strands-py/src/strands/experimental/bidi/models/openai.py
@@ -81,10 +81,10 @@ DEFAULT_SESSION_CONFIG = {
     },
 }
 
-# Sent as a system message after a reconnect. Replay restores the conversation text but not the
+# Sent as a system message after a restart. Replay restores the conversation text but not the
 # live audio state, so the fresh session can drift language or re-introduce itself; this steers it
 # to continue seamlessly.
-_RECONNECT_INSTRUCTION = (
+_RESTART_INSTRUCTION = (
     "The connection was re-established mid-conversation. Continue seamlessly from the prior "
     "context: do not greet or re-introduce yourself, and keep replying in the language already in use."
 )
@@ -828,16 +828,16 @@ class OpenAIRealtimeModel(BidiModel):
 
         logger.debug("openai realtime connection closed")
 
-    async def reconnect(
+    async def restart(
         self,
         system_prompt: str | None = None,
         tools: list[ToolSpec] | None = None,
         messages: Messages | None = None,
         **restart_kwargs: Any,
     ) -> None:
-        """Reconnect by closing the connection and starting a new one, replaying history.
+        """Restart by closing the connection and starting a new one, replaying history.
 
-        OpenAI's Realtime API exposes no server-side resume handle, so a reconnect re-establishes
+        OpenAI's Realtime API exposes no server-side resume handle, so a restart re-establishes
         the session and replays the accumulated conversation history to preserve context across the
         swap.
 
@@ -847,7 +847,7 @@ class OpenAIRealtimeModel(BidiModel):
             messages: Conversation history to replay into the new connection.
             **restart_kwargs: Reserved for provider-specific restart options.
         """
-        logger.debug("openai realtime reconnect starting")
+        logger.debug("openai realtime restart starting")
         await self.stop()
         await self.start(system_prompt, tools, messages, **restart_kwargs)
         # Re-anchor the fresh session so it continues the conversation rather than drifting. This is
@@ -860,13 +860,13 @@ class OpenAIRealtimeModel(BidiModel):
                     "item": {
                         "type": "message",
                         "role": "system",
-                        "content": [{"type": "input_text", "text": _RECONNECT_INSTRUCTION}],
+                        "content": [{"type": "input_text", "text": _RESTART_INSTRUCTION}],
                     },
                 }
             )
         except Exception as error:
-            logger.warning("error=<%s> | failed to send reconnect re-anchor message | continuing", error)
-        logger.debug("connection_id=<%s> | openai realtime reconnect complete", self._connection_id)
+            logger.warning("error=<%s> | failed to send restart re-anchor message | continuing", error)
+        logger.debug("connection_id=<%s> | openai realtime restart complete", self._connection_id)
 
     async def _send_event(self, event: dict[str, Any]) -> None:
         """Send event to OpenAI via WebSocket."""

--- a/strands-py/tests/strands/experimental/bidi/agent/test_agent.py
+++ b/strands-py/tests/strands/experimental/bidi/agent/test_agent.py
@@ -45,7 +45,7 @@ class MockBidiModel(BidiModel):
             self._started = False
             self._connection_id = None
 
-    async def reconnect(self, system_prompt=None, tools=None, messages=None, **restart_kwargs):
+    async def restart(self, system_prompt=None, tools=None, messages=None, **restart_kwargs):
         await self.stop()
         await self.start(system_prompt, tools, messages, **restart_kwargs)
 

--- a/strands-py/tests/strands/experimental/bidi/agent/test_loop.py
+++ b/strands-py/tests/strands/experimental/bidi/agent/test_loop.py
@@ -34,7 +34,9 @@ def time_tool():
 
 @pytest.fixture
 def agent(time_tool):
-    return BidiAgent(model=unittest.mock.AsyncMock(spec=BidiModel), tools=[time_tool])
+    model = unittest.mock.AsyncMock(spec=BidiModel)
+    model.restart = unittest.mock.AsyncMock()
+    return BidiAgent(model=model, tools=[time_tool])
 
 
 @pytest_asyncio.fixture
@@ -63,11 +65,9 @@ async def test_bidi_agent_loop_receive_restart_connection(loop, agent, agenerato
     ]
     assert tru_events == exp_events
 
-    # The reactive path reconnects through the single reconnect() method. start() is
-    # called once (at loop.start()); the restart goes through reconnect() with the
-    # timeout's restart_config forwarded.
+    # The reactive path restarts through the provider method and forwards the timeout config.
     assert agent.model.start.call_count == 1
-    agent.model.reconnect.assert_called_once_with(
+    agent.model.restart.assert_called_once_with(
         agent.system_prompt,
         agent.tool_registry.get_all_tool_specs(),
         agent.messages,
@@ -93,7 +93,7 @@ async def test_bidi_agent_loop_auto_reconnect_default_on(loop, agent, agenerator
         if len(received) >= 2:
             break
 
-    agent.model.reconnect.assert_called_once()
+    agent.model.restart.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -109,7 +109,7 @@ async def test_bidi_agent_loop_auto_reconnect_opt_out_surfaces_timeout(loop, age
         async for _ in loop.receive():
             pass
 
-    agent.model.reconnect.assert_not_called()
+    agent.model.restart.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -142,7 +142,7 @@ async def test_bidi_agent_loop_proactive_reconnect_before_deadline(loop, agent, 
     assert restart.reason == "scheduled"
     assert restart.turn_interrupted is False  # swapped at an idle boundary, no turn cut
 
-    agent.model.reconnect.assert_called()
+    agent.model.restart.assert_called()
 
     await loop.stop()
 
@@ -186,8 +186,8 @@ async def test_bidi_agent_loop_no_timer_when_auto_reconnect_disabled(loop, agent
     await loop.stop()
 
 
-class _NoReconnectModel(BidiModel):
-    """A provider that inherits the protocol's no-op reconnect(), like Gemini/OpenAI today."""
+class _NonRestartableModel(BidiModel):
+    """A provider without an optimized restart implementation."""
 
     def __init__(self):
         self.config = {}
@@ -207,12 +207,12 @@ class _NoReconnectModel(BidiModel):
 
 
 @pytest.mark.asyncio
-async def test_reconnect_falls_back_to_stop_start_when_provider_lacks_reconnect():
-    """A provider that has not implemented reconnect() is reconnected via stop() + start()."""
-    model = _NoReconnectModel()
+async def test_restart_falls_back_to_stop_start_when_provider_is_not_restartable():
+    """A non-restartable provider is restarted through stop() and start()."""
+    model = _NonRestartableModel()
     agent = BidiAgent(model=model, system_prompt="hi")
 
-    await agent._loop._reconnect_model({})
+    await agent._loop._restart_model({})
 
     assert model.stopped == 1
     assert model.started == ["hi"]  # start() called once with the agent's system prompt
@@ -228,7 +228,7 @@ class _StreamModel(BidiModel):
     def __init__(self):
         self.config = {}
         self.connection_config = {}
-        self.reconnect_calls = 0
+        self.restart_calls = 0
         self._closed = asyncio.Event()
         self._inbox: asyncio.Queue = asyncio.Queue()
 
@@ -239,8 +239,8 @@ class _StreamModel(BidiModel):
     async def stop(self):
         self._closed.set()
 
-    async def reconnect(self, system_prompt=None, tools=None, messages=None, **kwargs):
-        self.reconnect_calls += 1
+    async def restart(self, system_prompt=None, tools=None, messages=None, **kwargs):
+        self.restart_calls += 1
         await self.stop()
         await self.start(system_prompt, tools, messages, **kwargs)
 
@@ -277,10 +277,10 @@ async def test_reconnect_fences_superseded_reader_stream_close_error():
     await model.emit(first)
     assert await loop._event_queue.get() is first
 
-    # Proactive-style reconnect: reconnect() -> stop() closes the old stream, so the old
+    # Proactive-style restart closes the old stream, so the old
     # reader raises OSError. It is superseded, so that error must be dropped, not queued.
     await loop._restart_connection(None, loop._generation)
-    assert model.reconnect_calls == 1
+    assert model.restart_calls == 1
 
     second = BidiTextInputEvent(text="second")
     await model.emit(second)
@@ -382,7 +382,7 @@ async def test_stale_reactive_timeout_dropped_after_proactive_swap(loop, agent, 
 
     stale_generation = loop._generation
     await loop._restart_connection(None, loop._generation)  # a proactive swap advances the generation
-    reconnects = agent.model.reconnect.call_count
+    restarts = agent.model.restart.call_count
 
     # A timeout tagged with the pre-swap generation is now stale; receive() must drop it.
     await loop._event_queue.put(_ReaderError(stale_generation, BidiModelTimeoutError("stale timeout")))
@@ -392,7 +392,7 @@ async def test_stale_reactive_timeout_dropped_after_proactive_swap(loop, agent, 
     result = await asyncio.wait_for(loop.receive().__anext__(), timeout=2.0)
     assert result is sentinel
     await feed
-    assert agent.model.reconnect.call_count == reconnects  # no second reconnect from the stale timeout
+    assert agent.model.restart.call_count == restarts  # no second restart from the stale timeout
 
     await loop.stop()
 
@@ -452,9 +452,9 @@ async def test_tool_result_not_sent_when_completed_during_reconnect(agenerator):
         return "result"
 
     model = unittest.mock.AsyncMock(spec=BidiModel)
+    model.restart = unittest.mock.AsyncMock(side_effect=lambda *a, **k: order.append("restart"))
     model.connection_config = {}
     model.send.side_effect = lambda event: order.append("send")
-    model.reconnect.side_effect = lambda *a, **k: order.append("reconnect")
     model.receive = unittest.mock.Mock(return_value=agenerator([]))
 
     agent = BidiAgent(model=model, tools=[slow_tool], system_prompt="hi")
@@ -500,10 +500,10 @@ async def test_stale_reactive_restart_ignored_after_proactive_swap(agent, agener
     stale_generation = loop._generation
     await loop._restart_connection(None, loop._generation)  # a proactive swap advances the generation
     assert loop._generation == stale_generation + 1
-    reconnects = agent.model.reconnect.call_count
+    restarts = agent.model.restart.call_count
 
     await loop._restart_connection(BidiModelTimeoutError("stale"), stale_generation)
-    assert agent.model.reconnect.call_count == reconnects  # stale trigger ignored
+    assert agent.model.restart.call_count == restarts  # stale trigger ignored
 
     await loop.stop()
 
@@ -528,7 +528,7 @@ async def test_deadline_callback_does_not_reconnect_after_stop(agent, agenerator
     await loop.stop()  # stop() releases the boundary wait; the callback no-ops on _started
     await asyncio.wait_for(deadline_task, timeout=2)
 
-    agent.model.reconnect.assert_not_called()
+    agent.model.restart.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -669,13 +669,13 @@ async def test_proactive_reconnect_waits_for_turn_boundary(loop, agent, agenerat
     deadline = asyncio.create_task(loop._on_reconnect_deadline())
     for _ in range(10):
         await asyncio.sleep(0)
-    assert not agent.model.reconnect.called  # held: the turn has not finished
+    assert not agent.model.restart.called  # held: the turn has not finished
 
     # Turn completes -> boundary reached -> reconnect proceeds.
     loop._response_active = False
     loop._update_turn_state()
     await deadline
-    assert agent.model.reconnect.called
+    assert agent.model.restart.called
 
     await loop.stop()
 
@@ -710,32 +710,32 @@ async def test_bidi_agent_loop_reconnect_is_reentrancy_guarded(loop, agent, agen
     agent.model.connection_config = {}
     agent.model.receive = unittest.mock.Mock(return_value=agenerator([]))
 
-    # Block the reconnect so the first call holds the guard while the second is attempted.
+    # Block the restart so the first call holds the guard while the second is attempted.
     release = asyncio.Event()
-    reconnect_calls = 0
+    restart_calls = 0
 
-    async def blocking_reconnect(*_args, **_kwargs):
-        nonlocal reconnect_calls
-        reconnect_calls += 1
+    async def blocking_restart(*_args, **_kwargs):
+        nonlocal restart_calls
+        restart_calls += 1
         await release.wait()
 
-    agent.model.reconnect = blocking_reconnect
+    agent.model.restart = blocking_restart
 
     await loop.start()
 
     first = asyncio.create_task(loop._restart_connection(None, loop._generation))
     for _ in range(10):
         await asyncio.sleep(0)
-        if reconnect_calls == 1:
+        if restart_calls == 1:
             break
 
-    # First reconnect is now suspended mid-flight, still holding the guard.
+    # First restart is now suspended mid-flight, still holding the guard.
     await loop._restart_connection(None, loop._generation)
-    assert reconnect_calls == 1
+    assert restart_calls == 1
 
     release.set()
     await first
-    assert reconnect_calls == 1
+    assert restart_calls == 1
 
     await loop.stop()
 
@@ -750,14 +750,14 @@ async def test_bidi_agent_loop_proactive_reconnect_completes_when_reconnect_susp
     agent.model.connection_config = {"restart_after_s": 5}
     agent.model.receive = unittest.mock.Mock(return_value=agenerator([]))
 
-    reconnect_done = False
+    restart_done = False
 
-    async def suspending_reconnect(*_args, **_kwargs):
-        nonlocal reconnect_done
+    async def suspending_restart(*_args, **_kwargs):
+        nonlocal restart_done
         await asyncio.sleep(0)  # genuine suspension after the timer fires its deadline
-        reconnect_done = True
+        restart_done = True
 
-    agent.model.reconnect = suspending_reconnect
+    agent.model.restart = suspending_restart
 
     # Drive timing without wall time: the first cycle fires immediately, the re-armed cycle parks.
     sleep_count = 0
@@ -779,10 +779,10 @@ async def test_bidi_agent_loop_proactive_reconnect_completes_when_reconnect_susp
         await asyncio.sleep(0)
         while not loop._event_queue.empty():
             loop._event_queue.get_nowait()
-        if reconnect_done:
+        if restart_done:
             break
 
-    assert reconnect_done
+    assert restart_done
     assert loop._send_gate.is_set()
 
     await loop.stop()

--- a/strands-py/tests/strands/experimental/bidi/agent/test_loop_telemetry.py
+++ b/strands-py/tests/strands/experimental/bidi/agent/test_loop_telemetry.py
@@ -85,7 +85,9 @@ def otel_setup():
 
 @pytest.fixture
 def agent():
-    return BidiAgent(model=unittest.mock.AsyncMock(spec=BidiModel), tools=[mock_tool_func])
+    model = unittest.mock.AsyncMock(spec=BidiModel)
+    model.restart = unittest.mock.AsyncMock()
+    return BidiAgent(model=model, tools=[mock_tool_func])
 
 
 @pytest_asyncio.fixture
@@ -347,7 +349,7 @@ async def test_restart_failure_propagates_and_reports(loop, agent, agenerator):
     """A failed restart surfaces to receive(), keeps the gate closed, and fires the after-restart hook."""
     timeout_error = BidiModelTimeoutError("8 minute timeout")
     agent.model.receive = unittest.mock.Mock(side_effect=[timeout_error, agenerator([])])
-    agent.model.reconnect = unittest.mock.AsyncMock(side_effect=ConnectionError("restart failed"))
+    agent.model.restart = unittest.mock.AsyncMock(side_effect=ConnectionError("restart failed"))
 
     after_errors = []
     agent.hooks.add_callback(BidiAfterConnectionRestartEvent, lambda event: after_errors.append(event.exception))

--- a/strands-py/tests/strands/experimental/bidi/models/test_bedrock.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_bedrock.py
@@ -291,8 +291,8 @@ async def test_connection_config_overrides_merge_over_defaults(model_id, boto_se
 
 
 @pytest.mark.asyncio
-async def test_reconnect_replays_history_through_start_path(nova_model, mock_stream):
-    """reconnect() stops the old connection and re-initializes with the same context."""
+async def test_restart_replays_history_through_start_path(nova_model, mock_stream):
+    """restart() stops the old connection and re-initializes with the same context."""
     tools = [
         {
             "name": "get_weather",
@@ -309,7 +309,7 @@ async def test_reconnect_replays_history_through_start_path(nova_model, mock_str
     first_connection_id = nova_model._connection_id
     mock_stream.input_stream.send.reset_mock()
 
-    await nova_model.reconnect(system_prompt="You are helpful", tools=tools, messages=messages)
+    await nova_model.restart(system_prompt="You are helpful", tools=tools, messages=messages)
 
     # Old stream was closed and a fresh connection established with a new id.
     assert mock_stream.close.called
@@ -328,11 +328,11 @@ async def test_reconnect_replays_history_through_start_path(nova_model, mock_str
 
 
 @pytest.mark.asyncio
-async def test_reconnect_twice_does_not_raise(nova_model):
-    """Two reconnects in succession are safe (relies on idempotent stop())."""
+async def test_restart_twice_does_not_raise(nova_model):
+    """Two restarts in succession are safe because stop() is idempotent."""
     await nova_model.start(system_prompt="You are helpful")
-    await nova_model.reconnect(system_prompt="You are helpful")
-    await nova_model.reconnect(system_prompt="You are helpful")
+    await nova_model.restart(system_prompt="You are helpful")
+    await nova_model.restart(system_prompt="You are helpful")
     assert nova_model._connection_id is not None
     await nova_model.stop()
 
@@ -343,7 +343,7 @@ async def test_proactive_reconnect_end_to_end_through_agent(model_id, boto_sessi
 
     Drives the full chain against the real BedrockNovaSonicModel (mocked Bedrock transport):
     the loop reads Nova's connection_config, arms the proactive timer, emits a warning,
-    and reconnects through Nova's own reconnect() before the session deadline, replaying
+    and restarts through Nova's own restart() before the session deadline, replaying
     history via Nova's initialization path. No live AWS calls are made.
     """
     from strands.experimental.bidi.agent.agent import BidiAgent
@@ -393,7 +393,7 @@ async def test_proactive_reconnect_end_to_end_through_agent(model_id, boto_sessi
 
     assert warning_seen
     assert model._connection_id != first_connection_id
-    assert mock_stream.close.called  # old connection was torn down via reconnect -> stop
+    assert mock_stream.close.called  # old connection was torn down by restart()
 
     await agent.stop()
 

--- a/strands-py/tests/strands/experimental/bidi/models/test_google.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_google.py
@@ -283,12 +283,12 @@ async def test_stop_is_idempotent(mock_genai_client, model):
     assert mock_live_session_cm.__aexit__.call_count == 1
 
     # Second stop must be a no-op: the context manager is cleared on first stop, so it is
-    # not re-exited and no error is raised (reconnect() relies on this).
+    # not re-exited and no error is raised (restart() relies on this).
     await model.stop()
     assert mock_live_session_cm.__aexit__.call_count == 1
 
 
-# Reconnect / Connection Config Tests
+# Restart / Connection Config Tests
 
 
 def test_connection_config_declared(model):
@@ -329,13 +329,13 @@ def test_connection_config_override_via_provider_config(mock_genai_client, model
 
 
 @pytest.mark.asyncio
-async def test_reconnect_resumes_via_session_handle(mock_genai_client, model):
-    """reconnect() tears down the old connection and resumes the session via the tracked handle."""
+async def test_restart_resumes_via_session_handle(mock_genai_client, model):
+    """restart() tears down the old connection and resumes the session via the tracked handle."""
     mock_client, _, mock_live_session_cm = mock_genai_client
     await model.start()
     model._live_session_handle = "handle-abc"
 
-    await model.reconnect(system_prompt="hi")
+    await model.restart(system_prompt="hi")
 
     assert mock_live_session_cm.__aexit__.called  # old connection torn down
     assert model._connection_id is not None  # new connection established
@@ -348,13 +348,13 @@ async def test_reconnect_resumes_via_session_handle(mock_genai_client, model):
 
 
 @pytest.mark.asyncio
-async def test_reconnect_prefers_explicit_handle_from_restart_kwargs(mock_genai_client, model):
+async def test_restart_prefers_explicit_handle_from_restart_kwargs(mock_genai_client, model):
     """The reactive path's handle (passed via restart_kwargs) wins over the tracked one."""
     mock_client, _, _ = mock_genai_client
     await model.start()
     model._live_session_handle = "tracked"
 
-    await model.reconnect(system_prompt="hi", live_session_handle="from-error")
+    await model.restart(system_prompt="hi", live_session_handle="from-error")
 
     config = mock_client.aio.live.connect.call_args.kwargs["config"]
     assert config["session_resumption"].handle == "from-error"
@@ -385,13 +385,13 @@ async def test_fresh_start_clears_tracked_handle(mock_genai_client, model):
 
 
 @pytest.mark.asyncio
-async def test_reconnect_without_handle_starts_fresh_and_replays_history(mock_genai_client, model, messages):
-    """With no tracked handle, reconnect() starts a fresh session and replays history."""
+async def test_restart_without_handle_starts_fresh_and_replays_history(mock_genai_client, model, messages):
+    """With no tracked handle, restart() starts a fresh session and replays history."""
     mock_client, mock_live_session, _ = mock_genai_client
     await model.start()
     assert model._live_session_handle is None
 
-    await model.reconnect(system_prompt="hi", messages=messages)
+    await model.restart(system_prompt="hi", messages=messages)
 
     # Fresh session (no resumption handle), with history replayed via send_client_content.
     config = mock_client.aio.live.connect.call_args.kwargs["config"]
@@ -402,11 +402,11 @@ async def test_reconnect_without_handle_starts_fresh_and_replays_history(mock_ge
 
 
 @pytest.mark.asyncio
-async def test_reconnect_falls_back_to_fresh_session_when_resume_rejected(mock_genai_client, model, messages):
-    """A rejected resume handle is dropped and the reconnect retries with a fresh session + replay.
+async def test_restart_falls_back_to_fresh_session_when_resume_rejected(mock_genai_client, model, messages):
+    """A rejected resume handle is dropped and the restart retries with a fresh session and replay.
 
     Guards against the connection going permanently silent when the server refuses the handle:
-    the fallback the reconnect() docstring promises.
+    the fallback the restart() docstring promises.
     """
     mock_client, mock_live_session, mock_live_session_cm = mock_genai_client
     await model.start()
@@ -421,7 +421,7 @@ async def test_reconnect_falls_back_to_fresh_session_when_resume_rejected(mock_g
 
     mock_live_session_cm.__aenter__.side_effect = aenter_rejects_resume
 
-    await model.reconnect(system_prompt="hi", messages=messages)
+    await model.restart(system_prompt="hi", messages=messages)
 
     # Handle dropped, a fresh session established, and history replayed.
     assert model._live_session_handle is None
@@ -462,7 +462,7 @@ async def test_proactive_reconnect_end_to_end_through_agent(mock_genai_client, m
 
     Drives the full chain against the real GoogleGeminiLiveModel (mocked genai transport): the loop
     reads Gemini's connection_config, arms the proactive timer, emits a warning, and reconnects
-    through Gemini's own reconnect() before the deadline, resuming the session via its handle. No
+    through Gemini's own restart() before the deadline, resuming the session via its handle. No
     live network calls are made.
     """
     from strands.experimental.bidi.agent.agent import BidiAgent

--- a/strands-py/tests/strands/experimental/bidi/models/test_model.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_model.py
@@ -6,6 +6,7 @@ from typing import Any
 import pytest
 from pydantic import BaseModel
 
+from strands.experimental.bidi import Restartable
 from strands.experimental.bidi.models.model import BidiModel
 from strands.experimental.bidi.types.events import BidiInputEvent, BidiOutputEvent
 from strands.models import Model
@@ -47,6 +48,17 @@ class _TestBidiModel(BidiModel):
         pass
 
 
+class _TestRestartableBidiModel(_TestBidiModel):
+    async def restart(
+        self,
+        system_prompt: str | None = None,
+        tools: list[ToolSpec] | None = None,
+        messages: Messages | None = None,
+        **restart_kwargs: Any,
+    ) -> None:
+        pass
+
+
 def test_model_is_model():
     assert isinstance(_TestBidiModel(), Model)
 
@@ -68,12 +80,12 @@ def test_get_config_returns_copy():
     assert model.config == {"model_id": "test-model"}
 
 
-@pytest.mark.asyncio
-async def test_reconnect_raises_not_implemented():
-    model = _TestBidiModel()
+def test_model_without_restart_is_not_restartable():
+    assert not isinstance(_TestBidiModel(), Restartable)
 
-    with pytest.raises(NotImplementedError, match="reconnect is not implemented"):
-        await model.reconnect()
+
+def test_model_with_restart_is_restartable():
+    assert isinstance(_TestRestartableBidiModel(), Restartable)
 
 
 def test_stream_raises_not_implemented():

--- a/strands-py/tests/strands/experimental/bidi/models/test_openai.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_openai.py
@@ -18,7 +18,7 @@ import pytest
 
 from strands.experimental.bidi.models.model import BidiModelTimeoutError
 from strands.experimental.bidi.models.openai import (
-    _RECONNECT_INSTRUCTION,
+    _RESTART_INSTRUCTION,
     OPENAI_MAX_TIMEOUT_S,
     OPENAI_PROACTIVE_RECONNECT_MARGIN_S,
     OpenAIRealtimeModel,
@@ -949,7 +949,7 @@ async def test_tool_result_document_content_raises_error(mock_websockets_connect
     await model.stop()
 
 
-# Reconnect Tests
+# Restart Tests
 
 
 def test_connection_config_defaults_and_override(api_key, mock_websockets_connect):
@@ -975,15 +975,15 @@ def test_connection_config_defaults_and_override(api_key, mock_websockets_connec
 
 
 @pytest.mark.asyncio
-async def test_reconnect_reestablishes_and_replays_history(mock_websockets_connect, model, system_prompt, messages):
-    """reconnect() closes the old socket, opens a new one, and replays conversation history."""
+async def test_restart_reestablishes_and_replays_history(mock_websockets_connect, model, system_prompt, messages):
+    """restart() closes the old socket, opens a new one, and replays conversation history."""
     mock_connect, mock_ws = mock_websockets_connect
 
     await model.start()
     first_connection_id = model._connection_id
     mock_ws.send.reset_mock()
 
-    await model.reconnect(system_prompt=system_prompt, messages=messages)
+    await model.restart(system_prompt=system_prompt, messages=messages)
 
     # Old socket closed, a new connection opened, and the connection identity advanced.
     mock_ws.close.assert_called_once()
@@ -1005,14 +1005,14 @@ async def test_reconnect_reestablishes_and_replays_history(mock_websockets_conne
 
 
 @pytest.mark.asyncio
-async def test_reconnect_forwards_tools(mock_websockets_connect, model, tool_spec):
-    """Tools are re-sent on reconnect so the new session can still call them."""
+async def test_restart_forwards_tools(mock_websockets_connect, model, tool_spec):
+    """Tools are re-sent on restart so the new session can still call them."""
     _, mock_ws = mock_websockets_connect
 
     await model.start()
     mock_ws.send.reset_mock()
 
-    await model.reconnect(tools=[tool_spec])
+    await model.restart(tools=[tool_spec])
 
     tool_names = [
         tool["name"]
@@ -1026,7 +1026,7 @@ async def test_reconnect_forwards_tools(mock_websockets_connect, model, tool_spe
 
 
 @pytest.mark.asyncio
-async def test_reconnect_survives_reanchor_send_failure(mock_websockets_connect, model):
+async def test_restart_survives_reanchor_send_failure(mock_websockets_connect, model):
     """A failed re-anchor send is logged, not fatal: the reconnected session stays healthy."""
     _, mock_ws = mock_websockets_connect
 
@@ -1040,7 +1040,7 @@ async def test_reconnect_survives_reanchor_send_failure(mock_websockets_connect,
     mock_ws.send.side_effect = fail_on_anchor
 
     # Must not raise even though the re-anchor send fails.
-    await model.reconnect()
+    await model.restart()
 
     assert model._connection_id is not None
 
@@ -1049,14 +1049,14 @@ async def test_reconnect_survives_reanchor_send_failure(mock_websockets_connect,
 
 
 @pytest.mark.asyncio
-async def test_reconnect_sends_reanchor_system_message(mock_websockets_connect, model):
-    """reconnect() injects a system message so the fresh session continues rather than drifting."""
+async def test_restart_sends_reanchor_system_message(mock_websockets_connect, model):
+    """restart() injects a system message so the fresh session continues rather than drifting."""
     _, mock_ws = mock_websockets_connect
 
     await model.start()
     mock_ws.send.reset_mock()
 
-    await model.reconnect()
+    await model.restart()
 
     system_items = [
         json.loads(call[0][0])["item"]
@@ -1065,7 +1065,7 @@ async def test_reconnect_sends_reanchor_system_message(mock_websockets_connect, 
         and json.loads(call[0][0])["item"].get("role") == "system"
     ]
     assert system_items == [
-        {"type": "message", "role": "system", "content": [{"type": "input_text", "text": _RECONNECT_INSTRUCTION}]}
+        {"type": "message", "role": "system", "content": [{"type": "input_text", "text": _RESTART_INSTRUCTION}]}
     ]
 
     await model.stop()


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->
Renames the bidi model operation from `reconnect()` to `restart()` to reflect that it replaces an active connection rather than recovering a lost one. A runtime-checkable `Restartable` protocol now identifies providers with optimized restart behavior, replacing method-override inspection while preserving the `stop()`/`start()` fallback for other models.

```python
# Before
async def reconnect(self, system_prompt=None, tools=None, messages=None, **restart_kwargs):
    ...

# After
async def restart(self, system_prompt=None, tools=None, messages=None, **restart_kwargs):
    ...
```

`Restartable` is exported from `strands.experimental.bidi`.

Follow-up to PR #3874.

## Related Issues

<!-- Link to related issues using #issue-number format -->
https://github.com/strands-agents/harness-sdk/issues/3721

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Other (please describe): Follow-up work

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [ ] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
