### PR TITLE
feat: accept cache_config on Ollama, Writer, and SageMaker

### DIFF
--- a/strands-py/src/strands/models/_validation.py
+++ b/strands-py/src/strands/models/_validation.py
@@ -83,7 +83,7 @@ def _cache_config_fields_set(cache_config: CacheConfig) -> set[str]:
 
 
 def warn_on_cache_config_not_supported(
-    cache_config: CacheConfig,
+    cache_config: CacheConfig | None,
     provider: str,
     *,
     supported: Collection[str],
@@ -92,12 +92,15 @@ def warn_on_cache_config_not_supported(
     """Warn once about supplied cache_config fields a provider does not support.
 
     Args:
-        cache_config: The provider's configured cache settings.
+        cache_config: The provider's configured cache settings, if any. ``None`` is a no-op, so callers
+            can pass an unset config directly without guarding it.
         provider: Human-readable provider name for the warning message.
         supported: Names of ``CacheConfig`` fields the provider applies; the rest are the no-ops.
         stacklevel: Frames to skip so the warning points at the caller. Defaults to 4, correct when a
             mapper one frame below ``format_request`` invokes this.
     """
+    if cache_config is None:
+        return
     unsupported = sorted(field for field in _cache_config_fields_set(cache_config) if field not in supported)
     if unsupported:
         warnings.warn(

--- a/strands-py/src/strands/models/ollama.py
+++ b/strands-py/src/strands/models/ollama.py
@@ -17,8 +17,13 @@ from ..types.content import ContentBlock, Messages
 from ..types.exceptions import ContextWindowOverflowException
 from ..types.streaming import StopReason, StreamEvent
 from ..types.tools import ToolChoice, ToolSpec
-from ._validation import _has_location_source, validate_config_keys, warn_on_tool_choice_not_supported
-from .model import BaseModelConfig, Model
+from ._validation import (
+    _has_location_source,
+    validate_config_keys,
+    warn_on_cache_config_not_supported,
+    warn_on_tool_choice_not_supported,
+)
+from .model import BaseModelConfig, CacheConfig, Model
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +52,7 @@ class OllamaModel(Model):
 
         Attributes:
             additional_args: Any additional arguments to include in the request.
+            cache_config: Prompt caching settings. Ollama honors no cache fields, so any set field is ignored.
             keep_alive: Controls how long the model will stay loaded into memory following the request (default: "5m").
             max_tokens: Maximum number of tokens to generate in the response.
             model_id: Ollama model ID (e.g., "llama3", "mistral", "phi3").
@@ -57,6 +63,7 @@ class OllamaModel(Model):
         """
 
         additional_args: dict[str, Any] | None
+        cache_config: CacheConfig | None
         keep_alive: str | None
         max_tokens: int | None
         model_id: str
@@ -197,7 +204,7 @@ class OllamaModel(Model):
             TypeError: If a message contains a content block type that cannot be converted to an Ollama-compatible
                 format.
         """
-        return {
+        request = {
             "messages": self._format_request_messages(messages, system_prompt),
             "model": self.config["model_id"],
             "options": {
@@ -232,6 +239,9 @@ class OllamaModel(Model):
                 else {}
             ),
         }
+        # Ollama applies no CacheConfig fields; warn that any set field is ignored.
+        warn_on_cache_config_not_supported(self.config.get("cache_config"), "Ollama", supported=set(), stacklevel=3)
+        return request
 
     def format_chunk(self, event: dict[str, Any]) -> StreamEvent:
         """Format the Ollama response events into standardized message chunks.

--- a/strands-py/src/strands/models/sagemaker.py
+++ b/strands-py/src/strands/models/sagemaker.py
@@ -16,8 +16,8 @@ from typing_extensions import Unpack, override
 from ..types.content import ContentBlock, Messages
 from ..types.streaming import StreamEvent
 from ..types.tools import ToolChoice, ToolResult, ToolSpec
-from ._validation import validate_config_keys, warn_on_tool_choice_not_supported
-from .model import BaseModelConfig
+from ._validation import validate_config_keys, warn_on_cache_config_not_supported, warn_on_tool_choice_not_supported
+from .model import BaseModelConfig, CacheConfig
 from .openai import OpenAIModel
 
 T = TypeVar("T", bound=BaseModel)
@@ -200,6 +200,7 @@ class SageMakerAIModel(OpenAIModel):
         Attributes:
             endpoint_name: The name of the SageMaker endpoint to invoke
             inference_component_name: The name of the inference component to use
+            cache_config: Prompt caching settings. SageMaker honors no cache fields, so any set field is ignored.
 
             additional_args: Other request parameters, as supported by https://bit.ly/sagemaker-invoke-endpoint-params
         """
@@ -209,6 +210,7 @@ class SageMakerAIModel(OpenAIModel):
         inference_component_name: str | None
         target_model: str | None | None
         target_variant: str | None | None
+        cache_config: CacheConfig | None
         additional_args: dict[str, Any] | None
 
     def __init__(
@@ -373,6 +375,10 @@ class SageMakerAIModel(OpenAIModel):
         if additional_args:
             request.update(additional_args)
 
+        # SageMaker applies no CacheConfig fields; warn that any set field is ignored.
+        warn_on_cache_config_not_supported(
+            self.endpoint_config.get("cache_config"), "SageMaker", supported=set(), stacklevel=3
+        )
         return request
 
     @override

--- a/strands-py/src/strands/models/writer.py
+++ b/strands-py/src/strands/models/writer.py
@@ -18,8 +18,13 @@ from ..types.content import ContentBlock, Messages
 from ..types.exceptions import ContextWindowOverflowException, ModelThrottledException
 from ..types.streaming import StreamEvent
 from ..types.tools import ToolChoice, ToolResult, ToolSpec, ToolUse
-from ._validation import _has_location_source, validate_config_keys, warn_on_tool_choice_not_supported
-from .model import BaseModelConfig, Model
+from ._validation import (
+    _has_location_source,
+    validate_config_keys,
+    warn_on_cache_config_not_supported,
+    warn_on_tool_choice_not_supported,
+)
+from .model import BaseModelConfig, CacheConfig, Model
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +49,7 @@ class WriterModel(Model):
         Attributes:
             model_id: Model name to use (e.g. palmyra-x5, palmyra-x4, etc.).
             max_tokens: Maximum number of tokens to generate.
+            cache_config: Prompt caching settings. Writer honors no cache fields, so any set field is ignored.
             stop: Default stop sequences.
             stream_options: Additional options for streaming.
             temperature: What sampling temperature to use.
@@ -52,6 +58,7 @@ class WriterModel(Model):
 
         model_id: str
         max_tokens: int | None
+        cache_config: CacheConfig | None
         stop: str | list[str] | None
         stream_options: dict[str, Any]
         temperature: float | None
@@ -279,7 +286,7 @@ class WriterModel(Model):
             The formatted request.
         """
         request = {
-            **{k: v for k, v in self.config.items()},
+            **{k: v for k, v in self.config.items() if k != "cache_config"},
             "messages": self._format_request_messages(messages, system_prompt),
             "stream": True,
         }
@@ -304,6 +311,8 @@ class WriterModel(Model):
                 for tool_spec in tool_specs
             ]
 
+        # Writer applies no CacheConfig fields; warn that any set field is ignored.
+        warn_on_cache_config_not_supported(self.config.get("cache_config"), "Writer", supported=set(), stacklevel=3)
         return request
 
     def format_chunk(self, event: Any) -> StreamEvent:

--- a/strands-py/tests/strands/models/test_ollama.py
+++ b/strands-py/tests/strands/models/test_ollama.py
@@ -8,6 +8,7 @@ import pydantic
 import pytest
 
 import strands
+from strands.models.model import CacheConfig
 from strands.models.ollama import OllamaModel
 from strands.types.content import Messages
 from strands.types.exceptions import ContextWindowOverflowException
@@ -809,3 +810,47 @@ async def test_structured_output_non_overflow_response_error_propagates(
     messages = [{"role": "user", "content": [{"text": "test"}]}]
     with pytest.raises(ollama.ResponseError, match="not found"):
         await alist(model.structured_output(test_output_model_cls, messages))
+
+
+def test_cache_config_round_trips(host, model_id, captured_warnings):
+    """cache_config is a valid config field and survives get_config/update_config unchanged."""
+    cache_config = CacheConfig()
+    model = OllamaModel(host, model_id=model_id, cache_config=cache_config)
+
+    assert model.get_config()["cache_config"] is cache_config
+
+    updated = CacheConfig()
+    model.update_config(cache_config=updated)
+    assert model.get_config()["cache_config"] is updated
+
+    assert not any("Invalid configuration parameters" in str(warning.message) for warning in captured_warnings)
+
+
+def test_cache_config_default_is_silent_and_not_routed(host, model_id, messages, captured_warnings):
+    """A CacheConfig whose fields are all default warns about nothing and never reaches the request."""
+    model = OllamaModel(host, model_id=model_id, cache_config=CacheConfig(strategy="auto"))
+
+    request = model.format_request(messages)
+
+    assert "cache_config" not in request
+    assert not any("have no effect" in str(warning.message) for warning in captured_warnings)
+
+
+@pytest.mark.parametrize(
+    ("cache_config", "field"),
+    [
+        (CacheConfig(strategy="anthropic"), "strategy"),
+        (CacheConfig(ttl="1h"), "ttl"),
+        (CacheConfig(system_prompt_ttl="1h"), "system_prompt_ttl"),
+        (CacheConfig(cache_key="tenant-42"), "cache_key"),
+        (CacheConfig(tools_ttl=True), "tools_ttl"),
+    ],
+)
+def test_cache_config_unsupported_field_warns_and_is_not_routed(host, model_id, messages, cache_config, field):
+    """Ollama honors no cache field: a non-default field warns (naming the provider) and never reaches the request."""
+    model = OllamaModel(host, model_id=model_id, cache_config=cache_config)
+
+    with pytest.warns(UserWarning, match=rf"fields \['{field}'\] have no effect on Ollama"):
+        request = model.format_request(messages)
+
+    assert "cache_config" not in request

--- a/strands-py/tests/strands/models/test_sagemaker.py
+++ b/strands-py/tests/strands/models/test_sagemaker.py
@@ -9,6 +9,7 @@ import boto3
 import pytest
 from botocore.config import Config as BotocoreConfig
 
+from strands.models.model import CacheConfig
 from strands.models.sagemaker import (
     FunctionCall,
     SageMakerAIModel,
@@ -1016,3 +1017,65 @@ class TestSageMakerReasoningContent:
         ]
         assert len(reasoning_deltas) == 1
         assert reasoning_deltas[0]["contentBlockDelta"]["delta"]["reasoningContent"]["text"] == "Thinking..."
+
+
+def test_cache_config_round_trips(boto_session, endpoint_config, payload_config, captured_warnings):
+    """cache_config is a valid endpoint_config field and survives get_config/update_config unchanged."""
+    cache_config = CacheConfig()
+    model = SageMakerAIModel(
+        boto_session=boto_session,
+        endpoint_config={**endpoint_config, "cache_config": cache_config},
+        payload_config=payload_config,
+    )
+
+    assert model.get_config()["cache_config"] is cache_config
+
+    updated = CacheConfig()
+    model.update_config(cache_config=updated)
+    assert model.get_config()["cache_config"] is updated
+
+    assert not any("Invalid configuration parameters" in str(warning.message) for warning in captured_warnings)
+
+
+def test_cache_config_default_is_silent_and_not_routed(
+    boto_session, endpoint_config, payload_config, messages, captured_warnings
+):
+    """A CacheConfig whose fields are all default warns about nothing and never reaches the request."""
+    model = SageMakerAIModel(
+        boto_session=boto_session,
+        endpoint_config={**endpoint_config, "cache_config": CacheConfig(strategy="auto")},
+        payload_config=payload_config,
+    )
+
+    request = model.format_request(messages)
+
+    assert "cache_config" not in request
+    assert "cache_config" not in json.loads(request["Body"])
+    assert not any("have no effect" in str(warning.message) for warning in captured_warnings)
+
+
+@pytest.mark.parametrize(
+    ("cache_config", "field"),
+    [
+        (CacheConfig(strategy="anthropic"), "strategy"),
+        (CacheConfig(ttl="1h"), "ttl"),
+        (CacheConfig(system_prompt_ttl="1h"), "system_prompt_ttl"),
+        (CacheConfig(cache_key="tenant-42"), "cache_key"),
+        (CacheConfig(tools_ttl=True), "tools_ttl"),
+    ],
+)
+def test_cache_config_unsupported_field_warns_and_is_not_routed(
+    boto_session, endpoint_config, payload_config, messages, cache_config, field
+):
+    """SageMaker honors no cache field: a non-default field warns (naming the provider) and never reaches request."""
+    model = SageMakerAIModel(
+        boto_session=boto_session,
+        endpoint_config={**endpoint_config, "cache_config": cache_config},
+        payload_config=payload_config,
+    )
+
+    with pytest.warns(UserWarning, match=rf"fields \['{field}'\] have no effect on SageMaker"):
+        request = model.format_request(messages)
+
+    assert "cache_config" not in request
+    assert "cache_config" not in json.loads(request["Body"])

--- a/strands-py/tests/strands/models/test_writer.py
+++ b/strands-py/tests/strands/models/test_writer.py
@@ -7,6 +7,7 @@ import pytest
 import writerai
 
 import strands
+from strands.models.model import CacheConfig
 from strands.models.writer import WriterModel
 from strands.types.exceptions import ContextWindowOverflowException
 
@@ -635,3 +636,50 @@ async def test_structured_output_non_overflow_bad_request_propagates(
     messages = [{"role": "user", "content": [{"text": "test"}]}]
     with pytest.raises(writerai.BadRequestError, match="invalid 'model' parameter"):
         await alist(model.structured_output(test_output_model_cls, messages))
+
+
+def test_cache_config_round_trips(writer_client, model_id, captured_warnings):
+    """cache_config is a valid config field and survives get_config/update_config unchanged."""
+    _ = writer_client
+    cache_config = CacheConfig()
+    model = WriterModel(model_id=model_id, cache_config=cache_config)
+
+    assert model.get_config()["cache_config"] is cache_config
+
+    updated = CacheConfig()
+    model.update_config(cache_config=updated)
+    assert model.get_config()["cache_config"] is updated
+
+    assert not any("Invalid configuration parameters" in str(warning.message) for warning in captured_warnings)
+
+
+def test_cache_config_default_is_silent_and_not_routed(writer_client, model_id, messages, captured_warnings):
+    """A CacheConfig whose fields are all default warns about nothing and never reaches the request."""
+    _ = writer_client
+    model = WriterModel(model_id=model_id, cache_config=CacheConfig(strategy="auto"))
+
+    request = model.format_request(messages)
+
+    assert "cache_config" not in request
+    assert not any("have no effect" in str(warning.message) for warning in captured_warnings)
+
+
+@pytest.mark.parametrize(
+    ("cache_config", "field"),
+    [
+        (CacheConfig(strategy="anthropic"), "strategy"),
+        (CacheConfig(ttl="1h"), "ttl"),
+        (CacheConfig(system_prompt_ttl="1h"), "system_prompt_ttl"),
+        (CacheConfig(cache_key="tenant-42"), "cache_key"),
+        (CacheConfig(tools_ttl=True), "tools_ttl"),
+    ],
+)
+def test_cache_config_unsupported_field_warns_and_is_not_routed(writer_client, model_id, messages, cache_config, field):
+    """Writer honors no cache field: a non-default field warns (naming the provider) and never reaches the request."""
+    _ = writer_client
+    model = WriterModel(model_id=model_id, cache_config=cache_config)
+
+    with pytest.warns(UserWarning, match=rf"fields \['{field}'\] have no effect on Writer"):
+        request = model.format_request(messages)
+
+    assert "cache_config" not in request


### PR DESCRIPTION
## Description

`CacheConfig` is a provider-agnostic option, but the Ollama, Writer, and SageMaker providers rejected it outright — passing `cache_config` tripped `validate_config_keys` and surfaced as an "invalid configuration parameter" warning, since none of them declared the field. That breaks the promise that `CacheConfig` is uniform across providers and makes portable, provider-independent configuration impossible.

These three providers expose no prompt-cache controls to map onto (verified against the installed SDKs and APIs: the `ollama` `Options` type and `writerai` have no cache fields, and the SageMaker Runtime `invoke_endpoint` API has no cache parameter). So they now accept `cache_config` and route it through the existing `warn_on_cache_config_not_supported(..., supported=set())` helper, matching the llama.cpp pattern: every set field is a no-op that emits a single "have no effect on <provider>" warning rather than a misleading invalid-parameter one.

Worth noting for review: `SageMakerAIModel` subclasses `OpenAIModel`, which *does* map `cache_key`/`ttl`. SageMaker overrides `format_request` and never calls the OpenAI cache mapper, so those OpenAI-platform-specific params are correctly not applied — `supported=set()` is intentional, not an oversight.

## Public API Changes

`cache_config` is now a valid config field on all three providers. Setting it no longer errors; a non-default field warns that it is ignored.

## Related Issues

#1140

## Documentation PR

N/A

## Type of Change

New feature

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [x] I ran `hatch run prepare`

Ran the unit suites for the three providers. Also exercised each provider end to end: constructed the model with a populated `CacheConfig`, built the request under a warnings recorder, and confirmed the "have no effect on <provider>" warning fires and that `cache_config` never leaks into the outgoing request (including the JSON body for SageMaker and the spread config for Writer).

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
