### PR TITLE
docs: add Lelu to the integrations catalog

### DIFF
--- a/site/src/content/catalog/lelu.yaml
+++ b/site/src/content/catalog/lelu.yaml
@@ -1,0 +1,11 @@
+name: Lelu
+description: Authorization engine for AI agents that checks every tool call against policy and returns allow, deny, human review, or redirection to a safer tool.
+integrationType: intervention
+languages:
+  python:
+    package: lelu-agent-auth-sdk
+  typescript:
+    package: lelu-agent-auth
+github: https://github.com/Lelu-ai/lelu
+docsUrl: https://lelu-ai.com/docs/integrations/strands
+addedDate: 2026-09-05


### PR DESCRIPTION
Lelu is an open-source authorization engine for AI agents. It registers as an
`InterventionHandler` and checks every tool call against policy before it runs.

The four decisions map onto existing intervention actions: `allow` to `Proceed`,
`deny` to `Deny`, `compute` to `Transform`, and `human_review` to `Confirm`.

Available for both Python (`lelu-agent-auth-sdk`) and TypeScript
(`lelu-agent-auth`). On the TypeScript side `@strands-agents/sdk` is an optional
peer dependency, so it adds nothing for users who are not using Strands.

Docs: https://lelu-ai.com/docs/integrations/strands

## Integration submission

**Package name:** `lelu-agent-auth-sdk` (PyPI) / `lelu-agent-auth` (npm)
**Integration type:** intervention
**Languages published:** Python and TypeScript
**GitHub repo:** https://github.com/Lelu-ai/lelu
**What it does:** Checks every agent tool call against policy before it runs and returns allow, deny, human review, or redirection to a safer tool. Every decision is written to a signed, tamper-evident audit log.
**Relationship to service:** Official — I maintain Lelu. Left `maintainedBy` unset (defaults to `community`) rather than claiming `partner`, since there is no formal partnership with Strands.
**Docs link included:** `docsUrl` → https://lelu-ai.com/docs/integrations/strands

### Submitter checklist

#### Package
- [x] This is a reusable integration (library/plugin/provider), not an example agent or application built with Strands
- [x] Published to PyPI and/or npm under the exact `package` name in my entry (registry links are derived from it) — or this is a guide-only entry (no `package` in any language block) with a `docsUrl` pointing at the vendor's Strands guide
- [x] GitHub repository is public and includes a license

#### Entry
- [x] Description accurately states what the package does in one sentence
- [x] `integrationType` matches what the package actually is
- [x] All URLs are working (`github`, and `docsUrl` if set)
- [x] `addedDate` is set to today (the date I opened this PR)
- [x] `featured` and `badges` are left unset — those are granted by the Strands team

#### Docs (only if setting a `docsUrl`)
- [x] The linked page documents using this integration with Strands Agents

#### Conduct
- [x] I am the package maintainer, or I have the maintainer's explicit consent to list it
- [x] Entry uses the package's real name with no trademark misuse
