### PR TITLE
fix(skills-py): avoid leaking YAML parse error and dropping valid ski…

### DIFF
--- a/strands-py/src/strands/vended_plugins/skills/skill.py
+++ b/strands-py/src/strands/vended_plugins/skills/skill.py
@@ -80,7 +80,10 @@ def _parse_frontmatter(content: str) -> tuple[dict[str, Any], str]:
         # to improve cross-client compatibility. See: agentskills.io/client-implementation/adding-skills-support
         logger.warning("YAML parse failed, retrying with colon-quoting fallback")
         fixed = _fix_yaml_colons(frontmatter_str)
-        result = yaml.safe_load(fixed)
+        try:
+            result = yaml.safe_load(fixed)
+        except yaml.YAMLError as error:
+            raise ValueError(f"malformed YAML frontmatter: {error}") from error
 
     frontmatter: dict[str, Any] = result if isinstance(result, dict) else {}
     return frontmatter, body

--- a/strands-py/tests/strands/vended_plugins/skills/test_skill.py
+++ b/strands-py/tests/strands/vended_plugins/skills/test_skill.py
@@ -299,6 +299,13 @@ class TestParseFrontmatterYamlFallback:
         assert frontmatter["name"] == "my-skill"
         assert frontmatter["description"] == "A simple description"
 
+    def test_unrepairable_yaml_raises_value_error(self):
+        """Frontmatter the colon-quoting fallback cannot repair raises ValueError, not a raw
+        yaml.YAMLError, honoring the documented contract. Guards strands-agents/harness-sdk#4155."""
+        content = '---\nname: my-skill\ndescription: "unterminated\n---\nBody.'
+        with pytest.raises(ValueError, match="malformed YAML frontmatter"):
+            _parse_frontmatter(content)
+
 
 def _make_skill_dir(parent: Path, name: str, description: str = "A test skill", body: str = "Instructions.") -> Path:
     """Helper to create a skill directory with SKILL.md."""
@@ -464,6 +471,20 @@ class TestSkillFromDirectory:
         """Test FileNotFoundError for nonexistent directory."""
         with pytest.raises(FileNotFoundError):
             Skill.from_directory(tmp_path / "nonexistent")
+
+    def test_malformed_skill_does_not_abort_siblings(self, tmp_path, caplog):
+        """Test no skip for malformed YAML skills"""
+        _make_skill_dir(tmp_path, "good-skill")
+
+        bad_dir = tmp_path / "bad-skill"
+        bad_dir.mkdir()
+        (bad_dir / "SKILL.md").write_text('---\nname: bad-skill\ndescription: "unterminated\n---\nBody.')
+
+        with caplog.at_level(logging.WARNING):
+            skills = Skill.from_directory(tmp_path)
+
+        assert [s.name for s in skills] == ["good-skill"]
+        assert "skipping skill due to error: malformed YAML frontmatter" in caplog.text
 
     def test_loads_mismatched_name_with_warning(self, tmp_path, caplog):
         """Test that skills with name/directory mismatch are loaded with a warning."""


### PR DESCRIPTION
## Description

`Skill.from_content` documents `Raises: ValueError`, but a malformed-YAML retry path (`_parse_frontmatter`'s `_fix_yaml_colons` fallback) leaves its `yaml.safe_load` unwrapped, so frontmatter the fallback can't repair leaks a raw `yaml.YAMLError`.

This matters in `Skill.from_directory`: its per-skill `except (ValueError, FileNotFoundError)` is meant to skip one bad skill and load the rest, but the leaked `YAMLError` slips past it — so a single malformed `SKILL.md` aborts loading of every skill in that directory (and is silently dropped when reached via `AgentSkills`). Wrapping the fallback as `ValueError` restores the contract and the intended per-skill resilience.

## Related Issues

Resolves #4155

## Type of Change

Bug fix

## Testing

- [x] I ran `hatch run prepare`

Added regression tests for the leaked exception type and the `from_directory` batch resilience; both fail on the current code and pass with the fix.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
