### PR TITLE
feat(openai): honor system prompt cache points for OpenAI-compatible providers

### DIFF
--- a/strands-py/src/strands/models/openai.py
+++ b/strands-py/src/strands/models/openai.py
@@ -369,6 +369,12 @@ class OpenAIModel(Model):
     ) -> list[dict[str, Any]]:
         """Format system messages for OpenAI-compatible providers.
 
+        A caller-placed ``cachePoint`` block marks the preceding system text block as cacheable,
+        emitted as an Anthropic/Bedrock-compatible ``cache_control`` field on that block's content
+        part. Plain OpenAI has no such field and ignores it; gateways in front of Anthropic or
+        Bedrock (Portkey, LiteLLM, OpenRouter, ...) route it to the underlying provider's cache.
+        See https://github.com/strands-agents/harness-sdk/issues/1140.
+
         Args:
             system_prompt: System prompt to provide context to the model.
             system_prompt_content: System prompt content blocks to provide context to the model.
@@ -381,12 +387,39 @@ class OpenAIModel(Model):
         if system_prompt and system_prompt_content is None:
             system_prompt_content = [{"text": system_prompt}]
 
-        # TODO: Handle caching blocks https://github.com/strands-agents/harness-sdk/issues/1140
-        return [
-            {"role": "system", "content": content["text"]}
-            for content in system_prompt_content or []
-            if "text" in content
-        ]
+        formatted: list[dict[str, Any]] = []
+        for block in system_prompt_content or []:
+            if "cachePoint" in block:
+                if formatted and isinstance(formatted[-1]["content"], str):
+                    formatted[-1]["content"] = [
+                        {
+                            "type": "text",
+                            "text": formatted[-1]["content"],
+                            "cache_control": cls._format_cache_control(block["cachePoint"].get("ttl")),
+                        }
+                    ]
+                else:
+                    logger.warning("no preceding system text block accepts a cache point | skipped cache point")
+                continue
+            if "text" in block:
+                formatted.append({"role": "system", "content": block["text"]})
+
+        return formatted
+
+    @staticmethod
+    def _format_cache_control(ttl: str | None) -> dict[str, Any]:
+        """Build an Anthropic/Bedrock-compatible ``cache_control`` value for a system content part.
+
+        Args:
+            ttl: Optional TTL duration carried by the cache point.
+
+        Returns:
+            A cache_control dict.
+        """
+        cache_control: dict[str, Any] = {"type": "ephemeral"}
+        if ttl:
+            cache_control["ttl"] = ttl
+        return cache_control
 
     @classmethod
     def _format_regular_messages(cls, messages: Messages, **kwargs: Any) -> list[dict[str, Any]]:

--- a/strands-py/tests/strands/models/test_openai.py
+++ b/strands-py/tests/strands/models/test_openai.py
@@ -1751,20 +1751,54 @@ def test_format_request_messages_with_none_system_prompt_content():
     assert result == expected
 
 
-def test_format_request_messages_drops_cache_points():
-    """Test that cache points are dropped in OpenAI format_request_messages."""
+def test_format_request_messages_with_system_prompt_cache_point():
+    """Test that a system prompt cache point is translated to cache_control."""
     messages = [{"role": "user", "content": [{"text": "Hello"}]}]
     system_prompt_content = [{"text": "You are a helpful assistant."}, {"cachePoint": {"type": "default"}}]
 
     result = OpenAIModel.format_request_messages(messages, system_prompt_content=system_prompt_content)
 
-    # Cache points should be dropped, only text content included
+    expected = [
+        {
+            "role": "system",
+            "content": [
+                {"type": "text", "text": "You are a helpful assistant.", "cache_control": {"type": "ephemeral"}}
+            ],
+        },
+        {"role": "user", "content": [{"text": "Hello", "type": "text"}]},
+    ]
+
+    assert result == expected
+
+
+def test_format_request_messages_with_system_prompt_cache_point_ttl():
+    """Test that a system prompt cache point's ttl carries through to cache_control."""
+    messages = [{"role": "user", "content": [{"text": "Hello"}]}]
+    system_prompt_content = [
+        {"text": "You are a helpful assistant."},
+        {"cachePoint": {"type": "default", "ttl": "1h"}},
+    ]
+
+    result = OpenAIModel.format_request_messages(messages, system_prompt_content=system_prompt_content)
+
+    assert result[0]["content"][0]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+
+
+def test_format_request_messages_skips_leading_system_cache_point(caplog):
+    """A cache point with no preceding system text block is skipped and warned, not attached."""
+    caplog.set_level(logging.WARNING, logger="strands.models.openai")
+    messages = [{"role": "user", "content": [{"text": "Hello"}]}]
+    system_prompt_content = [{"cachePoint": {"type": "default"}}, {"text": "You are a helpful assistant."}]
+
+    result = OpenAIModel.format_request_messages(messages, system_prompt_content=system_prompt_content)
+
     expected = [
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": [{"text": "Hello", "type": "text"}]},
     ]
 
     assert result == expected
+    assert "no preceding system text block accepts a cache point" in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

`OpenAIModel._format_system_messages` dropped every `cachePoint` block on the
system prompt (the `# TODO: Handle caching blocks #1140` this closes),
silently discarding prompt caching for any OpenAI-compatible gateway that
proxies Chat Completions to Anthropic or Bedrock (Portkey, LiteLLM proxy,
OpenRouter, ...) and honors an Anthropic-style `cache_control` field on a
content part. Those providers charge full price for a system prompt that
should be a cheap cache read on every turn after the first.

A caller-placed `cachePoint` block now marks the immediately preceding
system text block as cacheable, emitting `cache_control` the same way the
`litellm` provider already does for its own system prompt formatting. A
caller that never places a `cachePoint` gets byte-identical output to
before — this only changes behavior for the feature this issue tracks.

## Related Issues

Closes #1140 for the OpenAI-compatible provider.

## Documentation PR

Not needed — `SystemContentBlock.cachePoint` is already documented as the
provider-agnostic caching mechanism; this only fixes the OpenAI provider's
handling of it to match the other providers.

## Type of Change

New feature

## Testing

- `hatch test tests/strands/models/test_openai.py` — 146 passed, including
  new cases for a system-prompt cache point (with and without `ttl`) and
  for a `cachePoint` with no preceding text block (skipped with a warning,
  matching the existing message-level `cachePoint` handling).
- `hatch test` (full suite, py3.13) — 6261 passed, 31 skipped.
- `hatch run lint` / `hatch run test-format` — clean.

- [x] I ran the equivalent of `hatch run prepare` (format, lint, full test suite) on py3.13; did not run the full `--all` multi-version matrix locally, which CI covers.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly (docstring updated; no user-facing doc site changes needed)
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
