### PR TITLE
Add AnyAPI MCP server to the community catalog

### DIFF
--- a/site/src/content/catalog/anyapi-mcp.yaml
+++ b/site/src/content/catalog/anyapi-mcp.yaml
@@ -1,0 +1,9 @@
+name: anyapi-mcp
+description: Remote MCP server giving Strands Agents hundreds of scraping and data APIs - social platforms, search results, and web pages - behind one key and one normalized JSON schema.
+integrationType: tool
+languages:
+  python: {}
+  typescript: {}
+github: https://github.com/getanyapi-com/skills
+docsUrl: https://getanyapi.com/docs/mcp-server
+addedDate: 2026-09-03


### PR DESCRIPTION
Adds `site/src/content/catalog/anyapi-mcp.yaml`.

AnyAPI is a remote MCP server (Streamable HTTP at `https://api.getanyapi.com/mcp`) that puts hundreds of third-party scraping and data APIs behind one key and one normalized JSON schema - social platforms, search results, Google Maps, and web pages that answer a plain fetch with a bot wall. An agent discovers an API by natural-language query, reads its input/output JSON Schema and exact USD price, then runs it.

**Shape of the entry.** No package: it is a hosted MCP server, so a Strands agent points `MCPClient` at the URL and needs nothing installed. That follows the existing `aidress-mcp` entry - `python: {}`, no `package`, a `docsUrl` to the vendor's own connect page. `maintainedBy` left unset (community), and no editorial fields set.

Both language blocks are listed because a hosted MCP server works the same from the Python and TypeScript SDKs.

**Verifiable without a credential.** The handshake and tool list are open, so the entry can be checked directly:

```
curl -s https://api.getanyapi.com/mcp -X POST \
  -H 'content-type: application/json' -H 'accept: application/json, text/event-stream' \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
```

Running an API needs a key, and one is self-serve with no signup form:

```
curl -s -X POST https://api.getanyapi.com/agent/signup -d '{}'
```

The linked repo `getanyapi-com/skills` is Apache-2.0 and is also our entry in the official MCP Registry (`io.github.getanyapi-com/anyapi`).

Disclosure: I work on AnyAPI.