### PR TITLE
fix(telemetry): read the model id through Model.get_config()

### DIFF
--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -68,7 +68,7 @@ from ..interventions.handler import InterventionHandler
 from ..interventions.registry import InterventionRegistry
 from ..memory import MemoryManager, MemoryManagerConfig
 from ..models.bedrock import BedrockModel
-from ..models.model import Model, _ModelPlugin
+from ..models.model import Model, _get_model_id, _ModelPlugin
 from ..models.routing import ModelRouter
 from ..plugins import Plugin
 from ..plugins.registry import _PluginRegistry
@@ -1874,7 +1874,7 @@ class Agent(AgentBase, LocalAgent):
         Args:
             messages: The input messages.
         """
-        model_id = self.model.config.get("model_id") if hasattr(self.model, "config") else None
+        model_id = _get_model_id(self.model)
         return self.tracer.start_agent_span(
             messages=messages,
             agent_name=self.name,

--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -21,6 +21,7 @@ from ..agent import _continuation
 from ..experimental.checkpoint import Checkpoint, CheckpointPosition
 from ..hooks import AfterModelCallEvent, AfterToolsEvent, BeforeModelCallEvent, BeforeToolsEvent
 from ..interrupt import PendingToolExecution
+from ..models.model import _get_model_id
 from ..telemetry.metrics import Trace, _total_prompt_tokens
 from ..telemetry.tracer import Tracer, get_tracer
 from ..tools._validator import validate_and_prepare_tools
@@ -709,7 +710,7 @@ def _make_invoke_model_terminal(
 
         system_prompt_str, system_prompt_content = split_system_prompt(ctx.system_prompt)
 
-        model_id = ctx.model.config.get("model_id") if hasattr(ctx.model, "config") else None
+        model_id = _get_model_id(ctx.model)
         model_invoke_span = tracer.start_model_invoke_span(
             messages=ctx.messages,
             parent_span=cycle_span,

--- a/strands-py/src/strands/memory/extraction/model_extractor.py
+++ b/strands-py/src/strands/memory/extraction/model_extractor.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from opentelemetry import trace as trace_api
 
-from ...models.model import Model
+from ...models.model import Model, _get_model_id
 from ...telemetry.tracer import get_tracer
 from ...types.content import Message
 from .types import ExtractionResult, ExtractorContext
@@ -83,7 +83,7 @@ class ModelExtractor:
         from ...event_loop.streaming import stream_messages
 
         tracer = get_tracer()
-        model_id = model.config.get("model_id") if hasattr(model, "config") else None
+        model_id = _get_model_id(model)
         span = tracer.start_model_invoke_span(messages=[prompt], model_id=model_id, system_prompt=self._system_prompt)
 
         final_message: Message | None = None

--- a/strands-py/src/strands/models/model.py
+++ b/strands-py/src/strands/models/model.py
@@ -341,6 +341,35 @@ class Model(abc.ABC):
         return input_tokens / context_window_limit
 
 
+def _config_model_id(config: Any) -> str | None:
+    """Read ``model_id`` off a model config, which may be a dict or an object with attributes."""
+    model_id = config.get("model_id") if isinstance(config, dict) else getattr(config, "model_id", None)
+    return model_id if isinstance(model_id, str) else None
+
+
+def _get_model_id(model: Model) -> str | None:
+    """Return the model id a provider reports, or None when it reports none.
+
+    ``get_config()`` is the accessor the :class:`Model` interface declares, so it is read first. The
+    public ``config`` attribute is a convention of the built-in providers rather than part of the
+    interface, so it only serves as a fallback.
+
+    Args:
+        model: The model to read the id from.
+
+    Returns:
+        The configured model id, or None when neither accessor reports one.
+    """
+    try:
+        declared = _config_model_id(model.get_config())
+    except Exception:
+        # The id only labels a span, so a provider that raises from get_config (or a router that
+        # forwards such a provider's error) must not fail the call being traced.
+        declared = None
+
+    return declared or _config_model_id(getattr(model, "config", None))
+
+
 class _ModelPlugin(Plugin):
     """Plugin that manages model-related lifecycle hooks."""
 

--- a/strands-py/tests/strands/agent/test_agent.py
+++ b/strands-py/tests/strands/agent/test_agent.py
@@ -3594,3 +3594,44 @@ async def test_agent_span_ends_on_generator_exit():
     assert len(agent_spans) == 1
     assert agent_spans[0].status.status_code == StatusCode.UNSET
     assert agent_spans[0].attributes["strands.cancellation.type"] == "GeneratorExit"
+
+
+@pytest.mark.asyncio
+async def test_agent_and_model_spans_carry_model_id_reported_only_by_get_config():
+    """Agent and model spans carry gen_ai.request.model for a provider written to the Model ABC.
+
+    Guards https://github.com/strands-agents/harness-sdk/issues/4205 — the id is read through
+    ``get_config()``, the accessor the interface declares, not an undeclared ``config`` attribute
+    that a custom provider need not expose.
+    """
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    tracer = Tracer()
+    tracer.tracer_provider = provider
+    tracer.tracer = provider.get_tracer(tracer.service_name)
+
+    class ByTheBookModel(MockedModelProvider):
+        def get_config(self):
+            return {"model_id": "my.custom.model-v1"}
+
+    model = ByTheBookModel([{"role": "assistant", "content": [{"text": "hi"}]}])
+
+    with (
+        unittest.mock.patch("strands.agent.agent.get_tracer", return_value=tracer),
+        unittest.mock.patch("strands.event_loop.event_loop.get_tracer", return_value=tracer),
+    ):
+        agent = Agent(model=model, callback_handler=None)
+        await agent.invoke_async("test")
+
+    provider.force_flush()
+    traced_model_ids = {
+        span.name: span.attributes.get("gen_ai.request.model")
+        for span in exporter.get_finished_spans()
+        if span.name == "chat" or span.name.startswith("invoke_agent")
+    }
+    assert traced_model_ids == {
+        "chat": "my.custom.model-v1",
+        "invoke_agent Strands Agents": "my.custom.model-v1",
+    }

--- a/strands-py/tests/strands/memory/test_model_extractor.py
+++ b/strands-py/tests/strands/memory/test_model_extractor.py
@@ -160,6 +160,27 @@ async def test_wraps_the_model_call_in_a_model_invoke_span():
 
 
 @pytest.mark.asyncio
+async def test_model_invoke_span_carries_the_model_id_reported_by_get_config():
+    """The extraction span names the model even when the provider only implements the Model ABC.
+
+    Guards https://github.com/strands-agents/harness-sdk/issues/4205.
+    """
+
+    class _ByTheBookModel(MockedModelProvider):
+        def get_config(self) -> Any:
+            return {"model_id": "extraction.model-v1"}
+
+    model = _ByTheBookModel([_assistant_text('[{"content": "fact"}]')])
+    extractor = ModelExtractor(model=model)
+
+    tracer = MagicMock()
+    with patch("strands.memory.extraction.model_extractor.get_tracer", return_value=tracer):
+        await extractor.extract([_user_turn("x")])
+
+    assert tracer.start_model_invoke_span.call_args.kwargs["model_id"] == "extraction.model-v1"
+
+
+@pytest.mark.asyncio
 async def test_ends_model_invoke_span_with_error_on_failure():
     """A model failure ends the span via end_span_with_error and re-raises."""
 

--- a/strands-py/tests/strands/models/test_model.py
+++ b/strands-py/tests/strands/models/test_model.py
@@ -1,5 +1,6 @@
 import json
 import math
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -8,7 +9,7 @@ from pydantic import BaseModel
 from strands.hooks.events import AfterInvocationEvent
 from strands.models import CacheConfig
 from strands.models import Model as SAModel
-from strands.models.model import _ModelPlugin
+from strands.models.model import _get_model_id, _ModelPlugin
 
 
 class Person(BaseModel):
@@ -685,3 +686,81 @@ class TestCacheConfig:
     def test_cache_key_round_trips(self):
         """cache_key preserves the value it was constructed with."""
         assert CacheConfig(cache_key="tenant-42").cache_key == "tenant-42"
+
+
+class TestGetModelId:
+    """Tests for _get_model_id.
+
+    Guards https://github.com/strands-agents/harness-sdk/issues/4205 — the model id reaches
+    telemetry through ``get_config()``, the accessor the ``Model`` interface declares, so a
+    provider written to the interface alone is not left without one.
+    """
+
+    class ByTheBookModel(SAModel):
+        """A provider that implements the abstract surface only, holding its config privately."""
+
+        def __init__(self, config=None):
+            self._config = {} if config is None else config
+
+        def update_config(self, **model_config):
+            self._config.update(model_config)
+
+        def get_config(self):
+            return self._config
+
+        async def structured_output(self, output_model, prompt=None, system_prompt=None, **kwargs):
+            yield {}
+
+        async def stream(self, messages, tool_specs=None, system_prompt=None):
+            yield {}
+
+    def test_reads_the_id_from_get_config(self):
+        """A provider that reports its id only from get_config() still has one."""
+        model = self.ByTheBookModel({"model_id": "my.custom.model-v1"})
+
+        assert _get_model_id(model) == "my.custom.model-v1"
+
+    def test_reads_the_id_off_a_non_dict_config(self):
+        """A config object that carries model_id as an attribute reports it too."""
+        model = self.ByTheBookModel(SimpleNamespace(model_id="object-config-v1"))
+
+        assert _get_model_id(model) == "object-config-v1"
+
+    def test_reads_the_id_from_a_config_attribute(self):
+        """The built-in providers' public config attribute is still honored."""
+        model = self.ByTheBookModel()
+        model.config = {"model_id": "built.in-v1"}
+
+        assert _get_model_id(model) == "built.in-v1"
+
+    def test_prefers_get_config_over_the_config_attribute(self):
+        """get_config() is the declared accessor, so it wins when the two disagree."""
+        model = self.ByTheBookModel({"model_id": "declared-v1"})
+        model.config = {"model_id": "stale-v1"}
+
+        assert _get_model_id(model) == "declared-v1"
+
+    def test_returns_none_when_no_id_is_configured(self):
+        """A provider that reports no id yields None rather than raising."""
+        assert _get_model_id(self.ByTheBookModel()) is None
+
+    def test_returns_none_when_get_config_returns_nothing(self):
+        """A provider whose get_config() returns None yields None."""
+        assert _get_model_id(TestModel()) is None
+
+    def test_falls_back_to_the_config_attribute_when_get_config_raises(self):
+        """A raising get_config() never reaches the caller, whose span it was only labelling."""
+
+        class RaisingConfigModel(self.ByTheBookModel):
+            def get_config(self):
+                raise RuntimeError("config unavailable")
+
+        model = RaisingConfigModel()
+        model.config = {"model_id": "still.known-v1"}
+
+        assert _get_model_id(model) == "still.known-v1"
+        assert _get_model_id(RaisingConfigModel()) is None
+
+    def test_returns_none_for_a_model_without_get_config(self):
+        """A duck-typed stand-in that never declared get_config() yields None."""
+        assert _get_model_id(SimpleNamespace()) is None


### PR DESCRIPTION
## Description

The model id that goes on the `gen_ai.request.model` span attribute was read from an undeclared `config` attribute, guarded by `hasattr`, at three call sites — `Agent._start_agent_trace_span`, the `InvokeModelStage` terminal in `event_loop.py`, and `ModelExtractor.extract`. `config` is a convention of the built-in providers, not part of the interface: the `Model` ABC declares `get_config()`, which is what the custom-provider guide tells implementors to write and what the SDK already uses for `context_window_limit`. A provider written to the ABC alone — or a pass-through wrapper that forwards the declared surface to an inner provider, the natural way to add replay or cost attribution — therefore emitted `chat` and `invoke_agent` spans with no model attribute, and nothing said why. This adds one private helper, `_get_model_id` in `models/model.py` (next to `Model`, mirroring how the `context_window_limit` property resolves its own field from `get_config()`), which reads the id from `get_config()` first and falls back to a `config` attribute so the built-in providers are unaffected, and uses it at all three call sites. Like the router's own label helper, it reports `None` rather than raising when a provider's config is unavailable, since the id only labels a span and must never fail the call being traced — `test_a_provider_whose_config_raises_neither_masks_a_guard_nor_breaks_routing` covers that invariant.

## Related Issues

Fixes #4205

## Documentation PR

No documentation change: the fix makes the behavior match what the custom model provider guide already documents.

## Type of Change

Bug fix

## Testing

- [ ] I ran `hatch run prepare`

From `strands-py/`:

- `hatch fmt --formatter` — the only files it rewrites are `src/strands/models/bedrock.py` and `tests/strands/models/test_bedrock.py`, both already unformatted on `main` and untouched by this change, so those rewrites were reverted; nothing in this diff needed reformatting.
- `hatch fmt --linter` — All checks passed.
- `hatch run test-lint` — `ruff check` all checks passed; `mypy ./src ./tests_typing` success, no issues in 299 source files.
- `hatch test tests/strands/models/test_model.py tests/strands/models/routing/test_router.py` — 130 passed.
- `hatch test` (the full unit suite on the default interpreter, Python 3.10) — 6212 passed, 39 skipped, 0 failed.

The two span-level tests were confirmed to fail against the unpatched source and pass with it. `hatch run prepare` was not run to completion: its `hatch test --all` step spans five interpreter versions, well past a reasonable local budget here, and its `hatch run format` step rewrites the two pre-existing unformatted Bedrock files listed above. Every other step of `prepare` was run individually and is reported above.

Tests added:

- `tests/strands/models/test_model.py::TestGetModelId` — the id is read from `get_config()` for a provider that implements only the ABC, from a non-dict config object, and from a `config` attribute when `get_config()` reports none; `get_config()` wins when the two disagree; `None` when neither reports one, when `get_config()` raises, and when a duck-typed stand-in never declared it.
- `tests/strands/agent/test_agent.py::test_agent_and_model_spans_carry_model_id_reported_only_by_get_config` — end to end through a real `TracerProvider`, the exported `invoke_agent` and `chat` spans both carry `gen_ai.request.model` for such a provider.
- `tests/strands/memory/test_model_extractor.py::test_model_invoke_span_carries_the_model_id_reported_by_get_config` — the extraction span carries the same.

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
