### PR TITLE
fix(context): fix various context manager parity items

### DIFF
--- a/strands-py/src/strands/_context_manager/retrieval_tool.py
+++ b/strands-py/src/strands/_context_manager/retrieval_tool.py
@@ -5,6 +5,7 @@ Registered automatically when the ContextManager has storage configured.
 
 from __future__ import annotations
 
+import base64
 import json
 import logging
 from typing import TYPE_CHECKING, Any
@@ -25,14 +26,18 @@ RETRIEVAL_TOOL_NAME = "retrieve_context"
 _DEFAULT_MAX_RESULT_TOKENS = 10_000
 
 
-_MEDIA_KEYS = frozenset({"image", "document", "video", "audio"})
+_MEDIA_KEYS = frozenset({"image", "document", "video"})
 
 
 def _restore_media(data: dict[str, Any]) -> ToolResultContent | None:
     """Reconstruct a media ToolResultContent from stash data, or None if not media."""
     for key in _MEDIA_KEYS:
         if key in data:
-            return ToolResultContent(**{key: data[key]})  # type: ignore[misc]
+            media = data[key]
+            source = media.get("source", {})
+            if isinstance(source.get("bytes"), str):
+                media = {**media, "source": {**source, "bytes": base64.b64decode(source["bytes"])}}
+            return ToolResultContent(**{key: media})  # type: ignore[misc]
     return None
 
 

--- a/strands-py/src/strands/_context_manager/retrieval_tool.py
+++ b/strands-py/src/strands/_context_manager/retrieval_tool.py
@@ -26,7 +26,7 @@ RETRIEVAL_TOOL_NAME = "retrieve_context"
 _DEFAULT_MAX_RESULT_TOKENS = 10_000
 
 
-_MEDIA_KEYS = frozenset({"image", "document", "video"})
+_MEDIA_KEYS = frozenset({"image", "document"})
 
 
 def _restore_media(data: dict[str, Any]) -> ToolResultContent | None:

--- a/strands-py/src/strands/_context_manager/retrieval_tool.py
+++ b/strands-py/src/strands/_context_manager/retrieval_tool.py
@@ -28,18 +28,11 @@ _DEFAULT_MAX_RESULT_TOKENS = 10_000
 _MEDIA_KEYS = frozenset({"image", "document", "video", "audio"})
 
 
-def _describe_media(data: dict[str, Any]) -> str | None:
-    """Return a short human-readable description if data is a media block, else None."""
+def _restore_media(data: dict[str, Any]) -> ToolResultContent | None:
+    """Reconstruct a media ToolResultContent from stash data, or None if not media."""
     for key in _MEDIA_KEYS:
-        media = data.get(key)
-        if media is None:
-            continue
-        fmt = media.get("format", "unknown")
-        source = media.get("source", {})
-        byte_val = source.get("bytes")
-        size = len(byte_val) if isinstance(byte_val, (str, bytes, bytearray)) else None
-        size_desc = f", {size} bytes" if size is not None else ""
-        return f"{key} ({fmt}{size_desc})"
+        if key in data:
+            return ToolResultContent(**{key: data[key]})  # type: ignore[misc]
     return None
 
 
@@ -76,12 +69,9 @@ def _create_retrieval_tool(stash: Stash, max_result_tokens: int | None = None) -
 
         if pattern is None and line_range is None:
             if isinstance(result, dict):
-                media_desc = _describe_media(result)
-                if media_desc is not None:
-                    text = f"Reference {reference} is {media_desc} and cannot be returned as text."
-                    return ToolResult(
-                        toolUseId=tool_use_id, status="error", content=[ToolResultContent(text=text)]
-                    )
+                media = _restore_media(result)
+                if media is not None:
+                    return ToolResult(toolUseId=tool_use_id, status="success", content=[media])
             full_text = json.dumps(result)
             if len(full_text) > max_chars:
                 full_text = full_text[:max_chars] + "\n\n[truncated]"

--- a/strands-py/src/strands/_context_manager/strategies/offload/summarize.py
+++ b/strands-py/src/strands/_context_manager/strategies/offload/summarize.py
@@ -155,6 +155,13 @@ class SummarizeStrategy(BaseOffloadStrategy):
             )
 
         if "text" not in block:
+            summary = await _summarize_content([block], model, self._config)
+            if summary:
+                logger.debug(
+                    "tracking_id=<%s>, tokens=<%s> | summarized media block", message.get("tracking_id"), tokens
+                )
+                marker = _format_summarized("media block", tokens, summary) + refs
+                return ContentBlock(text=marker)
             logger.debug("tracking_id=<%s>, tokens=<%s> | offloaded media block", message.get("tracking_id"), tokens)
             return ContentBlock(text=f"[Offloaded: ~{tokens} tokens]{refs}")
 

--- a/strands-py/src/strands/vended_plugins/context_offloader/search.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/search.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import re
 
 _MAX_PATTERN_LENGTH = 200
+_NESTED_QUANTIFIER = re.compile(r"[+*}]\s*\)\s*[+*?{]")
 
 _TEXT_APPLICATION_TYPES = frozenset(
     {
@@ -122,6 +123,8 @@ def _search_by_pattern(
     safe_input = pattern[:_MAX_PATTERN_LENGTH] if len(pattern) > _MAX_PATTERN_LENGTH else pattern
 
     try:
+        if _NESTED_QUANTIFIER.search(safe_input):
+            raise re.error("nested quantifier")
         regex = re.compile(safe_input)
     except re.error:
         regex = re.compile(re.escape(safe_input))

--- a/strands-py/src/strands/vended_plugins/context_offloader/search.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/search.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import re
 
 _MAX_PATTERN_LENGTH = 200
-_NESTED_QUANTIFIER = re.compile(r"[+*}]\s*\)\s*[+*?{]")
+_NESTED_QUANTIFIER = re.compile(r"[+*]\s*\)\s*[+*]")
 
 _TEXT_APPLICATION_TYPES = frozenset(
     {

--- a/strands-py/src/strands/vended_plugins/context_offloader/search.py
+++ b/strands-py/src/strands/vended_plugins/context_offloader/search.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import re
 
 _MAX_PATTERN_LENGTH = 200
+# Best-effort heuristic; does not catch all catastrophic patterns (e.g. (.*a){12}$).
 _NESTED_QUANTIFIER = re.compile(r"[+*]\s*\)\s*[+*]")
 
 _TEXT_APPLICATION_TYPES = frozenset(

--- a/strands-py/tests/strands/_context_manager/strategies/offload/test_summarize_strategy.py
+++ b/strands-py/tests/strands/_context_manager/strategies/offload/test_summarize_strategy.py
@@ -149,7 +149,7 @@ class TestSummarizeStrategyPerBlock:
         mock_agent.messages = messages
         context = ContextState(messages=messages, agent=mock_agent, utilization=0.5)
         assert await strategy.apply(context) is True
-        assert "[Offloaded: ~" in messages[1]["content"][0]["text"]
+        assert "[Summarized:" in messages[1]["content"][0]["text"]
 
 
 class TestSummarizeStrategyMessageLevel:

--- a/strands-py/tests/strands/_context_manager/strategies/offload/test_summarize_strategy.py
+++ b/strands-py/tests/strands/_context_manager/strategies/offload/test_summarize_strategy.py
@@ -151,6 +151,22 @@ class TestSummarizeStrategyPerBlock:
         assert await strategy.apply(context) is True
         assert "[Summarized:" in messages[1]["content"][0]["text"]
 
+    @pytest.mark.asyncio
+    async def test_falls_back_to_offloaded_when_media_summary_empty(self, mock_agent):
+        mock_agent.model.stream = _make_empty_stream()
+        strategy = Offload.summarize("*").when(threshold=100)
+        messages: Messages = [
+            Message(role="user", content=[ContentBlock(text="pin")]),
+            Message(
+                role="user",
+                content=[ContentBlock(image={"format": "png", "source": {"bytes": b"img"}})],
+            ),
+        ]
+        mock_agent.messages = messages
+        context = ContextState(messages=messages, agent=mock_agent, utilization=0.5)
+        assert await strategy.apply(context) is True
+        assert "[Offloaded:" in messages[1]["content"][0]["text"]
+
 
 class TestSummarizeStrategyMessageLevel:
     """Tests for message-level summarization — only tests unique to SummarizeStrategy."""

--- a/strands-py/tests/strands/_context_manager/test_retrieval_tool.py
+++ b/strands-py/tests/strands/_context_manager/test_retrieval_tool.py
@@ -136,27 +136,29 @@ class TestFullTextTruncation:
 
 
 class TestMediaBlockRetrieval:
-    """Tests for media block retrieval (image/document/video/audio)."""
+    """Tests for media block retrieval (image/document/video)."""
 
     @pytest.mark.asyncio
     async def test_restores_image_block(self, stash):
-        data = json.dumps({"image": {"format": "png", "source": {"bytes": "iVBOR"}}}).encode("utf-8")
+        data = json.dumps({"image": {"format": "png", "source": {"bytes": "UE5HX0RBVEE="}}}).encode("utf-8")
         ref = await stash.store("tool-1", 0, data)
         tool = _create_retrieval_tool(stash)
         result = await tool._tool_func({"toolUseId": "t1", "input": {"reference": ref}})
         assert result["status"] == "success"
         assert "image" in result["content"][0]
         assert result["content"][0]["image"]["format"] == "png"
+        assert result["content"][0]["image"]["source"]["bytes"] == b"PNG_DATA"
 
     @pytest.mark.asyncio
     async def test_restores_document_block(self, stash):
-        data = json.dumps({"document": {"format": "pdf", "source": {"bytes": "JVBER"}}}).encode("utf-8")
+        data = json.dumps({"document": {"format": "pdf", "source": {"bytes": "UERGX0RBVEE="}}}).encode("utf-8")
         ref = await stash.store("tool-1", 0, data)
         tool = _create_retrieval_tool(stash)
         result = await tool._tool_func({"toolUseId": "t1", "input": {"reference": ref}})
         assert result["status"] == "success"
         assert "document" in result["content"][0]
         assert result["content"][0]["document"]["format"] == "pdf"
+        assert result["content"][0]["document"]["source"]["bytes"] == b"PDF_DATA"
 
     @pytest.mark.asyncio
     async def test_returns_text_content_normally(self, stash):

--- a/strands-py/tests/strands/_context_manager/test_retrieval_tool.py
+++ b/strands-py/tests/strands/_context_manager/test_retrieval_tool.py
@@ -139,33 +139,32 @@ class TestMediaBlockRetrieval:
     """Tests for media block retrieval (image/document/video/audio)."""
 
     @pytest.mark.asyncio
-    async def test_returns_error_for_image_block(self, stash):
+    async def test_restores_image_block(self, stash):
         data = json.dumps({"image": {"format": "png", "source": {"bytes": "iVBOR"}}}).encode("utf-8")
         ref = await stash.store("tool-1", 0, data)
         tool = _create_retrieval_tool(stash)
         result = await tool._tool_func({"toolUseId": "t1", "input": {"reference": ref}})
-        assert result["status"] == "error"
-        assert "image" in result["content"][0]["text"]
-        assert "cannot be returned as text" in result["content"][0]["text"]
+        assert result["status"] == "success"
+        assert "image" in result["content"][0]
+        assert result["content"][0]["image"]["format"] == "png"
 
     @pytest.mark.asyncio
-    async def test_returns_error_for_document_block(self, stash):
+    async def test_restores_document_block(self, stash):
         data = json.dumps({"document": {"format": "pdf", "source": {"bytes": "JVBER"}}}).encode("utf-8")
         ref = await stash.store("tool-1", 0, data)
         tool = _create_retrieval_tool(stash)
         result = await tool._tool_func({"toolUseId": "t1", "input": {"reference": ref}})
-        assert result["status"] == "error"
-        assert "document" in result["content"][0]["text"]
+        assert result["status"] == "success"
+        assert "document" in result["content"][0]
+        assert result["content"][0]["document"]["format"] == "pdf"
 
     @pytest.mark.asyncio
-    async def test_includes_format_and_size_in_error(self, stash):
-        data = json.dumps({"image": {"format": "jpeg", "source": {"bytes": "abc123"}}}).encode("utf-8")
-        ref = await stash.store("tool-1", 0, data)
+    async def test_returns_text_content_normally(self, stash):
+        ref = await _store_text(stash, "hello world")
         tool = _create_retrieval_tool(stash)
         result = await tool._tool_func({"toolUseId": "t1", "input": {"reference": ref}})
-        assert result["status"] == "error"
-        assert "jpeg" in result["content"][0]["text"]
-        assert "6 bytes" in result["content"][0]["text"]
+        assert result["status"] == "success"
+        assert "hello world" in result["content"][0]["text"]
 
 
 class TestInvalidLineRange:

--- a/strands-py/tests/strands/_context_manager/test_stash_integration.py
+++ b/strands-py/tests/strands/_context_manager/test_stash_integration.py
@@ -297,7 +297,7 @@ class TestSummarizeWithStash:
         context = ContextState(messages=messages, agent=mock_agent, utilization=0.5, stash=stash)
         assert await strategy.apply(context) is True
         text = messages[1]["content"][0]["text"]
-        assert "[Offloaded:" in text
+        assert "[Summarized:" in text
         assert "ref:" in text
 
 

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_search.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_search.py
@@ -199,6 +199,11 @@ class TestSearchContentEdgeCases:
         result = _search_content(text, pattern=long_pattern, context_lines=0, max_chars=10_000)
         assert "No matches" in result
 
+    def test_nested_quantifier_falls_back_to_literal(self):
+        text = "(a+)+ hello\nother line"
+        result = _search_content(text, pattern="(a+)+", context_lines=0, max_chars=10_000)
+        assert "1 match" in result
+
     def test_empty_indices_format(self):
         from strands.vended_plugins.context_offloader.search import _format_lines
 

--- a/strands-py/tests/strands/vended_plugins/context_offloader/test_search.py
+++ b/strands-py/tests/strands/vended_plugins/context_offloader/test_search.py
@@ -200,9 +200,9 @@ class TestSearchContentEdgeCases:
         assert "No matches" in result
 
     def test_nested_quantifier_falls_back_to_literal(self):
-        text = "(a+)+ hello\nother line"
+        text = "aaa hello\nother line"
         result = _search_content(text, pattern="(a+)+", context_lines=0, max_chars=10_000)
-        assert "1 match" in result
+        assert "No matches" in result
 
     def test_empty_indices_format(self):
         from strands.vended_plugins.context_offloader.search import _format_lines

--- a/strands-ts/src/context-manager/__tests__/context-manager.test.ts
+++ b/strands-ts/src/context-manager/__tests__/context-manager.test.ts
@@ -62,14 +62,14 @@ describe('ContextManager', () => {
   })
 
   describe('initAgent', () => {
-    it('registers AfterModelCallEvent hook', () => {
+    it('registers AfterModelCallEvent hook', async () => {
       const cm = new ContextManager()
       const agent = makeMockAgent()
-      cm.initAgent(agent)
+      await cm.initAgent(agent)
       expect(agent.trackedHooks.length).toBeGreaterThan(0)
     })
 
-    it('initializes strategies with init context', () => {
+    it('initializes strategies with init context', async () => {
       let initCalled = false
       const strategy = {
         name: 'test',
@@ -80,7 +80,7 @@ describe('ContextManager', () => {
       }
       const cm = new ContextManager({ strategies: [strategy] })
       const agent = makeMockAgent()
-      cm.initAgent(agent)
+      await cm.initAgent(agent)
       expect(initCalled).toBe(true)
     })
   })
@@ -97,7 +97,7 @@ describe('ContextManager', () => {
       }
       const cm = new ContextManager({ strategies: [strategy] })
       const agent = makeMockAgent()
-      cm.initAgent(agent)
+      await cm.initAgent(agent)
 
       const event = makeOverflowEvent(agent)
       await invokeTrackedHook(agent, event)
@@ -117,7 +117,7 @@ describe('ContextManager', () => {
       }
       const cm = new ContextManager({ strategies: [strategy] })
       const agent = makeMockAgent()
-      cm.initAgent(agent)
+      await cm.initAgent(agent)
 
       const event = new AfterModelCallEvent({
         agent,
@@ -153,7 +153,7 @@ describe('ContextManager', () => {
         countTokens: async () => 10000,
         estimateUtilization: () => 1.5,
       })
-      cm.initAgent(agent)
+      await cm.initAgent(agent)
 
       const originalLength = messages.length
       const event = makeOverflowEvent(agent)
@@ -180,7 +180,7 @@ describe('ContextManager', () => {
         countTokens: async () => 100,
         estimateUtilization: () => 0.5,
       })
-      cm.initAgent(agent)
+      await cm.initAgent(agent)
 
       const originalLength = messages.length
       const event = makeOverflowEvent(agent)
@@ -208,7 +208,7 @@ describe('ContextManager', () => {
         countTokens: async () => 10000,
         estimateUtilization: () => 1.5,
       })
-      cm.initAgent(agent)
+      await cm.initAgent(agent)
 
       // First 3 overflows should retry
       for (let attempt = 0; attempt < 3; attempt++) {
@@ -236,7 +236,7 @@ describe('ContextManager', () => {
         countTokens: async () => 10000,
         estimateUtilization: () => 1.5,
       })
-      cm.initAgent(agent)
+      await cm.initAgent(agent)
 
       // Use 2 retries
       for (let attempt = 0; attempt < 2; attempt++) {
@@ -285,7 +285,7 @@ describe('ContextManager', () => {
         countTokens: async () => 10000,
         estimateUtilization: () => 1.5,
       })
-      cm.initAgent(agent)
+      await cm.initAgent(agent)
 
       const event = makeOverflowEvent(agent)
       await invokeTrackedHook(agent, event)
@@ -323,7 +323,7 @@ describe('ContextManager', () => {
         countTokens: async () => 10000,
         estimateUtilization: () => 1.5,
       })
-      cm.initAgent(agent)
+      await cm.initAgent(agent)
 
       const event = makeOverflowEvent(agent)
       await invokeTrackedHook(agent, event)
@@ -357,7 +357,7 @@ describe('ContextManager', () => {
         countTokens: async () => 10000,
         estimateUtilization: () => 1.5,
       })
-      cm.initAgent(agent)
+      await cm.initAgent(agent)
 
       const event = makeOverflowEvent(agent)
       await invokeTrackedHook(agent, event)
@@ -380,7 +380,7 @@ describe('ContextManager', () => {
       const agent = makeMockAgent({
         estimateUtilization: (tokens: number) => tokens / 10000,
       })
-      cm.initAgent(agent)
+      await cm.initAgent(agent)
 
       const event = makeBeforeEvent(agent, 5000)
       await invokeTrackedHook(agent, event)

--- a/strands-ts/src/context-manager/__tests__/retrieval-tool.test.ts
+++ b/strands-ts/src/context-manager/__tests__/retrieval-tool.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { createRetrievalTool, RETRIEVAL_TOOL_NAME } from '../retrieval-tool.js'
 import { Stash } from '../stash.js'
 import { InMemoryStorage } from '../../storage/in-memory-storage.js'
+import { ImageBlock } from '../../types/media.js'
 
 function invoke(retrievalTool: ReturnType<typeof createRetrievalTool>, input: unknown): Promise<unknown> {
   return (retrievalTool as unknown as { invoke(input: unknown): Promise<unknown> }).invoke(input)
@@ -67,15 +68,15 @@ describe('retrieval tool', () => {
     expect(result).toContain('Error: reference not found')
   })
 
-  it('returns media description error for image content instead of raw data', async () => {
+  it('restores image content as an ImageBlock instead of raw JSON', async () => {
     const stash = new Stash(new InMemoryStorage(), 'test-session', 'test-agent')
     const imageData = { image: { format: 'png', source: { bytes: 'iVBORw0KGgo=' } } }
     const ref = await stash.store('tool-img', 0, encodeJSON(imageData))
     const retrievalTool = createRetrievalTool(stash)
 
     const result = await invoke(retrievalTool, { reference: ref })
-    expect(result).toContain('image (png,')
-    expect(result).toContain('cannot be returned as text')
+    expect(result).toBeInstanceOf(ImageBlock)
+    expect((result as ImageBlock).format).toBe('png')
   })
 
   it('retrieves JSON content as parsed object', async () => {

--- a/strands-ts/src/context-manager/__tests__/retrieval-tool.test.ts
+++ b/strands-ts/src/context-manager/__tests__/retrieval-tool.test.ts
@@ -67,14 +67,15 @@ describe('retrieval tool', () => {
     expect(result).toContain('Error: reference not found')
   })
 
-  it('retrieves image content as JSON', async () => {
+  it('returns media description error for image content instead of raw data', async () => {
     const stash = new Stash(new InMemoryStorage(), 'test-session', 'test-agent')
     const imageData = { image: { format: 'png', source: { bytes: 'iVBORw0KGgo=' } } }
     const ref = await stash.store('tool-img', 0, encodeJSON(imageData))
     const retrievalTool = createRetrievalTool(stash)
 
     const result = await invoke(retrievalTool, { reference: ref })
-    expect(result).toEqual(imageData)
+    expect(result).toContain('image (png,')
+    expect(result).toContain('cannot be returned as text')
   })
 
   it('retrieves JSON content as parsed object', async () => {

--- a/strands-ts/src/context-manager/__tests__/stash-integration.test.ts
+++ b/strands-ts/src/context-manager/__tests__/stash-integration.test.ts
@@ -1,12 +1,19 @@
 import { describe, it, expect } from 'vitest'
 import { Offload } from '../strategies/offload/index.js'
 import { Stash } from '../stash.js'
-import { RETRIEVAL_TOOL_NAME } from '../retrieval-tool.js'
+import { ContextManager } from '../context-manager.js'
+import { createRetrievalTool, RETRIEVAL_TOOL_NAME } from '../retrieval-tool.js'
+import { PluginRegistry } from '../../plugins/registry.js'
 import { InMemoryStorage } from '../../storage/in-memory-storage.js'
 import { Message, TextBlock, ToolResultBlock, ToolUseBlock } from '../../types/messages.js'
 import { ImageBlock } from '../../types/media.js'
 import { createMockAgent } from '../../__fixtures__/agent-helpers.js'
+import type { Tool } from '../../tools/tool.js'
 import type { ContextState } from '../types.js'
+
+function invokeRetrievalTool(retrievalTool: Tool, input: unknown): Promise<unknown> {
+  return (retrievalTool as unknown as { invoke(input: unknown): Promise<unknown> }).invoke(input)
+}
 
 function makeToolResultMessage(text: string, toolUseId = 'tool-123'): Message {
   return new Message({
@@ -60,6 +67,44 @@ function makeContext(messages: Message[], stash?: Stash, utilization = 0.5): Con
   return base
 }
 
+describe('ContextManager tool registration', () => {
+  it('registers retrieve_context after plugin initialization', async () => {
+    const contextManager = new ContextManager()
+    const registry = new PluginRegistry([contextManager])
+    const agent = createMockAgent()
+
+    await registry.initialize(agent)
+
+    expect(agent.toolRegistry.get(RETRIEVAL_TOOL_NAME)).toBeDefined()
+  })
+
+  it('does not register retrieve_context when stash is disabled', async () => {
+    const contextManager = new ContextManager({ stash: false })
+    const registry = new PluginRegistry([contextManager])
+    const agent = createMockAgent()
+
+    await registry.initialize(agent)
+
+    expect(agent.toolRegistry.get(RETRIEVAL_TOOL_NAME)).toBeUndefined()
+  })
+
+  it('backfills stash from pre-existing messages at init', async () => {
+    const largeText = 'restored content '.repeat(500)
+    const messages = [makeToolResultMessage(largeText)]
+    const contextManager = new ContextManager()
+    const registry = new PluginRegistry([contextManager])
+    const agent = createMockAgent({ messages })
+
+    await registry.initialize(agent)
+
+    const stash = contextManager.stash!
+    const keys = await stash.list()
+    expect(keys.length).toBe(1)
+    const retrieved = await stash.retrieve(keys[0]!)
+    expect((retrieved!.data as { text: string }).text).toBe(largeText)
+  })
+})
+
 describe('Offload strategies with stash', () => {
   describe('truncate + stash', () => {
     it('persists original content to stash before truncating', async () => {
@@ -95,7 +140,7 @@ describe('Offload strategies with stash', () => {
 
       const block = messages[0]!.content[0] as ToolResultBlock
       const text = (block.content[0] as TextBlock).text
-      expect(text).toContain('[Stashed: ref:')
+      expect(text).toContain('[Stashed] [ref:')
     })
 
     it('does not stash when no stash is configured', async () => {
@@ -108,7 +153,7 @@ describe('Offload strategies with stash', () => {
 
       const block = messages[0]!.content[0] as ToolResultBlock
       const text = (block.content[0] as TextBlock).text
-      expect(text).not.toContain('[Stashed:')
+      expect(text).not.toContain('[Stashed]')
     })
   })
 
@@ -144,7 +189,7 @@ describe('Offload strategies with stash', () => {
 
       const block = messages[0]!.content[0] as ToolResultBlock
       const text = (block.content[0] as TextBlock).text
-      expect(text).toContain('[Dropped] ref:')
+      expect(text).toContain('[Dropped] [ref:')
     })
   })
 
@@ -250,6 +295,58 @@ describe('Offload strategies with stash', () => {
       expect(keys.length).toBe(1)
       const retrieved = await stash.retrieve(keys[0]!)
       expect((retrieved!.data as { text: string }).text).toBe(assistantText)
+    })
+  })
+
+  describe('media description in retrieval', () => {
+    it('returns error with description for image blocks instead of raw data', async () => {
+      const stash = new Stash(new InMemoryStorage(), 'test-session', 'test-agent')
+      const imageBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47])
+      const messages = [
+        new Message({
+          role: 'user',
+          content: [
+            new ToolResultBlock({
+              toolUseId: 'tool-img',
+              status: 'success',
+              content: [new ImageBlock({ format: 'png', source: { bytes: imageBytes } })],
+            }),
+          ],
+        }),
+      ]
+      await stashAll(stash, messages)
+
+      const retrievalTool = createRetrievalTool(stash)
+      const keys = await stash.list()
+      const result = await invokeRetrievalTool(retrievalTool, { reference: keys[0]! })
+
+      expect(result).toContain('image (png,')
+      expect(result).toContain('cannot be returned as text')
+    })
+
+    it('returns text content normally (not treated as media)', async () => {
+      const stash = new Stash(new InMemoryStorage(), 'test-session', 'test-agent')
+      const messages = [makeToolResultMessage('hello world')]
+      await stashAll(stash, messages)
+
+      const retrievalTool = createRetrievalTool(stash)
+      const keys = await stash.list()
+      const result = await invokeRetrievalTool(retrievalTool, { reference: keys[0]! })
+
+      expect(result).toEqual({ text: 'hello world' })
+    })
+
+    it('returns error with description for document blocks', async () => {
+      const stash = new Stash(new InMemoryStorage(), 'test-session', 'test-agent')
+      const docData = { document: { format: 'pdf', source: { bytes: 'base64encodedcontent' } } }
+      await stash.store('tool-doc', 0, new TextEncoder().encode(JSON.stringify(docData)))
+
+      const retrievalTool = createRetrievalTool(stash)
+      const keys = await stash.list()
+      const result = await invokeRetrievalTool(retrievalTool, { reference: keys[0]! })
+
+      expect(result).toContain('document (pdf,')
+      expect(result).toContain('cannot be returned as text')
     })
   })
 

--- a/strands-ts/src/context-manager/__tests__/stash-integration.test.ts
+++ b/strands-ts/src/context-manager/__tests__/stash-integration.test.ts
@@ -6,7 +6,7 @@ import { createRetrievalTool, RETRIEVAL_TOOL_NAME } from '../retrieval-tool.js'
 import { PluginRegistry } from '../../plugins/registry.js'
 import { InMemoryStorage } from '../../storage/in-memory-storage.js'
 import { Message, TextBlock, ToolResultBlock, ToolUseBlock } from '../../types/messages.js'
-import { ImageBlock } from '../../types/media.js'
+import { DocumentBlock, ImageBlock } from '../../types/media.js'
 import { createMockAgent } from '../../__fixtures__/agent-helpers.js'
 import type { Tool } from '../../tools/tool.js'
 import type { ContextState } from '../types.js'
@@ -298,8 +298,8 @@ describe('Offload strategies with stash', () => {
     })
   })
 
-  describe('media description in retrieval', () => {
-    it('returns error with description for image blocks instead of raw data', async () => {
+  describe('media restoration in retrieval', () => {
+    it('restores image blocks as ImageBlock instances', async () => {
       const stash = new Stash(new InMemoryStorage(), 'test-session', 'test-agent')
       const imageBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47])
       const messages = [
@@ -320,8 +320,8 @@ describe('Offload strategies with stash', () => {
       const keys = await stash.list()
       const result = await invokeRetrievalTool(retrievalTool, { reference: keys[0]! })
 
-      expect(result).toContain('image (png,')
-      expect(result).toContain('cannot be returned as text')
+      expect(result).toBeInstanceOf(ImageBlock)
+      expect((result as ImageBlock).format).toBe('png')
     })
 
     it('returns text content normally (not treated as media)', async () => {
@@ -336,7 +336,7 @@ describe('Offload strategies with stash', () => {
       expect(result).toEqual({ text: 'hello world' })
     })
 
-    it('returns error with description for document blocks', async () => {
+    it('restores document blocks as DocumentBlock instances', async () => {
       const stash = new Stash(new InMemoryStorage(), 'test-session', 'test-agent')
       const docData = { document: { format: 'pdf', source: { bytes: 'base64encodedcontent' } } }
       await stash.store('tool-doc', 0, new TextEncoder().encode(JSON.stringify(docData)))
@@ -345,8 +345,8 @@ describe('Offload strategies with stash', () => {
       const keys = await stash.list()
       const result = await invokeRetrievalTool(retrievalTool, { reference: keys[0]! })
 
-      expect(result).toContain('document (pdf,')
-      expect(result).toContain('cannot be returned as text')
+      expect(result).toBeInstanceOf(DocumentBlock)
+      expect((result as DocumentBlock).format).toBe('pdf')
     })
   })
 

--- a/strands-ts/src/context-manager/context-manager.ts
+++ b/strands-ts/src/context-manager/context-manager.ts
@@ -65,7 +65,7 @@ export class ContextManager implements Plugin {
     return [this._retrievalTool]
   }
 
-  initAgent(agent: LocalAgent): void {
+  async initAgent(agent: LocalAgent): Promise<void> {
     if (this._stashStorage !== false) {
       const storage = this._stashStorage ?? agent.storage ?? new InMemoryStorage()
       this._stashIsDurable = !(EPHEMERAL in storage)
@@ -75,6 +75,12 @@ export class ContextManager implements Plugin {
     if (this._stash) {
       const stash = this._stash
       const skipSet = this._retrievalToolUseIds
+
+      for (const message of agent.messages) {
+        trackRetrievalToolUseIds(message, skipSet)
+        await stash.storeMessage(message, skipSet)
+      }
+
       agent.addHook(MessageAddedEvent, async (event) => {
         trackRetrievalToolUseIds(event.message, skipSet)
         await stash.storeMessage(event.message, skipSet)

--- a/strands-ts/src/context-manager/methods/summarize.ts
+++ b/strands-ts/src/context-manager/methods/summarize.ts
@@ -13,6 +13,16 @@ import { logger } from '../../logging/logger.js'
 
 export const SUMMARIZED_PREFIX = '[Summarized:'
 
+/**
+ * Format a `[Summarized: ...]` marker with an optional summary body.
+ *
+ * @internal
+ */
+export function formatSummarized(description: string, tokens: number, summary?: string): string {
+  const header = `${SUMMARIZED_PREFIX} ${description}, ~${tokens.toLocaleString('en-US')} tokens]`
+  return summary ? `${header}\n\n${summary}` : header
+}
+
 // Subject to change as we benchmark summarization quality.
 const DEFAULT_SYSTEM_PROMPT = [
   'You are a summarization assistant. Produce a concise factual summary that preserves:',

--- a/strands-ts/src/context-manager/retrieval-tool.ts
+++ b/strands-ts/src/context-manager/retrieval-tool.ts
@@ -19,6 +19,8 @@ export const RETRIEVAL_TOOL_NAME = 'retrieve_context'
 const DEFAULT_MAX_RESULT_TOKENS = 10_000
 const CHARS_PER_TOKEN = 4
 
+const MEDIA_KEYS = ['image', 'document', 'video', 'audio'] as const
+
 const retrievalInputSchema = z.object({
   reference: z.string().describe('The reference key from the offload placeholder.'),
   pattern: z.string().optional().describe('Regex or keyword to grep for. Returns matching lines with context.'),
@@ -67,7 +69,15 @@ export function createRetrievalTool(stash: Stash, maxResultTokens?: number): Too
       }
 
       if (!input.pattern && !input.line_range) {
-        return result.data as JSONValue
+        if (result.data && typeof result.data === 'object' && !Array.isArray(result.data)) {
+          const mediaDesc = describeMedia(result.data as Record<string, unknown>)
+          if (mediaDesc) {
+            return `Reference ${input.reference} is ${mediaDesc} and cannot be returned as text.`
+          }
+        }
+        const serialized = JSON.stringify(result.data)
+        if (serialized.length <= maxChars) return result.data as JSONValue
+        return `${serialized.slice(0, maxChars)}\n\n[truncated]`
       }
 
       const text = extractText(result.data)
@@ -99,6 +109,25 @@ export function trackRetrievalToolUseIds(message: Message, skipSet: Set<string>)
       skipSet.add(block.toolUseId)
     }
   }
+}
+
+function describeMedia(data: Record<string, unknown>): string | null {
+  for (const key of MEDIA_KEYS) {
+    const media = data[key]
+    if (!media || typeof media !== 'object') continue
+    const record = media as Record<string, unknown>
+    const format = typeof record.format === 'string' ? record.format : 'unknown'
+    const source = record.source as Record<string, unknown> | undefined
+    const bytes = source?.bytes
+    const sizeDesc =
+      typeof bytes === 'string'
+        ? `, ${bytes.length} bytes`
+        : bytes instanceof Uint8Array
+          ? `, ${bytes.length} bytes`
+          : ''
+    return `${key} (${format}${sizeDesc})`
+  }
+  return null
 }
 
 function extractText(data: unknown): string | null {

--- a/strands-ts/src/context-manager/retrieval-tool.ts
+++ b/strands-ts/src/context-manager/retrieval-tool.ts
@@ -9,7 +9,7 @@
 import { z } from 'zod'
 import { tool } from '../tools/tool-factory.js'
 import { isSearchableContent, searchContent } from '../vended-plugins/context-offloader/search.js'
-import { AudioBlock, DocumentBlock, ImageBlock, VideoBlock } from '../types/media.js'
+import { DocumentBlock, ImageBlock, VideoBlock } from '../types/media.js'
 import type { JSONValue } from '../types/json.js'
 import type { Tool } from '../tools/tool.js'
 import { Message, ToolUseBlock } from '../types/messages.js'
@@ -108,11 +108,10 @@ export function trackRetrievalToolUseIds(message: Message, skipSet: Set<string>)
   }
 }
 
-function restoreMedia(data: Record<string, unknown>): ImageBlock | DocumentBlock | VideoBlock | AudioBlock | null {
+function restoreMedia(data: Record<string, unknown>): ImageBlock | DocumentBlock | VideoBlock | null {
   if ('image' in data) return ImageBlock.fromJSON(data as Parameters<typeof ImageBlock.fromJSON>[0])
   if ('document' in data) return DocumentBlock.fromJSON(data as Parameters<typeof DocumentBlock.fromJSON>[0])
   if ('video' in data) return VideoBlock.fromJSON(data as Parameters<typeof VideoBlock.fromJSON>[0])
-  if ('audio' in data) return AudioBlock.fromJSON(data as Parameters<typeof AudioBlock.fromJSON>[0])
   return null
 }
 

--- a/strands-ts/src/context-manager/retrieval-tool.ts
+++ b/strands-ts/src/context-manager/retrieval-tool.ts
@@ -9,6 +9,7 @@
 import { z } from 'zod'
 import { tool } from '../tools/tool-factory.js'
 import { isSearchableContent, searchContent } from '../vended-plugins/context-offloader/search.js'
+import { AudioBlock, DocumentBlock, ImageBlock, VideoBlock } from '../types/media.js'
 import type { JSONValue } from '../types/json.js'
 import type { Tool } from '../tools/tool.js'
 import { Message, ToolUseBlock } from '../types/messages.js'
@@ -18,8 +19,6 @@ export const RETRIEVAL_TOOL_NAME = 'retrieve_context'
 
 const DEFAULT_MAX_RESULT_TOKENS = 10_000
 const CHARS_PER_TOKEN = 4
-
-const MEDIA_KEYS = ['image', 'document', 'video', 'audio'] as const
 
 const retrievalInputSchema = z.object({
   reference: z.string().describe('The reference key from the offload placeholder.'),
@@ -70,10 +69,8 @@ export function createRetrievalTool(stash: Stash, maxResultTokens?: number): Too
 
       if (!input.pattern && !input.line_range) {
         if (result.data && typeof result.data === 'object' && !Array.isArray(result.data)) {
-          const mediaDesc = describeMedia(result.data as Record<string, unknown>)
-          if (mediaDesc) {
-            return `Reference ${input.reference} is ${mediaDesc} and cannot be returned as text.`
-          }
+          const media = restoreMedia(result.data as Record<string, unknown>)
+          if (media) return media as unknown as JSONValue
         }
         const serialized = JSON.stringify(result.data)
         if (serialized.length <= maxChars) return result.data as JSONValue
@@ -111,22 +108,11 @@ export function trackRetrievalToolUseIds(message: Message, skipSet: Set<string>)
   }
 }
 
-function describeMedia(data: Record<string, unknown>): string | null {
-  for (const key of MEDIA_KEYS) {
-    const media = data[key]
-    if (!media || typeof media !== 'object') continue
-    const record = media as Record<string, unknown>
-    const format = typeof record.format === 'string' ? record.format : 'unknown'
-    const source = record.source as Record<string, unknown> | undefined
-    const bytes = source?.bytes
-    const sizeDesc =
-      typeof bytes === 'string'
-        ? `, ${bytes.length} bytes`
-        : bytes instanceof Uint8Array
-          ? `, ${bytes.length} bytes`
-          : ''
-    return `${key} (${format}${sizeDesc})`
-  }
+function restoreMedia(data: Record<string, unknown>): ImageBlock | DocumentBlock | VideoBlock | AudioBlock | null {
+  if ('image' in data) return ImageBlock.fromJSON(data as Parameters<typeof ImageBlock.fromJSON>[0])
+  if ('document' in data) return DocumentBlock.fromJSON(data as Parameters<typeof DocumentBlock.fromJSON>[0])
+  if ('video' in data) return VideoBlock.fromJSON(data as Parameters<typeof VideoBlock.fromJSON>[0])
+  if ('audio' in data) return AudioBlock.fromJSON(data as Parameters<typeof AudioBlock.fromJSON>[0])
   return null
 }
 

--- a/strands-ts/src/context-manager/stash.ts
+++ b/strands-ts/src/context-manager/stash.ts
@@ -102,7 +102,7 @@ export class Stash {
       if (block instanceof ToolResultBlock) {
         if (skipToolUseIds?.has(block.toolUseId)) continue
         await this._storeToolResult(block).catch((error) => {
-          logger.debug(`toolUseId=<${block.toolUseId}>, error=<${error}> | failed to stash tool result`)
+          logger.warn(`toolUseId=<${block.toolUseId}>, error=<${error}> | failed to stash tool result`)
         })
       } else if (block instanceof ToolUseBlock || block instanceof CachePointBlock || block instanceof ReasoningBlock) {
         continue
@@ -110,7 +110,7 @@ export class Stash {
         try {
           await this.store(message.trackingId, blockIndex, encode(block.toJSON()))
         } catch (error) {
-          logger.debug(`trackingId=<${message.trackingId}>, error=<${error}> | failed to stash block`)
+          logger.warn(`trackingId=<${message.trackingId}>, error=<${error}> | failed to stash block`)
         }
       }
     }
@@ -196,7 +196,7 @@ export class Stash {
       try {
         await this.store(block.toolUseId, blockIndex, encode(item.toJSON()))
       } catch (error) {
-        logger.debug(
+        logger.warn(
           `toolUseId=<${block.toolUseId}>, blockIndex=<${blockIndex}>, error=<${error}> | failed to stash sub-block`
         )
       }

--- a/strands-ts/src/context-manager/stash.ts
+++ b/strands-ts/src/context-manager/stash.ts
@@ -101,9 +101,7 @@ export class Stash {
       const block = message.content[blockIndex]!
       if (block instanceof ToolResultBlock) {
         if (skipToolUseIds?.has(block.toolUseId)) continue
-        await this._storeToolResult(block).catch((error) => {
-          logger.warn(`toolUseId=<${block.toolUseId}>, error=<${error}> | failed to stash tool result`)
-        })
+        await this._storeToolResult(block)
       } else if (block instanceof ToolUseBlock || block instanceof CachePointBlock || block instanceof ReasoningBlock) {
         continue
       } else {

--- a/strands-ts/src/context-manager/stash.ts
+++ b/strands-ts/src/context-manager/stash.ts
@@ -28,8 +28,8 @@ function decode(bytes: Uint8Array): unknown {
 /** Format stash refs for display in placeholders. Returns '' when refs is empty. */
 export function formatStashRefs(refs: string[]): string {
   if (refs.length === 0) return ''
-  if (refs.length === 1) return ` ref: ${refs[0]!}`
-  return ` refs: ${refs.join(', ')}`
+  if (refs.length === 1) return ` [ref: ${refs[0]!}]`
+  return ` [refs: ${refs.join(', ')}]`
 }
 
 /**
@@ -193,7 +193,13 @@ export class Stash {
   private async _storeToolResult(block: ToolResultBlock): Promise<void> {
     for (let blockIndex = 0; blockIndex < block.content.length; blockIndex++) {
       const item = block.content[blockIndex]!
-      await this.store(block.toolUseId, blockIndex, encode(item.toJSON()))
+      try {
+        await this.store(block.toolUseId, blockIndex, encode(item.toJSON()))
+      } catch (error) {
+        logger.debug(
+          `toolUseId=<${block.toolUseId}>, blockIndex=<${blockIndex}>, error=<${error}> | failed to stash sub-block`
+        )
+      }
     }
   }
 }

--- a/strands-ts/src/context-manager/strategies/offload/base.ts
+++ b/strands-ts/src/context-manager/strategies/offload/base.ts
@@ -230,6 +230,7 @@ export function repairAlternation(messages: Message[]): void {
       messages[writeIndex - 1] = new Message({
         role: prev.role,
         content: [...prev.content, ...current.content],
+        trackingId: prev.trackingId,
       })
     } else {
       messages[writeIndex] = current

--- a/strands-ts/src/context-manager/strategies/offload/summarize.ts
+++ b/strands-ts/src/context-manager/strategies/offload/summarize.ts
@@ -134,6 +134,14 @@ export class SummarizeStrategy extends BaseOffloadStrategy {
       )
     }
 
+    const summary = await summarizeContent([block], model, this._config)
+    if (summary) {
+      logger.debug(`trackingId=<${message.trackingId}>, tokens=<${tokens}> | summarized media block`)
+      return new TextBlock(
+        `${SUMMARIZED_PREFIX} ~${tokens.toLocaleString()} tokens]${formatStashRefs(stashRefs)}\n\n${summary}`
+      )
+    }
+
     logger.debug(`trackingId=<${message.trackingId}>, tokens=<${tokens}> | offloaded media block`)
     return new TextBlock(`[Offloaded: ~${tokens} tokens]${formatStashRefs(stashRefs)}`)
   }

--- a/strands-ts/src/context-manager/strategies/offload/summarize.ts
+++ b/strands-ts/src/context-manager/strategies/offload/summarize.ts
@@ -118,7 +118,7 @@ export class SummarizeStrategy extends BaseOffloadStrategy {
         status: block.status,
         content: [
           new TextBlock(
-            `${SUMMARIZED_PREFIX} ~${tokens.toLocaleString()} tokens |${formatStashRefs(stashRefs)}]\n\n${summary}`
+            `${SUMMARIZED_PREFIX} ~${tokens.toLocaleString()} tokens]${formatStashRefs(stashRefs)}\n\n${summary}`
           ),
         ],
       })
@@ -130,12 +130,12 @@ export class SummarizeStrategy extends BaseOffloadStrategy {
 
       logger.debug(`trackingId=<${message.trackingId}>, tokens=<${tokens}> | summarized text block`)
       return new TextBlock(
-        `${SUMMARIZED_PREFIX} ~${tokens.toLocaleString()} tokens |${formatStashRefs(stashRefs)}]\n\n${summary}`
+        `${SUMMARIZED_PREFIX} ~${tokens.toLocaleString()} tokens]${formatStashRefs(stashRefs)}\n\n${summary}`
       )
     }
 
     logger.debug(`trackingId=<${message.trackingId}>, tokens=<${tokens}> | offloaded media block`)
-    return new TextBlock(`[Offloaded: ~${tokens} tokens${formatStashRefs(stashRefs)}]`)
+    return new TextBlock(`[Offloaded: ~${tokens} tokens]${formatStashRefs(stashRefs)}`)
   }
 
   private _resolveModel(agent: LocalAgent): Model | undefined {

--- a/strands-ts/src/context-manager/strategies/offload/summarize.ts
+++ b/strands-ts/src/context-manager/strategies/offload/summarize.ts
@@ -12,7 +12,7 @@ import type { LocalAgent } from '../../../types/agent.js'
 import type { ContextStrategy, ContextState } from '../../types.js'
 import {
   flattenMessagesToContent,
-  SUMMARIZED_PREFIX,
+  formatSummarized,
   summarizeContent,
   toolResultToContentBlocks,
   type SummarizeConfig,
@@ -81,11 +81,7 @@ export class SummarizeStrategy extends BaseOffloadStrategy {
     const totalTokens = await model.countTokens(safe)
     const summaryMessage = new Message({
       role: 'user',
-      content: [
-        new TextBlock(
-          `${SUMMARIZED_PREFIX} ${safe.length} messages, ~${totalTokens.toLocaleString()} tokens]\n\n${summary}`
-        ),
-      ],
+      content: [new TextBlock(formatSummarized(`${safe.length} messages`, totalTokens, summary))],
     })
 
     const { lowestIndex } = spliceWithPairs(messages, safe)
@@ -116,11 +112,7 @@ export class SummarizeStrategy extends BaseOffloadStrategy {
       return new ToolResultBlock({
         toolUseId: block.toolUseId,
         status: block.status,
-        content: [
-          new TextBlock(
-            `${SUMMARIZED_PREFIX} ~${tokens.toLocaleString()} tokens]${formatStashRefs(stashRefs)}\n\n${summary}`
-          ),
-        ],
+        content: [new TextBlock(`${formatSummarized('tool result', tokens, summary)}${formatStashRefs(stashRefs)}`)],
       })
     }
 
@@ -129,17 +121,13 @@ export class SummarizeStrategy extends BaseOffloadStrategy {
       if (!summary) return null
 
       logger.debug(`trackingId=<${message.trackingId}>, tokens=<${tokens}> | summarized text block`)
-      return new TextBlock(
-        `${SUMMARIZED_PREFIX} ~${tokens.toLocaleString()} tokens]${formatStashRefs(stashRefs)}\n\n${summary}`
-      )
+      return new TextBlock(`${formatSummarized('text block', tokens, summary)}${formatStashRefs(stashRefs)}`)
     }
 
     const summary = await summarizeContent([block], model, this._config)
     if (summary) {
       logger.debug(`trackingId=<${message.trackingId}>, tokens=<${tokens}> | summarized media block`)
-      return new TextBlock(
-        `${SUMMARIZED_PREFIX} ~${tokens.toLocaleString()} tokens]${formatStashRefs(stashRefs)}\n\n${summary}`
-      )
+      return new TextBlock(`${formatSummarized('media block', tokens, summary)}${formatStashRefs(stashRefs)}`)
     }
 
     logger.debug(`trackingId=<${message.trackingId}>, tokens=<${tokens}> | offloaded media block`)

--- a/strands-ts/src/context-manager/strategies/offload/truncate.ts
+++ b/strands-ts/src/context-manager/strategies/offload/truncate.ts
@@ -101,10 +101,10 @@ export class TruncateStrategy extends BaseOffloadStrategy {
       logger.debug(`trackingId=<${message.trackingId}>, tokens=<${tokens}> | truncated text block`)
       const truncated = truncateTextBlock(block, this._truncateConfig)
       const refs = formatStashRefs(stashRefs)
-      return refs ? new TextBlock(`${truncated.text}\n\n[Stashed:${refs}]`) : truncated
+      return refs ? new TextBlock(`${truncated.text}\n\n[Stashed]${refs}`) : truncated
     }
     logger.debug(`trackingId=<${message.trackingId}>, tokens=<${tokens}> | offloaded media block`)
-    return new TextBlock(`[Offloaded: ~${tokens} tokens${formatStashRefs(stashRefs)}]`)
+    return new TextBlock(`[Offloaded: ~${tokens} tokens]${formatStashRefs(stashRefs)}`)
   }
 }
 
@@ -116,7 +116,7 @@ function appendStashRefs(block: ToolResultBlock, stashRefs: string[]): ToolResul
   for (let index = 0; index < content.length; index++) {
     const item = content[index]!
     if (item instanceof TextBlock) {
-      content[index] = new TextBlock(`${item.text}\n\n[Stashed:${refs}]`)
+      content[index] = new TextBlock(`${item.text}\n\n[Stashed]${refs}`)
       return new ToolResultBlock({
         toolUseId: block.toolUseId,
         status: block.status,

--- a/strands-ts/src/plugins/__tests__/registry.test.ts
+++ b/strands-ts/src/plugins/__tests__/registry.test.ts
@@ -140,6 +140,33 @@ describe('PluginRegistry', () => {
       expect(mockAgent.toolRegistry.get(mockTool.name)).toBe(mockTool)
     })
 
+    it('calls getTools after initAgent so tools can depend on initialization state', async () => {
+      const mockTool = createRandomTool('deferred-tool')
+
+      class DeferredToolPlugin implements Plugin {
+        private _initialized = false
+
+        get name(): string {
+          return 'deferred-tool-plugin'
+        }
+
+        initAgent(_agent: LocalAgent): void {
+          this._initialized = true
+        }
+
+        getTools(): Tool[] {
+          return this._initialized ? [mockTool] : []
+        }
+      }
+
+      const plugin = new DeferredToolPlugin()
+      registry = new PluginRegistry([plugin])
+
+      await registry.initialize(mockAgent)
+
+      expect(mockAgent.toolRegistry.get(mockTool.name)).toBe(mockTool)
+    })
+
     it('handles async initAgent', async () => {
       class AsyncPlugin implements Plugin {
         public initialized = false

--- a/strands-ts/src/plugins/plugin.ts
+++ b/strands-ts/src/plugins/plugin.ts
@@ -69,7 +69,7 @@ export interface Plugin {
 
   /**
    * Returns tools provided by this plugin for auto-registration.
-   * Implement to provide plugin-specific tools.
+   * Called after {@link initAgent} resolves; may depend on state set there.
    *
    * @returns Array of tools to register with the agent
    */

--- a/strands-ts/src/plugins/registry.ts
+++ b/strands-ts/src/plugins/registry.ts
@@ -45,11 +45,11 @@ export class PluginRegistry {
     }
     this._plugins.set(plugin.name, plugin)
 
+    await plugin.initAgent(agent)
+
     const tools = plugin.getTools?.() ?? []
     if (tools.length > 0) {
       agent.toolRegistry.add(tools)
     }
-
-    await plugin.initAgent(agent)
   }
 }

--- a/strands-ts/src/vended-plugins/context-offloader/search.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/search.ts
@@ -30,9 +30,8 @@ function formatLines(lines: string[], indices: number[], matchedSet: Set<number>
   return output.join('\n')
 }
 
-// Mitigates ReDoS from overly long patterns. Short pathological patterns (e.g. `(a+)+$`)
-// are still possible but unlikely since the agent provides the pattern, not end users.
 const MAX_PATTERN_LENGTH = 200
+const NESTED_QUANTIFIER = /[+*}]\s*\)\s*[+*?{]/
 
 /** Finds lines matching a pattern, expands with context, and formats with truncation. */
 function searchByPattern(
@@ -47,6 +46,7 @@ function searchByPattern(
   let regex: RegExp
   const truncated = pattern.length > MAX_PATTERN_LENGTH ? pattern.slice(0, MAX_PATTERN_LENGTH) : pattern
   try {
+    if (NESTED_QUANTIFIER.test(truncated)) throw new Error('ReDoS')
     regex = new RegExp(truncated)
   } catch {
     regex = new RegExp(truncated.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))

--- a/strands-ts/src/vended-plugins/context-offloader/search.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/search.ts
@@ -31,7 +31,7 @@ function formatLines(lines: string[], indices: number[], matchedSet: Set<number>
 }
 
 const MAX_PATTERN_LENGTH = 200
-const NESTED_QUANTIFIER = /[+*}]\s*\)\s*[+*?{]/
+const NESTED_QUANTIFIER = /[+*]\s*\)\s*[+*]/
 
 /** Finds lines matching a pattern, expands with context, and formats with truncation. */
 function searchByPattern(

--- a/strands-ts/src/vended-plugins/context-offloader/search.ts
+++ b/strands-ts/src/vended-plugins/context-offloader/search.ts
@@ -31,6 +31,7 @@ function formatLines(lines: string[], indices: number[], matchedSet: Set<number>
 }
 
 const MAX_PATTERN_LENGTH = 200
+// Best-effort heuristic; does not catch all catastrophic patterns (e.g. (.*a){12}$).
 const NESTED_QUANTIFIER = /[+*]\s*\)\s*[+*]/
 
 /** Finds lines matching a pattern, expands with context, and formats with truncation. */


### PR DESCRIPTION
## Description

- Swap initAgent/getTools order in PluginRegistry so `retrieve_context` registers (Python parity in plugins)
- Per-block error handling in storeToolResult (no longer aborts on first failure)
- Preserve trackingId in repairAlternation
- Enforce maxChars cap on full retrieval path
- Consistent stash-ref placeholder format across strategies (`formatSummarized` helper with descriptor + locale-fixed token count)
- Backfill stash from pre-existing messages at init
- Restore actual media blocks (image/document) from stash instead of returning an error — the model can retrieve and "see" offloaded images again via `retrieve_context`
- Summarize standalone media blocks through the model before offloading (falls back to static `[Offloaded:]` if the model returns empty)
- Mitigate ReDoS in search pattern matching — best-effort nested quantifier detection with literal-match fallback
- Decode base64 bytes on restore in Python (stash JSON-encodes bytes on write; without decode the provider double-encodes)
- Drop audio/video from Python `_MEDIA_KEYS` (not valid `ToolResultContent` keys); video kept in TS where it is valid
- Bump stash write failure logging from debug to warn (cross-SDK parity)

## Related Issues

Fixes #4190, fixes #4191

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.