### PR TITLE
fix(openai): emit tool results before user text to preserve tool_use/tool_result adjacency

### DIFF
--- a/strands-ts/src/models/openai/__tests__/chat.test.ts
+++ b/strands-ts/src/models/openai/__tests__/chat.test.ts
@@ -1857,6 +1857,51 @@ describe('OpenAIModel', () => {
     })
   })
 
+  describe('tool result and text ordering', () => {
+    // Regression: an everyTurn context injector folds rendered text onto a tool-result turn, producing a
+    // mixed [toolResult, text] user message. Tool results must be emitted before that text so each `tool`
+    // message immediately follows the assistant `tool_calls` it answers — OpenAI rejects a request where a
+    // non-tool message wedges between them.
+    it.each([
+      { name: 'tool result then text', order: ['tu1', 'text'], roles: ['user', 'assistant', 'tool', 'user'] },
+      { name: 'text then tool result', order: ['text', 'tu1'], roles: ['user', 'assistant', 'tool', 'user'] },
+      {
+        name: 'text between parallel tool results',
+        order: ['tu1', 'text', 'tu2'],
+        roles: ['user', 'assistant', 'tool', 'tool', 'user'],
+      },
+    ])('keeps tool results adjacent to the assistant tool_calls for $name', async ({ order, roles }) => {
+      const toolUseIds = order.filter((entry) => entry !== 'text')
+      const captured: { request: any } = { request: null }
+      const provider = new OpenAIModel({ api: 'chat', client: createMockClientWithCapture(captured) })
+
+      await collectIterator(
+        provider.stream([
+          new Message({ role: 'user', content: [new TextBlock('task')] }),
+          new Message({
+            role: 'assistant',
+            content: toolUseIds.map((toolUseId) => new ToolUseBlock({ name: 'calc', toolUseId, input: {} })),
+          }),
+          new Message({
+            role: 'user',
+            content: order.map((entry) =>
+              entry === 'text'
+                ? new TextBlock('\n\nNOTE')
+                : new ToolResultBlock({ toolUseId: entry, status: 'success', content: [new TextBlock('42')] })
+            ),
+          }),
+        ])
+      )
+
+      const requestMessages = captured.request.messages
+      expect(requestMessages.map((message: any) => message.role)).toEqual(roles)
+      // The message immediately after the assistant tool_calls must be the first tool response.
+      expect(requestMessages[2]).toEqual({ role: 'tool', tool_call_id: 'tu1', content: '42' })
+      // The injected text trails the tool responses as its own user message.
+      expect(requestMessages.at(-1)).toEqual({ role: 'user', content: [{ type: 'text', text: '\n\nNOTE' }] })
+    })
+  })
+
   describe('error handling', () => {
     it('throws ContextWindowOverflowError for structured error with code', async () => {
       const mockClient = {

--- a/strands-ts/src/models/openai/__tests__/chat.test.ts
+++ b/strands-ts/src/models/openai/__tests__/chat.test.ts
@@ -1900,6 +1900,36 @@ describe('OpenAIModel', () => {
       // The injected text trails the tool responses as its own user message.
       expect(requestMessages.at(-1)).toEqual({ role: 'user', content: [{ type: 'text', text: '\n\nNOTE' }] })
     })
+
+    it('keeps media hoisted out of a tool result ahead of the injected text', async () => {
+      const captured: { request: any } = { request: null }
+      const provider = new OpenAIModel({ api: 'chat', client: createMockClientWithCapture(captured) })
+
+      await collectIterator(
+        provider.stream([
+          new Message({
+            role: 'user',
+            content: [
+              new ToolResultBlock({
+                toolUseId: 'tu1',
+                status: 'success',
+                content: [
+                  new TextBlock('42'),
+                  new ImageBlock({ format: 'png', source: { bytes: new Uint8Array([1]) } }),
+                ],
+              }),
+              new TextBlock('\n\nNOTE'),
+            ],
+          }),
+        ])
+      )
+
+      expect(captured.request.messages).toEqual([
+        { role: 'tool', tool_call_id: 'tu1', content: '42' },
+        { role: 'user', content: [{ type: 'image_url', image_url: { url: 'data:image/png;base64,AQ==' } }] },
+        { role: 'user', content: [{ type: 'text', text: '\n\nNOTE' }] },
+      ])
+    })
   })
 
   describe('error handling', () => {

--- a/strands-ts/src/models/openai/chat-adapter.ts
+++ b/strands-ts/src/models/openai/chat-adapter.ts
@@ -150,8 +150,10 @@ export function formatChatRequest(
 
 /**
  * Converts SDK messages into Chat Completions message params. Tool result blocks
- * are split out into separate `tool`-role messages; media inside tool results is
- * hoisted into a following user-role message (OpenAI restricts media to user role).
+ * are split out into separate `tool`-role messages, emitted before any text/media
+ * `user` message from the same turn so the tool responses stay adjacent to the
+ * assistant `tool_calls` they answer; media inside tool results is hoisted into a
+ * following user-role message (OpenAI restricts media to user role).
  */
 function formatChatMessages(messages: Message[]): OpenAI.Chat.Completions.ChatCompletionMessageParam[] {
   const openAIMessages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = []
@@ -160,6 +162,10 @@ function formatChatMessages(messages: Message[]): OpenAI.Chat.Completions.ChatCo
     if (message.role === 'user') {
       const toolResults = message.content.filter((b) => b.type === 'toolResultBlock')
       const otherContent = message.content.filter((b) => b.type !== 'toolResultBlock')
+
+      // OpenAI requires the assistant `tool_calls` message to be followed immediately by the matching
+      // `tool` responses, with no other message interposed
+      const deferredUserMessages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = []
 
       if (otherContent.length > 0) {
         const contentParts: OpenAI.Chat.Completions.ChatCompletionContentPart[] = []
@@ -223,7 +229,7 @@ function formatChatMessages(messages: Message[]): OpenAI.Chat.Completions.ChatCo
         }
 
         if (contentParts.length > 0) {
-          openAIMessages.push({ role: 'user', content: contentParts })
+          deferredUserMessages.push({ role: 'user', content: contentParts })
         }
       }
 
@@ -264,6 +270,7 @@ function formatChatMessages(messages: Message[]): OpenAI.Chat.Completions.ChatCo
       }
 
       openAIMessages.push(...userMessagesWithMedia)
+      openAIMessages.push(...deferredUserMessages)
     } else {
       const toolUseCalls: OpenAI.Chat.Completions.ChatCompletionMessageToolCall[] = []
       const textParts: string[] = []


### PR DESCRIPTION
## Description

An `everyTurn` context injector (`ContextInjector`, `MemoryManager`, or any always-fire predicate) folds its rendered text as a trailing `TextBlock` onto the last user message. When that message is an autonomous tool-result turn, its content becomes `[toolResult, text]`. The Chat Completions adapter split this into a `user` message (the text) emitted *before* the `tool` message (the result), wedging the injected text between the assistant `tool_calls` and the `tool_call_id` that answers it. OpenAI rejects that with a hard 400 — `An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'` — so an agent on OpenAI chat with an everyTurn injector dies the first time it enters a tool loop.

This is the OpenAI counterpart to #4138: the same bug class, where a provider with a distinct `tool` role must keep tool responses adjacent to the `tool_calls` they answer. The fix defers the text/media `user` message and emits it after the tool responses, preserving the injection layer's documented "the tool result stays first in the turn that answers a tool use" invariant on the wire.


## Related Issues

None filed. OpenAI counterpart to #4138 (same fix for the Vercel provider).

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

Added a regression test asserting that when injected text shares a tool-result turn, each `tool` message immediately follows the assistant `tool_calls` it answers and the text trails as its own `user` message (single, leading, and between-parallel-tool-results orderings).

Verified live against the OpenAI API (`gpt-5.4-mini`): pre-fix, both a hand-built mixed tool-result turn and a full agent tool loop driven by an everyTurn `ContextInjector` return the 400 above; post-fix, both complete. Also drove a no-network stress harness through a real `Agent` + everyTurn injector across single, deep-loop, parallel, error-status, streaming, and tool-result-media turns, rejecting any request that breaks `tool_calls → tool` adjacency — all green post-fix, all failing pre-fix.

- [x] I ran the TypeScript gate (`npm run build`, `type-check`, `lint`, `format:check`, unit tests)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.