### PR TITLE
catalog: add capsule-emit (Strands tool-call evidence)

### DIFF
--- a/site/src/content/catalog/capsule-emit.yaml
+++ b/site/src/content/catalog/capsule-emit.yaml
@@ -1,0 +1,9 @@
+name: capsule-emit
+description: Seals a tamper-evident, offline-verifiable capsule for every Strands tool call — a planned commitment record chained to its confirmed, failed, or blocked outcome.
+integrationType: plugin
+languages:
+  python:
+    package: capsule-emit[strands]
+github: https://github.com/action-state-group/capsule-emit
+docsUrl: https://github.com/action-state-group/capsule-emit/blob/main/docs/adapters/strands.md
+addedDate: 2026-09-08


### PR DESCRIPTION
## Integration submission

**Package name:** capsule-emit (listed with its `[strands]` extra: `capsule-emit[strands]`)
**Integration type:** plugin
**Languages published:** Python
**GitHub repo:** https://github.com/action-state-group/capsule-emit
**What it does:** A `HookProvider` that seals a tamper-evident, offline-verifiable capsule for every Strands tool call — a planned commitment record chained to its confirmed, failed, or blocked outcome. Observation-only; it never modifies a tool call.
**Relationship to service:** community-built
**Docs link included:** docsUrl — https://github.com/action-state-group/capsule-emit/blob/main/docs/adapters/strands.md

### Submitter checklist

#### Package
- [x] This is a reusable integration (a `HookProvider` plugin), not an example agent or application
- [x] Published to PyPI under the exact `package` name (`capsule-emit`, installed with the `[strands]` extra; registry links derive from it)
- [x] GitHub repository is public and includes a license (Apache-2.0)

#### Entry
- [x] Description accurately states what the package does in one sentence
- [x] `integrationType: plugin` matches what it is (a `HookProvider`-based recorder, same shape as the existing `sigil-sdk-strands` entry)
- [x] All URLs are working (`github`, `docsUrl`)
- [x] `addedDate` is set to today (the date I opened this PR)
- [x] `featured` and `badges` are left unset; `maintainedBy` is left unset (community)

#### Docs (docsUrl is set)
- [x] The linked page documents using this integration with Strands Agents

#### Conduct
- [x] I am the package maintainer (action-state-group maintains capsule-emit)
- [x] Entry uses the package's real name with no trademark misuse

---

Disclosure: this entry and its linked docs page were prepared with AI-agent assistance under human direction; every API claim was read from the released `strands-agents` wheel and exercised by the integration's test suite. A human author reviewed and is accountable for it.
