### PR TITLE
fix(sagemaker): persist tool result role conversion

### DIFF
--- a/strands-py/src/strands/models/sagemaker.py
+++ b/strands-py/src/strands/models/sagemaker.py
@@ -339,7 +339,8 @@ class SageMakerAIModel(OpenAIModel):
                 # Convert tool message to user message
                 tool_call_id = message.get("tool_call_id", "ABCDEF")
                 content = message.get("content", "")
-                message = {"role": "user", "content": f"Tool call ID '{tool_call_id}' returned: {content}"}
+                message.clear()
+                message.update(role="user", content=f"Tool call ID '{tool_call_id}' returned: {content}")
             # Cannot have both reasoning_text and text - if "text", content becomes an array of content["text"]
             for c in message.get("content", []):
                 if "text" in c:

--- a/strands-py/tests/strands/models/test_sagemaker.py
+++ b/strands-py/tests/strands/models/test_sagemaker.py
@@ -375,6 +375,41 @@ class TestSageMakerAIModel:
         payload = json.loads(request["Body"])
         assert payload.get("extra_payload_key") == "extra_payload_value"
 
+    def test_format_request_converts_tool_results_to_user_messages(
+        self, boto_session, endpoint_config, payload_config
+    ) -> None:
+        """Tool results configured as user messages must be converted in the request payload (#3299)."""
+        payload_config["tool_results_as_user_messages"] = True
+        model = SageMakerAIModel(
+            boto_session=boto_session,
+            endpoint_config=endpoint_config,
+            payload_config=payload_config,
+        )
+        messages: Messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "toolResult": {
+                            "toolUseId": "tool-call-id",
+                            "status": "success",
+                            "content": [{"text": "tool output"}],
+                        }
+                    }
+                ],
+            }
+        ]
+
+        request = model.format_request(messages)
+        tru_messages = json.loads(request["Body"])["messages"]
+        exp_messages = [
+            {
+                "role": "user",
+                "content": "Tool call ID 'tool-call-id' returned: tool output",
+            }
+        ]
+        assert tru_messages == exp_messages
+
     @pytest.mark.asyncio
     async def test_stream_with_streaming_enabled(self, sagemaker_client, model, messages):
         """Test streaming response with streaming enabled."""


### PR DESCRIPTION
## Description

When `tool_results_as_user_messages` is enabled, SageMaker request formatting currently rebinds only the loop-local `message`, so the serialized payload still contains a `tool` message. Persist the intended conversion in the existing message object so endpoints that require tool results as user messages receive the configured format.

Resolves #3299

## Related Issues

#3299

## Documentation PR

No documentation changes are needed because this restores the behavior of an existing configuration option.

## Type of Change

Bug fix

## Testing

- `hatch test tests/strands/models/test_sagemaker.py` — 33 passed
- `hatch test` — 6,208 passed, 34 skipped
- Ruff formatting and lint checks passed
- Mypy passed for `src/strands/models/sagemaker.py`
- Repository pre-commit checks passed, including the TypeScript build, 4,575 tests, lint, formatting, and type checks
- PR metrics: `size/xs`, `complexity/low` (no touched function increased in complexity)

- [ ] I ran `hatch run prepare`

`hatch run prepare` could not progress past first-time Python 3.10 static-analysis environment synchronization locally. The individual Python checks above and the repository pre-commit gate were run instead.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
