### PR TITLE
fix(telemetry): redact the agent span system prompt under the opt-in policy

### DIFF
--- a/strands-py/src/strands/telemetry/tracer.py
+++ b/strands-py/src/strands/telemetry/tracer.py
@@ -738,6 +738,7 @@ class Tracer:
         tools: list | None = None,
         custom_trace_attributes: Mapping[str, AttributeValue] | None = None,
         tools_config: dict | None = None,
+        system_prompt: str | None = None,
         **kwargs: Any,
     ) -> Span:
         """Start a new span for an agent invocation.
@@ -749,6 +750,8 @@ class Tracer:
             tools: Optional list of tools being used.
             custom_trace_attributes: Optional mapping of custom trace attributes to include in the span.
             tools_config: Optional dictionary of tool configurations.
+            system_prompt: Optional system prompt. Recorded under the existing ``system_prompt`` attribute
+                key, but policed by the redaction allowlist as ``gen_ai.system_instructions``.
             **kwargs: Additional attributes to add to the span.
 
         Returns:
@@ -781,6 +784,11 @@ class Tracer:
 
         # Add additional kwargs as attributes
         attributes.update({k: v for k, v in kwargs.items() if isinstance(v, (str, int, float, bool))})
+
+        # system prompts are sensitive and policed under gen_ai.system_instructions, even though this
+        # span records them under the legacy `system_prompt` key
+        if system_prompt is not None:
+            attributes["system_prompt"] = self._redact("gen_ai.system_instructions", system_prompt)
 
         span = self._start_span(
             f"invoke_agent {agent_name}", attributes=attributes, span_kind=trace_api.SpanKind.INTERNAL

--- a/strands-py/tests/strands/telemetry/test_tracer.py
+++ b/strands-py/tests/strands/telemetry/test_tracer.py
@@ -2592,6 +2592,45 @@ class TestSpanAttributeRedaction:
             }
             assert call_kwargs.get("tool.result") == "[REDACTED]"
 
+    def test_agent_span_system_prompt_redacted(self, mock_tracer, monkeypatch):
+        """The agent span's system prompt is policed under gen_ai.system_instructions."""
+        monkeypatch.setenv("OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_unredacted_attributes=")
+        with mock.patch("strands.telemetry.tracer.trace_api.get_tracer", return_value=mock_tracer):
+            tracer = Tracer()
+            tracer.tracer = mock_tracer
+            mock_span = mock.MagicMock()
+            mock_tracer.start_span.return_value = mock_span
+
+            tracer.start_agent_span(
+                messages=self._user_message(),
+                agent_name="Strands Agents",
+                system_prompt="confidential system prompt",
+            )
+
+            set_attrs_call = mock_span.set_attributes.call_args_list[0][0][0]
+            assert set_attrs_call["system_prompt"] == "[REDACTED]"
+
+    def test_agent_span_system_prompt_allowlisted(self, mock_tracer, monkeypatch):
+        """Allowlisting gen_ai.system_instructions keeps the agent span's system prompt verbatim."""
+        monkeypatch.setenv(
+            "OTEL_SEMCONV_STABILITY_OPT_IN",
+            "gen_ai_unredacted_attributes=gen_ai.system_instructions",
+        )
+        with mock.patch("strands.telemetry.tracer.trace_api.get_tracer", return_value=mock_tracer):
+            tracer = Tracer()
+            tracer.tracer = mock_tracer
+            mock_span = mock.MagicMock()
+            mock_tracer.start_span.return_value = mock_span
+
+            tracer.start_agent_span(
+                messages=self._user_message(),
+                agent_name="Strands Agents",
+                system_prompt="confidential system prompt",
+            )
+
+            set_attrs_call = mock_span.set_attributes.call_args_list[0][0][0]
+            assert set_attrs_call["system_prompt"] == "confidential system prompt"
+
 
 class TestSpanAttributesOnly:
     """Tests for the gen_ai_span_attributes_only opt-in.


### PR DESCRIPTION
## Description

`Agent._start_agent_trace_span()` passes `system_prompt=` to `Tracer.start_agent_span()`, which does not declare that parameter. The value lands in `**kwargs` and is copied verbatim into the span attributes by the generic `attributes.update({k: v for k, v in kwargs.items() ...})` fallback — a path that never touches `_redact()`.

The consequence is a redaction bypass rather than a cosmetic one. The opt-in policy added in #3111 classifies system prompts under `gen_ai.system_instructions` and redacts them when the operator asks for it. With `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_unredacted_attributes=` the prompt is duly redacted on the `chat` span and still exported in full on the sibling `invoke_agent` span. An operator who enables that token reasonably expects system instructions to be gone everywhere.

This declares `system_prompt` explicitly on `start_agent_span()` and routes it through `_redact()` under the canonical `gen_ai.system_instructions` name, so the allowlist governs it exactly as it governs the chat span.

The attribute **key is deliberately left as `system_prompt`**. Renaming it to `gen_ai.system_instructions` is the other half of #4210 and is a separate, contested decision: #1455 proposed that rename and was closed unmerged over exactly which name was correct, and the outcome of #1452 suggests some Langfuse users read the raw key today. Closing the redaction hole does not depend on settling that, and the reporter names this narrower step as a valid first move. The Datadog tag-splitting half of #4210 needs the rename and is left for that discussion.

## Related Issues

Partially addresses #4210 (the redaction bypass; the attribute rename is left to the semconv discussion in #822 / #1455).

## Documentation PR

Not applicable — no user-facing surface changes; the attribute key and default behaviour are unchanged.

## Type of Change

Bug fix

## Testing

Two tests in `TestSpanAttributeRedaction`, covering both directions of the allowlist:

- `test_agent_span_system_prompt_redacted` — with `gen_ai_unredacted_attributes=` the agent span's `system_prompt` attribute is `[REDACTED]`. Fails on `main` with `AssertionError: assert 'confidential system prompt' == '[REDACTED]'`; passes with the fix.
- `test_agent_span_system_prompt_allowlisted` — with `gen_ai_unredacted_attributes=gen_ai.system_instructions` the value is emitted verbatim. Passes before and after, guarding the backward-compatible default.

`hatch test tests/strands/telemetry/` — 174 passed. `hatch test tests/strands/agent/` — 814 passed. `hatch fmt --linter` — all checks passed; `ruff format --check` clean on both changed files (the two files the repo-wide formatter check flags are already unformatted on `main`).

- [x] I ran `hatch run prepare`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective
- [x] I have reviewed and understand every line of this change, including any AI-generated portions, and can explain why it works
- [x] The change is focused and small; unrelated work has been split out
- [x] New and existing unit tests pass locally with my changes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
