### PR TITLE
feat(bidi): add AudioCapable and typed model config

### DIFF
--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/agent.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/agent.mdx
@@ -220,18 +220,14 @@ from strands.experimental.bidi.models import BedrockNovaSonicModel
 
 model = BedrockNovaSonicModel(
     model_id="amazon.nova-2-sonic-v1:0",
-    provider_config={
-        "audio": {
-            "input_rate": 16000,
-            "output_rate": 16000,
-            "voice": "matthew",  # or "tiffany"
-            "channels": 1,
-            "format": "pcm"
-        }
+    region="us-east-1",
+    audio={
+        "input_rate": 16000,
+        "output_rate": 16000,
+        "channels": 1,
+        "format": "pcm",
+        "voice": "matthew",
     },
-    client_config={
-        "region": "us-east-1"
-    }
 )
 ```
 

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/bedrock.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/bedrock.mdx
@@ -47,24 +47,16 @@ import asyncio
 from strands.experimental.bidi import BidiAgent
 from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO
 from strands.experimental.bidi.models import BedrockNovaSonicModel
-from strands_tools import stop
-
-from strands_tools import calculator
+from strands_tools import calculator, stop
 
 
 async def main() -> None:
     model = BedrockNovaSonicModel(
         model_id="amazon.nova-2-sonic-v1:0",
-        provider_config={
-            "audio": {
-                "voice": "tiffany",
-            },
-        },
-        client_config={"region": "us-east-1"},  # available in us-east-1, us-west-2, eu-north-1, and ap-northeast-1
+        region="us-east-1",
+        audio={"voice": "tiffany"},
     )
-    # stop tool allows user to verbally stop agent execution.
     agent = BidiAgent(model=model, tools=[calculator, stop])
-
     audio_io = BidiAudioIO()
     text_io = BidiTextIO()
     await agent.run(inputs=[audio_io.input()], outputs=[audio_io.output(), text_io.output()])
@@ -116,27 +108,28 @@ boto_session = boto3.Session(
     region_name="your_region_name",
     profile_name="your_profile"  # Optional: Use a specific profile
 )
-model = BedrockNovaSonicModel(client_config={"boto_session": boto_session})
+model = BedrockNovaSonicModel(boto_session=boto_session)
 ```
 
 For more details on this approach, please refer to the [boto3 session docs](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html).
 
 ## Configuration
 
-### Client Configs
+### Client Options
 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `boto_session` | A `boto3.Session` instance under which AWS credentials are configured. | `None` |
 | `region` | Region under which credentials are configured. Cannot use if providing `boto_session`. | `us-east-1` |
 
-### Provider Configs
+### Model Config
 
 | Parameter | Description | Example | Options |
 | --------- | ----------- | ------- | ------- |
-| `audio` | `AudioConfig` instance. | `{"voice": "tiffany", "output_rate": 24000}` | [reference](@api/python/strands.experimental.bidi.types.model#AudioConfig); see [supported voices](https://docs.aws.amazon.com/nova/latest/nova2-userguide/sonic-language-support.html) for valid `voice` values |
-| `inference` | Session start `inferenceConfiguration`'s (as snake_case). | `{"top_p": 0.9, "max_tokens": 2048, "temperature": 0.7}` | [reference](https://docs.aws.amazon.com/nova/latest/nova2-userguide/sonic-input-events.html) |
-| `turn_detection` | Turn detection sensitivity. Nova Sonic v2 only; raises `ValueError` on v1. | `{"endpointingSensitivity": "MEDIUM"}` | `HIGH`, `MEDIUM`, `LOW` |
+| `model_id` | Nova Sonic model identifier. | `"amazon.nova-2-sonic-v1:0"` | Nova Sonic model IDs |
+| `audio` | Audio configuration. | `{"output_rate": 24000, "voice": "tiffany"}` | [reference](@api/python/strands.experimental.bidi.types.model#AudioConfig) |
+| `params` | Provider-specific session parameters, such as inference and turn detection configuration. | `{"inferenceConfiguration": {"temperature": 0.7}}` | [`sessionStart` fields](https://docs.aws.amazon.com/nova/latest/nova2-userguide/sonic-input-events.html) |
+| `connection` | Reconnect timing overrides. | `{"auto_reconnect": false}` | [reference](@api/python/strands.experimental.bidi.types.model#BidiConnectionConfig) |
 
 :::note
 The `audio` config accepts any sample rate supported by the underlying model API. Refer to the [Nova Sonic documentation](https://docs.aws.amazon.com/nova/latest/nova2-userguide/using-conversational-speech.html) for the full list of supported rates.

--- a/strands-py/README.md
+++ b/strands-py/README.md
@@ -262,22 +262,22 @@ if __name__ == "__main__":
 ```python
 from strands.experimental.bidi.models import BedrockNovaSonicModel
 
-# Configure audio settings and turn detection (v2 only)
+# Configure audio streams and Nova Sonic session parameters.
 model = BedrockNovaSonicModel(
-    provider_config={
-        "audio": {
-            "input_rate": 16000,
-            "output_rate": 16000,
-            "voice": "matthew"
+    audio={
+        "input_rate": 16000,
+        "output_rate": 16000,
+        "voice": "matthew",
+    },
+    params={
+        "turnDetectionConfiguration": {
+            "endpointingSensitivity": "MEDIUM"
         },
-        "turn_detection": {
-            "endpointingSensitivity": "MEDIUM"  # HIGH, MEDIUM, or LOW
-        },
-        "inference": {
-            "max_tokens": 2048,
+        "inferenceConfiguration": {
+            "maxTokens": 2048,
             "temperature": 0.7
-        }
-    }
+        },
+    },
 )
 
 # Configure I/O devices

--- a/strands-py/src/strands/experimental/bidi/__init__.py
+++ b/strands-py/src/strands/experimental/bidi/__init__.py
@@ -12,7 +12,7 @@ from ...types._events import (
 from .agent.agent import BidiAgent
 
 # Model interface (for custom implementations)
-from .models.model import BidiModel
+from .models.model import AudioCapable, BidiModel, BidiModelConfig
 
 # Built-in tools (deprecated - use strands_tools.stop instead)
 from .tools import stop_conversation
@@ -38,8 +38,8 @@ from .types.events import (
     ModalityUsage,
 )
 
-# Reconnect configuration (declared by providers, tunable via provider_config)
-from .types.model import BidiConnectionConfig
+# Reconnect configuration (declared by providers, tunable via model configuration)
+from .types.model import AudioConfig, BidiConnectionConfig
 
 if TYPE_CHECKING:
     from .io.audio import BidiAudioIO, BidiAudioIOConfig, BidiAudioProcessorConfig
@@ -73,7 +73,10 @@ __all__ = [
     "ToolResultEvent",
     "ToolStreamEvent",
     # Model interface
+    "AudioCapable",
+    "AudioConfig",
     "BidiModel",
+    "BidiModelConfig",
     # IO channels and configuration
     "BidiAudioProcessorConfig",
     "BidiAudioIOConfig",

--- a/strands-py/src/strands/experimental/bidi/agent/agent.py
+++ b/strands-py/src/strands/experimental/bidi/agent/agent.py
@@ -369,7 +369,10 @@ class BidiAgent:
 
             # Using custom audio config:
             model = BedrockNovaSonicModel(
-                provider_config={"audio": {"input_rate": 48000, "output_rate": 24000}}
+                audio={
+                    "input_rate": 48000,
+                    "output_rate": 24000,
+                }
             )
             audio_io = BidiAudioIO()
             agent = BidiAgent(model=model, tools=[calculator])

--- a/strands-py/src/strands/experimental/bidi/io/audio.py
+++ b/strands-py/src/strands/experimental/bidi/io/audio.py
@@ -3,7 +3,7 @@
 Reads user audio from input device and sends agent audio to output device using PyAudio. If a user interrupts the agent,
 the output buffer is cleared to stop playback.
 
-Audio configuration is provided by the model via agent.model.config["audio"].
+Audio configuration is provided by models that implement ``AudioCapable``.
 
 Optional microphone audio processing (acoustic echo cancellation, noise suppression, and automatic gain
 control) is enabled by passing ``audio_processor=True`` or a ``BidiAudioProcessorConfig`` to ``BidiAudioIO``. It
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any, TypedDict
 import pyaudio
 from typing_extensions import Unpack
 
+from ..models.model import AudioCapable
 from ..types.events import (
     BidiAudioInputEvent,
     BidiAudioStreamEvent,
@@ -194,14 +195,18 @@ class _BidiAudioInput(BidiInput):
         """
         logger.debug("starting audio input stream")
 
-        self._channels = agent.model.config["audio"]["channels"]
-        self._format = agent.model.config["audio"]["format"]
-        self._rate = agent.model.config["audio"]["input_rate"]
+        if not isinstance(agent.model, AudioCapable):
+            raise TypeError("BidiAudioIO requires a model that implements AudioCapable")
+
+        audio_config = agent.model.audio_config
+        self._channels = audio_config["channels"]
+        self._format = audio_config["format"]
+        self._rate = audio_config["input_rate"]
 
         if self._audio_processor is not None:
             self._audio_processor.start(
                 input_rate=self._rate,
-                output_rate=agent.model.config["audio"]["output_rate"],
+                output_rate=audio_config["output_rate"],
                 num_channels=self._channels,
             )
             if self._audio_processor.echo_cancellation_enabled:
@@ -301,8 +306,12 @@ class _BidiAudioOutput(BidiOutput):
         """
         logger.debug("starting audio output stream")
 
-        self._channels = agent.model.config["audio"]["channels"]
-        self._rate = agent.model.config["audio"]["output_rate"]
+        if not isinstance(agent.model, AudioCapable):
+            raise TypeError("BidiAudioIO requires a model that implements AudioCapable")
+
+        audio_config = agent.model.audio_config
+        self._channels = audio_config["channels"]
+        self._rate = audio_config["output_rate"]
 
         if self._audio_processor is not None:
             self._frames_per_buffer = self._audio_processor.frames_per_buffer(self._rate)

--- a/strands-py/src/strands/experimental/bidi/models/__init__.py
+++ b/strands-py/src/strands/experimental/bidi/models/__init__.py
@@ -2,10 +2,14 @@
 
 from typing import Any
 
-from .model import BidiModel, BidiModelTimeoutError
+from ..types.model import AudioConfig
+from .model import AudioCapable, BidiModel, BidiModelConfig, BidiModelTimeoutError
 
 __all__ = [
+    "AudioCapable",
+    "AudioConfig",
     "BidiModel",
+    "BidiModelConfig",
     "BidiModelTimeoutError",
 ]
 

--- a/strands-py/src/strands/experimental/bidi/models/bedrock.py
+++ b/strands-py/src/strands/experimental/bidi/models/bedrock.py
@@ -38,19 +38,19 @@ from aws_sdk_bedrock_runtime.models import (
     ModelTimeoutException,
     ValidationException,
 )
+from boto3.session import Session
 from smithy_aws_core.identity.static import StaticCredentialsResolver
 from smithy_core.aio.eventstream import DuplexEventStream
 from smithy_core.shapes import ShapeID
 from smithy_http.aio.crt import AWSCRTHTTPClient
+from typing_extensions import Unpack
 
-from ....models._validation import validate_region
+from ....models._validation import validate_config_keys, validate_region
 from ....types._events import ToolResultEvent, ToolUseStreamEvent
 from ....types.content import Messages
 from ....types.tools import ToolResult, ToolSpec, ToolUse
 from .._async import stop_all
 from ..types.events import (
-    AudioChannel,
-    AudioSampleRate,
     BidiAudioInputEvent,
     BidiAudioStreamEvent,
     BidiConnectionStartEvent,
@@ -64,38 +64,18 @@ from ..types.events import (
     BidiUsageEvent,
 )
 from ..types.model import AudioConfig, BidiConnectionConfig
-from .model import BidiModel, BidiModelTimeoutError
+from .model import (
+    AudioCapable,
+    BidiModel,
+    BidiModelConfig,
+    BidiModelTimeoutError,
+)
 
 logger = logging.getLogger(__name__)
 
 # Nova Sonic model identifiers
 NOVA_SONIC_V1_MODEL_ID = "amazon.nova-sonic-v1:0"
 NOVA_SONIC_V2_MODEL_ID = "amazon.nova-2-sonic-v1:0"
-
-_NOVA_INFERENCE_CONFIG_KEYS = {
-    "max_tokens": "maxTokens",
-    "temperature": "temperature",
-    "top_p": "topP",
-}
-
-NOVA_AUDIO_INPUT_CONFIG = {
-    "mediaType": "audio/lpcm",
-    "sampleRateHertz": 16000,
-    "sampleSizeBits": 16,
-    "channelCount": 1,
-    "audioType": "SPEECH",
-    "encoding": "base64",
-}
-
-NOVA_AUDIO_OUTPUT_CONFIG = {
-    "mediaType": "audio/lpcm",
-    "sampleRateHertz": 16000,
-    "sampleSizeBits": 16,
-    "channelCount": 1,
-    "voiceId": "matthew",
-    "encoding": "base64",
-    "audioType": "SPEECH",
-}
 
 NOVA_TEXT_CONFIG = {"mediaType": "text/plain"}
 NOVA_TOOL_CONFIG = {"mediaType": "application/json"}
@@ -106,7 +86,7 @@ _MAX_HISTORY_TOTAL_BYTES = 200 * 1024  # 200KB total history
 _STRANDS_USER_AGENT_EXTRA = "strands-agents"
 
 
-class BedrockNovaSonicModel(BidiModel):
+class BedrockNovaSonicModel(BidiModel, AudioCapable):
     """Amazon Bedrock Nova Sonic implementation for bidirectional streaming.
 
     Combines model configuration and connection state in a single class.
@@ -123,70 +103,48 @@ class BedrockNovaSonicModel(BidiModel):
 
     def __init__(
         self,
-        model_id: str = NOVA_SONIC_V2_MODEL_ID,
-        provider_config: dict[str, Any] | None = None,
-        client_config: dict[str, Any] | None = None,
-        **kwargs: Any,
+        *,
+        boto_session: Session | None = None,
+        region: str | None = None,
+        audio: AudioConfig | None = None,
+        **model_config: Unpack[BidiModelConfig],
     ) -> None:
         """Initialize Nova Sonic bidirectional model.
 
         Args:
-            model_id: Model identifier (default: amazon.nova-2-sonic-v1:0)
-            provider_config: Model behavior configuration including:
-                - audio: Audio input/output settings (sample rate, voice, etc.)
-                - inference: Model inference settings (max_tokens, temperature, top_p)
-                - turn_detection: Turn detection configuration (v2 only feature)
-                  - endpointingSensitivity: "HIGH" | "MEDIUM" | "LOW" (optional)
-                - connection: Reconnect overrides merged over the provider defaults
-                  (e.g. restart_after_s, auto_reconnect); see
-                  BidiConnectionConfig.
-            client_config: AWS authentication (boto_session OR region, not both)
-            **kwargs: Reserved for future parameters.
+            boto_session: Boto3 session used to resolve credentials and region.
+            region: AWS region. Cannot be combined with ``boto_session``.
+            audio: Audio configuration.
+            **model_config: Model configuration.
 
         Raises:
-            ValueError: If turn_detection is used with v1 model.
-            ValueError: If endpointingSensitivity is not HIGH, MEDIUM, or LOW.
-            ValueError: If the resolved AWS region is not a valid region identifier.
+            ValueError: If both ``boto_session`` and ``region`` are provided or the resolved region is invalid.
         """
-        # Store model ID
-        self.model_id = model_id
+        if boto_session is not None and region is not None:
+            raise ValueError("Cannot specify both 'boto_session' and 'region'")
+
+        validate_config_keys(model_config, BidiModelConfig)
+        self.config = BidiModelConfig(**model_config)
+        self.model_id = self.config.setdefault("model_id", NOVA_SONIC_V2_MODEL_ID)
 
         # Nova caps a connection at ~8 min; reconnect at 7 min, leaving headroom below the cap.
         # It also reports cumulative usage totals.
-        self.connection_config: BidiConnectionConfig = {"restart_after_s": 420}
+        self.connection_config = BidiConnectionConfig(**{"restart_after_s": 420, **self.config.get("connection", {})})
         self.usage_is_cumulative = True
 
-        provider_config = provider_config or {}
+        default_audio: AudioConfig = {
+            "input_rate": 16000,
+            "output_rate": 16000,
+            "channels": 1,
+            "format": "pcm",
+        }
+        self._audio_config = AudioConfig(**{**default_audio, **(audio or {})})
+        self.config["params"] = dict(self.config.get("params") or {})
+        self.config["connection"] = self.connection_config
 
-        # Merge any caller-supplied connection overrides over the provider defaults, so
-        # reconnect behavior can be tuned (or opted out via auto_reconnect) through
-        # provider_config without replacing the whole config.
-        self.connection_config = cast(
-            BidiConnectionConfig, {**self.connection_config, **provider_config.get("connection", {})}
-        )
-
-        # Validate turn_detection configuration
-        if "turn_detection" in provider_config and provider_config["turn_detection"]:
-            if model_id == NOVA_SONIC_V1_MODEL_ID:
-                raise ValueError(
-                    f"turn_detection is only supported in Nova Sonic v2. "
-                    f"Current model_id: {model_id}. Use {NOVA_SONIC_V2_MODEL_ID} instead."
-                )
-
-            # Validate endpointingSensitivity value if provided
-            sensitivity = provider_config["turn_detection"].get("endpointingSensitivity")
-            if sensitivity and sensitivity not in ["HIGH", "MEDIUM", "LOW"]:
-                raise ValueError(f"Invalid endpointingSensitivity: {sensitivity}. Must be HIGH, MEDIUM, or LOW")
-
-        # Resolve client config with defaults
-        self._client_config = self._resolve_client_config(client_config or {})
-
-        # Resolve provider config with defaults
-        self.config = self._resolve_provider_config(provider_config)
-
-        # Store session and region for later use
-        self._session = self._client_config["boto_session"]
-        self.region = self._client_config["region"]
+        self._session = boto_session or boto3.Session()
+        resolved_region = region if region is not None else self._session.region_name or "us-east-1"
+        self.region = validate_region(resolved_region)
 
         # Track API-provided identifiers
         self._connection_id: str | None = None
@@ -199,47 +157,12 @@ class BedrockNovaSonicModel(BidiModel):
         # Ensure certain events are sent in sequence when required
         self._send_lock = asyncio.Lock()
 
-        logger.debug("model_id=<%s> | nova sonic model initialized", model_id)
+        logger.debug("model_id=<%s> | nova sonic model initialized", self.model_id)
 
-    def _resolve_client_config(self, config: dict[str, Any]) -> dict[str, Any]:
-        """Resolve AWS client config (creates boto session if needed)."""
-        if "boto_session" in config and "region" in config:
-            raise ValueError("Cannot specify both 'boto_session' and 'region' in client_config")
-
-        resolved = config.copy()
-
-        # Create boto session if not provided
-        if "boto_session" not in resolved:
-            resolved["boto_session"] = boto3.Session()
-
-        # Resolve region from session or use default
-        if "region" not in resolved:
-            resolved["region"] = resolved["boto_session"].region_name or "us-east-1"
-
-        # Validate the region before it is interpolated into the service endpoint URL
-        validate_region(resolved["region"])
-
-        return resolved
-
-    def _resolve_provider_config(self, config: dict[str, Any]) -> dict[str, Any]:
-        """Merge user config with defaults (user takes precedence)."""
-        default_audio: AudioConfig = {
-            "input_rate": cast(AudioSampleRate, NOVA_AUDIO_INPUT_CONFIG["sampleRateHertz"]),
-            "output_rate": cast(AudioSampleRate, NOVA_AUDIO_OUTPUT_CONFIG["sampleRateHertz"]),
-            "channels": cast(AudioChannel, NOVA_AUDIO_INPUT_CONFIG["channelCount"]),
-            "format": "pcm",
-            "voice": cast(str, NOVA_AUDIO_OUTPUT_CONFIG["voiceId"]),
-        }
-
-        resolved = {
-            "audio": {
-                **default_audio,
-                **config.get("audio", {}),
-            },
-            "inference": config.get("inference", {}),
-            "turn_detection": config.get("turn_detection", {}),
-        }
-        return resolved
+    @property
+    def audio_config(self) -> AudioConfig:
+        """Get the resolved audio configuration."""
+        return self._audio_config
 
     async def start(
         self,
@@ -472,9 +395,9 @@ class BedrockNovaSonicModel(BidiModel):
         # Build audio input configuration from config
         audio_input_config = {
             "mediaType": "audio/lpcm",
-            "sampleRateHertz": self.config["audio"]["input_rate"],
+            "sampleRateHertz": self.audio_config["input_rate"],
             "sampleSizeBits": 16,
-            "channelCount": self.config["audio"]["channels"],
+            "channelCount": self.audio_config["channels"],
             "audioType": "SPEECH",
             "encoding": "base64",
         }
@@ -655,8 +578,8 @@ class BedrockNovaSonicModel(BidiModel):
             return BidiAudioStreamEvent(
                 audio=audio_content,
                 format="pcm",
-                sample_rate=cast(AudioSampleRate, self.config["audio"]["output_rate"]),
-                channels=cast(AudioChannel, self.config["audio"]["channels"]),
+                sample_rate=self.audio_config["output_rate"],
+                channels=self.audio_config["channels"],
             )
 
         # Handle text output (transcripts)
@@ -744,26 +667,18 @@ class BedrockNovaSonicModel(BidiModel):
 
     def _get_connection_start_event(self) -> str:
         """Generate Nova Sonic connection start event."""
-        inference_config = {_NOVA_INFERENCE_CONFIG_KEYS[key]: value for key, value in self.config["inference"].items()}
-
-        session_start_event: dict[str, Any] = {"event": {"sessionStart": {"inferenceConfiguration": inference_config}}}
-
-        # Add turn detection configuration if provided (v2 feature)
-        turn_detection_config = self.config.get("turn_detection", {})
-        if turn_detection_config:
-            session_start_event["event"]["sessionStart"]["turnDetectionConfiguration"] = turn_detection_config
+        session_start_event: dict[str, Any] = {"event": {"sessionStart": {**(self.config["params"] or {})}}}
 
         return json.dumps(session_start_event)
 
     def _get_prompt_start_event(self, tools: list[ToolSpec]) -> str:
         """Generate Nova Sonic prompt start event with tool configuration."""
-        # Build audio output configuration from config
         audio_output_config = {
             "mediaType": "audio/lpcm",
-            "sampleRateHertz": self.config["audio"]["output_rate"],
+            "sampleRateHertz": self.audio_config["output_rate"],
             "sampleSizeBits": 16,
-            "channelCount": self.config["audio"]["channels"],
-            "voiceId": self.config["audio"].get("voice", "matthew"),
+            "channelCount": self.audio_config["channels"],
+            "voiceId": self.audio_config.get("voice", "matthew"),
             "encoding": "base64",
             "audioType": "SPEECH",
         }

--- a/strands-py/src/strands/experimental/bidi/models/google.py
+++ b/strands-py/src/strands/experimental/bidi/models/google.py
@@ -46,7 +46,7 @@ from ..types.events import (
     ModalityUsage,
 )
 from ..types.model import AudioConfig, BidiConnectionConfig
-from .model import BidiModel, BidiModelTimeoutError
+from .model import AudioCapable, BidiModel, BidiModelTimeoutError
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +69,7 @@ class _TurnState:
     response_id: str | None = None
 
 
-class GoogleGeminiLiveModel(BidiModel):
+class GoogleGeminiLiveModel(BidiModel, AudioCapable):
     """Google Gemini Live implementation using the official Google GenAI SDK.
 
     Combines model configuration and connection state in a single class.
@@ -164,6 +164,11 @@ class GoogleGeminiLiveModel(BidiModel):
             },
         }
         return resolved
+
+    @property
+    def audio_config(self) -> AudioConfig:
+        """Get the resolved audio configuration."""
+        return cast(AudioConfig, self.config["audio"])
 
     async def start(
         self,

--- a/strands-py/src/strands/experimental/bidi/models/model.py
+++ b/strands-py/src/strands/experimental/bidi/models/model.py
@@ -16,19 +16,30 @@ Features:
 import abc
 import logging
 from collections.abc import AsyncIterable
-from typing import Any, NoReturn
+from typing import Any, NoReturn, Protocol, TypedDict, cast, runtime_checkable
 
 from ....models.model import Model
 from ....types._events import ToolResultEvent
 from ....types.content import Messages
 from ....types.tools import ToolSpec
-from ..types.events import (
-    BidiInputEvent,
-    BidiOutputEvent,
-)
-from ..types.model import BidiConnectionConfig
+from ..types.events import BidiInputEvent, BidiOutputEvent
+from ..types.model import AudioConfig, BidiConnectionConfig
 
 logger = logging.getLogger(__name__)
+
+
+class BidiModelConfig(TypedDict, total=False):
+    """Configuration shared by bidirectional model providers.
+
+    Attributes:
+        model_id: Provider model identifier.
+        params: Provider-specific keyword arguments passed to the model request or session.
+        connection: Reconnect timing overrides.
+    """
+
+    model_id: str
+    params: dict[str, Any] | None
+    connection: BidiConnectionConfig
 
 
 class BidiModel(Model, abc.ABC):
@@ -40,6 +51,7 @@ class BidiModel(Model, abc.ABC):
 
     Attributes:
         config: Configuration dictionary with provider-specific settings.
+        model_id: Provider model identifier.
         connection_config: Declared connection limit and reconnect timing. Providers that
             support proactive reconnect populate this; an empty config means reactive-only
             behavior.
@@ -48,7 +60,8 @@ class BidiModel(Model, abc.ABC):
             reporting deltas may omit it.
     """
 
-    config: dict[str, Any]
+    config: Any
+    model_id: str
     connection_config: BidiConnectionConfig
     usage_is_cumulative: bool
 
@@ -62,7 +75,7 @@ class BidiModel(Model, abc.ABC):
 
     def get_config(self) -> dict[str, Any]:
         """Return a copy of the model configuration."""
-        return self.config.copy()
+        return cast(dict[str, Any], self.config).copy()
 
     def structured_output(self, *args: Any, **kwargs: Any) -> NoReturn:
         """Raise because bidirectional models do not support structured output."""
@@ -196,3 +209,13 @@ class BidiModelTimeoutError(Exception):
         super().__init__(message)
 
         self.restart_config = restart_config
+
+
+@runtime_checkable
+class AudioCapable(Protocol):
+    """Protocol for models that support audio input and output."""
+
+    @property
+    def audio_config(self) -> AudioConfig:
+        """Get the resolved audio configuration."""
+        ...

--- a/strands-py/src/strands/experimental/bidi/models/openai.py
+++ b/strands-py/src/strands/experimental/bidi/models/openai.py
@@ -39,7 +39,7 @@ from ..types.events import (
     StopReason,
 )
 from ..types.model import AudioConfig, BidiConnectionConfig
-from .model import BidiModel, BidiModelTimeoutError
+from .model import AudioCapable, BidiModel, BidiModelTimeoutError
 
 logger = logging.getLogger(__name__)
 
@@ -90,7 +90,7 @@ _RECONNECT_INSTRUCTION = (
 )
 
 
-class OpenAIRealtimeModel(BidiModel):
+class OpenAIRealtimeModel(BidiModel, AudioCapable):
     """OpenAI Realtime API implementation for bidirectional streaming.
 
     Combines model configuration and connection state in a single class.
@@ -204,6 +204,11 @@ class OpenAIRealtimeModel(BidiModel):
             "inference": config.get("inference", {}),
         }
         return resolved
+
+    @property
+    def audio_config(self) -> AudioConfig:
+        """Get the resolved audio configuration."""
+        return cast(AudioConfig, self.config["audio"])
 
     async def start(
         self,

--- a/strands-py/src/strands/experimental/bidi/types/model.py
+++ b/strands-py/src/strands/experimental/bidi/types/model.py
@@ -13,20 +13,19 @@ from .events import AudioChannel, AudioFormat, AudioSampleRate
 class AudioConfig(TypedDict, total=False):
     """Audio configuration for bidirectional streaming models.
 
-    Defines standard audio parameters that model providers use to specify
-    their audio processing requirements. All fields are optional to support
-    models that may not use audio or only need specific parameters.
+    Defines common audio parameters supported by bidirectional model providers.
+    All fields are optional to support models that only need specific parameters.
 
     Model providers build this configuration by merging user-provided values
-    with their own defaults. The resulting configuration is then used by
-    audio I/O implementations to configure hardware appropriately.
+    with their own defaults. Audio I/O implementations use the stream settings
+    to configure hardware, while model providers apply settings such as voice.
 
     Attributes:
         input_rate: Input sample rate in Hz (e.g., 8000, 16000, 24000, 48000)
         output_rate: Output sample rate in Hz (e.g., 8000, 16000, 24000, 48000)
         channels: Number of audio channels (1=mono, 2=stereo)
         format: Audio encoding format
-        voice: Voice identifier for text-to-speech (e.g., "alloy", "matthew")
+        voice: Voice used for model audio output.
     """
 
     input_rate: AudioSampleRate

--- a/strands-py/tests/strands/experimental/bidi/io/test_audio.py
+++ b/strands-py/tests/strands/experimental/bidi/io/test_audio.py
@@ -261,6 +261,20 @@ def test_bidi_audio_io_output_configs(pyaudio_module, py_audio, audio_output):
     )
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("direction", ["input", "output"])
+async def test_bidi_audio_io_start_rejects_model_without_audio_capability(pyaudio_module, direction):
+    agent = unittest.mock.MagicMock()
+    agent.model = object()
+    audio_io = BidiAudioIO()
+    io = audio_io.input() if direction == "input" else audio_io.output()
+
+    with pytest.raises(TypeError, match="BidiAudioIO requires a model that implements AudioCapable"):
+        await io.start(agent)
+
+    pyaudio_module.PyAudio.assert_not_called()
+
+
 # ===========================================================================
 # Audio processing (echo cancellation, noise suppression, AGC)
 # ===========================================================================

--- a/strands-py/tests/strands/experimental/bidi/io/test_audio.py
+++ b/strands-py/tests/strands/experimental/bidi/io/test_audio.py
@@ -54,14 +54,11 @@ def audio_buffer():
 @pytest.fixture
 def agent():
     mock = unittest.mock.MagicMock()
-    mock.model.config = {
-        "audio": {
-            "input_rate": 24000,
-            "output_rate": 16000,
-            "channels": 2,
-            "format": "test-format",
-            "voice": "test-voice",
-        },
+    mock.model.audio_config = {
+        "input_rate": 24000,
+        "output_rate": 16000,
+        "channels": 2,
+        "format": "test-format",
     }
     return mock
 
@@ -70,14 +67,11 @@ def agent():
 def aec_agent():
     # Audio processing requires a supported input rate (16k/32k/48k) and mono.
     mock = unittest.mock.MagicMock()
-    mock.model.config = {
-        "audio": {
-            "input_rate": 16000,
-            "output_rate": 16000,
-            "channels": 1,
-            "format": "pcm",
-            "voice": "test-voice",
-        },
+    mock.model.audio_config = {
+        "input_rate": 16000,
+        "output_rate": 16000,
+        "channels": 1,
+        "format": "pcm",
     }
     return mock
 
@@ -85,14 +79,11 @@ def aec_agent():
 @pytest.fixture
 def agent_mixed_rates():
     mock = unittest.mock.MagicMock()
-    mock.model.config = {
-        "audio": {
-            "input_rate": 16000,
-            "output_rate": 24000,
-            "channels": 1,
-            "format": "pcm",
-            "voice": "test-voice",
-        },
+    mock.model.audio_config = {
+        "input_rate": 16000,
+        "output_rate": 24000,
+        "channels": 1,
+        "format": "pcm",
     }
     return mock
 

--- a/strands-py/tests/strands/experimental/bidi/models/test_bedrock.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_bedrock.py
@@ -131,6 +131,11 @@ async def test_invalid_region_rejected(model_id, region):
         BedrockNovaSonicModel(model_id=model_id, region=region)
 
 
+def test_bedrock_nova_sonic_model___init___rejects_boto_session_and_region(model_id, boto_session):
+    with pytest.raises(ValueError, match="Cannot specify both 'boto_session' and 'region'"):
+        BedrockNovaSonicModel(model_id=model_id, boto_session=boto_session, region="us-east-1")
+
+
 # Audio Configuration Tests
 
 

--- a/strands-py/tests/strands/experimental/bidi/models/test_bedrock.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_bedrock.py
@@ -80,7 +80,7 @@ def nova_model(model_id, boto_session, mock_client):
     """Create Nova Sonic model instance."""
     _ = mock_client
 
-    model = BedrockNovaSonicModel(model_id=model_id, client_config={"boto_session": boto_session})
+    model = BedrockNovaSonicModel(model_id=model_id, boto_session=boto_session)
     yield model
 
 
@@ -90,7 +90,7 @@ def nova_model(model_id, boto_session, mock_client):
 @pytest.mark.asyncio
 async def test_model_initialization(model_id, boto_session):
     """Test model initialization with configuration."""
-    model = BedrockNovaSonicModel(model_id=model_id, client_config={"boto_session": boto_session})
+    model = BedrockNovaSonicModel(model_id=model_id, boto_session=boto_session)
 
     assert model.model_id == model_id
     assert model.region == "us-east-1"
@@ -105,7 +105,7 @@ async def test_start_sets_strands_user_agent_on_bedrock_runtime_client(model_id,
         mock_instance.invoke_model_with_bidirectional_stream = AsyncMock(return_value=mock_stream)
         mock_cls.return_value = mock_instance
 
-        model = BedrockNovaSonicModel(model_id=model_id, client_config={"boto_session": boto_session})
+        model = BedrockNovaSonicModel(model_id=model_id, boto_session=boto_session)
 
         await model.start()
 
@@ -118,17 +118,17 @@ async def test_start_sets_strands_user_agent_on_bedrock_runtime_client(model_id,
 @pytest.mark.parametrize("region", ["us-east-1", "ap-southeast-1", "us-gov-east-1"])
 async def test_valid_region_accepted(model_id, region):
     """A well-formed region resolves successfully and is used for the model."""
-    model = BedrockNovaSonicModel(model_id=model_id, client_config={"region": region})
+    model = BedrockNovaSonicModel(model_id=model_id, region=region)
 
     assert model.region == region
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("region", ["x@attacker.com:443/#", "us-east-1\n"])
+@pytest.mark.parametrize("region", ["", "x@attacker.com:443/#", "us-east-1\n"])
 async def test_invalid_region_rejected(model_id, region):
     """A malformed region is rejected before it can reach the endpoint URL."""
     with pytest.raises(ValueError, match="invalid AWS region"):
-        BedrockNovaSonicModel(model_id=model_id, client_config={"region": region})
+        BedrockNovaSonicModel(model_id=model_id, region=region)
 
 
 # Audio Configuration Tests
@@ -137,54 +137,89 @@ async def test_invalid_region_rejected(model_id, region):
 @pytest.mark.asyncio
 async def test_audio_config_defaults(model_id, boto_session):
     """Test default audio configuration."""
-    model = BedrockNovaSonicModel(model_id=model_id, client_config={"boto_session": boto_session})
+    model = BedrockNovaSonicModel(model_id=model_id, boto_session=boto_session)
 
-    assert model.config["audio"]["input_rate"] == 16000
-    assert model.config["audio"]["output_rate"] == 16000
-    assert model.config["audio"]["channels"] == 1
-    assert model.config["audio"]["format"] == "pcm"
-    assert model.config["audio"]["voice"] == "matthew"
+    assert model.audio_config == {
+        "input_rate": 16000,
+        "output_rate": 16000,
+        "channels": 1,
+        "format": "pcm",
+    }
 
 
 @pytest.mark.asyncio
 async def test_audio_config_partial_override(model_id, boto_session):
     """Test partial audio configuration override."""
-    provider_config = {"audio": {"output_rate": 24000, "voice": "ruth"}}
     model = BedrockNovaSonicModel(
-        model_id=model_id, client_config={"boto_session": boto_session}, provider_config=provider_config
+        model_id=model_id,
+        boto_session=boto_session,
+        audio={"output_rate": 24000, "voice": "ruth"},
     )
 
-    # Overridden values
-    assert model.config["audio"]["output_rate"] == 24000
-    assert model.config["audio"]["voice"] == "ruth"
-
-    # Default values preserved
-    assert model.config["audio"]["input_rate"] == 16000
-    assert model.config["audio"]["channels"] == 1
-    assert model.config["audio"]["format"] == "pcm"
+    assert model.audio_config == {
+        "input_rate": 16000,
+        "output_rate": 24000,
+        "channels": 1,
+        "format": "pcm",
+        "voice": "ruth",
+    }
 
 
 @pytest.mark.asyncio
 async def test_audio_config_full_override(model_id, boto_session):
     """Test full audio configuration override."""
-    provider_config = {
-        "audio": {
-            "input_rate": 48000,
-            "output_rate": 48000,
-            "channels": 2,
-            "format": "pcm",
-            "voice": "stephen",
-        }
+    audio_config = {
+        "input_rate": 48000,
+        "output_rate": 48000,
+        "channels": 2,
+        "format": "pcm",
+        "voice": "stephen",
     }
     model = BedrockNovaSonicModel(
-        model_id=model_id, client_config={"boto_session": boto_session}, provider_config=provider_config
+        model_id=model_id,
+        boto_session=boto_session,
+        audio=audio_config,
     )
 
-    assert model.config["audio"]["input_rate"] == 48000
-    assert model.config["audio"]["output_rate"] == 48000
-    assert model.config["audio"]["channels"] == 2
-    assert model.config["audio"]["format"] == "pcm"
-    assert model.config["audio"]["voice"] == "stephen"
+    assert model.audio_config == audio_config
+
+
+@pytest.mark.parametrize(
+    ("audio", "expected"),
+    [
+        (
+            None,
+            {
+                "mediaType": "audio/lpcm",
+                "sampleRateHertz": 16000,
+                "sampleSizeBits": 16,
+                "channelCount": 1,
+                "voiceId": "matthew",
+                "encoding": "base64",
+                "audioType": "SPEECH",
+            },
+        ),
+        (
+            {"output_rate": 24000, "channels": 2, "voice": "ruth"},
+            {
+                "mediaType": "audio/lpcm",
+                "sampleRateHertz": 24000,
+                "sampleSizeBits": 16,
+                "channelCount": 2,
+                "voiceId": "ruth",
+                "encoding": "base64",
+                "audioType": "SPEECH",
+            },
+        ),
+    ],
+)
+def test_prompt_start_event_audio_output_config(boto_session, audio, expected):
+    """Prompt start uses the resolved audio output configuration."""
+    model = BedrockNovaSonicModel(boto_session=boto_session, audio=audio)
+
+    prompt_start = json.loads(model._get_prompt_start_event([]))["event"]["promptStart"]
+
+    assert prompt_start["audioOutputConfiguration"] == expected
 
 
 @pytest.mark.asyncio
@@ -275,11 +310,11 @@ async def test_connection_config_declared(nova_model):
 
 @pytest.mark.asyncio
 async def test_connection_config_overrides_merge_over_defaults(model_id, boto_session):
-    """provider_config['connection'] tunes individual fields without dropping the defaults."""
+    """Connection config tunes individual fields without dropping the defaults."""
     model = BedrockNovaSonicModel(
         model_id=model_id,
-        client_config={"boto_session": boto_session},
-        provider_config={"connection": {"auto_reconnect": False}},
+        boto_session=boto_session,
+        connection={"auto_reconnect": False},
     )
 
     # Overridden field takes the caller's value.
@@ -360,7 +395,7 @@ async def test_proactive_reconnect_end_to_end_through_agent(model_id, boto_sessi
     output.receive = AsyncMock(side_effect=blocking_receive)
     mock_stream.await_output = AsyncMock(return_value=(None, output))
 
-    model = BedrockNovaSonicModel(model_id=model_id, client_config={"boto_session": boto_session})
+    model = BedrockNovaSonicModel(model_id=model_id, boto_session=boto_session)
     # A small deadline; the injected clock below fires it without wall time.
     model.connection_config = {"restart_after_s": 1}
 
@@ -405,7 +440,7 @@ async def test_model_stop_after_start_failure(model_id, boto_session):
         mock_instance.invoke_model_with_bidirectional_stream.side_effect = RuntimeError("connection failed")
         mock_cls.return_value = mock_instance
 
-        model = BedrockNovaSonicModel(model_id=model_id, client_config={"boto_session": boto_session})
+        model = BedrockNovaSonicModel(model_id=model_id, boto_session=boto_session)
 
         with pytest.raises(RuntimeError, match="connection failed"):
             await model.start()
@@ -669,7 +704,7 @@ async def test_event_templates(nova_model):
     event = json.loads(event_json)
     assert "event" in event
     assert "sessionStart" in event["event"]
-    assert "inferenceConfiguration" in event["event"]["sessionStart"]
+    assert event["event"]["sessionStart"] == {}
 
     # Test prompt start event
     nova_model._connection_id = "test-connection"
@@ -772,10 +807,10 @@ async def test_message_history_empty_and_edge_cases(nova_model):
 @pytest.mark.asyncio
 async def test_custom_audio_rates_in_events(model_id, boto_session):
     """Test that audio events use configured sample rates."""
-    # Create model with custom audio configuration
-    provider_config = {"audio": {"output_rate": 48000, "channels": 2}}
     model = BedrockNovaSonicModel(
-        model_id=model_id, client_config={"boto_session": boto_session}, provider_config=provider_config
+        model_id=model_id,
+        boto_session=boto_session,
+        audio={"output_rate": 48000, "channels": 2},
     )
 
     # Test audio output event uses custom configuration
@@ -796,7 +831,7 @@ async def test_custom_audio_rates_in_events(model_id, boto_session):
 async def test_default_audio_rates_in_events(model_id, boto_session):
     """Test that audio events use default sample rates when no custom config."""
     # Create model without custom audio configuration
-    model = BedrockNovaSonicModel(model_id=model_id, client_config={"boto_session": boto_session})
+    model = BedrockNovaSonicModel(model_id=model_id, boto_session=boto_session)
 
     # Test audio output event uses defaults
     audio_bytes = b"test audio data"
@@ -827,20 +862,20 @@ async def test_nova_sonic_v1_instantiation(boto_session, mock_client):
     _ = mock_client  # Ensure mock is active
 
     # Test default creation
-    model = BedrockNovaSonicModel(model_id=NOVA_SONIC_V1_MODEL_ID, client_config={"boto_session": boto_session})
+    model = BedrockNovaSonicModel(model_id=NOVA_SONIC_V1_MODEL_ID, boto_session=boto_session)
     assert model.model_id == NOVA_SONIC_V1_MODEL_ID
     assert model.region == "us-east-1"
 
     # Test with custom config
-    provider_config = {"audio": {"voice": "joanna", "output_rate": 24000}}
-    client_config = {"boto_session": boto_session}
     model_custom = BedrockNovaSonicModel(
-        model_id=NOVA_SONIC_V1_MODEL_ID, provider_config=provider_config, client_config=client_config
+        model_id=NOVA_SONIC_V1_MODEL_ID,
+        boto_session=boto_session,
+        audio={"output_rate": 24000, "voice": "joanna"},
     )
 
     assert model_custom.model_id == NOVA_SONIC_V1_MODEL_ID
-    assert model_custom.config["audio"]["voice"] == "joanna"
-    assert model_custom.config["audio"]["output_rate"] == 24000
+    assert model_custom.audio_config["output_rate"] == 24000
+    assert model_custom.audio_config["voice"] == "joanna"
 
 
 @pytest.mark.asyncio
@@ -849,21 +884,26 @@ async def test_nova_sonic_v2_instantiation(boto_session, mock_client):
     _ = mock_client  # Ensure mock is active
 
     # Test default creation
-    model = BedrockNovaSonicModel(model_id=NOVA_SONIC_V2_MODEL_ID, client_config={"boto_session": boto_session})
+    model = BedrockNovaSonicModel(model_id=NOVA_SONIC_V2_MODEL_ID, boto_session=boto_session)
     assert model.model_id == NOVA_SONIC_V2_MODEL_ID
     assert model.region == "us-east-1"
 
     # Test with custom config
-    provider_config = {"audio": {"voice": "ruth", "input_rate": 48000}, "inference": {"temperature": 0.8}}
-    client_config = {"boto_session": boto_session}
     model_custom = BedrockNovaSonicModel(
-        model_id=NOVA_SONIC_V2_MODEL_ID, provider_config=provider_config, client_config=client_config
+        model_id=NOVA_SONIC_V2_MODEL_ID,
+        boto_session=boto_session,
+        audio={"input_rate": 48000, "voice": "ruth"},
+        params={"inferenceConfiguration": {"temperature": 0.8}},
     )
 
     assert model_custom.model_id == NOVA_SONIC_V2_MODEL_ID
-    assert model_custom.config["audio"]["voice"] == "ruth"
-    assert model_custom.config["audio"]["input_rate"] == 48000
-    assert model_custom.config["inference"]["temperature"] == 0.8
+    assert model_custom.audio_config["input_rate"] == 48000
+    assert (
+        json.loads(model_custom._get_connection_start_event())["event"]["sessionStart"]["inferenceConfiguration"][
+            "temperature"
+        ]
+        == 0.8
+    )
 
 
 @pytest.mark.asyncio
@@ -872,18 +912,18 @@ async def test_nova_sonic_v1_v2_compatibility(boto_session, mock_client):
     _ = mock_client  # Ensure mock is active
 
     # Create both models with same config
-    provider_config = {"audio": {"voice": "matthew"}}
-    client_config = {"boto_session": boto_session}
-
     model_v1 = BedrockNovaSonicModel(
-        model_id=NOVA_SONIC_V1_MODEL_ID, provider_config=provider_config, client_config=client_config
+        model_id=NOVA_SONIC_V1_MODEL_ID,
+        boto_session=boto_session,
+        audio={"voice": "matthew"},
     )
     model_v2 = BedrockNovaSonicModel(
-        model_id=NOVA_SONIC_V2_MODEL_ID, provider_config=provider_config, client_config=client_config
+        model_id=NOVA_SONIC_V2_MODEL_ID,
+        boto_session=boto_session,
+        audio={"voice": "matthew"},
     )
 
-    # Both should have the same config structure
-    assert model_v1.config["audio"]["voice"] == model_v2.config["audio"]["voice"]
+    assert model_v1.audio_config == model_v2.audio_config
     assert model_v1.region == model_v2.region
 
     # Only model_id should differ
@@ -898,81 +938,33 @@ async def test_backward_compatibility(boto_session, mock_client):
     _ = mock_client  # Ensure mock is active
 
     # Test that default behavior now uses v2 (updated default)
-    model_default = BedrockNovaSonicModel(client_config={"boto_session": boto_session})
+    model_default = BedrockNovaSonicModel(boto_session=boto_session)
     assert model_default.model_id == NOVA_SONIC_V2_MODEL_ID
 
     # Test that existing explicit v1 usage still works
-    model_explicit_v1 = BedrockNovaSonicModel(
-        model_id=NOVA_SONIC_V1_MODEL_ID, client_config={"boto_session": boto_session}
-    )
+    model_explicit_v1 = BedrockNovaSonicModel(model_id=NOVA_SONIC_V1_MODEL_ID, boto_session=boto_session)
     assert model_explicit_v1.model_id == NOVA_SONIC_V1_MODEL_ID
 
     # Test that explicit v2 usage works
-    model_explicit_v2 = BedrockNovaSonicModel(
-        model_id=NOVA_SONIC_V2_MODEL_ID, client_config={"boto_session": boto_session}
-    )
+    model_explicit_v2 = BedrockNovaSonicModel(model_id=NOVA_SONIC_V2_MODEL_ID, boto_session=boto_session)
     assert model_explicit_v2.model_id == NOVA_SONIC_V2_MODEL_ID
 
 
-@pytest.mark.asyncio
-async def test_turn_detection_v1_validation(boto_session, mock_client):
-    """Test that turn_detection raises error when used with v1 model."""
-    _ = mock_client  # Ensure mock is active
-
-    # Test that turn_detection with v1 raises ValueError
-    with pytest.raises(ValueError, match="turn_detection is only supported in Nova Sonic v2"):
-        BedrockNovaSonicModel(
-            model_id=NOVA_SONIC_V1_MODEL_ID,
-            provider_config={"turn_detection": {"endpointingSensitivity": "MEDIUM"}},
-            client_config={"boto_session": boto_session},
-        )
-
-    # Test that turn_detection with v2 works fine
-    model_v2 = BedrockNovaSonicModel(
-        model_id=NOVA_SONIC_V2_MODEL_ID,
-        provider_config={"turn_detection": {"endpointingSensitivity": "MEDIUM"}},
-        client_config={"boto_session": boto_session},
-    )
-    assert model_v2.config["turn_detection"]["endpointingSensitivity"] == "MEDIUM"
-
-    # Test that empty turn_detection dict doesn't raise error for v1
-    model_v1_empty = BedrockNovaSonicModel(
+def test_params_passed_to_session_start(boto_session):
+    """Provider parameters are passed directly to the Nova session start event."""
+    params = {
+        "inferenceConfiguration": {"temperature": 0.8},
+        "turnDetectionConfiguration": {"endpointingSensitivity": "MEDIUM"},
+    }
+    model = BedrockNovaSonicModel(
         model_id=NOVA_SONIC_V1_MODEL_ID,
-        provider_config={"turn_detection": {}},
-        client_config={"boto_session": boto_session},
+        params=params,
+        boto_session=boto_session,
     )
-    assert model_v1_empty.model_id == NOVA_SONIC_V1_MODEL_ID
 
+    session_start = json.loads(model._get_connection_start_event())["event"]["sessionStart"]
 
-@pytest.mark.asyncio
-async def test_turn_detection_sensitivity_validation(boto_session, mock_client):
-    """Test that endpointingSensitivity is validated at initialization."""
-    _ = mock_client  # Ensure mock is active
-
-    # Test invalid sensitivity value raises ValueError at init
-    with pytest.raises(ValueError, match="Invalid endpointingSensitivity.*Must be HIGH, MEDIUM, or LOW"):
-        BedrockNovaSonicModel(
-            model_id=NOVA_SONIC_V2_MODEL_ID,
-            provider_config={"turn_detection": {"endpointingSensitivity": "INVALID"}},
-            client_config={"boto_session": boto_session},
-        )
-
-    # Test valid sensitivity values work
-    for sensitivity in ["HIGH", "MEDIUM", "LOW"]:
-        model = BedrockNovaSonicModel(
-            model_id=NOVA_SONIC_V2_MODEL_ID,
-            provider_config={"turn_detection": {"endpointingSensitivity": sensitivity}},
-            client_config={"boto_session": boto_session},
-        )
-        assert model.config["turn_detection"]["endpointingSensitivity"] == sensitivity
-
-    # Test that turn_detection without sensitivity works (sensitivity is optional)
-    model_no_sensitivity = BedrockNovaSonicModel(
-        model_id=NOVA_SONIC_V2_MODEL_ID,
-        provider_config={"turn_detection": {}},
-        client_config={"boto_session": boto_session},
-    )
-    assert "endpointingSensitivity" not in model_no_sensitivity.config["turn_detection"]
+    assert session_start == params
 
 
 # Error Handling Tests

--- a/strands-py/tests/strands/experimental/bidi/models/test_bedrock.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_bedrock.py
@@ -131,7 +131,7 @@ async def test_invalid_region_rejected(model_id, region):
         BedrockNovaSonicModel(model_id=model_id, region=region)
 
 
-def test_bedrock_nova_sonic_model___init___rejects_boto_session_and_region(model_id, boto_session):
+def test___init__rejects_boto_session_and_region(model_id, boto_session):
     with pytest.raises(ValueError, match="Cannot specify both 'boto_session' and 'region'"):
         BedrockNovaSonicModel(model_id=model_id, boto_session=boto_session, region="us-east-1")
 

--- a/strands-py/tests/strands/experimental/bidi/models/test_google.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_google.py
@@ -1071,6 +1071,7 @@ def test_audio_config_defaults(mock_genai_client, model_id, api_key):
     assert model.config["audio"]["channels"] == 1
     assert model.config["audio"]["format"] == "pcm"
     assert "voice" not in model.config["audio"]  # No default voice
+    assert model.audio_config == model.config["audio"]
 
 
 def test_audio_config_partial_override(mock_genai_client, model_id, api_key):

--- a/strands-py/tests/strands/experimental/bidi/models/test_model.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_model.py
@@ -6,7 +6,7 @@ from typing import Any
 import pytest
 from pydantic import BaseModel
 
-from strands.experimental.bidi.models.model import BidiModel
+from strands.experimental.bidi.models.model import AudioCapable, AudioConfig, BidiModel
 from strands.experimental.bidi.types.events import BidiInputEvent, BidiOutputEvent
 from strands.models import Model
 from strands.types._events import ToolResultEvent
@@ -47,8 +47,24 @@ class _TestBidiModel(BidiModel):
         pass
 
 
+class _AudioBidiModel(_TestBidiModel):
+    @property
+    def audio_config(self) -> AudioConfig:
+        return {
+            "input_rate": 16000,
+            "output_rate": 24000,
+            "channels": 1,
+            "format": "pcm",
+        }
+
+
 def test_model_is_model():
     assert isinstance(_TestBidiModel(), Model)
+
+
+def test_audio_capable_identifies_audio_models():
+    assert isinstance(_AudioBidiModel(), AudioCapable)
+    assert not isinstance(_TestBidiModel(), AudioCapable)
 
 
 def test_update_config():

--- a/strands-py/tests/strands/experimental/bidi/models/test_openai.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_openai.py
@@ -133,6 +133,7 @@ def test_audio_config_defaults(api_key, model_name):
     assert model.config["audio"]["channels"] == 1
     assert model.config["audio"]["format"] == "pcm"
     assert model.config["audio"]["voice"] == "alloy"
+    assert model.audio_config == model.config["audio"]
 
 
 def test_audio_config_partial_override(api_key, model_name):


### PR DESCRIPTION
## Description

Adds an `AudioCapable` protocol for bidirectional models and updates `BidiAudioIO` to obtain resolved audio settings through that contract instead of reaching into provider-specific model configuration.

This also flattens and strongly types the `BedrockNovaSonicModel` input configuration:

- Promotes client and audio options such as `boto_session`, `region`, and `audio` to explicit keyword-only constructor arguments.
- Adds the shared `BidiModelConfig` typed dictionary for `model_id`, provider `params`, and connection overrides.
- Passes Nova Sonic session parameters directly through `params`, leaving provider validation to Bedrock.
- Implements `AudioCapable` on the current Bedrock, Google, and OpenAI bidirectional providers.
- Updates examples, API documentation, and unit tests for the new configuration shape.

Google and OpenAI retain their existing configuration shapes in this PR. Follow-up changes will harden their configuration contracts using the same flattened, strongly typed approach introduced here for Bedrock.

## Usage

```python
from strands.experimental.bidi import BidiAgent
from strands.experimental.bidi.io import BidiAudioIO
from strands.experimental.bidi.models import BedrockNovaSonicModel

model = BedrockNovaSonicModel(
    model_id="amazon.nova-2-sonic-v1:0",
    region="us-east-1",
    audio={
        "input_rate": 16000,
        "output_rate": 16000,
        "voice": "matthew",
    },
    params={
        "inferenceConfiguration": {
            "maxTokens": 2048,
            "temperature": 0.7,
        },
        "turnDetectionConfiguration": {
            "endpointingSensitivity": "MEDIUM",
        },
    },
    connection={"auto_reconnect": True},
)

agent = BidiAgent(model=model)
audio_io = BidiAudioIO()
```

`BidiAudioIO` now accepts any model implementing `AudioCapable`, which exposes its resolved `AudioConfig` through the `audio_config` property.

## Related Issues

N/A

## Documentation PR

Documentation and examples are included in this PR under `site/` and `strands-py/README.md`.

## Type of Change

Breaking change

The affected Bidi APIs are experimental. This replaces the nested Bedrock Nova Sonic `provider_config` and `client_config` constructor inputs with flattened, strongly typed keyword arguments.

## Testing

- [x] I ran `hatch run prepare`
- Python 3.10-3.14 test matrix passed
- Documentation tests passed (`128 passed`)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
