### PR TITLE
fix(file-editor): stop str_replace and insert from expanding tabs on the write path

### DIFF
--- a/strands-py/src/strands/vended_tools/file_editor/file_editor.py
+++ b/strands-py/src/strands/vended_tools/file_editor/file_editor.py
@@ -175,25 +175,26 @@ def _build_str_replace_result(
     Raises:
         ValueError: If ``old_str`` does not appear exactly once.
     """
-    file_content = original_content.replace("\t", "        ")
-    expanded_old = old_str.replace("\t", "        ")
-    expanded_new = new_str.replace("\t", "        ") if new_str else ""
+    if not old_str:
+        raise ValueError("No replacement was performed, old_str must not be empty.")
 
-    occurrences = file_content.count(expanded_old)
+    replacement = new_str or ""
+
+    occurrences = original_content.count(old_str)
     if occurrences == 0:
         raise ValueError(f"No replacement was performed, old_str `{old_str}` did not appear verbatim in {file_path}.")
     if occurrences > 1:
-        lines = file_content.split("\n")
-        line_numbers = [i + 1 for i, line in enumerate(lines) if expanded_old in line]
+        lines = original_content.split("\n")
+        line_numbers = [i + 1 for i, line in enumerate(lines) if old_str in line]
         raise ValueError(
             f"No replacement was performed. Multiple occurrences of old_str `{old_str}` in lines "
             f"{line_numbers}. Please ensure it is unique"
         )
 
-    new_content = file_content.replace(expanded_old, expanded_new, 1)
-    replacement_line = len(file_content[: file_content.index(expanded_old)].split("\n")) - 1
-    inserted_lines = len(expanded_new.split("\n"))
-    original_lines = len(expanded_old.split("\n"))
+    new_content = original_content.replace(old_str, replacement, 1)
+    replacement_line = len(original_content[: original_content.index(old_str)].split("\n")) - 1
+    inserted_lines = len(replacement.split("\n"))
+    original_lines = len(old_str.split("\n"))
     line_difference = inserted_lines - original_lines
 
     new_lines = new_content.split("\n")
@@ -218,10 +219,7 @@ def _build_insert_result(original_content: str, insert_line: int, new_str: str) 
     Raises:
         ValueError: If ``insert_line`` is out of bounds.
     """
-    file_text = original_content.replace("\t", "        ")
-    expanded_new = new_str.replace("\t", "        ")
-
-    file_text_lines = file_text.split("\n")
+    file_text_lines = original_content.split("\n")
     n_lines = len(file_text_lines)
 
     if insert_line < 0 or insert_line > n_lines:
@@ -230,10 +228,10 @@ def _build_insert_result(original_content: str, insert_line: int, new_str: str) 
             f"of the file: [0, {n_lines}]"
         )
 
-    new_str_lines = expanded_new.split("\n")
+    new_str_lines = new_str.split("\n")
     new_file_text_lines = (
         new_str_lines
-        if file_text == ""
+        if original_content == ""
         else [*file_text_lines[:insert_line], *new_str_lines, *file_text_lines[insert_line:]]
     )
 

--- a/strands-py/tests/strands/vended_tools/test_file_editor.py
+++ b/strands-py/tests/strands/vended_tools/test_file_editor.py
@@ -364,6 +364,37 @@ class TestInsert:
             await editor(command="insert", path=str(d), tool_context=ctx, insert_line=0, new_str="NEW")
 
 
+class TestPreservesUntouchedBytes:
+    """Guards #4049: an edit rewrites only the requested region."""
+
+    MAKEFILE = "build:\n\tgcc -o app main.c\n\ntest:\n\tpytest tests/\n"
+
+    @pytest.mark.asyncio
+    async def test_str_replace_leaves_tabs_outside_the_match(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "Makefile", self.MAKEFILE)
+
+        await editor(command="str_replace", path=file_path, old_str="test:", new_str="check:", tool_context=ctx)
+
+        assert (tmp_path / "Makefile").read_text() == self.MAKEFILE.replace("test:", "check:")
+
+    @pytest.mark.asyncio
+    async def test_insert_leaves_tabs_intact(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "Makefile", self.MAKEFILE)
+
+        await editor(command="insert", path=file_path, insert_line=0, new_str=".PHONY: build test", tool_context=ctx)
+
+        assert (tmp_path / "Makefile").read_text() == ".PHONY: build test\n" + self.MAKEFILE
+
+    @pytest.mark.asyncio
+    async def test_empty_old_str_reports_the_empty_argument(self, editor, ctx, tmp_path):
+        file_path = _write(tmp_path / "notes.txt", "alpha\nbeta\n")
+
+        with pytest.raises(ValueError, match="old_str must not be empty"):
+            await editor(command="str_replace", path=file_path, old_str="", new_str="x", tool_context=ctx)
+
+        assert (tmp_path / "notes.txt").read_text() == "alpha\nbeta\n"
+
+
 class TestFileSizeLimit:
     """The 1MB content size guard."""
 


### PR DESCRIPTION
## Description

`_build_str_replace_result` and `_build_insert_result` expanded tabs across the whole file before returning the content that gets written back to disk:

```python
file_content = original_content.replace("\t", "        ")
```

Both results go straight to `sandbox.write_text`, so editing one line rewrote every tab in the file. A Makefile stops building since make requires recipe lines to begin with a tab, and Go, tab-indented JS/TS and TSV files get silently reformatted.

The fix removes the tab-expansion calls from the write path. The existing matching and splicing logic works identically on raw content. Tab expansion stays in `_make_output`, which formats snippets for display only, so `view` is unchanged and the existing `test_expands_tabs` still passes.

Also rejects an empty `old_str` with a clear message (`old_str must not be empty`) instead of falling through to the confusing `Multiple occurrences of old_str `` in lines [1, 2, 3]` error.

## Related Issues

Fixes #4049

## Documentation PR

None needed — restores documented behavior rather than changing it.

## Type of Change

Bug fix

## Testing

Three regression tests in `TestPreservesUntouchedBytes`:

- `str_replace` on a Makefile target leaves the recipe tabs alone
- `insert` at line 0 leaves them alone
- an empty `old_str` reports the empty argument and leaves the file untouched

All three fail on `main` and pass here. Full test suite: 53 passed.

- [x] I ran `hatch test tests/strands/vended_tools/test_file_editor.py`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.