### PR TITLE
fix(mcp-py): added httpx2 adapter

### DIFF
--- a/strands-py/src/strands/tools/mcp/_compat.py
+++ b/strands-py/src/strands/tools/mcp/_compat.py
@@ -14,7 +14,7 @@ ignores the installed line doesn't need.
 """
 
 import asyncio
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncGenerator, AsyncIterator, Callable
 from contextlib import AbstractAsyncContextManager, AsyncExitStack, asynccontextmanager
 from datetime import timedelta
 from typing import Any
@@ -584,6 +584,65 @@ async def tools_changed_subscription(session: ClientSession) -> AsyncIterator[An
         yield subscription
 
 
+def _wrap_auth_for_httpx2(auth: httpx.Auth | None) -> Any:
+    """Translate an `httpx.Auth` handler into the auth protocol mcp 2.x expects.
+
+    mcp 2.x is built on `httpx2`, whose client rejects `httpx.Auth` instances at request time. The two Auth protocols
+    are identical apart from their request and response model classes, so an `httpx.Auth` is driven through an adapter
+    that converts the models at each step of the flow. Values that are not `httpx.Auth` instances, which includes the
+    `httpx2.Auth` implementations such as the 2.x OAuth providers, pass through unchanged.
+
+    The adapter mutates only the headers of the outgoing httpx2 request, which covers header-based schemes (basic,
+    bearer, digest, token refresh). It is async-only because every mcp 2.x transport drives auth through an async
+    client.
+    """
+    # Non-`httpx.Auth` values return before the httpx2 import so this path also
+    # works where httpx2 is absent (the mcp 1.x install with `MCP_V2` forced on
+    # in unit tests).
+    if not isinstance(auth, httpx.Auth):
+        return auth
+
+    import httpx2
+
+    wrapped = auth
+
+    class _HttpxAuthAdapter(httpx2.Auth):  # type: ignore[misc]
+        """Drives an `httpx.Auth` flow with httpx2 request and response models."""
+
+        requires_request_body = wrapped.requires_request_body
+        requires_response_body = wrapped.requires_response_body
+
+        async def async_auth_flow(self, request: Any) -> AsyncGenerator[Any, Any]:
+            request_body = None
+            if wrapped.requires_request_body:
+                await request.aread()
+                request_body = request.content
+            translated_request = httpx.Request(
+                str(request.method), str(request.url), headers=request.headers.raw, content=request_body
+            )
+            flow = wrapped.async_auth_flow(translated_request)
+            step = await flow.__anext__()
+            while True:
+                request.headers = httpx2.Headers(step.headers.raw)
+                response = yield request
+                response_body = b""
+                if wrapped.requires_response_body:
+                    await response.aread()
+                    response_body = response.content
+                translated_response = httpx.Response(
+                    response.status_code, headers=response.headers.raw, content=response_body, request=step
+                )
+                try:
+                    step = await flow.asend(translated_response)
+                except StopAsyncIteration:
+                    return
+
+        def sync_auth_flow(self, request: Any) -> Any:
+            raise RuntimeError("this auth adapter only supports async clients; mcp 2.x transports are async")
+
+    return _HttpxAuthAdapter()
+
+
 def streamable_http_transport(
     url: str, headers: dict[str, str] | None = None, auth: httpx.Auth | None = None
 ) -> AbstractAsyncContextManager[Any]:
@@ -611,6 +670,8 @@ def streamable_http_transport(
             streamable_http_client,
         )
 
+        transport_auth = _wrap_auth_for_httpx2(auth)
+
         # `streamable_http_client` closes an HTTPX client only when it created
         # it (`client_provided` check in mcp 2.x), so a caller-provided client
         # must be closed by the caller: enter both context managers together
@@ -618,7 +679,7 @@ def streamable_http_transport(
         @asynccontextmanager
         async def _owned_client_transport() -> AsyncIterator[Any]:
             async with (
-                create_mcp_http_client(headers=headers, auth=auth) as http_client,  # type: ignore[arg-type]
+                create_mcp_http_client(headers=headers, auth=transport_auth) as http_client,
                 streamable_http_client(url=url, http_client=http_client) as transport_streams,
             ):
                 yield transport_streams

--- a/strands-py/tests/strands/tools/mcp/test__compat.py
+++ b/strands-py/tests/strands/tools/mcp/test__compat.py
@@ -11,12 +11,14 @@ the `MCP_V2` flag forced.
 import importlib
 import inspect
 import sys
+from base64 import b64encode
 from collections.abc import Callable
 from contextlib import asynccontextmanager
 from datetime import timedelta
 from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import mcp.client.streamable_http as streamable_http_module
 import pytest
 
@@ -894,3 +896,110 @@ async def test_tools_changed_subscription_v2_degrades_on_a_legacy_connection(mon
 
     async with _compat.tools_changed_subscription(MagicMock()) as subscription:
         assert subscription is None
+
+
+@requires_mcp_v2
+def test_wrap_auth_passes_through_httpx2_auth_and_non_auth_values():
+    """Test that httpx2-native auth objects and non-`httpx.Auth` values are not wrapped."""
+    import httpx2
+
+    native_auth = httpx2.BasicAuth(username="user", password="pass")
+    opaque_auth = MagicMock()
+
+    assert _compat._wrap_auth_for_httpx2(native_auth) is native_auth
+    assert _compat._wrap_auth_for_httpx2(opaque_auth) is opaque_auth
+    assert _compat._wrap_auth_for_httpx2(None) is None
+
+
+@requires_mcp_v2
+@pytest.mark.asyncio
+async def test_wrap_auth_adapts_httpx_auth_to_httpx2_request():
+    """Test that a wrapped `httpx.Auth` applies its headers to the httpx2 request it is driven with."""
+    import httpx2
+
+    adapted = _compat._wrap_auth_for_httpx2(httpx.BasicAuth(username="user", password="pass"))
+    assert isinstance(adapted, httpx2.Auth)
+
+    request = httpx2.Request("POST", "https://example.com/mcp", headers={"x-existing": "kept"})
+    flow = adapted.async_auth_flow(request)
+
+    sent_request = await flow.__anext__()
+    tru_headers = (sent_request.headers.get("authorization"), sent_request.headers.get("x-existing"))
+    exp_headers = (f"Basic {b64encode(b'user:pass').decode()}", "kept")
+    assert tru_headers == exp_headers
+
+    with pytest.raises(StopAsyncIteration):
+        await flow.asend(httpx2.Response(200, request=sent_request))
+
+
+@requires_mcp_v2
+@pytest.mark.asyncio
+async def test_wrap_auth_forwards_responses_to_multi_round_flows():
+    """Test that a retry-on-401 `httpx.Auth` flow sees the httpx2 response and re-sends with new headers."""
+    import httpx2
+
+    class RetryOn401Auth(httpx.Auth):
+        def auth_flow(self, request):
+            request.headers["authorization"] = "Bearer stale"
+            response = yield request
+            if response.status_code == 401:
+                request.headers["authorization"] = "Bearer refreshed"
+                yield request
+
+    adapted = _compat._wrap_auth_for_httpx2(RetryOn401Auth())
+    request = httpx2.Request("POST", "https://example.com/mcp")
+    flow = adapted.async_auth_flow(request)
+
+    first_request = await flow.__anext__()
+    assert first_request.headers["authorization"] == "Bearer stale"
+
+    second_request = await flow.asend(httpx2.Response(401, request=first_request))
+    assert second_request.headers["authorization"] == "Bearer refreshed"
+
+    with pytest.raises(StopAsyncIteration):
+        await flow.asend(httpx2.Response(200, request=second_request))
+
+
+@requires_mcp_v2
+@pytest.mark.asyncio
+async def test_wrap_auth_feeds_bodies_to_body_hungry_flows():
+    """Test that the adapter reads the httpx2 request and response bodies for an auth that requires them."""
+    import httpx2
+
+    class SigningAuth(httpx.Auth):
+        requires_request_body = True
+        requires_response_body = True
+
+        def auth_flow(self, request):
+            request.headers["x-request-digest"] = request.content.decode()
+            response = yield request
+            request.headers["x-response-echo"] = response.content.decode()
+            yield request
+
+    adapted = _compat._wrap_auth_for_httpx2(SigningAuth())
+    request = httpx2.Request("POST", "https://example.com/mcp", content=b"payload")
+    flow = adapted.async_auth_flow(request)
+
+    first_request = await flow.__anext__()
+    assert first_request.headers["x-request-digest"] == "payload"
+
+    second_request = await flow.asend(httpx2.Response(401, content=b"denied", request=first_request))
+    assert second_request.headers["x-response-echo"] == "denied"
+
+    with pytest.raises(StopAsyncIteration):
+        await flow.asend(httpx2.Response(200, request=second_request))
+
+
+@requires_mcp_v2
+def test_wrap_auth_mirrors_body_flags_and_rejects_sync_flows():
+    """Test that the adapter mirrors the wrapped auth's body flags and refuses sync driving."""
+
+    class BodyHungryAuth(httpx.Auth):
+        requires_request_body = True
+        requires_response_body = True
+
+    adapted = _compat._wrap_auth_for_httpx2(BodyHungryAuth())
+    assert (adapted.requires_request_body, adapted.requires_response_body) == (True, True)
+
+    with pytest.raises(RuntimeError, match="async"):
+        next(adapted.sync_auth_flow(MagicMock()))


### PR DESCRIPTION
## Description

mcp 2.x is built on httpx2, and httpx2's client rejects `httpx.Auth` instances with `TypeError: Invalid "auth" argument`. The streamable HTTP transport takes `auth: httpx.Auth` and passes it straight into the client it builds, so with mcp 2.x installed every caller-supplied auth handler (basic, bearer, custom OAuth flows) failed to connect.

The two Auth protocols are identical apart from their request and response model classes. This PR adds `_wrap_auth_for_httpx2` in `_compat`, which drives a caller's `httpx.Auth` through an adapter that satisfies `httpx2.Auth` and converts the models at each step of the auth flow, including multi-round flows such as retry-after-401 token refresh. Values that already satisfy `httpx2.Auth` (for example the mcp 2.x OAuth providers) and values that are not `httpx.Auth` pass through unchanged. The adapter carries only header changes from the wrapped flow, which covers the header-based schemes. It is async-only because every mcp 2.x transport drives auth through an async client.

No public API change. The `auth` parameter keeps its `httpx.Auth` type, and the same values now work on both mcp lines.

## Related Issues

Part of #1659

## Documentation PR

No docs change. The documented `auth` usage now works unchanged under mcp 2.x.

## Type of Change

Bug fix

## Testing

- MCP unit tests on the mcp 1.x pin (`hatch test tests/strands/tools/mcp`), and the same suite again with `mcp==2.0.1` forced over the pin, mirroring the MCP 2.x Compat job
- main's `tests_integ/mcp/test_mcp_client_v2.py` under mcp 2.0.1 against this branch
- Manual check through a real `httpx2.AsyncClient` with a mock transport: raw `httpx.BasicAuth` is rejected with `TypeError: Invalid "auth" argument`, while the wrapped auth connects and the `Authorization` header reaches the outgoing request

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
