### PR TITLE
chore(bidi): upgrade pywebrtc audio to 0.2

### DIFF
--- a/strands-py/pyproject.toml
+++ b/strands-py/pyproject.toml
@@ -87,7 +87,7 @@ bidi = [
 ]
 bidi-google = ["google-genai>=2.0.0,<3.0.0"]
 bidi-openai = ["websockets>=16.0.0,<17.0.0"]
-bidi-aec = ["pywebrtc-audio>=0.1.0,<0.2.0", "numpy>=2.0.0,<3.0.0"]
+bidi-aec = ["pywebrtc-audio>=0.2.0,<0.3.0", "numpy>=2.0.0,<3.0.0"]
 # Excluded from aggregate extras because PyAudio requires PortAudio as a system level install.
 bidi-pyaudio = ["pyaudio>=0.2.0,<0.3.0"]
 bidi-all = ["strands-agents[a2a,bidi,bidi-aec,bidi-google,bidi-openai,docs,otel]"]

--- a/strands-py/src/strands/experimental/bidi/_audio.py
+++ b/strands-py/src/strands/experimental/bidi/_audio.py
@@ -70,7 +70,6 @@ class _BidiAudioProcessor:
         Raises:
             ValueError: If the audio format is invalid.
         """
-        self._validate_input_rate(input_rate)
         self._input_rate = input_rate
         self._output_rate = output_rate
         self._processor = AudioProcessor(
@@ -88,15 +87,6 @@ class _BidiAudioProcessor:
             output_rate,
             num_channels,
         )
-
-    def _validate_input_rate(self, input_rate: int) -> None:
-        """Validate that the input rate is supported."""
-        supported_rates = (16000, 32000, 48000)
-        if input_rate not in supported_rates:
-            raise ValueError(
-                f"input_rate=<{input_rate}> | audio processing supports sample rates "
-                f"{supported_rates}. Configure the model's audio input_rate accordingly."
-            )
 
     def add_far_data(self, data: bytes) -> None:
         """Add a played audio frame for echo cancellation."""

--- a/strands-py/tests/strands/experimental/bidi/io/test_audio.py
+++ b/strands-py/tests/strands/experimental/bidi/io/test_audio.py
@@ -68,7 +68,6 @@ def agent():
 
 @pytest.fixture
 def aec_agent():
-    # Audio processing requires a supported input rate (16k/32k/48k) and mono.
     mock = unittest.mock.MagicMock()
     mock.model.config = {
         "audio": {
@@ -446,16 +445,10 @@ def test_processor_construction_builds_audio_processor_with_config():
     )
 
 
-@pytest.mark.parametrize("rate", [16000, 32000, 48000])
+@pytest.mark.parametrize("rate", [8000, 16000, 24000, 44100, 48000, 96000, 384000])
 def test_processor_construction_accepts_supported_rates(rate):
     processor_patch, _, _ = _fake_audio_processor()
     with processor_patch:
-        _create_processor(input_rate=rate, output_rate=rate)
-
-
-@pytest.mark.parametrize("rate", [8000, 24000, 44100])
-def test_processor_construction_rejects_unsupported_rates(rate):
-    with pytest.raises(ValueError, match="audio processing supports sample rates"):
         _create_processor(input_rate=rate, output_rate=rate)
 
 

--- a/strands-py/tests/strands/experimental/bidi/io/test_audio.py
+++ b/strands-py/tests/strands/experimental/bidi/io/test_audio.py
@@ -421,7 +421,7 @@ def test_audio_config_is_keyword_only():
 
 
 # ---------------------------------------------------------------------------
-# _BidiAudioProcessor startup — sample rate gate and native processor construction
+# _BidiAudioProcessor startup and native processor construction
 # ---------------------------------------------------------------------------
 
 
@@ -446,10 +446,12 @@ def test_processor_construction_builds_audio_processor_with_config():
 
 
 @pytest.mark.parametrize("rate", [8000, 16000, 24000, 44100, 48000, 96000, 384000])
-def test_processor_construction_accepts_supported_rates(rate):
-    processor_patch, _, _ = _fake_audio_processor()
+def test_processor_construction_passes_input_rate_to_audio_processor(rate):
+    processor_patch, processor_class, _ = _fake_audio_processor()
     with processor_patch:
         _create_processor(input_rate=rate, output_rate=rate)
+
+    assert processor_class.call_args.kwargs["sample_rate"] == rate
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Upgrade the `bidi-aec` extra to `pywebrtc-audio>=0.2.0,<0.3.0`.

pywebrtc-audio 0.2.0 supports external sample rates from 8 kHz through 384 kHz by resampling to WebRTC internal processing rates. This removes the SDK redundant 16/32/48 kHz guard so providers can use their native rates, including OpenAI Realtime at 24 kHz.

## Related Issues

Related to https://github.com/strands-labs/pywebrtc-audio/pull/3

## Documentation PR

No documentation changes are required. Supported rates are enforced and documented by pywebrtc-audio.

## Type of Change

New feature

## Testing

- `hatch run prepare`
- Initialized audio processing at 24 kHz with the published `pywebrtc-audio==0.2.0` wheel
- Constructed Nova Sonic, Gemini Live, and OpenAI Realtime with their native audio rates

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.