### PR TITLE
fix(models): guard openai_responses against location-source documents

### DIFF
--- a/strands-py/src/strands/models/openai_responses.py
+++ b/strands-py/src/strands/models/openai_responses.py
@@ -63,7 +63,7 @@ from ._defaults import resolve_config_metadata  # noqa: E402
 from ._openai_bedrock import BedrockMantleConfig, resolve_bedrock_client_args  # noqa: E402
 from ._openai_cache import apply_cache_config  # noqa: E402
 from ._openai_errors import classify_openai_error  # noqa: E402
-from ._validation import validate_config_keys  # noqa: E402
+from ._validation import _has_location_source, validate_config_keys  # noqa: E402
 from .model import BaseModelConfig, CacheConfig, Model  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -650,12 +650,16 @@ class OpenAIResponsesModel(Model):
             if any("cachePoint" in content for content in contents):
                 logger.warning("cachePoint content block is not supported by OpenAI Responses | skipping")
 
+            if any(_has_location_source(content) for content in contents):
+                logger.warning("Location sources are not supported by OpenAI Responses | skipping content block")
+
             formatted_contents = [
                 cls._format_request_message_content(content, role=role)
                 for content in contents
                 if not any(
                     block_type in content for block_type in ["toolResult", "toolUse", "reasoningContent", "cachePoint"]
                 )
+                and not _has_location_source(content)
             ]
 
             formatted_tool_calls = [
@@ -784,6 +788,9 @@ class OpenAIResponsesModel(Model):
         has_media = False
 
         for content in tool_result["content"]:
+            if _has_location_source(cast(ContentBlock, content)):
+                logger.warning("Location sources are not supported by OpenAI Responses | skipping content block")
+                continue
             if "json" in content:
                 output_parts.append({"type": "input_text", "text": json.dumps(content["json"], ensure_ascii=False)})
             elif "text" in content:

--- a/strands-py/tests/strands/models/test_openai_responses.py
+++ b/strands-py/tests/strands/models/test_openai_responses.py
@@ -308,6 +308,30 @@ def test_format_request_tool_message_with_document():
     assert tru_result["output"][1]["filename"] == "document.pdf"
 
 
+def test_format_request_tool_message_skips_location_source_document(caplog):
+    tool_result = {
+        "content": [
+            {"text": "see attached"},
+            {
+                "document": {
+                    "format": "pdf",
+                    "name": "report",
+                    "source": {"location": {"type": "s3", "s3Location": {"uri": "s3://bucket/report.pdf"}}},
+                },
+            },
+        ],
+        "status": "success",
+        "toolUseId": "c4",
+    }
+
+    with caplog.at_level(logging.WARNING, logger="strands.models.openai_responses"):
+        tru_result = OpenAIResponsesModel._format_request_tool_message(tool_result)
+
+    assert tru_result["call_id"] == "c4"
+    assert tru_result["output"] == "see attached"
+    assert "Location sources are not supported by OpenAI Responses" in caplog.text
+
+
 def test_format_request_messages(system_prompt):
     messages = [
         {
@@ -443,6 +467,30 @@ def test_format_request_messages_skips_message_cache_point(caplog):
 
     assert result == [{"role": "user", "content": [{"type": "input_text", "text": "durable prefix"}]}]
     assert "cachePoint content block is not supported by OpenAI Responses" in caplog.text
+
+
+def test_format_request_messages_skips_location_source_document(caplog):
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"text": "analyze this document"},
+                {
+                    "document": {
+                        "format": "pdf",
+                        "name": "report",
+                        "source": {"location": {"type": "s3", "s3Location": {"uri": "s3://bucket/report.pdf"}}},
+                    },
+                },
+            ],
+        },
+    ]
+
+    with caplog.at_level(logging.WARNING, logger="strands.models.openai_responses"):
+        result = OpenAIResponsesModel._format_request_messages(messages)
+
+    assert result == [{"role": "user", "content": [{"type": "input_text", "text": "analyze this document"}]}]
+    assert "Location sources are not supported by OpenAI Responses" in caplog.text
 
 
 def test_format_request_messages_assistant_only_non_text_content_dropped_entirely(caplog):


### PR DESCRIPTION
## Description

`OpenAIResponsesModel` reads `source["bytes"]` unconditionally for image/document content, so a content block with a location source (S3, HTTP, etc.) raises a bare `KeyError: 'bytes'` instead of the warn-and-skip behavior the other eight providers already get from `_has_location_source` (added in an earlier PR that this provider wasn't wired into). Hits both the regular message-content path and the tool-result path, since `openai_responses.py` has its own separate formatter for tool results.

Fixed by calling `_has_location_source` in both places, matching what `openai.py`/`anthropic.py`/etc. already do for the message path, and added a matching guard in `_format_request_tool_message` since that path doesn't exist in the other providers.

## Related Issues

Resolves #4016

## Documentation PR

No doc changes needed — this brings `openai_responses` in line with documented behavior for the other providers.

## Type of Change

Bug fix

## Testing

Added a regression test for each path (`test_format_request_messages_skips_location_source_document`, `test_format_request_tool_message_skips_location_source_document`) reproducing the issue's repro and asserting the block is dropped with a warning instead of raising. Ran `ruff format --check`, `ruff check`, `mypy --strict` on the changed files, and the full `tests/strands/models/` suite (1342 passed) — `hatch` itself wasn't available in this sandbox, so I ran the underlying tools directly rather than the `hatch run prepare` wrapper.

- [x] I ran the underlying checks `hatch run prepare` wraps (ruff format/check, mypy --strict, pytest) — `hatch` itself wasn't available in this environment

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
