### PR TITLE
feat(python): add backgroundTasks to Agent

### DIFF
--- a/strands-py/src/strands/__init__.py
+++ b/strands-py/src/strands/__init__.py
@@ -3,6 +3,7 @@
 from . import agent, models, storage, telemetry, types
 from .agent.agent import Agent
 from .agent.base import AgentBase
+from .background_tasks import BackgroundTasksConfig
 from .event_loop._retry import ModelRetryStrategy
 from .interventions import InterventionHandler
 from .plugins import MultiAgentPlugin, Plugin
@@ -21,6 +22,7 @@ __all__ = [
     "Agent",
     "AgentBase",
     "AgentSkills",
+    "BackgroundTasksConfig",
     "InterventionHandler",
     "LocalAgent",
     "agent",

--- a/strands-py/src/strands/agent/_agent_as_tool.py
+++ b/strands-py/src/strands/agent/_agent_as_tool.py
@@ -218,8 +218,14 @@ class _AgentAsTool(AgentTool):
 
             # Forward the parent's cancellation signal so cancelling the parent also cancels
             # the sub-agent. Passed as the sub-agent's external signal: the sub-agent links it
-            # into its own event and never clears the parent's.
-            cancel_signal = getattr(invocation_state.get("agent"), "cancel_signal", None)
+            # into its own event and never clears the parent's. A framework-supplied tool
+            # context (background execution) carries the signal scoped to that call instead.
+            tool_context = kwargs.get("_tool_context")
+            cancel_signal = (
+                tool_context.cancel_signal
+                if tool_context is not None
+                else getattr(invocation_state.get("agent"), "cancel_signal", None)
+            )
 
             result = None
             async for event in self._agent.stream_async(prompt, cancel_signal=cancel_signal):

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -33,6 +33,7 @@ from pydantic import BaseModel
 
 from .. import _identifier
 from .._async import run_async
+from ..background_tasks import BackgroundTasksConfig
 from ..event_loop._retry import ModelRetryStrategy
 from ..event_loop.event_loop import INITIAL_DELAY, MAX_ATTEMPTS, MAX_DELAY, event_loop_cycle
 from ..experimental.checkpoint import Checkpoint, CheckpointPosition
@@ -47,6 +48,7 @@ from ..types._snapshot import (
 
 if TYPE_CHECKING:
     from .._context_manager.context_manager import ContextManager
+    from ..background_tasks._background_tasks import _BackgroundTasks
     from ..tools import ToolProvider
 from .._middleware import MiddlewareRegistry
 from .._middleware.stages import AgentStreamContext, AgentStreamStage
@@ -240,6 +242,7 @@ class Agent(AgentBase, LocalAgent):
         checkpointing: bool = False,
         sandbox: Sandbox | None = None,
         storage: Storage | None = None,
+        background_tasks: bool | BackgroundTasksConfig | None = None,
     ):
         """Initialize the Agent with the specified configuration.
 
@@ -348,6 +351,10 @@ class Agent(AgentBase, LocalAgent):
                 auto-namespaces under its own prefix (e.g., ``offloader/``) to avoid key
                 collisions. Storage specified directly on a subsystem always takes
                 precedence over this agent-level default. Defaults to None.
+            background_tasks: Background tool execution configuration. Pass ``True`` or a
+                :class:`~strands.background_tasks.BackgroundTasksConfig` to let the model run
+                tools in the background and receive their results when they finish. Defaults to
+                None (disabled).
 
         Raises:
             ValueError: If agent id contains path separators.
@@ -540,6 +547,12 @@ class Agent(AgentBase, LocalAgent):
 
         self.tool_executor = tool_executor or ConcurrentToolExecutor()
 
+        self._background_tasks: _BackgroundTasks | None = None
+        if background_tasks is not None and background_tasks is not False:
+            from ..background_tasks._background_tasks import _BackgroundTasks as _BackgroundTasksPlugin
+
+            self._background_tasks = _BackgroundTasksPlugin({} if background_tasks is True else background_tasks)
+
         if hooks:
             for hook in hooks:
                 if isinstance(hook, HookProvider):
@@ -561,6 +574,9 @@ class Agent(AgentBase, LocalAgent):
         if plugins_to_register:
             for plugin in plugins_to_register:
                 self._plugin_registry.add_and_init(plugin)
+
+        if self._background_tasks is not None:
+            self._plugin_registry.add_and_init(self._background_tasks)
 
         has_agent_delegation = any(plugin.name == "strands:agent-delegation" for plugin in (plugins_to_register or []))
         if not has_agent_delegation:
@@ -2034,7 +2050,10 @@ class Agent(AgentBase, LocalAgent):
 
         Raises:
             SnapshotException: If snapshot.schema_version is not "1.0".
+            RuntimeError: If background tasks are still tracked.
         """
+        if self._background_tasks is not None:
+            self._background_tasks.assert_can_load_snapshot()
         snapshot.validate()
 
         data = snapshot.data
@@ -2051,6 +2070,8 @@ class Agent(AgentBase, LocalAgent):
             self.system_prompt = copy.deepcopy(data["system_prompt"])
         if "model_state" in data:
             self._model_state = copy.deepcopy(data["model_state"])
+        if self._background_tasks is not None and "state" in data:
+            self._background_tasks.load_state()
 
     def _redact_user_content(self, content: list[ContentBlock], redact_message: str) -> list[ContentBlock]:
         """Redact user content preserving toolResult blocks.

--- a/strands-py/src/strands/background_tasks/__init__.py
+++ b/strands-py/src/strands/background_tasks/__init__.py
@@ -1,1 +1,9 @@
-"""Internal background task execution primitives."""
+"""Background tool execution.
+
+Only :class:`BackgroundTasksConfig` is public; the task engine, manager, and the plugin that
+connects them to an :class:`~strands.agent.Agent` are internal.
+"""
+
+from ._types import BackgroundTasksConfig
+
+__all__ = ["BackgroundTasksConfig"]

--- a/strands-py/src/strands/background_tasks/_background_tasks.py
+++ b/strands-py/src/strands/background_tasks/_background_tasks.py
@@ -1,0 +1,510 @@
+"""Background task policy, routing, persistence, and result delivery for one Agent."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import dataclasses
+import logging
+import threading
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+from .._middleware.stages import InvokeModelContext, InvokeModelStage
+from ..agent import _continuation
+from ..agent._agent_as_tool import _AgentAsTool
+from ..agent.agent import _CANCEL_POLL_INTERVAL
+from ..hooks import AfterInvocationEvent, AgentInitializedEvent, BeforeModelCallEvent, HookOrder
+from ..interrupt import Interrupt, InterruptException
+from ..models._validation import validate_config_keys
+from ..plugins import Plugin
+from ..tools.decorator import tool
+from ..tools.executors._executor import _lookup_tool
+from ..types.agent import LocalAgent
+from ..types.content import Messages
+from ..types.tools import AgentTool, ToolContext, ToolResult, ToolSpec, ToolUse
+from ._errors import BackgroundTaskNotFoundError
+from ._types import BackgroundTask, BackgroundTasksConfig, is_task_status_terminal
+from .in_process._engine import _timestamp
+from .in_process._manager import InProcessTaskManager, _MiddlewareInterrupt
+
+if TYPE_CHECKING:
+    from ..agent import Agent
+
+logger = logging.getLogger(__name__)
+
+_BACKGROUND_TASKS_STATE_KEY = "strands.background_tasks"
+_BACKGROUND_PROPERTY = "_background_execution"
+_MANAGE_TOOL_NAME = "strands_manage_background_task"
+_RESULT_TOOL_NAME = "strands_background_task_result"
+_COMPOSITE_SCHEMA_KEYS = {"$ref", "allOf", "anyOf", "oneOf", "not", "if", "then", "else"}
+_FOREGROUND_TOOL_NAMES = {
+    _MANAGE_TOOL_NAME,
+    "summarize_context",
+    "truncate_context",
+    "pin_context",
+}
+_BackgroundMode = Literal["never", "agentic", "always"]
+
+
+@dataclass(frozen=True)
+class _Policy:
+    mode: _BackgroundMode
+    # Whether the tool was named explicitly rather than matched by the "*" wildcard.
+    exact: bool
+
+
+class _BackgroundTasks(Plugin):
+    """Connect background task policy and lifecycle to one Agent."""
+
+    name = "strands:background-tasks"
+
+    def __init__(self, config: BackgroundTasksConfig) -> None:
+        """Initialize the plugin.
+
+        Args:
+            config: Background tool execution configuration.
+
+        Raises:
+            TypeError: If a tool is assigned conflicting execution modes.
+        """
+        validate_config_keys(config, BackgroundTasksConfig)
+        self._config = config
+        self._policy = _resolve_policy(config)
+        self._agent: Agent
+        self._manager: InProcessTaskManager
+        # Snapshots are written from the background runtime thread and read from the agent loop.
+        self._tasks: dict[str, BackgroundTask] = {}
+        self._tasks_lock = threading.Lock()
+        super().__init__()
+
+    def init_agent(self, agent: Agent) -> None:
+        """Validate exact policies, then attach the task manager, middleware, and lifecycle hooks.
+
+        Raises:
+            TypeError: If an explicitly configured tool cannot honor its execution mode.
+        """
+        self._agent = agent
+        for tool_instance in agent.tool_registry.registry.values():
+            policy = self._policy_for(tool_instance)
+            if policy is None or not policy.exact or policy.mode == "never":
+                continue
+            if not _can_execute_in_background(tool_instance):
+                raise TypeError(f"Tool '{tool_instance.tool_name}' cannot run in the background")
+            if policy.mode == "agentic" and not _can_select_background(tool_instance):
+                raise TypeError(f"Tool '{tool_instance.tool_name}' cannot use agentic background selection")
+
+        async def execute_tool(
+            selected_tool: AgentTool,
+            context: ToolContext[LocalAgent],
+            middleware_interrupt: _MiddlewareInterrupt,
+        ) -> ToolResult:
+            return await agent.tool_executor._execute_background(
+                agent, selected_tool, context, middleware_interrupt, self.assert_tool_can_run
+            )
+
+        manager_options: dict[str, Any] = {}
+        if "max_concurrency" in self._config:
+            manager_options["max_concurrency"] = self._config["max_concurrency"]
+        if "timeout" in self._config:
+            manager_options["timeout"] = self._config["timeout"]
+        self._manager = InProcessTaskManager(agent, execute_tool, on_task_updated=self._store_task, **manager_options)
+
+        agent._middleware_registry.add_middleware(InvokeModelStage.Input, self._transform_tool_specs)
+        agent.add_hook(self._before_model_call, BeforeModelCallEvent)
+        agent.add_hook(self._after_invocation, AfterInvocationEvent)
+        agent.add_hook(lambda event: self.load_state(), AgentInitializedEvent, order=HookOrder.SDK_LAST)
+
+    @tool(
+        name=_MANAGE_TOOL_NAME,
+        description=(
+            "List, inspect, or cancel background tasks. Completed results are delivered automatically; "
+            "do not poll with this tool."
+        ),
+    )
+    async def _manage_background_task(
+        self, mode: Literal["list", "get", "cancel"], task_id: str | None = None
+    ) -> dict[str, Any]:
+        """Manage tracked background tasks.
+
+        Args:
+            mode: Whether to list, inspect, or cancel background tasks.
+            task_id: The background task ID returned when the task was dispatched. Required for get and cancel.
+        """
+        if mode == "list":
+            listing = [
+                {"task_id": task["task_id"], "tool_name": task["tool_name"], "status": task["status"]}
+                for task in self._task_snapshots()
+            ]
+            return _json_tool_result({"tasks": listing})
+        if not task_id:
+            raise TypeError(f"Task ID is required for mode '{mode}'")
+        with self._tasks_lock:
+            task = self._tasks.get(task_id)
+        if task is None:
+            raise BackgroundTaskNotFoundError(task_id)
+        if mode == "get":
+            return _json_tool_result(task)
+        cancelled = task if is_task_status_terminal(task["status"]) else await self._manager.cancel(task_id)
+        return _json_tool_result({"task_id": cancelled["task_id"], "status": cancelled["status"]})
+
+    def route_tool_call(
+        self,
+        tool_use: ToolUse,
+        requested_tool: AgentTool | None,
+        effective_tool: AgentTool | None,
+    ) -> bool | ToolResult | None:
+        """Decide foreground versus background execution for one tool call.
+
+        Strips ``_background_execution`` from ``tool_use["input"]`` so the tool never sees the
+        selection flag.
+
+        Returns:
+            ``True`` to submit as a background task, an error ``ToolResult`` when admission is
+            rejected, or ``None`` to run in the foreground.
+        """
+        selected = False
+        tool_input = tool_use.get("input")
+        if isinstance(tool_input, dict) and _BACKGROUND_PROPERTY in tool_input:
+            stripped_input = dict(tool_input)
+            value = stripped_input.pop(_BACKGROUND_PROPERTY)
+            if not isinstance(value, bool):
+                return _tool_error(tool_use, f"'{_BACKGROUND_PROPERTY}' must be a boolean")
+            requested_policy = self._policy_for(requested_tool)
+            if requested_policy is not None and requested_policy.mode == "agentic":
+                selected = value
+            tool_use["input"] = stripped_input
+
+        policy = self._policy_for(effective_tool)
+        if policy is None or policy.mode == "never":
+            return None
+        if not _can_execute_in_background(effective_tool):
+            return (
+                _tool_error(tool_use, f"Tool '{tool_use['name']}' cannot run in the background")
+                if policy.exact
+                else None
+            )
+        if policy.mode == "agentic" and not _can_select_background(effective_tool):
+            return (
+                _tool_error(tool_use, f"Tool '{tool_use['name']}' cannot use agentic background selection")
+                if policy.exact
+                else None
+            )
+        return True if policy.mode == "always" or selected else None
+
+    async def submit_tool_call(
+        self,
+        tool_use: ToolUse,
+        invocation_state: dict[str, Any],
+        pass_id: str,
+        tool_instance: AgentTool,
+    ) -> ToolResult:
+        """Admit one background tool call and return its dispatch acknowledgement."""
+        if self._agent.cancel_signal.is_set():
+            return _tool_error(tool_use, "Tool execution cancelled")
+        try:
+            task = await self._manager.submit(tool_use, invocation_state, pass_id, tool_instance)
+        except Exception as error:
+            logger.warning("error=<%s> | background task admission failed", error)
+            return _tool_error(tool_use, "Background task admission failed")
+        acknowledgement = "\n".join(
+            [
+                "Background task dispatched.",
+                "",
+                f"Task ID: {task['task_id']}",
+                f"Tool: {task['tool_name']}",
+                f"Status: {task['status']}",
+                "",
+                "The task is running in the background. Continue without waiting or polling.",
+                "The final result will be delivered automatically when the task completes.",
+            ]
+        )
+        return {"toolUseId": tool_use["toolUseId"], "status": "success", "content": [{"text": acknowledgement}]}
+
+    def assert_tool_can_run(self, tool_instance: AgentTool | None) -> None:
+        """Reject a middleware-substituted tool that cannot run in the background.
+
+        Raises:
+            RuntimeError: If the tool is unknown, foreground-only, or configured as ``never``.
+        """
+        policy = self._policy_for(tool_instance)
+        if not _can_execute_in_background(tool_instance) or policy is None or policy.mode == "never":
+            raise RuntimeError("Tool cannot run in the background")
+
+    def assert_can_load_snapshot(self) -> None:
+        """Reject state replacement while the manager still tracks tasks.
+
+        Raises:
+            RuntimeError: If any background task is still tracked.
+        """
+        if self._manager.has_tasks():
+            raise RuntimeError("Cannot load a snapshot while background tasks are still tracked")
+
+    def load_state(self) -> None:
+        """Rebuild task snapshots from agent state after it was replaced.
+
+        Persisted work cannot resume in a new process, so non-terminal tasks are recorded as
+        failed and their interrupts are dropped from the agent's interrupt state.
+        """
+        stored: list[BackgroundTask] = self._agent.state.get(_BACKGROUND_TASKS_STATE_KEY) or []
+        recovered_interrupt_ids: set[str] = set()
+        tasks: dict[str, BackgroundTask] = {}
+        for task in stored:
+            if not is_task_status_terminal(task["status"]):
+                recovered_interrupt_ids.update(interrupt["id"] for interrupt in task.pop("interrupts", []))
+                task["status"] = "failed"
+                task["last_updated_at"] = _timestamp()
+                task["error"] = {
+                    "type": "execution_error",
+                    "message": "Background task cannot resume after restoring persisted state",
+                }
+            tasks[task["task_id"]] = task
+        with self._tasks_lock:
+            self._tasks = tasks
+        interrupt_state = self._agent._interrupt_state
+        for interrupt_id in recovered_interrupt_ids:
+            interrupt_state.interrupts.pop(interrupt_id, None)
+        if interrupt_state.activated and not interrupt_state.interrupts:
+            interrupt_state.deactivate()
+        self._persist_tasks()
+
+    async def _transform_tool_specs(self, context: InvokeModelContext) -> InvokeModelContext:
+        transformed: list[ToolSpec] = []
+        for spec in context.tool_specs:
+            tool_instance = _lookup_tool(context.agent, spec["name"])
+            policy = self._policy_for(tool_instance)
+            if policy is None or policy.mode != "agentic":
+                transformed.append(spec)
+                continue
+            if not _can_execute_in_background(tool_instance):
+                if policy.exact:
+                    raise TypeError(f"Tool '{spec['name']}' cannot use agentic background selection")
+                transformed.append(spec)
+                continue
+            selectable = _add_background_selection(spec)
+            if selectable is None and policy.exact:
+                raise TypeError(f"Tool '{spec['name']}' cannot use agentic background selection")
+            transformed.append(selectable or spec)
+        return dataclasses.replace(context, tool_specs=transformed)
+
+    async def _before_model_call(self, event: BeforeModelCallEvent) -> None:
+        """Resume tasks from interrupt responses, halt while any task awaits input, then deliver results."""
+        interrupt_state = self._agent._interrupt_state
+        responses = interrupt_state.context.get("responses")
+        if responses:
+            input_tasks = [task for task in await self._manager.list() if task["status"] == "input_required"]
+            task_interrupt_ids = {interrupt["id"] for task in input_tasks for interrupt in task.get("interrupts", [])}
+            for task in input_tasks:
+                interrupt_ids = {interrupt["id"] for interrupt in task.get("interrupts", [])}
+                task_responses = [
+                    content["interruptResponse"]
+                    for content in responses
+                    if content["interruptResponse"]["interruptId"] in interrupt_ids
+                ]
+                if task_responses:
+                    await self._manager.resume(task["task_id"], task_responses)
+            if all(interrupt_id in task_interrupt_ids for interrupt_id in interrupt_state.interrupts):
+                interrupt_state.deactivate()
+
+        tasks = self._task_snapshots()
+        pending_interrupts = [
+            interrupt
+            for task in tasks
+            if task["status"] == "input_required"
+            for interrupt in task.get("interrupts", [])
+        ]
+        if pending_interrupts:
+            # The agent surfaces every unanswered interrupt registered in its state, and resume()
+            # rejects responses for unregistered ids, so register them all before raising one.
+            for interrupt_data in pending_interrupts:
+                interrupt_state.interrupts.setdefault(
+                    interrupt_data["id"],
+                    Interrupt(id=interrupt_data["id"], name=interrupt_data["name"], reason=interrupt_data["reason"]),
+                )
+            raise InterruptException(interrupt_state.interrupts[pending_interrupts[0]["id"]])
+        self._deliver_ready(event, tasks)
+
+    async def _after_invocation(self, event: AfterInvocationEvent) -> None:
+        if self._agent._interrupt_state.activated:
+            return
+        tasks = self._task_snapshots()
+        while (
+            self._config.get("wait_for_completion", True)
+            and not self._agent.cancel_signal.is_set()
+            and not any(task["status"] == "input_required" for task in tasks)
+            and any(not is_task_status_terminal(task["status"]) for task in tasks)
+        ):
+            await self._await_next_settlement(tasks)
+            tasks = self._task_snapshots()
+        if any(task["status"] == "input_required" for task in tasks):
+            if event.resume is None:
+                event.resume = []
+            return
+        self._deliver_ready(event, tasks)
+
+    async def _await_next_settlement(self, tasks: Sequence[BackgroundTask]) -> None:
+        """Wait until one pending task settles or the invocation is cancelled."""
+        waiters = [
+            asyncio.ensure_future(self._manager.wait(task["task_id"]))
+            for task in tasks
+            if not is_task_status_terminal(task["status"])
+        ]
+        try:
+            while waiters and not self._agent.cancel_signal.is_set():
+                settled, _ = await asyncio.wait(
+                    waiters, timeout=_CANCEL_POLL_INTERVAL, return_when=asyncio.FIRST_COMPLETED
+                )
+                if settled:
+                    return
+        finally:
+            for waiter in waiters:
+                waiter.cancel()
+            await asyncio.gather(*waiters, return_exceptions=True)
+
+    def _deliver_ready(
+        self,
+        event: BeforeModelCallEvent | AfterInvocationEvent,
+        tasks: Sequence[BackgroundTask],
+    ) -> None:
+        """Queue terminal task results as a continuation of synthetic tool-use/tool-result pairs."""
+        terminal_tasks = [task for task in tasks if is_task_status_terminal(task["status"])]
+        if not terminal_tasks:
+            return
+        task_ids = [task["task_id"] for task in terminal_tasks]
+        messages: Messages = []
+        for task in terminal_tasks:
+            result = task.get("result")
+            content = (
+                result["content"]
+                if result is not None
+                else [{"text": task.get("error", {}).get("message", "Background task cancelled")}]
+            )
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "toolUse": {
+                                "name": _RESULT_TOOL_NAME,
+                                "toolUseId": task["task_id"],
+                                "input": {"tool_name": task["tool_name"]},
+                            }
+                        }
+                    ],
+                }
+            )
+            messages.append(
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "toolResult": {
+                                "toolUseId": task["task_id"],
+                                "status": "success" if task["status"] == "completed" else "error",
+                                "content": content,
+                            }
+                        }
+                    ],
+                }
+            )
+
+        async def on_appended() -> None:
+            live_task_ids = {task["task_id"] for task in await self._manager.list()}
+            await self._manager.remove([task_id for task_id in task_ids if task_id in live_task_ids])
+            with self._tasks_lock:
+                for task_id in task_ids:
+                    self._tasks.pop(task_id, None)
+            self._persist_tasks()
+
+        _continuation.add_input(event, _continuation._ContinuationInput(args=messages, on_appended=on_appended))
+
+    def _policy_for(self, tool_instance: AgentTool | None) -> _Policy | None:
+        if tool_instance is None:
+            return None
+        exact = self._policy.get(tool_instance.tool_name)
+        if exact is not None:
+            return _Policy(mode=exact, exact=True)
+        wildcard = self._policy.get("*")
+        return _Policy(mode=wildcard, exact=False) if wildcard is not None else None
+
+    def _store_task(self, task: BackgroundTask) -> None:
+        with self._tasks_lock:
+            self._tasks[task["task_id"]] = task
+        self._persist_tasks()
+
+    def _task_snapshots(self) -> list[BackgroundTask]:
+        with self._tasks_lock:
+            return list(self._tasks.values())
+
+    def _persist_tasks(self) -> None:
+        tasks = self._task_snapshots()
+        if tasks:
+            self._agent.state.set(_BACKGROUND_TASKS_STATE_KEY, tasks)
+        else:
+            self._agent.state.delete(_BACKGROUND_TASKS_STATE_KEY)
+
+
+def _resolve_policy(config: BackgroundTasksConfig) -> dict[str, _BackgroundMode]:
+    explicit_wildcard = "*" in config.get("always", []) or "*" in config.get("never", [])
+    assignments: list[tuple[_BackgroundMode, Sequence[AgentTool | str]]] = [
+        ("agentic", config.get("agentic", [] if explicit_wildcard else ["*"])),
+        ("always", config.get("always", [])),
+        ("never", config.get("never", [])),
+    ]
+    policy: dict[str, _BackgroundMode] = {}
+    for mode, selectors in assignments:
+        for selector in selectors:
+            name = selector if isinstance(selector, str) else selector.tool_name
+            existing = policy.get(name)
+            if existing is not None and existing != mode:
+                raise TypeError(f"Tool '{name}' cannot be configured as both '{existing}' and '{mode}'")
+            policy[name] = mode
+    return policy
+
+
+def _can_execute_in_background(tool_instance: AgentTool | None) -> bool:
+    return (
+        tool_instance is not None
+        and tool_instance.tool_name not in _FOREGROUND_TOOL_NAMES
+        and tool_instance.tool_type != "structured_output"
+        and not (isinstance(tool_instance, _AgentAsTool) and tool_instance.delegate)
+    )
+
+
+def _can_select_background(tool_instance: AgentTool) -> bool:
+    return _add_background_selection(tool_instance.tool_spec) is not None
+
+
+def _add_background_selection(tool_spec: ToolSpec) -> ToolSpec | None:
+    """Return a copy of the spec with the ``_background_execution`` flag, or None if the schema cannot take it."""
+    schema = tool_spec.get("inputSchema", {}).get("json", {})
+    properties = schema.get("properties")
+    if (
+        _COMPOSITE_SCHEMA_KEYS.intersection(schema)
+        or schema.get("type") not in (None, "object")
+        or (properties is not None and not isinstance(properties, dict))
+        or (isinstance(properties, dict) and _BACKGROUND_PROPERTY in properties)
+        or _BACKGROUND_PROPERTY in schema.get("required", [])
+    ):
+        return None
+    selectable = copy.deepcopy(tool_spec)
+    json_schema = selectable.setdefault("inputSchema", {}).setdefault("json", {})
+    json_schema["type"] = "object"
+    json_schema["properties"] = {
+        **json_schema.get("properties", {}),
+        _BACKGROUND_PROPERTY: {
+            "type": "boolean",
+            "description": "Run this tool in the background and continue without waiting for its result.",
+        },
+    }
+    return selectable
+
+
+def _tool_error(tool_use: ToolUse, message: str) -> ToolResult:
+    return {"toolUseId": tool_use["toolUseId"], "status": "error", "content": [{"text": message}]}
+
+
+def _json_tool_result(value: Any) -> dict[str, Any]:
+    # The decorator fills in toolUseId for a result that already carries status and content.
+    return {"status": "success", "content": [{"json": value}]}

--- a/strands-py/src/strands/background_tasks/_background_tasks.py
+++ b/strands-py/src/strands/background_tasks/_background_tasks.py
@@ -443,11 +443,13 @@ class _BackgroundTasks(Plugin):
             return list(self._tasks.values())
 
     def _persist_tasks(self) -> None:
-        tasks = self._task_snapshots()
-        if tasks:
-            self._agent.state.set(_BACKGROUND_TASKS_STATE_KEY, tasks)
-        else:
-            self._agent.state.delete(_BACKGROUND_TASKS_STATE_KEY)
+        # Snapshot and write under one lock so a concurrent remove cannot be overwritten by a stale snapshot.
+        with self._tasks_lock:
+            tasks = list(self._tasks.values())
+            if tasks:
+                self._agent.state.set(_BACKGROUND_TASKS_STATE_KEY, tasks)
+            else:
+                self._agent.state.delete(_BACKGROUND_TASKS_STATE_KEY)
 
 
 def _resolve_policy(config: BackgroundTasksConfig) -> dict[str, _BackgroundMode]:

--- a/strands-py/src/strands/background_tasks/_background_tasks.py
+++ b/strands-py/src/strands/background_tasks/_background_tasks.py
@@ -9,7 +9,7 @@ import logging
 import threading
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, TypeGuard
 
 from .._middleware.stages import InvokeModelContext, InvokeModelStage
 from ..agent import _continuation
@@ -23,7 +23,7 @@ from ..tools.decorator import tool
 from ..tools.executors._executor import _lookup_tool
 from ..types.agent import LocalAgent
 from ..types.content import Messages
-from ..types.tools import AgentTool, ToolContext, ToolResult, ToolSpec, ToolUse
+from ..types.tools import AgentTool, ToolContext, ToolResult, ToolResultContent, ToolSpec, ToolUse
 from ._errors import BackgroundTaskNotFoundError
 from ._types import BackgroundTask, BackgroundTasksConfig, is_task_status_terminal
 from .in_process._engine import _timestamp
@@ -154,7 +154,7 @@ class _BackgroundTasks(Plugin):
         tool_use: ToolUse,
         requested_tool: AgentTool | None,
         effective_tool: AgentTool | None,
-    ) -> bool | ToolResult | None:
+    ) -> Literal[True] | ToolResult | None:
         """Decide foreground versus background execution for one tool call.
 
         Strips ``_background_execution`` from ``tool_use["input"]`` so the tool never sees the
@@ -375,7 +375,7 @@ class _BackgroundTasks(Plugin):
         messages: Messages = []
         for task in terminal_tasks:
             result = task.get("result")
-            content = (
+            content: list[ToolResultContent] = (
                 result["content"]
                 if result is not None
                 else [{"text": task.get("error", {}).get("message", "Background task cancelled")}]
@@ -463,7 +463,7 @@ def _resolve_policy(config: BackgroundTasksConfig) -> dict[str, _BackgroundMode]
     return policy
 
 
-def _can_execute_in_background(tool_instance: AgentTool | None) -> bool:
+def _can_execute_in_background(tool_instance: AgentTool | None) -> TypeGuard[AgentTool]:
     return (
         tool_instance is not None
         and tool_instance.tool_name not in _FOREGROUND_TOOL_NAMES

--- a/strands-py/src/strands/background_tasks/_background_tasks.py
+++ b/strands-py/src/strands/background_tasks/_background_tasks.py
@@ -293,19 +293,7 @@ class _BackgroundTasks(Plugin):
         interrupt_state = self._agent._interrupt_state
         responses = interrupt_state.context.get("responses")
         if responses:
-            input_tasks = [task for task in await self._manager.list() if task["status"] == "input_required"]
-            task_interrupt_ids = {interrupt["id"] for task in input_tasks for interrupt in task.get("interrupts", [])}
-            for task in input_tasks:
-                interrupt_ids = {interrupt["id"] for interrupt in task.get("interrupts", [])}
-                task_responses = [
-                    content["interruptResponse"]
-                    for content in responses
-                    if content["interruptResponse"]["interruptId"] in interrupt_ids
-                ]
-                if task_responses:
-                    await self._manager.resume(task["task_id"], task_responses)
-            if all(interrupt_id in task_interrupt_ids for interrupt_id in interrupt_state.interrupts):
-                interrupt_state.deactivate()
+            await self._resume_interrupted_tasks(responses)
 
         tasks = self._task_snapshots()
         pending_interrupts = [
@@ -324,6 +312,23 @@ class _BackgroundTasks(Plugin):
                 )
             raise InterruptException(interrupt_state.interrupts[pending_interrupts[0]["id"]])
         self._deliver_ready(event, tasks)
+
+    async def _resume_interrupted_tasks(self, responses: list[dict[str, Any]]) -> None:
+        """Route interrupt responses to the tasks that raised them and clear the agent interrupt if none remain."""
+        interrupt_state = self._agent._interrupt_state
+        input_tasks = [task for task in await self._manager.list() if task["status"] == "input_required"]
+        task_interrupt_ids = {interrupt["id"] for task in input_tasks for interrupt in task.get("interrupts", [])}
+        for task in input_tasks:
+            interrupt_ids = {interrupt["id"] for interrupt in task.get("interrupts", [])}
+            task_responses = [
+                content["interruptResponse"]
+                for content in responses
+                if content["interruptResponse"]["interruptId"] in interrupt_ids
+            ]
+            if task_responses:
+                await self._manager.resume(task["task_id"], task_responses)
+        if all(interrupt_id in task_interrupt_ids for interrupt_id in interrupt_state.interrupts):
+            interrupt_state.deactivate()
 
     async def _after_invocation(self, event: AfterInvocationEvent) -> None:
         if self._agent._interrupt_state.activated:

--- a/strands-py/src/strands/background_tasks/_background_tasks.py
+++ b/strands-py/src/strands/background_tasks/_background_tasks.py
@@ -83,16 +83,23 @@ class _BackgroundTasks(Plugin):
         """Validate exact policies, then attach the task manager, middleware, and lifecycle hooks.
 
         Raises:
-            TypeError: If an explicitly configured tool cannot honor its execution mode.
+            TypeError: If a tool declares the reserved ``_background_execution`` parameter or an explicitly
+                configured tool cannot honor its execution mode. Every violation is reported in the one message.
         """
         self._agent = agent
+        errors: list[str] = []
         for tool_instance in agent.tool_registry.registry.values():
+            if _declares_background_property(tool_instance.tool_spec):
+                errors.append(f"Tool '{tool_instance.tool_name}' declares reserved parameter '{_BACKGROUND_PROPERTY}'")
+                continue
             policy = self._policy_for(tool_instance)
             if policy is None or not policy.exact or policy.mode == "never":
                 continue
             rejection = self._rejection_reason(tool_instance, policy.mode)
             if rejection is not None:
-                raise TypeError(f"Tool '{tool_instance.tool_name}' {rejection}")
+                errors.append(f"Tool '{tool_instance.tool_name}' {rejection}")
+        if errors:
+            raise TypeError("; ".join(errors))
 
         async def execute_tool(
             selected_tool: AgentTool,
@@ -261,17 +268,14 @@ class _BackgroundTasks(Plugin):
     async def _transform_tool_specs(self, context: InvokeModelContext) -> InvokeModelContext:
         transformed: list[ToolSpec] = []
         for spec in context.tool_specs:
+            if _declares_background_property(spec):
+                raise TypeError(f"Tool '{spec['name']}' declares reserved parameter '{_BACKGROUND_PROPERTY}'")
             tool_instance = _lookup_tool(context.agent, spec["name"])
             policy = self._policy_for(tool_instance)
             if policy is None or policy.mode != "agentic":
                 transformed.append(spec)
                 continue
-            if not self._supports_background_execution(tool_instance):
-                if policy.exact:
-                    raise TypeError(f"Tool '{spec['name']}' cannot use agentic background selection")
-                transformed.append(spec)
-                continue
-            selectable = _add_background_selection(spec)
+            selectable = _add_background_selection(spec) if self._supports_background_execution(tool_instance) else None
             if selectable is None and policy.exact:
                 raise TypeError(f"Tool '{spec['name']}' cannot use agentic background selection")
             transformed.append(selectable or spec)
@@ -478,6 +482,15 @@ def _resolve_policy(config: BackgroundTasksConfig) -> dict[str, _BackgroundMode]
     return policy
 
 
+def _declares_background_property(tool_spec: ToolSpec) -> bool:
+    """Whether the tool's own schema uses the reserved ``_background_execution`` name."""
+    schema = tool_spec.get("inputSchema", {}).get("json", {})
+    properties = schema.get("properties")
+    return (isinstance(properties, dict) and _BACKGROUND_PROPERTY in properties) or (
+        _BACKGROUND_PROPERTY in schema.get("required", [])
+    )
+
+
 def _add_background_selection(tool_spec: ToolSpec) -> ToolSpec | None:
     """Return a copy of the spec with the ``_background_execution`` flag, or None if the schema cannot take it."""
     schema = tool_spec.get("inputSchema", {}).get("json", {})
@@ -486,8 +499,6 @@ def _add_background_selection(tool_spec: ToolSpec) -> ToolSpec | None:
         _COMPOSITE_SCHEMA_KEYS.intersection(schema)
         or schema.get("type") not in (None, "object")
         or (properties is not None and not isinstance(properties, dict))
-        or (isinstance(properties, dict) and _BACKGROUND_PROPERTY in properties)
-        or _BACKGROUND_PROPERTY in schema.get("required", [])
     ):
         return None
     selectable = copy.deepcopy(tool_spec)

--- a/strands-py/src/strands/background_tasks/_background_tasks.py
+++ b/strands-py/src/strands/background_tasks/_background_tasks.py
@@ -90,10 +90,9 @@ class _BackgroundTasks(Plugin):
             policy = self._policy_for(tool_instance)
             if policy is None or not policy.exact or policy.mode == "never":
                 continue
-            if not _can_execute_in_background(tool_instance):
-                raise TypeError(f"Tool '{tool_instance.tool_name}' cannot run in the background")
-            if policy.mode == "agentic" and not _can_select_background(tool_instance):
-                raise TypeError(f"Tool '{tool_instance.tool_name}' cannot use agentic background selection")
+            rejection = self._rejection_reason(tool_instance, policy.mode)
+            if rejection is not None:
+                raise TypeError(f"Tool '{tool_instance.tool_name}' {rejection}")
 
         async def execute_tool(
             selected_tool: AgentTool,
@@ -179,18 +178,9 @@ class _BackgroundTasks(Plugin):
         policy = self._policy_for(effective_tool)
         if policy is None or policy.mode == "never":
             return None
-        if not _can_execute_in_background(effective_tool):
-            return (
-                _tool_error(tool_use, f"Tool '{tool_use['name']}' cannot run in the background")
-                if policy.exact
-                else None
-            )
-        if policy.mode == "agentic" and not _can_select_background(effective_tool):
-            return (
-                _tool_error(tool_use, f"Tool '{tool_use['name']}' cannot use agentic background selection")
-                if policy.exact
-                else None
-            )
+        rejection = self._rejection_reason(effective_tool, policy.mode)
+        if rejection is not None:
+            return _tool_error(tool_use, f"Tool '{tool_use['name']}' {rejection}") if policy.exact else None
         return True if policy.mode == "always" or selected else None
 
     async def submit_tool_call(
@@ -228,8 +218,7 @@ class _BackgroundTasks(Plugin):
         Raises:
             RuntimeError: If the tool is unknown, foreground-only, or configured as ``never``.
         """
-        policy = self._policy_for(tool_instance)
-        if not _can_execute_in_background(tool_instance) or policy is None or policy.mode == "never":
+        if not self._supports_background_execution(tool_instance):
             raise RuntimeError("Tool cannot run in the background")
 
     def assert_can_load_snapshot(self) -> None:
@@ -277,7 +266,7 @@ class _BackgroundTasks(Plugin):
             if policy is None or policy.mode != "agentic":
                 transformed.append(spec)
                 continue
-            if not _can_execute_in_background(tool_instance):
+            if not self._supports_background_execution(tool_instance):
                 if policy.exact:
                     raise TypeError(f"Tool '{spec['name']}' cannot use agentic background selection")
                 transformed.append(spec)
@@ -433,6 +422,25 @@ class _BackgroundTasks(Plugin):
         wildcard = self._policy.get("*")
         return _Policy(mode=wildcard, exact=False) if wildcard is not None else None
 
+    def _rejection_reason(self, tool_instance: AgentTool | None, mode: _BackgroundMode) -> str | None:
+        """Return why the tool cannot honor ``mode``, or None if it can."""
+        if not self._supports_background_execution(tool_instance):
+            return "cannot run in the background"
+        if mode == "agentic" and _add_background_selection(tool_instance.tool_spec) is None:
+            return "cannot use agentic background selection"
+        return None
+
+    def _supports_background_execution(self, tool_instance: AgentTool | None) -> TypeGuard[AgentTool]:
+        policy = self._policy_for(tool_instance)
+        return (
+            tool_instance is not None
+            and policy is not None
+            and policy.mode != "never"
+            and tool_instance.tool_name not in _FOREGROUND_TOOL_NAMES
+            and tool_instance.tool_type != "structured_output"
+            and not (isinstance(tool_instance, _AgentAsTool) and tool_instance.delegate)
+        )
+
     def _store_task(self, task: BackgroundTask) -> None:
         with self._tasks_lock:
             self._tasks[task["task_id"]] = task
@@ -468,19 +476,6 @@ def _resolve_policy(config: BackgroundTasksConfig) -> dict[str, _BackgroundMode]
                 raise TypeError(f"Tool '{name}' cannot be configured as both '{existing}' and '{mode}'")
             policy[name] = mode
     return policy
-
-
-def _can_execute_in_background(tool_instance: AgentTool | None) -> TypeGuard[AgentTool]:
-    return (
-        tool_instance is not None
-        and tool_instance.tool_name not in _FOREGROUND_TOOL_NAMES
-        and tool_instance.tool_type != "structured_output"
-        and not (isinstance(tool_instance, _AgentAsTool) and tool_instance.delegate)
-    )
-
-
-def _can_select_background(tool_instance: AgentTool) -> bool:
-    return _add_background_selection(tool_instance.tool_spec) is not None
 
 
 def _add_background_selection(tool_spec: ToolSpec) -> ToolSpec | None:

--- a/strands-py/src/strands/background_tasks/_types.py
+++ b/strands-py/src/strands/background_tasks/_types.py
@@ -1,12 +1,35 @@
-"""Internal background task snapshots."""
+"""Background task configuration and internal task snapshots."""
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Literal, TypeAlias
 
 from typing_extensions import NotRequired, TypedDict
 
-from strands.types.tools import ToolResultContent
+from strands.types.tools import AgentTool, ToolResultContent
+
+
+class BackgroundTasksConfig(TypedDict, total=False):
+    """Configure background tool execution.
+
+    Attributes:
+        wait_for_completion: Wait for background work before an invocation returns. Defaults to True.
+        agentic: Tools or registered tool names whose execution mode is selected by the model.
+            Defaults to ``["*"]``.
+        always: Tools or registered tool names that always execute in the background.
+        never: Tools or registered tool names that never execute in the background.
+        max_concurrency: Maximum number of physically executing background tasks. Defaults to 4.
+        timeout: Per-execution timeout in seconds. Defaults to infinity.
+    """
+
+    wait_for_completion: bool
+    agentic: Sequence[AgentTool | str]
+    always: Sequence[AgentTool | str]
+    never: Sequence[AgentTool | str]
+    max_concurrency: int
+    timeout: float
+
 
 BackgroundTaskStatus: TypeAlias = Literal[
     "queued",

--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -20,7 +20,7 @@ from .._middleware.stages import InvokeModelContext, InvokeModelStage
 from ..agent import _continuation
 from ..experimental.checkpoint import Checkpoint, CheckpointPosition
 from ..hooks import AfterModelCallEvent, AfterToolsEvent, BeforeModelCallEvent, BeforeToolsEvent
-from ..interrupt import PendingToolExecution
+from ..interrupt import InterruptException, PendingToolExecution
 from ..telemetry.metrics import Trace, _total_prompt_tokens
 from ..telemetry.tracer import Tracer, get_tracer
 from ..tools._validator import validate_and_prepare_tools
@@ -395,6 +395,7 @@ async def event_loop_cycle(
             EventLoopException,
             ContextWindowOverflowException,
             MaxTokensReachedException,
+            InterruptException,
         ) as e:
             # These exceptions should bubble up directly rather than get wrapped in an EventLoopException
             tracer.end_span_with_error(cycle_span, str(e), e)
@@ -452,6 +453,19 @@ async def recurse_event_loop(
     recursive_trace.end()
 
 
+async def _invoke_before_model_call_hooks(agent: "Agent", event: BeforeModelCallEvent) -> BeforeModelCallEvent:
+    """Run BeforeModelCallEvent hooks, raising any interrupt they registered.
+
+    No tool execution is pending at this point, so resuming re-enters the same model call.
+    """
+    event, interrupts = await agent.hooks.invoke_callbacks_async(event)
+    if not interrupts:
+        return event
+    for interrupt in interrupts:
+        agent._interrupt_state.interrupts.setdefault(interrupt.id, interrupt)
+    raise InterruptException(interrupts[0])
+
+
 async def _handle_model_execution(
     agent: "Agent",
     cycle_span: Any,
@@ -502,7 +516,7 @@ async def _handle_model_execution(
             )
             model_continuation: Messages | None = None
             try:
-                await agent.hooks.invoke_callbacks_async(before_model_call_event)
+                before_model_call_event = await _invoke_before_model_call_hooks(agent, before_model_call_event)
                 model_continuation = await _continuation.prepare(
                     before_model_call_event,
                     agent._convert_prompt_to_messages,
@@ -645,6 +659,8 @@ async def _handle_model_execution(
 
             break  # Success! Break out of retry loop
 
+        except InterruptException:
+            raise
         except Exception as e:
             after_model_call_event = AfterModelCallEvent(
                 agent=agent,

--- a/strands-py/src/strands/tools/decorator.py
+++ b/strands-py/src/strands/tools/decorator.py
@@ -395,7 +395,11 @@ class FunctionToolMetadata:
             raise ValueError(f"Validation failed for input parameters: {error_msg}") from e
 
     def inject_special_parameters(
-        self, validated_input: dict[str, Any], tool_use: ToolUse, invocation_state: dict[str, Any]
+        self,
+        validated_input: dict[str, Any],
+        tool_use: ToolUse,
+        invocation_state: dict[str, Any],
+        tool_context: ToolContext | None = None,
     ) -> None:
         """Inject special framework-provided parameters into the validated input.
 
@@ -407,17 +411,20 @@ class FunctionToolMetadata:
             tool_use: The tool use request containing tool invocation details.
             invocation_state: Caller-provided kwargs that were passed to the agent when it was invoked (agent(),
                               agent.invoke_async(), etc.).
+            tool_context: Framework-supplied context to inject as-is (e.g. a background task's context);
+                          when omitted, one is derived from ``invocation_state``.
         """
         if self._context_param and self._context_param in self.signature.parameters:
-            agent = invocation_state["agent"]
-            tool_context = ToolContext(
-                tool_use=tool_use,
-                agent=agent,
-                invocation_state=invocation_state,
-                # A BidiAgent has no cancellation signal; fall back to an inert event so tool
-                # authors never have to guard the field.
-                cancel_signal=getattr(agent, "cancel_signal", threading.Event()),
-            )
+            if tool_context is None:
+                agent = invocation_state["agent"]
+                tool_context = ToolContext(
+                    tool_use=tool_use,
+                    agent=agent,
+                    invocation_state=invocation_state,
+                    # A BidiAgent has no cancellation signal; fall back to an inert event so tool
+                    # authors never have to guard the field.
+                    cancel_signal=getattr(agent, "cancel_signal", threading.Event()),
+                )
             validated_input[self._context_param] = tool_context
 
         # Inject agent if requested (backward compatibility)
@@ -617,13 +624,14 @@ class DecoratedFunctionTool(AgentTool, Generic[P, R]):
         # This is a tool use call - process accordingly
         tool_use_id = tool_use.get("toolUseId", "unknown")
         tool_input: dict[str, Any] = tool_use.get("input", {})
+        tool_context = cast(ToolContext | None, kwargs.get("_tool_context"))
 
         try:
             # Validate input against the Pydantic model
             validated_input = self._metadata.validate_input(tool_input)
 
             # Inject special framework-provided parameters
-            self._metadata.inject_special_parameters(validated_input, tool_use, invocation_state)
+            self._metadata.inject_special_parameters(validated_input, tool_use, invocation_state, tool_context)
 
             # Note: "Too few arguments" expected for the _tool_func calls, hence the type ignore
 

--- a/strands-py/src/strands/tools/executors/_executor.py
+++ b/strands-py/src/strands/tools/executors/_executor.py
@@ -8,24 +8,27 @@ import abc
 import logging
 import threading
 import time
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Callable
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, cast
 
 from opentelemetry import trace as trace_api
 
-from ..._middleware.stages import ExecuteToolContext, ExecuteToolStage
+from ..._middleware.stages import ExecuteToolContext, ExecuteToolStage, MiddlewareInterruptResult
 from ...hooks import AfterToolCallEvent, BeforeToolCallEvent
 from ...interrupt import InterruptException
 from ...telemetry.metrics import Trace
 from ...telemetry.tracer import get_tracer, serialize
 from ...types._events import ToolCancelEvent, ToolInterruptEvent, ToolResultEvent, ToolStreamEvent, TypedEvent
 from ...types.agent import LocalAgent
-from ...types.content import Message
-from ...types.tools import ToolChoice, ToolChoiceAuto, ToolConfig, ToolResult, ToolUse
+from ...types.content import Message, _ensure_tracking_id
+from ...types.tools import AgentTool, ToolChoice, ToolChoiceAuto, ToolConfig, ToolContext, ToolResult, ToolUse
 from ..structured_output._structured_output_context import StructuredOutputContext
 
 if TYPE_CHECKING:  # pragma: no cover
     from ...agent import Agent
+    from ...background_tasks._background_tasks import _BackgroundTasks
+    from ...background_tasks.in_process._manager import _MiddlewareInterrupt
     from ...experimental.bidi import BidiAgent
 
 logger = logging.getLogger(__name__)
@@ -58,6 +61,86 @@ class ToolExecutor(abc.ABC):
         if not ToolExecutor._is_agent(agent):
             return True
         return not cast("Agent", agent)._observe_cancellation()
+
+    async def _execute_background(
+        self,
+        agent: "Agent",
+        selected_tool: AgentTool,
+        context: ToolContext[LocalAgent],
+        middleware_interrupt: "_MiddlewareInterrupt",
+        tool_guard: Callable[[AgentTool | None], None],
+    ) -> ToolResult:
+        """Execute one admitted background tool call through middleware and after-call hooks.
+
+        BeforeToolCallEvent already fired at admission, so only the ExecuteToolStage chain and
+        AfterToolCallEvent run here. Stream events reach the callback handler; the result is
+        returned to the task manager rather than yielded.
+
+        Args:
+            agent: The agent that admitted the tool call.
+            selected_tool: The tool to execute.
+            context: Task-scoped tool context carrying the task's cancel signal and interrupt state.
+            middleware_interrupt: Task-scoped ``interrupt()`` for ExecuteToolStage middleware.
+            tool_guard: Rejects a middleware-substituted tool that cannot run in the background.
+
+        Returns:
+            The hook-transformed tool result.
+
+        Raises:
+            InterruptException: If the tool or middleware requests input.
+        """
+        tool_use = context.tool_use
+        invocation_state = context.invocation_state
+        tracer = get_tracer()
+        while True:
+            tool_start_time = time.monotonic()
+            middleware_context = _BackgroundExecuteToolContext(
+                agent=agent,
+                tool=selected_tool,
+                tool_use=dict(tool_use),  # type: ignore[arg-type]
+                invocation_state=invocation_state,
+                cancel_signal=context.cancel_signal,
+                _interrupt_state=agent._interrupt_state,
+                _background_interrupt=middleware_interrupt,
+            )
+            result_event: ToolResultEvent | None = None
+            tool_call_span = tracer.start_tool_call_span(tool_use, custom_trace_attributes=agent.trace_attributes)
+            with trace_api.use_span(tool_call_span):
+                async for event in agent._middleware_registry.invoke(
+                    ExecuteToolStage,
+                    middleware_context,
+                    _make_execute_tool_terminal({}, tool_context=context, tool_guard=tool_guard),
+                ):
+                    if isinstance(event, ToolInterruptEvent):
+                        tracer.end_tool_call_span(tool_call_span, tool_result=None)
+                        raise InterruptException(event.interrupts[0])
+                    if isinstance(event, ToolResultEvent):
+                        result_event = event
+                    elif event.is_callback_event:
+                        event.prepare(invocation_state=invocation_state)
+                        agent.callback_handler(**event.as_dict())
+
+            if result_event is None:
+                raise RuntimeError(
+                    "ExecuteToolStage middleware chain did not yield a ToolResultEvent. "
+                    "Ensure middleware forwards events from next()."
+                )
+            tracer.end_tool_call_span(tool_call_span, result_event.tool_result, error=result_event.exception)
+            after_event, _ = await agent.hooks.invoke_callbacks_async(
+                AfterToolCallEvent[LocalAgent](
+                    agent=agent,
+                    selected_tool=selected_tool,
+                    tool_use=tool_use,
+                    invocation_state=invocation_state,
+                    result=result_event.tool_result,
+                    exception=result_event.exception,
+                    duration=time.monotonic() - tool_start_time,
+                )
+            )
+            if after_event.retry and not context.cancel_signal.is_set():
+                logger.debug("tool_name=<%s> | retry requested, retrying background tool call", tool_use["name"])
+                continue
+            return after_event.result
 
     @staticmethod
     async def _stream(
@@ -93,8 +176,7 @@ class ToolExecutor(abc.ABC):
         tool_name = tool_use["name"]
         structured_output_context = structured_output_context or StructuredOutputContext()
 
-        tool_info = agent.tool_registry.dynamic_tools.get(tool_name)
-        tool_func = tool_info if tool_info is not None else agent.tool_registry.registry.get(tool_name)
+        tool_func = _lookup_tool(agent, tool_name)
         tool_spec = tool_func.tool_spec if tool_func is not None else None
 
         current_span = trace_api.get_current_span()
@@ -120,6 +202,7 @@ class ToolExecutor(abc.ABC):
         # A BidiAgent has no cancellation signal; an inert event keeps the middleware and tool
         # contracts non-optional.
         cancel_signal = cast("Agent", agent).cancel_signal if ToolExecutor._is_agent(agent) else threading.Event()
+        background_tasks: _BackgroundTasks | None = getattr(agent, "_background_tasks", None)
 
         # Retry loop for tool execution - hooks can set after_event.retry = True to retry
         while True:
@@ -168,6 +251,27 @@ class ToolExecutor(abc.ABC):
                 tool_use = before_event.tool_use
                 invocation_state = before_event.invocation_state
 
+                if selected_tool is tool_func and tool_use["name"] != tool_name:
+                    selected_tool = _lookup_tool(agent, tool_use["name"])
+
+                tool_use, route = _route_background(
+                    background_tasks, tool_use, tool_func, selected_tool, invocation_state
+                )
+                if route is True:
+                    assert background_tasks is not None
+                    # No AfterToolCallEvent for the dispatch acknowledgement; the background
+                    # run emits it when the tool actually executes.
+                    # Keyed by the assistant message that requested the tool, so a resubmission of the
+                    # same request within that message returns the existing task.
+                    pass_id = _ensure_tracking_id(agent.messages[-1])
+                    result = await background_tasks.submit_tool_call(
+                        tool_use, invocation_state, pass_id, cast(AgentTool, selected_tool)
+                    )
+                    yield ToolResultEvent(result)
+                    tool_results.append(result)
+                    return
+                admission_error = route
+
                 if not selected_tool:
                     # Unknown tool: log here, but do NOT short-circuit. The middleware chain
                     # still runs with ctx.tool = None (matching TS), so middleware can observe
@@ -208,7 +312,7 @@ class ToolExecutor(abc.ABC):
                 async for event in agent._middleware_registry.invoke(
                     ExecuteToolStage,
                     middleware_context,
-                    _make_execute_tool_terminal(kwargs),
+                    _make_execute_tool_terminal(kwargs, admission_error),
                 ):
                     # Tool-originated interrupt: a ToolInterruptEvent yielded from tool.stream()
                     # (including sub-agent interrupts propagated via _AgentAsTool). Distinct from
@@ -392,8 +496,43 @@ class ToolExecutor(abc.ABC):
         pass
 
 
+def _route_background(
+    background_tasks: "_BackgroundTasks | None",
+    tool_use: ToolUse,
+    requested_tool: AgentTool | None,
+    selected_tool: AgentTool | None,
+    invocation_state: dict[str, Any],
+) -> tuple[ToolUse, "bool | ToolResult | None"]:
+    """Decide whether a tool call runs in the background.
+
+    Returns the tool use to execute and either True (dispatch), an admission error result, or None
+    (run in the foreground). Only model-driven calls carry a cycle id; direct tool calls always run
+    inline.
+    """
+    if background_tasks is None or "event_loop_cycle_id" not in invocation_state:
+        return tool_use, None
+    # Routing strips the selection flag from the input; copy first so the assistant message in
+    # history keeps the model's original request.
+    tool_use = cast(ToolUse, dict(tool_use))
+    return tool_use, background_tasks.route_tool_call(tool_use, requested_tool, selected_tool)
+
+
+def _lookup_tool(agent: "Agent | BidiAgent", tool_name: str) -> AgentTool | None:
+    """Resolve a tool by name, preferring dynamic tools over the static registry.
+
+    Also used after BeforeToolCallEvent: a hook that renames ``tool_use`` without selecting a
+    tool runs the tool registered under the new name, so routing and AfterToolCallEvent see it.
+    """
+    dynamic_tool = agent.tool_registry.dynamic_tools.get(tool_name)
+    return dynamic_tool if dynamic_tool is not None else agent.tool_registry.registry.get(tool_name)
+
+
 def _make_execute_tool_terminal(
     extra_kwargs: dict[str, Any],
+    preset_result: ToolResult | None = None,
+    *,
+    tool_context: ToolContext[LocalAgent] | None = None,
+    tool_guard: Callable[[AgentTool | None], None] | None = None,
 ) -> "Any":
     """Build the terminal for the ExecuteToolStage middleware chain.
 
@@ -414,6 +553,11 @@ def _make_execute_tool_terminal(
 
     Args:
         extra_kwargs: Extra keyword arguments forwarded to ``tool.stream()``.
+        preset_result: Error result yielded in place of running the tool, so middleware and the
+            after-hook still observe a rejected call.
+        tool_context: Task-scoped context handed to the tool instead of the one it would derive
+            from ``invocation_state`` (background execution only).
+        tool_guard: Validates the tool the middleware chain settled on before it runs.
 
     Returns:
         An async generator function suitable as a middleware terminal.
@@ -421,6 +565,13 @@ def _make_execute_tool_terminal(
 
     async def terminal(ctx: ExecuteToolContext) -> AsyncGenerator[TypedEvent, None]:
         tool_use = ctx.tool_use
+
+        if tool_guard is not None:
+            tool_guard(ctx.tool)
+
+        if preset_result is not None:
+            yield ToolResultEvent(preset_result, exception=ValueError(preset_result["content"][0]["text"]))
+            return
 
         # Unknown tool (not in the registry): the chain still ran so middleware could observe
         # or mock it, but with no tool to invoke the terminal yields the error result. The
@@ -442,8 +593,9 @@ def _make_execute_tool_terminal(
         # we wrap in ToolStreamEvent, and their last raw value is the result.
         yielded_any = False
         last_raw_event: Any = None
+        stream_kwargs = {**extra_kwargs, "_tool_context": tool_context} if tool_context is not None else extra_kwargs
         try:
-            async for event in ctx.tool.stream(tool_use, ctx.invocation_state, **extra_kwargs):
+            async for event in ctx.tool.stream(tool_use, ctx.invocation_state, **stream_kwargs):
                 if isinstance(event, ToolInterruptEvent):
                     yield event
                     return
@@ -493,3 +645,18 @@ def _make_execute_tool_terminal(
         yield ToolResultEvent(cast(ToolResult, last_raw_event))
 
     return terminal
+
+
+@dataclass
+class _BackgroundExecuteToolContext(ExecuteToolContext):
+    """ExecuteToolStage context for a background task.
+
+    ``interrupt()`` resolves against the task's own interrupt state, which the task manager
+    persists with the task, rather than the agent's live interrupt state.
+    """
+
+    _background_interrupt: "_MiddlewareInterrupt" = field(repr=False)
+
+    def interrupt(self, name: str, *, reason: Any = None, response: Any = None) -> MiddlewareInterruptResult:
+        """Request task-scoped human-in-the-loop input."""
+        return self._background_interrupt(name, reason=reason, response=response)

--- a/strands-py/src/strands/tools/executors/_executor.py
+++ b/strands-py/src/strands/tools/executors/_executor.py
@@ -275,7 +275,7 @@ class ToolExecutor(abc.ABC):
                     result = await background_tasks.submit_tool_call(
                         tool_use, invocation_state, pass_id, cast(AgentTool, selected_tool)
                     )
-                    yield ToolResultEvent(result, background_dispatch=True)
+                    yield ToolResultEvent(result, backgrounded=True)
                     tool_results.append(result)
                     return
                 admission_error = route
@@ -469,10 +469,14 @@ class ToolExecutor(abc.ABC):
             tool_success = result.get("status") == "success"
             tool_duration = time.time() - tool_start_time
             message = Message(role="user", content=[{"toolResult": result}])
-            # A background dispatch acknowledgement is not the tool running; the run records its own metrics.
-            if ToolExecutor._is_agent(agent) and not result_event.background_dispatch:
-                agent.event_loop_metrics.add_tool_usage(tool_use, tool_duration, tool_trace, tool_success, message)
-            cycle_trace.add_child(tool_trace)
+            # A background dispatch acknowledgement is not the tool running; the run records its own
+            # metrics and trace, so the ack only marks its span.
+            if result_event.backgrounded:
+                tool_call_span.set_attribute("strands.tool.backgrounded", True)
+            else:
+                if ToolExecutor._is_agent(agent):
+                    agent.event_loop_metrics.add_tool_usage(tool_use, tool_duration, tool_trace, tool_success, message)
+                cycle_trace.add_child(tool_trace)
 
             tracer.end_tool_call_span(tool_call_span, result, error=result_event.exception)
 

--- a/strands-py/src/strands/tools/executors/_executor.py
+++ b/strands-py/src/strands/tools/executors/_executor.py
@@ -10,7 +10,7 @@ import threading
 import time
 from collections.abc import AsyncGenerator, Callable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from opentelemetry import trace as trace_api
 
@@ -502,7 +502,7 @@ def _route_background(
     requested_tool: AgentTool | None,
     selected_tool: AgentTool | None,
     invocation_state: dict[str, Any],
-) -> tuple[ToolUse, "bool | ToolResult | None"]:
+) -> tuple[ToolUse, "Literal[True] | ToolResult | None"]:
     """Decide whether a tool call runs in the background.
 
     Returns the tool use to execute and either True (dispatch), an admission error result, or None

--- a/strands-py/src/strands/tools/executors/_executor.py
+++ b/strands-py/src/strands/tools/executors/_executor.py
@@ -126,6 +126,14 @@ class ToolExecutor(abc.ABC):
                     "Ensure middleware forwards events from next()."
                 )
             tracer.end_tool_call_span(tool_call_span, result_event.tool_result, error=result_event.exception)
+            # The cycle that dispatched this call has already ended, so the trace has no parent.
+            agent.event_loop_metrics.add_tool_usage(
+                tool_use,
+                time.monotonic() - tool_start_time,
+                Trace(f"Tool: {tool_use['name']}", raw_name=tool_use["name"]),
+                result_event.tool_result.get("status") == "success",
+                Message(role="user", content=[{"toolResult": result_event.tool_result}]),
+            )
             after_event, _ = await agent.hooks.invoke_callbacks_async(
                 AfterToolCallEvent[LocalAgent](
                     agent=agent,
@@ -267,7 +275,7 @@ class ToolExecutor(abc.ABC):
                     result = await background_tasks.submit_tool_call(
                         tool_use, invocation_state, pass_id, cast(AgentTool, selected_tool)
                     )
-                    yield ToolResultEvent(result)
+                    yield ToolResultEvent(result, background_dispatch=True)
                     tool_results.append(result)
                     return
                 admission_error = route
@@ -461,7 +469,8 @@ class ToolExecutor(abc.ABC):
             tool_success = result.get("status") == "success"
             tool_duration = time.time() - tool_start_time
             message = Message(role="user", content=[{"toolResult": result}])
-            if ToolExecutor._is_agent(agent):
+            # A background dispatch acknowledgement is not the tool running; the run records its own metrics.
+            if ToolExecutor._is_agent(agent) and not result_event.background_dispatch:
                 agent.event_loop_metrics.add_tool_usage(tool_use, tool_duration, tool_trace, tool_success, message)
             cycle_trace.add_child(tool_trace)
 

--- a/strands-py/src/strands/types/_events.py
+++ b/strands-py/src/strands/types/_events.py
@@ -283,17 +283,17 @@ class ToolResultEvent(TypedEvent):
     """Event emitted when a tool execution completes."""
 
     def __init__(
-        self, tool_result: ToolResult, exception: Exception | None = None, *, background_dispatch: bool = False
+        self, tool_result: ToolResult, exception: Exception | None = None, *, backgrounded: bool = False
     ) -> None:
         """Initialize tool result event."""
         super().__init__({"type": "tool_result", "tool_result": tool_result})
         self._exception = exception
-        self._background_dispatch = background_dispatch
+        self._backgrounded = backgrounded
 
     @property
-    def background_dispatch(self) -> bool:
+    def backgrounded(self) -> bool:
         """Whether this result only acknowledges that the tool was dispatched to the background."""
-        return self._background_dispatch
+        return self._backgrounded
 
     @property
     def exception(self) -> Exception | None:

--- a/strands-py/src/strands/types/_events.py
+++ b/strands-py/src/strands/types/_events.py
@@ -282,10 +282,18 @@ class EventLoopThrottleEvent(TypedEvent):
 class ToolResultEvent(TypedEvent):
     """Event emitted when a tool execution completes."""
 
-    def __init__(self, tool_result: ToolResult, exception: Exception | None = None) -> None:
+    def __init__(
+        self, tool_result: ToolResult, exception: Exception | None = None, *, background_dispatch: bool = False
+    ) -> None:
         """Initialize tool result event."""
         super().__init__({"type": "tool_result", "tool_result": tool_result})
         self._exception = exception
+        self._background_dispatch = background_dispatch
+
+    @property
+    def background_dispatch(self) -> bool:
+        """Whether this result only acknowledges that the tool was dispatched to the background."""
+        return self._background_dispatch
 
     @property
     def exception(self) -> Exception | None:

--- a/strands-py/src/strands/types/json_dict.py
+++ b/strands-py/src/strands/types/json_dict.py
@@ -80,6 +80,16 @@ class JSONSerializableDict:
         with self._lock:
             return self._version
 
+    def __getstate__(self) -> dict[str, Any]:
+        """Exclude the lock so the store stays picklable and deep-copyable."""
+        with self._lock:
+            return {name: value for name, value in self.__dict__.items() if name != "_lock"}
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        """Restore the store with a fresh lock."""
+        self.__dict__.update(state)
+        self._lock = threading.RLock()
+
     def _validate_key(self, key: str) -> None:
         """Validate that a key is valid.
 

--- a/strands-py/src/strands/types/json_dict.py
+++ b/strands-py/src/strands/types/json_dict.py
@@ -2,6 +2,7 @@
 
 import copy
 import json
+import threading
 from typing import Any
 
 
@@ -14,6 +15,8 @@ class JSONSerializableDict:
 
     def __init__(self, initial_state: dict[str, Any] | None = None):
         """Initialize JSONSerializableDict."""
+        # Background tasks persist snapshots from another thread while the agent loop reads.
+        self._lock = threading.RLock()
         self._data: dict[str, Any]
         self._version: int = 0
         if initial_state:
@@ -34,8 +37,10 @@ class JSONSerializableDict:
         """
         self._validate_key(key)
         self._validate_json_serializable(value)
-        self._data[key] = copy.deepcopy(value)
-        self._version += 1
+        stored = copy.deepcopy(value)
+        with self._lock:
+            self._data[key] = stored
+            self._version += 1
 
     def get(self, key: str | None = None) -> Any:
         """Get a value or entire data.
@@ -46,9 +51,9 @@ class JSONSerializableDict:
         Returns:
             The stored value, entire data dict, or None if not found
         """
-        if key is None:
-            return copy.deepcopy(self._data)
-        else:
+        with self._lock:
+            if key is None:
+                return copy.deepcopy(self._data)
             return copy.deepcopy(self._data.get(key))
 
     def delete(self, key: str) -> None:
@@ -58,8 +63,9 @@ class JSONSerializableDict:
             key: The key to delete
         """
         self._validate_key(key)
-        self._data.pop(key, None)
-        self._version += 1
+        with self._lock:
+            self._data.pop(key, None)
+            self._version += 1
 
     def _get_version(self) -> int:
         """Get the current version number of the store.
@@ -71,7 +77,8 @@ class JSONSerializableDict:
         Returns:
             The current version number.
         """
-        return self._version
+        with self._lock:
+            return self._version
 
     def _validate_key(self, key: str) -> None:
         """Validate that a key is valid.

--- a/strands-py/tests/strands/agent/test_agent_delegation.py
+++ b/strands-py/tests/strands/agent/test_agent_delegation.py
@@ -406,6 +406,46 @@ async def test_full_delegation_routes_to_specialist():
 
 
 @pytest.mark.asyncio
+async def test_full_delegation_delegate_tool_stays_foreground_with_background_tasks():
+    tech_support = Agent(
+        model=MockedModelProvider([{"role": "assistant", "content": [{"text": "Try rebooting your router."}]}]),
+        name="TechSupport",
+        callback_handler=None,
+    )
+    orchestrator = Agent(
+        model=MockedModelProvider(
+            [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "toolUse": {
+                                "toolUseId": "call-1",
+                                "name": "TechSupport",
+                                "input": {"input": "My wifi does not work", "_background_execution": True},
+                            }
+                        }
+                    ],
+                }
+            ]
+        ),
+        name="Orchestrator",
+        tools=[tech_support.as_tool(delegate=True)],
+        background_tasks={},
+        callback_handler=None,
+    )
+
+    result = await orchestrator.invoke_async("My wifi does not work")
+
+    tru_stop_reason = result.stop_reason
+    exp_stop_reason = "end_turn"
+    assert tru_stop_reason == exp_stop_reason
+    tru_text = [block["text"] for block in result.message["content"] if "text" in block]
+    exp_text = ["Try rebooting your router."]
+    assert tru_text == exp_text
+
+
+@pytest.mark.asyncio
 async def test_full_delegation_error_recovery():
     err = _mock_sub_agent("failing")
 

--- a/strands-py/tests/strands/agent/test_agent_hooks.py
+++ b/strands-py/tests/strands/agent/test_agent_hooks.py
@@ -15,6 +15,7 @@ from strands.hooks import (
     BeforeToolCallEvent,
     MessageAddedEvent,
 )
+from strands.interrupt import Interrupt, InterruptException
 from strands.types.content import Messages
 from strands.types.exceptions import ModelThrottledException
 from strands.types.tools import ToolResult, ToolUse
@@ -1117,3 +1118,31 @@ def test_hooks_param_callable_invoked_during_lifecycle():
 
     assert len(before_events) == 1
     assert isinstance(before_events[0], BeforeInvocationEvent)
+
+
+def test_before_model_call_hook_interrupt_stops_and_resumes_at_model_call():
+    interrupt = Interrupt(id="v1:model_call:approve", name="approve", reason="Approve the model call?")
+    responses_seen = []
+
+    def gate_model_call(event: BeforeModelCallEvent):
+        registered = event.agent._interrupt_state.interrupts.get(interrupt.id)
+        if registered is None or registered.response is None:
+            raise InterruptException(interrupt)
+        responses_seen.append(registered.response)
+
+    agent = Agent(
+        model=MockedModelProvider([{"role": "assistant", "content": [{"text": "Approved"}]}]),
+        callback_handler=None,
+    )
+    agent.hooks.add_callback(BeforeModelCallEvent, gate_model_call)
+
+    interrupted = agent("do something")
+    assert interrupted.stop_reason == "interrupt"
+    assert [pending.id for pending in interrupted.interrupts] == [interrupt.id]
+    assert len(agent.messages) == 1
+
+    result = agent([{"interruptResponse": {"interruptId": interrupt.id, "response": "yes"}}])
+    assert result.stop_reason == "end_turn"
+    assert result.message["content"][0]["text"] == "Approved"
+    assert responses_seen == ["yes"]
+    assert agent._interrupt_state.activated is False

--- a/strands-py/tests/strands/background_tasks/test_background_tasks.py
+++ b/strands-py/tests/strands/background_tasks/test_background_tasks.py
@@ -107,67 +107,66 @@ def _capture_tool_specs(agent: Agent) -> list[list[ToolSpec]]:
     return captured
 
 
-def test__init__disabled_by_default() -> None:
-    agent = Agent(model=MockedModelProvider([]), callback_handler=None)
-    assert _MANAGE_TOOL_NAME not in agent.tool_registry.registry
-
-
-@pytest.mark.parametrize("background_tasks", [True, {}])
-def test__init__registers_management_tool_when_enabled(background_tasks: Any) -> None:
-    agent = Agent(model=MockedModelProvider([]), background_tasks=background_tasks, callback_handler=None)
-    assert _MANAGE_TOOL_NAME in agent.tool_registry.registry
-
-
-def test__init__rejects_conflicting_tool_policies() -> None:
-    @tool(name="work")
-    def work() -> str:
-        """Perform work."""
-        return "done"
-
-    with pytest.raises(TypeError, match="Tool 'work' cannot be configured as both 'always' and 'never'"):
-        Agent(
-            model=MockedModelProvider([]),
-            tools=[work],
-            background_tasks={"always": [work], "never": [work]},
-            callback_handler=None,
-        )
-
-
-def test__init__rejects_exact_policy_on_tool_that_cannot_run_in_background() -> None:
-    @tool(name="summarize_context")
-    def incompatible() -> None:
-        """Cannot run in the background."""
-
-    with pytest.raises(TypeError, match="Tool 'summarize_context' cannot run in the background"):
-        Agent(
-            model=MockedModelProvider([]),
-            tools=[incompatible],
-            background_tasks={"always": [incompatible]},
-            callback_handler=None,
-        )
-
-
-def test__init__rejects_exact_agentic_policy_on_unselectable_tool() -> None:
-    with pytest.raises(TypeError, match="Tool 'custom' cannot use agentic background selection"):
-        Agent(
-            model=MockedModelProvider([]),
-            tools=[_unselectable_tool("custom")],
-            background_tasks={"agentic": ["custom"]},
-            callback_handler=None,
-        )
-
-
-def test__init__forwards_execution_limits_to_task_manager() -> None:
-    agent = Agent(
-        model=MockedModelProvider([]),
-        background_tasks={"max_concurrency": 2, "timeout": 5},
-        callback_handler=None,
+def _background_agent(
+    *tools: Any, responses: list[dict[str, Any]], callback_handler: Any = None, **config: Any
+) -> Agent:
+    """Build an agent whose model dispatches ``tools[0]`` to the background, then replies with ``responses``."""
+    dispatch = _assistant_tool_use(tools[0].tool_name, "work-use", {"_background_execution": True})
+    return Agent(
+        model=MockedModelProvider([dispatch, *responses]),
+        tools=list(tools),
+        background_tasks=config,
+        callback_handler=callback_handler,
     )
 
-    engine = agent._background_tasks._manager._engine
-    tru_limits = (engine._max_concurrency, engine._timeout)
-    exp_limits = (2, 5)
-    assert tru_limits == exp_limits
+
+@tool(name="work")
+def work() -> str:
+    """Perform work."""
+    return "done"
+
+
+@pytest.mark.parametrize(("background_tasks", "enabled"), [(None, False), (True, True), ({}, True)])
+def test__init__registers_management_tool_only_when_enabled(background_tasks: Any, enabled: bool) -> None:
+    agent = Agent(model=MockedModelProvider([]), background_tasks=background_tasks, callback_handler=None)
+    assert (_MANAGE_TOOL_NAME in agent.tool_registry.registry) is enabled
+
+
+@pytest.mark.parametrize(
+    ("tools", "config", "message"),
+    [
+        ([work], {"always": [work], "never": [work]}, "Tool 'work' cannot be configured as both 'always' and 'never'"),
+        (
+            [tool(name="summarize_context")(lambda: None)],
+            {"always": ["summarize_context"]},
+            "Tool 'summarize_context' cannot run in the background",
+        ),
+        (
+            [_unselectable_tool("custom")],
+            {"agentic": ["custom"]},
+            "Tool 'custom' cannot use agentic background selection",
+        ),
+    ],
+)
+def test__init__rejects_invalid_policies(tools: list[Any], config: dict[str, Any], message: str) -> None:
+    with pytest.raises(TypeError, match=message):
+        Agent(model=MockedModelProvider([]), tools=tools, background_tasks=config, callback_handler=None)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("policy", "late_tool"),
+    [
+        ("summarize_context", tool(name="summarize_context")(lambda: None)),
+        ("custom", _unselectable_tool("custom")),
+    ],
+)
+async def test_rejects_exact_agentic_policy_on_tool_registered_after_init(policy: str, late_tool: Any) -> None:
+    agent = Agent(model=MockedModelProvider([]), background_tasks={"agentic": [policy]}, callback_handler=None)
+    agent.tool_registry.register_tool(late_tool)
+
+    with pytest.raises(TypeError, match=f"Tool '{policy}' cannot use agentic background selection"):
+        await agent.invoke_async("Run.")
 
 
 @pytest.mark.asyncio
@@ -188,71 +187,34 @@ async def test_management_tool_rejects_missing_or_unknown_task(tool_input: dict[
 
 
 @pytest.mark.asyncio
-async def test_rejects_non_boolean_background_selection() -> None:
-    executions = 0
-
-    @tool(name="work")
-    def work() -> str:
-        """Perform work."""
-        nonlocal executions
-        executions += 1
-        return "done"
-
+@pytest.mark.parametrize(
+    ("tool_name", "tool_input", "message"),
+    [
+        ("work", {"_background_execution": "yes"}, "'_background_execution' must be a boolean"),
+        ("missing", {"_background_execution": True}, "Unknown tool: missing"),
+    ],
+)
+async def test_runs_rejected_selection_in_the_foreground(
+    tool_name: str, tool_input: dict[str, Any], message: str
+) -> None:
     agent = Agent(
-        model=MockedModelProvider(
-            [_assistant_tool_use("work", "work-use", {"_background_execution": "yes"}), _assistant_text("Rejected.")]
-        ),
+        model=MockedModelProvider([_assistant_tool_use(tool_name, "use", tool_input), _assistant_text("Done.")]),
         tools=[work],
         background_tasks={},
         callback_handler=None,
     )
 
-    await agent.invoke_async("Run work.")
+    await agent.invoke_async("Run.")
 
-    tru_result = _tool_result(agent, "work-use")
-    exp_result = {
-        "toolUseId": "work-use",
-        "status": "error",
-        "content": [{"text": "'_background_execution' must be a boolean"}],
-    }
+    tru_result = _tool_result(agent, "use")
+    exp_result = {"toolUseId": "use", "status": "error", "content": [{"text": message}]}
     assert tru_result == exp_result
-    assert executions == 0
-
-
-@pytest.mark.asyncio
-async def test_unknown_tool_runs_in_the_foreground() -> None:
-    agent = Agent(
-        model=MockedModelProvider(
-            [_assistant_tool_use("missing", "missing-use", {"_background_execution": True}), _assistant_text("Done.")]
-        ),
-        background_tasks={},
-        callback_handler=None,
-    )
-
-    await agent.invoke_async("Run missing.")
-
-    tru_status = _tool_result(agent, "missing-use")["status"]
-    exp_status = "error"
-    assert tru_status == exp_status
-    assert _deliveries(agent.messages) == []
     assert _persisted_tasks(agent) is None
 
 
 @pytest.mark.asyncio
 async def test_reports_admission_failure_as_tool_error() -> None:
-    @tool(name="work")
-    def work() -> str:
-        """Perform work."""
-        return "done"
-
-    agent = Agent(
-        model=MockedModelProvider(
-            [_assistant_tool_use("work", "work-use", {"_background_execution": True}), _assistant_text("Failed.")]
-        ),
-        tools=[work],
-        background_tasks={},
-        callback_handler=None,
-    )
+    agent = _background_agent(work, responses=[_assistant_text("Failed.")])
     agent._background_tasks._manager.submit = AsyncMock(side_effect=RuntimeError("runtime unavailable"))
 
     await agent.invoke_async("Run work.")
@@ -263,44 +225,17 @@ async def test_reports_admission_failure_as_tool_error() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("policy", "late_tool"),
-    [
-        ("summarize_context", tool(name="summarize_context")(lambda: None)),
-        ("custom", _unselectable_tool("custom")),
-    ],
-)
-async def test_rejects_exact_agentic_policy_on_tool_registered_after_init(policy: str, late_tool: Any) -> None:
-    agent = Agent(model=MockedModelProvider([]), background_tasks={"agentic": [policy]}, callback_handler=None)
-    agent.tool_registry.register_tool(late_tool)
-
-    with pytest.raises(TypeError, match=f"Tool '{policy}' cannot use agentic background selection"):
-        await agent.invoke_async("Run.")
-
-
-@pytest.mark.asyncio
 async def test_fails_task_when_middleware_substitutes_foreground_only_tool() -> None:
-    @tool(name="work")
-    def work() -> str:
-        """Perform work."""
-        return "done"
-
     @tool(name="foreground")
     def foreground() -> str:
         """Never runs in the background."""
         return "foreground"
 
-    agent = Agent(
-        model=MockedModelProvider(
-            [
-                _assistant_tool_use("work", "work-use", {"_background_execution": True}),
-                _assistant_text("Task admitted."),
-                _assistant_text("Result received."),
-            ]
-        ),
-        tools=[work, foreground],
-        background_tasks={"never": [foreground]},
-        callback_handler=None,
+    agent = _background_agent(
+        work,
+        foreground,
+        responses=[_assistant_text("Task admitted."), _assistant_text("Result received.")],
+        never=[foreground],
     )
 
     async def substitute(context: Any, next_fn: Any) -> AsyncGenerator[Any, None]:
@@ -319,23 +254,7 @@ async def test_fails_task_when_middleware_substitutes_foreground_only_tool() -> 
 
 @pytest.mark.asyncio
 async def test_fails_task_when_middleware_drops_tool_result() -> None:
-    @tool(name="work")
-    def work() -> str:
-        """Perform work."""
-        return "done"
-
-    agent = Agent(
-        model=MockedModelProvider(
-            [
-                _assistant_tool_use("work", "work-use", {"_background_execution": True}),
-                _assistant_text("Task admitted."),
-                _assistant_text("Result received."),
-            ]
-        ),
-        tools=[work],
-        background_tasks={},
-        callback_handler=None,
-    )
+    agent = _background_agent(work, responses=[_assistant_text("Task admitted."), _assistant_text("Result received.")])
 
     async def swallow(context: Any, next_fn: Any) -> AsyncGenerator[Any, None]:
         async for _ in next_fn(context):
@@ -355,37 +274,26 @@ async def test_fails_task_when_middleware_drops_tool_result() -> None:
 
 @pytest.mark.asyncio
 async def test_streams_background_tool_events_to_callback_handler() -> None:
-    @tool(name="work")
-    async def work() -> AsyncGenerator[str, None]:
+    @tool(name="progress")
+    async def progress() -> AsyncGenerator[str, None]:
         """Report progress, then finish."""
         yield "halfway"
         yield "done"
 
     callbacks: list[dict[str, Any]] = []
-    agent = Agent(
-        model=MockedModelProvider(
-            [
-                _assistant_tool_use("work", "work-use", {"_background_execution": True}),
-                _assistant_text("Task admitted."),
-                _assistant_text("Result received."),
-            ]
-        ),
-        tools=[work],
-        background_tasks={},
+    agent = _background_agent(
+        progress,
+        responses=[_assistant_text("Task admitted."), _assistant_text("Result received.")],
         callback_handler=lambda **kwargs: callbacks.append(kwargs),
     )
 
-    await agent.invoke_async("Run work.")
+    await agent.invoke_async("Run progress.")
 
     tru_stream_data = [
         callback["tool_stream_event"]["data"] for callback in callbacks if "tool_stream_event" in callback
     ]
     exp_stream_data = ["halfway", "done"]
     assert tru_stream_data == exp_stream_data
-
-    tru_result = _delivered_result(agent)
-    exp_result = {"toolUseId": ANY, "status": "success", "content": [{"text": "done"}]}
-    assert tru_result == exp_result
 
 
 @pytest.mark.asyncio
@@ -398,18 +306,13 @@ async def test_surfaces_and_resumes_interrupts_raised_by_background_tools() -> N
         responses.append(tool_context.interrupt("approve", reason="Approve work?"))
         return "approved"
 
-    agent = Agent(
-        model=MockedModelProvider(
-            [
-                _assistant_tool_use("approval", "approval-use", {"_background_execution": True}),
-                _assistant_text("Task admitted."),
-                _assistant_text("Task resumed."),
-                _assistant_text("Result received."),
-            ]
-        ),
-        tools=[approval],
-        background_tasks={},
-        callback_handler=None,
+    agent = _background_agent(
+        approval,
+        responses=[
+            _assistant_text("Task admitted."),
+            _assistant_text("Task resumed."),
+            _assistant_text("Result received."),
+        ],
     )
 
     interrupted = await agent.invoke_async("Run approval.")
@@ -478,15 +381,9 @@ async def test_dispatches_selected_calls_through_tool_pipeline_and_delivers_resu
     exp_deliveries = [{"name": _RESULT_TOOL_NAME, "toolUseId": ANY, "input": {"tool_name": "work"}}]
     assert tru_deliveries == exp_deliveries
 
-    tru_blocks = [block for message in agent.messages for block in message["content"]]
-    exp_result = {
-        "toolResult": {
-            "toolUseId": tru_deliveries[0]["toolUseId"],
-            "status": "success",
-            "content": [{"text": "done:background"}],
-        }
-    }
-    assert exp_result in tru_blocks
+    tru_result = _delivered_result(agent)
+    exp_result = {"toolUseId": ANY, "status": "success", "content": [{"text": "done:background"}]}
+    assert tru_result == exp_result
     assert _persisted_tasks(agent) is None
 
 
@@ -568,12 +465,7 @@ async def test_applies_always_and_never_policies_per_tool() -> None:
     exp_deliveries = [{"name": _RESULT_TOOL_NAME, "toolUseId": ANY, "input": {"tool_name": "background"}}]
     assert tru_deliveries == exp_deliveries
 
-    tru_incompatible_result = next(
-        block["toolResult"]
-        for message in agent.messages
-        for block in message["content"]
-        if "toolResult" in block and block["toolResult"]["toolUseId"] == "incompatible-use"
-    )
+    tru_incompatible_result = _tool_result(agent, "incompatible-use")
     exp_incompatible_result = {
         "toolUseId": "incompatible-use",
         "status": "error",
@@ -604,7 +496,7 @@ async def test_delivers_work_that_finishes_between_invocations() -> None:
             ]
         ),
         tools=[work],
-        background_tasks={"wait_for_completion": False},
+        background_tasks={"wait_for_completion": False, "max_concurrency": 1, "timeout": 5},
         callback_handler=None,
     )
 
@@ -880,11 +772,6 @@ async def test_surfaces_and_resumes_interrupts_from_background_tools() -> None:
 
 
 def test_direct_tool_calls_run_in_the_foreground() -> None:
-    @tool(name="work")
-    def work() -> str:
-        """Perform work."""
-        return "done"
-
     agent = Agent(
         model=MockedModelProvider([]), tools=[work], background_tasks={"always": [work]}, callback_handler=None
     )

--- a/strands-py/tests/strands/background_tasks/test_background_tasks.py
+++ b/strands-py/tests/strands/background_tasks/test_background_tasks.py
@@ -364,11 +364,15 @@ async def test_dispatches_selected_calls_through_tool_pipeline_and_delivers_resu
     agent.add_hook(retry_once, AfterToolCallEvent)
     agent._middleware_registry.add_middleware(ExecuteToolStage, count_execution)
 
-    await agent.invoke_async("Run work.")
+    result = await agent.invoke_async("Run work.")
 
     tru_middleware_calls = middleware_calls
     exp_middleware_calls = 2
     assert tru_middleware_calls == exp_middleware_calls
+
+    tru_metrics = (result.metrics.tool_metrics["work"].call_count, result.metrics.tool_metrics["work"].success_count)
+    exp_metrics = (2, 2)
+    assert tru_metrics == exp_metrics
 
     work_spec = next(spec for spec in tool_specs[0] if spec["name"] == "work")
     assert "_background_execution" in _schema_properties(work_spec)

--- a/strands-py/tests/strands/background_tasks/test_background_tasks.py
+++ b/strands-py/tests/strands/background_tasks/test_background_tasks.py
@@ -5,7 +5,7 @@ import threading
 import time
 from collections.abc import AsyncGenerator
 from typing import Any
-from unittest.mock import ANY
+from unittest.mock import ANY, AsyncMock
 
 import pytest
 
@@ -13,6 +13,7 @@ from strands import Agent, ToolContext, tool
 from strands._middleware.stages import ExecuteToolStage, InvokeModelStage
 from strands.hooks import AfterToolCallEvent, AgentInitializedEvent, BeforeToolCallEvent
 from strands.interrupt import Interrupt
+from strands.tools.tools import PythonAgentTool
 from strands.types._events import ToolResultEvent
 from strands.types.content import Messages
 from strands.types.tools import ToolResult, ToolSpec, ToolUse
@@ -71,6 +72,29 @@ async def _invoke_management_tool(agent: Agent, tool_input: dict[str, Any]) -> T
     return result
 
 
+def _tool_result(agent: Agent, tool_use_id: str) -> ToolResult:
+    return next(
+        block["toolResult"]
+        for message in agent.messages
+        for block in message["content"]
+        if "toolResult" in block and block["toolResult"]["toolUseId"] == tool_use_id
+    )
+
+
+def _delivered_result(agent: Agent) -> ToolResult:
+    [delivery] = _deliveries(agent.messages)
+    return _tool_result(agent, delivery["toolUseId"])
+
+
+def _unselectable_tool(tool_name: str) -> PythonAgentTool:
+    spec: ToolSpec = {
+        "name": tool_name,
+        "description": "Schema already declares the selection flag.",
+        "inputSchema": {"json": {"type": "object", "properties": {"_background_execution": {"type": "boolean"}}}},
+    }
+    return PythonAgentTool(tool_name, spec, lambda tool_use, **kwargs: {"status": "success", "content": []})
+
+
 def _capture_tool_specs(agent: Agent) -> list[list[ToolSpec]]:
     captured: list[list[ToolSpec]] = []
 
@@ -107,6 +131,300 @@ def test__init__rejects_conflicting_tool_policies() -> None:
             background_tasks={"always": [work], "never": [work]},
             callback_handler=None,
         )
+
+
+def test__init__rejects_exact_policy_on_tool_that_cannot_run_in_background() -> None:
+    @tool(name="summarize_context")
+    def incompatible() -> None:
+        """Cannot run in the background."""
+
+    with pytest.raises(TypeError, match="Tool 'summarize_context' cannot run in the background"):
+        Agent(
+            model=MockedModelProvider([]),
+            tools=[incompatible],
+            background_tasks={"always": [incompatible]},
+            callback_handler=None,
+        )
+
+
+def test__init__rejects_exact_agentic_policy_on_unselectable_tool() -> None:
+    with pytest.raises(TypeError, match="Tool 'custom' cannot use agentic background selection"):
+        Agent(
+            model=MockedModelProvider([]),
+            tools=[_unselectable_tool("custom")],
+            background_tasks={"agentic": ["custom"]},
+            callback_handler=None,
+        )
+
+
+def test__init__forwards_execution_limits_to_task_manager() -> None:
+    agent = Agent(
+        model=MockedModelProvider([]),
+        background_tasks={"max_concurrency": 2, "timeout": 5},
+        callback_handler=None,
+    )
+
+    engine = agent._background_tasks._manager._engine
+    tru_limits = (engine._max_concurrency, engine._timeout)
+    exp_limits = (2, 5)
+    assert tru_limits == exp_limits
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("tool_input", "message"),
+    [
+        ({"mode": "get"}, "Task ID is required for mode 'get'"),
+        ({"mode": "cancel", "task_id": "missing"}, "Background task 'missing' was not found"),
+    ],
+)
+async def test_management_tool_rejects_missing_or_unknown_task(tool_input: dict[str, Any], message: str) -> None:
+    agent = Agent(model=MockedModelProvider([]), background_tasks={}, callback_handler=None)
+
+    tru_result = await _invoke_management_tool(agent, tool_input)
+    exp_result = {"toolUseId": "management-use", "status": "error", "content": [{"text": ANY}]}
+    assert tru_result == exp_result
+    assert message in tru_result["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_rejects_non_boolean_background_selection() -> None:
+    executions = 0
+
+    @tool(name="work")
+    def work() -> str:
+        """Perform work."""
+        nonlocal executions
+        executions += 1
+        return "done"
+
+    agent = Agent(
+        model=MockedModelProvider(
+            [_assistant_tool_use("work", "work-use", {"_background_execution": "yes"}), _assistant_text("Rejected.")]
+        ),
+        tools=[work],
+        background_tasks={},
+        callback_handler=None,
+    )
+
+    await agent.invoke_async("Run work.")
+
+    tru_result = _tool_result(agent, "work-use")
+    exp_result = {
+        "toolUseId": "work-use",
+        "status": "error",
+        "content": [{"text": "'_background_execution' must be a boolean"}],
+    }
+    assert tru_result == exp_result
+    assert executions == 0
+
+
+@pytest.mark.asyncio
+async def test_unknown_tool_runs_in_the_foreground() -> None:
+    agent = Agent(
+        model=MockedModelProvider(
+            [_assistant_tool_use("missing", "missing-use", {"_background_execution": True}), _assistant_text("Done.")]
+        ),
+        background_tasks={},
+        callback_handler=None,
+    )
+
+    await agent.invoke_async("Run missing.")
+
+    tru_status = _tool_result(agent, "missing-use")["status"]
+    exp_status = "error"
+    assert tru_status == exp_status
+    assert _deliveries(agent.messages) == []
+    assert _persisted_tasks(agent) is None
+
+
+@pytest.mark.asyncio
+async def test_reports_admission_failure_as_tool_error() -> None:
+    @tool(name="work")
+    def work() -> str:
+        """Perform work."""
+        return "done"
+
+    agent = Agent(
+        model=MockedModelProvider(
+            [_assistant_tool_use("work", "work-use", {"_background_execution": True}), _assistant_text("Failed.")]
+        ),
+        tools=[work],
+        background_tasks={},
+        callback_handler=None,
+    )
+    agent._background_tasks._manager.submit = AsyncMock(side_effect=RuntimeError("runtime unavailable"))
+
+    await agent.invoke_async("Run work.")
+
+    tru_result = _tool_result(agent, "work-use")
+    exp_result = {"toolUseId": "work-use", "status": "error", "content": [{"text": "Background task admission failed"}]}
+    assert tru_result == exp_result
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("policy", "late_tool"),
+    [
+        ("summarize_context", tool(name="summarize_context")(lambda: None)),
+        ("custom", _unselectable_tool("custom")),
+    ],
+)
+async def test_rejects_exact_agentic_policy_on_tool_registered_after_init(policy: str, late_tool: Any) -> None:
+    agent = Agent(model=MockedModelProvider([]), background_tasks={"agentic": [policy]}, callback_handler=None)
+    agent.tool_registry.register_tool(late_tool)
+
+    with pytest.raises(TypeError, match=f"Tool '{policy}' cannot use agentic background selection"):
+        await agent.invoke_async("Run.")
+
+
+@pytest.mark.asyncio
+async def test_fails_task_when_middleware_substitutes_foreground_only_tool() -> None:
+    @tool(name="work")
+    def work() -> str:
+        """Perform work."""
+        return "done"
+
+    @tool(name="foreground")
+    def foreground() -> str:
+        """Never runs in the background."""
+        return "foreground"
+
+    agent = Agent(
+        model=MockedModelProvider(
+            [
+                _assistant_tool_use("work", "work-use", {"_background_execution": True}),
+                _assistant_text("Task admitted."),
+                _assistant_text("Result received."),
+            ]
+        ),
+        tools=[work, foreground],
+        background_tasks={"never": [foreground]},
+        callback_handler=None,
+    )
+
+    async def substitute(context: Any, next_fn: Any) -> AsyncGenerator[Any, None]:
+        context.tool = foreground
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(ExecuteToolStage, substitute)
+
+    await agent.invoke_async("Run work.")
+
+    tru_result = _delivered_result(agent)
+    exp_result = {"toolUseId": ANY, "status": "error", "content": [{"text": "Tool cannot run in the background"}]}
+    assert tru_result == exp_result
+
+
+@pytest.mark.asyncio
+async def test_fails_task_when_middleware_drops_tool_result() -> None:
+    @tool(name="work")
+    def work() -> str:
+        """Perform work."""
+        return "done"
+
+    agent = Agent(
+        model=MockedModelProvider(
+            [
+                _assistant_tool_use("work", "work-use", {"_background_execution": True}),
+                _assistant_text("Task admitted."),
+                _assistant_text("Result received."),
+            ]
+        ),
+        tools=[work],
+        background_tasks={},
+        callback_handler=None,
+    )
+
+    async def swallow(context: Any, next_fn: Any) -> AsyncGenerator[Any, None]:
+        async for _ in next_fn(context):
+            pass
+        return
+        yield
+
+    agent._middleware_registry.add_middleware(ExecuteToolStage, swallow)
+
+    await agent.invoke_async("Run work.")
+
+    tru_result = _delivered_result(agent)
+    exp_result = {"toolUseId": ANY, "status": "error", "content": [{"text": ANY}]}
+    assert tru_result == exp_result
+    assert "did not yield a ToolResultEvent" in tru_result["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_streams_background_tool_events_to_callback_handler() -> None:
+    @tool(name="work")
+    async def work() -> AsyncGenerator[str, None]:
+        """Report progress, then finish."""
+        yield "halfway"
+        yield "done"
+
+    callbacks: list[dict[str, Any]] = []
+    agent = Agent(
+        model=MockedModelProvider(
+            [
+                _assistant_tool_use("work", "work-use", {"_background_execution": True}),
+                _assistant_text("Task admitted."),
+                _assistant_text("Result received."),
+            ]
+        ),
+        tools=[work],
+        background_tasks={},
+        callback_handler=lambda **kwargs: callbacks.append(kwargs),
+    )
+
+    await agent.invoke_async("Run work.")
+
+    tru_stream_data = [
+        callback["tool_stream_event"]["data"] for callback in callbacks if "tool_stream_event" in callback
+    ]
+    exp_stream_data = ["halfway", "done"]
+    assert tru_stream_data == exp_stream_data
+
+    tru_result = _delivered_result(agent)
+    exp_result = {"toolUseId": ANY, "status": "success", "content": [{"text": "done"}]}
+    assert tru_result == exp_result
+
+
+@pytest.mark.asyncio
+async def test_surfaces_and_resumes_interrupts_raised_by_background_tools() -> None:
+    responses: list[str] = []
+
+    @tool(name="approval", context=True)
+    def approval(tool_context: ToolContext) -> str:
+        """Ask before finishing."""
+        responses.append(tool_context.interrupt("approve", reason="Approve work?"))
+        return "approved"
+
+    agent = Agent(
+        model=MockedModelProvider(
+            [
+                _assistant_tool_use("approval", "approval-use", {"_background_execution": True}),
+                _assistant_text("Task admitted."),
+                _assistant_text("Task resumed."),
+                _assistant_text("Result received."),
+            ]
+        ),
+        tools=[approval],
+        background_tasks={},
+        callback_handler=None,
+    )
+
+    interrupted = await agent.invoke_async("Run approval.")
+    tru_stop_reason = interrupted.stop_reason
+    exp_stop_reason = "interrupt"
+    assert tru_stop_reason == exp_stop_reason
+
+    await agent.invoke_async([{"interruptResponse": {"interruptId": interrupted.interrupts[0].id, "response": "yes"}}])
+
+    tru_responses = responses
+    exp_responses = ["yes"]
+    assert tru_responses == exp_responses
+    tru_result = _delivered_result(agent)
+    exp_result = {"toolUseId": ANY, "status": "success", "content": [{"text": "approved"}]}
+    assert tru_result == exp_result
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests/strands/background_tasks/test_background_tasks.py
+++ b/strands-py/tests/strands/background_tasks/test_background_tasks.py
@@ -89,7 +89,16 @@ def _delivered_result(agent: Agent) -> ToolResult:
 def _unselectable_tool(tool_name: str) -> PythonAgentTool:
     spec: ToolSpec = {
         "name": tool_name,
-        "description": "Schema already declares the selection flag.",
+        "description": "Composite schema cannot take the selection flag.",
+        "inputSchema": {"json": {"anyOf": [{"type": "object"}, {"type": "string"}]}},
+    }
+    return PythonAgentTool(tool_name, spec, lambda tool_use, **kwargs: {"status": "success", "content": []})
+
+
+def _conflicting_tool(tool_name: str) -> PythonAgentTool:
+    spec: ToolSpec = {
+        "name": tool_name,
+        "description": "Schema already declares the reserved selection flag.",
         "inputSchema": {"json": {"type": "object", "properties": {"_background_execution": {"type": "boolean"}}}},
     }
     return PythonAgentTool(tool_name, spec, lambda tool_use, **kwargs: {"status": "success", "content": []})
@@ -146,6 +155,22 @@ def test__init__registers_management_tool_only_when_enabled(background_tasks: An
             {"agentic": ["custom"]},
             "Tool 'custom' cannot use agentic background selection",
         ),
+        (
+            [_conflicting_tool("custom")],
+            {},
+            "Tool 'custom' declares reserved parameter '_background_execution'",
+        ),
+        (
+            [_conflicting_tool("custom")],
+            {"never": ["custom"]},
+            "Tool 'custom' declares reserved parameter '_background_execution'",
+        ),
+        (
+            [tool(name="summarize_context")(lambda: None), _unselectable_tool("custom")],
+            {"always": ["summarize_context"], "agentic": ["custom"]},
+            "^Tool 'summarize_context' cannot run in the background; "
+            "Tool 'custom' cannot use agentic background selection$",
+        ),
     ],
 )
 def test__init__rejects_invalid_policies(tools: list[Any], config: dict[str, Any], message: str) -> None:
@@ -166,6 +191,15 @@ async def test_rejects_exact_agentic_policy_on_tool_registered_after_init(policy
     agent.tool_registry.register_tool(late_tool)
 
     with pytest.raises(TypeError, match=f"Tool '{policy}' cannot use agentic background selection"):
+        await agent.invoke_async("Run.")
+
+
+@pytest.mark.asyncio
+async def test_rejects_reserved_parameter_on_tool_registered_after_init() -> None:
+    agent = Agent(model=MockedModelProvider([]), background_tasks=True, callback_handler=None)
+    agent.tool_registry.register_tool(_conflicting_tool("custom"))
+
+    with pytest.raises(TypeError, match="Tool 'custom' declares reserved parameter '_background_execution'"):
         await agent.invoke_async("Run.")
 
 

--- a/strands-py/tests/strands/background_tasks/test_background_tasks.py
+++ b/strands-py/tests/strands/background_tasks/test_background_tasks.py
@@ -1,0 +1,577 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from collections.abc import AsyncGenerator
+from typing import Any
+from unittest.mock import ANY
+
+import pytest
+
+from strands import Agent, ToolContext, tool
+from strands._middleware.stages import ExecuteToolStage, InvokeModelStage
+from strands.hooks import AfterToolCallEvent, AgentInitializedEvent, BeforeToolCallEvent
+from strands.interrupt import Interrupt
+from strands.types._events import ToolResultEvent
+from strands.types.content import Messages
+from strands.types.tools import ToolResult, ToolSpec, ToolUse
+from tests.fixtures.mocked_model_provider import MockedModelProvider
+
+_BACKGROUND_TASKS_STATE_KEY = "strands.background_tasks"
+_MANAGE_TOOL_NAME = "strands_manage_background_task"
+_RESULT_TOOL_NAME = "strands_background_task_result"
+
+
+def _assistant_text(text: str) -> dict[str, Any]:
+    return {"role": "assistant", "content": [{"text": text}]}
+
+
+def _assistant_tool_use(tool_name: str, tool_use_id: str, tool_input: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "role": "assistant",
+        "content": [{"toolUse": {"name": tool_name, "toolUseId": tool_use_id, "input": tool_input}}],
+    }
+
+
+def _deliveries(messages: Messages) -> list[ToolUse]:
+    return [
+        block["toolUse"]
+        for message in messages
+        for block in message["content"]
+        if "toolUse" in block and block["toolUse"]["name"] == _RESULT_TOOL_NAME
+    ]
+
+
+def _persisted_tasks(agent: Agent) -> list[dict[str, Any]] | None:
+    return agent.state.get(_BACKGROUND_TASKS_STATE_KEY)
+
+
+async def _wait_for_task_status(agent: Agent, status: str) -> None:
+    while True:
+        tasks = _persisted_tasks(agent)
+        if tasks is not None and tasks[0]["status"] == status:
+            return
+        await asyncio.sleep(0)
+
+
+def _schema_properties(spec: ToolSpec) -> dict[str, Any]:
+    return spec["inputSchema"]["json"]["properties"]
+
+
+async def _invoke_management_tool(agent: Agent, tool_input: dict[str, Any]) -> ToolResult:
+    # Direct tool calls are refused while the agent is interrupted, so stream the tool itself.
+    management_tool = agent.tool_registry.registry[_MANAGE_TOOL_NAME]
+    tool_use: ToolUse = {"name": _MANAGE_TOOL_NAME, "toolUseId": "management-use", "input": tool_input}
+    result: ToolResult | None = None
+    async for event in management_tool.stream(tool_use, {"agent": agent}):
+        if isinstance(event, ToolResultEvent):
+            result = event.tool_result
+    assert result is not None
+    return result
+
+
+def _capture_tool_specs(agent: Agent) -> list[list[ToolSpec]]:
+    captured: list[list[ToolSpec]] = []
+
+    async def capture(context: Any, next_fn: Any) -> AsyncGenerator[Any, None]:
+        captured.append(context.tool_specs)
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(InvokeModelStage, capture)
+    return captured
+
+
+def test__init__disabled_by_default() -> None:
+    agent = Agent(model=MockedModelProvider([]), callback_handler=None)
+    assert _MANAGE_TOOL_NAME not in agent.tool_registry.registry
+
+
+@pytest.mark.parametrize("background_tasks", [True, {}])
+def test__init__registers_management_tool_when_enabled(background_tasks: Any) -> None:
+    agent = Agent(model=MockedModelProvider([]), background_tasks=background_tasks, callback_handler=None)
+    assert _MANAGE_TOOL_NAME in agent.tool_registry.registry
+
+
+def test__init__rejects_conflicting_tool_policies() -> None:
+    @tool(name="work")
+    def work() -> str:
+        """Perform work."""
+        return "done"
+
+    with pytest.raises(TypeError, match="Tool 'work' cannot be configured as both 'always' and 'never'"):
+        Agent(
+            model=MockedModelProvider([]),
+            tools=[work],
+            background_tasks={"always": [work], "never": [work]},
+            callback_handler=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_dispatches_selected_calls_through_tool_pipeline_and_delivers_results() -> None:
+    @tool(name="work")
+    def work(value: str) -> str:
+        """Perform work."""
+        return f"done:{value}"
+
+    model = MockedModelProvider(
+        [
+            _assistant_tool_use("work", "work-use", {"value": "background", "_background_execution": True}),
+            _assistant_text("Task admitted."),
+            _assistant_text("Result received."),
+        ]
+    )
+    agent = Agent(model=model, tools=[work], background_tasks={"agentic": [work]}, callback_handler=None)
+    tool_specs = _capture_tool_specs(agent)
+    middleware_calls = 0
+    retried = False
+
+    def retry_once(event: AfterToolCallEvent) -> None:
+        nonlocal retried
+        if not retried:
+            retried = True
+            event.retry = True
+
+    async def count_execution(context: Any, next_fn: Any) -> AsyncGenerator[Any, None]:
+        nonlocal middleware_calls
+        middleware_calls += 1
+        async for event in next_fn(context):
+            yield event
+
+    agent.add_hook(retry_once, AfterToolCallEvent)
+    agent._middleware_registry.add_middleware(ExecuteToolStage, count_execution)
+
+    await agent.invoke_async("Run work.")
+
+    tru_middleware_calls = middleware_calls
+    exp_middleware_calls = 2
+    assert tru_middleware_calls == exp_middleware_calls
+
+    work_spec = next(spec for spec in tool_specs[0] if spec["name"] == "work")
+    assert "_background_execution" in _schema_properties(work_spec)
+
+    tru_requested_input = agent.messages[1]["content"][0]["toolUse"]["input"]
+    exp_requested_input = {"value": "background", "_background_execution": True}
+    assert tru_requested_input == exp_requested_input
+
+    tru_deliveries = _deliveries(agent.messages)
+    exp_deliveries = [{"name": _RESULT_TOOL_NAME, "toolUseId": ANY, "input": {"tool_name": "work"}}]
+    assert tru_deliveries == exp_deliveries
+
+    tru_blocks = [block for message in agent.messages for block in message["content"]]
+    exp_result = {
+        "toolResult": {
+            "toolUseId": tru_deliveries[0]["toolUseId"],
+            "status": "success",
+            "content": [{"text": "done:background"}],
+        }
+    }
+    assert exp_result in tru_blocks
+    assert _persisted_tasks(agent) is None
+
+
+@pytest.mark.asyncio
+async def test_applies_always_and_never_policies_per_tool() -> None:
+    executions: list[str] = []
+    seen_inputs: list[dict[str, Any]] = []
+
+    @tool(name="background", context=True)
+    def background(tool_context: ToolContext) -> None:
+        """Run in the background."""
+        seen_inputs.append(tool_context.tool_use["input"])
+        executions.append("background")
+
+    @tool(name="foreground", context=True)
+    def foreground(tool_context: ToolContext) -> None:
+        """Run in the foreground."""
+        seen_inputs.append(tool_context.tool_use["input"])
+        executions.append("foreground")
+
+    @tool(name="summarize_context")
+    def incompatible() -> None:
+        """Cannot run in the background."""
+        executions.append("incompatible")
+
+    model = MockedModelProvider(
+        [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "toolUse": {
+                            "name": "foreground",
+                            "toolUseId": "background-use",
+                            "input": {"_background_execution": False},
+                        }
+                    },
+                    {
+                        "toolUse": {
+                            "name": "foreground",
+                            "toolUseId": "foreground-use",
+                            "input": {"_background_execution": True},
+                        }
+                    },
+                    {"toolUse": {"name": "foreground", "toolUseId": "incompatible-use", "input": {}}},
+                ],
+            },
+            _assistant_text("Task admitted."),
+            _assistant_text("Result received."),
+        ]
+    )
+    agent = Agent(
+        model=model,
+        tools=[background, foreground],
+        background_tasks={"always": [background, incompatible], "never": ["*"]},
+        callback_handler=None,
+    )
+    tool_specs = _capture_tool_specs(agent)
+
+    def swap_tools(event: BeforeToolCallEvent) -> None:
+        if event.tool_use["toolUseId"] == "background-use":
+            event.tool_use["name"] = "background"
+        if event.tool_use["toolUseId"] == "incompatible-use":
+            event.selected_tool = incompatible
+
+    agent.add_hook(swap_tools, BeforeToolCallEvent)
+
+    await agent.invoke_async("Run both.")
+
+    tru_executions = sorted(executions)
+    exp_executions = ["background", "foreground"]
+    assert tru_executions == exp_executions
+
+    tru_inputs = seen_inputs
+    exp_inputs = [{}, {}]
+    assert tru_inputs == exp_inputs
+
+    tru_deliveries = _deliveries(agent.messages)
+    exp_deliveries = [{"name": _RESULT_TOOL_NAME, "toolUseId": ANY, "input": {"tool_name": "background"}}]
+    assert tru_deliveries == exp_deliveries
+
+    tru_incompatible_result = next(
+        block["toolResult"]
+        for message in agent.messages
+        for block in message["content"]
+        if "toolResult" in block and block["toolResult"]["toolUseId"] == "incompatible-use"
+    )
+    exp_incompatible_result = {
+        "toolUseId": "incompatible-use",
+        "status": "error",
+        "content": [{"text": "Tool 'foreground' cannot run in the background"}],
+    }
+    assert tru_incompatible_result == exp_incompatible_result
+
+    for tool_name in ("background", "foreground"):
+        tool_spec = next(spec for spec in tool_specs[0] if spec["name"] == tool_name)
+        assert "_background_execution" not in _schema_properties(tool_spec)
+
+
+@pytest.mark.asyncio
+async def test_delivers_work_that_finishes_between_invocations() -> None:
+    released = asyncio.Event()
+
+    @tool(name="work")
+    async def work() -> str:
+        """Perform deferred work."""
+        await released.wait()
+        return "done"
+
+    agent = Agent(
+        model=MockedModelProvider(
+            [
+                _assistant_tool_use("work", "work-use", {"_background_execution": True}),
+                _assistant_text("Task admitted."),
+            ]
+        ),
+        tools=[work],
+        background_tasks={"wait_for_completion": False},
+        callback_handler=None,
+    )
+
+    await agent.invoke_async("Run work.")
+    tru_deliveries = _deliveries(agent.messages)
+    exp_deliveries: list[ToolUse] = []
+    assert tru_deliveries == exp_deliveries
+    with pytest.raises(RuntimeError, match="Cannot load a snapshot while background tasks are still tracked"):
+        agent.load_snapshot(agent.take_snapshot(include=["state"]))
+
+    released.set()
+    await asyncio.wait_for(_wait_for_task_status(agent, "completed"), timeout=1)
+
+    tru_tasks = _persisted_tasks(agent)
+    exp_tasks = [
+        {
+            "task_id": ANY,
+            "tool_use_id": "work-use",
+            "tool_name": "work",
+            "status": "completed",
+            "created_at": ANY,
+            "last_updated_at": ANY,
+            "result": {"content": [{"text": "done"}]},
+        }
+    ]
+    assert tru_tasks == exp_tasks
+
+    snapshot = agent.take_snapshot(preset="session")
+    restored = Agent(
+        model=MockedModelProvider([_assistant_text("Result received.")]),
+        background_tasks={},
+        callback_handler=None,
+    )
+    restored.load_snapshot(snapshot)
+    await restored.invoke_async("Continue.")
+
+    tru_delivery_count = len(_deliveries(restored.messages))
+    exp_delivery_count = 1
+    assert tru_delivery_count == exp_delivery_count
+    assert _persisted_tasks(restored) is None
+
+
+def test_sync_background_work_survives_between_invocations() -> None:
+    released = threading.Event()
+
+    @tool(name="work")
+    async def work() -> str:
+        """Perform deferred work."""
+        while not released.is_set():
+            await asyncio.sleep(0)
+        return "done"
+
+    agent = Agent(
+        model=MockedModelProvider(
+            [
+                _assistant_tool_use("work", "work-use", {"_background_execution": True}),
+                _assistant_text("Task admitted."),
+                _assistant_text("Result received."),
+            ]
+        ),
+        tools=[work],
+        background_tasks={"wait_for_completion": False},
+        callback_handler=None,
+    )
+
+    agent("Run work.")
+    assert _deliveries(agent.messages) == []
+
+    released.set()
+    deadline = time.monotonic() + 1
+    while time.monotonic() < deadline:
+        tasks = _persisted_tasks(agent)
+        if tasks is not None and tasks[0]["status"] == "completed":
+            break
+        time.sleep(0.01)
+    else:
+        raise AssertionError("Background task did not complete")
+
+    agent("Continue.")
+    tru_delivery_count = len(_deliveries(agent.messages))
+    exp_delivery_count = 1
+    assert tru_delivery_count == exp_delivery_count
+    assert _persisted_tasks(agent) is None
+
+
+@pytest.mark.asyncio
+async def test_load_state_fails_restored_non_terminal_work() -> None:
+    created_at = "2026-08-27T12:00:00Z"
+    source = Agent(model=MockedModelProvider([]), callback_handler=None)
+    interrupt = Interrupt(id="v1:tool_call:working-use:approve", name="approve", reason="Approve restored work?")
+    source.state.set(
+        _BACKGROUND_TASKS_STATE_KEY,
+        [
+            {
+                "task_id": "working",
+                "tool_use_id": "working-use",
+                "tool_name": "working-work",
+                "status": "input_required",
+                "created_at": created_at,
+                "last_updated_at": created_at,
+                "interrupts": [
+                    {"id": interrupt.id, "name": interrupt.name, "reason": interrupt.reason, "source": "tool"}
+                ],
+            }
+        ],
+    )
+    source._interrupt_state.interrupts[interrupt.id] = interrupt
+    source._interrupt_state.activate()
+    snapshot = source.take_snapshot(preset="session")
+
+    def load_snapshot(event: AgentInitializedEvent) -> None:
+        event.agent.load_snapshot(snapshot)
+
+    agent = Agent(
+        model=MockedModelProvider([_assistant_text("Results received.")]),
+        background_tasks={},
+        hooks=[load_snapshot],
+        callback_handler=None,
+    )
+
+    tru_task = next(task for task in _persisted_tasks(agent) or [] if task["task_id"] == "working")
+    exp_task = {
+        "task_id": "working",
+        "tool_use_id": "working-use",
+        "tool_name": "working-work",
+        "status": "failed",
+        "created_at": created_at,
+        "last_updated_at": ANY,
+        "error": {"type": "execution_error", "message": ANY},
+    }
+    assert tru_task == exp_task
+    assert not agent._interrupt_state.activated
+
+    tru_cancelled = await _invoke_management_tool(agent, {"mode": "cancel", "task_id": "working"})
+    exp_cancelled = {
+        "toolUseId": "management-use",
+        "status": "success",
+        "content": [{"json": {"task_id": "working", "status": "failed"}}],
+    }
+    assert tru_cancelled == exp_cancelled
+
+    await agent.invoke_async("Continue.")
+
+    tru_deliveries = _deliveries(agent.messages)
+    exp_deliveries = [{"name": _RESULT_TOOL_NAME, "toolUseId": "working", "input": {"tool_name": "working-work"}}]
+    assert tru_deliveries == exp_deliveries
+
+
+@pytest.mark.asyncio
+async def test_surfaces_and_resumes_interrupts_from_background_tools() -> None:
+    blocked_started = asyncio.Event()
+
+    @tool(name="approval")
+    def approval() -> str:
+        """Wait for approval."""
+        return "approved"
+
+    @tool(name="blocked", context=True)
+    async def blocked(tool_context: ToolContext) -> str:
+        """Wait for cancellation."""
+        blocked_started.set()
+        while not tool_context.cancel_signal.is_set():
+            await asyncio.sleep(0)
+        return "cancelled"
+
+    model = MockedModelProvider(
+        [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "toolUse": {
+                            "name": "approval",
+                            "toolUseId": "approval-use",
+                            "input": {"_background_execution": True},
+                        }
+                    },
+                    {
+                        "toolUse": {
+                            "name": "blocked",
+                            "toolUseId": "blocked-use",
+                            "input": {"_background_execution": True},
+                        }
+                    },
+                ],
+            },
+            _assistant_text("Task admitted."),
+            _assistant_text("Task resumed."),
+            _assistant_text("Result received."),
+        ]
+    )
+    agent = Agent(model=model, tools=[approval, blocked], background_tasks={}, callback_handler=None)
+    tool_specs = _capture_tool_specs(agent)
+    response: str | None = None
+
+    async def interrupt_approval(context: Any, next_fn: Any) -> AsyncGenerator[Any, None]:
+        nonlocal response
+        if context.tool_use["name"] == "approval":
+            response = context.interrupt("approve", reason="Approve work?").response
+        async for event in next_fn(context):
+            yield event
+
+    agent._middleware_registry.add_middleware(ExecuteToolStage, interrupt_approval)
+
+    interrupted = await agent.invoke_async("Run approval.")
+    tru_stop_reason = interrupted.stop_reason
+    exp_stop_reason = "interrupt"
+    assert tru_stop_reason == exp_stop_reason
+    tru_interrupts = [
+        {"id": interrupt.id, "name": interrupt.name, "reason": interrupt.reason} for interrupt in interrupted.interrupts
+    ]
+    exp_interrupts = [{"id": ANY, "name": "approve", "reason": "Approve work?"}]
+    assert tru_interrupts == exp_interrupts
+
+    await blocked_started.wait()
+    management_spec = next(spec for spec in tool_specs[0] if spec["name"] == _MANAGE_TOOL_NAME)
+    assert "_background_execution" not in _schema_properties(management_spec)
+
+    blocked_task = next(task for task in _persisted_tasks(agent) or [] if task["tool_name"] == "blocked")
+    tru_blocked = await _invoke_management_tool(agent, {"mode": "get", "task_id": blocked_task["task_id"]})
+    exp_blocked = {
+        "toolUseId": "management-use",
+        "status": "success",
+        "content": [
+            {
+                "json": {
+                    "task_id": blocked_task["task_id"],
+                    "tool_use_id": "blocked-use",
+                    "tool_name": "blocked",
+                    "status": "working",
+                    "created_at": ANY,
+                    "last_updated_at": ANY,
+                }
+            }
+        ],
+    }
+    assert tru_blocked == exp_blocked
+
+    tru_listing = await _invoke_management_tool(agent, {"mode": "list"})
+    exp_listing = {
+        "toolUseId": "management-use",
+        "status": "success",
+        "content": [
+            {
+                "json": {
+                    "tasks": [
+                        {"task_id": ANY, "tool_name": "approval", "status": "input_required"},
+                        {"task_id": blocked_task["task_id"], "tool_name": "blocked", "status": "working"},
+                    ]
+                }
+            }
+        ],
+    }
+    assert tru_listing == exp_listing
+
+    tru_cancelled = await _invoke_management_tool(agent, {"mode": "cancel", "task_id": blocked_task["task_id"]})
+    exp_cancelled = {
+        "toolUseId": "management-use",
+        "status": "success",
+        "content": [{"json": {"task_id": blocked_task["task_id"], "status": "cancelled"}}],
+    }
+    assert tru_cancelled == exp_cancelled
+
+    await agent.invoke_async([{"interruptResponse": {"interruptId": interrupted.interrupts[0].id, "response": "yes"}}])
+
+    tru_response = response
+    exp_response = "yes"
+    assert tru_response == exp_response
+    tru_delivery_count = len(_deliveries(agent.messages))
+    exp_delivery_count = 2
+    assert tru_delivery_count == exp_delivery_count
+    assert _persisted_tasks(agent) is None
+
+
+def test_direct_tool_calls_run_in_the_foreground() -> None:
+    @tool(name="work")
+    def work() -> str:
+        """Perform work."""
+        return "done"
+
+    agent = Agent(
+        model=MockedModelProvider([]), tools=[work], background_tasks={"always": [work]}, callback_handler=None
+    )
+
+    tru_result = agent.tool.work(record_direct_tool_call=False)
+    exp_result = {"toolUseId": ANY, "status": "success", "content": [{"text": "done"}]}
+    assert tru_result == exp_result
+    assert _persisted_tasks(agent) is None

--- a/strands-py/tests/strands/event_loop/test_event_loop.py
+++ b/strands-py/tests/strands/event_loop/test_event_loop.py
@@ -161,6 +161,7 @@ def agent(model, system_prompt, messages, tool_registry, thread_pool, hook_regis
     mock.tool_executor = tool_executor
     mock._interrupt_state = _InterruptState()
     mock._cancel_signal = threading.Event()
+    mock._background_tasks = None
     mock._observe_cancellation = mock._cancel_signal.is_set
     mock._model_state = {}
     mock._system_prompt_content = None
@@ -936,7 +937,7 @@ async def test_request_state_initialization(alist):
     mock_agent.messages = []
     mock_agent.tool_registry.get_all_tool_specs.return_value = []
     mock_agent.event_loop_metrics.start_cycle.return_value = (0, MagicMock())
-    mock_agent.hooks.invoke_callbacks_async = AsyncMock()
+    mock_agent.hooks.invoke_callbacks_async = AsyncMock(side_effect=lambda event: (event, []))
     mock_agent._append_messages = Agent._append_messages.__get__(mock_agent, Agent)
 
     # Call without providing request_state

--- a/strands-py/tests/strands/tools/executors/conftest.py
+++ b/strands-py/tests/strands/tools/executors/conftest.py
@@ -122,6 +122,7 @@ def agent(tool_registry, hook_registry):
     mock_agent._interrupt_state = _InterruptState()
     mock_agent._cancel_signal = threading.Event()
     mock_agent._observe_cancellation = mock_agent._cancel_signal.is_set
+    mock_agent._background_tasks = None
     mock_agent._middleware_registry = MiddlewareRegistry()
     mock_agent.trace_attributes = {}
     return mock_agent

--- a/strands-py/tests/strands/tools/executors/test_executor.py
+++ b/strands-py/tests/strands/tools/executors/test_executor.py
@@ -76,6 +76,30 @@ async def test_executor_stream_yields_result(
 
 
 @pytest.mark.asyncio
+async def test_executor_stream_runs_tool_registered_under_hook_renamed_tool_use(
+    executor, agent, tool_results, invocation_state, hook_events, weather_tool, temperature_tool, alist
+):
+    def rename(event):
+        if isinstance(event, BeforeToolCallEvent):
+            event.tool_use["name"] = "temperature_tool"
+
+    agent.hooks.add_callback(BeforeToolCallEvent, rename)
+    tool_use: ToolUse = {"name": "weather_tool", "toolUseId": "1", "input": {}}
+
+    stream = executor._stream(agent, tool_use, tool_results, invocation_state)
+
+    tru_events = await alist(stream)
+    exp_events = [
+        ToolResultEvent({"toolUseId": "1", "status": "success", "content": [{"text": "75F"}]}),
+    ]
+    assert tru_events == exp_events
+
+    tru_after_tool = hook_events[-1].selected_tool
+    exp_after_tool = temperature_tool
+    assert tru_after_tool is exp_after_tool
+
+
+@pytest.mark.asyncio
 async def test_executor_stream_wraps_results(
     executor, agent, tool_results, invocation_state, hook_events, weather_tool, alist, agenerator
 ):

--- a/strands-py/tests/strands/tools/executors/test_executor.py
+++ b/strands-py/tests/strands/tools/executors/test_executor.py
@@ -264,6 +264,25 @@ async def test_executor_stream_with_trace(
 
 
 @pytest.mark.asyncio
+async def test_executor_stream_with_trace_marks_backgrounded_without_metrics_or_trace(
+    executor, tracer, agent, tool_results, cycle_trace, cycle_span, invocation_state, alist, agenerator
+):
+    """A background dispatch acknowledgement marks its span but records no metrics and no cycle trace node."""
+    tool_use: ToolUse = {"name": "weather_tool", "toolUseId": "1", "input": {}}
+    result = {"toolUseId": "1", "status": "success", "content": [{"text": "queued"}]}
+    with unittest.mock.patch.object(
+        ToolExecutor, "_stream", return_value=agenerator([ToolResultEvent(result, backgrounded=True)])
+    ):
+        stream = executor._stream_with_trace(agent, tool_use, tool_results, cycle_trace, cycle_span, invocation_state)
+        await alist(stream)
+
+    agent.event_loop_metrics.add_tool_usage.assert_not_called()
+    cycle_trace.add_child.assert_not_called()
+    tracer.start_tool_call_span.return_value.set_attribute.assert_called_once_with("strands.tool.backgrounded", True)
+    tracer.end_tool_call_span.assert_called_once_with(tracer.start_tool_call_span.return_value, result, error=None)
+
+
+@pytest.mark.asyncio
 async def test_executor_stream_with_trace_records_metrics_on_interrupt(
     executor, agent, tool_results, cycle_trace, cycle_span, invocation_state, alist
 ):

--- a/strands-py/tests/strands/types/test_json_dict.py
+++ b/strands-py/tests/strands/types/test_json_dict.py
@@ -1,5 +1,8 @@
 """Tests for JSONSerializableDict class."""
 
+import copy
+import pickle
+
 import pytest
 
 from strands.types.json_dict import JSONSerializableDict
@@ -174,3 +177,20 @@ def test_version_increments_independently():
     state.delete("key1")
     version_after_delete = state._get_version()
     assert version_after_delete == version_after_second_set + 1
+
+
+@pytest.mark.parametrize("clone", [copy.deepcopy, lambda state: pickle.loads(pickle.dumps(state))])
+def test_clone_round_trips_and_is_independent(clone):
+    state = JSONSerializableDict({"key": {"nested": [1, 2]}})
+    state.set("other", "value")
+
+    cloned = clone(state)
+    cloned.set("key", "changed")
+
+    tru_original = (state.get(), state._get_version())
+    exp_original = ({"key": {"nested": [1, 2]}, "other": "value"}, 1)
+    assert tru_original == exp_original
+
+    tru_cloned = (cloned.get(), cloned._get_version())
+    exp_cloned = ({"key": "changed", "other": "value"}, 2)
+    assert tru_cloned == exp_cloned


### PR DESCRIPTION
## Description

Adding a new, explicitly opt-in first-class param to `Agent`, `background_tasks: bool | BackgroundTasksConfig`. This is the Python counterpart of #4026.

The mechanism is integrated with the Agent via an internal `_BackgroundTasks` plugin that routes eligible tool calls between foreground and background execution, persists task state in `agent.state`, surfaces task interrupts at safe Agent boundaries, and delivers terminal outcomes as a synthetic assistant tool use followed by a matching user tool result. Background execution continues through the standard tool middleware, hook, retry, tracing, and cancellation paths.

This completes the in-process Background Tasks implementation for Python.

```mermaid
flowchart LR
    A["Agent"] -->|"tool call"| P["_BackgroundTasks"]

    P -->|"foreground"| X["ToolExecutor"]
    P -->|"background"| M["InProcessTaskManager"]
    M -->|"schedule / manage"| E["InProcessTaskEngine"]
    E -->|"execute via callback"| X

    M -->|"completed results"| P
    P -.->|"deliver via hooks"| A

    classDef focus fill:#2da44e,stroke:#116329,color:#fff,stroke-width:3px
    class P focus
```

- **`_BackgroundTasks`** connects the feature to the Agent, chooses foreground or background execution, persists delivery state, and delivers finished results through hooks.
- **`InProcessTaskManager`** turns approved tool calls into tasks and provides the operations used to inspect, wait for, cancel, resume, and remove them.
- **`InProcessTaskEngine`** schedules local task execution and handles concurrency, cancellation, timeouts, and pause/resume state.

Plumbing changes needed to support this in Python:

- `ToolExecutor` gains `_execute_background`, which runs an admitted call through `ExecuteToolStage` middleware and `AfterToolCallEvent` with a task-scoped `ToolContext` and interrupt state. Admission errors still flow through the middleware chain and after-hook so observers see the rejected call.
- `@tool` and `_AgentAsTool` accept a framework-supplied `_tool_context` so a background call carries its own cancel signal instead of the agent's.
- `BeforeModelCallEvent` hooks can now raise an interrupt, which is how a background task awaiting input halts the loop before the next model call.
- `JSONSerializableDict` is guarded by a lock, since task snapshots are persisted from the runtime thread while the agent loop reads state.

### Public API Changes

`Agent.__init__` now accepts `background_tasks`, and `BackgroundTasksConfig` is exported from `strands`. Once enabled, tools can be selected by the model through the injected `_background_execution` boolean, forced into the background with `always`, or kept in the foreground with `never`.

Default (mechanism is opt-in):

```python
agent = Agent(
    model=model,
    tools=[deep_research, update_record],
    background_tasks=True,
)
```

With extra configuration:

```python
agent = Agent(
    model=model,
    tools=[deep_research, update_record],
    background_tasks={
        "agentic": [deep_research],
        "never": [update_record],
        "max_concurrency": 4,
        "timeout": 60,
        "wait_for_completion": False,
    },
)
```

The integration also registers the foreground-only `strands_manage_background_task` tool so the model can inspect or cancel a dispatched task. Completed results are delivered automatically and do not require polling.

## Related Issues

Part of #2496

Design: #3531

Engine / manager prerequisite: #4115

TypeScript counterpart: #4026

## Documentation PR

Will follow in a separate PR

## Type of Change

New feature

## Testing

- [x] I ran `hatch run prepare`

Unit tests cover model-selected, `always`, and `never` routing; policy validation at init and for tools registered later; result delivery within and across invocations; snapshot persistence and restore; interrupts raised by background tools and by middleware, including resume; management tool list/get/cancel; hook-driven retry; middleware substitution and dropped results; and stream events reaching the callback handler.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
