### PR TITLE
fix(openai): keep maxTokens when a Responses function call is cut off (TypeScript)

### DIFF
--- a/strands-ts/src/models/openai/__tests__/responses.test.ts
+++ b/strands-ts/src/models/openai/__tests__/responses.test.ts
@@ -694,6 +694,32 @@ describe("OpenAIModel (api: 'responses')", () => {
       expect(metadata?.usage).toEqual({ inputTokens: 10, outputTokens: 5, totalTokens: 15 })
     })
 
+    it('keeps stopReason=maxTokens when a function call is cut off by max_output_tokens', async () => {
+      const client = createMockClient(async function* () {
+        yield { type: 'response.created', response: { id: 'r' } }
+        yield {
+          type: 'response.output_item.added',
+          item: { type: 'function_call', id: 'item_1', call_id: 'call_1', name: 'write_file' },
+        }
+        yield {
+          type: 'response.function_call_arguments.delta',
+          item_id: 'item_1',
+          delta: '{"path": "notes.md", "content": "Lorem ipsum dol',
+        }
+        yield {
+          type: 'response.incomplete',
+          response: {
+            incomplete_details: { reason: 'max_output_tokens' },
+            usage: { input_tokens: 10, output_tokens: 50, total_tokens: 60 },
+          },
+        }
+      })
+      const model = new OpenAIModel({ api: 'responses', client })
+      const events = await collectIterator(model.stream([new Message({ role: 'user', content: [new TextBlock('x')] })]))
+      const stop = events.find((e: any) => e.type === 'modelMessageStopEvent') as any
+      expect(stop?.stopReason).toBe('maxTokens')
+    })
+
     it('plumbs prompt-cache reads (input_tokens_details.cached_tokens) into cacheReadInputTokens', async () => {
       const client = createMockClient(async function* () {
         yield { type: 'response.created', response: { id: 'r' } }

--- a/strands-ts/src/models/openai/responses-adapter.ts
+++ b/strands-ts/src/models/openai/responses-adapter.ts
@@ -583,8 +583,10 @@ export function finalizeResponsesStream(state: ResponsesStreamState): ModelStrea
     events.push({ type: 'modelContentBlockStopEvent' })
   }
 
+  // maxTokens wins over toolUse: a function call that is still in flight when the
+  // response is cut off has truncated arguments, so it must not be executed.
   let stopReason = state.stopReason
-  if (state.toolCalls.size > 0) {
+  if (state.toolCalls.size > 0 && stopReason !== 'maxTokens') {
     stopReason = 'toolUse'
   }
 


### PR DESCRIPTION
## Description

TypeScript port of #4139.

When the Responses API stream emits `response.incomplete` with `incomplete_details.reason === 'max_output_tokens'` after a `function_call` output item has started, `finalizeResponsesStream` reported `stopReason: 'toolUse'` instead of `'maxTokens'`. `Model.streamAggregated` then either threw a generic `ModelError('unable to parse tool input JSON')` (partial arguments) or executed the tool with `input: {}` (cut off before any argument bytes), instead of throwing `MaxTokensError`.

Root cause: `state.toolCalls` is populated on `response.output_item.added`, i.e. before any arguments have streamed, and the finalizer unconditionally overrode the stop reason with `'toolUse'` whenever that map was non-empty. So any function call in flight when the response was cut off won over the `'maxTokens'` set by the `response.incomplete` handler.

Changes:
- `responses-adapter.ts`: only override with `'toolUse'` when the stop reason is not already `'maxTokens'`. This matches the chat adapter, which maps `finish_reason: 'length'` to `'maxTokens'` regardless of accumulated tool-call deltas, and the Python Responses model after #4139.
- `responses.test.ts`: add a regression test for a function call cut off by `max_output_tokens`, asserting `stopReason === 'maxTokens'`.

## Related Issues

Fixes #4158

## Documentation PR

No documentation change needed.

## Type of Change

Bug fix

## Testing

- `npx vitest run --project unit-node src/models/openai/__tests__/responses.test.ts`: 61 passed (60 existing + 1 new). The new test fails on `main` without the source change (`expected 'toolUse' to be 'maxTokens'`) and passes with it.
- `npx vitest run --project unit-node` (full strands-ts unit suite): 165 files, 4560 tests passed, no type errors.
- `eslint src/models/openai`, `prettier --check` on the two changed files, `tsc --noEmit --project src/tsconfig.json`: clean.
- Repro from #4158 now prints `stopReason: 'maxTokens'` at the model level, and the agent throws `MaxTokensError` for both the partial-arguments and no-arguments-yet cases instead of parsing or executing the truncated tool call.

- [ ] I ran `hatch run prepare` (this is a strands-ts-only change; I ran the corresponding `npm run` lint / format / type-check / test commands above)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
