### PR TITLE
fix(sandbox): preserve UTF-8 across stream chunk boundaries

### DIFF
--- a/strands-ts/src/sandbox/__tests__/posix-shell.test.node.ts
+++ b/strands-ts/src/sandbox/__tests__/posix-shell.test.node.ts
@@ -329,6 +329,28 @@ describe.skipIf(process.platform === 'win32')('PosixShellSandbox', () => {
       expect(result.exitCode).toBe(137)
     })
 
+    it('decodes multibyte UTF-8 sequences split across chunk boundaries', async () => {
+      // Regression guard for #4156. A UTF-8 character straddling a pipe read
+      // boundary must not be decoded as two invalid halves. The helper writes
+      // 'café☕' as two Buffers split mid-'é' (byte 4 of 5), so a per-chunk decode
+      // would yield U+FFFD replacements.
+      const script =
+        "const b=Buffer.from('café☕','utf8');" +
+        'process.stdout.write(b.subarray(0,4));' +
+        'setTimeout(()=>process.stdout.write(b.subarray(4)),20)'
+      const chunks: (StreamChunk | ExecutionResult)[] = []
+      for await (const chunk of streamProcess('node', ['-e', script])) {
+        chunks.push(chunk)
+      }
+      const result = chunks.find((c): c is ExecutionResult => c.type === 'executionResult')
+      expect(result?.stdout).toBe('café☕')
+      const streamed = chunks
+        .filter((c): c is StreamChunk => c.type === 'streamChunk' && c.streamType === 'stdout')
+        .map((c) => c.data)
+        .join('')
+      expect(streamed).toBe('café☕')
+    })
+
     it('returns enoentMessage when spawned binary does not exist', async () => {
       const chunks: (StreamChunk | ExecutionResult)[] = []
       for await (const chunk of streamProcess('nonexistent_binary_xyz_12345', [], {

--- a/strands-ts/src/sandbox/stream-process.ts
+++ b/strands-ts/src/sandbox/stream-process.ts
@@ -50,6 +50,11 @@ export async function* streamProcess(
   options?: StreamProcessOptions
 ): AsyncGenerator<StreamChunk | ExecutionResult, void, undefined> {
   const proc = spawn(command, args)
+  // Decode with a StringDecoder that holds partial multibyte bytes across chunk
+  // boundaries, so a UTF-8 sequence split across two pipe reads is not decoded
+  // as two invalid halves.
+  proc.stdout?.setEncoding('utf8')
+  proc.stderr?.setEncoding('utf8')
   const chunks: StreamChunk[] = []
   let stdout = ''
   let stderr = ''


### PR DESCRIPTION
Fixes #4156.

### Why

`streamProcess` is the single output path for every sandbox — `NotASandboxLocalEnvironment`, `DockerSandbox`, and `SshSandbox` all stream a child process's output through it. It spawns the child with no encoding, so `proc.stdout`/`proc.stderr` emit **Buffer** chunks, and each chunk is decoded on its own with `const text = String(data)` (= `buffer.toString('utf8')`).

That per-chunk decode is only correct when character boundaries line up with chunk boundaries — which they don't in general. A multibyte UTF-8 sequence (an accent, an emoji, a CJK glyph) that straddles a pipe read boundary is split across two `data` events; each half is an invalid byte sequence and decodes to `U+FFFD` (`�`). The corruption lands in both the incremental `StreamChunk.data` and the final `ExecutionResult.stdout`/`stderr`, and it's silent — it only shows up on non-ASCII output that's large or slow enough to span a read boundary, so it slips through casual testing.

### The fix

Set the stream encoding once, right after spawn:

```ts
proc.stdout?.setEncoding('utf8')
proc.stderr?.setEncoding('utf8')
```

Node's `Readable` then decodes through an internal `StringDecoder` that **holds partial multibyte bytes across chunks** and emits complete characters. The existing `String(data)` becomes a harmless no-op on an already-decoded string, so there's no behavior change for ASCII or for output whose characters don't span a boundary — only the corrupted case is fixed.

### Test

`strands-ts/src/sandbox/__tests__/posix-shell.test.node.ts` gains a regression guard (linked to #4156) that writes `café☕` as two Buffers split mid-`é` (byte 4 of 5):
- **Before:** `ExecutionResult.stdout` and the streamed data are `caf��☕`.
- **After:** both are `café☕`.

Verified against the repo's full CI on the touched package (`strands-ts`): `eslint` 0, `prettier --check` 0, browser-bundle 0, `tsc` build 0, and `vitest run --project unit-node` 0 — 4560/4560 passing (posix-shell file 47/47, sandbox suite 105/105).
