### PR TITLE
fix(session): remove orphaned toolResults at any index, not only the first

### DIFF
--- a/strands-py/src/strands/session/repository_session_manager.py
+++ b/strands-py/src/strands/session/repository_session_manager.py
@@ -262,7 +262,7 @@ class RepositorySessionManager(SessionManager):
         """Fix broken tool use/result pairs in message history.
 
         Handles orphaned toolUse (no corresponding toolResult), stale toolResult (IDs that don't match
-        the preceding toolUse), and orphaned toolResult at conversation start (no preceding toolUse).
+        the preceding toolUse), and orphaned toolResult at any index (no preceding toolUse).
 
         Uses a declarative rebuild: for each assistant message with toolUse, the next message's toolResult
         content is rebuilt to have exactly one result per toolUse ID, filling gaps with error results and
@@ -274,15 +274,26 @@ class RepositorySessionManager(SessionManager):
         Returns:
             Fixed list of messages with proper tool use/result pairs
         """
-        if messages:
-            first_message = messages[0]
-            if first_message["role"] == "user" and any("toolResult" in content for content in first_message["content"]):
-                logger.warning(
-                    "Session message history starts with orphaned toolResult with no preceding toolUse. "
-                    "This typically happens when messages are truncated due to pagination limits. "
-                    "Removing orphaned toolResult message to maintain valid conversation structure."
-                )
-                messages.pop(0)
+        # Reverse iteration keeps the lower indices valid after a removal.
+        for index in range(len(messages) - 1, -1, -1):
+            message = messages[index]
+            if message["role"] != "user" or not any("toolResult" in content for content in message["content"]):
+                continue
+            previous_message = messages[index - 1] if index > 0 else None
+            if previous_message is not None and any("toolUse" in content for content in previous_message["content"]):
+                continue
+
+            logger.warning(
+                "message_index=<%d> | orphaned toolResult with no preceding toolUse. "
+                "This typically happens when messages are truncated due to pagination limits. "
+                "Removing orphaned toolResult to maintain valid conversation structure.",
+                index,
+            )
+            remaining_content = [content for content in message["content"] if "toolResult" not in content]
+            if remaining_content:
+                message["content"] = remaining_content
+            else:
+                messages.pop(index)
 
         # Snapshot eligible indices before iterating. Trailing message excluded (handled by agent class
         # at prompt-arrival time). Reverse iteration keeps snapshotted indices valid after inserts.

--- a/strands-py/tests/strands/session/test_repository_session_manager.py
+++ b/strands-py/tests/strands/session/test_repository_session_manager.py
@@ -1198,3 +1198,98 @@ def test_initialize_multi_agent_calls_read_for_existing_session(mock_repository)
     # read_multi_agent should be called for existing session
     assert len(read_multi_agent_calls) == 1
     assert read_multi_agent_calls[0] == ("existing-session", "test-multi-agent")
+
+
+def test_fix_broken_tool_use_removes_orphaned_tool_result_mid_conversation(session_manager):
+    """Orphaned toolResult after a message that carries no toolUse is removed (issue #3651)."""
+    messages = [
+        {"role": "user", "content": [{"text": "Where do I live?"}]},
+        {"role": "assistant", "content": [{"text": "You live in Seattle, USA."}]},
+        {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "toolUseId": "orphaned-result-123",
+                        "status": "success",
+                        "content": [{"text": "Seattle, USA"}],
+                    }
+                }
+            ],
+        },
+        {"role": "assistant", "content": [{"text": "Anything else?"}]},
+    ]
+
+    fixed_messages = session_manager._fix_broken_tool_use(messages)
+
+    assert len(fixed_messages) == 3
+    assert not any("toolResult" in content for message in fixed_messages for content in message["content"])
+    assert fixed_messages[2]["content"][0]["text"] == "Anything else?"
+
+
+def test_fix_broken_tool_use_keeps_non_tool_result_content_of_orphaned_message(session_manager):
+    """Only the orphaned toolResult blocks are dropped; other content in that message survives."""
+    messages = [
+        {"role": "assistant", "content": [{"text": "Summary of earlier conversation."}]},
+        {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "toolUseId": "orphaned-result-123",
+                        "status": "success",
+                        "content": [{"text": "Seattle, USA"}],
+                    }
+                },
+                {"text": "and what about Portland?"},
+            ],
+        },
+    ]
+
+    fixed_messages = session_manager._fix_broken_tool_use(messages)
+
+    assert len(fixed_messages) == 2
+    assert fixed_messages[1]["content"] == [{"text": "and what about Portland?"}]
+
+
+def test_fix_broken_tool_use_removes_orphaned_tool_result_after_prepended_message(session_manager):
+    """A prepended summary message must not hide an orphaned toolResult at the window head."""
+    messages = [
+        {"role": "assistant", "content": [{"text": "Summary of earlier conversation."}]},
+        {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "toolUseId": "orphaned-result-123",
+                        "status": "success",
+                        "content": [{"text": "42"}],
+                    }
+                }
+            ],
+        },
+        {"role": "assistant", "content": [{"text": "done"}]},
+    ]
+
+    fixed_messages = session_manager._fix_broken_tool_use(messages)
+
+    assert len(fixed_messages) == 2
+    assert fixed_messages[0]["content"][0]["text"] == "Summary of earlier conversation."
+    assert fixed_messages[1]["content"][0]["text"] == "done"
+
+
+def test_fix_broken_tool_use_keeps_paired_tool_result_after_a_text_turn(session_manager):
+    """A toolResult that does follow a toolUse is left alone."""
+    messages = [
+        {"role": "user", "content": [{"text": "What is the weather?"}]},
+        {"role": "assistant", "content": [{"toolUse": {"toolUseId": "abc", "name": "weather", "input": {}}}]},
+        {
+            "role": "user",
+            "content": [{"toolResult": {"toolUseId": "abc", "status": "success", "content": [{"text": "sunny"}]}}],
+        },
+        {"role": "assistant", "content": [{"text": "It is sunny."}]},
+    ]
+
+    fixed_messages = session_manager._fix_broken_tool_use(messages)
+
+    assert fixed_messages == messages

--- a/strands-py/tests/strands/session/test_repository_session_manager.py
+++ b/strands-py/tests/strands/session/test_repository_session_manager.py
@@ -562,11 +562,12 @@ def test_fix_broken_tool_use_does_not_change_valid_message(session_manager):
             ],
         },
     ]
+    expected = copy.deepcopy(messages)
 
     fixed_messages = session_manager._fix_broken_tool_use(messages)
 
     # Should remain unchanged since toolUse is in last message
-    assert fixed_messages == messages
+    assert fixed_messages == expected
 
 
 # ============================================================================
@@ -743,11 +744,12 @@ def test_fix_broken_tool_use_does_not_affect_normal_conversations(session_manage
         {"role": "assistant", "content": [{"text": "Hi there!"}]},
         {"role": "user", "content": [{"text": "How are you?"}]},
     ]
+    expected = copy.deepcopy(messages)
 
     fixed_messages = session_manager._fix_broken_tool_use(messages)
 
     # Should remain unchanged
-    assert fixed_messages == messages
+    assert fixed_messages == expected
 
 
 # ============================================================================
@@ -1222,9 +1224,11 @@ def test_fix_broken_tool_use_removes_orphaned_tool_result_mid_conversation(sessi
 
     fixed_messages = session_manager._fix_broken_tool_use(messages)
 
-    assert len(fixed_messages) == 3
-    assert not any("toolResult" in content for message in fixed_messages for content in message["content"])
-    assert fixed_messages[2]["content"][0]["text"] == "Anything else?"
+    assert fixed_messages == [
+        {"role": "user", "content": [{"text": "Where do I live?"}]},
+        {"role": "assistant", "content": [{"text": "You live in Seattle, USA."}]},
+        {"role": "assistant", "content": [{"text": "Anything else?"}]},
+    ]
 
 
 def test_fix_broken_tool_use_keeps_non_tool_result_content_of_orphaned_message(session_manager):
@@ -1248,8 +1252,10 @@ def test_fix_broken_tool_use_keeps_non_tool_result_content_of_orphaned_message(s
 
     fixed_messages = session_manager._fix_broken_tool_use(messages)
 
-    assert len(fixed_messages) == 2
-    assert fixed_messages[1]["content"] == [{"text": "and what about Portland?"}]
+    assert fixed_messages == [
+        {"role": "assistant", "content": [{"text": "Summary of earlier conversation."}]},
+        {"role": "user", "content": [{"text": "and what about Portland?"}]},
+    ]
 
 
 def test_fix_broken_tool_use_removes_orphaned_tool_result_after_prepended_message(session_manager):
@@ -1273,9 +1279,10 @@ def test_fix_broken_tool_use_removes_orphaned_tool_result_after_prepended_messag
 
     fixed_messages = session_manager._fix_broken_tool_use(messages)
 
-    assert len(fixed_messages) == 2
-    assert fixed_messages[0]["content"][0]["text"] == "Summary of earlier conversation."
-    assert fixed_messages[1]["content"][0]["text"] == "done"
+    assert fixed_messages == [
+        {"role": "assistant", "content": [{"text": "Summary of earlier conversation."}]},
+        {"role": "assistant", "content": [{"text": "done"}]},
+    ]
 
 
 def test_fix_broken_tool_use_keeps_paired_tool_result_after_a_text_turn(session_manager):
@@ -1289,7 +1296,8 @@ def test_fix_broken_tool_use_keeps_paired_tool_result_after_a_text_turn(session_
         },
         {"role": "assistant", "content": [{"text": "It is sunny."}]},
     ]
+    expected = copy.deepcopy(messages)
 
     fixed_messages = session_manager._fix_broken_tool_use(messages)
 
-    assert fixed_messages == messages
+    assert fixed_messages == expected


### PR DESCRIPTION
## Description

`_fix_broken_tool_use` only checks `messages[0]` for a toolResult with no preceding toolUse. Everything after that is handled by the rebuild loop, which walks the messages that *contain* a toolUse and repairs the one after each. A user message whose previous message has no toolUse at all is never visited by either, so it survives the repair and the provider rejects the turn.

This drops orphaned toolResult blocks wherever they occur, not just first. If the message has other content, only the toolResult blocks go and the rest stays; the message is removed only when nothing is left.

One thing the title hides: that changes index 0 too. The old branch was `messages.pop(0)`, so a first message carrying a toolResult *and* the user's own text lost the text as well. Now the text stays. I think that is the better behaviour, but it is a change on a path that already worked, so I would rather flag it than have you find it. I ran the old and new versions of the function side by side and they agree everywhere except there.

@surecloud-jleite, this lines up with the part of your report I can account for: your `ValidationException` names `messages.11` and says the previous turn has fewer toolUse blocks, and it is the same index every retry because nothing in the repair pass ever touches that index.

Worth saying what this does not do, since you offered to test it. The repair still runs in memory only, so the `mismatched toolUse/toolResult pairing, rebuilding` warning will keep showing up on every restore even once the turn stops failing. Persisting the repaired history needs a way to remove a stored message, and `SessionRepository` has create/read/update but no delete, so that read like your design call rather than something to bolt on here.

## Related Issues

Refs #3651

## Type of Change

Bug fix

## Testing

Four tests in `tests/strands/session/test_repository_session_manager.py`: an orphan mid-conversation, an orphan behind a prepended summary message, one where the orphaned message also carries text, and a control where the toolResult does follow a toolUse. The first three fail on main.

I ran the pieces of `hatch run prepare` directly rather than the wrapper: `ruff check`, `ruff format --check` and `mypy ./src` are clean on both changed files, and `pytest tests/strands` is green on 3.10 and 3.14, the two ends of the matrix. The two failures under `tests/strands/storage/` fail the same way on main here, they look like permission tests run as root.

I could not reproduce the original production history, only the shape, so the tests drive `_fix_broken_tool_use` directly.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] My changes generate no new warnings

