### PR TITLE
fix(mistral): preserve image blocks in requests

### DIFF
--- a/strands-py/src/strands/models/mistral.py
+++ b/strands-py/src/strands/models/mistral.py
@@ -236,7 +236,7 @@ class MistralModel(Model):
             role = message["role"]
             contents = message["content"]
 
-            text_contents: list[str] = []
+            message_contents: list[str | dict[str, Any]] = []
             tool_calls: list[dict[str, Any]] = []
             tool_messages: list[dict[str, Any]] = []
 
@@ -250,19 +250,25 @@ class MistralModel(Model):
                     logger.warning("cachePoint content block is not supported by Mistral | skipping")
                     continue
 
-                if "text" in content:
-                    formatted_content = self._format_request_message_content(content)
-                    if isinstance(formatted_content, str):
-                        text_contents.append(formatted_content)
+                if "text" in content or "image" in content:
+                    message_contents.append(self._format_request_message_content(content))
                 elif "toolUse" in content:
                     tool_calls.append(self._format_request_message_tool_call(content["toolUse"]))
                 elif "toolResult" in content:
                     tool_messages.append(self._format_request_tool_message(content["toolResult"]))
 
-            if text_contents or tool_calls:
+            if message_contents or tool_calls:
+                message_content: str | list[dict[str, Any]]
+                if any(isinstance(content, dict) for content in message_contents):
+                    message_content = [
+                        {"type": "text", "text": content} if isinstance(content, str) else content
+                        for content in message_contents
+                    ]
+                else:
+                    message_content = " ".join(content for content in message_contents if isinstance(content, str))
                 formatted_message: dict[str, Any] = {
                     "role": role,
-                    "content": " ".join(text_contents) if text_contents else "",
+                    "content": message_content,
                 }
 
                 if tool_calls:

--- a/strands-py/tests/strands/models/test_mistral.py
+++ b/strands-py/tests/strands/models/test_mistral.py
@@ -1,13 +1,20 @@
+import base64
+import copy
 import logging
 import unittest.mock
 
 import pydantic
 import pytest
+from mistralai.client.models import UserMessage
 
 import strands
 from strands.models import CacheConfig
 from strands.models.mistral import MistralModel
 from strands.types.exceptions import ContextWindowOverflowException, ModelThrottledException
+
+PNG_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC"
+IMAGE = {"image": {"format": "png", "source": {"bytes": base64.b64decode(PNG_BASE64)}}}
+IMAGE_CHUNK = {"type": "image_url", "image_url": f"data:image/png;base64,{PNG_BASE64}"}
 
 
 @pytest.fixture
@@ -124,6 +131,46 @@ def test_format_request_default(model, messages, model_id):
     }
 
     assert actual_request == exp_request
+
+
+@pytest.mark.parametrize(
+    "contents, exp_content",
+    [
+        ([IMAGE], [IMAGE_CHUNK]),
+        (
+            [{"text": "Describe this"}, IMAGE],
+            [{"type": "text", "text": "Describe this"}, IMAGE_CHUNK],
+        ),
+        (
+            [{"text": "Before"}, IMAGE, {"text": "After"}],
+            [{"type": "text", "text": "Before"}, IMAGE_CHUNK, {"type": "text", "text": "After"}],
+        ),
+        ([IMAGE, {"text": "After"}], [IMAGE_CHUNK, {"type": "text", "text": "After"}]),
+        ([IMAGE, IMAGE], [IMAGE_CHUNK, IMAGE_CHUNK]),
+        (
+            [{"text": "First"}, {"text": "Second"}, IMAGE],
+            [{"type": "text", "text": "First"}, {"type": "text", "text": "Second"}, IMAGE_CHUNK],
+        ),
+        ([{"text": "First"}, {"text": "Second"}], "First Second"),
+    ],
+    ids=["image-only", "text-image", "text-image-text", "image-text", "two-images", "text-text-image", "text-only"],
+)
+def test_format_request_preserves_image_blocks(contents, exp_content):
+    """Image blocks retain their position in the provider request (#4197)."""
+    model = MistralModel(api_key="test-key", model_id="pixtral-12b-latest")
+    messages = [{"role": "user", "content": copy.deepcopy(contents)}]
+    original_messages = copy.deepcopy(messages)
+
+    tru_request = model.format_request(messages)
+    exp_request = {
+        "model": "pixtral-12b-latest",
+        "messages": [{"role": "user", "content": exp_content}],
+        "stream": True,
+    }
+
+    assert tru_request == exp_request
+    assert messages == original_messages
+    UserMessage.model_validate(tru_request["messages"][0])
 
 
 def test_cache_config_round_trips(model_id, max_tokens, captured_warnings):


### PR DESCRIPTION
## Description

Mistral requests silently drop user images, and image-only messages disappear entirely. Preserve ordered image and text chunks in multimodal requests while retaining the existing string format for text-only messages.

AI assistance: Codex helped implement and test this change; the author has reviewed and understands every line.

## Related Issues

Fixes #4197, reported by @ebarkhordar.

## Documentation PR

No documentation change is needed for this existing image-input behavior.

## Type of Change

Bug fix

## Testing

Python 3.11.15 on macOS arm64. The final Mistral suite gives 6 failures / 48 passes before the fix and 54 passes after it. The repository pre-push script passes: Ruff, mypy (299 files), and 6,214 unit tests, with 34 skips and 86 warnings. Live provider integration and the OS/Python matrix were not run. A separate whole-tree formatting check reports two unchanged Bedrock files; both changed files pass formatting.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
