### PR TITLE
fix: catch YAMLError in skill frontmatter fallback parser

### DIFF
--- a/strands-py/src/strands/vended_plugins/skills/skill.py
+++ b/strands-py/src/strands/vended_plugins/skills/skill.py
@@ -80,7 +80,10 @@ def _parse_frontmatter(content: str) -> tuple[dict[str, Any], str]:
         # to improve cross-client compatibility. See: agentskills.io/client-implementation/adding-skills-support
         logger.warning("YAML parse failed, retrying with colon-quoting fallback")
         fixed = _fix_yaml_colons(frontmatter_str)
-        result = yaml.safe_load(fixed)
+        try:
+            result = yaml.safe_load(fixed)
+        except yaml.YAMLError as error:
+            raise ValueError(f"malformed YAML frontmatter: {error}") from error
 
     frontmatter: dict[str, Any] = result if isinstance(result, dict) else {}
     return frontmatter, body

--- a/strands-py/tests/strands/vended_plugins/skills/test_skill.py
+++ b/strands-py/tests/strands/vended_plugins/skills/test_skill.py
@@ -292,6 +292,12 @@ class TestParseFrontmatterYamlFallback:
         assert "Use when" in frontmatter["description"]
         assert body == "Body."
 
+    def test_fallback_raises_value_error_on_unfixable_yaml(self):
+        """Test that unfixable YAML raises ValueError, not yaml.YAMLError."""
+        content = '---\nname: my-skill\ndescription: "unterminated quote\n---\nBody.'
+        with pytest.raises(ValueError, match="malformed YAML frontmatter"):
+            _parse_frontmatter(content)
+
     def test_fallback_preserves_valid_yaml(self):
         """Test that valid YAML is parsed normally without triggering fallback."""
         content = "---\nname: my-skill\ndescription: A simple description\n---\nBody."
@@ -464,6 +470,21 @@ class TestSkillFromDirectory:
         """Test FileNotFoundError for nonexistent directory."""
         with pytest.raises(FileNotFoundError):
             Skill.from_directory(tmp_path / "nonexistent")
+
+    def test_skips_unfixable_yaml_and_loads_siblings(self, tmp_path, caplog):
+        """Test that a skill with unfixable YAML is skipped without aborting sibling loading."""
+        _make_skill_dir(tmp_path, "good-skill")
+
+        bad_dir = tmp_path / "bad-yaml"
+        bad_dir.mkdir()
+        (bad_dir / "SKILL.md").write_text('---\nname: bad-yaml\ndescription: "unterminated\n---\nBody.')
+
+        with caplog.at_level(logging.WARNING):
+            skills = Skill.from_directory(tmp_path)
+
+        assert len(skills) == 1
+        assert skills[0].name == "good-skill"
+        assert "skipping skill due to error" in caplog.text
 
     def test_loads_mismatched_name_with_warning(self, tmp_path, caplog):
         """Test that skills with name/directory mismatch are loaded with a warning."""


### PR DESCRIPTION
## Summary

Fixes #4155

When the YAML fallback parser in `_parse_frontmatter` fails to parse malformed frontmatter, it now raises `ValueError` instead of letting `yaml.YAMLError` escape. This ensures `Skill.from_directory()` can gracefully skip the broken skill and continue loading siblings.

## Changes

- Wrapped the fallback `yaml.safe_load()` call with try/except that converts `yaml.YAMLError` to `ValueError`
- Added test for unfixable YAML raising `ValueError`
- Added integration test proving `from_directory()` skips bad skills without aborting

## Testing

- All existing tests pass (79 passed)
- New tests verify the fix works as expected
- Formatter and linter passed

## Checklist

- [x] Code follows project style guidelines
- [x] Tests added for the fix
- [x] All tests pass locally
- [x] Commit message follows conventional commits format