### PR TITLE
fix: gate the deprecated cache_tools point on the resolved cache strategy

### DIFF
--- a/strands-py/src/strands/models/bedrock.py
+++ b/strands-py/src/strands/models/bedrock.py
@@ -598,6 +598,9 @@ class BedrockModel(Model):
         if not cache_tools:
             return []
 
+        if cache_config is not None and self._cache_strategy != "anthropic":
+            return []
+
         if isinstance(cache_tools, CacheToolsConfig):
             cache_type, ttl = cache_tools.type, cache_tools.ttl
         else:

--- a/strands-py/tests/strands/models/test_bedrock.py
+++ b/strands-py/tests/strands/models/test_bedrock.py
@@ -5193,6 +5193,54 @@ def test_format_request_tools_ttl_false_overrides_deprecated_cache_tools(bedrock
     assert not any("cachePoint" in tool for tool in tru_request["toolConfig"]["tools"])
 
 
+def test_format_request_auto_skips_tools_cache_point_for_a_model_without_caching(bedrock_client, messages, tool_spec):
+    """cache_tools follows the resolved strategy: auto on a non-Anthropic model emits no tools cache point.
+
+    Regression guard for https://github.com/strands-agents/harness-sdk/issues/4168.
+    """
+    _ = bedrock_client
+    with pytest.warns(DeprecationWarning, match="cache_tools is deprecated"):
+        model = BedrockModel(
+            model_id="amazon.nova-pro-v1:0",
+            cache_config=CacheConfig(strategy="auto"),
+            cache_tools=CacheToolsConfig(ttl="1h"),
+        )
+
+    tru_request = model.format_request(messages, tool_specs=[tool_spec])
+
+    assert not any("cachePoint" in tool for tool in tru_request["toolConfig"]["tools"])
+
+
+def test_format_request_auto_keeps_tools_cache_point_for_a_claude_model(bedrock_client, messages, tool_spec):
+    """cache_config resolving to anthropic leaves the deprecated cache_tools point in place."""
+    _ = bedrock_client
+    with pytest.warns(DeprecationWarning, match="cache_tools is deprecated"):
+        model = BedrockModel(
+            model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
+            cache_config=CacheConfig(strategy="auto"),
+            cache_tools=CacheToolsConfig(ttl="1h"),
+        )
+
+    tru_point = model.format_request(messages, tool_specs=[tool_spec])["toolConfig"]["tools"][-1]
+
+    assert tru_point == {"cachePoint": {"type": "default", "ttl": "1h"}}
+
+
+def test_format_request_auto_cache_tools_inherits_shared_ttl_for_a_claude_model(bedrock_client, messages, tool_spec):
+    """A cache_tools point with no ttl of its own still inherits cache_config.ttl under an active strategy."""
+    _ = bedrock_client
+    with pytest.warns(DeprecationWarning, match="cache_tools is deprecated"):
+        model = BedrockModel(
+            model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
+            cache_config=CacheConfig(strategy="auto", ttl="1h"),
+            cache_tools=CacheToolsConfig(),
+        )
+
+    tru_point = model.format_request(messages, tool_specs=[tool_spec])["toolConfig"]["tools"][-1]
+
+    assert tru_point == {"cachePoint": {"type": "default", "ttl": "1h"}}
+
+
 def test_format_request_applies_the_configured_ttl_to_a_system_cache_point(bedrock_client, messages):
     """Bedrock rejects a TTL that exceeds an earlier checkpoint's, so a configured ttl that reached the
     message cache point but not the system point ahead of it would emit an invalid request.
@@ -5340,9 +5388,9 @@ def test_format_request_leaves_a_tools_cache_point_alone_for_a_model_without_cac
         model_id="meta.llama3-70b-instruct-v1:0", cache_config=CacheConfig(ttl="1h"), cache_tools="default"
     )
 
-    tru_point = model.format_request(messages, tool_specs=[tool_spec])["toolConfig"]["tools"][-1]
+    tru_request = model.format_request(messages, tool_specs=[tool_spec])
 
-    assert tru_point == {"cachePoint": {"type": "default"}}
+    assert not any("cachePoint" in tool for tool in tru_request["toolConfig"]["tools"])
 
 
 def test_format_request_leaves_a_tools_cache_point_alone_for_an_empty_configured_ttl(


### PR DESCRIPTION
## Description

Under `strategy="auto"`, BedrockModel resolves to no caching for non-Anthropic models, and every auto-managed cache point honors that except the deprecated cache_tools path. 

`_build_deprecated_cache_tools_point` appended a cachePoint to `toolConfig.tools` whenever `cache_tools` was set, so `CacheConfig(strategy="auto")` + `cache_tools `on a non-Anthropic model sent a tools cache point that Bedrock rejects with AccessDeniedException. 

This PR gates the deprecated path on the resolved strategy. The guard keys on `cache_config is not None` rather than `_cache_strategy == "anthropic"` alone.

## Related Issues

Fixes #4168.

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

Ran `hatch test tests/strands/models/test_bedrock.py` (full file green), plus the linter, formatter check, and cognitive-complexity gate on the touched functions. Added tests covering the reported case (non-Anthropic + `strategy="auto"` → no tools cache point), the no-over-correction case (Claude + `strategy="auto"` → point retained), and TTL inheritance under an active strategy. The assertions check the exact `toolConfig.tools` wire payload that triggered the rejection. A live integration test would need the non-Anthropic inference profiles from the issue, which aren't provisioned in CI.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.