### PR TITLE
fix(telemetry): mark failed Graph and Swarm spans as ERROR

### DIFF
--- a/strands-ts/src/multiagent/__tests__/graph.tracer.test.ts
+++ b/strands-ts/src/multiagent/__tests__/graph.tracer.test.ts
@@ -89,6 +89,7 @@ describe('Graph tracer integration', () => {
       expect(endOpts).toEqual({
         duration: expect.any(Number),
         usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        status: Status.COMPLETED,
       })
       expect(endOpts.duration).toBeGreaterThanOrEqual(0)
     })
@@ -176,11 +177,13 @@ describe('Graph tracer integration', () => {
       expect(result.status).toBe(Status.FAILED)
       const [span, endOpts] = tracer.endNodeSpan.mock.calls[0]!
       expect(span).toStrictEqual({ mock: 'nodeSpan' })
-      expect(endOpts).toEqual({
-        status: Status.FAILED,
-        duration: expect.any(Number),
-      })
+      expect(endOpts.status).toBe(Status.FAILED)
+      expect(endOpts.error).toEqual(expect.objectContaining({ message: 'agent exploded' }))
       expect(endOpts.duration).toBeGreaterThanOrEqual(0)
+
+      const [, graphEndOpts] = tracer.endMultiAgentSpan.mock.calls[0]!
+      expect(graphEndOpts.status).toBe(Status.FAILED)
+      expect(graphEndOpts.error).toBeUndefined()
     })
 
     it('ends node span with CANCELLED status and zero duration when cancelled by hook', async () => {

--- a/strands-ts/src/multiagent/__tests__/swarm.tracer.test.ts
+++ b/strands-ts/src/multiagent/__tests__/swarm.tracer.test.ts
@@ -113,6 +113,7 @@ describe('Swarm tracer integration', () => {
       expect(endOpts).toEqual({
         duration: expect.any(Number),
         usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        status: Status.COMPLETED,
       })
       expect(endOpts.duration).toBeGreaterThanOrEqual(0)
     })
@@ -207,11 +208,13 @@ describe('Swarm tracer integration', () => {
       expect(result.status).toBe(Status.FAILED)
       const [span, endOpts] = tracer.endNodeSpan.mock.calls[0]!
       expect(span).toStrictEqual({ mock: 'nodeSpan' })
-      expect(endOpts).toEqual({
-        status: Status.FAILED,
-        duration: expect.any(Number),
-      })
+      expect(endOpts.status).toBe(Status.FAILED)
+      expect(endOpts.error).toEqual(expect.objectContaining({ message: 'agent exploded' }))
       expect(endOpts.duration).toBeGreaterThanOrEqual(0)
+
+      const [, swarmEndOpts] = tracer.endMultiAgentSpan.mock.calls[0]!
+      expect(swarmEndOpts.status).toBe(Status.FAILED)
+      expect(swarmEndOpts.error).toBeUndefined()
     })
 
     it('ends node span with CANCELLED status and zero duration when cancelled by hook', async () => {

--- a/strands-ts/src/multiagent/graph.ts
+++ b/strands-ts/src/multiagent/graph.ts
@@ -442,7 +442,7 @@ export class Graph implements MultiAgent {
 
       this._tracer.endMultiAgentSpan(multiAgentSpan, {
         duration: Date.now() - state.startTime,
-        ...(result && { usage: result.usage }),
+        ...(result && { usage: result.usage, status: result.status }),
         ...(caughtError && { error: caughtError }),
       })
 
@@ -555,7 +555,12 @@ export class Graph implements MultiAgent {
       }
 
       const result = next.value
-      this._tracer.endNodeSpan(nodeSpan, { status: result.status, duration: result.duration, usage: result.usage })
+      this._tracer.endNodeSpan(nodeSpan, {
+        status: result.status,
+        duration: result.duration,
+        usage: result.usage,
+        ...(result.status === Status.FAILED && result.error ? { error: result.error } : {}),
+      })
       queue.push({ type: 'result', node, result })
 
       await queue.send({

--- a/strands-ts/src/multiagent/swarm.ts
+++ b/strands-ts/src/multiagent/swarm.ts
@@ -412,7 +412,7 @@ export class Swarm implements MultiAgent {
       if (execTimeoutHandle !== undefined) clearTimeout(execTimeoutHandle)
       this._tracer.endMultiAgentSpan(multiAgentSpan, {
         duration: Date.now() - state.startTime,
-        ...(result && { usage: result.usage }),
+        ...(result && { usage: result.usage, status: result.status }),
         ...(caughtError && { error: caughtError }),
       })
 
@@ -508,7 +508,12 @@ export class Swarm implements MultiAgent {
       }
 
       const result = next.value
-      this._tracer.endNodeSpan(nodeSpan, { status: result.status, duration: result.duration, usage: result.usage })
+      this._tracer.endNodeSpan(nodeSpan, {
+        status: result.status,
+        duration: result.duration,
+        usage: result.usage,
+        ...(result.status === Status.FAILED && result.error ? { error: result.error } : {}),
+      })
       state.results.push(result)
 
       yield* this._emit(new AfterNodeCallEvent({ orchestrator: this, state, nodeId: node.id, invocationState }))

--- a/strands-ts/src/telemetry/__tests__/tracer.test.node.ts
+++ b/strands-ts/src/telemetry/__tests__/tracer.test.node.ts
@@ -1399,6 +1399,81 @@ describe('Tracer', () => {
     })
   })
 
+  describe('endNodeSpan', () => {
+    it('sets OK status on success', () => {
+      const tracer = new Tracer()
+      const span = tracer.startNodeSpan({ nodeId: 'broken', nodeType: 'node' })
+
+      tracer.endNodeSpan(span, { status: 'COMPLETED', duration: 5 })
+
+      expect(mockSpan.getAttributeValue('gen_ai.agent.status')).toBe('COMPLETED')
+      expect(mockSpan.calls.setStatus).toContainEqual({ status: { code: SpanStatusCode.OK } })
+      expect(mockSpan.calls.recordException).toHaveLength(0)
+    })
+
+    it('sets ERROR status and records the exception when a node result retains an error', () => {
+      const tracer = new Tracer()
+      const span = tracer.startNodeSpan({ nodeId: 'broken', nodeType: 'node' })
+      const error = new Error('broken stuff')
+
+      tracer.endNodeSpan(span, { status: 'FAILED', duration: 5, error })
+
+      expect(mockSpan.getAttributeValue('gen_ai.agent.status')).toBe('FAILED')
+      expect(mockSpan.calls.setStatus).toContainEqual({
+        status: { code: SpanStatusCode.ERROR, message: 'broken stuff' },
+      })
+      expect(mockSpan.calls.recordException).toContainEqual({ exception: error, time: undefined })
+    })
+
+    it('handles null span gracefully', () => {
+      const tracer = new Tracer()
+
+      expect(() => tracer.endNodeSpan(null, { status: 'FAILED', error: new Error('x') })).not.toThrow()
+    })
+  })
+
+  describe('endMultiAgentSpan', () => {
+    it('sets OK status on success', () => {
+      const tracer = new Tracer()
+      const span = tracer.startMultiAgentSpan({ orchestratorId: 'test-graph', orchestratorType: 'graph' })
+
+      tracer.endMultiAgentSpan(span, { duration: 10 })
+
+      expect(mockSpan.calls.setStatus).toContainEqual({ status: { code: SpanStatusCode.OK } })
+      expect(mockSpan.calls.recordException).toHaveLength(0)
+    })
+
+    it('sets ERROR status without recording an exception when the aggregate result failed', () => {
+      const tracer = new Tracer()
+      const span = tracer.startMultiAgentSpan({ orchestratorId: 'test-graph', orchestratorType: 'graph' })
+
+      tracer.endMultiAgentSpan(span, { duration: 10, status: 'FAILED' })
+
+      expect(mockSpan.getAttributeValue('gen_ai.agent.status')).toBe('FAILED')
+      expect(mockSpan.calls.setStatus).toContainEqual({ status: { code: SpanStatusCode.ERROR } })
+      expect(mockSpan.calls.recordException).toHaveLength(0)
+    })
+
+    it('records the exception when orchestration itself threw', () => {
+      const tracer = new Tracer()
+      const span = tracer.startMultiAgentSpan({ orchestratorId: 'test-graph', orchestratorType: 'graph' })
+      const error = new Error('max steps reached')
+
+      tracer.endMultiAgentSpan(span, { duration: 10, error })
+
+      expect(mockSpan.calls.setStatus).toContainEqual({
+        status: { code: SpanStatusCode.ERROR, message: 'max steps reached' },
+      })
+      expect(mockSpan.calls.recordException).toContainEqual({ exception: error, time: undefined })
+    })
+
+    it('handles null span gracefully', () => {
+      const tracer = new Tracer()
+
+      expect(() => tracer.endMultiAgentSpan(null, { status: 'FAILED' })).not.toThrow()
+    })
+  })
+
   describe('currentSpanContext', () => {
     it('returns undefined when no span is active', () => {
       vi.mocked(trace.getActiveSpan).mockReturnValue(undefined)

--- a/strands-ts/src/telemetry/tracer.ts
+++ b/strands-ts/src/telemetry/tracer.ts
@@ -590,10 +590,11 @@ export class Tracer {
 
     try {
       const attributes: Record<string, AttributeValue> = {}
+      if (options.status) attributes['gen_ai.agent.status'] = options.status
       if (options.duration !== undefined) attributes['gen_ai.agent.execution_time'] = options.duration
       if (options.usage) this._setUsageAttributes(attributes, options.usage)
 
-      this._endSpan(span, attributes, options.error)
+      this._endSpan(span, attributes, options.error, options.status === 'FAILED')
     } catch (err) {
       logger.warn(`error=<${err}> | failed to end multi-agent span`)
     }
@@ -646,7 +647,7 @@ export class Tracer {
       if (options.duration !== undefined) attributes['gen_ai.agent.execution_time'] = options.duration
       if (options.usage) this._setUsageAttributes(attributes, options.usage)
 
-      this._endSpan(span, attributes, options.error)
+      this._endSpan(span, attributes, options.error, options.status === 'FAILED')
     } catch (err) {
       logger.warn(`error=<${err}> | failed to end node span`)
     }
@@ -1001,7 +1002,7 @@ export class Tracer {
   /**
    * End a span with the given attributes and optional error.
    */
-  private _endSpan(span: Span, attributes?: Record<string, AttributeValue>, error?: Error): void {
+  private _endSpan(span: Span, attributes?: Record<string, AttributeValue>, error?: Error, failed?: boolean): void {
     try {
       const endAttributes: Record<string, AttributeValue> = { 'gen_ai.event.end_time': new Date().toISOString() }
       if (attributes) Object.assign(endAttributes, attributes)
@@ -1011,6 +1012,8 @@ export class Tracer {
       if (error) {
         span.setStatus({ code: SpanStatusCode.ERROR, message: error.message })
         span.recordException(error)
+      } else if (failed) {
+        span.setStatus({ code: SpanStatusCode.ERROR })
       } else {
         span.setStatus({ code: SpanStatusCode.OK })
       }

--- a/strands-ts/src/telemetry/types.ts
+++ b/strands-ts/src/telemetry/types.ts
@@ -136,6 +136,8 @@ export interface EndMultiAgentSpanOptions {
   duration?: number | undefined
   /** Aggregated token usage across all node executions. */
   usage?: Usage | undefined
+  /** Aggregate result status. */
+  status?: string | undefined
 }
 
 /**


### PR DESCRIPTION
## Description

`Node.stream()` catches a thrown exception and returns a `FAILED` `NodeResult` with `error` set. Graph and Swarm then end the node span on the normal result path without passing that error, so `_endSpan()` marks the span `OK`. The same gap hits the enclosing multi-agent span: a returned `status: FAILED` does not populate `caughtError`.

A failed custom node therefore produces:

- `NodeResult.status === FAILED`
- `gen_ai.agent.status = FAILED`
- OpenTelemetry span status `OK`
- no exception event

This PR forwards `result.error` into `endNodeSpan` when the node result is `FAILED`, and passes the aggregate result status into `endMultiAgentSpan`. A `FAILED` status marks the parent span `ERROR` without recording a second exception event.

## Related Issues

Fixes #4166.

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

- `npx vitest run --project unit-node src/telemetry/__tests__/tracer.test.node.ts src/multiagent/__tests__/graph.tracer.test.ts src/multiagent/__tests__/swarm.tracer.test.ts` (131 passed)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
