### PR TITLE
fix(ts): reject resume for an already-answered interrupt

### DIFF
--- a/strands-ts/src/agent/__tests__/agent.interrupt.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.interrupt.test.ts
@@ -475,6 +475,50 @@ describe('Agent interrupt system', () => {
 
       expect(finalResult.stopReason).toBe('endTurn')
     })
+
+    it('rejects a resume for an interrupt that was already answered', async () => {
+      const model = new MockMessageModel()
+        .addTurn({
+          type: 'toolUseBlock',
+          name: 'confirmTool',
+          toolUseId: 'tool-1',
+          input: {},
+        })
+        .addTurn({ type: 'textBlock', text: 'Done' })
+        // Extra turn so a phantom model call surfaces as history corruption
+        // rather than as the mock model running out of turns.
+        .addTurn({ type: 'textBlock', text: 'Phantom' })
+
+      const tool = createMockTool('confirmTool', (context) => {
+        const response = context.interrupt({ name: 'confirm', reason: 'Confirm?' })
+        return `Got: ${response}`
+      })
+
+      const agent = new Agent({ model, tools: [tool], printer: false })
+
+      const interruptResult = await agent.invoke('Test')
+      expect(interruptResult.stopReason).toBe('interrupt')
+
+      const response = new InterruptResponseContent({
+        interruptId: interruptResult.interrupts![0]!.id,
+        response: 'approved',
+      })
+
+      const finalResult = await agent.invoke([response])
+      expect(finalResult.stopReason).toBe('endTurn')
+
+      const callCountAfterResume = model.callCount
+      const rolesAfterResume = agent.messages.map((m) => m.role)
+
+      // Re-sending the same response must not be silently accepted: the interrupt
+      // is no longer active, so there is nothing to resume.
+      await expect(agent.invoke([response])).rejects.toThrow(TypeError)
+      await expect(agent.invoke([response])).rejects.toThrow(/no longer active|not in an interrupted state/i)
+
+      // No phantom model call, and no consecutive assistant messages appended.
+      expect(model.callCount).toBe(callCountAfterResume)
+      expect(agent.messages.map((m) => m.role)).toEqual(rolesAfterResume)
+    })
   })
 
   describe('multiple hook interrupts', () => {

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -1193,6 +1193,16 @@ export class Agent implements LocalAgent, InvokableAgent {
         // Process interrupt responses before middleware runs so context.interrupt() can find them
         const interruptResponses = this._extractInterruptResponses(currentArgs)
         if (interruptResponses.length > 0) {
+          // Counterpart to the "non-interrupt input while interrupted" check in _stream():
+          // once the interrupt has been answered the state is deactivated, so there is
+          // nothing to resume. Accepting the responses here would silently drop them and
+          // issue a phantom model call, appending an assistant message directly after the
+          // previous one — role alternation real providers reject.
+          if (!this._interruptState.activated) {
+            throw new TypeError(
+              'Agent is not in an interrupted state. The interrupt being answered is no longer active (it was already answered or the interrupt state was cleared).'
+            )
+          }
           this._interruptState.resume(interruptResponses)
         }
 


### PR DESCRIPTION
## Description

Answering an interrupt that is no longer active was silently accepted. `stream()` extracts `interruptResponse` blocks and hands them to `InterruptState.resume()`, which returns early when the state is not `activated` — the state a completed interrupt cycle leaves behind after `deactivate()`. The responses are then dropped without a trace: no user turn is appended, the model is called anyway, and the reply lands as an `assistant` message directly after the previous `assistant` message. That role sequence is rejected by real providers, so the failure surfaces far from its cause, on the *next* invocation.

The agent already has the mirror-image guard one layer down — `_stream()` throws a `TypeError` when non-interrupt input arrives while the agent *is* interrupted. This PR adds the missing counterpart: interrupt input arriving while the agent is *not* interrupted is rejected with the same error type, at the same point where the responses would otherwise be swallowed.

Rejecting is the right behaviour rather than a no-op because the caller believes it is completing a turn. Under `concurrentInvocationMode: 'cancelPrevious'` (#3834) a bare call cancels an in-flight resume, and re-sending the interrupt response is the natural reaction — which is exactly how a caller walks into this hole today, with the damage deferred to a later request.

## Related Issues

Resolves #4171

## Documentation PR

None needed — no public API surface changes; the new error is a validation error on an already-documented input path.

## Type of Change

Bug fix

## Testing

New unit test in `agent.interrupt.test.ts` drives the full cycle — interrupt, resume to `endTurn`, resume again with the same `InterruptResponseContent` — and asserts the second resume rejects, `model.callCount` does not advance, and `agent.messages` roles are unchanged.

Against `upstream/main` the test fails on the corruption itself: the stale resume resolves with `stopReason: 'endTurn'`, having consumed an extra model turn and appended a second consecutive `assistant` message. With the fix, it rejects.

`npx vitest run --project unit-node` — 165 files, 4576 tests, all passing. `npm run lint`, `npm run format:check` and `npm run type-check` (after `npm run build`, which `test/integ`'s project references require) are clean.

- [x] I ran the TypeScript equivalent of `hatch run prepare` (`lint` / `format:check` / `type-check` / `test`); this change is TypeScript-only.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
