### PR TITLE
feat(mcp-py): relax mcp version to <2.2

### DIFF
--- a/.github/workflows/python-integration-test.yml
+++ b/.github/workflows/python-integration-test.yml
@@ -112,6 +112,12 @@ jobs:
             scope: bidi
             test-path: tests_integ/bidi
             artifact-name: bidi-test-results
+          # The 1.x-era MCP integration tests build servers and transports from `mcp` names that 2.x renamed, so the
+          # main scope (which resolves mcp 2.x) ignores them and this scope reruns them on a forced mcp 1.x.
+          - python-version: '3.10'
+            scope: mcp-1x
+            test-path: tests_integ/mcp
+            artifact-name: mcp-1x-test-results
     environment:
       name: ${{ needs.authorization-check.outputs.approval-env }}
       deployment: false
@@ -148,6 +154,8 @@ jobs:
           AWS_REGION: us-east-1
           AWS_REGION_NAME: us-east-1
           STRANDS_TEST_API_KEYS_SECRET_NAME: ${{ secrets.STRANDS_TEST_API_KEYS_SECRET_NAME }}
+          # Caps the hatch-test env at mcp 1.x via the pyproject override.
+          STRANDS_TEST_MCP_V1: ${{ matrix.scope == 'mcp-1x' && '1' || '' }}
         id: tests
         run: |
           hatch test ${{ matrix.test-path }}

--- a/.github/workflows/python-test-lint.yml
+++ b/.github/workflows/python-test-lint.yml
@@ -88,15 +88,13 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-  unit-test-mcp-v2:
-    name: MCP 2.x Compat
-    # The dependency pin is `mcp<2`, so the unit-test matrix only ever exercises the 1.x line and the 2.x branches of
-    # `_compat` run against mocks there. This job force-installs the 2.x line over the pin to verify against the real
-    # package that `import strands` succeeds, the MCP client suite passes, and SEP-2663 task support works. The 1.x
-    # experimental task tests are excluded: 2.x moved tasks to the SEP-2663 extension, so that workflow is 1.x-only.
-    # The job also runs the modern-protocol integ tests, which use an in-process server and need no credentials. The
-    # forced install resolves the newest 2.x below the `<2.2` support ceiling, so a breaking upstream 2.x release
-    # surfaces here rather than for users.
+  unit-test-mcp-v1:
+    name: MCP 1.x Compat
+    # The dependency range spans both `mcp` major versions and fresh installs resolve mcp 2.x, so the unit-test matrix
+    # only ever exercises 2.x and the 1.x branches of `_compat` run against mocks there. This job force-installs mcp
+    # 1.x to verify against the real package that `import strands` succeeds and the MCP client suite passes, including
+    # the legacy 2025-11-25 task workflow, which is 1.x-only. The modern-protocol integ tests
+    # (tests_integ/mcp/test_mcp_client_v2.py) require 2.x, so they run in the integration-test workflow's main scope.
     runs-on: strands-agents_ubuntu-latest_4-core
     timeout-minutes: 10
     permissions:
@@ -116,7 +114,7 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Install package, then force mcp 2.x over the pin
+      - name: Install package, then force mcp 1.x
         run: |
           pip install --no-cache-dir -e . \
             "pytest>=9.0.0,<10.0.0" \
@@ -124,23 +122,16 @@ jobs:
             "pytest-timeout>=2.0.0,<3.0.0" \
             "pytest-cov>=6.0.0,<8.0.0" \
             "moto>=5.1.0,<6.0.0"
-          pip install --no-cache-dir "mcp>=2.0.0,<2.2"
+          pip install --no-cache-dir "mcp>=1.23.0,<2.0.0"
 
       - name: Verify import and version flag
-        run: python -c "import strands; from strands.tools.mcp import _compat; assert _compat.MCP_V2"
+        run: python -c "import strands; from strands.tools.mcp import _compat; assert not _compat.MCP_V2"
 
-      # With coverage: the 2.x branches of `_compat` execute only in this job,
+      # With coverage: the 1.x branches of `_compat` execute only in this job,
       # so without this upload they always show as uncovered on the patch.
       - name: Run MCP tests
         run: |
-          pytest tests/strands/tools/mcp --ignore=tests/strands/tools/mcp/test_mcp_client_tasks.py -vv --cov=src/strands --cov-report=xml
-
-      # The server is mcp 2.x's own MCPServer running in-process, so the tests
-      # need no external endpoint or credentials and can run in this job.
-      # --noconftest: tests_integ/conftest.py's session-start guard demands the
-      # provider API keys this credential-free job deliberately does not set.
-      - name: Run mcp 2.x integration tests
-        run: pytest tests_integ/mcp/test_mcp_client_v2.py -vv --noconftest --cov=src/strands --cov-append --cov-report=xml
+          pytest tests/strands/tools/mcp -vv --cov=src/strands --cov-report=xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7

--- a/strands-py/AGENTS.md
+++ b/strands-py/AGENTS.md
@@ -219,7 +219,7 @@ class XModel(Model):
 The SDK supports MCP task-augmented execution for long-running tools. This feature is experimental and subject to change. Which task protocol runs depends on the installed `mcp` line:
 
 - **mcp 2.x**: finalized SEP-2663 Tasks (protocol `2026-07-28`) — `tools/call` returns a direct result or a task handle, followed by `tasks/get` / `tasks/update` / `tasks/cancel`.
-- **mcp 1.x** (the runtime pin `mcp<2.0.0`): the legacy 2025-11-25 flow — `call_tool_as_task`, `poll_task`, `get_task_result`.
+- **mcp 1.x**: the legacy 2025-11-25 flow — `call_tool_as_task`, `poll_task`, `get_task_result`.
 
 ### Configuration
 
@@ -255,8 +255,8 @@ Task-augmented execution is used when ALL conditions are met:
 
 - `src/strands/tools/mcp/mcp_tasks.py` - `TasksConfig`, task result models, and defaults
 - `src/strands/tools/mcp/mcp_client.py` - Task execution logic (2.x: `_call_tool_with_task_and_poll_async`; 1.x: `_call_tool_as_task_and_poll_async`) and the public task lifecycle methods (`submit_tool_*`, `get_task_*`, `update_task_*`, `cancel_task_*`)
-- `tests/strands/tools/mcp/test_mcp_client_tasks.py` - Unit tests (1.x flow)
-- `tests/strands/tools/mcp/test_mcp_client_tasks_v2.py` - Unit tests (2.x flow; runs in the MCP 2.x Compat CI job)
+- `tests/strands/tools/mcp/test_mcp_client_tasks.py` - Unit tests (1.x flow; runs in the MCP 1.x Compat CI job)
+- `tests/strands/tools/mcp/test_mcp_client_tasks_v2.py` - Unit tests (2.x flow)
 - `tests_integ/mcp/test_mcp_client_tasks.py` - Integration tests
 - `tests_integ/mcp/task_echo_server.py` - Test server with task support
 

--- a/strands-py/AGENTS.md
+++ b/strands-py/AGENTS.md
@@ -347,4 +347,5 @@ Comments are to-the-point, state only what cannot be inferred from the code, and
   - [TESTING.md](./docs/TESTING.md) - Testing reference
   - [HOOKS.md](./docs/HOOKS.md) - Hooks system guide
   - [MCP_CLIENT_ARCHITECTURE.md](./docs/MCP_CLIENT_ARCHITECTURE.md) - MCP threading design
+  - [MCP_VERSIONS.md](./docs/MCP_VERSIONS.md) - MCP 1.x/2.x support and migration
 - [PR.md](../team/PR.md) - PR description guidelines

--- a/strands-py/README.md
+++ b/strands-py/README.md
@@ -119,7 +119,7 @@ with aws_docs_client:
    response = agent("Tell me about Amazon Bedrock and how to use it with Python")
 ```
 
-The SDK works with both major versions of the `mcp` package through a built-in compatibility layer, so code that uses `MCPClient` runs unchanged on either version. A fresh install resolves to mcp 2.x, and pinning `mcp<2` keeps you on 1.x. See [docs/MCP_VERSIONS.md](./docs/MCP_VERSIONS.md) for support status and migration notes.
+The SDK works with both major versions of the `mcp` package through a built-in compatibility layer, so most code that uses `MCPClient` runs unchanged on either version. A fresh install resolves to mcp 2.x, and pinning `mcp<2` keeps you on 1.x. See [docs/MCP_VERSIONS.md](./docs/MCP_VERSIONS.md) for support status, the behavior differences on 2.x, and migration notes.
 
 ### Multiple Model Providers
 

--- a/strands-py/README.md
+++ b/strands-py/README.md
@@ -103,7 +103,7 @@ response = agent("Use any tools you find in the tools directory")
 
 ### MCP Support
 
-Seamlessly integrate Model Context Protocol (MCP) servers:
+Connect to Model Context Protocol (MCP) servers:
 
 ```python
 from strands import Agent
@@ -118,6 +118,8 @@ with aws_docs_client:
    agent = Agent(tools=aws_docs_client.list_tools_sync())
    response = agent("Tell me about Amazon Bedrock and how to use it with Python")
 ```
+
+The SDK works with both major versions of the `mcp` package through a built-in compatibility layer, so code that uses `MCPClient` runs unchanged on either version. A fresh install resolves to mcp 2.x, and pinning `mcp<2` keeps you on 1.x. See [docs/MCP_VERSIONS.md](./docs/MCP_VERSIONS.md) for support status and migration notes.
 
 ### Multiple Model Providers
 

--- a/strands-py/docs/MCP_VERSIONS.md
+++ b/strands-py/docs/MCP_VERSIONS.md
@@ -1,0 +1,42 @@
+# MCP 1.x and 2.x Support and Migration
+
+This page explains which major versions of the `mcp` package the Strands Python SDK supports, how to install each one, and what to check when moving from 1.x to 2.x. The threading design of the client itself is covered in [MCP_CLIENT_ARCHITECTURE.md](./MCP_CLIENT_ARCHITECTURE.md).
+
+## What changed in mcp 2.0
+
+The official `mcp` package made 2.0 a breaking release. The changes that affect Strands:
+
+- The default protocol revision is `2026-07-28`, which adds multi round-trip requests (a tool call can pause to ask the client for input) and an extension registry.
+- Many public names were renamed or relocated. For example, the server class `FastMCP` became `MCPServer`, the transport factory `streamablehttp_client` became `streamable_http_client`, and model attributes moved from camelCase to snake_case.
+- Tasks left the core protocol. The experimental 2025-11-25 task API (`ClientSession.experimental`) was removed, and the finalized replacement (SEP-2663) lives in the `io.modelcontextprotocol/tasks` extension.
+- The client credentials OAuth provider renamed its `scopes` argument to `scope`.
+
+## What Strands does about it
+
+The SDK ships a compatibility layer (`src/strands/tools/mcp/_compat.py`) that handles the renames and most behavior differences, so `MCPClient` and the tools it produces work the same on both versions. Code that only uses the Strands API needs no changes when the installed `mcp` version changes. The overall adoption work is tracked in #1659.
+
+## Choosing a version
+
+The dependency range is `mcp>=1.23.0,<2.2`. A fresh install resolves to the newest 2.x release in that range.
+
+To stay on 1.x, pin it in your own project:
+
+```
+pip install strands-agents "mcp<2"
+```
+
+Pinning an exact `mcp` version works too and is the safest way to control upgrades. The upper bound excludes `mcp` releases we have not verified yet, and we raise it as we test new releases. Every release line inside the current range has been verified: 1.29.x and 2.1.x, each exercised end to end against live MCP servers over stdio, streamable HTTP, and SSE.
+
+CI covers both major versions on every PR: the regular test matrix resolves mcp 2.x, and the "MCP 1.x Compat" job force-installs mcp 1.x and runs the MCP client suite against it.
+
+## Migrating your code
+
+If your code only uses the Strands API, nothing changes. `MCPClient`, `Agent(tools=client.list_tools_sync())`, tool calls, prompts, resources, and OAuth client credentials behave the same on both versions.
+
+Three things behave differently on 2.x:
+
+- `read_timeout_seconds` on tool calls bounds each request round instead of the whole call, because a 2.x tool call can involve several round trips.
+- 2.x validates `ToolAnnotations` strictly and drops unknown extra keys that 1.x preserved.
+- MCP Tasks currently require mcp 1.x. The task client is built on the experimental 2025-11-25 API (`ClientSession.experimental`) that 2.x removed, so passing `tasks_config` to `MCPClient` on a 2.x install raises `ImportError` at construction. Pin `mcp<2` to keep using tasks. Support for the finalized SEP-2663 task extension on 2.x is tracked in #4125.
+
+The compatibility layer only covers the Strands API. If you write your own MCP server with the `mcp` package, or build transports from `mcp` APIs yourself before passing them to `MCPClient`, that code uses `mcp` directly and the renames above apply to it. Follow the official guide at [modelcontextprotocol/python-sdk `docs/migration.md`](https://github.com/modelcontextprotocol/python-sdk/blob/main/docs/migration.md) for that part of the migration.

--- a/strands-py/docs/MCP_VERSIONS.md
+++ b/strands-py/docs/MCP_VERSIONS.md
@@ -27,7 +27,7 @@ pip install strands-agents "mcp<2"
 
 Pinning an exact `mcp` version works too and is the safest way to control upgrades. The upper bound excludes `mcp` releases we have not verified yet, and we raise it as we test new releases. Every release line inside the current range has been verified: 1.29.x and 2.1.x, each exercised end to end against live MCP servers over stdio, streamable HTTP, and SSE.
 
-CI covers both major versions on every PR: the regular test matrix resolves mcp 2.x, and the "MCP 1.x Compat" job force-installs mcp 1.x and runs the MCP client suite against it.
+CI covers both major versions on every PR: the regular test matrix resolves mcp 2.x, and the "MCP 1.x Compat" job force-installs mcp 1.x and runs the MCP client suite against it. Integration tests split the same way: the main scope runs on 2.x, and the mcp-1x scope forces mcp 1.x to run the 1.x-era MCP integration suite.
 
 ## Migrating your code
 
@@ -37,6 +37,6 @@ Three things behave differently on 2.x:
 
 - `read_timeout_seconds` on tool calls bounds each request round instead of the whole call, because a 2.x tool call can involve several round trips.
 - 2.x validates `ToolAnnotations` strictly and drops unknown extra keys that 1.x preserved.
-- MCP Tasks currently require mcp 1.x. The task client is built on the experimental 2025-11-25 API (`ClientSession.experimental`) that 2.x removed, so passing `tasks_config` to `MCPClient` on a 2.x install raises `ImportError` at construction. Pin `mcp<2` to keep using tasks. Support for the finalized SEP-2663 task extension on 2.x is tracked in #4125.
+- MCP Tasks work on both versions through `tasks_config`: the client drives the finalized SEP-2663 task extension on 2.x and the legacy 2025-11-25 experimental flow on 1.x, and tool calls return the same results either way. The manual task lifecycle methods (`submit_tool_sync`, `get_task_sync`, `update_task_sync`, `cancel_task_sync`, and their `_async` pairs) require 2.x and raise `RuntimeError` on 1.x.
 
 The compatibility layer only covers the Strands API. If you write your own MCP server with the `mcp` package, or build transports from `mcp` APIs yourself before passing them to `MCPClient`, that code uses `mcp` directly and the renames above apply to it. Follow the official guide at [modelcontextprotocol/python-sdk `docs/migration.md`](https://github.com/modelcontextprotocol/python-sdk/blob/main/docs/migration.md) for that part of the migration.

--- a/strands-py/docs/MCP_VERSIONS.md
+++ b/strands-py/docs/MCP_VERSIONS.md
@@ -21,22 +21,24 @@ The dependency range is `mcp>=1.23.0,<2.2`. A fresh install resolves to the newe
 
 To stay on 1.x, pin it in your own project:
 
-```
+```bash
 pip install strands-agents "mcp<2"
 ```
 
-Pinning an exact `mcp` version works too and is the safest way to control upgrades. The upper bound excludes `mcp` releases we have not verified yet, and we raise it as we test new releases. Every release line inside the current range has been verified: 1.29.x and 2.1.x, each exercised end to end against live MCP servers over stdio, streamable HTTP, and SSE.
+Pinning an exact `mcp` version works too and is the safest way to control upgrades. The upper bound excludes `mcp` releases we have not verified yet, and we raise it as we test new releases. CI exercises the newest release of each major line in the range. Older releases inside the range are accepted but not individually tested.
 
-CI covers both major versions on every PR: the regular test matrix resolves mcp 2.x, and the "MCP 1.x Compat" job force-installs mcp 1.x and runs the MCP client suite against it. Integration tests split the same way: the main scope runs on 2.x, and the mcp-1x scope forces mcp 1.x to run the 1.x-era MCP integration suite.
+CI covers both major versions on every PR that touches the Python SDK: the regular test matrix resolves mcp 2.x, and the "MCP 1.x Compat" job force-installs mcp 1.x and runs the MCP client suite against it. Integration tests split the same way: the main scope runs on 2.x, and the mcp-1x scope forces mcp 1.x to run the 1.x-era MCP integration suite.
 
 ## Migrating your code
 
-If your code only uses the Strands API, nothing changes. `MCPClient`, `Agent(tools=client.list_tools_sync())`, tool calls, prompts, resources, and OAuth client credentials behave the same on both versions.
+If your code only uses the Strands API, little changes. `MCPClient`, `Agent(tools=client.list_tools_sync())`, tool calls, prompts, resources, and OAuth client credentials work the same way on both versions, apart from the differences below.
 
-Three things behave differently on 2.x:
+These behave differently on 2.x:
 
 - `read_timeout_seconds` on tool calls bounds each request round instead of the whole call, because a 2.x tool call can involve several round trips.
-- 2.x validates `ToolAnnotations` strictly and drops unknown extra keys that 1.x preserved.
+- 2.x drops unknown `ToolAnnotations` keys that 1.x preserves.
+- `get_prompt` and `read_resource` return the installed `mcp` package's own result models, and 2.x renamed their fields from camelCase to snake_case (for example `mimeType` became `mime_type`). Code that reads fields on those results follows the installed version.
+- `auth_provider` on `MCPClient` takes an HTTPX auth object, and mcp 2.x is built on `httpx2`, which rejects `httpx.Auth` instances at request time. On a 2.x install, pass an `httpx2`-compatible auth object instead. OAuth client credentials passed through the `auth` config are unaffected, because the SDK builds the provider from the installed `mcp` package.
 - MCP Tasks work on both versions through `tasks_config`: the client drives the finalized SEP-2663 task extension on 2.x and the legacy 2025-11-25 experimental flow on 1.x, and tool calls return the same results either way. The manual task lifecycle methods (`submit_tool_sync`, `get_task_sync`, `update_task_sync`, `cancel_task_sync`, and their `_async` pairs) require 2.x and raise `RuntimeError` on 1.x.
 
 The compatibility layer only covers the Strands API. If you write your own MCP server with the `mcp` package, or build transports from `mcp` APIs yourself before passing them to `MCPClient`, that code uses `mcp` directly and the renames above apply to it. Follow the official guide at [modelcontextprotocol/python-sdk `docs/migration.md`](https://github.com/modelcontextprotocol/python-sdk/blob/main/docs/migration.md) for that part of the migration.

--- a/strands-py/docs/README.md
+++ b/strands-py/docs/README.md
@@ -9,6 +9,7 @@ This folder contains documentation for contributors and developers working on th
 - [HOOKS.md](./HOOKS.md) - Hooks system rules and usage guide
 - [PR.md](../../team/PR.md) - Pull request description guidelines
 - [MCP_CLIENT_ARCHITECTURE.md](./MCP_CLIENT_ARCHITECTURE.md) - MCP client threading architecture and design decisions
+- [MCP_VERSIONS.md](./MCP_VERSIONS.md) - MCP 1.x/2.x support status, install options, and migration notes
 
 ## Related Documentation
 

--- a/strands-py/pyproject.toml
+++ b/strands-py/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "docstring_parser>=0.15,<1.0",
     "httpx>=0.28.1,<1.0.0",
     "jsonschema>=4.0.0,<5.0.0",
-    "mcp>=1.23.0,<2.0.0",
+    "mcp>=1.23.0,<2.2",
     "pydantic>=2.4.0,<3.0.0",
     "typing-extensions>=4.13.2,<5.0.0",
     "pyyaml>=6.0.0,<7.0.0",
@@ -249,6 +249,14 @@ ignore_missing_imports = true
 # one, so each branch's ignores are "unused" when checked against the other.
 module = ["strands.tools.mcp._compat"]
 warn_unused_ignores = false
+
+[[tool.mypy.overrides]]
+# The task workflow and transport plumbing here are written against the mcp
+# 1.x types, and the default environment now resolves mcp 2.x. Remove this
+# exemption when the SEP-2663 task implementation replaces the 1.x-typed
+# code (#4125).
+module = ["strands.tools.mcp.mcp_client", "strands.tools.mcp.mcp_instrumentation"]
+ignore_errors = true
 
 [tool.ruff]
 line-length = 120

--- a/strands-py/pyproject.toml
+++ b/strands-py/pyproject.toml
@@ -252,18 +252,15 @@ module = [
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
-# _compat branches on which mcp major line is installed; mypy only ever sees
-# one, so each branch's ignores are "unused" when checked against the other.
-module = ["strands.tools.mcp._compat"]
+# These modules branch on which mcp major line is installed; mypy only ever sees one line's types, so each branch's
+# per-line ignores are "unused" when checked against the other line.
+module = [
+    "strands.tools.mcp._compat",
+    "strands.tools.mcp.mcp_client",
+    "strands.tools.mcp.mcp_instrumentation",
+    "strands.tools.mcp.mcp_tasks",
+]
 warn_unused_ignores = false
-
-[[tool.mypy.overrides]]
-# The task workflow and transport plumbing here are written against the mcp
-# 1.x types, and the default environment now resolves mcp 2.x. Remove this
-# exemption when the SEP-2663 task implementation replaces the 1.x-typed
-# code (#4125).
-module = ["strands.tools.mcp.mcp_client", "strands.tools.mcp.mcp_instrumentation"]
-ignore_errors = true
 
 [tool.ruff]
 line-length = 120

--- a/strands-py/pyproject.toml
+++ b/strands-py/pyproject.toml
@@ -175,6 +175,13 @@ dependencies = [
 [[tool.hatch.envs.hatch-test.matrix]]
 python = ["3.14", "3.13", "3.12", "3.11", "3.10"]
 
+# The dependency range spans both `mcp` majors and resolves to 2.x. Setting STRANDS_TEST_MCP_V1=1 caps the env at
+# 1.x so the 1.x-era MCP tests can run against the real package (the mcp-1x scope in python-integration-test.yml).
+[tool.hatch.envs.hatch-test.overrides]
+env.STRANDS_TEST_MCP_V1.dependencies = [
+    { value = "mcp>=1.23.0,<2.0.0", if = ["1"] },
+]
+
 [tool.hatch.envs.hatch-test.scripts]
 run = "pytest{env:HATCH_TEST_ARGS:} {args}" # Run with: hatch test
 run-cov = "pytest{env:HATCH_TEST_ARGS:} {args} --cov --cov-config=pyproject.toml --cov-report html --cov-report xml {args}" # Run with: hatch test -c

--- a/strands-py/src/strands/tools/mcp/_compat.py
+++ b/strands-py/src/strands/tools/mcp/_compat.py
@@ -155,7 +155,11 @@ async def call_tool(
     """
     if not MCP_V2:
         return await session.call_tool(
-            name, arguments, read_timeout_seconds, progress_callback=progress_callback, meta=meta
+            name,
+            arguments,
+            read_timeout_seconds,  # type: ignore[arg-type]
+            progress_callback=progress_callback,
+            meta=meta,
         )
 
     timeout = read_timeout(read_timeout_seconds)
@@ -205,7 +209,7 @@ def client_credentials_auth(
             client_secret=client_secret,
             scope=scope,  # type: ignore[call-arg]
         )
-    return ClientCredentialsOAuthProvider(
+    return ClientCredentialsOAuthProvider(  # type: ignore[return-value]
         server_url=server_url,
         storage=storage,
         client_id=client_id,
@@ -614,7 +618,7 @@ def streamable_http_transport(
         @asynccontextmanager
         async def _owned_client_transport() -> AsyncIterator[Any]:
             async with (
-                create_mcp_http_client(headers=headers, auth=auth) as http_client,
+                create_mcp_http_client(headers=headers, auth=auth) as http_client,  # type: ignore[arg-type]
                 streamable_http_client(url=url, http_client=http_client) as transport_streams,
             ):
                 yield transport_streams

--- a/strands-py/src/strands/tools/mcp/mcp_client.py
+++ b/strands-py/src/strands/tools/mcp/mcp_client.py
@@ -1750,13 +1750,17 @@ class MCPClient(ToolProvider):
         try:
             cancellation: Coroutine[Any, Any, Any]
             if task_id := cancellation_state.get("task_id"):
-                cancellation = self._cancel_task_async(task_id) if MCP_V2 else session.experimental.cancel_task(task_id)
+                if MCP_V2:
+                    cancellation = self._cancel_task_async(task_id)
+                else:
+                    cancellation = session.experimental.cancel_task(task_id)  # type: ignore[attr-defined]
             elif (request_id := cancellation_state.get("request_id")) is not None:
                 cancellation = session.send_notification(
                     ClientNotification(
-                        CancelledNotification(
+                        CancelledNotification(  # type: ignore[operator]
                             params=CancelledNotificationParams(
-                                requestId=request_id, reason="Strands agent invocation cancelled"
+                                requestId=request_id,  # type: ignore[call-arg]
+                                reason="Strands agent invocation cancelled",
                             )
                         )
                     )
@@ -1950,7 +1954,7 @@ class MCPClient(ToolProvider):
             return self._has_server_task_support()
 
         # Local import to avoid errors on old SDK versions that don't support Tasks
-        from mcp.types import TASK_OPTIONAL, TASK_REQUIRED
+        from mcp.types import TASK_OPTIONAL, TASK_REQUIRED  # type: ignore[attr-defined]
 
         # Server capability check (per MCP spec)
         if not self._has_server_task_support():
@@ -1977,7 +1981,7 @@ class MCPClient(ToolProvider):
         Returns:
             MCPCallToolResult with isError=True and the message as text content.
         """
-        return MCPCallToolResult(
+        return MCPCallToolResult(  # type: ignore[call-arg]
             isError=True,
             content=[MCPTextContent(type="text", text=message)],
         )
@@ -2309,7 +2313,12 @@ class MCPClient(ToolProvider):
             MCPCallToolResult: The final tool result after task completion.
         """
         # Local import to avoid errors on old SDK versions that don't support Tasks
-        from mcp.types import TASK_STATUS_CANCELLED, TASK_STATUS_COMPLETED, TASK_STATUS_FAILED, GetTaskResult
+        from mcp.types import (  # type: ignore[attr-defined]
+            TASK_STATUS_CANCELLED,
+            TASK_STATUS_COMPLETED,
+            TASK_STATUS_FAILED,
+            GetTaskResult,
+        )
 
         session = cast(ClientSession, self._background_thread_session)
 
@@ -2323,7 +2332,7 @@ class MCPClient(ToolProvider):
         if cancellation_state is not None:
             cancellation_state["session"] = session
         create_task = asyncio.create_task(
-            session.experimental.call_tool_as_task(
+            session.experimental.call_tool_as_task(  # type: ignore[attr-defined]
                 name=name,
                 arguments=arguments,
                 ttl=ttl_ms,
@@ -2366,7 +2375,7 @@ class MCPClient(ToolProvider):
         async def _poll_until_terminal() -> GetTaskResult | None:
             """Inner function to poll task status until terminal state."""
             final = None
-            async for task in session.experimental.poll_task(task_id):
+            async for task in session.experimental.poll_task(task_id):  # type: ignore[attr-defined]
                 self._log_debug_with_thread(
                     "tool=<%s>, task_id=<%s>, status=<%s> | task status update",
                     name,
@@ -2395,7 +2404,7 @@ class MCPClient(ToolProvider):
             return self._create_task_error_result(f"Task {task_id} polling completed without status")
 
         if final_status.status == TASK_STATUS_FAILED:
-            error_msg = final_status.statusMessage or "Task failed"
+            error_msg = final_status.statusMessage or "Task failed"  # type: ignore[attr-defined]
             self._log_debug_with_thread("tool=<%s>, task_id=<%s>, error=<%s> | task failed", name, task_id, error_msg)
             return self._create_task_error_result(error_msg)
 
@@ -2407,9 +2416,10 @@ class MCPClient(ToolProvider):
         if final_status.status == TASK_STATUS_COMPLETED:
             self._log_debug_with_thread("tool=<%s>, task_id=<%s> | task completed, fetching result", name, task_id)
             try:
-                result = await session.experimental.get_task_result(task_id, MCPCallToolResult)
+                experimental_session = session.experimental  # type: ignore[attr-defined]
+                result = await experimental_session.get_task_result(task_id, MCPCallToolResult)
                 self._log_debug_with_thread("tool=<%s>, task_id=<%s> | task result retrieved", name, task_id)
-                return result
+                return result  # type: ignore[no-any-return]
             except Exception as e:
                 # Handle race condition: task completed but result retrieval failed
                 # (e.g., result expired, network error, server restarted)
@@ -2596,7 +2606,7 @@ def _config_transport_callable(name: str, transport: str, server: dict[str, Any]
                 env=server.get("env"),
                 cwd=os.path.expanduser(server["cwd"]) if server.get("cwd") else None,
             )
-            return lambda: stdio_client(params)
+            return lambda: stdio_client(params)  # type: ignore[return-value]
 
         case "streamable-http":
             url = server.get("url")

--- a/strands-py/src/strands/tools/mcp/mcp_instrumentation.py
+++ b/strands-py/src/strands/tools/mcp/mcp_instrumentation.py
@@ -217,9 +217,9 @@ class TransportContextExtractingReader(ObjectProxy):
         """
         async for item in self.__wrapped__:
             if isinstance(item, SessionMessage):
-                request = item.message.root
+                request = item.message.root  # type: ignore[union-attr]
             elif type(item) is JSONRPCMessage:
-                request = item.root
+                request = item.root  # type: ignore[unreachable]
             else:
                 yield item
                 continue

--- a/strands-py/tests/strands/tools/mcp/test_mcp_client_tasks.py
+++ b/strands-py/tests/strands/tools/mcp/test_mcp_client_tasks.py
@@ -17,6 +17,8 @@ from strands.tools.mcp.mcp_tasks import DEFAULT_TASK_POLL_TIMEOUT, DEFAULT_TASK_
 
 from .conftest import create_server_capabilities
 
+pytestmark = pytest.mark.skipif(MCP_V2, reason="the legacy 2025-11-25 task workflow requires mcp 1.x")
+
 
 class TestTasksOptIn:
     """Tests for task opt-in behavior via tasks config."""

--- a/strands-py/tests_integ/mcp/conftest.py
+++ b/strands-py/tests_integ/mcp/conftest.py
@@ -1,0 +1,15 @@
+from strands.tools.mcp._compat import MCP_V2
+
+# These modules build fixture servers and transports from 1.x-only `mcp` names (`FastMCP`, `streamablehttp_client`,
+# `McpError`), so on a 2.x install they fail at import and cannot be collected. The mcp-1x scope in
+# python-integration-test.yml forces mcp 1.x and runs them there.
+if MCP_V2:
+    collect_ignore = [
+        "test_mcp_client.py",
+        "test_mcp_client_structured_content_and_metadata.py",
+        "test_mcp_client_tasks.py",
+        "test_mcp_elicitation.py",
+        "test_mcp_output_schema.py",
+        "test_mcp_resources.py",
+        "test_mcp_tool_provider.py",
+    ]


### PR DESCRIPTION
## Description

Widens the range to `mcp>=1.23.0,<2.2`, so a fresh install now resolves mcp 2.x. 
Projects that need to stay on 1.x pin `mcp<2` themselves. The upper bound excludes `mcp` releases we have not verified yet and moves up as we test new ones.

Because the unit-test matrix now resolves 2.x, the force-install compat job flips direction: `unit-test-mcp-v2` becomes `unit-test-mcp-v1` ("MCP 1.x Compat"), force-installing mcp 1.x so the 1.x branches of `_compat` still run against the real package. The legacy 2025-11-25 task tests are gated to 1.x, matching the workflow they exercise.

A new developer doc, `strands-py/docs/MCP_VERSIONS.md`, covers the support status, install options, and what behaves differently on 2.x. The README's MCP section links to it.

## Related Issues

Part of #1659

## Documentation PR

Developer docs are included in this PR (`strands-py/docs/MCP_VERSIONS.md` and a README pointer). No `site/` changes.

## Type of Change

New feature

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

CI exercises both `mcp` lines on this PR: the regular unit-test matrix resolves 2.x, and the renamed MCP 1.x Compat job force-installs 1.x and runs the full MCP client suite against it.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
