### PR TITLE
feat(anthropic): use the API's native automatic caching for cache_config strategy="auto"

### DIFF
--- a/site/src/content/docs/user-guide/concepts/model-providers/anthropic.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/anthropic.mdx
@@ -272,7 +272,10 @@ to set one.
 automatic caching, a single request-level setting whose breakpoint the API places and
 advances itself; `"anthropic"` injects an explicit cache point on the last user message
 instead. Automatic caching is not offered on Amazon Bedrock, so `BedrockModel` injects
-an explicit cache point under both strategies.
+an explicit cache point under both strategies. On a call that carries
+per-call content — a [context injector](../plugins/context-injector)'s block, the
+agentic status line — `"auto"` also places an explicit point, ahead
+of the content that changes every call; the automatic breakpoint would land inside it.
 </Tab>
 <Tab label="TypeScript">
 
@@ -286,7 +289,10 @@ a provider switch unchanged.
 automatic caching, a single request-level setting whose breakpoint the API places and
 advances itself; `'anthropic'` injects an explicit cache point on the last user message
 instead. Automatic caching is not offered on Amazon Bedrock, so `BedrockModel` injects
-an explicit cache point under both strategies.
+an explicit cache point under both strategies. On a call that carries
+per-call content — a [context injector](../plugins/context-injector)'s block, the
+agentic status line — `'auto'` also places an explicit point, ahead
+of the content that changes every call; the automatic breakpoint would land inside it.
 </Tab>
 </Tabs>
 

--- a/site/src/content/docs/user-guide/concepts/model-providers/anthropic.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/anthropic.mdx
@@ -215,8 +215,10 @@ every call. The mechanism, the cost model, and the cache metrics match
 [Amazon Bedrock](./amazon-bedrock#caching); this section covers what differs here.
 
 Caching is off by default. Set <Syntax py="cache_config" ts="cacheConfig" /> to cache
-the system prompt and add a cache point to the last user message, which caches
-everything before it:
+the system prompt and the conversation. The conversation is cached with the API's
+[automatic caching](https://docs.claude.com/en/docs/build-with-claude/prompt-caching#automatic-caching):
+the API places the cache breakpoint on the last cacheable block itself and moves it
+forward as the conversation grows:
 
 <Tabs>
 <Tab label="Python">
@@ -266,7 +268,11 @@ definitions can be cached without caching the conversation. Passing a plain stri
 (`"default"`) only switches it on: the value is not a TTL. Use `CacheToolsConfig(ttl=...)`
 to set one.
 
-`strategy` is ignored by this provider.
+`strategy` selects how the conversation is cached: `"auto"` (the default) uses the API's
+automatic caching, a single request-level setting whose breakpoint the API places and
+advances itself; `"anthropic"` injects an explicit cache point on the last user message
+instead. Automatic caching is not offered on Amazon Bedrock, so `BedrockModel` injects
+an explicit cache point under both strategies.
 </Tab>
 <Tab label="TypeScript">
 
@@ -276,15 +282,20 @@ to `false` to leave that part uncached). The shape and the per-field behavior ar
 same as on [Amazon Bedrock](./amazon-bedrock#tool-caching), so a configuration survives
 a provider switch unchanged.
 
-`strategy` is ignored by this provider.
+`strategy` selects how the conversation is cached: `'auto'` (the default) uses the API's
+automatic caching, a single request-level setting whose breakpoint the API places and
+advances itself; `'anthropic'` injects an explicit cache point on the last user message
+instead. Automatic caching is not offered on Amazon Bedrock, so `BedrockModel` injects
+an explicit cache point under both strategies.
 </Tab>
 </Tabs>
 
 #### Placing cache points by hand
 
 Placement works as it does on [Amazon Bedrock](./amazon-bedrock#messages-caching): a
-cache point you put in the last user message is kept where you put it, automatic
-placement is suspended for that message, and points in earlier messages are removed.
+cache point you put in the last user message is kept where you put it (under the
+`anthropic` strategy it replaces the injected point for that message), and points in
+earlier messages are removed.
 Place your point *ahead* of content that is rebuilt on every call, otherwise it lands
 inside the cached prefix and every request writes an entry that none ever reads.
 
@@ -295,9 +306,11 @@ Two constraints are specific to this API:
   block, or a media block sourced by location, ahead of it cannot be honored, so
   automatic placement applies instead.
 - **Maximum of four cache points per request**, shared across the tool definitions, the
-  system prompt, and the messages. Automatic placement uses one per part it caches, so
-  hand-placing several of your own alongside it can exceed the limit, and the API rejects
-  the request.
+  system prompt, and the messages. Each managed part uses one (the automatic conversation
+  cache consumes a slot too), so hand-placing several of your own alongside them can
+  exceed the limit, and the API rejects the request. When four explicit points already
+  exist, Strands skips the automatic conversation cache rather than send a request the
+  API would reject.
 
 A prompt below the model's minimum cacheable length is not cached: if both cache metrics
 stay at zero, that is the likely cause. See

--- a/strands-py/src/strands/models/anthropic.py
+++ b/strands-py/src/strands/models/anthropic.py
@@ -46,6 +46,11 @@ _CACHEABLE_BLOCK_TYPES = frozenset({"document", "image", "text", "tool_result", 
 # ``ephemeral`` is the only cache type the Anthropic API supports
 _ANTHROPIC_CACHE_TYPE = "ephemeral"
 
+# The API rejects a request carrying more explicit block-level cache breakpoints than this, and rejects
+# the top-level automatic-caching field once this many are already present.
+# https://docs.claude.com/en/docs/build-with-claude/prompt-caching
+_MAX_CACHE_BREAKPOINTS = 4
+
 
 class AnthropicModel(Model):
     """Anthropic model provider implementation."""
@@ -69,8 +74,10 @@ class AnthropicModel(Model):
         """Configuration options for Anthropic models.
 
         Attributes:
-            cache_config: Configuration for prompt caching. Adds a cache point to the last user message,
-                caching everything before it. Caching is off when unset.
+            cache_config: Configuration for prompt caching. ``strategy="auto"`` (the default) turns on the
+                API's automatic caching, which places the cache breakpoint server-side and moves it forward
+                as the conversation grows; ``strategy="anthropic"`` injects an explicit cache point on the
+                last user message instead. Caching is off when unset.
             cache_tools: Caches the tool definitions (deprecated, use CacheConfig(tools_ttl=...)). Superseded
                 by an explicitly set cache_config.tools_ttl.
             max_tokens: Maximum number of tokens to generate.
@@ -237,6 +244,9 @@ class AnthropicModel(Model):
         """
         cache_config = self.config.get("cache_config")
         configured_ttl = cache_config.ttl if cache_config else None
+        # Under "auto" the API's automatic caching places the breakpoint server-side, so no managed
+        # block-level point is injected; hand-placed cache points are still honored.
+        native_auto = cache_config is not None and cache_config.strategy == "auto"
         formatted_messages = []
 
         for message_idx, message in enumerate(messages):
@@ -272,7 +282,7 @@ class AnthropicModel(Model):
             # block that survived translation. It is skipped when a caller-placed point already marked one.
             # Per-call trailing blocks apply only to the cache-target message, which is where a producer
             # appends content rebuilt every call.
-            if message_idx == cache_target_idx and not marked:
+            if message_idx == cache_target_idx and not marked and not native_auto:
                 if self._attach_cache_control(formatted_contents, configured_ttl, dynamic_trailing_blocks):
                     logger.debug("msg_idx=<%d> | added cache point to last user message", message_idx)
                 else:
@@ -308,6 +318,46 @@ class AnthropicModel(Model):
                 return True
 
         return False
+
+    def _resolve_automatic_cache(self, request: dict[str, Any]) -> dict[str, Any] | None:
+        """Resolve the top-level ``cache_control`` that turns on the API's automatic caching.
+
+        Automatic caching has the API place the cache breakpoint on the last cacheable block and move it
+        forward as the conversation grows, replacing the client-side injection ``strategy="anthropic"``
+        keeps. Not sent when the caller supplied a top-level ``cache_control`` through ``params`` or when
+        the request already carries the API's maximum of explicit breakpoints, which it would reject.
+
+        Args:
+            request: The formatted request, inspected for existing cache breakpoints.
+
+        Returns:
+            The cache_control value, or None when automatic caching must not be sent.
+        """
+        cache_config = self.config.get("cache_config")
+        if cache_config is None or cache_config.strategy != "auto":
+            return None
+        if "cache_control" in request:
+            return None
+        if self._count_cache_breakpoints(request) >= _MAX_CACHE_BREAKPOINTS:
+            logger.warning(
+                "count=<%d> | explicit cache breakpoints at the API limit, skipped automatic caching",
+                _MAX_CACHE_BREAKPOINTS,
+            )
+            return None
+        return self._format_cache_control(cache_config.ttl)
+
+    @staticmethod
+    def _count_cache_breakpoints(request: dict[str, Any]) -> int:
+        """Count the explicit block-level cache breakpoints in a formatted request."""
+        blocks = list(request.get("tools") or [])
+        system = request.get("system")
+        if isinstance(system, list):
+            blocks.extend(system)
+        for message in request.get("messages") or []:
+            content = message.get("content")
+            if isinstance(content, list):
+                blocks.extend(content)
+        return sum(1 for block in blocks if isinstance(block, dict) and "cache_control" in block)
 
     def _resolve_tools_cache(self) -> dict[str, Any] | None:
         """Return the Anthropic ``cache_control`` payload for tool definitions, if enabled.
@@ -468,6 +518,11 @@ class AnthropicModel(Model):
             **({"system": system} if system else {}),
             **(self.config.get("params") or {}),
         }
+
+        if (automatic_cache := self._resolve_automatic_cache(request)) is not None:
+            # extra_body merges the field into the request body on every supported anthropic version; the
+            # pinned floor (0.21.0) predates the SDK's native top-level cache_control parameter.
+            request["extra_body"] = {"cache_control": automatic_cache, **(request.get("extra_body") or {})}
 
         return request
 

--- a/strands-py/src/strands/models/anthropic.py
+++ b/strands-py/src/strands/models/anthropic.py
@@ -245,8 +245,9 @@ class AnthropicModel(Model):
         cache_config = self.config.get("cache_config")
         configured_ttl = cache_config.ttl if cache_config else None
         # Under "auto" the API's automatic caching places the breakpoint server-side, so no managed
-        # block-level point is injected; hand-placed cache points are still honored.
-        native_auto = cache_config is not None and cache_config.strategy == "auto"
+        # block-level point is injected; hand-placed cache points are still honored. A per-call trailing
+        # tail falls back to explicit placement, which alone can keep the breakpoint ahead of it.
+        native_auto = cache_config is not None and cache_config.strategy == "auto" and not dynamic_trailing_blocks
         formatted_messages = []
 
         for message_idx, message in enumerate(messages):
@@ -319,22 +320,28 @@ class AnthropicModel(Model):
 
         return False
 
-    def _resolve_automatic_cache(self, request: dict[str, Any]) -> dict[str, Any] | None:
+    def _resolve_automatic_cache(
+        self, request: dict[str, Any], dynamic_trailing_blocks: int = 0
+    ) -> dict[str, Any] | None:
         """Resolve the top-level ``cache_control`` that turns on the API's automatic caching.
 
         Automatic caching has the API place the cache breakpoint on the last cacheable block and move it
         forward as the conversation grows, replacing the client-side injection ``strategy="anthropic"``
         keeps. Not sent when the caller supplied a top-level ``cache_control`` through ``params`` or when
         the request already carries the API's maximum of explicit breakpoints, which it would reject.
+        A per-call trailing tail also disables it: the automatic breakpoint would land inside content
+        rebuilt every call, so every request would write a cache entry that none ever reads.
 
         Args:
             request: The formatted request, inspected for existing cache breakpoints.
+            dynamic_trailing_blocks: How many trailing blocks of the last user message are rebuilt on
+                every call. Nonzero falls back to the explicit placement that stays ahead of them.
 
         Returns:
             The cache_control value, or None when automatic caching must not be sent.
         """
         cache_config = self.config.get("cache_config")
-        if cache_config is None or cache_config.strategy != "auto":
+        if cache_config is None or cache_config.strategy != "auto" or dynamic_trailing_blocks:
             return None
         if "cache_control" in request:
             return None
@@ -519,7 +526,7 @@ class AnthropicModel(Model):
             **(self.config.get("params") or {}),
         }
 
-        if (automatic_cache := self._resolve_automatic_cache(request)) is not None:
+        if (automatic_cache := self._resolve_automatic_cache(request, dynamic_trailing_blocks)) is not None:
             # extra_body merges the field into the request body on every supported anthropic version; the
             # pinned floor (0.21.0) predates the SDK's native top-level cache_control parameter.
             request["extra_body"] = {"cache_control": automatic_cache, **(request.get("extra_body") or {})}

--- a/strands-py/src/strands/models/model.py
+++ b/strands-py/src/strands/models/model.py
@@ -139,7 +139,9 @@ class CacheConfig:
 
     Attributes:
         strategy: Caching strategy to use.
-            - "auto": Automatically detect model support and inject cachePoint to maximize cache coverage
+            - "auto": Automatically maximize cache coverage. Bedrock detects model support and injects a
+              cachePoint; Anthropic turns on the API's native automatic caching, which places the
+              breakpoint server-side.
             - "anthropic": Inject cachePoint in Anthropic-compatible format without model support check
         ttl: Optional TTL duration for cache entries (e.g. "5m", "1h").
             When specified, auto-injected cache points will include this TTL value. Bedrock requires

--- a/strands-py/tests/strands/models/test_anthropic.py
+++ b/strands-py/tests/strands/models/test_anthropic.py
@@ -1475,7 +1475,7 @@ class TestPromptCaching:
         assert self._breakpoints(request) == []
 
     def test_cache_config_adds_breakpoint_to_last_user_message(self, model, messages, model_id, max_tokens):
-        model.update_config(cache_config=CacheConfig(strategy="auto"))
+        model.update_config(cache_config=CacheConfig(strategy="anthropic"))
 
         assert model.format_request(messages) == {
             "max_tokens": max_tokens,
@@ -1486,19 +1486,127 @@ class TestPromptCaching:
             "tools": [],
         }
 
-    def test_auto_and_anthropic_strategies_coincide(self, model, messages, tool_specs):
-        """Documented behavior: the Anthropic API caches on every active Claude model, so ``auto`` has no
-        model-support check to apply and the two strategies produce the same request."""
+    def test_auto_and_anthropic_strategies_differ(self, model, messages, tool_specs):
+        """``auto`` delegates breakpoint placement to the API's automatic caching; ``anthropic`` keeps
+        the client-side injection on the last user message."""
         model.update_config(cache_config=CacheConfig(strategy="auto"))
         auto_request = model.format_request(messages, tool_specs)
 
         model.update_config(cache_config=CacheConfig(strategy="anthropic"))
         anthropic_request = model.format_request(messages, tool_specs)
 
-        assert auto_request == anthropic_request
+        assert auto_request["extra_body"] == {"cache_control": {"type": "ephemeral"}}
+        assert [bp for bp in self._breakpoints(auto_request) if bp[0] == "messages"] == []
+        assert "extra_body" not in anthropic_request
+        assert [bp for bp in self._breakpoints(anthropic_request) if bp[0] == "messages"] == [
+            ("messages", 0, {"type": "ephemeral"})
+        ]
+
+    def test_auto_turns_on_automatic_caching(self, model, messages, model_id, max_tokens):
+        """``auto`` sends the API's top-level cache_control instead of injecting a block-level point. The
+        field rides in extra_body because the pinned anthropic floor predates the native parameter."""
+        model.update_config(cache_config=CacheConfig(strategy="auto"))
+
+        assert model.format_request(messages) == {
+            "max_tokens": max_tokens,
+            "messages": [{"role": "user", "content": [{"type": "text", "text": "test"}]}],
+            "model": model_id,
+            "tools": [],
+            "extra_body": {"cache_control": {"type": "ephemeral"}},
+        }
+
+    def test_automatic_caching_carries_the_configured_ttl(self, model, messages):
+        model.update_config(cache_config=CacheConfig(strategy="auto", ttl="1h"))
+
+        request = model.format_request(messages)
+
+        assert request["extra_body"] == {"cache_control": {"type": "ephemeral", "ttl": "1h"}}
+
+    def test_automatic_caching_keeps_the_tools_and_system_sections(self, model, messages, tool_specs):
+        """Automatic caching covers the conversation; the tools and system sections keep their own
+        breakpoints and TTLs."""
+        model.update_config(cache_config=CacheConfig(strategy="auto", tools_ttl=True))
+
+        request = model.format_request(messages, tool_specs, system_prompt="static prompt")
+
+        assert self._breakpoints(request) == [
+            ("tools", "t2", {"type": "ephemeral"}),
+            ("system", "text", {"type": "ephemeral"}),
+        ]
+        assert request["extra_body"] == {"cache_control": {"type": "ephemeral"}}
+
+    def test_automatic_caching_still_strips_accumulated_cache_points(self, model):
+        """The breakpoint-budget protection applies under both strategies; only the placement moved."""
+        messages = [
+            {"role": "user", "content": [{"text": "one"}, {"cachePoint": {"type": "default"}}]},
+            {"role": "assistant", "content": [{"text": "two"}]},
+            {"role": "user", "content": [{"text": "three"}]},
+        ]
+        model.update_config(cache_config=CacheConfig(strategy="auto"))
+
+        request = model.format_request(messages)
+
+        assert self._breakpoints(request) == []
+        assert request["extra_body"] == {"cache_control": {"type": "ephemeral"}}
+
+    def test_automatic_caching_coexists_with_an_honored_cache_point(self, model):
+        """A hand-placed boundary in the last user message is still emitted alongside the top-level field."""
+        messages = [
+            {"role": "user", "content": [{"text": "stable"}, {"cachePoint": {"type": "default"}}, {"text": "volatile"}]}
+        ]
+        model.update_config(cache_config=CacheConfig(strategy="auto"))
+
+        request = model.format_request(messages)
+
+        assert self._breakpoints(request) == [("messages", 0, {"type": "ephemeral"})]
+        assert request["extra_body"] == {"cache_control": {"type": "ephemeral"}}
+
+    def test_automatic_caching_skipped_at_the_breakpoint_limit(self, model, messages, caplog):
+        """The API rejects the top-level field when the maximum of explicit breakpoints already exists."""
+        system = [{"type": "text", "text": f"chunk {i}", "cache_control": {"type": "ephemeral"}} for i in range(4)]
+        model.update_config(cache_config=CacheConfig(strategy="auto"), params={"system": system})
+
+        request = model.format_request(messages)
+
+        assert "extra_body" not in request
+        assert "skipped automatic caching" in caplog.text
+
+    def test_caller_supplied_top_level_cache_control_wins(self, model, messages):
+        """A cache_control passed through params is the caller's own placement; auto defers to it."""
+        model.update_config(
+            cache_config=CacheConfig(strategy="auto", ttl="1h"),
+            params={"cache_control": {"type": "ephemeral", "ttl": "5m"}},
+        )
+
+        request = model.format_request(messages)
+
+        assert request["cache_control"] == {"type": "ephemeral", "ttl": "5m"}
+        assert "extra_body" not in request
+
+    def test_automatic_caching_merges_with_params_extra_body(self, model, messages):
+        """Caller extra_body entries survive, and a caller cache_control there takes precedence."""
+        model.update_config(cache_config=CacheConfig(strategy="auto"), params={"extra_body": {"service_tier": "flex"}})
+
+        request = model.format_request(messages)
+
+        assert request["extra_body"] == {"cache_control": {"type": "ephemeral"}, "service_tier": "flex"}
+
+    def test_cross_sdk_automatic_caching_parity(self, model, messages):
+        """Pins the automatic-caching value shared with strands-ts, which sends the same top-level
+        cache_control natively rather than through extra_body. Update both together or the SDKs drift.
+
+        The mirror of this test is "turns on automatic caching for the auto strategy" in
+        strands-ts/src/models/__tests__/anthropic.test.ts.
+        """
+        model.update_config(cache_config=CacheConfig(strategy="auto", ttl="1h"))
+
+        request = model.format_request(messages)
+
+        assert request["extra_body"] == {"cache_control": {"type": "ephemeral", "ttl": "1h"}}
+        assert self._breakpoints(request) == []
 
     def test_cache_config_ttl_is_carried_onto_cache_control(self, model, messages):
-        model.update_config(cache_config=CacheConfig(strategy="auto", ttl="1h"))
+        model.update_config(cache_config=CacheConfig(strategy="anthropic", ttl="1h"))
 
         request = model.format_request(messages)
 
@@ -1549,7 +1657,7 @@ class TestPromptCaching:
 
     def test_tools_ttl_true_derives_from_shared_ttl(self, model, messages, tool_specs):
         """tools_ttl=True mirrors system_prompt_ttl: it derives the tools section duration from cache_config.ttl."""
-        model.update_config(cache_config=CacheConfig(strategy="auto", ttl="1h", tools_ttl=True))
+        model.update_config(cache_config=CacheConfig(strategy="anthropic", ttl="1h", tools_ttl=True))
 
         breakpoints = self._breakpoints(model.format_request(messages, tool_specs))
 
@@ -1560,7 +1668,7 @@ class TestPromptCaching:
 
     def test_tools_ttl_string_sets_the_section_duration(self, model, messages, tool_specs):
         """A tools_ttl string sets the tools section's own duration rather than deriving from the shared ttl."""
-        model.update_config(cache_config=CacheConfig(strategy="auto", ttl="1h", tools_ttl="5m"))
+        model.update_config(cache_config=CacheConfig(strategy="anthropic", ttl="1h", tools_ttl="5m"))
 
         breakpoints = self._breakpoints(model.format_request(messages, tool_specs))
 
@@ -1571,7 +1679,7 @@ class TestPromptCaching:
 
     def test_tools_ttl_true_without_shared_ttl_stays_untimed(self, model, messages, tool_specs):
         """With nothing to derive from, tools_ttl=True still caches the tools but at the API default."""
-        model.update_config(cache_config=CacheConfig(strategy="auto", tools_ttl=True))
+        model.update_config(cache_config=CacheConfig(strategy="anthropic", tools_ttl=True))
 
         breakpoints = self._breakpoints(model.format_request(messages, tool_specs))
 
@@ -1600,7 +1708,7 @@ class TestPromptCaching:
         """An explicitly set tools_ttl wins over the deprecated cache_tools when both are set."""
         with pytest.warns(DeprecationWarning, match="cache_tools is deprecated"):
             model.update_config(
-                cache_config=CacheConfig(strategy="auto", ttl="1h", tools_ttl="5m"),
+                cache_config=CacheConfig(strategy="anthropic", ttl="1h", tools_ttl="5m"),
                 cache_tools=CacheToolsConfig(ttl="1h"),
             )
 
@@ -1624,7 +1732,7 @@ class TestPromptCaching:
         assert not any(bp[0] == "tools" for bp in breakpoints)
 
     def test_both_options_produce_two_breakpoints(self, model, messages, tool_specs):
-        model.update_config(cache_config=CacheConfig(strategy="auto"), cache_tools="default")
+        model.update_config(cache_config=CacheConfig(strategy="anthropic"), cache_tools="default")
 
         breakpoints = self._breakpoints(model.format_request(messages, tool_specs))
 
@@ -1686,7 +1794,7 @@ class TestPromptCaching:
             {"role": "assistant", "content": [{"text": "two"}]},
             {"role": "user", "content": [{"text": "three"}]},
         ]
-        model.update_config(cache_config=CacheConfig(strategy="auto"))
+        model.update_config(cache_config=CacheConfig(strategy="anthropic"))
 
         request = model.format_request(messages, tool_specs)
 
@@ -1833,7 +1941,7 @@ class TestPromptCaching:
         strands-ts/src/models/__tests__/anthropic.test.ts.
         """
         caplog.set_level(logging.WARNING, logger="strands.models.anthropic")
-        model.update_config(cache_config=CacheConfig(strategy="auto"))
+        model.update_config(cache_config=CacheConfig(strategy="anthropic"))
         messages = [{"role": "user", "content": [{"cachePoint": {"type": "default"}}, {"text": "one"}]}]
 
         request = model.format_request(messages)
@@ -1844,7 +1952,7 @@ class TestPromptCaching:
     def test_honored_point_falls_back_when_everything_ahead_is_dropped_in_translation(self, model):
         """An image with a location source is an accepted carrier by block type but never reaches the API,
         so a point behind one has nothing to mark and automatic placement applies instead."""
-        model.update_config(cache_config=CacheConfig(strategy="auto"))
+        model.update_config(cache_config=CacheConfig(strategy="anthropic"))
         messages = [
             {
                 "role": "user",
@@ -1864,7 +1972,7 @@ class TestPromptCaching:
 
     def test_honored_point_falls_back_when_only_a_reasoning_block_is_ahead_of_it(self, model):
         """The API rejects ``cache_control`` on a thinking block, so it cannot carry an honored boundary."""
-        model.update_config(cache_config=CacheConfig(strategy="auto"))
+        model.update_config(cache_config=CacheConfig(strategy="anthropic"))
         messages = [
             {
                 "role": "user",
@@ -1892,7 +2000,7 @@ class TestPromptCaching:
         strands-ts/src/models/__tests__/anthropic.test.ts.
         """
         caplog.set_level(logging.WARNING, logger="strands.models.anthropic")
-        model.update_config(cache_config=CacheConfig(strategy="auto"))
+        model.update_config(cache_config=CacheConfig(strategy="anthropic"))
         messages = [
             {"role": "user", "content": [{"text": "stable"}]},
             {"role": "user", "content": [{"cachePoint": {"type": "default"}}]},
@@ -1956,7 +2064,7 @@ class TestPromptCaching:
                 ],
             }
         ]
-        model.update_config(cache_config=CacheConfig(strategy="auto"))
+        model.update_config(cache_config=CacheConfig(strategy="anthropic"))
 
         request = model.format_request(messages)
 
@@ -1972,7 +2080,7 @@ class TestPromptCaching:
                 "content": [{"reasoningContent": {"reasoningText": {"text": "thinking", "signature": "sig"}}}],
             }
         ]
-        model.update_config(cache_config=CacheConfig(strategy="auto"))
+        model.update_config(cache_config=CacheConfig(strategy="anthropic"))
 
         request = model.format_request(messages)
 
@@ -2027,7 +2135,7 @@ class TestPromptCaching:
         """An image with a location source is an accepted cache carrier by block type but is dropped when
         the request is formatted. The breakpoint has to fall back to the block before it rather than
         vanish, or enabling caching would remove the caching that worked without it."""
-        model.update_config(cache_config=CacheConfig(strategy="auto"))
+        model.update_config(cache_config=CacheConfig(strategy="anthropic"))
         messages = [
             {
                 "role": "user",
@@ -2079,7 +2187,7 @@ class TestPromptCaching:
 
     def test_breakpoint_lands_on_the_last_of_several_cacheable_blocks(self, model):
         """Placement on the *last* cacheable block is what makes the cached prefix cover the whole turn."""
-        model.update_config(cache_config=CacheConfig(strategy="auto"))
+        model.update_config(cache_config=CacheConfig(strategy="anthropic"))
         messages = [
             {
                 "role": "user",
@@ -2130,7 +2238,7 @@ class TestPromptCaching:
         Text-only parity cannot catch a breakpoint lost while translating a media block, which is exactly
         what regressed in the TypeScript implementation.
         """
-        model.update_config(cache_config=CacheConfig(strategy="auto"))
+        model.update_config(cache_config=CacheConfig(strategy="anthropic"))
         messages = [
             {
                 "role": "user",
@@ -2165,7 +2273,9 @@ class TestPromptCaching:
         The mirror of this test lives in strands-ts/src/models/__tests__/anthropic.test.ts. Update both
         together or the two SDKs will drift.
         """
-        model.update_config(cache_config=CacheConfig(strategy="auto", ttl="1h"), cache_tools=CacheToolsConfig(ttl="1h"))
+        model.update_config(
+            cache_config=CacheConfig(strategy="anthropic", ttl="1h"), cache_tools=CacheToolsConfig(ttl="1h")
+        )
         messages = [
             {"role": "user", "content": [{"text": "hello"}]},
             {"role": "assistant", "content": [{"text": "hi"}]},
@@ -2194,7 +2304,7 @@ class TestPromptCaching:
 
     def test_dynamic_trailing_blocks_keeps_the_cache_point_ahead_of_per_call_content(self, model):
         """The reusable prefix ends where per-call content begins, so the cache point precedes it."""
-        model.update_config(cache_config=CacheConfig(strategy="auto"))
+        model.update_config(cache_config=CacheConfig(strategy="anthropic"))
         messages = [{"role": "user", "content": [{"text": "durable ask"}, {"text": "per-call"}]}]
 
         request = model.format_request(messages, dynamic_trailing_blocks=1)
@@ -2206,7 +2316,7 @@ class TestPromptCaching:
         ]
 
     def test_dynamic_trailing_blocks_covers_every_block_of_a_multi_block_tail(self, model):
-        model.update_config(cache_config=CacheConfig(strategy="auto"))
+        model.update_config(cache_config=CacheConfig(strategy="anthropic"))
         messages = [{"role": "user", "content": [{"text": "durable ask"}, {"text": "injected"}, {"text": "status"}]}]
 
         request = model.format_request(messages, dynamic_trailing_blocks=2)
@@ -2220,7 +2330,7 @@ class TestPromptCaching:
 
     def test_dynamic_trailing_blocks_skips_the_cache_point_when_nothing_durable_precedes_it(self, model):
         """With no durable prefix there is nothing worth a cache point, so none is emitted."""
-        model.update_config(cache_config=CacheConfig(strategy="auto"))
+        model.update_config(cache_config=CacheConfig(strategy="anthropic"))
         messages = [{"role": "user", "content": [{"text": "per-call only"}]}]
 
         request = model.format_request(messages, dynamic_trailing_blocks=1)
@@ -2228,7 +2338,7 @@ class TestPromptCaching:
         assert self._breakpoints(request) == []
 
     def test_dynamic_trailing_blocks_carries_the_configured_ttl(self, model):
-        model.update_config(cache_config=CacheConfig(strategy="auto", ttl="1h"))
+        model.update_config(cache_config=CacheConfig(strategy="anthropic", ttl="1h"))
         messages = [{"role": "user", "content": [{"text": "durable ask"}, {"text": "per-call"}]}]
 
         request = model.format_request(messages, dynamic_trailing_blocks=1)
@@ -2236,7 +2346,7 @@ class TestPromptCaching:
         assert self._breakpoints(request) == [("messages", 0, {"type": "ephemeral", "ttl": "1h"})]
 
     def test_no_dynamic_trailing_blocks_places_the_cache_point_on_the_last_block(self, model):
-        model.update_config(cache_config=CacheConfig(strategy="auto"))
+        model.update_config(cache_config=CacheConfig(strategy="anthropic"))
         messages = [{"role": "user", "content": [{"text": "durable ask"}, {"text": "also durable"}]}]
 
         request = model.format_request(messages)
@@ -2264,7 +2374,7 @@ class TestPromptCaching:
         assert request["system"] == [{"type": "text", "text": "static prompt", "cache_control": {"type": "ephemeral"}}]
 
     def test_auto_injects_a_system_cache_point_on_the_last_block(self, model, messages):
-        model.update_config(cache_config=CacheConfig(strategy="auto"))
+        model.update_config(cache_config=CacheConfig(strategy="anthropic"))
         system_prompt_content = [{"text": "Heavy context"}, {"text": "More context"}]
 
         request = model.format_request(messages, system_prompt_content=system_prompt_content)
@@ -2300,7 +2410,7 @@ class TestPromptCaching:
         assert request["system"][0]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
 
     def test_hand_placed_system_cache_point_is_not_doubled(self, model, messages):
-        model.update_config(cache_config=CacheConfig(strategy="auto"))
+        model.update_config(cache_config=CacheConfig(strategy="anthropic"))
         system_prompt_content = [
             {"text": "Heavy context"},
             {"cachePoint": {"type": "default"}},

--- a/strands-py/tests/strands/models/test_anthropic.py
+++ b/strands-py/tests/strands/models/test_anthropic.py
@@ -1591,6 +1591,21 @@ class TestPromptCaching:
 
         assert request["extra_body"] == {"cache_control": {"type": "ephemeral"}, "service_tier": "flex"}
 
+    def test_auto_with_per_call_trailing_blocks_falls_back_to_explicit_placement(self, model):
+        """Automatic caching cannot keep its breakpoint ahead of per-call content: it lands inside the
+        rebuilt tail, and every request writes a cache entry that none ever reads (verified live). A
+        declared tail therefore gets the explicit point placed ahead of it, and no top-level field."""
+        model.update_config(cache_config=CacheConfig(strategy="auto"))
+        messages = [{"role": "user", "content": [{"text": "durable ask"}, {"text": "per-call"}]}]
+
+        request = model.format_request(messages, dynamic_trailing_blocks=1)
+
+        assert "extra_body" not in request
+        assert request["messages"][0]["content"] == [
+            {"type": "text", "text": "durable ask", "cache_control": {"type": "ephemeral"}},
+            {"type": "text", "text": "per-call"},
+        ]
+
     def test_cross_sdk_automatic_caching_parity(self, model, messages):
         """Pins the automatic-caching value shared with strands-ts, which sends the same top-level
         cache_control natively rather than through extra_body. Update both together or the SDKs drift.

--- a/strands-ts/src/models/__tests__/anthropic.test.ts
+++ b/strands-ts/src/models/__tests__/anthropic.test.ts
@@ -1279,6 +1279,25 @@ describe('AnthropicModel', () => {
       warnSpy.mockRestore()
     })
 
+    it('falls back to explicit placement for a per-call trailing tail under auto', async () => {
+      // Automatic caching cannot keep its breakpoint ahead of per-call content: it lands inside the
+      // rebuilt tail, and every request writes a cache entry that none ever reads (verified live).
+      const { captured, mockClient } = setupCapture()
+      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'auto' } })
+      const message = new Message({
+        role: 'user',
+        content: [new TextBlock('durable ask'), new TextBlock('per-call')],
+      })
+
+      await collectIterator(provider.stream([message], { dynamicTrailingBlocks: 1 }))
+
+      expect(captured.request.cache_control).toBeUndefined()
+      expect(captured.request.messages[0].content).toEqual([
+        { type: 'text', text: 'durable ask', cache_control: { type: 'ephemeral' } },
+        { type: 'text', text: 'per-call' },
+      ])
+    })
+
     it('defers to a caller-supplied top-level cache_control', async () => {
       // A cache_control passed through params is the caller's own placement; auto does not override it.
       const { captured, mockClient } = setupCapture()

--- a/strands-ts/src/models/__tests__/anthropic.test.ts
+++ b/strands-ts/src/models/__tests__/anthropic.test.ts
@@ -1145,7 +1145,7 @@ describe('AnthropicModel', () => {
 
     it('adds a breakpoint to the last user message', async () => {
       const { captured, mockClient } = setupCapture()
-      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'auto' } })
+      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'anthropic' } })
 
       await collectIterator(provider.stream([userMessage('one'), userMessage('two')]))
 
@@ -1153,21 +1153,20 @@ describe('AnthropicModel', () => {
     })
 
     it('caches every section when no strategy is given', async () => {
-      // strategy defaults to 'auto', so a config that omits it still enables caching.
+      // strategy defaults to 'auto', so a config that omits it still enables caching: the tools keep
+      // their block-level point and the conversation is covered by the top-level automatic cache.
       const { captured, mockClient } = setupCapture()
       const provider = new AnthropicModel({ client: mockClient, cacheConfig: {} })
 
       await collectIterator(provider.stream([userMessage('Hi')], { toolSpecs }))
 
-      expect(breakpoints(captured.request)).toEqual([
-        ['tools', 't2', { type: 'ephemeral' }],
-        ['messages', 0, { type: 'ephemeral' }],
-      ])
+      expect(breakpoints(captured.request)).toEqual([['tools', 't2', { type: 'ephemeral' }]])
+      expect(captured.request.cache_control).toEqual({ type: 'ephemeral' })
     })
 
-    it('treats auto and anthropic strategies the same', async () => {
-      // The Anthropic API caches on every active Claude model, so auto has no model-support check to
-      // apply and the two strategies produce the same request.
+    it('treats auto and anthropic strategies differently', async () => {
+      // auto delegates breakpoint placement to the API's automatic caching; anthropic keeps the
+      // client-side injection on the last user message.
       const auto = setupCapture()
       await collectIterator(
         new AnthropicModel({ client: auto.mockClient, cacheConfig: { strategy: 'auto' } }).stream([userMessage('Hi')], {
@@ -1183,7 +1182,115 @@ describe('AnthropicModel', () => {
         )
       )
 
-      expect(auto.captured.request).toEqual(explicit.captured.request)
+      expect(auto.captured.request.cache_control).toEqual({ type: 'ephemeral' })
+      expect(breakpoints(auto.captured.request).filter((bp) => (bp as unknown[])[0] === 'messages')).toEqual([])
+      expect(explicit.captured.request.cache_control).toBeUndefined()
+      expect(breakpoints(explicit.captured.request).filter((bp) => (bp as unknown[])[0] === 'messages')).toEqual([
+        ['messages', 0, { type: 'ephemeral' }],
+      ])
+    })
+
+    it('turns on automatic caching for the auto strategy', async () => {
+      // Pins the automatic-caching value shared with strands-py, which sends the same top-level
+      // cache_control through extra_body since its pinned anthropic floor predates the native
+      // parameter. The mirror of this test is test_cross_sdk_automatic_caching_parity in
+      // strands-py/tests/strands/models/test_anthropic.py. Update both together or the SDKs drift.
+      const { captured, mockClient } = setupCapture()
+      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'auto', ttl: '1h' } })
+
+      await collectIterator(provider.stream([userMessage('Hi')]))
+
+      expect(captured.request.cache_control).toEqual({ type: 'ephemeral', ttl: '1h' })
+      expect(breakpoints(captured.request)).toEqual([])
+    })
+
+    it('carries a messagesTTL onto the automatic cache_control', async () => {
+      const { captured, mockClient } = setupCapture()
+      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { ttl: '1h', messagesTTL: '5m' } })
+
+      await collectIterator(provider.stream([userMessage('Hi')]))
+
+      expect(captured.request.cache_control).toEqual({ type: 'ephemeral', ttl: '5m' })
+    })
+
+    it('does not emit automatic caching when messagesTTL is false', async () => {
+      const { captured, mockClient } = setupCapture()
+      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { messagesTTL: false } })
+
+      await collectIterator(provider.stream([userMessage('Hi')]))
+
+      expect(captured.request.cache_control).toBeUndefined()
+    })
+
+    it('still strips accumulated cache points under automatic caching', async () => {
+      // The breakpoint-budget protection applies under both strategies; only the placement moved.
+      const { captured, mockClient } = setupCapture()
+      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'auto' } })
+      const messages = [
+        new Message({
+          role: 'user',
+          content: [new TextBlock('one'), new CachePointBlock({ cacheType: 'default' })],
+        }),
+        new Message({ role: 'assistant', content: [new TextBlock('two')] }),
+        userMessage('three'),
+      ]
+
+      await collectIterator(provider.stream(messages))
+
+      expect(breakpoints(captured.request)).toEqual([])
+      expect(captured.request.cache_control).toEqual({ type: 'ephemeral' })
+    })
+
+    it('keeps an honored cache point alongside automatic caching', async () => {
+      const { captured, mockClient } = setupCapture()
+      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'auto' } })
+      const messages = [
+        new Message({
+          role: 'user',
+          content: [new TextBlock('stable'), new CachePointBlock({ cacheType: 'default' }), new TextBlock('volatile')],
+        }),
+      ]
+
+      await collectIterator(provider.stream(messages))
+
+      expect(breakpoints(captured.request)).toEqual([['messages', 0, { type: 'ephemeral' }]])
+      expect(captured.request.cache_control).toEqual({ type: 'ephemeral' })
+    })
+
+    it('skips automatic caching at the explicit breakpoint limit', async () => {
+      // The API rejects the top-level field when the maximum of explicit breakpoints already exists.
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const { captured, mockClient } = setupCapture()
+      const system = Array.from({ length: 4 }, (_, i) => ({
+        type: 'text',
+        text: `chunk ${i}`,
+        cache_control: { type: 'ephemeral' },
+      }))
+      const provider = new AnthropicModel({
+        client: mockClient,
+        cacheConfig: { strategy: 'auto' },
+        params: { system },
+      })
+
+      await collectIterator(provider.stream([userMessage('Hi')]))
+
+      expect(captured.request.cache_control).toBeUndefined()
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('skipped automatic caching'))
+      warnSpy.mockRestore()
+    })
+
+    it('defers to a caller-supplied top-level cache_control', async () => {
+      // A cache_control passed through params is the caller's own placement; auto does not override it.
+      const { captured, mockClient } = setupCapture()
+      const provider = new AnthropicModel({
+        client: mockClient,
+        cacheConfig: { strategy: 'auto', ttl: '1h' },
+        params: { cache_control: { type: 'ephemeral', ttl: '5m' } },
+      })
+
+      await collectIterator(provider.stream([userMessage('Hi')]))
+
+      expect(captured.request.cache_control).toEqual({ type: 'ephemeral', ttl: '5m' })
     })
 
     it('ignores cacheKey: it does not change the request shape', async () => {
@@ -1208,7 +1315,7 @@ describe('AnthropicModel', () => {
 
     it('carries cacheConfig ttl onto cache_control', async () => {
       const { captured, mockClient } = setupCapture()
-      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'auto', ttl: '1h' } })
+      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'anthropic', ttl: '1h' } })
 
       await collectIterator(provider.stream([userMessage('Hi')]))
 
@@ -1241,7 +1348,7 @@ describe('AnthropicModel', () => {
       const { captured, mockClient } = setupCapture()
       const provider = new AnthropicModel({
         client: mockClient,
-        cacheConfig: { ttl: '5m', toolsTTL: '1h' },
+        cacheConfig: { strategy: 'anthropic', ttl: '5m', toolsTTL: '1h' },
       })
 
       await collectIterator(provider.stream([userMessage('Hi')], { toolSpecs }))
@@ -1283,14 +1390,15 @@ describe('AnthropicModel', () => {
 
       await collectIterator(provider.stream([userMessage('Hi')], { toolSpecs }))
 
-      expect(breakpoints(captured.request)).toEqual([['messages', 0, { type: 'ephemeral' }]])
+      expect(breakpoints(captured.request)).toEqual([])
+      expect(captured.request.cache_control).toEqual({ type: 'ephemeral' })
     })
 
     it('produces two breakpoints when both sections are on', async () => {
       const { captured, mockClient } = setupCapture()
       const provider = new AnthropicModel({
         client: mockClient,
-        cacheConfig: { strategy: 'auto' },
+        cacheConfig: { strategy: 'anthropic' },
       })
 
       await collectIterator(provider.stream([userMessage('Hi')], { toolSpecs }))
@@ -1357,7 +1465,7 @@ describe('AnthropicModel', () => {
 
     it('strips a cache point in an earlier message', async () => {
       const { captured, mockClient } = setupCapture()
-      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'auto' } })
+      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'anthropic' } })
       const messages = [
         new Message({
           role: 'user',
@@ -1377,7 +1485,7 @@ describe('AnthropicModel', () => {
     it('places the breakpoint after the last cacheable block', async () => {
       // Anthropic rejects cache_control on a reasoning block, so the cache point skips back past it.
       const { captured, mockClient } = setupCapture()
-      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'auto' } })
+      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'anthropic' } })
       const messages = [
         new Message({
           role: 'user',
@@ -1461,7 +1569,7 @@ describe('AnthropicModel', () => {
 
     it('auto-injects a system cache point on the last block of an array prompt', async () => {
       const { captured, mockClient } = setupCapture()
-      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'auto' } })
+      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'anthropic' } })
       const systemPrompt = [new TextBlock('Heavy context'), new TextBlock('More context')]
 
       await collectIterator(provider.stream([userMessage('Hi')], { systemPrompt }))
@@ -1501,7 +1609,7 @@ describe('AnthropicModel', () => {
 
     it('does not double a hand-placed system cache point', async () => {
       const { captured, mockClient } = setupCapture()
-      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'auto' } })
+      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'anthropic' } })
       const systemPrompt = [
         new TextBlock('Heavy context'),
         new CachePointBlock({ cacheType: 'default' }),
@@ -1525,7 +1633,7 @@ describe('AnthropicModel', () => {
       // the request is formatted. Choosing the target before formatting used to leave the request with
       // no cache_control at all, so enabling caching removed the caching that worked without it.
       const { captured, mockClient } = setupCapture()
-      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'auto' } })
+      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'anthropic' } })
       const messages = [
         new Message({
           role: 'user',
@@ -1582,7 +1690,7 @@ describe('AnthropicModel', () => {
 
     it('places the breakpoint on the last of several cacheable blocks', async () => {
       const { captured, mockClient } = setupCapture()
-      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'auto' } })
+      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'anthropic' } })
       const messages = [
         new Message({
           role: 'user',
@@ -1611,10 +1719,8 @@ describe('AnthropicModel', () => {
 
       await collectIterator(provider.stream([userMessage('Hi')], { toolSpecs }))
 
-      expect(breakpoints(captured.request)).toEqual([
-        ['tools', 't2', { type: 'ephemeral' }],
-        ['messages', 0, { type: 'ephemeral' }],
-      ])
+      expect(breakpoints(captured.request)).toEqual([['tools', 't2', { type: 'ephemeral' }]])
+      expect(captured.request.cache_control).toEqual({ type: 'ephemeral' })
     })
 
     it('treats an empty ttl on a hand-placed cache point as unset', async () => {
@@ -1813,7 +1919,7 @@ describe('AnthropicModel', () => {
       // strands-py/tests/strands/models/test_anthropic.py.
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const { captured, mockClient } = setupCapture()
-      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'auto' } })
+      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'anthropic' } })
       const messages = [
         new Message({
           role: 'user',
@@ -1831,7 +1937,7 @@ describe('AnthropicModel', () => {
     it('falls back to automatic placement when everything ahead is dropped in translation', async () => {
       // An image with a location source is an accepted carrier by block type but never reaches the API.
       const { captured, mockClient } = setupCapture()
-      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'auto' } })
+      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'anthropic' } })
       const messages = [
         new Message({
           role: 'user',
@@ -1853,7 +1959,7 @@ describe('AnthropicModel', () => {
     it('falls back to automatic placement when only a reasoning block is ahead of the point', async () => {
       // The API rejects cache_control on a thinking block, so it cannot carry an honored boundary.
       const { captured, mockClient } = setupCapture()
-      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'auto' } })
+      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'anthropic' } })
       const messages = [
         new Message({
           role: 'user',
@@ -1880,7 +1986,7 @@ describe('AnthropicModel', () => {
       // strands-py/tests/strands/models/test_anthropic.py.
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const { captured, mockClient } = setupCapture()
-      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'auto' } })
+      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'anthropic' } })
       const messages = [
         userMessage('stable'),
         new Message({ role: 'user', content: [new CachePointBlock({ cacheType: 'default' })] }),
@@ -1980,7 +2086,7 @@ describe('AnthropicModel', () => {
       // Text-only parity cannot catch a breakpoint lost while translating a media block, which is
       // exactly what regressed here.
       const { captured, mockClient } = setupCapture()
-      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'auto' } })
+      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'anthropic' } })
       const messages = [
         new Message({
           role: 'user',
@@ -2016,7 +2122,7 @@ describe('AnthropicModel', () => {
       const { captured, mockClient } = setupCapture()
       const provider = new AnthropicModel({
         client: mockClient,
-        cacheConfig: { strategy: 'auto', ttl: '1h' },
+        cacheConfig: { strategy: 'anthropic', ttl: '1h' },
       })
       const messages = [
         userMessage('hello'),
@@ -2048,7 +2154,7 @@ describe('AnthropicModel', () => {
     it('keeps the cache point ahead of per-call trailing content', async () => {
       // The reusable prefix ends where per-call content begins, so the cache point precedes it.
       const { captured, mockClient } = setupCapture()
-      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'auto' } })
+      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'anthropic' } })
       const message = new Message({
         role: 'user',
         content: [new TextBlock('durable ask'), new TextBlock('per-call')],
@@ -2064,7 +2170,7 @@ describe('AnthropicModel', () => {
 
     it('keeps the cache point ahead of a multi-block per-call tail', async () => {
       const { captured, mockClient } = setupCapture()
-      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'auto' } })
+      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'anthropic' } })
       const message = new Message({
         role: 'user',
         content: [new TextBlock('durable ask'), new TextBlock('injected'), new TextBlock('status')],
@@ -2089,7 +2195,7 @@ describe('AnthropicModel', () => {
 
     it('carries the configured ttl onto the per-call-tail cache point', async () => {
       const { captured, mockClient } = setupCapture()
-      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'auto', ttl: '1h' } })
+      const provider = new AnthropicModel({ client: mockClient, cacheConfig: { strategy: 'anthropic', ttl: '1h' } })
       const message = new Message({
         role: 'user',
         content: [new TextBlock('durable ask'), new TextBlock('per-call')],

--- a/strands-ts/src/models/__tests__/cache-portability.test.ts
+++ b/strands-ts/src/models/__tests__/cache-portability.test.ts
@@ -83,6 +83,9 @@ describe('cacheConfig portability across providers', () => {
       if (!Array.isArray(message.content)) continue
       for (const block of message.content) if (block.cache_control) messagePoints.push(block.cache_control)
     }
+    // Under the default auto strategy the conversation is cached by the top-level automatic
+    // cache_control rather than a block-level point; both mean the messages section is on.
+    if (captured.request?.cache_control) messagePoints.push(captured.request.cache_control)
     return {
       tools: (captured.request?.tools ?? [])
         .filter((entry: any) => entry.cache_control)

--- a/strands-ts/src/models/anthropic.ts
+++ b/strands-ts/src/models/anthropic.ts
@@ -35,6 +35,13 @@ const CONTEXT_WINDOW_OVERFLOW_ERRORS = [
  */
 const ANTHROPIC_CACHE_TYPE = 'ephemeral' as const
 
+/**
+ * The API rejects a request carrying more explicit block-level cache breakpoints than this, and rejects
+ * the top-level automatic-caching field once this many are already present.
+ * https://docs.claude.com/en/docs/build-with-claude/prompt-caching
+ */
+const MAX_CACHE_BREAKPOINTS = 4
+
 const TEXT_FILE_FORMATS = ['txt', 'md', 'markdown', 'csv', 'json', 'xml', 'html', 'yml', 'yaml', 'js', 'ts', 'py']
 
 export interface AnthropicModelConfig extends BaseModelConfig {
@@ -70,10 +77,10 @@ export interface AnthropicModelConfig extends BaseModelConfig {
   useNativeTokenCount?: boolean
 
   /**
-   * Prompt caching configuration. Setting it caches the tool definitions and adds a cache point
-   * to the last user message; caching is off when unset.
-   *
-   * `strategy` has no effect here, since prompt caching is supported on every active Claude model.
+   * Prompt caching configuration. `strategy: 'auto'` (the default) turns on the API's automatic
+   * caching, which places the cache breakpoint server-side and moves it forward as the conversation
+   * grows; `strategy: 'anthropic'` injects an explicit cache point on the last user message instead.
+   * Both cache the tool definitions and system prompt. Caching is off when unset.
    */
   cacheConfig?: CacheConfig
 }
@@ -415,6 +422,9 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
     if (!this._config.modelId) throw new Error('Model ID is required')
 
     const messagesCache = this._cacheSection('messagesTTL')
+    // Under 'auto' the API's automatic caching places the breakpoint server-side, so no managed
+    // block-level point is injected; hand-placed cache points are still honored.
+    const nativeAuto = messagesCache.enabled && (this._config.cacheConfig?.strategy ?? 'auto') === 'auto'
     // The cache point goes on the last user message with content, not counting cache point blocks.
     let cacheTargetMessage = -1
     if (messagesCache.enabled) {
@@ -429,7 +439,13 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
     const request: Anthropic.MessageStreamParams = {
       model: this._config.modelId,
       max_tokens: this._config.maxTokens ?? MODEL_DEFAULTS.anthropic.maxTokens,
-      messages: this._formatMessages(messages, messagesCache, cacheTargetMessage, options?.dynamicTrailingBlocks ?? 0),
+      messages: this._formatMessages(
+        messages,
+        messagesCache,
+        cacheTargetMessage,
+        options?.dynamicTrailingBlocks ?? 0,
+        nativeAuto
+      ),
       stream: true,
     }
 
@@ -470,14 +486,44 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
     if (this._config.stopSequences !== undefined) request.stop_sequences = this._config.stopSequences
     if (this._config.params) Object.assign(request, this._config.params)
 
+    if (nativeAuto) this._applyAutomaticCache(request, messagesCache)
+
     return request
+  }
+
+  /**
+   * Applies the API's automatic caching: one top-level `cache_control`, placed server-side on the last
+   * cacheable block. Skipped when the caller supplied their own through `params` or when the request
+   * already carries the API's maximum of explicit breakpoints, which it would reject.
+   */
+  private _applyAutomaticCache(request: Anthropic.MessageStreamParams, messagesCache: ResolvedCacheSection): void {
+    if (request.cache_control !== undefined) return
+    if (this._countCacheBreakpoints(request) >= MAX_CACHE_BREAKPOINTS) {
+      logger.warn(
+        `count=<${MAX_CACHE_BREAKPOINTS}> | explicit cache breakpoints at the API limit, skipped automatic caching`
+      )
+      return
+    }
+    request.cache_control = this._formatCacheControl(messagesCache.ttl)
+  }
+
+  /** Counts the explicit block-level cache breakpoints in a formatted request. */
+  private _countCacheBreakpoints(request: Anthropic.MessageStreamParams): number {
+    const blocks: { cache_control?: Anthropic.CacheControlEphemeral | null }[] = [...(request.tools ?? [])]
+    if (Array.isArray(request.system)) blocks.push(...request.system)
+    for (const message of request.messages) {
+      if (Array.isArray(message.content))
+        blocks.push(...(message.content as { cache_control?: Anthropic.CacheControlEphemeral | null }[]))
+    }
+    return blocks.filter((block) => block.cache_control != null).length
   }
 
   private _formatMessages(
     messages: Message[],
     messagesCache: ResolvedCacheSection = { enabled: false },
     cacheTargetMessage = -1,
-    dynamicTrailingBlocks = 0
+    dynamicTrailingBlocks = 0,
+    nativeAuto = false
   ): Anthropic.MessageParam[] {
     let strippedCachePoints = 0
     const cacheManaged = messagesCache.enabled
@@ -521,7 +567,7 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
       // Placed after formatting so the cache point lands on a block that survived translation.
       // Per-call trailing blocks apply only to the cache-target message, where a producer appends
       // content rebuilt every call.
-      if (isCacheTarget && !marked) {
+      if (isCacheTarget && !marked && !nativeAuto) {
         if (this._attachCacheControl(content, messagesCache.ttl, dynamicTrailingBlocks)) {
           logger.debug(`msg_idx=<${messageIndex}> | added cache point to last user message`)
         } else {

--- a/strands-ts/src/models/anthropic.ts
+++ b/strands-ts/src/models/anthropic.ts
@@ -422,9 +422,12 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
     if (!this._config.modelId) throw new Error('Model ID is required')
 
     const messagesCache = this._cacheSection('messagesTTL')
+    const dynamicTrailingBlocks = options?.dynamicTrailingBlocks ?? 0
     // Under 'auto' the API's automatic caching places the breakpoint server-side, so no managed
-    // block-level point is injected; hand-placed cache points are still honored.
-    const nativeAuto = messagesCache.enabled && (this._config.cacheConfig?.strategy ?? 'auto') === 'auto'
+    // block-level point is injected; hand-placed cache points are still honored. A per-call trailing
+    // tail falls back to explicit placement, which alone can keep the breakpoint ahead of it.
+    const nativeAuto =
+      messagesCache.enabled && (this._config.cacheConfig?.strategy ?? 'auto') === 'auto' && dynamicTrailingBlocks === 0
     // The cache point goes on the last user message with content, not counting cache point blocks.
     let cacheTargetMessage = -1
     if (messagesCache.enabled) {
@@ -439,13 +442,7 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
     const request: Anthropic.MessageStreamParams = {
       model: this._config.modelId,
       max_tokens: this._config.maxTokens ?? MODEL_DEFAULTS.anthropic.maxTokens,
-      messages: this._formatMessages(
-        messages,
-        messagesCache,
-        cacheTargetMessage,
-        options?.dynamicTrailingBlocks ?? 0,
-        nativeAuto
-      ),
+      messages: this._formatMessages(messages, messagesCache, cacheTargetMessage, dynamicTrailingBlocks, nativeAuto),
       stream: true,
     }
 
@@ -494,7 +491,9 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
   /**
    * Applies the API's automatic caching: one top-level `cache_control`, placed server-side on the last
    * cacheable block. Skipped when the caller supplied their own through `params` or when the request
-   * already carries the API's maximum of explicit breakpoints, which it would reject.
+   * already carries the API's maximum of explicit breakpoints, which it would reject. Never reached
+   * with a per-call trailing tail: its breakpoint would land inside content rebuilt every call, so
+   * every request would write a cache entry that none ever reads.
    */
   private _applyAutomaticCache(request: Anthropic.MessageStreamParams, messagesCache: ResolvedCacheSection): void {
     if (request.cache_control !== undefined) return

--- a/strands-ts/src/models/model.ts
+++ b/strands-ts/src/models/model.ts
@@ -71,10 +71,12 @@ class CitationAccumulator {
  */
 export interface CacheConfig {
   /**
-   * Whether to skip caching for models that do not support it.
-   * - "auto": cache only when the model is known to support it
-   * - "anthropic": cache without that check, for model identifiers it cannot inspect
-   *   (an application inference profile, for example)
+   * Caching strategy to use.
+   * - "auto": automatically maximize cache coverage. Bedrock caches only when the model is known to
+   *   support it; Anthropic turns on the API's native automatic caching, which places the breakpoint
+   *   server-side.
+   * - "anthropic": inject explicit cache points without that check, for model identifiers Bedrock
+   *   cannot inspect (an application inference profile, for example)
    *
    * @defaultValue 'auto'
    */


### PR DESCRIPTION
## Description

`cache_config` / `cacheConfig` with `strategy="auto"` on the Anthropic model provider now turns on the API's **native automatic caching** — a single top-level `cache_control` field whose breakpoint the API places on the last cacheable block and advances as the conversation grows — instead of injecting an explicit block-level cache point on the last user message. `strategy="anthropic"` keeps the explicit injection, giving the two strategies a genuine behavioral distinction on this provider (they deliberately coincided after #3571).

**Design decisions**

| Aspect | Behavior |
|---|---|
| `strategy="auto"` (default) | Emits top-level `cache_control` (with `cache_config.ttl` when set); no managed block-level point |
| `strategy="anthropic"` | Unchanged: explicit block-level cache point on the last user message |
| Python transport | `extra_body` — the pinned floor `anthropic==0.21.0` predates the SDK's native top-level parameter; verified with a mock-transport probe that `extra_body` lands the field top-level on the wire on 0.21.0 (sync **and** async clients), so no floor raise is needed |
| TypeScript transport | Native `cache_control` param (`@anthropic-ai/sdk` 0.109.1 carries it in `MessageCreateParamsBase`) |
| 400 guard | Top-level field skipped (with a warning) when the request already carries the API's maximum of 4 explicit breakpoints |
| Caller deference | A caller-supplied top-level `cache_control` via `params` (or inside a caller `extra_body` in Python) wins; auto never overrides it |
| Per-call trailing content | A declared per-call tail (`dynamic_trailing_blocks` / `dynamicTrailingBlocks` > 0, e.g. a context injector block or the agentic status line) falls back to explicit block-level placement ahead of the tail — the automatic breakpoint would land inside content rebuilt every call, so every request would write the prefix and none would read it (verified live: write=5445/read=0 without the fallback) |
| Hand-placed cache points, stripping, `tools_ttl` / `system_prompt_ttl` | Unchanged under both strategies; a hand-placed point in the last user message coexists with the top-level field |
| Bedrock | Untouched — automatic caching is not offered on Amazon Bedrock |

## Related Issues

Fixes #3573

## Documentation PR

Included: `site/src/content/docs/user-guide/concepts/model-providers/anthropic.mdx` documents the strategy distinction and the per-call-content fallback in both language tabs.

## Type of Change

New feature

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare` — 6034 passed (Python 3.10 + 3.13 matrix, lint, format, type-check)
- [x] TypeScript: `npm run build` + `npm test` — 4583 tests + typecheck green
- [x] Site: `npm run build` green, link checker reports no broken links
- [x] Live against the Anthropic API:
  - `tests_integ/models/test_model_anthropic.py -k earns_a_read` — the auto path writes on turn 1 and **reads** on turn 2 (native automatic caching earns cache hits through `extra_body`)
  - `tests_integ/test_prompt_cache_per_call_content.py -k anthropic` — both params pass on this branch (they fail without the per-call-tail fallback)
  - `ttl="1h"` accepted on the top-level field
- [x] Wire-level probe on the pinned floor `anthropic==0.21.0` (mock transport): `extra_body={"cache_control": ...}` serializes top-level on both `Anthropic` and `AsyncAnthropic` `messages.stream`
- Cross-SDK parity pinned by paired tests (`test_cross_sdk_automatic_caching_parity` ↔ `turns on automatic caching for the auto strategy`)

## Review Loop Summary

This PR went through 2 pre-PR review iterations before publication:

| Iteration | Run | Outcome |
|-----------|-----|---------|
| impl | [33909038650](https://github.com/agent-of-mkmeral/strands-coder-private/actions/runs/33909038650) | Implementation in both SDKs + docs; readiness green |
| 1 | [33915322899](https://github.com/agent-of-mkmeral/strands-coder-private/actions/runs/33915322899) | 🔴 found & fixed (`c20afdff`): native automatic caching defeated per-call trailing-content protection — the automatic breakpoint lands inside the volatile tail, so every request wrote the full prefix and none read it (verified live). A declared tail now falls back to explicit placement ahead of it, both SDKs, with unit tests + docs |
| 2 | [33919212105](https://github.com/agent-of-mkmeral/strands-coder-private/actions/runs/33919212105) | Re-verified the fix live (both integ tests pass; auto path still earns reads), re-probed the 0.21.0 floor (sync + async), full readiness re-run in all three projects — no must-fix or should-fix findings; converged |

## Remaining Findings

None blocking. One cosmetic cross-SDK nit noted for the record: when counting existing breakpoints for the 400 guard, Python counts a block where the `cache_control` key is present while TypeScript counts `cache_control != null` — only distinguishable by hand-crafting a `cache_control: null` block through `params`, which neither SDK produces.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
