### PR TITLE
fix(anthropic): include cache tokens in totalTokens

### DIFF
--- a/strands-py/src/strands/models/anthropic.py
+++ b/strands-py/src/strands/models/anthropic.py
@@ -635,10 +635,12 @@ class AnthropicModel(Model):
                 output_tokens = usage["output_tokens"]
                 cache_read = usage.get("cache_read_input_tokens") or 0
                 cache_write = usage.get("cache_creation_input_tokens") or 0
+                # Anthropic's input_tokens excludes tokens read from or written to the cache, so the
+                # billed total is the sum of all four counters.
                 usage_chunk: Usage = {
                     "inputTokens": input_tokens,
                     "outputTokens": output_tokens,
-                    "totalTokens": input_tokens + output_tokens,
+                    "totalTokens": input_tokens + output_tokens + cache_read + cache_write,
                 }
                 if cache_read:
                     usage_chunk["cacheReadInputTokens"] = cache_read

--- a/strands-py/tests/strands/models/test_anthropic.py
+++ b/strands-py/tests/strands/models/test_anthropic.py
@@ -865,9 +865,8 @@ def test_format_chunk_metadata(model):
 
 
 def test_format_chunk_metadata_with_cache_tokens(model):
-    """When prompt caching is active, Anthropic returns cache_read_input_tokens
-    and cache_creation_input_tokens alongside input_tokens; surface them so
-    downstream cost accounting reflects what the user is billed for."""
+    """Anthropic reports input_tokens net of the cache, so the cache counters are surfaced and the
+    total is the sum of all four counters (#3546)."""
     event = {
         "type": "metadata",
         "usage": {
@@ -884,7 +883,7 @@ def test_format_chunk_metadata_with_cache_tokens(model):
             "usage": {
                 "inputTokens": 5,
                 "outputTokens": 7,
-                "totalTokens": 12,
+                "totalTokens": 162,
                 "cacheReadInputTokens": 100,
                 "cacheWriteInputTokens": 50,
             },

--- a/strands-py/tests/strands/telemetry/test_metrics.py
+++ b/strands-py/tests/strands/telemetry/test_metrics.py
@@ -681,20 +681,17 @@ def test_latest_context_size_does_not_double_count_subset_cache_tokens(event_loo
     assert event_loop_metrics.latest_context_size == 12936
 
 
-def test_latest_context_size_undercounts_anthropic_direct_cache(event_loop_metrics, mock_get_meter_provider):
-    """Documents the #3546 known limitation: Anthropic-direct cache is not counted.
+def test_latest_context_size_counts_anthropic_direct_cache(event_loop_metrics, mock_get_meter_provider):
+    """Counts the cache read from an Anthropic-direct usage payload (#3546).
 
-    Anthropic-direct reports cache as a separate counter yet computes totalTokens as
-    inputTokens + outputTokens, so it is arithmetically indistinguishable from a subset provider and
-    the cache read is dropped -- an undercount that matches the prior baseline. Adapter-side
-    normalization to the disjoint convention (#3546) will make totalTokens include the cache and flip
-    this to the total prompt (5858); this test guards the boundary so that flip is intentional.
+    The Anthropic adapter reports inputTokens net of the cache and a totalTokens that includes it,
+    so the payload is disjoint and the cache read counts toward the prompt.
     """
     event_loop_metrics.reset_usage_metrics()
     event_loop_metrics.start_cycle(attributes={"event_loop_cycle_id": "c1"})
-    event_loop_metrics.update_usage(Usage(inputTokens=10, outputTokens=4, totalTokens=14, cacheReadInputTokens=5848))
+    event_loop_metrics.update_usage(Usage(inputTokens=10, outputTokens=4, totalTokens=5862, cacheReadInputTokens=5848))
 
-    assert event_loop_metrics.latest_context_size == 10
+    assert event_loop_metrics.latest_context_size == 5858
 
 
 @pytest.mark.parametrize(

--- a/strands-ts/src/models/__tests__/anthropic.test.ts
+++ b/strands-ts/src/models/__tests__/anthropic.test.ts
@@ -236,6 +236,37 @@ describe('AnthropicModel', () => {
       expect(events[5]).toEqual({ type: 'modelMessageStopEvent', stopReason: 'endTurn' })
     })
 
+    it('reports a total that includes cache reads and writes', async () => {
+      // Anthropic reports input_tokens net of the cache, so the four counters sum to the total (#3546).
+      const mockClient = createMockClient(async function* () {
+        yield {
+          type: 'message_start',
+          message: {
+            role: 'assistant',
+            usage: { input_tokens: 5, cache_read_input_tokens: 100, cache_creation_input_tokens: 50 },
+          },
+        }
+        yield { type: 'message_delta', delta: { stop_reason: 'end_turn' }, usage: { output_tokens: 7 } }
+        yield { type: 'message_stop' }
+      })
+
+      const provider = new AnthropicModel({ client: mockClient })
+      const messages = [new Message({ role: 'user', content: [new TextBlock('Hi')] })]
+
+      const events = await collectIterator(provider.stream(messages))
+
+      expect(events[1]).toEqual({
+        type: 'modelMetadataEvent',
+        usage: {
+          inputTokens: 5,
+          outputTokens: 7,
+          totalTokens: 162,
+          cacheReadInputTokens: 100,
+          cacheWriteInputTokens: 50,
+        },
+      })
+    })
+
     it('handles tool use events', async () => {
       const mockClient = createMockClient(async function* () {
         yield { type: 'message_start', message: { role: 'assistant', usage: { input_tokens: 10 } } }

--- a/strands-ts/src/models/__tests__/streaming.test.ts
+++ b/strands-ts/src/models/__tests__/streaming.test.ts
@@ -72,14 +72,9 @@ describe('totalPromptTokens', () => {
     ).toBe(12936)
   })
 
-  // #3546 known limitation: Anthropic-direct reports cache as a separate counter yet computes
-  // totalTokens as inputTokens + outputTokens, so it is arithmetically indistinguishable from a subset
-  // provider and the cache read is dropped -- an undercount matching the prior baseline. Adapter-side
-  // normalization to the disjoint convention (#3546) will make totalTokens include the cache and flip
-  // this to the total prompt; this test guards the boundary so that flip is intentional.
-  it('undercounts Anthropic-direct cache where totalTokens excludes the separate cache counter', () => {
-    expect(totalPromptTokens({ inputTokens: 10, outputTokens: 4, totalTokens: 14, cacheReadInputTokens: 5848 })).toBe(
-      10
+  it('counts the cache read from an Anthropic-direct payload, whose totalTokens includes the cache', () => {
+    expect(totalPromptTokens({ inputTokens: 10, outputTokens: 4, totalTokens: 5862, cacheReadInputTokens: 5848 })).toBe(
+      5858
     )
   })
 

--- a/strands-ts/src/models/anthropic.ts
+++ b/strands-ts/src/models/anthropic.ts
@@ -281,7 +281,13 @@ export class AnthropicModel extends Model<AnthropicModelConfig> {
             break
 
           case 'message_stop':
-            usage.totalTokens = usage.inputTokens + usage.outputTokens
+            // Anthropic's input_tokens excludes tokens read from or written to the cache, so the
+            // billed total is the sum of all four counters.
+            usage.totalTokens =
+              usage.inputTokens +
+              usage.outputTokens +
+              (usage.cacheReadInputTokens ?? 0) +
+              (usage.cacheWriteInputTokens ?? 0)
             yield {
               type: 'modelMetadataEvent',
               usage,


### PR DESCRIPTION
## Description

Anthropic reports `input_tokens` net of the prompt cache: tokens read from or written to the cache arrive only in `cache_read_input_tokens` and `cache_creation_input_tokens`. The Anthropic adapter in both SDKs computes `totalTokens` as input + output, so every cached token is missing from the total. A 40k-token cached call reports `totalTokens: 8`.

This is the one adapter where the SDK derives the total itself rather than passing the provider's through, and it is the gap the convention-inference helper from #3886 documents as a known limitation: because input + output equals the total, an Anthropic-direct payload is indistinguishable from a subset-convention provider, so context sizing, proactive compaction, `limits.total_tokens`, and `gen_ai.usage.input_tokens` all under-count the cache on this provider. #2302, which added the cache counters, described recomputing the total to include them; the shipped arithmetic did not. This lands that total.

The total now sums all four counters, which is what Bedrock Converse already reports for the same Anthropic models. The two "known limitation" tests from #3886 flip to the full-prompt value.

## Related Issues

Part of #3546. Completes the `totalTokens` change described in #2302.

## Documentation PR

N/A. The Anthropic provider page already states cache activity is reported in the same fields Bedrock uses; this change makes that hold for the total as well.

## Type of Change

Bug fix

## Testing

- [ ] I ran `hatch run prepare` (hatch is not installed locally; ran the equivalent gates directly: ruff format/check, mypy on `src` and `tests_typing`, and the full `tests/strands` unit suite; for TypeScript, `npm run build`, `lint`, `format:check`, `type-check`, `check:browser-bundle`, and `test:coverage` via the repo's `pre-push` script)

Verified live rather than only against unit fixtures, since the value that changes is a provider-reported number. Ran Claude Haiku 4.5 and Claude Sonnet 5 in `eu-north-1` with a ~30–40k-token cached system prompt, two turns each, through every route to an Anthropic model on Bedrock: `BedrockModel` on Converse (untouched by this change, used as the reference), and `AnthropicModel` in both SDKs against Bedrock Mantle's Anthropic Messages endpoint (`https://bedrock-mantle.{region}.api.aws/anthropic`), which returns the same Anthropic usage payload the direct API does. Every call satisfied `inputTokens + outputTokens + cacheReadInputTokens + cacheWriteInputTokens == totalTokens`, and the fixed adapter's numbers matched Converse exactly for the same prompt.

Sonnet 5 through the fixed Python adapter:

```
turn 1  inputTokens=2  outputTokens=6  cacheRead=40292  cacheWrite=0   totalTokens=40300   context_size=40294
turn 2  inputTokens=2  outputTokens=6  cacheRead=40292  cacheWrite=13  totalTokens=40313   context_size=40307
```

The same two calls on `main` report `totalTokens=8` and `context_size=2`.

The Anthropic API itself was not exercised (no key available); the raw payload above is the Anthropic Messages format as served by Bedrock, whose `input_tokens: 9, cache_read_input_tokens: 30479` shape confirms the cache is excluded from input.

## Callouts

`totalTokens` on Anthropic-direct grows by the cached amount on any cached call, so a `limits.total_tokens` cap trips sooner and `context_size` reports the full prompt instead of the uncached remainder. This follows the #3886 and #4080 precedent of shipping a value correction as a `fix:`. Uncached calls are unchanged.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
