### PR TITLE
docs(catalog): add Agent Guild native MCP guide

### DIFF
--- a/site/src/content/catalog/agent-guild.yaml
+++ b/site/src/content/catalog/agent-guild.yaml
@@ -1,0 +1,8 @@
+name: Agent Guild
+description: Inspect public A2A and MCP endpoints before delegation with free live preflight checks and current paid-operation terms through native MCP tools.
+integrationType: tool
+languages:
+  python: {}
+github: https://github.com/AgentTanuki/agent-guild
+docsUrl: https://github.com/AgentTanuki/agent-guild/blob/bf19d667d3a2f0c3330795c397bda40302677326/docs/integrations/strands.md
+addedDate: 2026-09-08


### PR DESCRIPTION
## Integration submission

**Package name:** Agent Guild (guide-only; no Strands-specific package)
**Integration type:** tool
**Languages published:** Python guide
**GitHub repo:** https://github.com/AgentTanuki/agent-guild
**What it does:** Gives a Strands agent free live checks of a public A2A or MCP endpoint before delegation, plus current paid-operation terms. The native MCP example exposes only `guild_preflight` and `guild_paid_operations` and supplies no payment credentials.
**Relationship to service:** Maintained by AgentTanuki, the Agent Guild project maintainer; submitted as a community catalog entry.
**Docs link included:** https://github.com/AgentTanuki/agent-guild/blob/bf19d667d3a2f0c3330795c397bda40302677326/docs/integrations/strands.md

Submitted through the [vendor-guide route](https://strandsagents.com/docs/integrations/get-featured/). The guide explains the URL disclosure and remote probes, distinguishes free checks from paid operations, and leaves enforcement of delegation policy to the application.

### Submitter checklist

#### Package
- [x] This is a reusable integration (library/plugin/provider), not an example agent or application built with Strands
- [x] Published to PyPI and/or npm under the exact `package` name in my entry (registry links are derived from it) — or this is a guide-only entry (no `package` in any language block) with a `docsUrl` pointing at the vendor's Strands guide
- [x] GitHub repository is public and includes a license

#### Entry
- [x] Description accurately states what the package does in one sentence
- [x] `integrationType` matches what the package actually is
- [x] All URLs are working (`github`, and `docsUrl` if set)
- [x] `addedDate` is set to today (the date I opened this PR)
- [x] `featured` and `badges` are left unset — those are granted by the Strands team

#### Docs (only if setting a `docsUrl`)
- [ ] The linked page documents using this integration with Strands Agents

#### Conduct
- [x] I am the package maintainer, or I have the maintainer's explicit consent to list it
- [x] Entry uses the package's real name with no trademark misuse

### Validation

The linked guide was published and read back at its immutable revision. The documentation checkbox is left for reviewer confirmation.

The guide's setup installs released `strands-agents` 1.54.0 and `mcp` 1.30.0. Local HTTP MCP protocol fixtures verified the two free calls, preservation of cautionary results, error handling, exact tool filtering, and `Agent` tool registration. No live service call, model inference, registration, or payment was used in that validation.

---

### For reviewers

- Package installs cleanly and imports without error against the current SDK release (guide-only entries: the `docsUrl` guide's setup steps work instead)
- Description matches what the package's README says it does
- No existing catalog entry for this package (`site/src/content/catalog/`)
- All URLs are reachable and resolve to the expected destinations
- `addedDate` matches the submission date and `featured`/`badges` are unset (CI labels the PR `catalog: editorial-review` if a non-maintainer sets them)
- The `docsUrl` page (if set) is a real Strands integration guide, not a generic product page
