### PR TITLE
fix(mcp-py): resolve the OAuth scope keyword rename on mcp 2.x

### DIFF
--- a/.github/workflows/python-test-lint.yml
+++ b/.github/workflows/python-test-lint.yml
@@ -93,10 +93,12 @@ jobs:
     # The dependency pin is `mcp<2`, so the unit-test matrix only ever
     # exercises the 1.x line and the 2.x branches of `_compat` run against
     # mocks there. This job force-installs the 2.x line over the pin to verify
-    # against the real package that `import strands` succeeds and the compat
-    # layer resolves the 2.x names. Scoped to the compat tests; the full suite
-    # is not expected to pass on 2.x while the pin holds. Pinned to `2.0.*` so
-    # upstream 2.x releases cannot break unrelated PRs; bump deliberately.
+    # against the real package that `import strands` succeeds and the MCP
+    # client suite passes. The task tests are excluded: 2.x moved tasks to the
+    # SEP-2663 extension and the client still implements the 1.x experimental
+    # API, so the task workflow is 1.x-only until that lands. Pinned to
+    # `2.0.*` so upstream 2.x releases cannot break unrelated PRs; bump
+    # deliberately.
     runs-on: strands-agents_ubuntu-latest_4-core
     timeout-minutes: 10
     permissions:
@@ -131,10 +133,9 @@ jobs:
 
       # With coverage: the 2.x branches of `_compat` execute only in this job,
       # so without this upload they always show as uncovered on the patch.
-      - name: Run compat tests
+      - name: Run MCP tests
         run: |
-          pytest tests/strands/tools/mcp/test__compat.py -vv --cov=src/strands --cov-report=xml
-          pytest tests/strands/tools/mcp/test_mcp_client.py -k 'tools_changed or session_message' -vv --cov=src/strands --cov-append --cov-report=xml
+          pytest tests/strands/tools/mcp --ignore=tests/strands/tools/mcp/test_mcp_client_tasks.py -vv --cov=src/strands --cov-report=xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7

--- a/strands-py/src/strands/tools/mcp/_compat.py
+++ b/strands-py/src/strands/tools/mcp/_compat.py
@@ -28,6 +28,7 @@ __all__ = [
     "GetSessionIdCallback",
     "MCPError",
     "call_tool",
+    "client_credentials_auth",
     "get_prompt",
     "input_schema",
     "is_error",
@@ -166,6 +167,43 @@ async def call_tool(
         )
 
     return await _drive_input_required(session, call_once)
+
+
+def client_credentials_auth(
+    server_url: str, storage: Any, client_id: str, client_secret: str, scope: str | None
+) -> httpx.Auth:
+    """Construct the OAuth client_credentials provider, on either `mcp` major line.
+
+    `mcp` 2.x renamed the provider's `scopes` keyword to `scope`. The import
+    path and the space-joined scope string value are the same on both lines.
+
+    Args:
+        server_url: The MCP server endpoint URL the grant authenticates against.
+        storage: The provider's token storage.
+        client_id: The OAuth client identifier.
+        client_secret: The OAuth client secret.
+        scope: Space-joined OAuth scopes to request, if any.
+
+    Returns:
+        The provider, an HTTPX auth implementation.
+    """
+    from mcp.client.auth.extensions.client_credentials import ClientCredentialsOAuthProvider
+
+    if MCP_V2:
+        return ClientCredentialsOAuthProvider(  # type: ignore[return-value]
+            server_url=server_url,
+            storage=storage,
+            client_id=client_id,
+            client_secret=client_secret,
+            scope=scope,  # type: ignore[call-arg]
+        )
+    return ClientCredentialsOAuthProvider(
+        server_url=server_url,
+        storage=storage,
+        client_id=client_id,
+        client_secret=client_secret,
+        scopes=scope,  # type: ignore[call-arg]
+    )
 
 
 async def get_prompt(session: ClientSession, name: str, arguments: dict[str, str] | None) -> Any:

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -32,7 +32,6 @@ from urllib.parse import urlparse
 import anyio
 import httpx
 from mcp import ClientSession, ListToolsResult, StdioServerParameters, stdio_client
-from mcp.client.auth.extensions.client_credentials import ClientCredentialsOAuthProvider
 from mcp.client.session import ElicitationFnT, ProgressFnT
 from mcp.client.sse import sse_client
 from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
@@ -66,6 +65,7 @@ from ..tool_provider import ToolProvider
 from ._compat import (
     MCP_V2,
     MCPError,
+    client_credentials_auth,
     is_error,
     is_tools_list_changed,
     mime_type,
@@ -1905,12 +1905,12 @@ def _build_client_credentials_auth(url: str, auth: MCPClientCredentials) -> http
     scopes = values.get("scopes")
     if scopes is not None and not (isinstance(scopes, list) and all(isinstance(scope, str) for scope in scopes)):
         raise ValueError("MCPClient: 'auth' requires 'scopes' to be a list of strings")
-    return ClientCredentialsOAuthProvider(
+    return client_credentials_auth(
         server_url=url,
         storage=_InMemoryTokenStorage(),
         client_id=values["client_id"],
         client_secret=values["client_secret"],
-        scopes=" ".join(scopes) if scopes else None,
+        scope=" ".join(scopes) if scopes else None,
     )
 
 

--- a/strands-py/tests/strands/tools/mcp/conftest.py
+++ b/strands-py/tests/strands/tools/mcp/conftest.py
@@ -17,6 +17,36 @@ def make_mcp_error(code: int, message: str = "", data: Any = None) -> Exception:
     return MCPError(error=ErrorData(code=code, message=message, data=data))
 
 
+def assert_session_call_tool_once_with(
+    mock_session: Any,
+    name: str,
+    arguments: dict[str, Any] | None,
+    read_timeout_seconds: Any = None,
+    progress_callback: Any = None,
+    meta: Any = None,
+) -> None:
+    """Assert the exact `session.call_tool` invocation a direct tool call makes on the installed line.
+
+    The 2.x compat shim converts the timeout to float seconds and carries the
+    SEP-2322 multi round-trip keywords on every call; 1.x sends the plain form.
+    """
+    if _compat.MCP_V2:
+        mock_session.call_tool.assert_called_once_with(
+            name,
+            arguments,
+            _compat.read_timeout(read_timeout_seconds),
+            progress_callback=progress_callback,
+            meta=meta,
+            input_responses=None,
+            request_state=None,
+            allow_input_required=True,
+        )
+        return
+    mock_session.call_tool.assert_called_once_with(
+        name, arguments, read_timeout_seconds, progress_callback=progress_callback, meta=meta
+    )
+
+
 @pytest.fixture
 def mock_transport():
     """Create a mock MCP transport."""
@@ -41,6 +71,9 @@ def mock_session():
     mock_init_result = MagicMock()
     mock_init_result.instructions = None
     mock_session.initialize = AsyncMock(return_value=mock_init_result)
+    # The 2.x negotiation reads instructions from the session itself; without an
+    # explicit default the AsyncMock would hand back an auto-created attribute.
+    mock_session.instructions = None
     # Default: no task support (get_server_capabilities is sync, not async!)
     mock_session.get_server_capabilities = MagicMock(return_value=None)
 

--- a/strands-py/tests/strands/tools/mcp/test_mcp_agent_tool.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_agent_tool.py
@@ -7,18 +7,24 @@ from mcp.types import Tool as MCPTool
 from mcp.types import ToolAnnotations
 
 from strands.tools.mcp import MCPAgentTool, MCPClient
+from strands.tools.mcp._compat import MCP_V2
 from strands.types._events import ToolResultEvent
+
+
+def make_mcp_tool(**overrides) -> MCPTool:
+    """Build a real MCP tool model; camelCase kwargs construct on both `mcp` major lines."""
+    fields = {
+        "name": "test_tool",
+        "description": "A test tool",
+        "inputSchema": {"type": "object", "properties": {}},
+    }
+    fields.update(overrides)
+    return MCPTool(**fields)
 
 
 @pytest.fixture
 def mock_mcp_tool():
-    mock_tool = MagicMock(spec=MCPTool)
-    mock_tool.name = "test_tool"
-    mock_tool.description = "A test tool"
-    mock_tool.inputSchema = {"type": "object", "properties": {}}
-    mock_tool.outputSchema = None  # MCP tools can have optional outputSchema
-    mock_tool.annotations = None  # MCP tools can have optional annotations
-    return mock_tool
+    return make_mcp_tool()
 
 
 @pytest.fixture
@@ -55,77 +61,82 @@ def test_tool_spec_with_description(mcp_agent_tool, mock_mcp_tool):
     assert "outputSchema" not in tool_spec
 
 
-def test_tool_spec_without_description(mock_mcp_tool, mock_mcp_client):
-    mock_mcp_tool.description = None
+def test_tool_spec_without_description(mock_mcp_client):
+    tool = make_mcp_tool(description=None)
 
-    agent_tool = MCPAgentTool(mock_mcp_tool, mock_mcp_client)
+    agent_tool = MCPAgentTool(tool, mock_mcp_client)
     tool_spec = agent_tool.tool_spec
 
     assert tool_spec["description"] == "Tool which performs test_tool"
 
 
-def test_tool_spec_with_output_schema(mock_mcp_tool, mock_mcp_client):
-    mock_mcp_tool.outputSchema = {"type": "object", "properties": {"result": {"type": "string"}}}
+def test_tool_spec_with_output_schema(mock_mcp_client):
+    tool = make_mcp_tool(outputSchema={"type": "object", "properties": {"result": {"type": "string"}}})
 
-    agent_tool = MCPAgentTool(mock_mcp_tool, mock_mcp_client)
+    agent_tool = MCPAgentTool(tool, mock_mcp_client)
     tool_spec = agent_tool.tool_spec
 
     assert "outputSchema" in tool_spec
     assert tool_spec["outputSchema"]["json"] == {"type": "object", "properties": {"result": {"type": "string"}}}
 
 
-def test_tool_spec_without_output_schema(mock_mcp_tool, mock_mcp_client):
-    mock_mcp_tool.outputSchema = None
+def test_tool_spec_without_output_schema(mock_mcp_client):
+    tool = make_mcp_tool(outputSchema=None)
 
-    agent_tool = MCPAgentTool(mock_mcp_tool, mock_mcp_client)
+    agent_tool = MCPAgentTool(tool, mock_mcp_client)
     tool_spec = agent_tool.tool_spec
 
     assert "outputSchema" not in tool_spec
 
 
-def test_tool_spec_with_annotations(mock_mcp_tool, mock_mcp_client):
-    mock_mcp_tool.annotations = ToolAnnotations(title="Test Tool", readOnlyHint=True)
+def test_tool_spec_with_annotations(mock_mcp_client):
+    tool = make_mcp_tool(annotations=ToolAnnotations(title="Test Tool", readOnlyHint=True))
 
-    agent_tool = MCPAgentTool(mock_mcp_tool, mock_mcp_client)
+    agent_tool = MCPAgentTool(tool, mock_mcp_client)
     tool_spec = agent_tool.tool_spec
 
     assert tool_spec["annotations"] == {"title": "Test Tool", "readOnlyHint": True}
 
 
-def test_tool_spec_without_annotations(mock_mcp_tool, mock_mcp_client):
-    mock_mcp_tool.annotations = None
+def test_tool_spec_without_annotations(mock_mcp_client):
+    tool = make_mcp_tool(annotations=None)
 
-    agent_tool = MCPAgentTool(mock_mcp_tool, mock_mcp_client)
+    agent_tool = MCPAgentTool(tool, mock_mcp_client)
     tool_spec = agent_tool.tool_spec
 
     assert "annotations" not in tool_spec
 
 
-def test_tool_spec_with_empty_annotations(mock_mcp_tool, mock_mcp_client):
-    mock_mcp_tool.annotations = ToolAnnotations()
+def test_tool_spec_with_empty_annotations(mock_mcp_client):
+    tool = make_mcp_tool(annotations=ToolAnnotations())
 
-    agent_tool = MCPAgentTool(mock_mcp_tool, mock_mcp_client)
+    agent_tool = MCPAgentTool(tool, mock_mcp_client)
     tool_spec = agent_tool.tool_spec
 
     assert "annotations" not in tool_spec
 
 
-def test_tool_spec_preserves_explicit_false_hints(mock_mcp_tool, mock_mcp_client):
-    mock_mcp_tool.annotations = ToolAnnotations(readOnlyHint=False, destructiveHint=False)
+def test_tool_spec_preserves_explicit_false_hints(mock_mcp_client):
+    tool = make_mcp_tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False))
 
-    agent_tool = MCPAgentTool(mock_mcp_tool, mock_mcp_client)
+    agent_tool = MCPAgentTool(tool, mock_mcp_client)
     tool_spec = agent_tool.tool_spec
 
     assert tool_spec["annotations"] == {"readOnlyHint": False, "destructiveHint": False}
 
 
-def test_tool_spec_preserves_unknown_annotation_keys(mock_mcp_tool, mock_mcp_client):
-    mock_mcp_tool.annotations = ToolAnnotations(readOnlyHint=True, futureHint="x")
+def test_tool_spec_passes_through_what_the_model_retains_for_unknown_annotation_keys(mock_mcp_client):
+    tool = make_mcp_tool(annotations=ToolAnnotations(readOnlyHint=True, futureHint="x"))
 
-    agent_tool = MCPAgentTool(mock_mcp_tool, mock_mcp_client)
+    agent_tool = MCPAgentTool(tool, mock_mcp_client)
     tool_spec = agent_tool.tool_spec
 
-    assert tool_spec["annotations"] == {"readOnlyHint": True, "futureHint": "x"}
+    # The annotations pass through opaquely, so the spec carries exactly what the
+    # installed line's model keeps: 1.x allows extra keys, 2.x discards them at validation.
+    if MCP_V2:
+        assert tool_spec["annotations"] == {"readOnlyHint": True}
+    else:
+        assert tool_spec["annotations"] == {"readOnlyHint": True, "futureHint": "x"}
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client.py
@@ -29,10 +29,11 @@ from pydantic import AnyUrl
 
 import strands.tools.mcp.mcp_client as mcp_client_module
 from strands.tools.mcp import MCPClient
+from strands.tools.mcp._compat import MCP_V2, next_cursor, resource_templates
 from strands.tools.mcp.mcp_types import MCPToolResult
 from strands.types.exceptions import MCPClientInitializationError
 
-from .conftest import make_mcp_error
+from .conftest import assert_session_call_tool_once_with, make_mcp_error
 
 # Fixtures mock_transport and mock_session are imported from conftest.py
 
@@ -62,13 +63,15 @@ def test_mcp_client_context_manager(mock_transport, mock_session):
 def test_server_instructions_default(mock_transport, mock_session):
     """Test that server_instructions defaults to None when server returns None."""
     mock_session.initialize.return_value.instructions = None
+    mock_session.instructions = None
     with MCPClient(mock_transport["transport_callable"]) as client:
         assert client.server_instructions is None
 
 
 def test_server_instructions_from_server(mock_transport, mock_session):
-    """Test that server_instructions is populated from InitializeResult."""
+    """Test that server_instructions is populated from the negotiated session."""
     mock_session.initialize.return_value.instructions = "Use tool A before tool B."
+    mock_session.instructions = "Use tool A before tool B."
     with MCPClient(mock_transport["transport_callable"]) as client:
         assert client.server_instructions == "Use tool A before tool B."
 
@@ -133,9 +136,7 @@ def test_call_tool_sync_status(mock_transport, mock_session, is_error, expected_
     with MCPClient(mock_transport["transport_callable"]) as client:
         result = client.call_tool_sync(tool_use_id="test-123", name="test_tool", arguments={"param": "value"})
 
-        mock_session.call_tool.assert_called_once_with(
-            "test_tool", {"param": "value"}, None, progress_callback=None, meta=None
-        )
+        assert_session_call_tool_once_with(mock_session, "test_tool", {"param": "value"})
 
         assert result["status"] == expected_status
         assert result["toolUseId"] == "test-123"
@@ -218,9 +219,7 @@ def test_call_tool_sync_with_structured_content(mock_transport, mock_session):
     with MCPClient(mock_transport["transport_callable"]) as client:
         result = client.call_tool_sync(tool_use_id="test-123", name="test_tool", arguments={"param": "value"})
 
-        mock_session.call_tool.assert_called_once_with(
-            "test_tool", {"param": "value"}, None, progress_callback=None, meta=None
-        )
+        assert_session_call_tool_once_with(mock_session, "test_tool", {"param": "value"})
 
         assert result["status"] == "success"
         assert result["toolUseId"] == "test-123"
@@ -258,9 +257,7 @@ def test_call_tool_sync_forwards_meta(mock_transport, mock_session):
             tool_use_id="test-123", name="test_tool", arguments={"param": "value"}, meta=meta
         )
 
-        mock_session.call_tool.assert_called_once_with(
-            "test_tool", {"param": "value"}, None, progress_callback=None, meta=meta
-        )
+        assert_session_call_tool_once_with(mock_session, "test_tool", {"param": "value"}, meta=meta)
         assert result["status"] == "success"
 
 
@@ -273,7 +270,7 @@ def test_call_tool_sync_forwards_instance_progress_callback(mock_transport, mock
     with MCPClient(mock_transport["transport_callable"], progress_callback=cb) as client:
         result = client.call_tool_sync(tool_use_id="test-123", name="test_tool", arguments={})
 
-        mock_session.call_tool.assert_called_once_with("test_tool", {}, None, progress_callback=cb, meta=None)
+        assert_session_call_tool_once_with(mock_session, "test_tool", {}, progress_callback=cb)
         assert result["status"] == "success"
 
 
@@ -289,7 +286,7 @@ def test_call_tool_sync_per_call_progress_callback_overrides_instance(mock_trans
             tool_use_id="test-123", name="test_tool", arguments={}, progress_callback=per_call_cb
         )
 
-        mock_session.call_tool.assert_called_once_with("test_tool", {}, None, progress_callback=per_call_cb, meta=None)
+        assert_session_call_tool_once_with(mock_session, "test_tool", {}, progress_callback=per_call_cb)
         assert result["status"] == "success"
 
 
@@ -301,7 +298,7 @@ def test_call_tool_sync_no_progress_callback_by_default(mock_transport, mock_ses
     with MCPClient(mock_transport["transport_callable"]) as client:
         client.call_tool_sync(tool_use_id="test-123", name="test_tool", arguments={})
 
-        mock_session.call_tool.assert_called_once_with("test_tool", {}, None, progress_callback=None, meta=None)
+        assert_session_call_tool_once_with(mock_session, "test_tool", {})
 
 
 def test_call_tool_sync_pre_set_cancel_signal_skips_request(mock_transport, mock_session):
@@ -331,7 +328,7 @@ def test_call_tool_sync_cancel_signal_cancels_only_in_flight_call(mock_transport
     cancel_signal = threading.Event()
     mock_content = MCPTextContent(type="text", text="done")
 
-    async def call_tool(name, arguments, read_timeout_seconds, progress_callback=None, meta=None):
+    async def call_tool(name, arguments, read_timeout_seconds, progress_callback=None, meta=None, **kwargs):
         if name == "slow_tool":
             first_call_started.set()
             try:
@@ -361,10 +358,15 @@ def test_call_tool_sync_cancel_signal_cancels_only_in_flight_call(mock_transport
         "cancelled": True,
     }
     assert first_call_cancelled.wait(timeout=1)
-    mock_session.send_notification.assert_awaited_once()
-    notification = mock_session.send_notification.await_args.args[0].root
-    assert notification.method == "notifications/cancelled"
-    assert notification.params.requestId == 0
+    if MCP_V2:
+        # The 2.x dispatcher sends the cancel itself when the awaiting task is
+        # cancelled; the client hand-sends nothing.
+        mock_session.send_notification.assert_not_awaited()
+    else:
+        mock_session.send_notification.assert_awaited_once()
+        notification = mock_session.send_notification.await_args.args[0].root
+        assert notification.method == "notifications/cancelled"
+        assert notification.params.requestId == 0
     assert second_result["status"] == "success"
     assert mock_session.call_tool.call_count == 2
 
@@ -375,7 +377,7 @@ def test_call_tool_sync_cancel_on_v2_sends_no_hand_built_notification(mock_trans
     call_cancelled = threading.Event()
     cancel_signal = threading.Event()
 
-    async def call_tool(name, arguments, read_timeout_seconds, progress_callback=None, meta=None):
+    async def call_tool(name, arguments, read_timeout_seconds, progress_callback=None, meta=None, **kwargs):
         call_started.set()
         try:
             await asyncio.Event().wait()
@@ -414,7 +416,7 @@ async def test_call_tool_async_cancel_signal_cancels_only_matching_call(mock_tra
 
     assigned_request_ids = {}
 
-    async def call_tool(name, arguments, read_timeout_seconds, progress_callback=None, meta=None):
+    async def call_tool(name, arguments, read_timeout_seconds, progress_callback=None, meta=None, **kwargs):
         request_id = mock_session._request_id
         mock_session._request_id += 1
         assigned_request_ids[name] = request_id
@@ -460,10 +462,15 @@ async def test_call_tool_async_cancel_signal_cancels_only_matching_call(mock_tra
     ]
     assert cancelled_result["cancelled"] is True
     assert slow_call_cancelled.is_set()
-    notifications = [call.args[0].root for call in mock_session.send_notification.await_args_list]
-    assert all(notification.method == "notifications/cancelled" for notification in notifications)
-    cancelled_request_ids = {notification.params.requestId for notification in notifications}
-    assert assigned_request_ids["slow_tool"] in cancelled_request_ids
+    if MCP_V2:
+        # The 2.x dispatcher sends the cancel itself when the awaiting task is
+        # cancelled; the client hand-sends nothing.
+        mock_session.send_notification.assert_not_awaited()
+    else:
+        notifications = [call.args[0].root for call in mock_session.send_notification.await_args_list]
+        assert all(notification.method == "notifications/cancelled" for notification in notifications)
+        cancelled_request_ids = {notification.params.requestId for notification in notifications}
+        assert assigned_request_ids["slow_tool"] in cancelled_request_ids
     assert assigned_request_ids["slow_tool"] > assigned_request_ids["first_tool"]
     assert assigned_request_ids["slow_tool"] != assigned_request_ids["fast_tool"]
     assert completed_result["status"] == "success"
@@ -477,7 +484,7 @@ async def test_call_tool_async_cancel_without_sdk_request_id_still_cancels_local
     cancel_signal = threading.Event()
     del mock_session._request_id
 
-    async def call_tool(name, arguments, read_timeout_seconds, progress_callback=None, meta=None):
+    async def call_tool(name, arguments, read_timeout_seconds, progress_callback=None, meta=None, **kwargs):
         call_started.set()
         await asyncio.Event().wait()
 
@@ -495,6 +502,7 @@ async def test_call_tool_async_cancel_without_sdk_request_id_still_cancels_local
     mock_session.send_notification.assert_not_awaited()
 
 
+@pytest.mark.skipif(MCP_V2, reason="hand-sent cancellation is 1.x-only; the 2.x dispatcher sends the cancel itself")
 @pytest.mark.asyncio
 async def test_call_tool_async_logs_remote_cancellation_failure(mock_transport, mock_session, caplog):
     """Test an immediate remote notification failure is observed and logged."""
@@ -503,7 +511,7 @@ async def test_call_tool_async_logs_remote_cancellation_failure(mock_transport, 
     mock_session._request_id = 7
     mock_session.send_notification.side_effect = RuntimeError("notification failed")
 
-    async def call_tool(name, arguments, read_timeout_seconds, progress_callback=None, meta=None):
+    async def call_tool(name, arguments, read_timeout_seconds, progress_callback=None, meta=None, **kwargs):
         call_started.set()
         await asyncio.Event().wait()
 
@@ -528,7 +536,7 @@ async def test_call_tool_async_cancel_wins_when_result_and_signal_are_ready(mock
     cancel_signal = threading.Event()
     mock_content = MCPTextContent(type="text", text="late result")
 
-    async def call_tool(name, arguments, read_timeout_seconds, progress_callback=None, meta=None):
+    async def call_tool(name, arguments, read_timeout_seconds, progress_callback=None, meta=None, **kwargs):
         cancel_signal.set()
         return MCPCallToolResult(isError=False, content=[mock_content])
 
@@ -552,7 +560,7 @@ async def test_call_tool_async_tracks_cancellation_resistant_invocation(mock_tra
     cancel_signal = threading.Event()
     mock_session._request_id = 0
 
-    async def call_tool(name, arguments, read_timeout_seconds, progress_callback=None, meta=None):
+    async def call_tool(name, arguments, read_timeout_seconds, progress_callback=None, meta=None, **kwargs):
         call_started.set()
         try:
             await asyncio.Event().wait()
@@ -586,7 +594,7 @@ async def test_call_tool_async_caller_cancellation_cleans_up_background_call(moc
     call_cancelled = asyncio.Event()
     mock_session._request_id = 0
 
-    async def call_tool(name, arguments, read_timeout_seconds, progress_callback=None, meta=None):
+    async def call_tool(name, arguments, read_timeout_seconds, progress_callback=None, meta=None, **kwargs):
         call_started.set()
         try:
             await asyncio.Event().wait()
@@ -610,7 +618,12 @@ async def test_call_tool_async_caller_cancellation_cleans_up_background_call(moc
         second_result = await client.call_tool_async(tool_use_id="completed", name="fast_tool", arguments={})
 
     assert call_cancelled.is_set()
-    mock_session.send_notification.assert_awaited_once()
+    if MCP_V2:
+        # The 2.x dispatcher sends the cancel itself when the awaiting task is
+        # cancelled; the client hand-sends nothing.
+        mock_session.send_notification.assert_not_awaited()
+    else:
+        mock_session.send_notification.assert_awaited_once()
     assert second_result["status"] == "success"
 
 
@@ -624,7 +637,7 @@ async def test_call_tool_async_caller_cancellation_timeout_preserves_cancelled_e
     release_call = threading.Event()
     mock_session._request_id = 0
 
-    async def resistant_call(name, arguments, read_timeout_seconds, progress_callback=None, meta=None):
+    async def resistant_call(name, arguments, read_timeout_seconds, progress_callback=None, meta=None, **kwargs):
         call_started.set()
         try:
             await asyncio.Event().wait()
@@ -961,7 +974,7 @@ def test_list_prompts_sync(mock_transport, mock_session):
         mock_session.list_prompts.assert_called_once_with(params=None)
         assert len(result.prompts) == 1
         assert result.prompts[0].name == "test_prompt"
-        assert result.nextCursor is None
+        assert next_cursor(result) is None
 
 
 def test_list_prompts_sync_with_pagination_token(mock_transport, mock_session):
@@ -975,7 +988,7 @@ def test_list_prompts_sync_with_pagination_token(mock_transport, mock_session):
         mock_session.list_prompts.assert_called_once_with(params=PaginatedRequestParams(cursor="current_page_token"))
         assert len(result.prompts) == 1
         assert result.prompts[0].name == "test_prompt"
-        assert result.nextCursor == "next_page_token"
+        assert next_cursor(result) == "next_page_token"
 
 
 def test_list_prompts_sync_session_not_active():
@@ -994,7 +1007,16 @@ def test_get_prompt_sync(mock_transport, mock_session):
     with MCPClient(mock_transport["transport_callable"]) as client:
         result = client.get_prompt_sync("test_prompt_id", {"key": "value"})
 
-        mock_session.get_prompt.assert_called_once_with("test_prompt_id", arguments={"key": "value"})
+        if MCP_V2:
+            mock_session.get_prompt.assert_called_once_with(
+                "test_prompt_id",
+                arguments={"key": "value"},
+                input_responses=None,
+                request_state=None,
+                allow_input_required=True,
+            )
+        else:
+            mock_session.get_prompt.assert_called_once_with("test_prompt_id", arguments={"key": "value"})
         assert len(result.messages) == 1
         assert result.messages[0].role == "user"
         assert result.messages[0].content.text == "This is a test prompt"
@@ -1167,7 +1189,7 @@ def test_call_tool_sync_embedded_nested_text(mock_transport, mock_session):
     with MCPClient(mock_transport["transport_callable"]) as client:
         result = client.call_tool_sync(tool_use_id="er-text", name="get_file_contents", arguments={})
 
-        mock_session.call_tool.assert_called_once_with("get_file_contents", {}, None, progress_callback=None, meta=None)
+        assert_session_call_tool_once_with(mock_session, "get_file_contents", {})
         assert result["status"] == "success"
         assert len(result["content"]) == 1
         assert result["content"][0]["text"] == "inner text"
@@ -1192,7 +1214,7 @@ def test_call_tool_sync_embedded_nested_base64_textual_mime(mock_transport, mock
     with MCPClient(mock_transport["transport_callable"]) as client:
         result = client.call_tool_sync(tool_use_id="er-blob", name="get_file_contents", arguments={})
 
-        mock_session.call_tool.assert_called_once_with("get_file_contents", {}, None, progress_callback=None, meta=None)
+        assert_session_call_tool_once_with(mock_session, "get_file_contents", {})
         assert result["status"] == "success"
         assert len(result["content"]) == 1
         assert result["content"][0]["text"] == '{"k":"v"}'
@@ -1218,7 +1240,7 @@ def test_call_tool_sync_embedded_image_blob(mock_transport, mock_session):
     with MCPClient(mock_transport["transport_callable"]) as client:
         result = client.call_tool_sync(tool_use_id="er-image", name="get_file_contents", arguments={})
 
-        mock_session.call_tool.assert_called_once_with("get_file_contents", {}, None, progress_callback=None, meta=None)
+        assert_session_call_tool_once_with(mock_session, "get_file_contents", {})
         assert result["status"] == "success"
         assert len(result["content"]) == 1
         assert "image" in result["content"][0]
@@ -1243,7 +1265,7 @@ def test_call_tool_sync_embedded_non_textual_blob_dropped(mock_transport, mock_s
     with MCPClient(mock_transport["transport_callable"]) as client:
         result = client.call_tool_sync(tool_use_id="er-binary", name="get_file_contents", arguments={})
 
-        mock_session.call_tool.assert_called_once_with("get_file_contents", {}, None, progress_callback=None, meta=None)
+        assert_session_call_tool_once_with(mock_session, "get_file_contents", {})
         assert result["status"] == "success"
         assert len(result["content"]) == 0  # Content should be dropped
 
@@ -1266,7 +1288,7 @@ def test_call_tool_sync_embedded_multiple_textual_mimes(mock_transport, mock_ses
     with MCPClient(mock_transport["transport_callable"]) as client:
         result = client.call_tool_sync(tool_use_id="er-yaml", name="get_file_contents", arguments={})
 
-        mock_session.call_tool.assert_called_once_with("get_file_contents", {}, None, progress_callback=None, meta=None)
+        assert_session_call_tool_once_with(mock_session, "get_file_contents", {})
         assert result["status"] == "success"
         assert len(result["content"]) == 1
         assert "key: value" in result["content"][0]["text"]
@@ -1286,14 +1308,21 @@ def test_call_tool_sync_embedded_unknown_resource_type_dropped(mock_transport, m
     mock_embedded_resource = MagicMock()
     mock_embedded_resource.resource = UnknownResourceContents()
 
+    # A loose mock stands in for the result model, so both lines' attribute
+    # spellings need explicit values.
     mock_session.call_tool.return_value = MagicMock(
-        isError=False, content=[mock_embedded_resource], structuredContent=None
+        isError=False,
+        is_error=False,
+        content=[mock_embedded_resource],
+        structuredContent=None,
+        structured_content=None,
+        meta=None,
     )
 
     with MCPClient(mock_transport["transport_callable"]) as client:
         result = client.call_tool_sync(tool_use_id="er-unknown", name="get_file_contents", arguments={})
 
-        mock_session.call_tool.assert_called_once_with("get_file_contents", {}, None, progress_callback=None, meta=None)
+        assert_session_call_tool_once_with(mock_session, "get_file_contents", {})
         assert result["status"] == "success"
         assert len(result["content"]) == 0  # Unknown resource type should be dropped
 
@@ -1617,9 +1646,7 @@ def test_call_tool_sync_with_meta_and_structured_content(mock_transport, mock_se
     with MCPClient(mock_transport["transport_callable"]) as client:
         result = client.call_tool_sync(tool_use_id="test-123", name="test_tool", arguments={"param": "value"})
 
-        mock_session.call_tool.assert_called_once_with(
-            "test_tool", {"param": "value"}, None, progress_callback=None, meta=None
-        )
+        assert_session_call_tool_once_with(mock_session, "test_tool", {"param": "value"})
 
         assert result["status"] == "success"
         assert result["toolUseId"] == "test-123"
@@ -1635,7 +1662,7 @@ def test_call_tool_sync_with_meta_and_structured_content(mock_transport, mock_se
 def test_list_resources_sync(mock_transport, mock_session):
     """Test that list_resources_sync correctly retrieves resources."""
     mock_resource = Resource(
-        uri=AnyUrl("file://documents/test.txt"), name="test.txt", description="A test document", mimeType="text/plain"
+        uri="file://documents/test.txt", name="test.txt", description="A test document", mimeType="text/plain"
     )
     mock_session.list_resources.return_value = ListResourcesResult(resources=[mock_resource])
 
@@ -1646,13 +1673,13 @@ def test_list_resources_sync(mock_transport, mock_session):
         assert len(result.resources) == 1
         assert result.resources[0].name == "test.txt"
         assert str(result.resources[0].uri) == "file://documents/test.txt"
-        assert result.nextCursor is None
+        assert next_cursor(result) is None
 
 
 def test_list_resources_sync_with_pagination_token(mock_transport, mock_session):
     """Test that list_resources_sync correctly passes pagination token and returns next cursor."""
     mock_resource = Resource(
-        uri=AnyUrl("file://documents/test.txt"), name="test.txt", description="A test document", mimeType="text/plain"
+        uri="file://documents/test.txt", name="test.txt", description="A test document", mimeType="text/plain"
     )
     mock_session.list_resources.return_value = ListResourcesResult(resources=[mock_resource], nextCursor="next_page")
 
@@ -1662,7 +1689,7 @@ def test_list_resources_sync_with_pagination_token(mock_transport, mock_session)
         mock_session.list_resources.assert_called_once_with(params=PaginatedRequestParams(cursor="current_page"))
         assert len(result.resources) == 1
         assert result.resources[0].name == "test.txt"
-        assert result.nextCursor == "next_page"
+        assert next_cursor(result) == "next_page"
 
 
 def test_list_resources_sync_session_not_active():
@@ -1675,9 +1702,7 @@ def test_list_resources_sync_session_not_active():
 
 def test_read_resource_sync(mock_transport, mock_session):
     """Test that read_resource_sync correctly reads a resource."""
-    mock_content = TextResourceContents(
-        uri=AnyUrl("file://documents/test.txt"), text="Resource content", mimeType="text/plain"
-    )
+    mock_content = TextResourceContents(uri="file://documents/test.txt", text="Resource content", mimeType="text/plain")
     mock_session.read_resource.return_value = ReadResourceResult(contents=[mock_content])
 
     with MCPClient(mock_transport["transport_callable"]) as client:
@@ -1695,9 +1720,7 @@ def test_read_resource_sync(mock_transport, mock_session):
 
 def test_read_resource_sync_with_anyurl(mock_transport, mock_session):
     """Test that read_resource_sync correctly handles AnyUrl input."""
-    mock_content = TextResourceContents(
-        uri=AnyUrl("file://documents/test.txt"), text="Resource content", mimeType="text/plain"
-    )
+    mock_content = TextResourceContents(uri="file://documents/test.txt", text="Resource content", mimeType="text/plain")
     mock_session.read_resource.return_value = ReadResourceResult(contents=[mock_content])
 
     with MCPClient(mock_transport["transport_callable"]) as client:
@@ -1734,10 +1757,11 @@ def test_list_resource_templates_sync(mock_transport, mock_session):
         result = client.list_resource_templates_sync()
 
         mock_session.list_resource_templates.assert_called_once_with(params=None)
-        assert len(result.resourceTemplates) == 1
-        assert result.resourceTemplates[0].name == "document_template"
-        assert result.resourceTemplates[0].uriTemplate == "file://documents/{name}"
-        assert result.nextCursor is None
+        templates = resource_templates(result)
+        assert len(templates) == 1
+        assert templates[0].name == "document_template"
+        assert (templates[0].uri_template if MCP_V2 else templates[0].uriTemplate) == "file://documents/{name}"
+        assert next_cursor(result) is None
 
 
 def test_list_resource_templates_sync_with_pagination_token(mock_transport, mock_session):
@@ -1758,9 +1782,10 @@ def test_list_resource_templates_sync_with_pagination_token(mock_transport, mock
         mock_session.list_resource_templates.assert_called_once_with(
             params=PaginatedRequestParams(cursor="current_page")
         )
-        assert len(result.resourceTemplates) == 1
-        assert result.resourceTemplates[0].name == "document_template"
-        assert result.nextCursor == "next_page"
+        templates = resource_templates(result)
+        assert len(templates) == 1
+        assert templates[0].name == "document_template"
+        assert next_cursor(result) == "next_page"
 
 
 def test_list_resource_templates_sync_session_not_active():

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client_auth.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client_auth.py
@@ -7,7 +7,11 @@ import pytest
 from mcp.client.auth.extensions.client_credentials import ClientCredentialsOAuthProvider
 
 from strands.tools.mcp import MCPClient, MCPClientCredentials
+from strands.tools.mcp._compat import MCP_V2
 from strands.tools.mcp.mcp_client import _InMemoryTokenStorage
+
+# mcp 2.x renamed the provider's `scopes` keyword to `scope`.
+SCOPE_KWARG = "scope" if MCP_V2 else "scopes"
 
 
 @pytest.fixture
@@ -52,7 +56,7 @@ def test_headers_passed_to_transport(streamablehttp_transport):
 
 
 def test_auth_builds_client_credentials_provider(streamablehttp_transport):
-    with patch("strands.tools.mcp.mcp_client.ClientCredentialsOAuthProvider") as provider_cls:
+    with patch("mcp.client.auth.extensions.client_credentials.ClientCredentialsOAuthProvider") as provider_cls:
         client = MCPClient(
             url="https://mcp.example.com",
             auth=MCPClientCredentials(client_id="id", client_secret="secret"),
@@ -65,20 +69,20 @@ def test_auth_builds_client_credentials_provider(streamablehttp_transport):
         storage=ANY,
         client_id="id",
         client_secret="secret",
-        scopes=None,
+        **{SCOPE_KWARG: None},
     )
     assert isinstance(provider_cls.call_args.kwargs["storage"], _InMemoryTokenStorage)
     assert streamablehttp_transport.call_args.kwargs["auth"] is provider_cls.return_value
 
 
 def test_auth_scopes_joined_with_spaces():
-    with patch("strands.tools.mcp.mcp_client.ClientCredentialsOAuthProvider") as provider_cls:
+    with patch("mcp.client.auth.extensions.client_credentials.ClientCredentialsOAuthProvider") as provider_cls:
         MCPClient(
             url="https://mcp.example.com",
             auth=MCPClientCredentials(client_id="id", client_secret="secret", scopes=["read", "write"]),
         )
 
-    assert provider_cls.call_args.kwargs["scopes"] == "read write"
+    assert provider_cls.call_args.kwargs[SCOPE_KWARG] == "read write"
 
 
 def test_auth_provider_passed_through(streamablehttp_transport):

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client_load_servers.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client_load_servers.py
@@ -5,7 +5,11 @@ from unittest.mock import ANY, patch
 
 import pytest
 
+from strands.tools.mcp._compat import MCP_V2
 from strands.tools.mcp.mcp_client import MCPClient
+
+# mcp 2.x renamed the provider's `scopes` keyword to `scope`.
+SCOPE_KWARG = "scope" if MCP_V2 else "scopes"
 
 
 @pytest.fixture
@@ -332,7 +336,7 @@ def test_mixed_config_non_opted_in_failure_aborts_whole_load(mock_client, transp
 
 
 def test_config_auth_builds_client_credentials_provider(mock_client, transports):
-    with patch("strands.tools.mcp.mcp_client.ClientCredentialsOAuthProvider") as provider_cls:
+    with patch("mcp.client.auth.extensions.client_credentials.ClientCredentialsOAuthProvider") as provider_cls:
         MCPClient.load_servers(
             {
                 "srv": {
@@ -348,7 +352,7 @@ def test_config_auth_builds_client_credentials_provider(mock_client, transports)
         storage=ANY,
         client_id="id",
         client_secret="secret",
-        scopes="read write",
+        **{SCOPE_KWARG: "read write"},
     )
     assert transports["http"].call_args.kwargs["auth"] is provider_cls.return_value
 
@@ -356,7 +360,7 @@ def test_config_auth_builds_client_credentials_provider(mock_client, transports)
 def test_auth_interpolates_env_vars(mock_client, transports, monkeypatch):
     monkeypatch.setenv("OAUTH_ID", "env-id")
     monkeypatch.setenv("OAUTH_SECRET", "env-secret")
-    with patch("strands.tools.mcp.mcp_client.ClientCredentialsOAuthProvider") as provider_cls:
+    with patch("mcp.client.auth.extensions.client_credentials.ClientCredentialsOAuthProvider") as provider_cls:
         MCPClient.load_servers(
             {
                 "srv": {

--- a/strands-py/tests/strands/tools/mcp/test_mcp_instrumentation.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_instrumentation.py
@@ -418,8 +418,11 @@ class TestMCPInstrumentation:
             assert mock_register.call_count == first_call_count
 
     def test_mcp_instrumentation_registers_server_side_hooks(self):
-        """Test that mcp_instrumentation registers the transport and session wrappers."""
-        with patch("strands.tools.mcp.mcp_instrumentation.register_post_import_hook") as mock_register:
+        """Test that mcp_instrumentation registers the transport and session wrappers on the 1.x line."""
+        with (
+            patch("strands.tools.mcp.mcp_instrumentation.MCP_V2", False),
+            patch("strands.tools.mcp.mcp_instrumentation.register_post_import_hook") as mock_register,
+        ):
             mcp_instrumentation()
 
             # Verify register_post_import_hook was called for transport and session wrappers


### PR DESCRIPTION
## Description

mcp 2.x renamed the `ClientCredentialsOAuthProvider` constructor keyword `scopes` to `scope`. 
The OAuth client_credentials support added in #3554 still passes `scopes`, so on an mcp 2.x install `MCPClient(url=..., auth={...})` raises `TypeError` at construction. 
The rename is now resolved once in `_compat.client_credentials_auth`, alongside the other 1.x/2.x renames. The feature is otherwise unchanged, and there are no public API changes.

The gap survived CI because the forced-2.x job only ran the compat tests, so the client's OAuth path never executed against the real 2.x package. That job now runs the entire MCP unit suite on 2.x. The task tests are excluded there because the task workflow uses the 1.x experimental API and stays 1.x-only until SEP-2663 support lands; they keep running unchanged in the regular 1.x matrix.

## Related Issues

#1659

## Documentation PR

No documentation changes needed.

## Type of Change

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

Ran the full `tests/strands/tools/mcp` suite against both installed lines: mcp 1.29.1 (309 passed, with only the pre-existing 2.x-only skips) and mcp 2.0.1 (295 passed, 0 failures outside the excluded task tests, which fail on 2.x with or without this change). `hatch fmt --formatter --check` and `hatch fmt --linter` (ruff and mypy) pass. Also reproduced the original bug on mcp 2.0.1 before the fix: `MCPClient(url=..., auth={"client_id": ..., "client_secret": ...})` raised `TypeError: unexpected keyword argument 'scopes'`, and succeeds with this change.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [ ] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
