### PR TITLE
fix(models): declare model_state and dynamic_trailing_blocks on Model.stream()

### DIFF
--- a/site/src/content/docs/user-guide/concepts/model-providers/custom_model_provider.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/custom_model_provider.mdx
@@ -194,6 +194,17 @@ The `stream` method accepts three parameters:
 - [`list[ToolSpec]`](@api/python/strands.types.tools#ToolSpec): List of tool specifications that the model can decide to use.
 - `SystemPrompt`: A system prompt string given to the Model to prompt it how to answer the user.
 
+Beyond those, the SDK passes keyword arguments that a provider can either declare by name or leave to `**kwargs`:
+
+- `tool_choice`: Selection strategy for tool invocation.
+- `system_prompt_content`: System prompt content blocks for advanced features like caching.
+- `invocation_state`: Caller-provided state/context that was passed to the agent when it was invoked.
+- `model_state`: Runtime state for model providers (e.g., server-side response ids).
+- `dynamic_trailing_blocks`: How many trailing blocks of the last user message are rebuilt on every call, so a provider placing cache points keeps its own ahead of them.
+- `cancel_signal`: Event a provider can observe to abort an in-flight request.
+
+Keep `**kwargs` in your signature so a later addition to this list does not break your provider.
+
 ```python
     @override
     async def stream(

--- a/site/src/content/docs/user-guide/concepts/model-providers/custom_model_provider.mdx
+++ b/site/src/content/docs/user-guide/concepts/model-providers/custom_model_provider.mdx
@@ -200,7 +200,7 @@ Beyond those, the SDK passes keyword arguments that a provider can either declar
 - `system_prompt_content`: System prompt content blocks for advanced features like caching.
 - `invocation_state`: Caller-provided state/context that was passed to the agent when it was invoked.
 - `model_state`: Runtime state for model providers (e.g., server-side response ids).
-- `dynamic_trailing_blocks`: How many trailing blocks of the last user message are rebuilt on every call, so a provider placing cache points keeps its own ahead of them.
+- `dynamic_trailing_blocks`: How many content blocks at the end of the final user message may change between calls. A provider that inserts prompt cache points should place them before that boundary so the cached prefix stays stable; `0` means no such tail.
 - `cancel_signal`: Event a provider can observe to abort an in-flight request.
 
 Keep `**kwargs` in your signature so a later addition to this list does not break your provider.

--- a/strands-py/src/strands/models/model.py
+++ b/strands-py/src/strands/models/model.py
@@ -256,6 +256,8 @@ class Model(abc.ABC):
         tool_choice: ToolChoice | None = None,
         system_prompt_content: list[SystemContentBlock] | None = None,
         invocation_state: dict[str, Any] | None = None,
+        model_state: dict[str, Any] | None = None,
+        dynamic_trailing_blocks: int = 0,
         cancel_signal: threading.Event | None = None,
         **kwargs: Any,
     ) -> AsyncIterable[StreamEvent]:
@@ -274,6 +276,9 @@ class Model(abc.ABC):
             tool_choice: Selection strategy for tool invocation.
             system_prompt_content: System prompt content blocks for advanced features like caching.
             invocation_state: Caller-provided state/context that was passed to the agent when it was invoked.
+            model_state: Runtime state for model providers (e.g., server-side response ids).
+            dynamic_trailing_blocks: How many trailing blocks of the last user message are rebuilt on every
+                call, so a provider placing cache points keeps its own ahead of them.
             cancel_signal: Event a provider can observe to abort an in-flight request. Support is
                 provider-dependent; a provider that ignores it still cancels at the SDK's
                 between-chunk checkpoint.

--- a/strands-py/src/strands/models/model.py
+++ b/strands-py/src/strands/models/model.py
@@ -277,8 +277,9 @@ class Model(abc.ABC):
             system_prompt_content: System prompt content blocks for advanced features like caching.
             invocation_state: Caller-provided state/context that was passed to the agent when it was invoked.
             model_state: Runtime state for model providers (e.g., server-side response ids).
-            dynamic_trailing_blocks: How many trailing blocks of the last user message are rebuilt on every
-                call, so a provider placing cache points keeps its own ahead of them.
+            dynamic_trailing_blocks: How many content blocks at the end of the final user message may
+                change between calls. A provider that inserts prompt cache points should place them
+                before that boundary so the cached prefix stays stable; 0 means no such tail.
             cancel_signal: Event a provider can observe to abort an in-flight request. Support is
                 provider-dependent; a provider that ignores it still cancels at the SDK's
                 between-chunk checkpoint.

--- a/strands-py/tests/strands/event_loop/test_streaming.py
+++ b/strands-py/tests/strands/event_loop/test_streaming.py
@@ -1,3 +1,4 @@
+import inspect
 import threading
 import unittest.mock
 from typing import cast
@@ -6,6 +7,7 @@ import pytest
 
 import strands
 import strands.event_loop
+from strands.models import Model
 from strands.types._events import ModelStopReason, TypedEvent
 from strands.types.content import Message, Messages
 from strands.types.streaming import (
@@ -14,6 +16,7 @@ from strands.types.streaming import (
     MessageStartEvent,
     MessageStopEvent,
 )
+from tests.fixtures.mocked_model_provider import MockedModelProvider
 
 
 @pytest.fixture(autouse=True)
@@ -1741,3 +1744,66 @@ async def test_stream_messages_forwards_cancel_signal_to_model(agenerator, alist
     await alist(stream)
 
     assert mock_model.stream.call_args.kwargs["cancel_signal"] is cancel_signal
+
+
+def _declared_stream_keywords() -> set[str]:
+    return {
+        name
+        for name, parameter in inspect.signature(Model.stream).parameters.items()
+        if parameter.kind is inspect.Parameter.KEYWORD_ONLY
+    }
+
+
+class _StreamKeywordSpy(MockedModelProvider):
+    """Records the keyword arguments the event loop hands to stream()."""
+
+    def __init__(self, agent_responses):
+        super().__init__(agent_responses)
+        self.seen_keywords: set[str] = set()
+
+    async def stream(self, messages, tool_specs=None, system_prompt=None, **kwargs):
+        self.seen_keywords |= set(kwargs)
+        async for event in super().stream(messages, tool_specs, system_prompt, **kwargs):
+            yield event
+
+
+@pytest.mark.asyncio
+async def test_stream_messages_sends_only_keywords_declared_on_the_model_abc():
+    """A provider that spells out the keyword-only parameters of Model.stream still receives every keyword.
+
+    Guards https://github.com/strands-agents/harness-sdk/issues/4206.
+    """
+    model = _StreamKeywordSpy([{"role": "assistant", "content": [{"text": "ok"}]}])
+
+    await strands.Agent(model=model, callback_handler=None).invoke_async("hello")
+
+    assert model.seen_keywords
+    tru_undeclared = model.seen_keywords - _declared_stream_keywords()
+    exp_undeclared: set[str] = set()
+    assert tru_undeclared == exp_undeclared
+
+
+@pytest.mark.asyncio
+async def test_stream_messages_sends_dynamic_trailing_blocks_as_a_declared_keyword(agenerator, alist):
+    """The cache-point hint reaches the model only when non-zero, so it needs the same declaration.
+
+    Guards https://github.com/strands-agents/harness-sdk/issues/4206.
+    """
+    mock_model = unittest.mock.MagicMock()
+    mock_model.stream.return_value = agenerator([{"contentBlockStop": {}}])
+
+    stream = strands.event_loop.streaming.stream_messages(
+        mock_model,
+        system_prompt=None,
+        messages=[{"role": "user", "content": [{"text": "Hello"}]}],
+        tool_specs=None,
+        system_prompt_content=None,
+        dynamic_trailing_blocks=2,
+    )
+
+    await alist(stream)
+
+    assert mock_model.stream.call_args.kwargs["dynamic_trailing_blocks"] == 2
+    tru_undeclared = set(mock_model.stream.call_args.kwargs) - _declared_stream_keywords()
+    exp_undeclared: set[str] = set()
+    assert tru_undeclared == exp_undeclared


### PR DESCRIPTION
## Description

`stream_messages` calls `model.stream()` with `model_state` on every call, and with `dynamic_trailing_blocks` whenever the context carries cache points, but neither name appears on `Model.stream()` — the ABC declares only `tool_choice`, `system_prompt_content`, `invocation_state` and `cancel_signal`. A provider or wrapper written against the documented interface therefore either fails or loses data: one that spells out the keyword-only parameters raises `TypeError: ... unexpected keyword argument 'model_state'` from deep inside `streaming.py`, and one that accepts `**kwargs` but forwards only the declared names drops both silently, so a wrapped `openai_responses` model loses its server-side conversation continuity and a wrapped `bedrock` or `anthropic` model stops hitting the prompt cache. This declares both as keyword-only parameters on the ABC, reusing the wording already at the call site and in `bedrock.py`, so what a provider author can read matches what the runtime sends.

The change is purely additive and `**kwargs` stays: every built-in provider already accepts `**kwargs`, and the ones that consume these values (`bedrock` and `anthropic` for `dynamic_trailing_blocks`, `openai_responses` for `model_state`) are untouched. `Model.structured_output()` was checked for the same drift and has none — `Agent.structured_output()` passes only `system_prompt`.

## Related Issues

Fixes #4206

## Documentation PR

Included here: the custom model provider guide now lists the keyword arguments a `stream()` implementation can expect, and says to keep `**kwargs` for later additions.

## Type of Change

Bug fix

## Testing

The two new tests fail on `main` (`{'model_state'}` and `{'dynamic_trailing_blocks', 'model_state'}` undeclared) and pass with the fix.

From `strands-py/`:

```
hatch fmt --formatter                                   # 0 files reformatted in this change
hatch fmt --linter                                      # All checks passed!
hatch run test-lint                                     # ruff check: passed; mypy ./src ./tests_typing: no issues in 299 source files
hatch test tests/strands/event_loop tests/strands/models # 1514 passed, 4 skipped
hatch test                                              # 6204 passed, 39 skipped
hatch run prepare                                       # exit 0; hatch test --all green on 3.10-3.14
```

I also ran the issue's reproduction script against this branch:

```
keyword-only params declared on Model.stream(): ['cancel_signal', 'dynamic_trailing_blocks', 'invocation_state', 'model_state', 'system_prompt_content', 'tool_choice']
keyword args passed by the event loop         : ['cancel_signal', 'invocation_state', 'model_state', 'system_prompt_content', 'tool_choice']
passed but undeclared                         : []
strict wrapper: ran
```

One note on the formatter: with the ruff version the static-analysis env resolves (0.16.6, from the `>=0.13.0,<0.17.0` range), `hatch fmt --formatter` also reformats `src/strands/models/bedrock.py` and `tests/strands/models/test_bedrock.py`, which this PR does not touch. I reverted those two files to keep the diff focused.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
