### PR TITLE
fix(openai-responses): map cache_write_tokens to cacheWriteInputTokens

### DIFF
--- a/strands-py/src/strands/models/openai_responses.py
+++ b/strands-py/src/strands/models/openai_responses.py
@@ -916,6 +916,13 @@ class OpenAIResponsesModel(Model):
                     if isinstance(cached, int) and cached:
                         usage_data["cacheReadInputTokens"] = cached
 
+                    # Reported first-party from GPT-5.6, where cache writes are billed at 1.25x the
+                    # uncached input rate. Dropping it leaves cacheWriteInputTokens structurally 0,
+                    # so the write premium is invisible to any cost consumer.
+                    cache_write = getattr(tokens_details, "cache_write_tokens", None)
+                    if isinstance(cache_write, int) and cache_write:
+                        usage_data["cacheWriteInputTokens"] = cache_write
+
                 return {
                     "metadata": {
                         "usage": usage_data,

--- a/strands-py/tests/strands/models/test_openai_responses.py
+++ b/strands-py/tests/strands/models/test_openai_responses.py
@@ -737,6 +737,78 @@ def test_format_chunk_metadata_with_cache_tokens(model):
     }
 
 
+def test_format_chunk_metadata_with_cache_write_tokens(model):
+    """cache_write_tokens maps to cacheWriteInputTokens.
+
+    GPT-5.6 reports cache writes alongside reads and bills them at 1.25x the uncached input
+    rate, so a dropped counter understates cost rather than merely losing detail.
+    """
+    mock_usage = unittest.mock.Mock()
+    mock_usage.input_tokens = 100
+    mock_usage.output_tokens = 50
+    mock_usage.total_tokens = 150
+
+    mock_tokens_details = unittest.mock.Mock()
+    mock_tokens_details.cached_tokens = 25
+    mock_tokens_details.cache_write_tokens = 40
+    mock_usage.input_tokens_details = mock_tokens_details
+
+    event = {"chunk_type": "metadata", "data": mock_usage}
+
+    assert model._format_chunk(event) == {
+        "metadata": {
+            "usage": {
+                "inputTokens": 100,
+                "outputTokens": 50,
+                "totalTokens": 150,
+                "cacheReadInputTokens": 25,
+                "cacheWriteInputTokens": 40,
+            },
+            "metrics": {"latencyMs": 0},
+        },
+    }
+
+
+def test_format_chunk_metadata_with_zero_cache_write_tokens(model):
+    """A zero write counter is omitted, matching how cached_tokens is handled."""
+    mock_usage = unittest.mock.Mock()
+    mock_usage.input_tokens = 100
+    mock_usage.output_tokens = 50
+    mock_usage.total_tokens = 150
+
+    mock_tokens_details = unittest.mock.Mock()
+    mock_tokens_details.cached_tokens = 25
+    mock_tokens_details.cache_write_tokens = 0
+    mock_usage.input_tokens_details = mock_tokens_details
+
+    event = {"chunk_type": "metadata", "data": mock_usage}
+
+    usage = model._format_chunk(event)["metadata"]["usage"]
+
+    assert usage["cacheReadInputTokens"] == 25
+    assert "cacheWriteInputTokens" not in usage
+
+
+def test_format_chunk_metadata_on_an_sdk_pin_without_cache_write_tokens(model):
+    """Pins predating the field report no write counter; the mapping stays silent."""
+
+    class _TokensDetails:
+        cached_tokens = 25
+
+    mock_usage = unittest.mock.Mock()
+    mock_usage.input_tokens = 100
+    mock_usage.output_tokens = 50
+    mock_usage.total_tokens = 150
+    mock_usage.input_tokens_details = _TokensDetails()
+
+    event = {"chunk_type": "metadata", "data": mock_usage}
+
+    usage = model._format_chunk(event)["metadata"]["usage"]
+
+    assert usage["cacheReadInputTokens"] == 25
+    assert "cacheWriteInputTokens" not in usage
+
+
 def test_format_chunk_metadata_with_zero_cached_tokens(model):
     """Test _format_chunk for metadata when cached_tokens is 0."""
     mock_usage = unittest.mock.Mock()


### PR DESCRIPTION
## Description

The Responses adapter reads `cached_tokens` off `input_tokens_details` but not `cache_write_tokens`, so `cacheWriteInputTokens` is structurally absent for every OpenAI model on this path.

That counter is not cosmetic. GPT-5.6 reports cache writes first-party and [bills them at 1.25x the uncached input rate](https://aws.amazon.com/blogs/machine-learning/introducing-explicit-prompt-caching-for-openai-gpt-5-6-models-on-amazon-bedrock/), so a consumer computing cost as a weighted sum over the four counters silently understates every turn that writes to cache — and cannot distinguish a cold prefix write from an ordinary uncached call at all. Bedrock already returns the field for OpenAI models on Converse ([@aristide1997's measurement in #3546](https://github.com/strands-agents/harness-sdk/issues/3546)), so today the *same model* reports a write bucket through `BedrockModel` and not through this adapter.

This is the "Responses adapter still drops `cacheWriteInputTokens`" line item in the open-work list on #3546.

## Change

```python
if tokens_details := getattr(event["data"], "input_tokens_details", None):
    cached = getattr(tokens_details, "cached_tokens", None)
    if isinstance(cached, int) and cached:
        usage_data["cacheReadInputTokens"] = cached

    cache_write = getattr(tokens_details, "cache_write_tokens", None)
    if isinstance(cache_write, int) and cache_write:
        usage_data["cacheWriteInputTokens"] = cache_write
```

Symmetric with the existing `cached_tokens` handling — `getattr` + present-and-non-zero — so `openai` pins predating the field, and providers that never report it, are unaffected. The field is read off `input_tokens_details`, where the Responses API puts it.

## Scope

Deliberately narrow. It is purely additive: it populates a counter that is currently always absent, and touches nothing else.

In particular it does **not** address the inclusive-vs-disjoint convention question that #3546 also tracks, and it is not a substitute for it — `input_tokens` remains inclusive of both cache buckets on this adapter, so a consumer summing the four counters still over-counts. I kept the two apart because they have very different review surfaces, and #3561 suggests the broad version is the harder conversation. Happy to fold this in if a maintainer would rather it land as part of that.

One consequence worth stating plainly: on a consumer that sums the counters, this change makes an existing over-count slightly larger on write turns, because the written tokens are inside `input_tokens` too. It is still the right change — the alternative is a counter that is permanently zero and a 1.25x premium that no consumer can see — but a maintainer weighing the ordering against the #3546 work should know.

## Testing

Three cases added to `test_openai_responses.py`, matching the shape of the existing `cached_tokens` tests:

- `cache_write_tokens` present -> `cacheWriteInputTokens`
- zero write counter omitted, mirroring the `cached_tokens` behavior
- an `input_tokens_details` without the attribute at all (an older `openai` pin) stays silent

`strands-py/tests/strands/models/test_openai_responses.py` -> 140 passed.

## Related

- #3546 — the umbrella issue; this is one line item from its "what is still in main" list
- #3561 — the broad convention fix, closed unmerged

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
