### PR TITLE
feat(bidi) compress event queues to be one event queue for bidi lifecycle events

### DIFF
--- a/strands-py/src/strands/experimental/bidi/agent/_reconnect_timer.py
+++ b/strands-py/src/strands/experimental/bidi/agent/_reconnect_timer.py
@@ -79,15 +79,22 @@ class BidiReconnectTimer:
 
         The warning fires ``warning_lead_s`` before the deadline. When the lead is zero
         or exceeds the deadline, the warning is emitted immediately and the remaining
-        wait runs down to the deadline.
+        wait runs down to the deadline. The deadline countdown continues while warning
+        delivery is backpressured, but the deadline callback still follows the warning.
         """
         warning_at_s = max(deadline_s - warning_lead_s, 0)
 
         await self._sleep(warning_at_s)
         time_left_s = deadline_s - warning_at_s
-        await self._on_warning(time_left_s)
+        deadline_sleep: asyncio.Future[None] = asyncio.ensure_future(self._sleep(deadline_s - warning_at_s))
+        try:
+            await self._on_warning(time_left_s)
+            await deadline_sleep
+        finally:
+            if not deadline_sleep.done():
+                deadline_sleep.cancel()
+            await asyncio.gather(deadline_sleep, return_exceptions=True)
 
-        await self._sleep(deadline_s - warning_at_s)
         # Detach before the callback re-arms this timer; cancelling a live self-reference
         # would abort the reconnect the callback runs.
         self._task = None

--- a/strands-py/src/strands/experimental/bidi/agent/loop.py
+++ b/strands-py/src/strands/experimental/bidi/agent/loop.py
@@ -285,14 +285,22 @@ class _BidiAgentLoop:
                     if not self._auto_reconnect_enabled():
                         logger.debug("auto_reconnect disabled | surfacing timeout to caller")
                         raise error
-                    yield BidiConnectionRestartEvent(
+                    restart_event = BidiConnectionRestartEvent(
                         reason="timeout",
                         timeout_error=error,
                         turn_interrupted=not self._turn_complete.is_set(),
                     )
-                    # Raise-time generation: a swap during the yield makes _restart_connection
-                    # decline this now-stale trigger.
-                    await self._restart_connection(error, event.generation)
+                    try:
+                        await self._restart_connection(
+                            error,
+                            event.generation,
+                            restart_event=restart_event,
+                        )
+                    except Exception:
+                        # The restart event was queued before the failing swap. Surface it before
+                        # preserving the existing behavior of raising the restart failure.
+                        yield self._event_queue.get_nowait()
+                        raise
                     continue
                 raise error
 
@@ -409,7 +417,7 @@ class _BidiAgentLoop:
             timeout_error: Timeout error on the reactive path, or ``None`` when proactive.
             generation: Connection generation the trigger was raised for; the restart is declined
                 as stale if the connection has since been swapped.
-            restart_event: Scheduled restart event to emit before the proactive swap.
+            restart_event: Restart event to emit before an accepted swap.
 
         Returns:
             ``True`` if this call performed the swap, ``False`` if it declined. Raises if the

--- a/strands-py/src/strands/experimental/bidi/agent/loop.py
+++ b/strands-py/src/strands/experimental/bidi/agent/loop.py
@@ -80,7 +80,7 @@ class _BidiAgentLoop:
         _agent: BidiAgent instance to loop.
         _started: Flag if agent loop has started.
         _task_pool: Track active async tasks created in loop.
-        _event_queue: Queue model and tool call events for receiver.
+        _event_queue: Queue output and connection lifecycle events for receiver.
         _invocation_state: Optional context to pass to tools during execution.
             This allows passing custom data (user_id, session_id, database connections, etc.)
             that tools can access via their invocation_state parameter.
@@ -100,11 +100,6 @@ class _BidiAgentLoop:
         self._started = False
         self._task_pool = _TaskPool()
         self._event_queue: asyncio.Queue
-        # Connection-lifecycle events (warning, restart); unbounded and drained by receive() with
-        # priority over the data queue, so a busy consumer neither drops them nor stalls the timer.
-        self._lifecycle_queue: asyncio.Queue
-        # Holds a data event pulled alongside a lifecycle event, for the next receive() iteration.
-        self._pending_data: BidiOutputEvent | Exception | None = None
         self._invocation_state: dict[str, Any]
         self._model_task: asyncio.Task | None = None
 
@@ -190,8 +185,6 @@ class _BidiAgentLoop:
         self._reset_turn_state()
 
         self._event_queue = asyncio.Queue(maxsize=1)
-        self._lifecycle_queue = asyncio.Queue()
-        self._pending_data = None
 
         self._task_pool = _TaskPool()
         self._model_task = self._task_pool.create(self._run_model(self._generation))
@@ -279,7 +272,7 @@ class _BidiAgentLoop:
             raise RuntimeError("loop not started | call start before receiving")
 
         while True:
-            event = await self._next_event()
+            event = await self._event_queue.get()
             if isinstance(event, _ReaderError):
                 if event.generation != self._generation:
                     # Superseded reader: its connection was already replaced, so drop the error
@@ -313,31 +306,6 @@ class _BidiAgentLoop:
 
             yield event
 
-    async def _next_event(self) -> Any:
-        """Return the next event, draining the lifecycle queue with priority over data events.
-
-        When both queues are idle, waits on whichever produces first; a data event pulled
-        alongside a lifecycle event is held in ``_pending_data`` for the next call.
-        """
-        if not self._lifecycle_queue.empty():
-            return self._lifecycle_queue.get_nowait()
-        if self._pending_data is not None:
-            event, self._pending_data = self._pending_data, None
-            return event
-        if not self._event_queue.empty():
-            return self._event_queue.get_nowait()
-
-        get_lifecycle = asyncio.ensure_future(self._lifecycle_queue.get())
-        get_data = asyncio.ensure_future(self._event_queue.get())
-        done, pending = await asyncio.wait({get_lifecycle, get_data}, return_when=asyncio.FIRST_COMPLETED)
-        for task in pending:
-            task.cancel()
-        if get_lifecycle in done:
-            if get_data in done:
-                self._pending_data = get_data.result()
-            return get_lifecycle.result()
-        return get_data.result()
-
     def _connection_config(self) -> BidiConnectionConfig:
         """Return the model's declared connection config, or an empty config if none.
 
@@ -370,13 +338,9 @@ class _BidiAgentLoop:
         self._reconnect_timer.arm(deadline_s, _MODEL_RESTART_WARNING_S)
 
     async def _on_reconnect_warning(self, time_left_s: int) -> None:
-        """Timer callback: surface an approaching-reconnect warning to the receiver.
-
-        Emitted on the lifecycle queue: non-blocking (so it never stalls the timer's run to the
-        deadline) and unbounded (so a busy consumer never drops it).
-        """
+        """Timer callback: surface an approaching-reconnect warning to the receiver."""
         logger.debug("time_left_s=<%.1f> | emitting connection warning", time_left_s)
-        self._lifecycle_queue.put_nowait(BidiConnectionWarningEvent(time_left_s=time_left_s))
+        await self._event_queue.put(BidiConnectionWarningEvent(time_left_s=time_left_s))
 
     async def _on_reconnect_deadline(self) -> None:
         """Timer callback: align to a turn boundary, then reconnect proactively.
@@ -392,17 +356,11 @@ class _BidiAgentLoop:
         # A forced swap (the wait timed out) leaves _turn_complete clear: an in-progress or owed
         # turn is being cut and won't be answered on replay. Capture before the swap resets it.
         turn_interrupted = not self._turn_complete.is_set()
+        restart_event = BidiConnectionRestartEvent(reason="scheduled", turn_interrupted=turn_interrupted)
         try:
-            reconnected = await self._restart_connection(None, generation)
+            await self._restart_connection(None, generation, restart_event=restart_event)
         except Exception as error:
             await self._event_queue.put(error)
-            return
-        # Announce an actual swap on the lifecycle queue: non-blocking, and priority-drained by
-        # receive() so it precedes any output from the new connection.
-        if reconnected:
-            self._lifecycle_queue.put_nowait(
-                BidiConnectionRestartEvent(reason="scheduled", turn_interrupted=turn_interrupted)
-            )
 
     async def _await_turn_boundary(self) -> None:
         """Wait for the current turn to finish, bounded so the reconnect beats the limit.
@@ -434,16 +392,24 @@ class _BidiAgentLoop:
         else:
             self._turn_complete.set()
 
-    async def _restart_connection(self, timeout_error: BidiModelTimeoutError | None, generation: int) -> bool:
+    async def _restart_connection(
+        self,
+        timeout_error: BidiModelTimeoutError | None,
+        generation: int,
+        *,
+        restart_event: BidiConnectionRestartEvent | None = None,
+    ) -> bool:
         """Restart the model connection, reactively (after timeout) or proactively (timer).
 
         The single guard point for both paths: declines when the loop has stopped, when the
-        connection was already swapped since the trigger, or when a restart is in flight.
+        connection was already swapped since the trigger, or when a restart is in flight. A
+        supplied restart event is emitted after these checks and before the connection is swapped.
 
         Args:
             timeout_error: Timeout error on the reactive path, or ``None`` when proactive.
             generation: Connection generation the trigger was raised for; the restart is declined
                 as stale if the connection has since been swapped.
+            restart_event: Scheduled restart event to emit before the proactive swap.
 
         Returns:
             ``True`` if this call performed the swap, ``False`` if it declined. Raises if the
@@ -470,6 +436,14 @@ class _BidiAgentLoop:
 
         try:
             self._send_gate.clear()
+            if restart_event is not None:
+                await self._event_queue.put(restart_event)
+                if not self._started:
+                    # stop() can run while the bounded queue put is suspended.
+                    logger.debug(  # type: ignore[unreachable]
+                        "loop stopped while emitting restart event | ignoring restart trigger"
+                    )
+                    return False
             self._fold_token_baseline()
 
             # A raising before-restart hook propagates out with the send gate left closed.

--- a/strands-py/tests/strands/experimental/bidi/agent/test_loop.py
+++ b/strands-py/tests/strands/experimental/bidi/agent/test_loop.py
@@ -135,12 +135,10 @@ async def test_bidi_agent_loop_proactive_reconnect_before_deadline(loop, agent, 
 
     # The proactive timer emits the warning and scheduled restart on the bounded event stream.
     warning = await loop._event_queue.get()
-    assert isinstance(warning, BidiConnectionWarningEvent)
+    assert warning == BidiConnectionWarningEvent(time_left_s=5)
 
     restart = await loop._event_queue.get()
-    assert isinstance(restart, BidiConnectionRestartEvent)
-    assert restart.reason == "scheduled"
-    assert restart.turn_interrupted is False  # swapped at an idle boundary, no turn cut
+    assert restart == BidiConnectionRestartEvent(reason="scheduled", turn_interrupted=False)
 
     agent.model.restart.assert_called()
 
@@ -172,8 +170,7 @@ async def test_scheduled_restart_event_emitted_before_model_restart(loop, agent,
 
     assert order == ["event", "restart"]
     restart = await loop._event_queue.get()
-    assert isinstance(restart, BidiConnectionRestartEvent)
-    assert restart.reason == "scheduled"
+    assert restart == BidiConnectionRestartEvent(reason="scheduled", turn_interrupted=False)
     assert await asyncio.wait_for(loop._event_queue.get(), timeout=2.0) is output
 
     await loop.stop()
@@ -447,7 +444,7 @@ async def test_connection_events_share_bounded_event_queue(loop, agent, agenerat
     await warning_put
 
     second = await asyncio.wait_for(loop.receive().__anext__(), timeout=2.0)
-    assert isinstance(second, BidiConnectionWarningEvent)
+    assert second == BidiConnectionWarningEvent(time_left_s=10)
     assert loop._event_queue.maxsize == 1
 
     await loop.stop()
@@ -468,7 +465,7 @@ async def test_connection_event_delivered_while_consumer_idle(loop, agent, agene
 
     asyncio.create_task(emit())
     first = await asyncio.wait_for(consumer.__anext__(), timeout=2.0)
-    assert isinstance(first, BidiConnectionWarningEvent)
+    assert first == BidiConnectionWarningEvent(time_left_s=10)
 
     await loop.stop()
 
@@ -593,7 +590,7 @@ async def test_deadline_callback_does_not_restart_after_stop_while_queue_full(ag
     await asyncio.wait_for(deadline_task, timeout=2)
 
     agent.model.restart.assert_not_called()
-    assert isinstance(loop._event_queue.get_nowait(), BidiConnectionRestartEvent)
+    assert loop._event_queue.get_nowait() == BidiConnectionRestartEvent(reason="scheduled", turn_interrupted=False)
 
 
 @pytest.mark.asyncio
@@ -711,8 +708,7 @@ async def test_forced_swap_flags_interrupted_turn(agent, agenerator):
         await loop._on_reconnect_deadline()
 
     restart = await loop._event_queue.get()
-    assert isinstance(restart, BidiConnectionRestartEvent)
-    assert restart.turn_interrupted is True
+    assert restart == BidiConnectionRestartEvent(reason="scheduled", turn_interrupted=True)
 
     await loop.stop()
 

--- a/strands-py/tests/strands/experimental/bidi/agent/test_loop.py
+++ b/strands-py/tests/strands/experimental/bidi/agent/test_loop.py
@@ -76,6 +76,26 @@ async def test_bidi_agent_loop_receive_restart_connection(loop, agent, agenerato
 
 
 @pytest.mark.asyncio
+async def test_reactive_restart_failure_yields_event_before_raising(loop, agent, agenerator):
+    """A failed reactive restart still notifies the caller before surfacing the failure."""
+    timeout_error = BidiModelTimeoutError("test timeout")
+    restart_error = RuntimeError("restart failed")
+    agent.model.connection_config = {}
+    agent.model.receive = unittest.mock.Mock(side_effect=timeout_error)
+    agent.model.restart.side_effect = restart_error
+
+    await loop.start()
+    consumer = loop.receive()
+
+    event = await consumer.__anext__()
+    assert event == BidiConnectionRestartEvent(reason="timeout", timeout_error=timeout_error)
+    with pytest.raises(RuntimeError, match="restart failed"):
+        await consumer.__anext__()
+
+    await loop.stop()
+
+
+@pytest.mark.asyncio
 async def test_bidi_agent_loop_auto_reconnect_default_on(loop, agent, agenerator):
     """Auto reconnect is the default: a timeout triggers reconnect without any opt-in."""
     # AsyncMock(spec=BidiModel) generates connection_config as a Mock; force the realistic
@@ -422,6 +442,47 @@ async def test_stale_reactive_timeout_dropped_after_proactive_swap(loop, agent, 
     assert result is sentinel
     await feed
     assert agent.model.restart.call_count == restarts  # no second restart from the stale timeout
+
+    await loop.stop()
+
+
+@pytest.mark.asyncio
+async def test_reactive_timeout_during_scheduled_restart_emits_no_duplicate(loop, agent, agenerator):
+    """A timeout cannot emit another restart event after a scheduled restart is accepted."""
+    agent.model.connection_config = {}
+    agent.model.receive = unittest.mock.Mock(return_value=agenerator([]))
+    hook_started = asyncio.Event()
+    release_hook = asyncio.Event()
+
+    async def block_restart(_event):
+        hook_started.set()
+        await release_hook.wait()
+
+    agent.hooks.add_callback(BidiBeforeConnectionRestartEvent, block_restart)
+
+    await loop.start()
+    loop._reconnect_timer.cancel()
+    generation = loop._generation
+
+    deadline = asyncio.create_task(loop._on_reconnect_deadline())
+    await hook_started.wait()
+
+    consumer = loop.receive()
+    scheduled = await consumer.__anext__()
+    assert scheduled == BidiConnectionRestartEvent(reason="scheduled")
+
+    await loop._event_queue.put(_ReaderError(generation, BidiModelTimeoutError("duplicate timeout")))
+    next_event = asyncio.create_task(consumer.__anext__())
+    await asyncio.sleep(0)
+    assert not next_event.done()
+
+    sentinel = BidiTextInputEvent(text="after duplicate timeout")
+    await loop._event_queue.put(sentinel)
+    assert await asyncio.wait_for(next_event, timeout=2.0) is sentinel
+
+    release_hook.set()
+    await deadline
+    agent.model.restart.assert_called_once()
 
     await loop.stop()
 

--- a/strands-py/tests/strands/experimental/bidi/agent/test_loop.py
+++ b/strands-py/tests/strands/experimental/bidi/agent/test_loop.py
@@ -133,16 +133,48 @@ async def test_bidi_agent_loop_proactive_reconnect_before_deadline(loop, agent, 
 
     await loop.start()
 
-    # The proactive timer enqueues a warning, then reconnects, then enqueues the scheduled event.
-    warning = await loop._lifecycle_queue.get()
+    # The proactive timer emits the warning and scheduled restart on the bounded event stream.
+    warning = await loop._event_queue.get()
     assert isinstance(warning, BidiConnectionWarningEvent)
 
-    restart = await loop._lifecycle_queue.get()
+    restart = await loop._event_queue.get()
     assert isinstance(restart, BidiConnectionRestartEvent)
     assert restart.reason == "scheduled"
     assert restart.turn_interrupted is False  # swapped at an idle boundary, no turn cut
 
     agent.model.restart.assert_called()
+
+    await loop.stop()
+
+
+@pytest.mark.asyncio
+async def test_scheduled_restart_event_emitted_before_model_restart(loop, agent, agenerator):
+    """The scheduled restart event precedes provider restart and new-connection output."""
+    agent.model.connection_config = {}
+    output = BidiTextInputEvent(text="new-connection output")
+    agent.model.receive = unittest.mock.Mock(side_effect=[agenerator([]), agenerator([output])])
+    order = []
+
+    await loop.start()
+    loop._reconnect_timer.cancel()
+
+    original_put = loop._event_queue.put
+
+    async def recording_put(event):
+        if isinstance(event, BidiConnectionRestartEvent):
+            order.append("event")
+        await original_put(event)
+
+    agent.model.restart.side_effect = lambda *_args, **_kwargs: order.append("restart")
+
+    with unittest.mock.patch.object(loop._event_queue, "put", side_effect=recording_put):
+        await loop._on_reconnect_deadline()
+
+    assert order == ["event", "restart"]
+    restart = await loop._event_queue.get()
+    assert isinstance(restart, BidiConnectionRestartEvent)
+    assert restart.reason == "scheduled"
+    assert await asyncio.wait_for(loop._event_queue.get(), timeout=2.0) is output
 
     await loop.stop()
 
@@ -398,40 +430,45 @@ async def test_stale_reactive_timeout_dropped_after_proactive_swap(loop, agent, 
 
 
 @pytest.mark.asyncio
-async def test_lifecycle_events_take_priority_over_data_in_receive(loop, agent, agenerator):
-    """A queued lifecycle event is delivered before an older data event (in-order, not dropped)."""
+async def test_connection_events_share_bounded_event_queue(loop, agent, agenerator):
+    """Connection events preserve FIFO order and backpressure on the size-one event queue."""
     agent.model.receive = unittest.mock.Mock(return_value=agenerator([]))
     await loop.start()
     loop._reconnect_timer.cancel()
 
     data = BidiTextInputEvent(text="new-connection output")
-    warning = BidiConnectionWarningEvent(time_left_s=10.0)
-    await loop._event_queue.put(data)  # data queued first...
-    loop._lifecycle_queue.put_nowait(warning)  # ...lifecycle second, but wins
+    await loop._event_queue.put(data)
+    warning_put = asyncio.create_task(loop._on_reconnect_warning(10))
+    await asyncio.sleep(0)
+    assert not warning_put.done()
 
     first = await asyncio.wait_for(loop.receive().__anext__(), timeout=2.0)
-    assert first is warning
+    assert first is data
+    await warning_put
+
+    second = await asyncio.wait_for(loop.receive().__anext__(), timeout=2.0)
+    assert isinstance(second, BidiConnectionWarningEvent)
+    assert loop._event_queue.maxsize == 1
 
     await loop.stop()
 
 
 @pytest.mark.asyncio
-async def test_lifecycle_event_delivered_while_consumer_idle(loop, agent, agenerator):
-    """A lifecycle event emitted while both queues are empty still wakes receive()."""
+async def test_connection_event_delivered_while_consumer_idle(loop, agent, agenerator):
+    """A connection event emitted while the queue is empty wakes receive()."""
     agent.model.receive = unittest.mock.Mock(return_value=agenerator([]))
     await loop.start()
     loop._reconnect_timer.cancel()
 
     consumer = loop.receive()
-    warning = BidiConnectionWarningEvent(time_left_s=10.0)
 
     async def emit():
-        await asyncio.sleep(0)  # let the consumer reach the both-queues-empty wait
-        loop._lifecycle_queue.put_nowait(warning)
+        await asyncio.sleep(0)
+        await loop._on_reconnect_warning(10)
 
     asyncio.create_task(emit())
     first = await asyncio.wait_for(consumer.__anext__(), timeout=2.0)
-    assert first is warning
+    assert isinstance(first, BidiConnectionWarningEvent)
 
     await loop.stop()
 
@@ -529,6 +566,34 @@ async def test_deadline_callback_does_not_reconnect_after_stop(agent, agenerator
     await asyncio.wait_for(deadline_task, timeout=2)
 
     agent.model.restart.assert_not_called()
+    assert loop._event_queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_deadline_callback_does_not_restart_after_stop_while_queue_full(agent, agenerator):
+    """A restart blocked on event backpressure must not restart the model after stop()."""
+    agent.model.connection_config = {}
+    agent.model.receive = unittest.mock.Mock(return_value=agenerator([]))
+
+    loop = agent._loop
+    await loop.start()
+    loop._reconnect_timer.cancel()
+
+    queued = BidiTextInputEvent(text="queued")
+    await loop._event_queue.put(queued)
+    deadline_task = asyncio.create_task(loop._on_reconnect_deadline())
+    for _ in range(10):
+        await asyncio.sleep(0)
+        if loop._reconnecting:
+            break
+    assert loop._reconnecting
+
+    await loop.stop()
+    assert loop._event_queue.get_nowait() is queued
+    await asyncio.wait_for(deadline_task, timeout=2)
+
+    agent.model.restart.assert_not_called()
+    assert isinstance(loop._event_queue.get_nowait(), BidiConnectionRestartEvent)
 
 
 @pytest.mark.asyncio
@@ -645,7 +710,7 @@ async def test_forced_swap_flags_interrupted_turn(agent, agenerator):
     with unittest.mock.patch("strands.experimental.bidi.agent.loop._MODEL_RESTART_TURN_TIMEOUT_S", 0):
         await loop._on_reconnect_deadline()
 
-    restart = await loop._lifecycle_queue.get()
+    restart = await loop._event_queue.get()
     assert isinstance(restart, BidiConnectionRestartEvent)
     assert restart.turn_interrupted is True
 

--- a/strands-py/tests/strands/experimental/bidi/agent/test_reconnect_timer.py
+++ b/strands-py/tests/strands/experimental/bidi/agent/test_reconnect_timer.py
@@ -59,6 +59,46 @@ async def test_timer_fires_warning_then_deadline():
 
 
 @pytest.mark.asyncio
+async def test_timer_deadline_countdown_continues_while_warning_is_blocked():
+    """Warning backpressure does not add its duration to the deadline countdown."""
+    warning_started = asyncio.Event()
+    release_warning = asyncio.Event()
+    deadline_sleep_started = asyncio.Event()
+    deadline_elapsed = asyncio.Event()
+    deadlines = []
+    sleep_count = 0
+
+    async def fake_sleep(_seconds):
+        nonlocal sleep_count
+        sleep_count += 1
+        if sleep_count == 2:
+            deadline_sleep_started.set()
+            await deadline_elapsed.wait()
+
+    async def blocked_warning(_time_left_s):
+        warning_started.set()
+        await release_warning.wait()
+
+    timer = BidiReconnectTimer(
+        on_warning=blocked_warning,
+        on_deadline=lambda: _record(deadlines, None),
+        sleep=fake_sleep,
+    )
+    timer.arm(deadline_s=420, warning_lead_s=30)
+
+    await warning_started.wait()
+    await deadline_sleep_started.wait()
+    deadline_elapsed.set()
+    await asyncio.sleep(0)
+    assert deadlines == []  # warning ordering is preserved even after the deadline elapses
+
+    release_warning.set()
+    await timer._task
+
+    assert deadlines == [None]
+
+
+@pytest.mark.asyncio
 async def test_timer_cancel_is_safe_when_idle():
     """cancel() before arming does not raise."""
     timer = BidiReconnectTimer(on_warning=_noop_arg, on_deadline=_noop)


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

Restores a single max-size-1 queue for bidi output and connection lifecycle events, preserving FIFO ordering and backpressure. Scheduled restart events are now emitted after restart eligibility checks but before the provider restart, ensuring consumers observe the transition before new-connection output.

Follow-up to PR #3874.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->
## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [ ] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
