### PR TITLE
docs(ollama): add section on using OllamaModel with llmman

### DIFF
--- a/site/src/content/docs/user-guide/concepts/model-providers/ollama.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/ollama.mdx
@@ -199,6 +199,31 @@ creative_agent = Agent(model=creative_model)
 factual_agent = Agent(model=factual_model)
 ```
 
+### Using with llmman
+
+[llmman](https://github.com/llmmanorg/llmman) is a local model runner that serves the Ollama API
+(alongside OpenAI- and Anthropic-compatible ones) on port 17434. Because `/api/chat` (including
+`tools`, `images`, and `format`) is served unchanged, `OllamaModel` works against it by pointing
+`host` at the llmman port:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/llmmanorg/llmman/main/install.sh | sh
+llmman pull gemma4
+llmman serve
+```
+
+```python
+from strands import Agent
+from strands.models.ollama import OllamaModel
+
+llmman_model = OllamaModel(
+    host="http://localhost:17434",  # llmman server address
+    model_id="gemma4",  # or e.g. "hf.co/unsloth/Qwen3.5-0.8B-GGUF"
+)
+
+agent = Agent(model=llmman_model)
+```
+
 ### Structured Output
 
 Ollama supports structured output for models that have tool calling capabilities. When you pass `structured_output_model` parameter to the [agent invocation](@api/python/strands.agent.agent#Agent.__call__), the Strands SDK converts your Pydantic models to tool specifications that compatible Ollama models can understand.


### PR DESCRIPTION
## Description

Adds a "Using with llmman" section to the Ollama provider page. [llmman](https://github.com/llmmanorg/llmman) is a local model runner that serves the Ollama API on port 17434.

- Only `site/.../model-providers/ollama.mdx` changes: install/pull/serve steps plus an `OllamaModel` snippet with `host="http://localhost:17434"`.
- No `LlmmanModel` class: the only difference from Ollama is the port, and a new public class would need API bar-raising review first.
- No catalog entry: llmman has no published `strands-*` package or vendor-hosted Strands guide yet.

## Related Issues

None.

## Documentation PR

This PR is the documentation change.

## Type of Change

Documentation update

## Testing

**Testing:** `npm run build` in `site/` renders the new section; `python -m py_compile` on the snippet. Not run against a live llmman server.

- [ ] I ran `hatch run prepare` (docs-only, no Python source touched)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works (docs-only)
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

> AI-assisted, reviewed before submitting.
