### PR TITLE
fix(models): resolve nested Bedrock model prefixes

### DIFF
--- a/strands-py/src/strands/models/_defaults.py
+++ b/strands-py/src/strands/models/_defaults.py
@@ -29,7 +29,7 @@ DEFAULT_CONTEXT_WINDOW_LIMIT = 200_000
 # Users can always override with an explicit context_window_limit in their model config.
 #
 # For Bedrock models with cross-region prefixes (e.g. us., eu., global.),
-# get_context_window_limit strips the prefix before lookup so only the base model ID is needed here.
+# get_context_window_limit strips prefixes before lookup so only the base model ID is needed here.
 _CONTEXT_WINDOW_LIMITS: dict[str, int] = {
     # Anthropic (direct API)
     "claude-sonnet-4-6": 1_000_000,
@@ -145,8 +145,8 @@ _CONTEXT_WINDOW_LIMITS: dict[str, int] = {
 def get_context_window_limit(model_id: str) -> int | None:
     """Look up the context window limit for a model ID.
 
-    For Bedrock cross-region model IDs (e.g. ``us.anthropic.claude-sonnet-4-6``),
-    the region prefix is stripped as a fallback if the direct lookup fails.
+    For Bedrock model IDs with prefixes (e.g. ``us.anthropic.claude-sonnet-4-6``),
+    prefixes are stripped as a fallback if the direct lookup fails.
 
     Args:
         model_id: The model ID to look up.
@@ -158,16 +158,16 @@ def get_context_window_limit(model_id: str) -> int | None:
     if direct is not None:
         return direct
 
-    # Fallback: strip prefix before first dot and retry (handles cross-region prefixes)
-    dot_index = model_id.find(".")
-    if dot_index != -1:
-        stripped = model_id[dot_index + 1 :]
+    # Fallback: strip prefixes before each dot and retry (handles nested cross-region prefixes and ARNs)
+    stripped = model_id
+    while (dot_index := stripped.find(".")) != -1:
+        stripped = stripped[dot_index + 1 :]
         result = _CONTEXT_WINDOW_LIMITS.get(stripped)
         if result is not None:
             logger.debug(
                 "model_id=<%s>, stripped_id=<%s> | resolved context window limit via prefix strip", model_id, stripped
             )
-        return result
+            return result
 
     return None
 

--- a/strands-py/tests/strands/models/test_defaults.py
+++ b/strands-py/tests/strands/models/test_defaults.py
@@ -36,6 +36,17 @@ class TestGetContextWindowLimit:
         assert get_context_window_limit("eu.anthropic.claude-sonnet-4-6") == 1_000_000
         assert get_context_window_limit("ap.anthropic.claude-sonnet-4-6") == 1_000_000
 
+    def test_strips_nested_bedrock_prefixes(self):
+        # Guards against nested Bedrock prefixes failing model metadata lookup (#4220)
+        assert get_context_window_limit("us.openai.gpt-5.6-luna") == 1_050_000
+        assert get_context_window_limit("global.openai.gpt-5.6-luna") == 1_050_000
+        assert (
+            get_context_window_limit(
+                "arn:aws:bedrock:eu-west-2:123456789012:inference-profile/global.openai.gpt-5.6-luna"
+            )
+            == 1_050_000
+        )
+
     def test_strips_any_prefix_as_fallback(self):
         # Any prefix before the first dot is stripped if direct lookup fails
         assert get_context_window_limit("custom.anthropic.claude-sonnet-4-6") == 1_000_000


### PR DESCRIPTION
## Description

Resolve context-window metadata for Bedrock OpenAI models using regional, global, and inference-profile prefixes. The lookup now strips nested dot-separated prefixes until it finds the base model ID.

## Related Issues

Resolves #4220

## Documentation PR

No documentation changes are needed.

## Type of Change

Bug fix

## Testing

- `hatch test tests/strands/models/test_defaults.py` — 14 passed
- `hatch fmt --linter` — passed
- Ruff formatting and checks for the changed files — passed

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small
- [x] I have added tests that prove my fix is effective
- [x] No documentation changes are needed
- [x] My changes generate no new warnings
- [x] No dependent changes are required
