### PR TITLE
fix(models/sagemaker): tolerate usage fields UsageMetadata does not declare

### DIFF
--- a/strands-py/src/strands/models/sagemaker.py
+++ b/strands-py/src/strands/models/sagemaker.py
@@ -1,5 +1,6 @@
 """Amazon SageMaker model provider."""
 
+import dataclasses
 import json
 import logging
 import os
@@ -40,6 +41,20 @@ class UsageMetadata:
     completion_tokens: int
     prompt_tokens: int
     prompt_tokens_details: int | None = 0
+
+    @classmethod
+    def from_usage(cls, usage: dict[str, Any]) -> "UsageMetadata":
+        """Build usage metadata from an OpenAI-compatible usage object.
+
+        Args:
+            usage: The usage object as the endpoint sent it.
+
+        Returns:
+            Usage metadata carrying the fields this class declares.
+        """
+        # The wire schema is the endpoint's, not ours, so keys we do not declare are dropped.
+        names = {field.name for field in dataclasses.fields(cls)}
+        return cls(**{key: value for key, value in usage.items() if key in names})
 
 
 @dataclass
@@ -430,7 +445,7 @@ class SageMakerAIModel(OpenAIModel):
                     choices = content.get("choices")
                     if not choices:
                         if usage := content.get("usage"):
-                            yield self.format_chunk({"chunk_type": "metadata", "data": UsageMetadata(**usage)})
+                            yield self.format_chunk({"chunk_type": "metadata", "data": UsageMetadata.from_usage(usage)})
                         continue
                     if finish_reason:
                         continue
@@ -476,7 +491,7 @@ class SageMakerAIModel(OpenAIModel):
 
                     usage = content.get("usage") or choice.get("usage")
                     if usage:
-                        yield self.format_chunk({"chunk_type": "metadata", "data": UsageMetadata(**usage)})
+                        yield self.format_chunk({"chunk_type": "metadata", "data": UsageMetadata.from_usage(usage)})
 
                     if choice["finish_reason"] is not None:
                         finish_reason = choice["finish_reason"]
@@ -568,7 +583,7 @@ class SageMakerAIModel(OpenAIModel):
                 # Handle usage metadata
                 if final_response_json.get("usage"):
                     yield self.format_chunk(
-                        {"chunk_type": "metadata", "data": UsageMetadata(**final_response_json.get("usage"))}
+                        {"chunk_type": "metadata", "data": UsageMetadata.from_usage(final_response_json["usage"])}
                     )
         except (
             self.client.exceptions.InternalFailure,

--- a/strands-py/tests/strands/models/test_sagemaker.py
+++ b/strands-py/tests/strands/models/test_sagemaker.py
@@ -196,6 +196,72 @@ async def test_stream_preserves_choice_local_usage(sagemaker_client, model, mess
     assert metadata == {"inputTokens": 1, "outputTokens": 2, "totalTokens": 3}
 
 
+@pytest.mark.asyncio
+async def test_stream_usage_only_chunk_tolerates_undeclared_wire_field(sagemaker_client, model, messages, alist):
+    """A trailing usage chunk carrying completion_tokens_details still reports usage."""
+    usage = {
+        "prompt_tokens": 10,
+        "completion_tokens": 20,
+        "total_tokens": 30,
+        "completion_tokens_details": {"reasoning_tokens": 4},
+    }
+    events = [
+        {"choices": [{"delta": {"content": "answer"}, "finish_reason": None}]},
+        {"choices": [{"delta": {}, "finish_reason": "stop"}]},
+        {"choices": [], "usage": usage},
+    ]
+    payload = "".join(f"data: {json.dumps(event)}\n\n" for event in events) + "data: [DONE]\n\n"
+    sagemaker_client.invoke_endpoint_with_response_stream.return_value = {"Body": _payload_parts(payload)}
+
+    response = await alist(model.stream(messages))
+
+    metadata = [event["metadata"]["usage"] for event in response if "metadata" in event]
+    assert metadata == [{"inputTokens": 10, "outputTokens": 20, "totalTokens": 30}]
+    assert response[-1] == {"messageStop": {"stopReason": "end_turn"}}
+
+
+@pytest.mark.asyncio
+async def test_stream_choice_local_usage_tolerates_undeclared_wire_field(sagemaker_client, model, messages, alist):
+    """Usage nested in a choice survives an undeclared field from the endpoint."""
+    usage = {
+        "prompt_tokens": 1,
+        "completion_tokens": 2,
+        "total_tokens": 3,
+        "completion_tokens_details": {"reasoning_tokens": 0},
+    }
+    event = {"choices": [{"delta": {}, "finish_reason": "stop", "usage": usage}]}
+    sagemaker_client.invoke_endpoint_with_response_stream.return_value = {"Body": _payload_parts(json.dumps(event))}
+
+    response = await alist(model.stream(messages))
+
+    metadata = next(item["metadata"]["usage"] for item in response if "metadata" in item)
+    assert metadata == {"inputTokens": 1, "outputTokens": 2, "totalTokens": 3}
+
+
+@pytest.mark.asyncio
+async def test_stream_non_streaming_usage_tolerates_undeclared_wire_field(sagemaker_client, model, messages, alist):
+    """The non-streaming branch reports usage that carries an undeclared field."""
+    model.payload_config["stream"] = False
+    body = unittest.mock.MagicMock()
+    body.read.return_value = json.dumps(
+        {
+            "choices": [{"message": {"content": "answer", "tool_calls": None}, "finish_reason": "stop"}],
+            "usage": {
+                "prompt_tokens": 7,
+                "completion_tokens": 8,
+                "total_tokens": 15,
+                "completion_tokens_details": {"reasoning_tokens": 2},
+            },
+        }
+    ).encode("utf-8")
+    sagemaker_client.invoke_endpoint.return_value = {"Body": body}
+
+    response = await alist(model.stream(messages))
+
+    metadata = next(item["metadata"]["usage"] for item in response if "metadata" in item)
+    assert metadata == {"inputTokens": 7, "outputTokens": 8, "totalTokens": 15}
+
+
 class TestSageMakerAIModel:
     """Test suite for SageMakerAIModel."""
 
@@ -745,6 +811,27 @@ class TestDataClasses:
         assert usage.completion_tokens == 30
         assert usage.prompt_tokens == 70
         assert usage.prompt_tokens_details == 5
+
+    def test_usage_metadata_from_usage_ignores_undeclared_fields(self):
+        """from_usage drops wire fields the dataclass does not declare."""
+        usage = UsageMetadata.from_usage(
+            {
+                "total_tokens": 100,
+                "completion_tokens": 30,
+                "prompt_tokens": 70,
+                "completion_tokens_details": {"reasoning_tokens": 12},
+            }
+        )
+
+        assert usage == UsageMetadata(total_tokens=100, completion_tokens=30, prompt_tokens=70)
+
+    def test_usage_metadata_from_usage_keeps_every_declared_field(self):
+        """from_usage forwards a usage object that carries only declared fields unchanged."""
+        usage = UsageMetadata.from_usage(
+            {"total_tokens": 100, "completion_tokens": 30, "prompt_tokens": 70, "prompt_tokens_details": 5}
+        )
+
+        assert usage == UsageMetadata(total_tokens=100, completion_tokens=30, prompt_tokens=70, prompt_tokens_details=5)
 
     def test_function_call(self):
         """Test FunctionCall dataclass."""


### PR DESCRIPTION
## Description

`SageMakerAIModel` extends `OpenAIModel` because the endpoint speaks the OpenAI-compatible schema, which is what the `openai` pin in the `sagemaker` extra records (`strands-py/pyproject.toml:62`). That schema's usage object carries five fields. `UsageMetadata` declares four, and all three sites that build it splat the endpoint's dict straight in, so a usage payload carrying `completion_tokens_details` raises `TypeError` out of `stream()` after the caller has already consumed part of the response.

#4036 is what makes this easy to hit. It added the usage-only chunk branch so a trailing usage event is no longer discarded, which routes exactly that payload into the constructor.

The invariant is that the endpoint owns the wire schema: `UsageMetadata` should consume the fields it declares and ignore the rest. `from_usage` filters on `dataclasses.fields` and the three call sites go through it, so a usage object made only of declared keys builds the same value it did before and nothing moves on the path that already worked.

This keeps the stream alive and reports the token counts. It does not change how cache token details are reported, which is a separate concern I left alone.

## Related Issues

None.

## Documentation PR

No documentation change needed.

## Type of Change

Bug fix

## Testing

- Three stream-level tests, one per construction site (usage-only chunk, usage on a choice, non-streaming). Each fails on `main` with the `TypeError` and passes here.
- Two unit tests on `from_usage`, that an undeclared field is dropped and that every declared field survives. I confirmed the second one can fail by making the filter drop `prompt_tokens_details`.
- `tests/strands/models/test_sagemaker.py` is 44 passed on 3.10 and on 3.14; the same file on `main` with these tests added is 5 failed, 39 passed.
- `ruff check`, `ruff format --check` and `mypy ./src ./tests_typing` are clean. I have not run this against a live SageMaker endpoint, so the payloads under test are the shapes the repo's own stream parser hands the constructor.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
