### PR TITLE
feat: export context manager types as experimental

### DIFF
--- a/strands-py/src/strands/_context_manager/__init__.py
+++ b/strands-py/src/strands/_context_manager/__init__.py
@@ -1,4 +1,5 @@
-"""Experimental and internal. Do not export.
+"""Context management modes and strategies that operate on an agent's conversation.
 
-Context management modes and strategies that operate on an agent's conversation.
+Internal implementation. Public experimental API is re-exported from
+``strands.experimental.context_manager``.
 """

--- a/strands-py/src/strands/_context_manager/methods/__init__.py
+++ b/strands-py/src/strands/_context_manager/methods/__init__.py
@@ -1,1 +1,1 @@
-"""Experimental and internal. Reduction method primitives."""
+"""Reduction method primitives for context management."""

--- a/strands-py/src/strands/_context_manager/strategies/__init__.py
+++ b/strands-py/src/strands/_context_manager/strategies/__init__.py
@@ -1,1 +1,1 @@
-"""Experimental and internal. Context management strategies."""
+"""Context management strategies."""

--- a/strands-py/src/strands/_context_manager/strategies/offload/__init__.py
+++ b/strands-py/src/strands/_context_manager/strategies/offload/__init__.py
@@ -1,4 +1,4 @@
-"""Experimental and internal. Offload strategies — reduce content in the context window."""
+"""Offload strategies — reduce content in the context window."""
 
 from __future__ import annotations
 

--- a/strands-py/src/strands/experimental/__init__.py
+++ b/strands-py/src/strands/experimental/__init__.py
@@ -3,7 +3,7 @@
 This module implements experimental features that are subject to change in future revisions without notice.
 """
 
-from . import checkpoint, steering, tools
+from . import checkpoint, context_manager, steering, tools
 from .agent_config import config_to_agent
 
-__all__ = ["checkpoint", "config_to_agent", "tools", "steering"]
+__all__ = ["checkpoint", "config_to_agent", "context_manager", "tools", "steering"]

--- a/strands-py/src/strands/experimental/context_manager/__init__.py
+++ b/strands-py/src/strands/experimental/context_manager/__init__.py
@@ -1,0 +1,28 @@
+"""Experimental context management types for strategy-driven context reduction.
+
+This module is experimental and subject to change in future revisions without notice.
+
+The ContextManager is a first-class agent component that manages context reduction
+via an ordered strategy pipeline. Pass it via the ``context_manager`` parameter on
+the Agent constructor.
+"""
+
+from ..._context_manager.context_manager import ContextManager
+from ..._context_manager.methods.summarize import SummarizeConfig
+from ..._context_manager.methods.truncate import TruncateConfig
+from ..._context_manager.strategies.offload import Offload
+from ..._context_manager.strategies.offload.base import OffloadConditions, OffloadTarget
+from ..._context_manager.types import ContextManagerConfig, ContextState, ContextStrategy, StashConfig
+
+__all__ = [
+    "ContextManager",
+    "ContextManagerConfig",
+    "ContextState",
+    "ContextStrategy",
+    "Offload",
+    "OffloadConditions",
+    "OffloadTarget",
+    "StashConfig",
+    "SummarizeConfig",
+    "TruncateConfig",
+]

--- a/strands-py/src/strands/experimental/context_manager/__init__.py
+++ b/strands-py/src/strands/experimental/context_manager/__init__.py
@@ -12,11 +12,10 @@ from ..._context_manager.methods.summarize import SummarizeConfig
 from ..._context_manager.methods.truncate import TruncateConfig
 from ..._context_manager.strategies.offload import Offload
 from ..._context_manager.strategies.offload.base import OffloadConditions, OffloadTarget
-from ..._context_manager.types import ContextManagerConfig, ContextState, ContextStrategy, StashConfig
+from ..._context_manager.types import ContextState, ContextStrategy, StashConfig
 
 __all__ = [
     "ContextManager",
-    "ContextManagerConfig",
     "ContextState",
     "ContextStrategy",
     "Offload",

--- a/strands-ts/src/context-manager/context-manager.ts
+++ b/strands-ts/src/context-manager/context-manager.ts
@@ -30,7 +30,6 @@ import { createRetrievalTool, trackRetrievalToolUseIds } from './retrieval-tool.
  * overflow recovery — no separate ConversationManager is needed.
  *
  * @experimental
- * @internal
  */
 export class ContextManager implements Plugin {
   readonly name = 'strands:context-manager'

--- a/strands-ts/src/context-manager/methods/summarize.ts
+++ b/strands-ts/src/context-manager/methods/summarize.ts
@@ -4,8 +4,6 @@
  * Compresses text via an LLM call. The method is target-agnostic — it operates
  * on any text (a tool result, a range of messages, raw storage content).
  * Strategies handle selection and placement.
- *
- * @internal
  */
 
 import type { Model } from '../../models/model.js'
@@ -30,6 +28,8 @@ const DEFAULT_SYSTEM_PROMPT = [
 
 /**
  * Configuration for the summarize method.
+ *
+ * @experimental
  */
 export interface SummarizeConfig {
   /** Model to use for summarization. When omitted, uses the agent's model. */

--- a/strands-ts/src/context-manager/methods/truncate.ts
+++ b/strands-ts/src/context-manager/methods/truncate.ts
@@ -2,8 +2,6 @@
  * Truncate reduction method.
  *
  * Replaces content with a preview (head, tail, or head-tail).
- *
- * @internal
  */
 
 import { JsonBlock, TextBlock, ToolResultBlock } from '../../types/messages.js'
@@ -16,6 +14,8 @@ const CHARS_PER_TOKEN = 4
 
 /**
  * Configuration for the truncate method.
+ *
+ * @experimental
  */
 export interface TruncateConfig {
   /** Number of tokens to keep as preview text. Defaults to 1,000. */

--- a/strands-ts/src/context-manager/strategies/offload/base.ts
+++ b/strands-ts/src/context-manager/strategies/offload/base.ts
@@ -61,8 +61,6 @@ export interface OffloadConditions {
 /**
  * Intermediate builder result that allows chaining `.when()` conditions.
  * Also implements `ContextStrategy` directly so it can be used without `.when()`.
- *
- * @experimental
  */
 export interface OffloadStrategyBuilder extends ContextStrategy {
   /** Add conditions that determine when this strategy fires. */

--- a/strands-ts/src/context-manager/strategies/offload/base.ts
+++ b/strands-ts/src/context-manager/strategies/offload/base.ts
@@ -1,7 +1,5 @@
 /**
  * Base offload strategy and shared infrastructure.
- *
- * @internal
  */
 
 import { logger } from '../../../logging/logger.js'
@@ -30,6 +28,8 @@ import { RETRIEVAL_TOOL_NAME } from '../../retrieval-tool.js'
  * - `"userText"` — text blocks in user messages (excluding tool results)
  * - `string[]` — tool results from specific tools, namespaced with `tool::` (e.g. `['tool::bash']`); prefix with `!` to exclude
  * - `"*"` — all content in the context window (tool results + text blocks)
+ *
+ * @experimental
  */
 export type OffloadTarget = '*' | 'toolResults' | 'toolResultErrors' | 'assistantText' | 'userText' | string[]
 
@@ -44,6 +44,8 @@ export type OffloadTarget = '*' | 'toolResults' | 'toolResultErrors' | 'assistan
  * When multiple strategies target the same content, they don't conflict — strategies
  * run as an ordered pipeline, and once an earlier strategy shrinks a block, it falls
  * below the next strategy's threshold and gets skipped automatically.
+ *
+ * @experimental
  */
 export interface OffloadConditions {
   /** Token threshold above which individual blocks are offloaded. */
@@ -59,6 +61,8 @@ export interface OffloadConditions {
 /**
  * Intermediate builder result that allows chaining `.when()` conditions.
  * Also implements `ContextStrategy` directly so it can be used without `.when()`.
+ *
+ * @experimental
  */
 export interface OffloadStrategyBuilder extends ContextStrategy {
   /** Add conditions that determine when this strategy fires. */

--- a/strands-ts/src/context-manager/strategies/offload/index.ts
+++ b/strands-ts/src/context-manager/strategies/offload/index.ts
@@ -1,7 +1,7 @@
 /**
  * Offload strategies — reduce content in the context window.
  *
- * @internal
+ * @experimental
  */
 
 import type { TruncateConfig } from '../../methods/truncate.js'

--- a/strands-ts/src/context-manager/types.ts
+++ b/strands-ts/src/context-manager/types.ts
@@ -13,6 +13,8 @@ import type { Message } from '../types/messages.js'
  *
  * Strategies are applied in order during `apply()`. Each decides whether
  * to act based on the current context state (utilization, message count, etc.).
+ *
+ * @experimental
  */
 export interface ContextStrategy {
   /** Stable identifier for logging and observability. */
@@ -33,6 +35,8 @@ export interface ContextStrategy {
 
 /**
  * State passed to strategies during apply().
+ *
+ * @experimental
  */
 export interface ContextState {
   /** The agent's current message array (the context window). Strategies mutate this in place. */
@@ -50,6 +54,8 @@ export interface ContextState {
 
 /**
  * Configuration for the L1 stash (offloaded content persistence).
+ *
+ * @experimental
  */
 export interface StashConfig {
   /** Storage backend. Defaults to InMemoryStorage when omitted. */
@@ -65,6 +71,8 @@ export interface StashConfig {
 
 /**
  * Full configuration for a ContextManager instance.
+ *
+ * @experimental
  */
 export interface ContextManagerConfig {
   /**

--- a/strands-ts/src/experimental/index.ts
+++ b/strands-ts/src/experimental/index.ts
@@ -8,3 +8,20 @@
 export { Checkpoint, CHECKPOINT_SCHEMA_VERSION } from './checkpoint.js'
 export type { CheckpointPosition, CheckpointData, CheckpointResumeContent } from './checkpoint.js'
 export { CheckpointError } from '../errors.js'
+
+// Context management (experimental)
+export { ContextManager } from '../context-manager/context-manager.js'
+export type {
+  ContextManagerConfig,
+  ContextStrategy,
+  ContextState,
+  StashConfig,
+} from '../context-manager/types.js'
+export { Offload } from '../context-manager/strategies/offload/index.js'
+export type {
+  OffloadTarget,
+  OffloadConditions,
+  OffloadStrategyBuilder,
+} from '../context-manager/strategies/offload/base.js'
+export type { TruncateConfig } from '../context-manager/methods/truncate.js'
+export type { SummarizeConfig } from '../context-manager/methods/summarize.js'

--- a/strands-ts/src/experimental/index.ts
+++ b/strands-ts/src/experimental/index.ts
@@ -11,17 +11,8 @@ export { CheckpointError } from '../errors.js'
 
 // Context management (experimental)
 export { ContextManager } from '../context-manager/context-manager.js'
-export type {
-  ContextManagerConfig,
-  ContextStrategy,
-  ContextState,
-  StashConfig,
-} from '../context-manager/types.js'
+export type { ContextManagerConfig, ContextStrategy, ContextState, StashConfig } from '../context-manager/types.js'
 export { Offload } from '../context-manager/strategies/offload/index.js'
-export type {
-  OffloadTarget,
-  OffloadConditions,
-  OffloadStrategyBuilder,
-} from '../context-manager/strategies/offload/base.js'
+export type { OffloadTarget, OffloadConditions } from '../context-manager/strategies/offload/base.js'
 export type { TruncateConfig } from '../context-manager/methods/truncate.js'
 export type { SummarizeConfig } from '../context-manager/methods/summarize.js'


### PR DESCRIPTION

## Description
Promote ContextManager, Offload, and related config types from internal to experimental in both Python and TypeScript SDKs.

Python: strands.experimental.context_manager
TypeScript: @strands-agents/sdk/experimental


## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [ ] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
