### PR TITLE
ci(typescript): add install-size guard to pack test

### DIFF
--- a/.github/workflows/typescript-test-package-pack.yml
+++ b/.github/workflows/typescript-test-package-pack.yml
@@ -93,6 +93,19 @@ jobs:
           npx tsc --noEmit
           npx tsx verify.ts
 
+          # Guard against dependency bloat (#4169). Measure the installed
+          # footprint a consumer would see — the same tree that ends up in a
+          # Lambda / AgentCore zip. 250 MB is the AgentCore code-package limit;
+          # we use that as the ceiling.
+          SIZE_KB=$(du -sk node_modules | cut -f1)
+          SIZE_MB=$(( SIZE_KB / 1024 ))
+          echo "[pack-test] node_modules install size: ${SIZE_MB} MB"
+          MAX_MB=250
+          if [ "$SIZE_MB" -gt "$MAX_MB" ]; then
+            echo "::error::Install size ${SIZE_MB} MB exceeds ${MAX_MB} MB limit. A dependency may be pulling in unexpected native binaries."
+            exit 1
+          fi
+
       # Upload for release-typescript.yml's inspect/publish path to consume.
       # PR-triggered runs also upload (short retention) — harmless.
       - name: Upload tarball for downstream inspect/publish

--- a/.github/workflows/typescript-test-package-pack.yml
+++ b/.github/workflows/typescript-test-package-pack.yml
@@ -93,14 +93,14 @@ jobs:
           npx tsc --noEmit
           npx tsx verify.ts
 
-          # Guard against dependency bloat (#4169). Measure the installed
-          # footprint a consumer would see — the same tree that ends up in a
-          # Lambda / AgentCore zip. 250 MB is the AgentCore code-package limit;
-          # we use that as the ceiling.
-          SIZE_KB=$(du -sk node_modules | cut -f1)
-          SIZE_MB=$(( SIZE_KB / 1024 ))
-          echo "[pack-test] node_modules install size: ${SIZE_MB} MB"
-          MAX_MB=250
+          # Guard against dependency bloat (#4169). Reinstall without the
+          # test fixture's devDependencies so we measure only what a consumer
+          # ships, then check against a tight ceiling.
+          npm install --ignore-scripts --no-audit --no-fund --omit=dev "$TARBALL_PATH"
+          SIZE_BYTES=$(du -sb node_modules | cut -f1)
+          SIZE_MB=$(( SIZE_BYTES / 1048576 ))
+          echo "[pack-test] consumer node_modules install size: ${SIZE_MB} MB"
+          MAX_MB=150
           if [ "$SIZE_MB" -gt "$MAX_MB" ]; then
             echo "::error::Install size ${SIZE_MB} MB exceeds ${MAX_MB} MB limit. A dependency may be pulling in unexpected native binaries."
             exit 1


### PR DESCRIPTION


## Description
Measure the consumer-facing node_modules size in the isolated pack- install test and fail if it exceeds 250 MB (AgentCore's code-package limit). This would have caught #4169 before release.


Ran this test on both #4169 and before it to validate this CI step catches and blocks
## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [ ] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
