### PR TITLE
fix(session): filter malformed immutable snapshot IDs

### DIFF
--- a/strands-py/src/strands/session/snapshot_session_manager.py
+++ b/strands-py/src/strands/session/snapshot_session_manager.py
@@ -371,7 +371,11 @@ class SnapshotSessionManager(SessionManager):
 
         history_prefix = f"{_snapshots_prefix(self.session_id, agent.agent_id)}{_IMMUTABLE_HISTORY}/"
         keys = await self._resolved_storage.list(history_prefix)
-        ids = sorted(match.group(1) for key in keys if (match := _SNAPSHOT_REGEX.search(key)))
+        ids = sorted(
+            snapshot_id
+            for key in keys
+            if (match := _SNAPSHOT_REGEX.search(key)) and is_uuid7(snapshot_id := match.group(1))
+        )
         if start_after is not None:
             ids = [snapshot_id for snapshot_id in ids if snapshot_id > start_after]
         if limit is not None:

--- a/strands-py/tests/strands/session/test_snapshot_session_manager.py
+++ b/strands-py/tests/strands/session/test_snapshot_session_manager.py
@@ -678,10 +678,14 @@ async def test_list_snapshot_ids_pagination(storage):
     agent("three")
 
     all_ids = await manager.list_snapshot_ids(agent)
+    history_prefix = "session/s1/scopes/agent/a1/snapshots/immutable_history/"
+    await storage.write(f"{history_prefix}snapshot_not-a-uuid.json", b"invalid")
+
     assert len(all_ids) == 3
     assert all_ids == sorted(all_ids)
 
     assert await manager.list_snapshot_ids(agent, limit=2) == all_ids[:2]
+    assert "not-a-uuid" not in await manager.list_snapshot_ids(agent)
     assert await manager.list_snapshot_ids(agent, limit=0) == []
     assert await manager.list_snapshot_ids(agent, start_after=all_ids[0]) == all_ids[1:]
 

--- a/strands-py/tests/strands/session/test_snapshot_session_manager.py
+++ b/strands-py/tests/strands/session/test_snapshot_session_manager.py
@@ -678,14 +678,16 @@ async def test_list_snapshot_ids_pagination(storage):
     agent("three")
 
     all_ids = await manager.list_snapshot_ids(agent)
-    history_prefix = "session/s1/scopes/agent/a1/snapshots/immutable_history/"
-    await storage.write(f"{history_prefix}snapshot_not-a-uuid.json", b"invalid")
-
     assert len(all_ids) == 3
     assert all_ids == sorted(all_ids)
 
+    # guards against a malformed key sorting ahead of valid ids and displacing them from a
+    # limited page (#4198); "000-bad" sorts before every real UUIDv7 id
+    history_prefix = "session/s1/scopes/agent/a1/snapshots/immutable_history/"
+    await storage.write(f"{history_prefix}snapshot_000-bad.json", b"invalid")
+    assert await manager.list_snapshot_ids(agent) == all_ids
+
     assert await manager.list_snapshot_ids(agent, limit=2) == all_ids[:2]
-    assert "not-a-uuid" not in await manager.list_snapshot_ids(agent)
     assert await manager.list_snapshot_ids(agent, limit=0) == []
     assert await manager.list_snapshot_ids(agent, start_after=all_ids[0]) == all_ids[1:]
 


### PR DESCRIPTION
## Description
`list_snapshot_ids()` could return storage-key suffixes that `restore_snapshot()` rejects, allowing malformed or foreign immutable-history objects to appear as public snapshot handles and consume pagination capacity. Filter enumerated IDs with the existing canonical UUIDv7 validator before sorting, and limiting so the list and restore APIs uphold the same contract.

## Related Issues

Closes #4198 

## Documentation PR

None - no public API or documented workflow changes.

## Type of Change

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
