### PR TITLE
feat(py): add mcp_router vended tool

### DIFF
--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -475,6 +475,8 @@ agent = Agent(tools=[tool])
 
 Lets your agent connect to Model Context Protocol servers at runtime, list the tools they expose, invoke one, and disconnect. The factory takes a developer-set allowlist of server configurations; the model can only initiate connections to servers on that list.
 
+The tool exposes four commands: `connect` (opens a connection to an allowlisted server), `list_tools` (returns the tools the server exposes), `call_tool` (invokes a tool by name), and `disconnect` (closes the connection). Only one server can be connected at a time — connecting to a new server automatically closes the current one.
+
 _Supported in: all platforms (Python)._
 
 :::caution[Security Warning]
@@ -495,7 +497,10 @@ mcp_client = make_mcp_client(servers=[
     {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]},
 ])
 agent = Agent(tools=[mcp_client])
-agent("Connect to the MCP server and list its tools.")
+agent(
+    "Connect to https://mcp.example.com/mcp, list its tools, "
+    "call the echo tool with message 'hello', then disconnect."
+)
 ```
 
 </Tab>

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -473,12 +473,12 @@ agent = Agent(tools=[tool])
 
 ### MCP Client
 
-Lets your agent connect to Model Context Protocol servers at runtime, list the tools they expose, invoke one, and disconnect. The factory takes a developer-set allowlist of exact URLs; the model can only connect to servers on that list, never to an arbitrary URL of its choosing.
+Lets your agent connect to Model Context Protocol servers at runtime, list the tools they expose, invoke one, and disconnect. The factory takes a developer-set allowlist of server configurations; the model can only initiate connections to servers on that list.
 
 _Supported in: all platforms (Python)._
 
 :::caution[Security Warning]
-An MCP server is arbitrary code behind a network endpoint. If the model can point the tool at any URL, a prompt-injection attacker can reach out to their own MCP server, run tools there, and route the result back through your agent. The allowlist is mandatory and must be non-empty. The tool also enforces an SSRF guard that rejects hosts resolving to private, loopback, link-local, cloud-metadata, and other non-public addresses, and refuses to follow HTTP redirects, but the allowlist is the primary control. Only allowlist URLs whose DNS you trust.
+The allowlist controls which servers the model may connect to. For HTTP servers, treat this like any network request — egress control belongs at the encapsulation layer. For stdio servers, the allowlisted command is spawned as a local process with access to the host filesystem, environment variables, and network. Only allowlist commands you would run directly on the host.
 :::
 
 **Example:**
@@ -490,7 +490,10 @@ An MCP server is arbitrary code behind a network endpoint. If the model can poin
 from strands import Agent
 from strands.vended_tools import make_mcp_client
 
-mcp_client = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+mcp_client = make_mcp_client(servers=[
+    {"url": "https://mcp.example.com/mcp"},
+    {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]},
+])
 agent = Agent(tools=[mcp_client])
 agent("Connect to the MCP server and list its tools.")
 ```

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -13,6 +13,7 @@ sourceLinks:
   - path: strands-ts/src/experimental/vended-tools/stop/stop.ts
   - path: strands-py/src/strands/vended_tools/http_request/http_request.py
   - path: strands-py/src/strands/vended_tools/notebook/notebook.py
+  - path: strands-py/src/strands/vended_tools/mcp_client/mcp_client.py
   - path: strands-py/src/strands/vended_tools/shell/shell.py
   - path: strands-py/src/strands/vended_tools/sleep/sleep.py
   - path: strands-py/src/strands/vended_tools/web_fetch/web_fetch.py
@@ -41,6 +42,7 @@ Each tool is imported from its own subpath under `@strands-agents/sdk/vended-too
 | [HTTP Request](#http-request) | Make HTTP requests to external APIs | Python, TypeScript (Node.js 22+, browsers) |
 | [Notebook](#notebook) | Manage persistent text notebooks | Python, TypeScript (Node.js, browsers) |
 | [Bash](#bash) | Execute shell commands with persistent sessions | Python, TypeScript (Node.js, Unix/Linux/macOS) |
+| [MCP Client](#mcp-client) | Connect to Model Context Protocol servers on a developer-set allowlist | Python |
 | [Sleep](#sleep) | Pause execution for a bounded, cancellable duration | Python, TypeScript (Node.js, browsers) |
 | [Stop](#stop-experimental) | Gracefully end the agent loop when the task is complete | Python, TypeScript (Node.js, browsers) |
 | [Web Fetch](#web-fetch) | Fetch a URL and return cleaned markdown for a model to read | Python |
@@ -462,6 +464,35 @@ tool = make_web_fetch(
     model=BedrockModel(model_id="us.amazon.nova-micro-v1:0"),
 )
 agent = Agent(tools=[tool])
+```
+
+</Tab>
+</Tabs>
+
+---
+
+### MCP Client
+
+Lets your agent connect to Model Context Protocol servers at runtime, list the tools they expose, invoke one, and disconnect. The factory takes a developer-set allowlist of exact URLs; the model can only connect to servers on that list, never to an arbitrary URL of its choosing.
+
+_Supported in: all platforms (Python)._
+
+:::caution[Security Warning]
+An MCP server is arbitrary code behind a network endpoint. If the model can point the tool at any URL, a prompt-injection attacker can reach out to their own MCP server, run tools there, and route the result back through your agent. The allowlist is mandatory and must be non-empty. The tool also enforces an SSRF guard that rejects hosts resolving to private, loopback, link-local, cloud-metadata, and other non-public addresses, and refuses to follow HTTP redirects, but the allowlist is the primary control. Only allowlist URLs whose DNS you trust.
+:::
+
+**Example:**
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.vended_tools import make_mcp_client
+
+mcp_client = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+agent = Agent(tools=[mcp_client])
+agent("Connect to the MCP server and list its tools.")
 ```
 
 </Tab>

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -475,7 +475,7 @@ agent = Agent(tools=[tool])
 
 Lets your agent connect to Model Context Protocol servers at runtime, list the tools they expose, invoke one, and disconnect. The factory takes a developer-set allowlist of server configurations; the model can only initiate connections to servers on that list.
 
-The tool exposes four commands: `connect` (opens a connection to an allowlisted server), `list_tools` (returns the tools the server exposes), `call_tool` (invokes a tool by name), and `disconnect` (closes the connection). Only one server can be connected at a time — connecting to a new server automatically closes the current one.
+The tool exposes four commands: `connect` (opens a named connection to an allowlisted server using a `connection_id`), `list_tools` (returns the tools the server exposes), `call_tool` (invokes a tool by name), and `disconnect` (closes a connection).
 
 _Supported in: all platforms (Python)._
 

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -492,14 +492,14 @@ The allowlist controls which servers the model may connect to. For HTTP servers,
 from strands import Agent
 from strands.vended_tools import make_mcp_client
 
-mcp_client = make_mcp_client(servers=[
-    {"url": "https://mcp.example.com/mcp"},
-    {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]},
-])
+mcp_client = make_mcp_client(servers={
+    "files": {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]},
+    "my-api": {"url": "https://mcp.example.com/mcp"},
+})
 agent = Agent(tools=[mcp_client])
 agent(
-    "Connect to https://mcp.example.com/mcp, list its tools, "
-    "call the echo tool with message 'hello', then disconnect."
+    "Connect to 'files', list its tools, "
+    "call the read_file tool on /tmp/hello.txt, then disconnect."
 )
 ```
 

--- a/strands-py/src/strands/vended_tools/__init__.py
+++ b/strands-py/src/strands/vended_tools/__init__.py
@@ -34,9 +34,9 @@ from typing import Any
 
 from ._bash import _RENAME_RATIONALE, make_bash  # noqa: F401  deprecated tool, kept importable until v2.0.0
 from .file_editor import file_editor, make_file_editor
-from .mcp_client import make_mcp_client
 from .http_request import http_request, make_http_request
 from .notebook import make_notebook, notebook
+from .mcp_client import make_mcp_client
 from .shell import make_shell, shell
 from .sleep import make_sleep, sleep
 

--- a/strands-py/src/strands/vended_tools/__init__.py
+++ b/strands-py/src/strands/vended_tools/__init__.py
@@ -34,6 +34,7 @@ from typing import Any
 
 from ._bash import _RENAME_RATIONALE, make_bash  # noqa: F401  deprecated tool, kept importable until v2.0.0
 from .file_editor import file_editor, make_file_editor
+from .mcp_client import make_mcp_client
 from .http_request import http_request, make_http_request
 from .notebook import make_notebook, notebook
 from .shell import make_shell, shell
@@ -69,6 +70,7 @@ __all__ = [
     "make_file_editor",
     "make_http_request",
     "make_notebook",
+    "make_mcp_client",
     "make_shell",
     "make_sleep",
     "notebook",

--- a/strands-py/src/strands/vended_tools/__init__.py
+++ b/strands-py/src/strands/vended_tools/__init__.py
@@ -35,8 +35,8 @@ from typing import Any
 from ._bash import _RENAME_RATIONALE, make_bash  # noqa: F401  deprecated tool, kept importable until v2.0.0
 from .file_editor import file_editor, make_file_editor
 from .http_request import http_request, make_http_request
-from .notebook import make_notebook, notebook
 from .mcp_client import make_mcp_client
+from .notebook import make_notebook, notebook
 from .shell import make_shell, shell
 from .sleep import make_sleep, sleep
 

--- a/strands-py/src/strands/vended_tools/mcp_client/__init__.py
+++ b/strands-py/src/strands/vended_tools/mcp_client/__init__.py
@@ -1,0 +1,22 @@
+"""Agent-callable MCP client tool for connecting to Model Context Protocol servers at runtime.
+
+Provides :func:`make_mcp_client` (a factory that returns a tool bound to a developer-set
+URL allowlist) for use cases where the agent, not the developer, decides which server to
+talk to at runtime. Developer-wired MCP clients remain the primary path
+(``strands.tools.mcp.MCPClient``); this tool is the agent-facing shim.
+
+Example Usage:
+    ```python
+    from strands import Agent
+    from strands.vended_tools import make_mcp_client
+
+    mcp_client_tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+    agent = Agent(tools=[mcp_client_tool])
+    ```
+"""
+
+from .mcp_client import make_mcp_client
+
+__all__ = [
+    "make_mcp_client",
+]

--- a/strands-py/src/strands/vended_tools/mcp_client/__init__.py
+++ b/strands-py/src/strands/vended_tools/mcp_client/__init__.py
@@ -1,7 +1,7 @@
 """Agent-callable MCP client tool for connecting to Model Context Protocol servers at runtime.
 
 Provides :func:`make_mcp_client` (a factory that returns a tool bound to a developer-set
-URL allowlist) for use cases where the agent, not the developer, decides which server to
+server allowlist) for use cases where the agent, not the developer, decides which server to
 talk to at runtime. Developer-wired MCP clients remain the primary path
 (``strands.tools.mcp.MCPClient``); this tool is the agent-facing shim.
 
@@ -10,7 +10,7 @@ Example Usage:
     from strands import Agent
     from strands.vended_tools import make_mcp_client
 
-    mcp_client_tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+    mcp_client_tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
     agent = Agent(tools=[mcp_client_tool])
     ```
 """

--- a/strands-py/src/strands/vended_tools/mcp_client/__init__.py
+++ b/strands-py/src/strands/vended_tools/mcp_client/__init__.py
@@ -10,7 +10,9 @@ Example Usage:
     from strands import Agent
     from strands.vended_tools import make_mcp_client
 
-    mcp_client_tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+    mcp_client_tool = make_mcp_client(servers={
+        "my-api": {"url": "https://mcp.example.com/mcp"},
+    })
     agent = Agent(tools=[mcp_client_tool])
     ```
 """

--- a/strands-py/src/strands/vended_tools/mcp_client/mcp_client.py
+++ b/strands-py/src/strands/vended_tools/mcp_client/mcp_client.py
@@ -16,7 +16,6 @@ import logging
 import threading
 import weakref
 from typing import TYPE_CHECKING, Any, cast
-from urllib.parse import urlsplit
 from uuid import uuid4
 
 from ...tools.decorator import tool
@@ -29,9 +28,6 @@ if TYPE_CHECKING:
     from ...tools.decorator import DecoratedFunctionTool
 
 logger = logging.getLogger(__name__)
-
-_DEFAULT_SCHEME_PORTS = {"http": 80, "https": 443}
-_ALLOWED_SCHEMES = frozenset(_DEFAULT_SCHEME_PORTS)
 
 
 class MCPClientToolError(RuntimeError):
@@ -125,24 +121,17 @@ def make_mcp_client(
 # ---- Internals ----------------------------------------------------------------
 
 
-def _stop_client_on_gc(client: MCPClient) -> None:
-    """Stop an MCPClient from a GC finalizer; runs stop() in a daemon thread with a 1 s cap."""
-    thread = threading.Thread(target=client.stop, args=(None, None, None), daemon=True)
-    thread.start()
-    thread.join(timeout=1.0)
-
-
 def _validate_servers(servers: list[MCPServerConfig]) -> dict[str, MCPServerConfig]:
     """Validate server configs and return a map keyed by server identifier.
 
-    For HTTP entries the key is the canonicalised URL; for stdio entries it is
+    For HTTP entries the key is the URL verbatim; for stdio entries it is
     the full command invocation (``command`` + space-joined ``args``).
 
     Returns:
         A dict keyed by server identifier mapping to the original config.
 
     Raises:
-        ValueError: If ``servers`` is empty, or an HTTP entry has an invalid URL.
+        ValueError: If ``servers`` is empty or a config entry is invalid.
     """
     if not servers:
         raise ValueError("`servers` must not be empty; the mcp_client tool requires at least one server")
@@ -160,17 +149,9 @@ def _validate_servers(servers: list[MCPServerConfig]) -> dict[str, MCPServerConf
         if url:
             if command:
                 raise ValueError(
-                    f"Server config has both 'url' ({url!r}) and 'command' ({command!r}); "
-                    "provide one or the other"
+                    f"Server config has both 'url' ({url!r}) and 'command' ({command!r}); provide one or the other"
                 )
-            parsed = urlsplit(url)
-            if parsed.scheme.lower() not in _ALLOWED_SCHEMES:
-                raise ValueError(
-                    f"Server URL {url!r} has unsupported scheme {parsed.scheme!r}; only http and https are supported"
-                )
-            if not parsed.hostname:
-                raise ValueError(f"Server URL {url!r} has no host")
-            key = _canonicalise_url(url)
+            key = url
         elif command:
             key = " ".join([command] + list(config.get("args") or []))
         else:
@@ -185,24 +166,15 @@ def _validate_servers(servers: list[MCPServerConfig]) -> dict[str, MCPServerConf
     return server_map
 
 
-def _canonicalise_url(url: str) -> str:
-    """Canonicalise a URL for allowlist matching.
+def _stop_client_on_gc(client: MCPClient) -> None:
+    """Stop an MCPClient when its owning agent is garbage-collected.
 
-    Lowercase scheme/host, strip the trailing slash on the path, drop the port when it
-    matches the scheme default (so ``https://host`` and ``https://host:443`` match), and
-    drop userinfo and fragment.
+    Runs ``stop()`` on a daemon thread with a 1 s join cap so a wedged transport
+    cannot stall the garbage collector thread indefinitely.
     """
-    parsed = urlsplit(url)
-    scheme = parsed.scheme.lower()
-    host = (parsed.hostname or "").lower()
-    # Re-bracket IPv6 addresses stripped by urlsplit
-    if ":" in host:
-        host = f"[{host}]"
-    default_port = _DEFAULT_SCHEME_PORTS.get(scheme)
-    port = f":{parsed.port}" if parsed.port and parsed.port != default_port else ""
-    path = parsed.path.rstrip("/")
-    query = f"?{parsed.query}" if parsed.query else ""
-    return f"{scheme}://{host}{port}{path}{query}"
+    thread = threading.Thread(target=client.stop, args=(None, None, None), daemon=True)
+    thread.start()
+    thread.join(timeout=1.0)
 
 
 async def _handle_connect(
@@ -212,14 +184,7 @@ async def _handle_connect(
     server_map: dict[str, MCPServerConfig],
     server: str,
 ) -> str:
-    is_http = server.lower().startswith(("http://", "https://"))
-    try:
-        key = _canonicalise_url(server) if is_http else server
-    except ValueError:
-        permitted = ", ".join(sorted(server_map))
-        raise MCPClientToolError(f"Server {server!r} is not a valid URL. Permitted servers: {permitted}") from None
-
-    if key not in server_map:
+    if server not in server_map:
         permitted = ", ".join(sorted(server_map))
         raise MCPClientToolError(f"Server {server!r} is not on the allowlist. Permitted servers: {permitted}")
 
@@ -228,27 +193,35 @@ async def _handle_connect(
     if existing is not None:
         await _handle_disconnect(clients, agent)
 
-    config = cast(dict[str, Any], server_map[key])
+    config = cast(dict[str, Any], server_map[server])
     loaded = MCPClient.load_servers({"vended": config})
     client = loaded[0]
 
     try:
         await asyncio.to_thread(client.start)
+        # Read after start() so concurrent connects each see and stop the other's client.
+        previous = clients.get(agent)
         clients[agent] = client
         weakref.finalize(agent, _stop_client_on_gc, client)
     except BaseException:
+        # start() failed or task was cancelled — stop the partially-started client before re-raising.
         try:
             client.stop(None, None, None)
         except Exception:
             logger.debug("failed to stop MCP client after connect failure", exc_info=True)
         raise
 
-    logger.debug("server=<%s> | opened MCP connection", key)
-    return f"Successfully connected to {key}"
+    if previous is not None:
+        try:
+            await asyncio.to_thread(previous.stop, None, None, None)
+        except RuntimeError:
+            logger.debug("previous MCP connection was already closed")
+
+    logger.debug("server=<%s> | opened MCP connection", server)
+    return f"Successfully connected to {server}"
 
 
 async def _handle_list_tools(client: MCPClient) -> list[ToolSpec]:
-    """Return the tool list from the client, using server-side names so call_tool can invoke them directly."""
     agent_tools = await asyncio.to_thread(
         lambda: client._list_all_tools_sync()  # noqa: SLF001
     )

--- a/strands-py/src/strands/vended_tools/mcp_client/mcp_client.py
+++ b/strands-py/src/strands/vended_tools/mcp_client/mcp_client.py
@@ -6,7 +6,7 @@ The tool exposes four commands — ``connect``, ``list_tools``, ``call_tool``,
 ``disconnect`` — letting an agent open a connection to an MCP server, discover its
 tools, invoke one, and close the connection. Each server is configured with a
 :class:`~strands.tools.mcp.MCPServerConfig`; all fields are forwarded to
-:class:`~strands.tools.mcp.MCPClient`. Sessions are isolated per agent.
+:class:`~strands.tools.mcp.MCPClient`. One connection is held per agent at a time.
 """
 
 from __future__ import annotations
@@ -23,7 +23,7 @@ from ...tools.decorator import tool
 from ...tools.mcp.mcp_client import MCPClient, MCPServerConfig
 from ...tools.mcp.mcp_types import MCPToolResult
 from ...types.tools import ToolContext, ToolSpec
-from .types import MCP_CLIENT_DESCRIPTION, Command, ConnectOutput, _Session
+from .types import MCP_CLIENT_DESCRIPTION, Command
 
 if TYPE_CHECKING:
     from ...tools.decorator import DecoratedFunctionTool
@@ -61,23 +61,21 @@ def make_mcp_client(
     """
     server_map = _validate_servers(servers)
 
-    # Combine the description constant with the list of permitted servers
     if description is None:
         permitted = ", ".join(f"'{s}'" for s in sorted(server_map))
         description = f"{MCP_CLIENT_DESCRIPTION} Permitted servers: {permitted}."
 
-    # Per-agent session tables using WeakKeyDictionary so agents can be garbage collected normally.
-    sessions: weakref.WeakKeyDictionary[Any, dict[str, _Session]] = weakref.WeakKeyDictionary()
+    # One MCPClient per agent. WeakKeyDictionary so agents can be garbage collected normally.
+    clients: weakref.WeakKeyDictionary[Any, MCPClient] = weakref.WeakKeyDictionary()
 
     @tool(name=name, description=description, context="tool_context")
     async def mcp_client_tool(
         command: Command,
         tool_context: ToolContext,
         server: str | None = None,
-        session_id: str | None = None,
         tool_name: str | None = None,
         arguments: dict[str, Any] | None = None,
-    ) -> ConnectOutput | list[ToolSpec] | MCPToolResult | str:
+    ) -> list[ToolSpec] | MCPToolResult | str:
         """Manage a runtime MCP client connection.
 
         Args:
@@ -85,43 +83,39 @@ def make_mcp_client(
             tool_context: Injected by the framework. Not user-facing.
             server: Server to connect to for ``connect``. For HTTP servers, a URL; for stdio servers,
                 the full command invocation. Must match the developer-set allowlist verbatim.
-            session_id: Identifier returned by ``connect``, required for the other three commands.
             tool_name: Tool name to invoke, required for ``call_tool``.
             arguments: Arguments to pass to the invoked tool, for ``call_tool``.
+
+        Raises:
+            MCPClientToolError: If a required argument is missing, the server is not on the allowlist,
+                no connection is active, or the connection fails to start.
         """
         agent = tool_context.agent
 
         if command == "connect":
             if not server:
                 raise MCPClientToolError("`server` is required for command='connect'")
-            return await _handle_connect(
-                sessions,
-                agent,
-                server_map=server_map,
-                server=server,
-            )
+            return await _handle_connect(clients, agent, server_map=server_map, server=server)
 
-        # All other commands require an active session.
-        if not session_id:
-            raise MCPClientToolError("`session_id` is required")
-        session = sessions.get(agent, {}).get(session_id)
-        if session is None:
-            raise MCPClientToolError(f"No active session for id {session_id!r}")
+        client = clients.get(agent)
+        if client is None:
+            raise MCPClientToolError("No active connection. Call 'connect' first.")
 
         if command == "list_tools":
-            return await _handle_list_tools(session)
+            return await _handle_list_tools(client)
 
         if command == "call_tool":
             if not tool_name:
                 raise MCPClientToolError("`tool_name` is required for command='call_tool'")
-            return await session.client.call_tool_async(
+            return await client.call_tool_async(
                 tool_use_id=str(uuid4()),
                 name=tool_name,
                 arguments=arguments,
                 cancel_signal=tool_context.cancel_signal,
             )
+
         if command == "disconnect":
-            return await _handle_disconnect(session, sessions, agent, session_id)
+            return await _handle_disconnect(clients, agent)
 
         raise MCPClientToolError(f"Unknown command: {command}")
 
@@ -131,13 +125,11 @@ def make_mcp_client(
 # ---- Internals ----------------------------------------------------------------
 
 
-def _close_agent_sessions(agent_sessions: dict[str, _Session]) -> None:
-    """Close all open MCP sessions for a single agent."""
-    for session_id, session in list(agent_sessions.items()):
-        thread = threading.Thread(target=session.client.stop, args=(None, None, None), daemon=True)
-        thread.start()
-        thread.join(timeout=1.0)
-        logger.debug("session_id=<%s> | closed MCP session during GC", session_id)
+def _stop_client_on_gc(client: MCPClient) -> None:
+    """Stop an MCPClient from a GC finalizer; runs stop() in a daemon thread with a 1 s cap."""
+    thread = threading.Thread(target=client.stop, args=(None, None, None), daemon=True)
+    thread.start()
+    thread.join(timeout=1.0)
 
 
 def _validate_servers(servers: list[MCPServerConfig]) -> dict[str, MCPServerConfig]:
@@ -165,12 +157,12 @@ def _validate_servers(servers: list[MCPServerConfig]) -> dict[str, MCPServerConf
             )
         url = config.get("url")
         command = config.get("command")
-        if url and command:
-            raise ValueError(
-                f"Server config has both 'url' ({url!r}) and 'command' ({command!r}); "
-                "provide one or the other, or set 'transport' explicitly"
-            )
         if url:
+            if command:
+                raise ValueError(
+                    f"Server config has both 'url' ({url!r}) and 'command' ({command!r}); "
+                    "provide one or the other"
+                )
             parsed = urlsplit(url)
             if parsed.scheme.lower() not in _ALLOWED_SCHEMES:
                 raise ValueError(
@@ -214,70 +206,65 @@ def _canonicalise_url(url: str) -> str:
 
 
 async def _handle_connect(
-    sessions: dict[Any, dict[str, _Session]],
+    clients: weakref.WeakKeyDictionary[Any, MCPClient],
     agent: Any,
     *,
     server_map: dict[str, MCPServerConfig],
     server: str,
-) -> ConnectOutput:
+) -> str:
     is_http = server.lower().startswith(("http://", "https://"))
     try:
         key = _canonicalise_url(server) if is_http else server
     except ValueError:
         permitted = ", ".join(sorted(server_map))
         raise MCPClientToolError(f"Server {server!r} is not a valid URL. Permitted servers: {permitted}") from None
+
     if key not in server_map:
         permitted = ", ".join(sorted(server_map))
         raise MCPClientToolError(f"Server {server!r} is not on the allowlist. Permitted servers: {permitted}")
 
+    # Stop any existing connection before opening a new one.
+    existing = clients.get(agent)
+    if existing is not None:
+        await _handle_disconnect(clients, agent)
+
     config = cast(dict[str, Any], server_map[key])
-    clients = MCPClient.load_servers({"vended": config})
-    if not clients:
-        raise MCPClientToolError(f"Server {server!r} failed to initialise; check the server config")
-    client = clients[0]
+    loaded = MCPClient.load_servers({"vended": config})
+    client = loaded[0]
 
     try:
-        # Push blocking start() off the event loop so concurrent tool invocations are not serialised.
         await asyncio.to_thread(client.start)
-        session_id = str(uuid4())
-        agent_sessions = sessions.get(agent)
-        if agent_sessions is None:
-            agent_sessions = {}
-            sessions[agent] = agent_sessions
-            weakref.finalize(agent, _close_agent_sessions, agent_sessions)
-        agent_sessions[session_id] = _Session(client=client, key=key)
+        clients[agent] = client
+        weakref.finalize(agent, _stop_client_on_gc, client)
     except BaseException:
-        # Cancellation during start() or the session-table write — stop the client before re-raising.
         try:
             client.stop(None, None, None)
         except Exception:
             logger.debug("failed to stop MCP client after connect failure", exc_info=True)
         raise
 
-    logger.debug("session_id=<%s>, server=<%s> | opened MCP session", session_id, key)
-    return ConnectOutput(session_id=session_id, server=key)
+    logger.debug("server=<%s> | opened MCP connection", key)
+    return f"Successfully connected to {key}"
 
 
-async def _handle_list_tools(session: _Session) -> list[ToolSpec]:
-    """Return the tool list from the client, including server-side names so call_tool can invoke them directly."""
+async def _handle_list_tools(client: MCPClient) -> list[ToolSpec]:
+    """Return the tool list from the client, using server-side names so call_tool can invoke them directly."""
     agent_tools = await asyncio.to_thread(
-        lambda: session.client._list_all_tools_sync()  # noqa: SLF001
+        lambda: client._list_all_tools_sync()  # noqa: SLF001
     )
     return [{**t.tool_spec, "name": t.mcp_tool.name} for t in agent_tools]
 
 
 async def _handle_disconnect(
-    session: _Session,
-    sessions: dict[Any, dict[str, _Session]],
+    clients: weakref.WeakKeyDictionary[Any, MCPClient],
     agent: Any,
-    session_id: str,
 ) -> str:
-    try:
-        await asyncio.to_thread(session.client.stop, None, None, None)
-    except RuntimeError:
-        logger.debug("session_id=<%s> | MCP connection was already closed", session_id)
-    finally:
-        agent_sessions = sessions.get(agent)
-        if agent_sessions is not None:
-            agent_sessions.pop(session_id, None)
-    return f"Session successfully disconnected: {session_id}"
+    client = clients.get(agent)
+    if client is not None:
+        try:
+            await asyncio.to_thread(client.stop, None, None, None)
+        except RuntimeError:
+            logger.debug("MCP connection was already closed")
+        finally:
+            clients.pop(agent, None)
+    return "Successfully disconnected"

--- a/strands-py/src/strands/vended_tools/mcp_client/mcp_client.py
+++ b/strands-py/src/strands/vended_tools/mcp_client/mcp_client.py
@@ -6,14 +6,14 @@ The tool exposes four commands — ``connect``, ``list_tools``, ``call_tool``,
 ``disconnect`` — letting an agent open a connection to an MCP server, discover its
 tools, invoke one, and close the connection. Each server is configured with a
 :class:`~strands.tools.mcp.MCPServerConfig`; all fields are forwarded to
-:class:`~strands.tools.mcp.MCPClient`. Sessions are isolated per agent and closed
-automatically when the agent is garbage-collected.
+:class:`~strands.tools.mcp.MCPClient`. Sessions are isolated per agent.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 import weakref
 from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urlsplit
@@ -66,7 +66,7 @@ def make_mcp_client(
         permitted = ", ".join(f"'{s}'" for s in sorted(server_map))
         description = f"{MCP_CLIENT_DESCRIPTION} Permitted servers: {permitted}."
 
-    # Per-agent session tables. WeakKeyDictionary releases the session table when an agent is garbage-collected.
+    # Per-agent session tables using WeakKeyDictionary so agents can be garbage collected normally.
     sessions: weakref.WeakKeyDictionary[Any, dict[str, _Session]] = weakref.WeakKeyDictionary()
 
     @tool(name=name, description=description, context="tool_context")
@@ -84,9 +84,8 @@ def make_mcp_client(
             command: The operation to perform: ``connect``, ``list_tools``, ``call_tool``, ``disconnect``.
             tool_context: Injected by the framework. Not user-facing.
             server: Server to connect to for ``connect``. For HTTP servers, a URL; for stdio servers,
-                the full command invocation (e.g. ``"npx -y @modelcontextprotocol/server-filesystem"``).
-                Must match the developer-set allowlist verbatim.
-            session_id: Session identifier returned by ``connect``, required for the other three commands.
+                the full command invocation. Must match the developer-set allowlist verbatim.
+            session_id: Identifier returned by ``connect``, required for the other three commands.
             tool_name: Tool name to invoke, required for ``call_tool``.
             arguments: Arguments to pass to the invoked tool, for ``call_tool``.
         """
@@ -110,7 +109,7 @@ def make_mcp_client(
             raise MCPClientToolError(f"No active session for id {session_id!r}")
 
         if command == "list_tools":
-            return await _handle_list_tools(session.client)
+            return await _handle_list_tools(session)
 
         if command == "call_tool":
             if not tool_name:
@@ -130,6 +129,15 @@ def make_mcp_client(
 
 
 # ---- Internals ----------------------------------------------------------------
+
+
+def _close_agent_sessions(agent_sessions: dict[str, _Session]) -> None:
+    """Close all open MCP sessions for a single agent."""
+    for session_id, session in list(agent_sessions.items()):
+        thread = threading.Thread(target=session.client.stop, args=(None, None, None), daemon=True)
+        thread.start()
+        thread.join(timeout=1.0)
+        logger.debug("session_id=<%s> | closed MCP session during GC", session_id)
 
 
 def _validate_servers(servers: list[MCPServerConfig]) -> dict[str, MCPServerConfig]:
@@ -175,6 +183,11 @@ def _validate_servers(servers: list[MCPServerConfig]) -> dict[str, MCPServerConf
             key = " ".join([command] + list(config.get("args") or []))
         else:
             raise ValueError("Each server config must have either a 'url' (HTTP) or 'command' (stdio) field")
+        if key in server_map and server_map[key] != config:
+            raise ValueError(
+                f"Server key {key!r} is produced by two different configs; "
+                "remove the duplicate or disambiguate (e.g. use explicit ports or distinct commands)"
+            )
         server_map[key] = config
 
     return server_map
@@ -190,6 +203,9 @@ def _canonicalise_url(url: str) -> str:
     parsed = urlsplit(url)
     scheme = parsed.scheme.lower()
     host = (parsed.hostname or "").lower()
+    # Re-bracket IPv6 addresses stripped by urlsplit
+    if ":" in host:
+        host = f"[{host}]"
     default_port = _DEFAULT_SCHEME_PORTS.get(scheme)
     port = f":{parsed.port}" if parsed.port and parsed.port != default_port else ""
     path = parsed.path.rstrip("/")
@@ -197,24 +213,19 @@ def _canonicalise_url(url: str) -> str:
     return f"{scheme}://{host}{port}{path}{query}"
 
 
-def _close_agent_sessions(agent_sessions: dict[str, _Session]) -> None:
-    """Best-effort transport teardown for all sessions in an agent's table."""
-    for session in agent_sessions.values():
-        try:
-            session.client.stop(None, None, None)
-        except Exception:
-            logger.debug("failed to stop MCP client during GC cleanup", exc_info=True)
-
-
 async def _handle_connect(
-    sessions: weakref.WeakKeyDictionary[Any, dict[str, _Session]],
+    sessions: dict[Any, dict[str, _Session]],
     agent: Any,
     *,
     server_map: dict[str, MCPServerConfig],
     server: str,
 ) -> ConnectOutput:
     is_http = server.lower().startswith(("http://", "https://"))
-    key = _canonicalise_url(server) if is_http else server
+    try:
+        key = _canonicalise_url(server) if is_http else server
+    except ValueError:
+        permitted = ", ".join(sorted(server_map))
+        raise MCPClientToolError(f"Server {server!r} is not a valid URL. Permitted servers: {permitted}") from None
     if key not in server_map:
         permitted = ", ".join(sorted(server_map))
         raise MCPClientToolError(f"Server {server!r} is not on the allowlist. Permitted servers: {permitted}")
@@ -229,9 +240,10 @@ async def _handle_connect(
         # Push blocking start() off the event loop so concurrent tool invocations are not serialised.
         await asyncio.to_thread(client.start)
         session_id = str(uuid4())
-        agent_sessions = sessions.setdefault(agent, {})
-        # Register a finalizer on first connect to close open transports when the agent is garbage collected.
-        if not agent_sessions:
+        agent_sessions = sessions.get(agent)
+        if agent_sessions is None:
+            agent_sessions = {}
+            sessions[agent] = agent_sessions
             weakref.finalize(agent, _close_agent_sessions, agent_sessions)
         agent_sessions[session_id] = _Session(client=client, key=key)
     except BaseException:
@@ -246,22 +258,26 @@ async def _handle_connect(
     return ConnectOutput(session_id=session_id, server=key)
 
 
-async def _handle_list_tools(client: MCPClient) -> list[ToolSpec]:
-    """Return the tool list from the client."""
-    tools = await client.load_tools()
-    return [t.tool_spec for t in tools]
+async def _handle_list_tools(session: _Session) -> list[ToolSpec]:
+    """Return the tool list from the client, including server-side names so call_tool can invoke them directly."""
+    agent_tools = await asyncio.to_thread(
+        lambda: session.client._list_all_tools_sync()  # noqa: SLF001
+    )
+    return [{**t.tool_spec, "name": t.mcp_tool.name} for t in agent_tools]
 
 
 async def _handle_disconnect(
     session: _Session,
-    sessions: weakref.WeakKeyDictionary[Any, dict[str, _Session]],
+    sessions: dict[Any, dict[str, _Session]],
     agent: Any,
     session_id: str,
 ) -> str:
     try:
-        # `stop` blocks until the transport tears down. Push it off the event loop.
         await asyncio.to_thread(session.client.stop, None, None, None)
+    except RuntimeError:
+        logger.debug("session_id=<%s> | MCP connection was already closed", session_id)
     finally:
-        agent_sessions = sessions.get(agent, {})
-        agent_sessions.pop(session_id, None)
+        agent_sessions = sessions.get(agent)
+        if agent_sessions is not None:
+            agent_sessions.pop(session_id, None)
     return f"Session successfully disconnected: {session_id}"

--- a/strands-py/src/strands/vended_tools/mcp_client/mcp_client.py
+++ b/strands-py/src/strands/vended_tools/mcp_client/mcp_client.py
@@ -1,0 +1,630 @@
+"""Agent-callable MCP client tool.
+
+Exposes a single tool with four operations — ``connect``, ``list_tools``, ``call_tool``,
+``disconnect`` — that lets an agent, at runtime, open a connection to a Model Context
+Protocol server, discover its tools, invoke one, and tear the connection down. The tool
+is a thin shim over :class:`~strands.tools.mcp.MCPClient`; all transport, session, and
+protocol handling lives in that class.
+
+**Security model.** This is one of the highest-risk tools to vend: an MCP server can
+implement arbitrary logic, so the model must never be allowed to point the tool at an
+arbitrary URL. The factory takes a developer-set allowlist of exact URLs at construction;
+the tool rejects every ``connect`` that does not match one. In addition:
+
+- Only ``http://`` and ``https://`` URLs are accepted; the tool uses the streamable-http
+  MCP transport. Stdio, SSE, and WebSocket are out of scope: stdio expands the attack
+  surface substantially (subprocess spawn); SSE is being deprecated by the MCP spec in
+  favour of streamable-http; WebSocket is not a documented MCP client transport.
+- The URL's host is rejected outright when it matches a DNS suffix denylist
+  (``.internal``, ``.local``, ``.localhost``, ``.corp``, ``.home``, ``.lan``,
+  ``.intranet``, ``.private``, ``.i2p``, ``.onion``) before any DNS lookup.
+- The URL's host is then resolved and every returned address is checked with
+  :attr:`ipaddress._BaseAddress.is_global` for the private/loopback/CGNAT/shared-
+  address baseline, layered with **explicit** ``is_multicast``, ``is_reserved``,
+  ``is_unspecified``, ``is_link_local``, and IPv6-site-local (``fec0::/10``)
+  rejections: on all supported CPython versions (3.10–3.14) ``is_global`` is
+  ``True`` for IPv4 and IPv6 multicast, and ``fec0::/10`` slips through on some
+  releases, so ``is_global`` alone is not sufficient. IPv4-mapped IPv6
+  (``::ffff:a.b.c.d``, including the fully expanded form) is unwrapped first so
+  the underlying IPv4 category is what gets checked. A short list of
+  cloud-metadata addresses is also spelt out explicitly for defence in depth.
+- The httpx client that MCP uses under the hood is configured with
+  ``follow_redirects=False`` so an allowlisted URL cannot be 3xx'd to a private
+  endpoint the guard never saw.
+- Session IDs are generated with :mod:`secrets` and scoped to the agent that opened
+  them via a :func:`weakref.ref`; another agent using the same tool instance cannot
+  use a session it did not open, and a garbage-collected agent's sessions become
+  unreachable and are dropped from the session table on the next access or connect.
+- The number of live sessions the tool may hold is capped (default: 8), reserved
+  synchronously at connect entry so racing connects cannot overshoot the cap.
+- Blocking MCP client calls (``start``, ``list_tools_sync``, ``stop``) are pushed
+  off the event loop with :func:`asyncio.to_thread` so a slow handshake does not
+  stall other tools.
+- The tool set exposed by the server is fetched once at connect and cached on
+  the session; ``list_tools`` reads that cache and ``call_tool`` validates the
+  requested name against it locally. The cache can go stale if the server
+  changes its tool set mid-session, which is not a supported MCP flow today.
+- Tool-call text and ``structured_content`` are size-capped before being returned to
+  the model.
+
+**Limits.** The public-host classification is a check-time judgment. Between the
+guard's ``getaddrinfo`` and the MCP transport's own ``getaddrinfo``, an
+attacker-controlled resolver could return a public IP first and a private IP second
+(DNS rebinding). MCP's transport layer does not expose a hook for pinned-IP connects,
+so this shim relies on the allowlist pointing at endpoints whose operator does not
+serve time-varying DNS. Do not allowlist a hostname you do not control DNS for.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import json
+import logging
+import secrets
+import socket
+import weakref
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any, Literal, cast
+from urllib.parse import urlparse
+
+import httpx
+from mcp.client.streamable_http import streamablehttp_client
+
+from ...tools.decorator import tool
+from ...tools.mcp.mcp_client import MCPClient
+from ...types.tools import ToolContext
+
+if TYPE_CHECKING:
+    from ...tools.decorator import DecoratedFunctionTool
+
+logger = logging.getLogger(__name__)
+
+
+_MCP_CLIENT_DESCRIPTION = (
+    "Connects to Model Context Protocol (MCP) servers at runtime. Supports four operations: "
+    "'connect' (open a session to an allowlisted server URL), 'list_tools' (list the tools "
+    "the connected server exposes), 'call_tool' (invoke a tool on a connected server), and "
+    "'disconnect' (close a session). URLs must be on a developer-set allowlist."
+)
+
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+_DEFAULT_SCHEME_PORTS = {"http": 80, "https": 443}
+_DEFAULT_SESSION_LIMIT = 8
+_DEFAULT_STARTUP_TIMEOUT = 30
+_DEFAULT_CALL_TIMEOUT_SECONDS = 60
+_MAX_RESULT_TEXT_CHARS = 100_000
+_MAX_STRUCTURED_CONTENT_BYTES = 100_000
+
+# Hostname suffixes we reject before DNS. Names on these zones are intended for
+# internal use even when they happen to resolve to a public IP for some resolver.
+_BLOCKED_HOST_SUFFIXES: tuple[str, ...] = (
+    ".internal",
+    ".local",
+    ".localhost",
+    ".corp",
+    ".home",
+    ".lan",
+    ".intranet",
+    ".private",
+    ".i2p",
+    ".onion",
+)
+
+# Site-local IPv6 (`fec0::/10`, deprecated in RFC 3879 but not caught by
+# `is_global` on some CPython releases). Layer an explicit rejection.
+_IPV6_SITE_LOCAL = ipaddress.IPv6Network("fec0::/10")
+
+# Cloud-metadata endpoints. `is_global` already rejects link-local (169.254/16) and
+# the unique-local IPv6 space, but naming them explicitly guards against a future
+# refactor that weakens a generic predicate.
+_BLOCKED_METADATA_ADDRESSES: frozenset[str] = frozenset(
+    {
+        "169.254.169.254",  # AWS / Azure / DigitalOcean
+        "fd00:ec2::254",  # AWS IPv6
+        "100.100.100.200",  # Alibaba
+        "192.0.0.192",  # Oracle Cloud
+    }
+)
+
+Op = Literal["connect", "list_tools", "call_tool", "disconnect"]
+
+
+class _Session:
+    """A single live MCP connection owned by exactly one agent."""
+
+    __slots__ = ("client", "url", "owner_ref", "tools")
+
+    def __init__(
+        self,
+        client: MCPClient,
+        url: str,
+        owner_ref: weakref.ref,
+        tools: dict[str, Any],
+    ) -> None:
+        self.client = client
+        self.url = url
+        self.owner_ref = owner_ref
+        # Tool set cached at connect time. Keyed by tool name; the value is the
+        # server-provided metadata used to render `list_tools` and validate the
+        # `tool_name` passed to `call_tool`. Matches the TypeScript side, which
+        # also caches at connect so both SDKs surface an "unknown tool" error
+        # locally instead of forwarding an unadvertised name to the server.
+        self.tools = tools
+
+
+def make_mcp_client(
+    *,
+    allowed_urls: list[str],
+    name: str = "mcp_client",
+    description: str = _MCP_CLIENT_DESCRIPTION,
+    session_limit: int = _DEFAULT_SESSION_LIMIT,
+    startup_timeout: int = _DEFAULT_STARTUP_TIMEOUT,
+) -> DecoratedFunctionTool:
+    """Create an agent-callable MCP client tool bound to a developer-set URL allowlist.
+
+    The returned tool exposes ``connect``, ``list_tools``, ``call_tool``, and ``disconnect``
+    operations under a single tool name. Every ``connect`` is checked against ``allowed_urls``;
+    only URLs that appear verbatim (after normalisation) are accepted.
+
+    Args:
+        allowed_urls: Exact URLs the tool may connect to. The list is normalised (scheme
+            lowercased, trailing slash stripped) and each entry must use ``http`` or
+            ``https``. Must not be empty; the tool is deliberately useless without an
+            explicit allowlist.
+        name: Tool name. Defaults to ``"mcp_client"``.
+        description: Tool description shown to the model.
+        session_limit: Maximum number of concurrent live sessions across all agents using
+            this tool instance. Defaults to 8.
+        startup_timeout: Seconds to wait for the initial MCP handshake before treating a
+            connection as failed. Defaults to 30.
+
+    Returns:
+        A decorated tool that manages MCP sessions.
+
+    Raises:
+        ValueError: If ``allowed_urls`` is empty or contains an entry that is not a
+            valid, http-family URL.
+    """
+    if not isinstance(session_limit, int) or isinstance(session_limit, bool) or session_limit <= 0:
+        raise ValueError(f"`session_limit` must be a positive integer, got {session_limit!r}")
+
+    normalised_allowlist = _normalise_allowlist(allowed_urls)
+    sessions: dict[str, _Session] = {}
+    # Reserved-slot counter. Incremented synchronously before any `await` in
+    # `_handle_connect`, so racing connects can never overshoot the cap even
+    # while the blocking `client.start()` is off the event loop in a worker
+    # thread. Held in a single-element list so nested functions can mutate it.
+    reserved: list[int] = [0]
+
+    @tool(name=name, description=description, context="tool_context")
+    async def mcp_client_tool(
+        op: Op,
+        tool_context: ToolContext,
+        server_url: str | None = None,
+        session_id: str | None = None,
+        tool_name: str | None = None,
+        arguments: dict[str, Any] | None = None,
+        timeout: int = _DEFAULT_CALL_TIMEOUT_SECONDS,
+    ) -> dict[str, Any]:
+        """Manage a runtime MCP client connection.
+
+        Args:
+            op: The operation to perform: ``connect``, ``list_tools``, ``call_tool``, ``disconnect``.
+            tool_context: Injected by the framework. Not user-facing.
+            server_url: Server URL for ``connect``. Must match the developer-set allowlist verbatim.
+            session_id: Session identifier returned by ``connect``, required for the other three ops.
+            tool_name: Tool name to invoke, required for ``call_tool``.
+            arguments: Arguments to pass to the invoked tool, for ``call_tool``.
+            timeout: Per-call timeout in seconds. Defaults to 60. Applies to ``call_tool`` only.
+        """
+        agent = tool_context.agent
+
+        if op == "connect":
+            if not server_url:
+                raise ValueError("`server_url` is required for op='connect'")
+            return await _handle_connect(
+                sessions,
+                reserved,
+                allowlist=normalised_allowlist,
+                session_limit=session_limit,
+                startup_timeout=startup_timeout,
+                server_url=server_url,
+                agent=agent,
+            )
+
+        if op == "list_tools":
+            session = _resolve_session(sessions, session_id, agent)
+            return _handle_list_tools(session)
+
+        if op == "call_tool":
+            if not tool_name:
+                raise ValueError("`tool_name` is required for op='call_tool'")
+            session = _resolve_session(sessions, session_id, agent)
+            return await _handle_call_tool(session, tool_name, arguments, timeout)
+
+        if op == "disconnect":
+            session = _resolve_session(sessions, session_id, agent)
+            return await _handle_disconnect(sessions, cast(str, session_id), session)
+
+        raise ValueError(f"Unknown op: {op}")
+
+    return mcp_client_tool
+
+
+# ---- URL validation ----------------------------------------------------------------
+
+
+def _normalise_allowlist(urls: list[str]) -> frozenset[str]:
+    """Normalise the developer-set allowlist and validate each entry."""
+    if not urls:
+        raise ValueError("`allowed_urls` must not be empty; the mcp_client tool requires an explicit allowlist")
+
+    normalised: set[str] = set()
+    for raw in urls:
+        parsed = urlparse(raw)
+        if parsed.scheme.lower() not in _ALLOWED_SCHEMES:
+            raise ValueError(
+                f"Allowlist entry {raw!r} has unsupported scheme {parsed.scheme!r}; only http and https are supported"
+            )
+        if not parsed.hostname:
+            raise ValueError(f"Allowlist entry {raw!r} has no host")
+        _reject_userinfo_and_fragment(raw, parsed)
+        normalised.add(_canonicalise_url(raw))
+    return frozenset(normalised)
+
+
+def _reject_userinfo_and_fragment(raw: str, parsed: Any) -> None:
+    """Reject URLs carrying credentials or fragments.
+
+    Both are stripped by :func:`_canonicalise_url`, so leaving them accepted would
+    let ``https://user:pass@host/path`` canonicalise to the same string as
+    ``https://host/path`` and bypass the verbatim allowlist match.
+    """
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError(f"URL {raw!r} carries credentials; strip the userinfo before allowlisting or connecting")
+    if parsed.fragment:
+        raise ValueError(f"URL {raw!r} carries a fragment; strip it before allowlisting or connecting")
+
+
+def _canonicalise_url(url: str) -> str:
+    """Canonicalise a URL for allowlist matching.
+
+    Lowercase scheme/host, strip the trailing slash on the path, drop the port when it
+    matches the scheme default (so ``https://host`` and ``https://host:443`` match), and
+    drop the fragment. Userinfo is dropped too; :func:`_reject_userinfo_and_fragment`
+    refuses URLs carrying credentials or fragments before this function ever sees them.
+    """
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+    host = (parsed.hostname or "").lower()
+    default_port = _DEFAULT_SCHEME_PORTS.get(scheme)
+    port = f":{parsed.port}" if parsed.port and parsed.port != default_port else ""
+    path = parsed.path.rstrip("/")
+    query = f"?{parsed.query}" if parsed.query else ""
+    return f"{scheme}://{host}{port}{path}{query}"
+
+
+def _assert_public_host(url: str) -> None:
+    """Reject URLs whose host is on the suffix denylist or resolves to non-public space.
+
+    Applied on top of the allowlist as defence in depth: even if the allowlist entry
+    itself points at an internal address, the guard still refuses.
+
+    The classification is a check-time judgment. A DNS-rebinding resolver can return a
+    different address to the MCP transport's own ``getaddrinfo`` at connect time; the
+    MCP client SDK does not expose a hook for pinned-IP connects, so this guard alone
+    does not close the TOCTOU window. Do not allowlist a hostname whose DNS you do not
+    control.
+    """
+    host = (urlparse(url).hostname or "").lower()
+    if host.endswith("."):
+        host = host[:-1]
+
+    for suffix in _BLOCKED_HOST_SUFFIXES:
+        bare = suffix.lstrip(".")
+        if host == bare or host.endswith(suffix):
+            raise ValueError(f"Refusing to connect to {url!r}: hostname {host!r} matches blocked suffix {suffix!r}")
+
+    try:
+        ip = ipaddress.ip_address(host)
+        addresses: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = [ip]
+    except ValueError:
+        try:
+            infos = socket.getaddrinfo(host, None)
+        except socket.gaierror as e:
+            raise ValueError(f"Could not resolve host {host!r}: {e}") from e
+        addresses = []
+        for info in infos:
+            sockaddr = info[4]
+            try:
+                addresses.append(ipaddress.ip_address(sockaddr[0]))
+            except ValueError:
+                continue
+
+    if not addresses:
+        raise ValueError(f"Could not resolve host {host!r} to any IP address")
+
+    for addr in addresses:
+        # Unwrap IPv4-mapped IPv6 first so subsequent checks apply to the embedded v4.
+        if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped is not None:
+            addr = addr.ipv4_mapped
+        if str(addr) in _BLOCKED_METADATA_ADDRESSES:
+            raise ValueError(f"Refusing to connect to {url!r}: host {host!r} resolves to metadata address {addr}")
+        # `is_global` is True for multicast on every supported CPython (3.10–3.14); the
+        # site-local `fec0::/10` range also slips through on some releases. Layer
+        # explicit rejections on top so the guard doesn't inherit those quirks.
+        if addr.is_multicast or addr.is_reserved or addr.is_unspecified or addr.is_link_local:
+            raise ValueError(f"Refusing to connect to {url!r}: host {host!r} resolves to non-public address {addr}")
+        if isinstance(addr, ipaddress.IPv6Address) and addr in _IPV6_SITE_LOCAL:
+            raise ValueError(f"Refusing to connect to {url!r}: host {host!r} resolves to non-public address {addr}")
+        if not addr.is_global:
+            raise ValueError(f"Refusing to connect to {url!r}: host {host!r} resolves to non-public address {addr}")
+
+
+# ---- Operation handlers ------------------------------------------------------------
+
+
+async def _handle_connect(
+    sessions: dict[str, _Session],
+    reserved: list[int],
+    *,
+    allowlist: frozenset[str],
+    session_limit: int,
+    startup_timeout: int,
+    server_url: str,
+    agent: Any,
+) -> dict[str, Any]:
+    parsed = urlparse(server_url)
+    _reject_userinfo_and_fragment(server_url, parsed)
+
+    canonical = _canonicalise_url(server_url)
+    if canonical not in allowlist:
+        raise ValueError(f"URL {server_url!r} is not on the developer-set allowlist")
+
+    scheme = parsed.scheme.lower()
+    if scheme not in _ALLOWED_SCHEMES:
+        # Defence in depth: the allowlist already screens this.
+        raise ValueError(f"unsupported scheme {scheme!r}")
+
+    _assert_public_host(server_url)
+
+    # Drop sessions whose owning agent has been garbage-collected before enforcing
+    # the cap. Left in place they'd count toward the limit forever and pin the
+    # underlying transport open.
+    _purge_dead_sessions(sessions)
+
+    if len(sessions) + reserved[0] >= session_limit:
+        raise RuntimeError(
+            f"Refusing to open a new MCP session: "
+            f"{len(sessions) + reserved[0]}/{session_limit} concurrent sessions in use"
+        )
+
+    transport_callable = _make_http_transport(server_url)
+
+    # Reserve a slot synchronously before any `await`. Without this a burst of
+    # concurrent connects would all pass the cap check, then race to `start()`
+    # in worker threads and overshoot.
+    reserved[0] += 1
+    client = MCPClient(transport_callable, startup_timeout=startup_timeout)
+    try:
+        # `MCPClient.start()` blocks the calling thread until the MCP handshake
+        # completes or `startup_timeout` elapses. Push it off the event loop so
+        # concurrent invocations of the tool are not serialised.
+        await asyncio.to_thread(client.start)
+        try:
+            # Cache the tool list at connect time. `call_tool` validates the
+            # requested name against this cache so an unadvertised name fails
+            # locally instead of being forwarded to the server. TypeScript
+            # does the same; both SDKs accept that the cache goes stale if
+            # the server changes its tool set mid-session, which is not a
+            # supported MCP flow today.
+            tools = await asyncio.to_thread(_list_tools_via_client, client)
+        except BaseException:
+            # A failure past `start()` leaves the client connected. Tear it down
+            # so we do not leak the transport.
+            try:
+                await asyncio.to_thread(client.stop, None, None, None)
+            except Exception:  # pragma: no cover - best-effort cleanup
+                logger.debug("failed to tear down MCP client after connect failure", exc_info=True)
+            raise
+    finally:
+        reserved[0] -= 1
+
+    session_id = secrets.token_urlsafe(24)
+    sessions[session_id] = _Session(
+        client=client,
+        url=canonical,
+        owner_ref=weakref.ref(agent),
+        tools=tools,
+    )
+    logger.debug("session_id=<%s>, url=<%s> | opened MCP session", session_id, canonical)
+
+    return {"session_id": session_id, "server_url": canonical}
+
+
+def _list_tools_via_client(client: MCPClient) -> dict[str, dict[str, Any]]:
+    """Pull the full tool list from an MCP client and return it keyed by name."""
+    tools: dict[str, dict[str, Any]] = {}
+    pagination_token: str | None = None
+    while True:
+        paginated = client.list_tools_sync(pagination_token)
+        for agent_tool in paginated:
+            mcp_tool = agent_tool.mcp_tool
+            entry: dict[str, Any] = {
+                "name": mcp_tool.name,
+                "description": mcp_tool.description or "",
+                "input_schema": mcp_tool.inputSchema,
+            }
+            if mcp_tool.outputSchema:
+                entry["output_schema"] = mcp_tool.outputSchema
+            tools[mcp_tool.name] = entry
+        pagination_token = paginated.pagination_token
+        if pagination_token is None:
+            break
+    return tools
+
+
+def _handle_list_tools(session: _Session) -> dict[str, Any]:
+    return {"tools": list(session.tools.values())}
+
+
+async def _handle_call_tool(
+    session: _Session,
+    tool_name: str,
+    arguments: dict[str, Any] | None,
+    timeout: int,
+) -> dict[str, Any]:
+    if tool_name not in session.tools:
+        raise ValueError(f"Tool {tool_name!r} is not exposed by the connected server")
+
+    tool_use_id = secrets.token_urlsafe(12)
+    result = await session.client.call_tool_async(
+        tool_use_id=tool_use_id,
+        name=tool_name,
+        arguments=arguments,
+        read_timeout_seconds=timedelta(seconds=timeout),
+    )
+
+    truncated = False
+    text_parts: list[str] = []
+    for content in result.get("content", []):
+        text = content.get("text") if isinstance(content, dict) else None
+        if isinstance(text, str):
+            text_parts.append(text)
+
+    joined = "\n".join(text_parts)
+    if len(joined) > _MAX_RESULT_TEXT_CHARS:
+        joined = joined[:_MAX_RESULT_TEXT_CHARS]
+        truncated = True
+
+    response: dict[str, Any] = {
+        "status": result.get("status", "error"),
+        "text": joined,
+    }
+    if truncated:
+        response["truncated"] = True
+    if "structuredContent" in result:
+        response["structured_content"] = _cap_structured_content(result["structuredContent"], response)
+    if result.get("isError"):
+        response["is_error"] = True
+    return response
+
+
+def _cap_structured_content(value: Any, response: dict[str, Any]) -> Any:
+    """Serialise ``value`` to JSON and, if it exceeds the size cap, return a marker.
+
+    Left as-is when small; when too large, replaced with an object announcing the
+    truncation so the model can see the content was dropped rather than silently
+    receiving a shortened blob.
+    """
+    try:
+        encoded = json.dumps(value)
+    except (TypeError, ValueError):
+        # Non-JSON-serialisable — reject rather than smuggle an opaque object through.
+        response["truncated"] = True
+        return {"__truncated__": True, "reason": "structured_content was not JSON-serialisable"}
+    encoded_bytes = len(encoded.encode("utf-8"))
+    if encoded_bytes <= _MAX_STRUCTURED_CONTENT_BYTES:
+        return value
+    response["truncated"] = True
+    # `size` reports the same unit the cap is measured in (bytes) so a non-ASCII
+    # payload's reported size matches the check.
+    return {"__truncated__": True, "reason": "structured_content exceeded size cap", "size": encoded_bytes}
+
+
+async def _handle_disconnect(
+    sessions: dict[str, _Session],
+    session_id: str,
+    session: _Session,
+) -> dict[str, Any]:
+    try:
+        # `stop` blocks until the transport tears down. Push it off the event loop.
+        await asyncio.to_thread(session.client.stop, None, None, None)
+    finally:
+        sessions.pop(session_id, None)
+    return {"disconnected": True}
+
+
+def _purge_dead_sessions(sessions: dict[str, _Session]) -> None:
+    """Remove sessions whose owning agent has been garbage-collected.
+
+    A dead weakref means the agent that opened the session no longer exists, so
+    the session is permanently unreachable via :func:`_resolve_session`. Left in
+    place these entries would count against the ``session_limit`` forever and
+    pin the underlying MCP transport open. Best-effort ``stop`` for the same
+    reason — failures are logged, not raised.
+    """
+    dead: list[str] = [sid for sid, s in sessions.items() if s.owner_ref() is None]
+    for sid in dead:
+        session = sessions.pop(sid, None)
+        if session is None:
+            continue
+        try:
+            session.client.stop(None, None, None)
+        except Exception:  # pragma: no cover - best-effort cleanup
+            logger.debug("failed to stop MCP client for GC'd session %s", sid, exc_info=True)
+
+
+def _resolve_session(sessions: dict[str, _Session], session_id: str | None, agent: Any) -> _Session:
+    """Look up a session, rejecting missing ids and cross-agent access.
+
+    The owner is held as a weakref: if the agent that opened the session has been
+    garbage-collected, ``owner_ref()`` returns ``None`` and the session is
+    unreachable — the caller gets the same "no active session" error as an
+    unknown id. When we observe a dead owner we also drop the session and
+    best-effort stop its client so the resource doesn't leak.
+    """
+    if not session_id:
+        raise ValueError("`session_id` is required")
+    session = sessions.get(session_id)
+    if session is None:
+        raise ValueError(f"No active session for id {session_id!r}")
+    owner = session.owner_ref()
+    if owner is None:
+        # Dead weakref: reap this specific session as we walk past it. Callers see
+        # the same "no active session" error as an unknown id.
+        sessions.pop(session_id, None)
+        try:
+            session.client.stop(None, None, None)
+        except Exception:  # pragma: no cover - best-effort cleanup
+            logger.debug("failed to stop MCP client for GC'd session %s", session_id, exc_info=True)
+        raise ValueError(f"No active session for id {session_id!r}")
+    if owner is not agent:
+        raise ValueError(f"No active session for id {session_id!r}")
+    return session
+
+
+# ---- Transports --------------------------------------------------------------------
+
+
+def _no_redirect_httpx_client_factory(
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None = None,
+    auth: httpx.Auth | None = None,
+) -> httpx.AsyncClient:
+    """MCP-shaped ``httpx.AsyncClient`` factory that refuses to follow redirects.
+
+    MCP's default factory sets ``follow_redirects=True``, which would allow an
+    allowlisted URL to be 3xx'd to a private endpoint the SSRF guard never saw. We
+    override to ``False`` so a redirect surfaces as an ``httpx.HTTPStatusError`` (or a
+    3xx status the caller can see) instead of a silent hop to the new location.
+    """
+    kwargs: dict[str, Any] = {"follow_redirects": False}
+    if timeout is None:
+        kwargs["timeout"] = httpx.Timeout(30.0, read=300.0)
+    else:
+        kwargs["timeout"] = timeout
+    if headers is not None:
+        kwargs["headers"] = headers
+    if auth is not None:
+        kwargs["auth"] = auth
+    return httpx.AsyncClient(**kwargs)
+
+
+def _make_http_transport(url: str):  # type: ignore[no-untyped-def]
+    """Return a zero-arg callable that opens a streamable-http transport for ``url``."""
+    return lambda: streamablehttp_client(
+        url=url,
+        httpx_client_factory=_no_redirect_httpx_client_factory,
+    )

--- a/strands-py/src/strands/vended_tools/mcp_client/mcp_client.py
+++ b/strands-py/src/strands/vended_tools/mcp_client/mcp_client.py
@@ -1,290 +1,183 @@
 """Agent-callable MCP client tool.
 
-Exposes a single tool with four operations — ``connect``, ``list_tools``, ``call_tool``,
-``disconnect`` — that lets an agent, at runtime, open a connection to a Model Context
-Protocol server, discover its tools, invoke one, and tear the connection down. The tool
-is a thin shim over :class:`~strands.tools.mcp.MCPClient`; all transport, session, and
-protocol handling lives in that class.
+Provides :func:`make_mcp_client` (a factory bound to a developer-set server allowlist).
 
-**Security model.** This is one of the highest-risk tools to vend: an MCP server can
-implement arbitrary logic, so the model must never be allowed to point the tool at an
-arbitrary URL. The factory takes a developer-set allowlist of exact URLs at construction;
-the tool rejects every ``connect`` that does not match one. In addition:
-
-- Only ``http://`` and ``https://`` URLs are accepted; the tool uses the streamable-http
-  MCP transport. Stdio, SSE, and WebSocket are out of scope: stdio expands the attack
-  surface substantially (subprocess spawn); SSE is being deprecated by the MCP spec in
-  favour of streamable-http; WebSocket is not a documented MCP client transport.
-- The URL's host is rejected outright when it matches a DNS suffix denylist
-  (``.internal``, ``.local``, ``.localhost``, ``.corp``, ``.home``, ``.lan``,
-  ``.intranet``, ``.private``, ``.i2p``, ``.onion``) before any DNS lookup.
-- The URL's host is then resolved and every returned address is checked with
-  :attr:`ipaddress._BaseAddress.is_global` for the private/loopback/CGNAT/shared-
-  address baseline, layered with **explicit** ``is_multicast``, ``is_reserved``,
-  ``is_unspecified``, ``is_link_local``, and IPv6-site-local (``fec0::/10``)
-  rejections: on all supported CPython versions (3.10–3.14) ``is_global`` is
-  ``True`` for IPv4 and IPv6 multicast, and ``fec0::/10`` slips through on some
-  releases, so ``is_global`` alone is not sufficient. IPv4-mapped IPv6
-  (``::ffff:a.b.c.d``, including the fully expanded form) is unwrapped first so
-  the underlying IPv4 category is what gets checked. A short list of
-  cloud-metadata addresses is also spelt out explicitly for defence in depth.
-- The httpx client that MCP uses under the hood is configured with
-  ``follow_redirects=False`` so an allowlisted URL cannot be 3xx'd to a private
-  endpoint the guard never saw.
-- Session IDs are generated with :mod:`secrets` and scoped to the agent that opened
-  them via a :func:`weakref.ref`; another agent using the same tool instance cannot
-  use a session it did not open, and a garbage-collected agent's sessions become
-  unreachable and are dropped from the session table on the next access or connect.
-- The number of live sessions the tool may hold is capped (default: 8), reserved
-  synchronously at connect entry so racing connects cannot overshoot the cap.
-- Blocking MCP client calls (``start``, ``list_tools_sync``, ``stop``) are pushed
-  off the event loop with :func:`asyncio.to_thread` so a slow handshake does not
-  stall other tools.
-- The tool set exposed by the server is fetched once at connect and cached on
-  the session; ``list_tools`` reads that cache and ``call_tool`` validates the
-  requested name against it locally. The cache can go stale if the server
-  changes its tool set mid-session, which is not a supported MCP flow today.
-- Tool-call text and ``structured_content`` are size-capped before being returned to
-  the model.
-
-**Limits.** The public-host classification is a check-time judgment. Between the
-guard's ``getaddrinfo`` and the MCP transport's own ``getaddrinfo``, an
-attacker-controlled resolver could return a public IP first and a private IP second
-(DNS rebinding). MCP's transport layer does not expose a hook for pinned-IP connects,
-so this shim relies on the allowlist pointing at endpoints whose operator does not
-serve time-varying DNS. Do not allowlist a hostname you do not control DNS for.
+The tool exposes four commands — ``connect``, ``list_tools``, ``call_tool``,
+``disconnect`` — letting an agent open a connection to an MCP server, discover its
+tools, invoke one, and close the connection. Each server is configured with a
+:class:`~strands.tools.mcp.MCPServerConfig`; all fields are forwarded to
+:class:`~strands.tools.mcp.MCPClient`. Sessions are isolated per agent and closed
+automatically when the agent is garbage-collected.
 """
 
 from __future__ import annotations
 
 import asyncio
-import ipaddress
-import json
 import logging
-import secrets
-import socket
 import weakref
-from datetime import timedelta
-from typing import TYPE_CHECKING, Any, Literal, cast
-from urllib.parse import urlparse
-
-import httpx
-from mcp.client.streamable_http import streamablehttp_client
+from typing import TYPE_CHECKING, Any, cast
+from urllib.parse import urlsplit
+from uuid import uuid4
 
 from ...tools.decorator import tool
-from ...tools.mcp.mcp_client import MCPClient
-from ...types.tools import ToolContext
+from ...tools.mcp.mcp_client import MCPClient, MCPServerConfig
+from ...tools.mcp.mcp_types import MCPToolResult
+from ...types.tools import ToolContext, ToolSpec
+from .types import MCP_CLIENT_DESCRIPTION, Command, ConnectOutput, _Session
 
 if TYPE_CHECKING:
     from ...tools.decorator import DecoratedFunctionTool
 
 logger = logging.getLogger(__name__)
 
-
-_MCP_CLIENT_DESCRIPTION = (
-    "Connects to Model Context Protocol (MCP) servers at runtime. Supports four operations: "
-    "'connect' (open a session to an allowlisted server URL), 'list_tools' (list the tools "
-    "the connected server exposes), 'call_tool' (invoke a tool on a connected server), and "
-    "'disconnect' (close a session). URLs must be on a developer-set allowlist."
-)
-
-_ALLOWED_SCHEMES = frozenset({"http", "https"})
 _DEFAULT_SCHEME_PORTS = {"http": 80, "https": 443}
-_DEFAULT_SESSION_LIMIT = 8
-_DEFAULT_STARTUP_TIMEOUT = 30
-_DEFAULT_CALL_TIMEOUT_SECONDS = 60
-_MAX_RESULT_TEXT_CHARS = 100_000
-_MAX_STRUCTURED_CONTENT_BYTES = 100_000
-
-# Hostname suffixes we reject before DNS. Names on these zones are intended for
-# internal use even when they happen to resolve to a public IP for some resolver.
-_BLOCKED_HOST_SUFFIXES: tuple[str, ...] = (
-    ".internal",
-    ".local",
-    ".localhost",
-    ".corp",
-    ".home",
-    ".lan",
-    ".intranet",
-    ".private",
-    ".i2p",
-    ".onion",
-)
-
-# Site-local IPv6 (`fec0::/10`, deprecated in RFC 3879 but not caught by
-# `is_global` on some CPython releases). Layer an explicit rejection.
-_IPV6_SITE_LOCAL = ipaddress.IPv6Network("fec0::/10")
-
-# Cloud-metadata endpoints. `is_global` already rejects link-local (169.254/16) and
-# the unique-local IPv6 space, but naming them explicitly guards against a future
-# refactor that weakens a generic predicate.
-_BLOCKED_METADATA_ADDRESSES: frozenset[str] = frozenset(
-    {
-        "169.254.169.254",  # AWS / Azure / DigitalOcean
-        "fd00:ec2::254",  # AWS IPv6
-        "100.100.100.200",  # Alibaba
-        "192.0.0.192",  # Oracle Cloud
-    }
-)
-
-Op = Literal["connect", "list_tools", "call_tool", "disconnect"]
+_ALLOWED_SCHEMES = frozenset(_DEFAULT_SCHEME_PORTS)
 
 
-class _Session:
-    """A single live MCP connection owned by exactly one agent."""
-
-    __slots__ = ("client", "url", "owner_ref", "tools")
-
-    def __init__(
-        self,
-        client: MCPClient,
-        url: str,
-        owner_ref: weakref.ref,
-        tools: dict[str, Any],
-    ) -> None:
-        self.client = client
-        self.url = url
-        self.owner_ref = owner_ref
-        # Tool set cached at connect time. Keyed by tool name; the value is the
-        # server-provided metadata used to render `list_tools` and validate the
-        # `tool_name` passed to `call_tool`. Matches the TypeScript side, which
-        # also caches at connect so both SDKs surface an "unknown tool" error
-        # locally instead of forwarding an unadvertised name to the server.
-        self.tools = tools
+class MCPClientToolError(RuntimeError):
+    """Raised when an mcp_client tool operation fails."""
 
 
 def make_mcp_client(
     *,
-    allowed_urls: list[str],
     name: str = "mcp_client",
-    description: str = _MCP_CLIENT_DESCRIPTION,
-    session_limit: int = _DEFAULT_SESSION_LIMIT,
-    startup_timeout: int = _DEFAULT_STARTUP_TIMEOUT,
+    description: str | None = None,
+    servers: list[MCPServerConfig],
 ) -> DecoratedFunctionTool:
-    """Create an agent-callable MCP client tool bound to a developer-set URL allowlist.
-
-    The returned tool exposes ``connect``, ``list_tools``, ``call_tool``, and ``disconnect``
-    operations under a single tool name. Every ``connect`` is checked against ``allowed_urls``;
-    only URLs that appear verbatim (after normalisation) are accepted.
+    """Create an agent-callable MCP client tool bound to a developer-set server allowlist.
 
     Args:
-        allowed_urls: Exact URLs the tool may connect to. The list is normalised (scheme
-            lowercased, trailing slash stripped) and each entry must use ``http`` or
-            ``https``. Must not be empty; the tool is deliberately useless without an
-            explicit allowlist.
         name: Tool name. Defaults to ``"mcp_client"``.
-        description: Tool description shown to the model.
-        session_limit: Maximum number of concurrent live sessions across all agents using
-            this tool instance. Defaults to 8.
-        startup_timeout: Seconds to wait for the initial MCP handshake before treating a
-            connection as failed. Defaults to 30.
+        description: Tool description shown to the model. Defaults to a description
+            that includes the list of permitted servers.
+        servers: Server configurations the tool may connect to. Each entry must have either
+            a ``url`` field (streamable-http) or a ``command`` field (stdio). Must not be empty.
 
     Returns:
         A decorated tool that manages MCP sessions.
 
     Raises:
-        ValueError: If ``allowed_urls`` is empty or contains an entry that is not a
-            valid, http-family URL.
+        ValueError: If ``servers`` is empty or contains an invalid entry.
     """
-    if not isinstance(session_limit, int) or isinstance(session_limit, bool) or session_limit <= 0:
-        raise ValueError(f"`session_limit` must be a positive integer, got {session_limit!r}")
+    server_map = _validate_servers(servers)
 
-    normalised_allowlist = _normalise_allowlist(allowed_urls)
-    sessions: dict[str, _Session] = {}
-    # Reserved-slot counter. Incremented synchronously before any `await` in
-    # `_handle_connect`, so racing connects can never overshoot the cap even
-    # while the blocking `client.start()` is off the event loop in a worker
-    # thread. Held in a single-element list so nested functions can mutate it.
-    reserved: list[int] = [0]
+    # Combine the description constant with the list of permitted servers
+    if description is None:
+        permitted = ", ".join(f"'{s}'" for s in sorted(server_map))
+        description = f"{MCP_CLIENT_DESCRIPTION} Permitted servers: {permitted}."
+
+    # Per-agent session tables. WeakKeyDictionary releases the session table when an agent is garbage-collected.
+    sessions: weakref.WeakKeyDictionary[Any, dict[str, _Session]] = weakref.WeakKeyDictionary()
 
     @tool(name=name, description=description, context="tool_context")
     async def mcp_client_tool(
-        op: Op,
+        command: Command,
         tool_context: ToolContext,
-        server_url: str | None = None,
+        server: str | None = None,
         session_id: str | None = None,
         tool_name: str | None = None,
         arguments: dict[str, Any] | None = None,
-        timeout: int = _DEFAULT_CALL_TIMEOUT_SECONDS,
-    ) -> dict[str, Any]:
+    ) -> ConnectOutput | list[ToolSpec] | MCPToolResult | str:
         """Manage a runtime MCP client connection.
 
         Args:
-            op: The operation to perform: ``connect``, ``list_tools``, ``call_tool``, ``disconnect``.
+            command: The operation to perform: ``connect``, ``list_tools``, ``call_tool``, ``disconnect``.
             tool_context: Injected by the framework. Not user-facing.
-            server_url: Server URL for ``connect``. Must match the developer-set allowlist verbatim.
-            session_id: Session identifier returned by ``connect``, required for the other three ops.
+            server: Server to connect to for ``connect``. For HTTP servers, a URL; for stdio servers,
+                the full command invocation (e.g. ``"npx -y @modelcontextprotocol/server-filesystem"``).
+                Must match the developer-set allowlist verbatim.
+            session_id: Session identifier returned by ``connect``, required for the other three commands.
             tool_name: Tool name to invoke, required for ``call_tool``.
             arguments: Arguments to pass to the invoked tool, for ``call_tool``.
-            timeout: Per-call timeout in seconds. Defaults to 60. Applies to ``call_tool`` only.
         """
         agent = tool_context.agent
 
-        if op == "connect":
-            if not server_url:
-                raise ValueError("`server_url` is required for op='connect'")
+        if command == "connect":
+            if not server:
+                raise MCPClientToolError("`server` is required for command='connect'")
             return await _handle_connect(
                 sessions,
-                reserved,
-                allowlist=normalised_allowlist,
-                session_limit=session_limit,
-                startup_timeout=startup_timeout,
-                server_url=server_url,
-                agent=agent,
+                agent,
+                server_map=server_map,
+                server=server,
             )
 
-        if op == "list_tools":
-            session = _resolve_session(sessions, session_id, agent)
-            return _handle_list_tools(session)
+        # All other commands require an active session.
+        if not session_id:
+            raise MCPClientToolError("`session_id` is required")
+        session = sessions.get(agent, {}).get(session_id)
+        if session is None:
+            raise MCPClientToolError(f"No active session for id {session_id!r}")
 
-        if op == "call_tool":
+        if command == "list_tools":
+            return await _handle_list_tools(session.client)
+
+        if command == "call_tool":
             if not tool_name:
-                raise ValueError("`tool_name` is required for op='call_tool'")
-            session = _resolve_session(sessions, session_id, agent)
-            return await _handle_call_tool(session, tool_name, arguments, timeout)
+                raise MCPClientToolError("`tool_name` is required for command='call_tool'")
+            return await session.client.call_tool_async(
+                tool_use_id=str(uuid4()),
+                name=tool_name,
+                arguments=arguments,
+                cancel_signal=tool_context.cancel_signal,
+            )
+        if command == "disconnect":
+            return await _handle_disconnect(session, sessions, agent, session_id)
 
-        if op == "disconnect":
-            session = _resolve_session(sessions, session_id, agent)
-            return await _handle_disconnect(sessions, cast(str, session_id), session)
-
-        raise ValueError(f"Unknown op: {op}")
+        raise MCPClientToolError(f"Unknown command: {command}")
 
     return mcp_client_tool
 
 
-# ---- URL validation ----------------------------------------------------------------
+# ---- Internals ----------------------------------------------------------------
 
 
-def _normalise_allowlist(urls: list[str]) -> frozenset[str]:
-    """Normalise the developer-set allowlist and validate each entry."""
-    if not urls:
-        raise ValueError("`allowed_urls` must not be empty; the mcp_client tool requires an explicit allowlist")
+def _validate_servers(servers: list[MCPServerConfig]) -> dict[str, MCPServerConfig]:
+    """Validate server configs and return a map keyed by server identifier.
 
-    normalised: set[str] = set()
-    for raw in urls:
-        parsed = urlparse(raw)
-        if parsed.scheme.lower() not in _ALLOWED_SCHEMES:
-            raise ValueError(
-                f"Allowlist entry {raw!r} has unsupported scheme {parsed.scheme!r}; only http and https are supported"
-            )
-        if not parsed.hostname:
-            raise ValueError(f"Allowlist entry {raw!r} has no host")
-        _reject_userinfo_and_fragment(raw, parsed)
-        normalised.add(_canonicalise_url(raw))
-    return frozenset(normalised)
+    For HTTP entries the key is the canonicalised URL; for stdio entries it is
+    the full command invocation (``command`` + space-joined ``args``).
 
+    Returns:
+        A dict keyed by server identifier mapping to the original config.
 
-def _reject_userinfo_and_fragment(raw: str, parsed: Any) -> None:
-    """Reject URLs carrying credentials or fragments.
-
-    Both are stripped by :func:`_canonicalise_url`, so leaving them accepted would
-    let ``https://user:pass@host/path`` canonicalise to the same string as
-    ``https://host/path`` and bypass the verbatim allowlist match.
+    Raises:
+        ValueError: If ``servers`` is empty, or an HTTP entry has an invalid URL.
     """
-    if parsed.username is not None or parsed.password is not None:
-        raise ValueError(f"URL {raw!r} carries credentials; strip the userinfo before allowlisting or connecting")
-    if parsed.fragment:
-        raise ValueError(f"URL {raw!r} carries a fragment; strip it before allowlisting or connecting")
+    if not servers:
+        raise ValueError("`servers` must not be empty; the mcp_client tool requires at least one server")
+
+    server_map: dict[str, MCPServerConfig] = {}
+
+    for config in servers:
+        if config.get("disabled"):
+            raise ValueError(
+                f"Server config with url={config.get('url')!r} command={config.get('command')!r} "
+                "is disabled; remove it from the list or set disabled=False"
+            )
+        url = config.get("url")
+        command = config.get("command")
+        if url and command:
+            raise ValueError(
+                f"Server config has both 'url' ({url!r}) and 'command' ({command!r}); "
+                "provide one or the other, or set 'transport' explicitly"
+            )
+        if url:
+            parsed = urlsplit(url)
+            if parsed.scheme.lower() not in _ALLOWED_SCHEMES:
+                raise ValueError(
+                    f"Server URL {url!r} has unsupported scheme {parsed.scheme!r}; only http and https are supported"
+                )
+            if not parsed.hostname:
+                raise ValueError(f"Server URL {url!r} has no host")
+            key = _canonicalise_url(url)
+        elif command:
+            key = " ".join([command] + list(config.get("args") or []))
+        else:
+            raise ValueError("Each server config must have either a 'url' (HTTP) or 'command' (stdio) field")
+        server_map[key] = config
+
+    return server_map
 
 
 def _canonicalise_url(url: str) -> str:
@@ -292,10 +185,9 @@ def _canonicalise_url(url: str) -> str:
 
     Lowercase scheme/host, strip the trailing slash on the path, drop the port when it
     matches the scheme default (so ``https://host`` and ``https://host:443`` match), and
-    drop the fragment. Userinfo is dropped too; :func:`_reject_userinfo_and_fragment`
-    refuses URLs carrying credentials or fragments before this function ever sees them.
+    drop userinfo and fragment.
     """
-    parsed = urlparse(url)
+    parsed = urlsplit(url)
     scheme = parsed.scheme.lower()
     host = (parsed.hostname or "").lower()
     default_port = _DEFAULT_SCHEME_PORTS.get(scheme)
@@ -305,326 +197,71 @@ def _canonicalise_url(url: str) -> str:
     return f"{scheme}://{host}{port}{path}{query}"
 
 
-def _assert_public_host(url: str) -> None:
-    """Reject URLs whose host is on the suffix denylist or resolves to non-public space.
-
-    Applied on top of the allowlist as defence in depth: even if the allowlist entry
-    itself points at an internal address, the guard still refuses.
-
-    The classification is a check-time judgment. A DNS-rebinding resolver can return a
-    different address to the MCP transport's own ``getaddrinfo`` at connect time; the
-    MCP client SDK does not expose a hook for pinned-IP connects, so this guard alone
-    does not close the TOCTOU window. Do not allowlist a hostname whose DNS you do not
-    control.
-    """
-    host = (urlparse(url).hostname or "").lower()
-    if host.endswith("."):
-        host = host[:-1]
-
-    for suffix in _BLOCKED_HOST_SUFFIXES:
-        bare = suffix.lstrip(".")
-        if host == bare or host.endswith(suffix):
-            raise ValueError(f"Refusing to connect to {url!r}: hostname {host!r} matches blocked suffix {suffix!r}")
-
-    try:
-        ip = ipaddress.ip_address(host)
-        addresses: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = [ip]
-    except ValueError:
+def _close_agent_sessions(agent_sessions: dict[str, _Session]) -> None:
+    """Best-effort transport teardown for all sessions in an agent's table."""
+    for session in agent_sessions.values():
         try:
-            infos = socket.getaddrinfo(host, None)
-        except socket.gaierror as e:
-            raise ValueError(f"Could not resolve host {host!r}: {e}") from e
-        addresses = []
-        for info in infos:
-            sockaddr = info[4]
-            try:
-                addresses.append(ipaddress.ip_address(sockaddr[0]))
-            except ValueError:
-                continue
-
-    if not addresses:
-        raise ValueError(f"Could not resolve host {host!r} to any IP address")
-
-    for addr in addresses:
-        # Unwrap IPv4-mapped IPv6 first so subsequent checks apply to the embedded v4.
-        if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped is not None:
-            addr = addr.ipv4_mapped
-        if str(addr) in _BLOCKED_METADATA_ADDRESSES:
-            raise ValueError(f"Refusing to connect to {url!r}: host {host!r} resolves to metadata address {addr}")
-        # `is_global` is True for multicast on every supported CPython (3.10–3.14); the
-        # site-local `fec0::/10` range also slips through on some releases. Layer
-        # explicit rejections on top so the guard doesn't inherit those quirks.
-        if addr.is_multicast or addr.is_reserved or addr.is_unspecified or addr.is_link_local:
-            raise ValueError(f"Refusing to connect to {url!r}: host {host!r} resolves to non-public address {addr}")
-        if isinstance(addr, ipaddress.IPv6Address) and addr in _IPV6_SITE_LOCAL:
-            raise ValueError(f"Refusing to connect to {url!r}: host {host!r} resolves to non-public address {addr}")
-        if not addr.is_global:
-            raise ValueError(f"Refusing to connect to {url!r}: host {host!r} resolves to non-public address {addr}")
-
-
-# ---- Operation handlers ------------------------------------------------------------
+            session.client.stop(None, None, None)
+        except Exception:
+            logger.debug("failed to stop MCP client during GC cleanup", exc_info=True)
 
 
 async def _handle_connect(
-    sessions: dict[str, _Session],
-    reserved: list[int],
-    *,
-    allowlist: frozenset[str],
-    session_limit: int,
-    startup_timeout: int,
-    server_url: str,
+    sessions: weakref.WeakKeyDictionary[Any, dict[str, _Session]],
     agent: Any,
-) -> dict[str, Any]:
-    parsed = urlparse(server_url)
-    _reject_userinfo_and_fragment(server_url, parsed)
+    *,
+    server_map: dict[str, MCPServerConfig],
+    server: str,
+) -> ConnectOutput:
+    is_http = server.lower().startswith(("http://", "https://"))
+    key = _canonicalise_url(server) if is_http else server
+    if key not in server_map:
+        permitted = ", ".join(sorted(server_map))
+        raise MCPClientToolError(f"Server {server!r} is not on the allowlist. Permitted servers: {permitted}")
 
-    canonical = _canonicalise_url(server_url)
-    if canonical not in allowlist:
-        raise ValueError(f"URL {server_url!r} is not on the developer-set allowlist")
+    config = cast(dict[str, Any], server_map[key])
+    clients = MCPClient.load_servers({"vended": config})
+    if not clients:
+        raise MCPClientToolError(f"Server {server!r} failed to initialise; check the server config")
+    client = clients[0]
 
-    scheme = parsed.scheme.lower()
-    if scheme not in _ALLOWED_SCHEMES:
-        # Defence in depth: the allowlist already screens this.
-        raise ValueError(f"unsupported scheme {scheme!r}")
-
-    _assert_public_host(server_url)
-
-    # Drop sessions whose owning agent has been garbage-collected before enforcing
-    # the cap. Left in place they'd count toward the limit forever and pin the
-    # underlying transport open.
-    _purge_dead_sessions(sessions)
-
-    if len(sessions) + reserved[0] >= session_limit:
-        raise RuntimeError(
-            f"Refusing to open a new MCP session: "
-            f"{len(sessions) + reserved[0]}/{session_limit} concurrent sessions in use"
-        )
-
-    transport_callable = _make_http_transport(server_url)
-
-    # Reserve a slot synchronously before any `await`. Without this a burst of
-    # concurrent connects would all pass the cap check, then race to `start()`
-    # in worker threads and overshoot.
-    reserved[0] += 1
-    client = MCPClient(transport_callable, startup_timeout=startup_timeout)
     try:
-        # `MCPClient.start()` blocks the calling thread until the MCP handshake
-        # completes or `startup_timeout` elapses. Push it off the event loop so
-        # concurrent invocations of the tool are not serialised.
+        # Push blocking start() off the event loop so concurrent tool invocations are not serialised.
         await asyncio.to_thread(client.start)
+        session_id = str(uuid4())
+        agent_sessions = sessions.setdefault(agent, {})
+        # Register a finalizer on first connect to close open transports when the agent is garbage collected.
+        if not agent_sessions:
+            weakref.finalize(agent, _close_agent_sessions, agent_sessions)
+        agent_sessions[session_id] = _Session(client=client, key=key)
+    except BaseException:
+        # Cancellation during start() or the session-table write — stop the client before re-raising.
         try:
-            # Cache the tool list at connect time. `call_tool` validates the
-            # requested name against this cache so an unadvertised name fails
-            # locally instead of being forwarded to the server. TypeScript
-            # does the same; both SDKs accept that the cache goes stale if
-            # the server changes its tool set mid-session, which is not a
-            # supported MCP flow today.
-            tools = await asyncio.to_thread(_list_tools_via_client, client)
-        except BaseException:
-            # A failure past `start()` leaves the client connected. Tear it down
-            # so we do not leak the transport.
-            try:
-                await asyncio.to_thread(client.stop, None, None, None)
-            except Exception:  # pragma: no cover - best-effort cleanup
-                logger.debug("failed to tear down MCP client after connect failure", exc_info=True)
-            raise
-    finally:
-        reserved[0] -= 1
+            client.stop(None, None, None)
+        except Exception:
+            logger.debug("failed to stop MCP client after connect failure", exc_info=True)
+        raise
 
-    session_id = secrets.token_urlsafe(24)
-    sessions[session_id] = _Session(
-        client=client,
-        url=canonical,
-        owner_ref=weakref.ref(agent),
-        tools=tools,
-    )
-    logger.debug("session_id=<%s>, url=<%s> | opened MCP session", session_id, canonical)
-
-    return {"session_id": session_id, "server_url": canonical}
+    logger.debug("session_id=<%s>, server=<%s> | opened MCP session", session_id, key)
+    return ConnectOutput(session_id=session_id, server=key)
 
 
-def _list_tools_via_client(client: MCPClient) -> dict[str, dict[str, Any]]:
-    """Pull the full tool list from an MCP client and return it keyed by name."""
-    tools: dict[str, dict[str, Any]] = {}
-    pagination_token: str | None = None
-    while True:
-        paginated = client.list_tools_sync(pagination_token)
-        for agent_tool in paginated:
-            mcp_tool = agent_tool.mcp_tool
-            entry: dict[str, Any] = {
-                "name": mcp_tool.name,
-                "description": mcp_tool.description or "",
-                "input_schema": mcp_tool.inputSchema,
-            }
-            if mcp_tool.outputSchema:
-                entry["output_schema"] = mcp_tool.outputSchema
-            tools[mcp_tool.name] = entry
-        pagination_token = paginated.pagination_token
-        if pagination_token is None:
-            break
-    return tools
-
-
-def _handle_list_tools(session: _Session) -> dict[str, Any]:
-    return {"tools": list(session.tools.values())}
-
-
-async def _handle_call_tool(
-    session: _Session,
-    tool_name: str,
-    arguments: dict[str, Any] | None,
-    timeout: int,
-) -> dict[str, Any]:
-    if tool_name not in session.tools:
-        raise ValueError(f"Tool {tool_name!r} is not exposed by the connected server")
-
-    tool_use_id = secrets.token_urlsafe(12)
-    result = await session.client.call_tool_async(
-        tool_use_id=tool_use_id,
-        name=tool_name,
-        arguments=arguments,
-        read_timeout_seconds=timedelta(seconds=timeout),
-    )
-
-    truncated = False
-    text_parts: list[str] = []
-    for content in result.get("content", []):
-        text = content.get("text") if isinstance(content, dict) else None
-        if isinstance(text, str):
-            text_parts.append(text)
-
-    joined = "\n".join(text_parts)
-    if len(joined) > _MAX_RESULT_TEXT_CHARS:
-        joined = joined[:_MAX_RESULT_TEXT_CHARS]
-        truncated = True
-
-    response: dict[str, Any] = {
-        "status": result.get("status", "error"),
-        "text": joined,
-    }
-    if truncated:
-        response["truncated"] = True
-    if "structuredContent" in result:
-        response["structured_content"] = _cap_structured_content(result["structuredContent"], response)
-    if result.get("isError"):
-        response["is_error"] = True
-    return response
-
-
-def _cap_structured_content(value: Any, response: dict[str, Any]) -> Any:
-    """Serialise ``value`` to JSON and, if it exceeds the size cap, return a marker.
-
-    Left as-is when small; when too large, replaced with an object announcing the
-    truncation so the model can see the content was dropped rather than silently
-    receiving a shortened blob.
-    """
-    try:
-        encoded = json.dumps(value)
-    except (TypeError, ValueError):
-        # Non-JSON-serialisable — reject rather than smuggle an opaque object through.
-        response["truncated"] = True
-        return {"__truncated__": True, "reason": "structured_content was not JSON-serialisable"}
-    encoded_bytes = len(encoded.encode("utf-8"))
-    if encoded_bytes <= _MAX_STRUCTURED_CONTENT_BYTES:
-        return value
-    response["truncated"] = True
-    # `size` reports the same unit the cap is measured in (bytes) so a non-ASCII
-    # payload's reported size matches the check.
-    return {"__truncated__": True, "reason": "structured_content exceeded size cap", "size": encoded_bytes}
+async def _handle_list_tools(client: MCPClient) -> list[ToolSpec]:
+    """Return the tool list from the client."""
+    tools = await client.load_tools()
+    return [t.tool_spec for t in tools]
 
 
 async def _handle_disconnect(
-    sessions: dict[str, _Session],
-    session_id: str,
     session: _Session,
-) -> dict[str, Any]:
+    sessions: weakref.WeakKeyDictionary[Any, dict[str, _Session]],
+    agent: Any,
+    session_id: str,
+) -> str:
     try:
         # `stop` blocks until the transport tears down. Push it off the event loop.
         await asyncio.to_thread(session.client.stop, None, None, None)
     finally:
-        sessions.pop(session_id, None)
-    return {"disconnected": True}
-
-
-def _purge_dead_sessions(sessions: dict[str, _Session]) -> None:
-    """Remove sessions whose owning agent has been garbage-collected.
-
-    A dead weakref means the agent that opened the session no longer exists, so
-    the session is permanently unreachable via :func:`_resolve_session`. Left in
-    place these entries would count against the ``session_limit`` forever and
-    pin the underlying MCP transport open. Best-effort ``stop`` for the same
-    reason — failures are logged, not raised.
-    """
-    dead: list[str] = [sid for sid, s in sessions.items() if s.owner_ref() is None]
-    for sid in dead:
-        session = sessions.pop(sid, None)
-        if session is None:
-            continue
-        try:
-            session.client.stop(None, None, None)
-        except Exception:  # pragma: no cover - best-effort cleanup
-            logger.debug("failed to stop MCP client for GC'd session %s", sid, exc_info=True)
-
-
-def _resolve_session(sessions: dict[str, _Session], session_id: str | None, agent: Any) -> _Session:
-    """Look up a session, rejecting missing ids and cross-agent access.
-
-    The owner is held as a weakref: if the agent that opened the session has been
-    garbage-collected, ``owner_ref()`` returns ``None`` and the session is
-    unreachable — the caller gets the same "no active session" error as an
-    unknown id. When we observe a dead owner we also drop the session and
-    best-effort stop its client so the resource doesn't leak.
-    """
-    if not session_id:
-        raise ValueError("`session_id` is required")
-    session = sessions.get(session_id)
-    if session is None:
-        raise ValueError(f"No active session for id {session_id!r}")
-    owner = session.owner_ref()
-    if owner is None:
-        # Dead weakref: reap this specific session as we walk past it. Callers see
-        # the same "no active session" error as an unknown id.
-        sessions.pop(session_id, None)
-        try:
-            session.client.stop(None, None, None)
-        except Exception:  # pragma: no cover - best-effort cleanup
-            logger.debug("failed to stop MCP client for GC'd session %s", session_id, exc_info=True)
-        raise ValueError(f"No active session for id {session_id!r}")
-    if owner is not agent:
-        raise ValueError(f"No active session for id {session_id!r}")
-    return session
-
-
-# ---- Transports --------------------------------------------------------------------
-
-
-def _no_redirect_httpx_client_factory(
-    headers: dict[str, str] | None = None,
-    timeout: httpx.Timeout | None = None,
-    auth: httpx.Auth | None = None,
-) -> httpx.AsyncClient:
-    """MCP-shaped ``httpx.AsyncClient`` factory that refuses to follow redirects.
-
-    MCP's default factory sets ``follow_redirects=True``, which would allow an
-    allowlisted URL to be 3xx'd to a private endpoint the SSRF guard never saw. We
-    override to ``False`` so a redirect surfaces as an ``httpx.HTTPStatusError`` (or a
-    3xx status the caller can see) instead of a silent hop to the new location.
-    """
-    kwargs: dict[str, Any] = {"follow_redirects": False}
-    if timeout is None:
-        kwargs["timeout"] = httpx.Timeout(30.0, read=300.0)
-    else:
-        kwargs["timeout"] = timeout
-    if headers is not None:
-        kwargs["headers"] = headers
-    if auth is not None:
-        kwargs["auth"] = auth
-    return httpx.AsyncClient(**kwargs)
-
-
-def _make_http_transport(url: str):  # type: ignore[no-untyped-def]
-    """Return a zero-arg callable that opens a streamable-http transport for ``url``."""
-    return lambda: streamablehttp_client(
-        url=url,
-        httpx_client_factory=_no_redirect_httpx_client_factory,
-    )
+        agent_sessions = sessions.get(agent, {})
+        agent_sessions.pop(session_id, None)
+    return f"Session successfully disconnected: {session_id}"

--- a/strands-py/src/strands/vended_tools/mcp_client/mcp_client.py
+++ b/strands-py/src/strands/vended_tools/mcp_client/mcp_client.py
@@ -166,13 +166,17 @@ def _validate_servers(servers: list[MCPServerConfig]) -> dict[str, MCPServerConf
     return server_map
 
 
-def _stop_client_on_gc(client: MCPClient) -> None:
-    """Stop an MCPClient when its owning agent is garbage-collected.
+def _stop_client(client: MCPClient) -> None:
+    """Best-effort stop: call ``stop()`` and swallow exceptions."""
+    try:
+        client.stop(None, None, None)
+    except Exception:
+        logger.debug("failed to stop MCP client", exc_info=True)
 
-    Runs ``stop()`` on a daemon thread with a 1 s join cap so a wedged transport
-    cannot stall the garbage collector thread indefinitely.
-    """
-    thread = threading.Thread(target=client.stop, args=(None, None, None), daemon=True)
+
+def _stop_client_in_background(client: MCPClient) -> None:
+    """Stop the client on a daemon thread with a 1 s join cap."""
+    thread = threading.Thread(target=_stop_client, args=(client,), daemon=True)
     thread.start()
     thread.join(timeout=1.0)
 
@@ -188,11 +192,6 @@ async def _handle_connect(
         permitted = ", ".join(sorted(server_map))
         raise MCPClientToolError(f"Server {server!r} is not on the allowlist. Permitted servers: {permitted}")
 
-    # Stop any existing connection before opening a new one.
-    existing = clients.get(agent)
-    if existing is not None:
-        await _handle_disconnect(clients, agent)
-
     config = cast(dict[str, Any], server_map[server])
     loaded = MCPClient.load_servers({"vended": config})
     client = loaded[0]
@@ -202,20 +201,14 @@ async def _handle_connect(
         # Read after start() so concurrent connects each see and stop the other's client.
         previous = clients.get(agent)
         clients[agent] = client
-        weakref.finalize(agent, _stop_client_on_gc, client)
+        weakref.finalize(agent, _stop_client_in_background, client)
     except BaseException:
         # start() failed or task was cancelled — stop the partially-started client before re-raising.
-        try:
-            client.stop(None, None, None)
-        except Exception:
-            logger.debug("failed to stop MCP client after connect failure", exc_info=True)
+        _stop_client(client)
         raise
 
     if previous is not None:
-        try:
-            await asyncio.to_thread(previous.stop, None, None, None)
-        except RuntimeError:
-            logger.debug("previous MCP connection was already closed")
+        await asyncio.to_thread(_stop_client, previous)
 
     logger.debug("server=<%s> | opened MCP connection", server)
     return f"Successfully connected to {server}"
@@ -235,9 +228,7 @@ async def _handle_disconnect(
     client = clients.get(agent)
     if client is not None:
         try:
-            await asyncio.to_thread(client.stop, None, None, None)
-        except RuntimeError:
-            logger.debug("MCP connection was already closed")
+            await asyncio.to_thread(_stop_client, client)
         finally:
             clients.pop(agent, None)
     return "Successfully disconnected"

--- a/strands-py/src/strands/vended_tools/mcp_client/mcp_client.py
+++ b/strands-py/src/strands/vended_tools/mcp_client/mcp_client.py
@@ -98,7 +98,7 @@ def make_mcp_client(
             raise MCPClientToolError("No active connection. Call 'connect' first.")
 
         if command == "list_tools":
-            return await _handle_list_tools(client)
+            return await asyncio.to_thread(_handle_list_tools, client)
 
         if command == "call_tool":
             if not tool_name:
@@ -214,11 +214,16 @@ async def _handle_connect(
     return f"Successfully connected to {server}"
 
 
-async def _handle_list_tools(client: MCPClient) -> list[ToolSpec]:
-    agent_tools = await asyncio.to_thread(
-        lambda: client._list_all_tools_sync()  # noqa: SLF001
-    )
-    return [{**t.tool_spec, "name": t.mcp_tool.name} for t in agent_tools]
+def _handle_list_tools(client: MCPClient) -> list[ToolSpec]:
+    all_tools = []
+    pagination_token = None
+    while True:
+        page = client.list_tools_sync(pagination_token)
+        all_tools.extend(page)
+        pagination_token = page.pagination_token
+        if pagination_token is None:
+            break
+    return [{**t.tool_spec, "name": t.mcp_tool.name} for t in all_tools]
 
 
 async def _handle_disconnect(

--- a/strands-py/src/strands/vended_tools/mcp_client/mcp_client.py
+++ b/strands-py/src/strands/vended_tools/mcp_client/mcp_client.py
@@ -39,28 +39,29 @@ def make_mcp_client(
     *,
     name: str = "mcp_client",
     description: str | None = None,
-    servers: list[MCPServerConfig],
+    servers: dict[str, MCPServerConfig],
 ) -> DecoratedFunctionTool:
     """Create an agent-callable MCP client tool bound to a developer-set server allowlist.
 
     Args:
         name: Tool name. Defaults to ``"mcp_client"``.
         description: Tool description shown to the model. Defaults to a description
-            that includes the list of permitted servers.
-        servers: Server configurations the tool may connect to. Each entry must have either
-            a ``url`` field (streamable-http) or a ``command`` field (stdio). Must not be empty.
+            that includes the list of permitted server names.
+        servers: Allowlisted servers keyed by name. The name is passed to ``connect``; the config
+            is forwarded to :class:`~strands.tools.mcp.MCPClient`. Must not be empty.
 
     Returns:
         A decorated tool that manages MCP sessions.
 
     Raises:
-        ValueError: If ``servers`` is empty or contains an invalid entry.
+        ValueError: If ``servers`` is empty.
     """
-    server_map = _validate_servers(servers)
+    if not servers:
+        raise ValueError("`servers` must not be empty; the mcp_client tool requires at least one server")
 
     if description is None:
-        permitted = ", ".join(f"'{s}'" for s in sorted(server_map))
-        description = f"{MCP_CLIENT_DESCRIPTION} Permitted servers: {permitted}."
+        permitted = ", ".join(f"'{s}'" for s in sorted(servers))
+        description = f"{MCP_CLIENT_DESCRIPTION} Permitted server names: {permitted}."
 
     # One connection per agent. WeakKeyDictionary so agents can be garbage collected normally.
     connections: weakref.WeakKeyDictionary[Any, _Connection] = weakref.WeakKeyDictionary()
@@ -69,7 +70,7 @@ def make_mcp_client(
     async def mcp_client_tool(
         command: Command,
         tool_context: ToolContext,
-        server: str | None = None,
+        server_name: str | None = None,
         tool_name: str | None = None,
         arguments: dict[str, Any] | None = None,
     ) -> list[ToolSpec] | MCPToolResult | str:
@@ -78,8 +79,7 @@ def make_mcp_client(
         Args:
             command: The operation to perform: ``connect``, ``list_tools``, ``call_tool``, ``disconnect``.
             tool_context: Injected by the framework. Not user-facing.
-            server: Server to connect to for ``connect``. For HTTP servers, a URL; for stdio servers,
-                the full command invocation. Must match the developer-set allowlist verbatim.
+            server_name: Server name to connect to for ``connect``. Must be in the developer-set allowlist.
             tool_name: Tool name to invoke, required for ``call_tool``.
             arguments: Arguments to pass to the invoked tool, for ``call_tool``.
 
@@ -90,9 +90,9 @@ def make_mcp_client(
         agent = tool_context.agent
 
         if command == "connect":
-            if not server:
-                raise MCPClientToolError("`server` is required for command='connect'")
-            return await _handle_connect(connections, agent, server_map=server_map, server=server)
+            if not server_name:
+                raise MCPClientToolError("`server_name` is required for command='connect'")
+            return await _handle_connect(connections, agent, servers=servers, server_name=server_name)
 
         conn = connections.get(agent)
         if conn is None:
@@ -123,42 +123,6 @@ def make_mcp_client(
 # ---- Internals ----------------------------------------------------------------
 
 
-def _validate_servers(servers: list[MCPServerConfig]) -> dict[str, MCPServerConfig]:
-    """Validate server configs and return a map keyed by server identifier.
-
-    For HTTP entries the key is the URL verbatim; for stdio entries it is
-    the full command invocation (``command`` + space-joined ``args``).
-
-    Returns:
-        A dict keyed by server identifier mapping to the original config.
-
-    Raises:
-        ValueError: If ``servers`` is empty or no entry has a ``url`` or ``command`` field.
-    """
-    if not servers:
-        raise ValueError("`servers` must not be empty; the mcp_client tool requires at least one server")
-
-    server_map: dict[str, MCPServerConfig] = {}
-
-    for config in servers:
-        url = config.get("url")
-        command = config.get("command")
-        if url:
-            key = url
-        elif command:
-            key = " ".join([command] + list(config.get("args") or []))
-        else:
-            raise ValueError("Each server config must have either a 'url' (HTTP) or 'command' (stdio) field")
-        if key in server_map and server_map[key] != config:
-            raise ValueError(
-                f"Server key {key!r} is produced by two different configs; "
-                "remove the duplicate or disambiguate (e.g. use explicit ports or distinct commands)"
-            )
-        server_map[key] = config
-
-    return server_map
-
-
 def _stop_client(client: MCPClient) -> None:
     """Best-effort stop: call ``stop()`` and swallow exceptions."""
     try:
@@ -178,17 +142,17 @@ async def _handle_connect(
     connections: weakref.WeakKeyDictionary[Any, _Connection],
     agent: Any,
     *,
-    server_map: dict[str, MCPServerConfig],
-    server: str,
+    servers: dict[str, MCPServerConfig],
+    server_name: str,
 ) -> str:
-    if server not in server_map:
-        permitted = ", ".join(sorted(server_map))
-        raise MCPClientToolError(f"Server {server!r} is not on the allowlist. Permitted servers: {permitted}")
+    if server_name not in servers:
+        permitted = ", ".join(sorted(servers))
+        raise MCPClientToolError(f"Server {server_name!r} is not on the allowlist. Permitted servers: {permitted}")
 
-    config = cast(dict[str, Any], server_map[server])
-    loaded = MCPClient.load_servers({"vended": config})
+    config = cast(dict[str, Any], servers[server_name])
+    loaded = MCPClient.load_servers({server_name: config})
     if not loaded:
-        raise MCPClientToolError(f"Server {server!r} failed to initialise; check the server config")
+        raise MCPClientToolError(f"Server {server_name!r} failed to initialise; check the server config")
     client = loaded[0]
 
     try:
@@ -207,8 +171,8 @@ async def _handle_connect(
         previous.finalizer.detach()
         await asyncio.to_thread(_stop_client, previous.client)
 
-    logger.debug("server=<%s> | opened MCP connection", server)
-    return f"Successfully connected to {server}"
+    logger.debug("server_name=<%s> | opened MCP connection", server_name)
+    return f"Successfully connected to {server_name}"
 
 
 def _handle_list_tools(client: MCPClient) -> list[ToolSpec]:

--- a/strands-py/src/strands/vended_tools/mcp_client/mcp_client.py
+++ b/strands-py/src/strands/vended_tools/mcp_client/mcp_client.py
@@ -3,10 +3,10 @@
 Provides :func:`make_mcp_client` (a factory bound to a developer-set server allowlist).
 
 The tool exposes four commands — ``connect``, ``list_tools``, ``call_tool``,
-``disconnect`` — letting an agent open a connection to an MCP server, discover its
-tools, invoke one, and close the connection. Each server is configured with a
+``disconnect`` — letting an agent open named connections to MCP servers, discover their
+tools, invoke them, and close the connections. Each server is configured with a
 :class:`~strands.tools.mcp.MCPServerConfig`; all fields are forwarded to
-:class:`~strands.tools.mcp.MCPClient`. One connection is held per agent at a time.
+:class:`~strands.tools.mcp.MCPClient`. Connections are isolated per agent.
 """
 
 from __future__ import annotations
@@ -15,7 +15,7 @@ import asyncio
 import logging
 import threading
 import weakref
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 from uuid import uuid4
 
 from ...tools.decorator import tool
@@ -23,12 +23,14 @@ from ...tools.mcp.mcp_agent_tool import MCPAgentTool
 from ...tools.mcp.mcp_client import MCPClient, MCPServerConfig
 from ...tools.mcp.mcp_types import MCPToolResult
 from ...types.tools import ToolContext, ToolSpec
-from .types import MCP_CLIENT_DESCRIPTION, Command, _Connection
+from .types import MCP_CLIENT_DESCRIPTION
 
 if TYPE_CHECKING:
     from ...tools.decorator import DecoratedFunctionTool
 
 logger = logging.getLogger(__name__)
+
+_DEFAULT_MAX_CONNECTIONS = 10
 
 
 class MCPClientToolError(RuntimeError):
@@ -40,6 +42,7 @@ def make_mcp_client(
     name: str = "mcp_client",
     description: str | None = None,
     servers: dict[str, MCPServerConfig],
+    max_connections: int = _DEFAULT_MAX_CONNECTIONS,
 ) -> DecoratedFunctionTool:
     """Create an agent-callable MCP client tool bound to a developer-set server allowlist.
 
@@ -49,55 +52,65 @@ def make_mcp_client(
             that includes the list of permitted server names.
         servers: Allowlisted servers keyed by name. The name is passed to ``connect``; the config
             is forwarded to :class:`~strands.tools.mcp.MCPClient`. Must not be empty.
+        max_connections: Maximum simultaneous open connections per agent. Defaults to ``10``.
 
     Returns:
-        A decorated tool that manages MCP sessions.
+        A decorated tool that manages MCP connections.
 
     Raises:
-        ValueError: If ``servers`` is empty.
+        ValueError: If ``servers`` is empty or ``max_connections`` is not positive.
     """
     if not servers:
         raise ValueError("`servers` must not be empty; the mcp_client tool requires at least one server")
+    if max_connections < 1:
+        raise ValueError("`max_connections` must be at least 1")
 
     if description is None:
         permitted = ", ".join(f"'{s}'" for s in sorted(servers))
         description = f"{MCP_CLIENT_DESCRIPTION} Permitted server names: {permitted}."
 
-    # One connection per agent. WeakKeyDictionary so agents can be garbage collected normally.
-    connections: weakref.WeakKeyDictionary[Any, _Connection] = weakref.WeakKeyDictionary()
+    # Per-agent connections with WeakKeyDictionary so agents can be garbage collected.
+    connections_map: weakref.WeakKeyDictionary[Any, dict[str, MCPClient]] = weakref.WeakKeyDictionary()
 
     @tool(name=name, description=description, context="tool_context")
     async def mcp_client_tool(
-        command: Command,
+        command: Literal["connect", "list_tools", "call_tool", "disconnect"],
         tool_context: ToolContext,
+        connection_id: str | None = None,
         server_name: str | None = None,
         tool_name: str | None = None,
         arguments: dict[str, Any] | None = None,
     ) -> list[ToolSpec] | MCPToolResult | str:
-        """Manage a runtime MCP client connection.
+        """Manage runtime MCP client connections.
 
         Args:
             command: The operation to perform: ``connect``, ``list_tools``, ``call_tool``, ``disconnect``.
             tool_context: Injected by the framework. Not user-facing.
-            server_name: Server name to connect to for ``connect``. Must be in the developer-set allowlist.
+            server_name: Server name to connect to, required for ``connect``.
+            connection_id: A descriptive name for this connection, required for all commands.
+                Must be unique per agent. Reusing an active id is rejected.
             tool_name: Tool name to invoke, required for ``call_tool``.
             arguments: Arguments to pass to the invoked tool, for ``call_tool``.
 
         Raises:
-            MCPClientToolError: If a required argument is missing, the server is not on the allowlist,
-                no connection is active, or the connection fails to start.
+            MCPClientToolError: If a required argument is missing, the server is not on
+                the allowlist, the connection cap is reached, no matching connection exists,
+                or the connection fails to start.
         """
         agent = tool_context.agent
+
+        if not connection_id:
+            raise MCPClientToolError("`connection_id` is required for all commands")
 
         if command == "connect":
             if not server_name:
                 raise MCPClientToolError("`server_name` is required for command='connect'")
-            return await _handle_connect(connections, agent, servers=servers, server_name=server_name)
+            return await _handle_connect(connections_map, agent, servers, server_name, connection_id, max_connections)
 
-        conn = connections.get(agent)
-        if conn is None:
-            raise MCPClientToolError("No active connection. Call 'connect' first.")
-        client = conn.client
+        connections = connections_map.get(agent, {})
+        client = connections.get(connection_id)
+        if client is None:
+            raise MCPClientToolError(f"No active connection for id {connection_id!r}")
 
         if command == "list_tools":
             return await asyncio.to_thread(_handle_list_tools, client)
@@ -113,7 +126,7 @@ def make_mcp_client(
             )
 
         if command == "disconnect":
-            return await _handle_disconnect(connections, agent)
+            return await _handle_disconnect(connections, connection_id)
 
         raise MCPClientToolError(f"Unknown command: {command}")
 
@@ -124,26 +137,30 @@ def make_mcp_client(
 
 
 def _stop_client(client: MCPClient) -> None:
-    """Best-effort stop: call ``stop()`` and swallow exceptions."""
     try:
         client.stop(None, None, None)
     except Exception:
         logger.debug("failed to stop MCP client", exc_info=True)
 
 
-def _stop_client_in_background(client: MCPClient) -> None:
-    """Stop the client on a daemon thread with a 1 s join cap."""
-    thread = threading.Thread(target=_stop_client, args=(client,), daemon=True)
-    thread.start()
-    thread.join(timeout=1.0)
+def _cleanup(connections: dict[str, MCPClient]) -> None:
+    threads = []
+    for connection_id, client in list(connections.items()):
+        logger.debug("connection_id=<%s> | closing MCP connection during GC", connection_id)
+        thread = threading.Thread(target=_stop_client, args=(client,), daemon=True)
+        thread.start()
+        threads.append(thread)
+    for thread in threads:
+        thread.join(timeout=1.0)
 
 
 async def _handle_connect(
-    connections: weakref.WeakKeyDictionary[Any, _Connection],
+    connections_map: weakref.WeakKeyDictionary[Any, dict[str, MCPClient]],
     agent: Any,
-    *,
     servers: dict[str, MCPServerConfig],
     server_name: str,
+    connection_id: str,
+    max_connections: int,
 ) -> str:
     if server_name not in servers:
         permitted = ", ".join(sorted(servers))
@@ -158,21 +175,37 @@ async def _handle_connect(
     try:
         # start() blocks until the MCP background thread signals ready — run it off the event loop.
         await asyncio.to_thread(client.start)
-        # Read after start() so concurrent connects each see and stop the other's client.
-        previous = connections.get(agent)
-        finalizer = weakref.finalize(agent, _stop_client_in_background, client)
-        connections[agent] = _Connection(client=client, finalizer=finalizer)
     except BaseException:
-        # start() failed or task was cancelled — stop the partially-started client before re-raising.
         _stop_client(client)
         raise
 
-    if previous is not None:
-        previous.finalizer.detach()
-        await asyncio.to_thread(_stop_client, previous.client)
+    # Cap and duplicate checks after all awaits to avoid race conditions.
+    connections = connections_map.get(agent)
+    if connections is None:
+        connections = {}
+        connections_map[agent] = connections
+        # Stop all open connections if the agent is garbage collected without calling disconnect.
+        weakref.finalize(agent, _cleanup, connections)
 
-    logger.debug("server_name=<%s> | opened MCP connection", server_name)
-    return f"Successfully connected to {server_name}"
+    if len(connections) >= max_connections:
+        _stop_client(client)
+        active_ids = ", ".join(sorted(connections))
+        raise MCPClientToolError(
+            f"Connection limit of {max_connections} reached. "
+            f"Disconnect one of the active connections before opening a new one. "
+            f"Active connection_ids: {active_ids}"
+        )
+
+    if connection_id in connections:
+        _stop_client(client)
+        raise MCPClientToolError(
+            f"Connection {connection_id!r} already exists. Disconnect it first or use a different connection_id."
+        )
+
+    connections[connection_id] = client
+
+    logger.debug("connection_id=<%s>, server_name=<%s> | opened MCP connection", connection_id, server_name)
+    return f"Successfully connected to {server_name} as {connection_id!r}"
 
 
 def _handle_list_tools(client: MCPClient) -> list[ToolSpec]:
@@ -188,12 +221,8 @@ def _handle_list_tools(client: MCPClient) -> list[ToolSpec]:
     return [{**t.tool_spec, "name": t.mcp_tool.name} for t in all_tools]
 
 
-async def _handle_disconnect(
-    connections: weakref.WeakKeyDictionary[Any, _Connection],
-    agent: Any,
-) -> str:
-    conn = connections.pop(agent, None)
-    if conn is not None:
-        conn.finalizer.detach()
-        await asyncio.to_thread(_stop_client, conn.client)
+async def _handle_disconnect(connections: dict[str, MCPClient], connection_id: str) -> str:
+    client = connections.pop(connection_id, None)
+    if client is not None:
+        await asyncio.to_thread(_stop_client, client)
     return "Successfully disconnected"

--- a/strands-py/src/strands/vended_tools/mcp_client/mcp_client.py
+++ b/strands-py/src/strands/vended_tools/mcp_client/mcp_client.py
@@ -19,10 +19,11 @@ from typing import TYPE_CHECKING, Any, cast
 from uuid import uuid4
 
 from ...tools.decorator import tool
+from ...tools.mcp.mcp_agent_tool import MCPAgentTool
 from ...tools.mcp.mcp_client import MCPClient, MCPServerConfig
 from ...tools.mcp.mcp_types import MCPToolResult
 from ...types.tools import ToolContext, ToolSpec
-from .types import MCP_CLIENT_DESCRIPTION, Command
+from .types import MCP_CLIENT_DESCRIPTION, Command, _Connection
 
 if TYPE_CHECKING:
     from ...tools.decorator import DecoratedFunctionTool
@@ -61,8 +62,8 @@ def make_mcp_client(
         permitted = ", ".join(f"'{s}'" for s in sorted(server_map))
         description = f"{MCP_CLIENT_DESCRIPTION} Permitted servers: {permitted}."
 
-    # One MCPClient per agent. WeakKeyDictionary so agents can be garbage collected normally.
-    clients: weakref.WeakKeyDictionary[Any, MCPClient] = weakref.WeakKeyDictionary()
+    # One connection per agent. WeakKeyDictionary so agents can be garbage collected normally.
+    connections: weakref.WeakKeyDictionary[Any, _Connection] = weakref.WeakKeyDictionary()
 
     @tool(name=name, description=description, context="tool_context")
     async def mcp_client_tool(
@@ -91,11 +92,12 @@ def make_mcp_client(
         if command == "connect":
             if not server:
                 raise MCPClientToolError("`server` is required for command='connect'")
-            return await _handle_connect(clients, agent, server_map=server_map, server=server)
+            return await _handle_connect(connections, agent, server_map=server_map, server=server)
 
-        client = clients.get(agent)
-        if client is None:
+        conn = connections.get(agent)
+        if conn is None:
             raise MCPClientToolError("No active connection. Call 'connect' first.")
+        client = conn.client
 
         if command == "list_tools":
             return await asyncio.to_thread(_handle_list_tools, client)
@@ -111,7 +113,7 @@ def make_mcp_client(
             )
 
         if command == "disconnect":
-            return await _handle_disconnect(clients, agent)
+            return await _handle_disconnect(connections, agent)
 
         raise MCPClientToolError(f"Unknown command: {command}")
 
@@ -182,7 +184,7 @@ def _stop_client_in_background(client: MCPClient) -> None:
 
 
 async def _handle_connect(
-    clients: weakref.WeakKeyDictionary[Any, MCPClient],
+    connections: weakref.WeakKeyDictionary[Any, _Connection],
     agent: Any,
     *,
     server_map: dict[str, MCPServerConfig],
@@ -194,46 +196,48 @@ async def _handle_connect(
 
     config = cast(dict[str, Any], server_map[server])
     loaded = MCPClient.load_servers({"vended": config})
+    if not loaded:
+        raise MCPClientToolError(f"Server {server!r} failed to initialise; check the server config")
     client = loaded[0]
 
     try:
         await asyncio.to_thread(client.start)
         # Read after start() so concurrent connects each see and stop the other's client.
-        previous = clients.get(agent)
-        clients[agent] = client
-        weakref.finalize(agent, _stop_client_in_background, client)
+        previous = connections.get(agent)
+        finalizer = weakref.finalize(agent, _stop_client_in_background, client)
+        connections[agent] = _Connection(client=client, finalizer=finalizer)
     except BaseException:
         # start() failed or task was cancelled — stop the partially-started client before re-raising.
         _stop_client(client)
         raise
 
     if previous is not None:
-        await asyncio.to_thread(_stop_client, previous)
+        previous.finalizer.detach()
+        await asyncio.to_thread(_stop_client, previous.client)
 
     logger.debug("server=<%s> | opened MCP connection", server)
     return f"Successfully connected to {server}"
 
 
 def _handle_list_tools(client: MCPClient) -> list[ToolSpec]:
-    all_tools = []
-    pagination_token = None
+    all_tools: list[MCPAgentTool] = []
+    pagination_token: str | None = None
     while True:
         page = client.list_tools_sync(pagination_token)
         all_tools.extend(page)
         pagination_token = page.pagination_token
         if pagination_token is None:
             break
+    # Get mcp_tool.name instead of tool_name (may be prefixed) so call_tool works verbatim.
     return [{**t.tool_spec, "name": t.mcp_tool.name} for t in all_tools]
 
 
 async def _handle_disconnect(
-    clients: weakref.WeakKeyDictionary[Any, MCPClient],
+    connections: weakref.WeakKeyDictionary[Any, _Connection],
     agent: Any,
 ) -> str:
-    client = clients.get(agent)
-    if client is not None:
-        try:
-            await asyncio.to_thread(_stop_client, client)
-        finally:
-            clients.pop(agent, None)
+    conn = connections.pop(agent, None)
+    if conn is not None:
+        conn.finalizer.detach()
+        await asyncio.to_thread(_stop_client, conn.client)
     return "Successfully disconnected"

--- a/strands-py/src/strands/vended_tools/mcp_client/mcp_client.py
+++ b/strands-py/src/strands/vended_tools/mcp_client/mcp_client.py
@@ -133,7 +133,7 @@ def _validate_servers(servers: list[MCPServerConfig]) -> dict[str, MCPServerConf
         A dict keyed by server identifier mapping to the original config.
 
     Raises:
-        ValueError: If ``servers`` is empty or a config entry is invalid.
+        ValueError: If ``servers`` is empty or no entry has a ``url`` or ``command`` field.
     """
     if not servers:
         raise ValueError("`servers` must not be empty; the mcp_client tool requires at least one server")
@@ -141,18 +141,9 @@ def _validate_servers(servers: list[MCPServerConfig]) -> dict[str, MCPServerConf
     server_map: dict[str, MCPServerConfig] = {}
 
     for config in servers:
-        if config.get("disabled"):
-            raise ValueError(
-                f"Server config with url={config.get('url')!r} command={config.get('command')!r} "
-                "is disabled; remove it from the list or set disabled=False"
-            )
         url = config.get("url")
         command = config.get("command")
         if url:
-            if command:
-                raise ValueError(
-                    f"Server config has both 'url' ({url!r}) and 'command' ({command!r}); provide one or the other"
-                )
             key = url
         elif command:
             key = " ".join([command] + list(config.get("args") or []))
@@ -201,6 +192,7 @@ async def _handle_connect(
     client = loaded[0]
 
     try:
+        # start() blocks until the MCP background thread signals ready — run it off the event loop.
         await asyncio.to_thread(client.start)
         # Read after start() so concurrent connects each see and stop the other's client.
         previous = connections.get(agent)

--- a/strands-py/src/strands/vended_tools/mcp_client/types.py
+++ b/strands-py/src/strands/vended_tools/mcp_client/types.py
@@ -1,0 +1,42 @@
+"""Shared types and constants for the mcp_client tool."""
+
+from __future__ import annotations
+
+from typing import Literal, TypedDict
+
+from ...tools.mcp.mcp_client import MCPClient
+
+Command = Literal["connect", "list_tools", "call_tool", "disconnect"]
+"""Commands supported by the mcp_client tool."""
+
+
+class ConnectOutput(TypedDict):
+    """Output of the ``connect`` command.
+
+    Attributes:
+        session_id: Opaque identifier for the new session. Pass to subsequent commands.
+        server: The server identifier used to open the session (canonical URL or full command invocation).
+    """
+
+    session_id: str
+    server: str
+
+
+class _Session:
+    """A single live MCP connection."""
+
+    __slots__ = ("client", "key")
+
+    def __init__(self, client: MCPClient, key: str) -> None:
+        self.client = client
+        self.key = key
+
+
+MCP_CLIENT_DESCRIPTION = (
+    "Connects to Model Context Protocol (MCP) servers at runtime. Supports four commands: "
+    "'connect' (open a session to a server — a URL for HTTP servers or a command invocation for stdio), "
+    "'list_tools' (list the tools the connected server exposes), "
+    "'call_tool' (invoke a tool on a connected server), and "
+    "'disconnect' (close a session)."
+)
+"""Description for the mcp_client tool shown to the model."""

--- a/strands-py/src/strands/vended_tools/mcp_client/types.py
+++ b/strands-py/src/strands/vended_tools/mcp_client/types.py
@@ -14,7 +14,7 @@ MCP_CLIENT_DESCRIPTION = (
     "'list_tools' returns the tools the connected server exposes, including their names and input schemas. "
     "'call_tool' invokes a named tool on the connected server and returns its result. "
     "'disconnect' closes the connection. "
-    "Only one server can be connected at a time. "
-    "Avoid reconnecting to the same server unless the connection has been explicitly disconnected."
+    "Only one server can be connected at a time: connecting to a different server closes the current connection, "
+    "and reconnecting to the same server restarts it and discards its state. Disconnect when done."
 )
 """Description for the mcp_client tool shown to the model."""

--- a/strands-py/src/strands/vended_tools/mcp_client/types.py
+++ b/strands-py/src/strands/vended_tools/mcp_client/types.py
@@ -14,8 +14,8 @@ class ConnectOutput(TypedDict):
     """Output of the ``connect`` command.
 
     Attributes:
-        session_id: Opaque identifier for the new session. Pass to subsequent commands.
-        server: The server identifier used to open the session (canonical URL or full command invocation).
+        session_id: Opaque identifier for the new session. Pass to subsequent commands to identify this connection.
+        server: The server used to open the session.
     """
 
     session_id: str
@@ -33,10 +33,12 @@ class _Session:
 
 
 MCP_CLIENT_DESCRIPTION = (
-    "Connects to Model Context Protocol (MCP) servers at runtime. Supports four commands: "
-    "'connect' (open a session to a server — a URL for HTTP servers or a command invocation for stdio), "
-    "'list_tools' (list the tools the connected server exposes), "
-    "'call_tool' (invoke a tool on a connected server), and "
-    "'disconnect' (close a session)."
+    "Connects to Model Context Protocol (MCP) servers at runtime to discover and invoke their tools. "
+    "'connect' opens a connection to a server and returns a session_id (the connection handle) and the "
+    "server identifier. "
+    "'list_tools' returns the tools the server exposes, including their names and input schemas. "
+    "'call_tool' invokes a named tool on the server and returns its result. "
+    "'disconnect' closes the connection. "
+    "Sessions persist across turns — reuse the session_id rather than reconnecting, and disconnect when done."
 )
 """Description for the mcp_client tool shown to the model."""

--- a/strands-py/src/strands/vended_tools/mcp_client/types.py
+++ b/strands-py/src/strands/vended_tools/mcp_client/types.py
@@ -2,43 +2,19 @@
 
 from __future__ import annotations
 
-from typing import Literal, TypedDict
-
-from ...tools.mcp.mcp_client import MCPClient
+from typing import Literal
 
 Command = Literal["connect", "list_tools", "call_tool", "disconnect"]
 """Commands supported by the mcp_client tool."""
 
 
-class ConnectOutput(TypedDict):
-    """Output of the ``connect`` command.
-
-    Attributes:
-        session_id: Opaque identifier for the new session. Pass to subsequent commands to identify this connection.
-        server: The server used to open the session.
-    """
-
-    session_id: str
-    server: str
-
-
-class _Session:
-    """A single live MCP connection."""
-
-    __slots__ = ("client", "key")
-
-    def __init__(self, client: MCPClient, key: str) -> None:
-        self.client = client
-        self.key = key
-
-
 MCP_CLIENT_DESCRIPTION = (
     "Connects to Model Context Protocol (MCP) servers at runtime to discover and invoke their tools. "
-    "'connect' opens a connection to a server and returns a session_id (the connection handle) and the "
-    "server identifier. "
-    "'list_tools' returns the tools the server exposes, including their names and input schemas. "
-    "'call_tool' invokes a named tool on the server and returns its result. "
+    "'connect' opens a connection to a permitted server. "
+    "'list_tools' returns the tools the connected server exposes, including their names and input schemas. "
+    "'call_tool' invokes a named tool on the connected server and returns its result. "
     "'disconnect' closes the connection. "
-    "Sessions persist across turns — reuse the session_id rather than reconnecting, and disconnect when done."
+    "Only one server can be connected at a time. "
+    "Avoid reconnecting to the same server unless the connection has been explicitly disconnected."
 )
 """Description for the mcp_client tool shown to the model."""

--- a/strands-py/src/strands/vended_tools/mcp_client/types.py
+++ b/strands-py/src/strands/vended_tools/mcp_client/types.py
@@ -2,31 +2,12 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
-
-if TYPE_CHECKING:
-    from ...tools.mcp.mcp_client import MCPClient
-
-Command = Literal["connect", "list_tools", "call_tool", "disconnect"]
-"""Commands supported by the mcp_client tool."""
-
-
-@dataclass
-class _Connection:
-    """A live MCP connection and its GC finalizer handle."""
-
-    client: MCPClient
-    finalizer: Any
-
-
 MCP_CLIENT_DESCRIPTION = (
     "Connects to Model Context Protocol (MCP) servers at runtime to discover and invoke their tools. "
     "'connect' opens a connection to a permitted server. "
     "'list_tools' returns the tools the connected server exposes, including their names and input schemas. "
-    "'call_tool' invokes a named tool on the connected server and returns its result. "
-    "'disconnect' closes the connection. "
-    "Only one server can be connected at a time: connecting to a different server closes the current connection, "
-    "and reconnecting to the same server restarts it and discards its state. Disconnect when done."
+    "'call_tool' invokes a named tool on a connected server and returns its result. "
+    "'disconnect' closes a connection. "
+    "Use connection_id to identify which connection to use for list_tools, call_tool, and disconnect."
 )
 """Description for the mcp_client tool shown to the model."""

--- a/strands-py/src/strands/vended_tools/mcp_client/types.py
+++ b/strands-py/src/strands/vended_tools/mcp_client/types.py
@@ -2,10 +2,22 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from ...tools.mcp.mcp_client import MCPClient
 
 Command = Literal["connect", "list_tools", "call_tool", "disconnect"]
 """Commands supported by the mcp_client tool."""
+
+
+@dataclass
+class _Connection:
+    """A live MCP connection and its GC finalizer handle."""
+
+    client: MCPClient
+    finalizer: Any
 
 
 MCP_CLIENT_DESCRIPTION = (

--- a/strands-py/tests/strands/vended_tools/test_mcp_client.py
+++ b/strands-py/tests/strands/vended_tools/test_mcp_client.py
@@ -1,0 +1,710 @@
+"""Tests for the vended MCP client tool.
+
+The tool is a thin shim over ``strands.tools.mcp.MCPClient``. These tests exercise the
+security surface — allowlist enforcement, SSRF guard, session scoping, session cap — with
+the real code paths, and cover the connect->list->call->disconnect happy path by patching
+``MCPClient`` so no real MCP server is needed.
+"""
+
+from __future__ import annotations
+
+import gc
+import socket
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from strands.types.tools import ToolContext
+from strands.vended_tools import make_mcp_client
+from strands.vended_tools.mcp_client.mcp_client import (
+    _canonicalise_url,
+    _cap_structured_content,
+    _no_redirect_httpx_client_factory,
+    _normalise_allowlist,
+)
+
+
+class _StubAgent:
+    """A minimal agent stand-in that supports weakref (SimpleNamespace does not)."""
+
+    def __init__(self, label: str | None = None) -> None:
+        self.label = label
+
+
+def _tool_context(agent: Any | None = None) -> ToolContext:
+    """Build a ToolContext with a distinct sentinel agent object for identity checks."""
+    if agent is None:
+        agent = _StubAgent()
+    return ToolContext(
+        tool_use={"name": "mcp_client", "toolUseId": "test-id", "input": {}},
+        agent=agent,
+        invocation_state={},
+    )
+
+
+class _FakeMCPTool:
+    def __init__(self, name: str, description: str, input_schema: dict[str, Any]) -> None:
+        self.name = name
+        self.description = description
+        self.inputSchema = input_schema
+        self.outputSchema: dict[str, Any] | None = None
+
+
+class _FakeAgentTool:
+    def __init__(self, tool: _FakeMCPTool) -> None:
+        self.mcp_tool = tool
+
+
+class _FakePaginatedList(list):
+    def __init__(self, items: list[Any], token: str | None = None) -> None:
+        super().__init__(items)
+        self.pagination_token = token
+
+
+def _fake_mcp_client_class(
+    *,
+    list_tools_return: list[_FakeAgentTool] | None = None,
+    call_tool_return: dict[str, Any] | None = None,
+) -> Any:
+    """Return a MagicMock-based MCPClient replacement whose start/stop record calls."""
+    instance = MagicMock()
+    instance.start = MagicMock()
+    instance.stop = MagicMock()
+    instance.list_tools_sync = MagicMock(return_value=_FakePaginatedList(list_tools_return or [], token=None))
+
+    async def _call(*args: Any, **kwargs: Any) -> Any:
+        return call_tool_return or {"status": "success", "content": [{"text": "ok"}]}
+
+    instance.call_tool_async = _call
+    return MagicMock(return_value=instance), instance
+
+
+def _mcp_instance(tools: list[_FakeAgentTool] | None = None) -> MagicMock:
+    """Return a MagicMock configured to look enough like an ``MCPClient`` that connect works.
+
+    ``_list_tools_via_client`` reads ``pagination_token`` off the returned page and
+    iterates it, so a bare ``MagicMock`` (whose ``pagination_token`` is another
+    ``MagicMock`` rather than ``None``) would loop forever.
+    """
+    instance = MagicMock()
+    instance.list_tools_sync = MagicMock(return_value=_FakePaginatedList(tools or [], token=None))
+    return instance
+
+
+class TestAllowlistEnforcement:
+    """URL allowlist rejects anything the developer didn't sign off on."""
+
+    @pytest.mark.asyncio
+    async def test_url_not_on_allowlist_is_rejected(self):
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with pytest.raises(ValueError, match="not on the developer-set allowlist"):
+            await tool(op="connect", server_url="https://evil.example.com/mcp", tool_context=_tool_context())
+
+    @pytest.mark.asyncio
+    async def test_allowlist_match_is_scheme_and_host_case_insensitive(self):
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with (
+            patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai,
+            patch("strands.vended_tools.mcp_client.mcp_client.MCPClient") as client_cls,
+        ):
+            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+            instance = _mcp_instance()
+            client_cls.return_value = instance
+            result = await tool(
+                op="connect",
+                server_url="HTTPS://MCP.EXAMPLE.COM/mcp",
+                tool_context=_tool_context(),
+            )
+        assert "session_id" in result
+        instance.start.assert_called_once()
+
+    def test_empty_allowlist_is_rejected_at_construction(self):
+        with pytest.raises(ValueError, match="must not be empty"):
+            make_mcp_client(allowed_urls=[])
+
+    def test_disallowed_scheme_in_allowlist_is_rejected_at_construction(self):
+        with pytest.raises(ValueError, match="unsupported scheme"):
+            make_mcp_client(allowed_urls=["file:///etc/passwd"])
+
+    def test_missing_host_in_allowlist_is_rejected(self):
+        with pytest.raises(ValueError, match="no host"):
+            make_mcp_client(allowed_urls=["https:///"])
+
+    def test_allowlist_entry_with_userinfo_is_rejected(self):
+        # A canonicaliser that dropped userinfo would let `https://user:pass@host/x`
+        # collide with `https://host/x` on the allowlist. Reject at construction.
+        with pytest.raises(ValueError, match="credentials"):
+            make_mcp_client(allowed_urls=["https://user:pass@mcp.example.com/mcp"])
+
+    def test_allowlist_entry_with_fragment_is_rejected(self):
+        with pytest.raises(ValueError, match="fragment"):
+            make_mcp_client(allowed_urls=["https://mcp.example.com/mcp#anchor"])
+
+    @pytest.mark.asyncio
+    async def test_connect_url_with_userinfo_is_rejected(self):
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with pytest.raises(ValueError, match="credentials"):
+            await tool(
+                op="connect",
+                server_url="https://user:pass@mcp.example.com/mcp",
+                tool_context=_tool_context(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_connect_url_with_fragment_is_rejected(self):
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with pytest.raises(ValueError, match="fragment"):
+            await tool(
+                op="connect",
+                server_url="https://mcp.example.com/mcp#x",
+                tool_context=_tool_context(),
+            )
+
+    @pytest.mark.parametrize("bad", [0, -1, 1.5, True, False, "8"])
+    def test_session_limit_must_be_positive_integer(self, bad):
+        with pytest.raises(ValueError, match="positive integer"):
+            make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"], session_limit=bad)  # type: ignore[arg-type]
+
+
+class TestSSRFGuard:
+    """The SSRF guard rejects hostnames that resolve to non-public addresses."""
+
+    @pytest.mark.asyncio
+    async def test_hostname_resolving_to_private_ip_is_rejected(self):
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai:
+            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("10.0.0.5", 0))]
+            with pytest.raises(ValueError, match="non-public address"):
+                await tool(
+                    op="connect",
+                    server_url="https://mcp.example.com/mcp",
+                    tool_context=_tool_context(),
+                )
+
+    @pytest.mark.asyncio
+    async def test_hostname_resolving_to_loopback_is_rejected(self):
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai:
+            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", 0))]
+            with pytest.raises(ValueError, match="non-public address"):
+                await tool(
+                    op="connect",
+                    server_url="https://mcp.example.com/mcp",
+                    tool_context=_tool_context(),
+                )
+
+    @pytest.mark.asyncio
+    async def test_literal_private_ip_in_url_is_rejected(self):
+        tool = make_mcp_client(allowed_urls=["http://192.168.1.1/mcp"])
+        with pytest.raises(ValueError, match="non-public address"):
+            await tool(op="connect", server_url="http://192.168.1.1/mcp", tool_context=_tool_context())
+
+    @pytest.mark.asyncio
+    async def test_link_local_metadata_ip_is_rejected(self):
+        tool = make_mcp_client(allowed_urls=["http://169.254.169.254/mcp"])
+        with pytest.raises(ValueError, match="metadata address|non-public address"):
+            await tool(op="connect", server_url="http://169.254.169.254/mcp", tool_context=_tool_context())
+
+    @pytest.mark.asyncio
+    async def test_cgnat_ip_is_rejected(self):
+        tool = make_mcp_client(allowed_urls=["http://100.64.0.1/mcp"])
+        with pytest.raises(ValueError, match="non-public address"):
+            await tool(op="connect", server_url="http://100.64.0.1/mcp", tool_context=_tool_context())
+
+    @pytest.mark.asyncio
+    async def test_ipv4_mapped_cgnat_is_rejected(self):
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai:
+            gai.return_value = [(socket.AF_INET6, socket.SOCK_STREAM, 0, "", ("::ffff:100.64.0.1", 0, 0, 0))]
+            with pytest.raises(ValueError, match="non-public address"):
+                await tool(
+                    op="connect",
+                    server_url="https://mcp.example.com/mcp",
+                    tool_context=_tool_context(),
+                )
+
+    @pytest.mark.asyncio
+    async def test_ipv4_mapped_private_is_rejected(self):
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai:
+            gai.return_value = [(socket.AF_INET6, socket.SOCK_STREAM, 0, "", ("::ffff:10.0.0.5", 0, 0, 0))]
+            with pytest.raises(ValueError, match="non-public address"):
+                await tool(
+                    op="connect",
+                    server_url="https://mcp.example.com/mcp",
+                    tool_context=_tool_context(),
+                )
+
+    @pytest.mark.asyncio
+    async def test_ipv4_multicast_is_rejected(self):
+        """`is_global` returns True for multicast on CPython — the guard must layer explicit checks."""
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai:
+            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("239.255.0.1", 0))]
+            with pytest.raises(ValueError, match="non-public address"):
+                await tool(
+                    op="connect",
+                    server_url="https://mcp.example.com/mcp",
+                    tool_context=_tool_context(),
+                )
+
+    @pytest.mark.asyncio
+    async def test_ipv6_multicast_is_rejected(self):
+        """`is_global` also returns True for IPv6 multicast (`ff00::/8`) on CPython."""
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai:
+            gai.return_value = [(socket.AF_INET6, socket.SOCK_STREAM, 0, "", ("ff02::1", 0, 0, 0))]
+            with pytest.raises(ValueError, match="non-public address"):
+                await tool(
+                    op="connect",
+                    server_url="https://mcp.example.com/mcp",
+                    tool_context=_tool_context(),
+                )
+
+    @pytest.mark.asyncio
+    async def test_ipv6_site_local_is_rejected(self):
+        """`fec0::/10` slips through `is_global` on some Python versions — explicit block."""
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai:
+            gai.return_value = [(socket.AF_INET6, socket.SOCK_STREAM, 0, "", ("fec0::1", 0, 0, 0))]
+            with pytest.raises(ValueError, match="non-public address"):
+                await tool(
+                    op="connect",
+                    server_url="https://mcp.example.com/mcp",
+                    tool_context=_tool_context(),
+                )
+
+    @pytest.mark.asyncio
+    async def test_unresolvable_host_is_rejected(self):
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai:
+            gai.side_effect = socket.gaierror("nope")
+            with pytest.raises(ValueError, match="Could not resolve host"):
+                await tool(
+                    op="connect",
+                    server_url="https://mcp.example.com/mcp",
+                    tool_context=_tool_context(),
+                )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "svc.internal",
+            "db.corp",
+            "printer.local",
+            "example.LOCAL",
+            "gateway.home",
+            "onboarding.i2p",
+            "secret.onion",
+            "svc.internal.",  # trailing dot
+        ],
+    )
+    async def test_suffix_denylist_rejects_before_dns(self, host):
+        tool = make_mcp_client(allowed_urls=[f"https://{host}/mcp"])
+        with pytest.raises(ValueError, match="blocked suffix"):
+            await tool(op="connect", server_url=f"https://{host}/mcp", tool_context=_tool_context())
+
+
+class TestSessionScoping:
+    """Sessions are scoped to the agent that opened them."""
+
+    @pytest.mark.asyncio
+    async def test_session_id_from_another_agent_is_rejected(self):
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with (
+            patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai,
+            patch("strands.vended_tools.mcp_client.mcp_client.MCPClient") as client_cls,
+        ):
+            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+            client_cls.return_value = _mcp_instance()
+
+            agent_a = _StubAgent(label="a")
+            agent_b = _StubAgent(label="b")
+
+            connected = await tool(
+                op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context(agent_a)
+            )
+            session_id = connected["session_id"]
+
+            with pytest.raises(ValueError, match="No active session"):
+                await tool(op="list_tools", session_id=session_id, tool_context=_tool_context(agent_b))
+
+    @pytest.mark.asyncio
+    async def test_gc_of_owning_agent_invalidates_sessions(self):
+        """If the owning agent is garbage-collected, its sessions become unreachable.
+
+        The check-that-fresh-agent-cannot-list-sessions branch of this test is not
+        specific to GC — cross-agent rejection would fire whether the tool held an
+        ``id(agent)`` or a ``weakref.ref(agent)``. To exercise the GC-specific path
+        we also keep our own :class:`weakref.ref` to the agent and assert it is
+        dead after :func:`gc.collect`; that assertion fails if GC didn't actually
+        run (e.g. because something held a strong reference), which is what the
+        second-pass reviewer asked us to prove.
+        """
+        import weakref as _weakref
+
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with (
+            patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai,
+            patch("strands.vended_tools.mcp_client.mcp_client.MCPClient") as client_cls,
+        ):
+            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+            client_cls.return_value = _mcp_instance()
+
+            class _Agent:
+                pass
+
+            agent = _Agent()
+            # Independent weakref: dies iff the agent object is GC'd. Distinct from
+            # the tool's internal weakref so it proves GC actually happened.
+            gc_witness = _weakref.ref(agent)
+
+            connected = await tool(
+                op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context(agent)
+            )
+            session_id = connected["session_id"]
+
+            # Sanity: while a strong reference exists, our witness is alive.
+            assert gc_witness() is agent
+
+            # Drop the only strong reference and run GC.
+            del agent
+            gc.collect()
+
+            # This is the GC-specific assertion. If nothing else holds `agent`, this
+            # is None; if it isn't, GC didn't actually clean up and the test fails.
+            assert gc_witness() is None
+
+            # And the enforcement path still returns the shared error string.
+            with pytest.raises(ValueError, match="No active session"):
+                await tool(
+                    op="list_tools",
+                    session_id=session_id,
+                    tool_context=_tool_context(_Agent()),
+                )
+
+    @pytest.mark.asyncio
+    async def test_unknown_session_id_is_rejected(self):
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with pytest.raises(ValueError, match="No active session"):
+            await tool(op="list_tools", session_id="does-not-exist", tool_context=_tool_context())
+
+    @pytest.mark.asyncio
+    async def test_missing_session_id_is_rejected(self):
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with pytest.raises(ValueError, match="required"):
+            await tool(op="list_tools", tool_context=_tool_context())
+
+
+class TestSessionLimit:
+    """The tool refuses to open more than ``session_limit`` sessions concurrently."""
+
+    @pytest.mark.asyncio
+    async def test_session_limit_rejects_further_connects(self):
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"], session_limit=1)
+        # Persistent agents: otherwise the ephemeral `_tool_context()` agents get
+        # garbage-collected between calls and the dead-session purge in connect
+        # frees the slot before the cap check.
+        agent_a = _StubAgent(label="a")
+        agent_b = _StubAgent(label="b")
+        with (
+            patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai,
+            patch("strands.vended_tools.mcp_client.mcp_client.MCPClient") as client_cls,
+        ):
+            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+            client_cls.return_value = _mcp_instance()
+            await tool(op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context(agent_a))
+            with pytest.raises(RuntimeError, match="concurrent sessions"):
+                await tool(
+                    op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context(agent_b)
+                )
+
+    @pytest.mark.asyncio
+    async def test_dead_sessions_are_purged_before_enforcing_cap(self):
+        # If a session's owning agent is garbage-collected, the slot should be
+        # reclaimed automatically at the next connect. Otherwise a stream of
+        # connect-and-forget agents pins the cap at zero forever.
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"], session_limit=1)
+        with (
+            patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai,
+            patch("strands.vended_tools.mcp_client.mcp_client.MCPClient") as client_cls,
+        ):
+            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+            client_cls.return_value = _mcp_instance()
+
+            class _Agent:
+                pass
+
+            ephemeral = _Agent()
+            await tool(
+                op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context(ephemeral)
+            )
+            del ephemeral
+            gc.collect()
+
+            # A second connect from a fresh agent should now succeed: the first
+            # session is unreachable and its slot has been returned to the pool.
+            client_cls.return_value = _mcp_instance()
+            connected = await tool(
+                op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context()
+            )
+            assert "session_id" in connected
+
+
+class TestHappyPath:
+    """A full connect -> list_tools -> call_tool -> disconnect flow."""
+
+    @pytest.mark.asyncio
+    async def test_full_lifecycle(self):
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        fake_tool = _FakeMCPTool(
+            name="echo",
+            description="Echoes input",
+            input_schema={"type": "object", "properties": {"msg": {"type": "string"}}},
+        )
+        client_class, instance = _fake_mcp_client_class(
+            list_tools_return=[_FakeAgentTool(fake_tool)],
+            call_tool_return={
+                "status": "success",
+                "content": [{"text": "hello world"}],
+            },
+        )
+
+        agent = _StubAgent(label="a")
+
+        with (
+            patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai,
+            patch("strands.vended_tools.mcp_client.mcp_client.MCPClient", client_class),
+        ):
+            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+
+            connect_result = await tool(
+                op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context(agent)
+            )
+            assert "session_id" in connect_result
+            assert connect_result["server_url"] == "https://mcp.example.com/mcp"
+            instance.start.assert_called_once()
+
+            list_result = await tool(
+                op="list_tools", session_id=connect_result["session_id"], tool_context=_tool_context(agent)
+            )
+            assert len(list_result["tools"]) == 1
+            assert list_result["tools"][0]["name"] == "echo"
+
+            call_result = await tool(
+                op="call_tool",
+                session_id=connect_result["session_id"],
+                tool_name="echo",
+                arguments={"msg": "hi"},
+                tool_context=_tool_context(agent),
+            )
+            assert call_result["status"] == "success"
+            assert call_result["text"] == "hello world"
+            assert "truncated" not in call_result
+
+            disconnect_result = await tool(
+                op="disconnect", session_id=connect_result["session_id"], tool_context=_tool_context(agent)
+            )
+            assert disconnect_result == {"disconnected": True}
+            instance.stop.assert_called_once()
+
+            with pytest.raises(ValueError, match="No active session"):
+                await tool(op="list_tools", session_id=connect_result["session_id"], tool_context=_tool_context(agent))
+
+    @pytest.mark.asyncio
+    async def test_call_tool_rejects_name_not_advertised_by_server(self):
+        # Both SDKs cache the tool set at connect and reject unadvertised names
+        # locally, so an obvious typo fails with a clear error instead of hitting
+        # the server. Mirror-tested on the TypeScript side.
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        fake_tool = _FakeMCPTool(name="echo", description="", input_schema={"type": "object"})
+        client_class, _ = _fake_mcp_client_class(list_tools_return=[_FakeAgentTool(fake_tool)])
+        agent = _StubAgent()
+        with (
+            patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai,
+            patch("strands.vended_tools.mcp_client.mcp_client.MCPClient", client_class),
+        ):
+            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+            connected = await tool(
+                op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context(agent)
+            )
+            with pytest.raises(ValueError, match="not exposed by the connected server"):
+                await tool(
+                    op="call_tool",
+                    session_id=connected["session_id"],
+                    tool_name="not_a_real_tool",
+                    tool_context=_tool_context(agent),
+                )
+
+
+class TestResultTruncation:
+    """Oversized tool-call results are truncated before being returned to the model."""
+
+    @pytest.mark.asyncio
+    async def test_oversized_text_is_truncated(self):
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        big_text = "x" * 250_000
+        fake_tool = _FakeMCPTool(name="anything", description="", input_schema={"type": "object"})
+        client_class, _ = _fake_mcp_client_class(
+            list_tools_return=[_FakeAgentTool(fake_tool)],
+            call_tool_return={"status": "success", "content": [{"text": big_text}]},
+        )
+        agent = _StubAgent(label="a")
+
+        with (
+            patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai,
+            patch("strands.vended_tools.mcp_client.mcp_client.MCPClient", client_class),
+        ):
+            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+            connect_result = await tool(
+                op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context(agent)
+            )
+            call_result = await tool(
+                op="call_tool",
+                session_id=connect_result["session_id"],
+                tool_name="anything",
+                tool_context=_tool_context(agent),
+            )
+        assert call_result["truncated"] is True
+        assert len(call_result["text"]) < len(big_text)
+
+    @pytest.mark.asyncio
+    async def test_oversized_structured_content_is_capped(self):
+        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        big_structured = {"payload": "y" * 250_000}
+        fake_tool = _FakeMCPTool(name="anything", description="", input_schema={"type": "object"})
+        client_class, _ = _fake_mcp_client_class(
+            list_tools_return=[_FakeAgentTool(fake_tool)],
+            call_tool_return={
+                "status": "success",
+                "content": [{"text": "ok"}],
+                "structuredContent": big_structured,
+            },
+        )
+        agent = _StubAgent(label="a")
+
+        with (
+            patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai,
+            patch("strands.vended_tools.mcp_client.mcp_client.MCPClient", client_class),
+        ):
+            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+            connect_result = await tool(
+                op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context(agent)
+            )
+            call_result = await tool(
+                op="call_tool",
+                session_id=connect_result["session_id"],
+                tool_name="anything",
+                tool_context=_tool_context(agent),
+            )
+        assert call_result["truncated"] is True
+        assert call_result["structured_content"] != big_structured
+        assert call_result["structured_content"].get("__truncated__") is True
+
+
+class TestUrlNormalisation:
+    """The URL canonicalisation used for allowlist matching."""
+
+    def test_canonicalise_strips_trailing_slash(self):
+        assert _canonicalise_url("https://Example.com/mcp/") == "https://example.com/mcp"
+
+    def test_canonicalise_lowercases_scheme_and_host(self):
+        assert _canonicalise_url("HTTPS://EXAMPLE.COM/PATH") == "https://example.com/PATH"
+
+    def test_canonicalise_preserves_non_default_port_and_query(self):
+        assert _canonicalise_url("https://Example.com:8443/mcp?token=abc") == "https://example.com:8443/mcp?token=abc"
+
+    def test_canonicalise_drops_default_https_port(self):
+        # `https://host` and `https://host:443` must canonicalise identically so an
+        # allowlist entry without the port still matches a connect URL that names it.
+        assert _canonicalise_url("https://mcp.example.com:443/mcp") == "https://mcp.example.com/mcp"
+
+    def test_canonicalise_drops_default_http_port(self):
+        assert _canonicalise_url("http://mcp.example.com:80/mcp") == "http://mcp.example.com/mcp"
+
+    def test_normalise_allowlist_deduplicates(self):
+        allowlist = _normalise_allowlist(["https://example.com/mcp", "HTTPS://EXAMPLE.COM/mcp/"])
+        assert allowlist == frozenset({"https://example.com/mcp"})
+
+    def test_normalise_allowlist_treats_default_port_as_equal(self):
+        allowlist = _normalise_allowlist(["https://example.com/mcp", "https://example.com:443/mcp"])
+        assert allowlist == frozenset({"https://example.com/mcp"})
+
+
+class TestNoRedirect:
+    """The httpx client used by MCP refuses to follow redirects."""
+
+    def test_no_redirect_factory_disables_follow_redirects(self):
+        # `_no_redirect_httpx_client_factory` is the MCP-shaped hook that guarantees
+        # an allowlisted URL cannot be 3xx'd to a private endpoint the SSRF guard
+        # never saw. Assert the resulting client is actually configured that way.
+        client = _no_redirect_httpx_client_factory()
+        assert client.follow_redirects is False
+
+
+class TestStructuredContentCap:
+    """Structured content is size-capped and reports the size in the unit it caps in."""
+
+    def test_non_json_serialisable_structured_content_is_replaced(self):
+        # Sets are not JSON-serialisable; the cap must swap the value for a marker
+        # rather than smuggle an opaque blob through to the model.
+        response: dict[str, Any] = {"status": "success", "text": ""}
+        capped = _cap_structured_content({"key": {1, 2, 3}}, response)
+        assert response.get("truncated") is True
+        assert capped == {"__truncated__": True, "reason": "structured_content was not JSON-serialisable"}
+
+    def test_capped_size_is_reported_in_bytes(self):
+        # A payload of multi-byte characters exceeding the byte cap should report
+        # the byte length in `size`, matching the unit the cap is measured in.
+        multibyte = "é" * 90_000  # each character is two UTF-8 bytes → 180_000 bytes
+        response: dict[str, Any] = {"status": "success", "text": ""}
+        capped = _cap_structured_content({"payload": multibyte}, response)
+        assert response.get("truncated") is True
+        assert isinstance(capped, dict)
+        assert capped["__truncated__"] is True
+        # `size` should be a byte count (>= 180_000), not a character count (~90_000).
+        assert capped["size"] > 100_000
+
+
+class TestToolMetadata:
+    """The tool exposes a sensible name, description, and input schema."""
+
+    def test_custom_name(self):
+        t = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"], name="my_mcp")
+        assert t.tool_name == "my_mcp"
+
+    def test_schema_exposes_op_field_and_hides_context(self):
+        t = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        props = t.tool_spec["inputSchema"]["json"]["properties"]
+        assert "op" in props
+        assert "server_url" in props
+        assert "session_id" in props
+        assert "tool_context" not in props
+
+
+class TestConnectInputValidation:
+    """Connect requires ``server_url``; call_tool requires ``tool_name``."""
+
+    @pytest.mark.asyncio
+    async def test_connect_without_url_is_rejected(self):
+        t = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        with pytest.raises(ValueError, match="server_url"):
+            await t(op="connect", tool_context=_tool_context())
+
+    @pytest.mark.asyncio
+    async def test_call_tool_without_name_is_rejected(self):
+        t = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+        agent = _StubAgent()
+        with (
+            patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai,
+            patch("strands.vended_tools.mcp_client.mcp_client.MCPClient") as client_cls,
+        ):
+            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
+            client_cls.return_value = _mcp_instance()
+            connect_result = await t(
+                op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context(agent)
+            )
+            with pytest.raises(ValueError, match="tool_name"):
+                await t(op="call_tool", session_id=connect_result["session_id"], tool_context=_tool_context(agent))

--- a/strands-py/tests/strands/vended_tools/test_mcp_client.py
+++ b/strands-py/tests/strands/vended_tools/test_mcp_client.py
@@ -36,7 +36,7 @@ def _tool_context(agent: Any | None = None) -> ToolContext:
     )
 
 
-def _make_mcp_tool(name: str = "test_tool", description: str = "A test tool", **kwargs) -> MCPTool:
+def _make_mcp_tool(name: str = "test_tool", description: str = "A test tool", **kwargs: Any) -> MCPTool:
     """Build a real MCPTool; delegates to mcp.types.Tool so tool_spec works correctly."""
     return MCPTool(
         name=name,
@@ -46,7 +46,7 @@ def _make_mcp_tool(name: str = "test_tool", description: str = "A test tool", **
     )
 
 
-def _make_agent_tool(name: str = "test_tool", description: str = "A test tool", **kwargs) -> MCPAgentTool:
+def _make_agent_tool(name: str = "test_tool", description: str = "A test tool", **kwargs: Any) -> MCPAgentTool:
     """Wrap a real MCPTool in a real MCPAgentTool backed by a MagicMock client."""
     return MCPAgentTool(mcp_tool=_make_mcp_tool(name=name, description=description, **kwargs), mcp_client=MagicMock())
 
@@ -70,7 +70,7 @@ def _fake_mcp_client_class(
 
 
 def _mcp_instance(tools: list[MCPAgentTool] | None = None) -> MagicMock:
-    """Return a MagicMock that satisfies _build_client_from_config's return contract."""
+    """Return a MagicMock that satisfies load_servers' return contract."""
     instance = MagicMock()
     instance._list_all_tools_sync = MagicMock(return_value=tools or [])
     return instance
@@ -80,68 +80,64 @@ class TestSessionLifecycle:
     """A full connect -> list_tools -> call_tool -> disconnect flow."""
 
     @pytest.mark.asyncio
-    async def test_full_lifecycle(self):
+    async def test_full_lifecycle(self) -> None:
         tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
         client_class, instance = _fake_mcp_client_class(
             list_tools_return=[_make_agent_tool(name="echo", description="Echoes input")],
-            call_tool_return={
-                "status": "success",
-                "content": [{"text": "hello world"}],
-            },
+            call_tool_return={"status": "success", "content": [{"text": "hello world"}]},
         )
-
-        agent = _StubAgent(label="a")
+        agent = _StubAgent()
 
         with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers", client_class):
             connect_result = await tool(
                 command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent)
             )
-            assert "session_id" in connect_result
-            assert connect_result["server"] == "https://mcp.example.com/mcp"
+            assert connect_result == "Successfully connected to https://mcp.example.com/mcp"
             instance.start.assert_called_once()
 
-            list_result = await tool(
-                command="list_tools", session_id=connect_result["session_id"], tool_context=_tool_context(agent)
-            )
+            list_result = await tool(command="list_tools", tool_context=_tool_context(agent))
             assert len(list_result) == 1
             assert list_result[0]["name"] == "echo"
 
             call_result = await tool(
                 command="call_tool",
-                session_id=connect_result["session_id"],
                 tool_name="echo",
                 arguments={"msg": "hi"},
                 tool_context=_tool_context(agent),
             )
             assert call_result["status"] == "success"
             assert call_result["content"][0]["text"] == "hello world"
-            assert "truncated" not in call_result
-            # Verify the correct tool name and arguments were forwarded to the server.
-            instance.call_tool_async.assert_called_once()
             call_kwargs = instance.call_tool_async.call_args.kwargs
             assert call_kwargs["name"] == "echo"
             assert call_kwargs["arguments"] == {"msg": "hi"}
 
-            disconnect_result = await tool(
-                command="disconnect", session_id=connect_result["session_id"], tool_context=_tool_context(agent)
-            )
-            assert disconnect_result == f"Session successfully disconnected: {connect_result['session_id']}"
+            disconnect_result = await tool(command="disconnect", tool_context=_tool_context(agent))
+            assert disconnect_result == "Successfully disconnected"
             instance.stop.assert_called_once()
 
-            with pytest.raises(MCPClientToolError, match="No active session"):
-                await tool(
-                    command="list_tools",
-                    session_id=connect_result["session_id"],
-                    tool_context=_tool_context(agent),
-                )
+            with pytest.raises(MCPClientToolError, match="No active connection"):
+                await tool(command="list_tools", tool_context=_tool_context(agent))
 
+    @pytest.mark.asyncio
+    async def test_connect_stops_existing_client_before_reconnecting(self) -> None:
+        """connect always stops the existing client and starts a fresh one."""
+        tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        client_class, instance = _fake_mcp_client_class()
+        agent = _StubAgent()
+
+        with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers", client_class):
+            await tool(command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent))
+            await tool(command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent))
+
+        # Second connect must stop the first client and start a new one.
+        assert instance.stop.call_count == 1
+        assert instance.start.call_count == 2
 
 class TestConfigForwarding:
     """The matched server config is forwarded correctly to MCPClient."""
 
     @pytest.mark.asyncio
-    async def test_matched_config_reaches_load_servers(self):
-        """Verify that the config corresponding to the connected server is passed to load_servers."""
+    async def test_matched_config_reaches_load_servers(self) -> None:
         server_config = {"url": "https://mcp.example.com/mcp", "headers": {"X-Api-Key": "secret"}}
         tool = make_mcp_client(servers=[server_config])
         agent = _StubAgent()
@@ -155,8 +151,7 @@ class TestConfigForwarding:
         assert passed_config["headers"] == {"X-Api-Key": "secret"}
 
     @pytest.mark.asyncio
-    async def test_stdio_connect_key_round_trips_to_output(self):
-        """A stdio server's key (full invocation) is returned in ConnectOutput.server."""
+    async def test_stdio_connect_key_round_trips_to_output(self) -> None:
         tool = make_mcp_client(servers=[{"command": "npx", "args": ["-y", "my-server"]}])
         agent = _StubAgent()
 
@@ -164,140 +159,60 @@ class TestConfigForwarding:
             mock_load.return_value = [_mcp_instance()]
             result = await tool(command="connect", server="npx -y my-server", tool_context=_tool_context(agent))
 
-        assert result["server"] == "npx -y my-server"
+        assert "npx -y my-server" in result
 
 
 class TestAllowlistEnforcement:
     """Server allowlist rejects anything the developer didn't sign off on."""
 
     @pytest.mark.asyncio
-    async def test_url_not_on_allowlist_is_rejected(self):
+    async def test_url_not_on_allowlist_is_rejected(self) -> None:
         tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
         with pytest.raises(MCPClientToolError, match="not on the allowlist"):
             await tool(command="connect", server="https://evil.example.com/mcp", tool_context=_tool_context())
 
     @pytest.mark.asyncio
-    async def test_allowlist_match_is_scheme_and_host_case_insensitive(self):
+    async def test_allowlist_match_is_scheme_and_host_case_insensitive(self) -> None:
         tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
         with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers") as client_cls:
             instance = _mcp_instance()
             client_cls.return_value = [instance]
             result = await tool(
-                command="connect",
-                server="HTTPS://MCP.EXAMPLE.COM/mcp",
-                tool_context=_tool_context(),
+                command="connect", server="HTTPS://MCP.EXAMPLE.COM/mcp", tool_context=_tool_context()
             )
-        assert "session_id" in result
+        assert "Successfully connected" in result
         instance.start.assert_called_once()
 
-    def test_empty_allowlist_is_rejected_at_construction(self):
+    def test_empty_allowlist_is_rejected_at_construction(self) -> None:
         with pytest.raises(ValueError, match="must not be empty"):
             make_mcp_client(servers=[])
 
-    def test_disallowed_scheme_in_allowlist_is_rejected_at_construction(self):
+    def test_disallowed_scheme_in_allowlist_is_rejected_at_construction(self) -> None:
         with pytest.raises(ValueError, match="unsupported scheme"):
             make_mcp_client(servers=[{"url": "file:///etc/passwd"}])
 
-    def test_missing_host_in_allowlist_is_rejected(self):
+    def test_missing_host_in_allowlist_is_rejected(self) -> None:
         with pytest.raises(ValueError, match="no host"):
             make_mcp_client(servers=[{"url": "https:///"}])
 
-    def test_stdio_config_is_rejected_at_construction(self):
+    def test_stdio_config_is_rejected_at_construction(self) -> None:
         with pytest.raises(ValueError, match="url.*or.*command|command.*or.*url|must have either"):
             make_mcp_client(servers=[{"args": ["server.js"]}])
 
-    def test_stdio_config_is_accepted_at_construction(self):
-        # A stdio config with command+args must be accepted; transport creation happens at connect time.
+    def test_stdio_config_is_accepted_at_construction(self) -> None:
         tool = make_mcp_client(servers=[{"command": "node", "args": ["server.js"]}])
         assert tool.tool_name == "mcp_client"
+        assert "node server.js" in tool.tool_spec["description"]
 
-    def test_config_with_both_url_and_command_is_rejected(self):
+    def test_config_with_both_url_and_command_is_rejected(self) -> None:
         with pytest.raises(ValueError, match="both 'url'.*and 'command'|both.*url.*command"):
             make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp", "command": "node"}])
 
-    def test_disabled_config_is_rejected_at_construction(self):
+    def test_disabled_config_is_rejected_at_construction(self) -> None:
         with pytest.raises(ValueError, match="disabled"):
             make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp", "disabled": True}])
 
-
-class TestConnectInputValidation:
-    """Connect requires ``server``; call_tool requires ``tool_name``."""
-
-    @pytest.mark.asyncio
-    async def test_connect_without_server_is_rejected(self):
-        t = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
-        with pytest.raises(MCPClientToolError, match="server"):
-            await t(command="connect", tool_context=_tool_context())
-
-    @pytest.mark.asyncio
-    async def test_call_tool_without_name_is_rejected(self):
-        t = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
-        agent = _StubAgent()
-        with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers") as client_cls:
-            client_cls.return_value = [_mcp_instance()]
-            connect_result = await t(
-                command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent)
-            )
-            with pytest.raises(MCPClientToolError, match="tool_name"):
-                await t(command="call_tool", session_id=connect_result["session_id"], tool_context=_tool_context(agent))
-
-
-class TestSessionScoping:
-    """Sessions are scoped to the agent that opened them."""
-
-    @pytest.mark.asyncio
-    async def test_session_id_from_another_agent_is_rejected(self):
-        tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
-        with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers") as client_cls:
-            client_cls.return_value = [_mcp_instance()]
-
-            agent_a = _StubAgent(label="a")
-            agent_b = _StubAgent(label="b")
-
-            connected = await tool(
-                command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent_a)
-            )
-            with pytest.raises(MCPClientToolError, match="No active session"):
-                await tool(
-                    command="list_tools", session_id=connected["session_id"], tool_context=_tool_context(agent_b)
-                )
-
-    @pytest.mark.asyncio
-    async def test_unknown_session_id_is_rejected(self):
-        tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
-        with pytest.raises(MCPClientToolError, match="No active session"):
-            await tool(command="list_tools", session_id="does-not-exist", tool_context=_tool_context())
-
-    @pytest.mark.asyncio
-    async def test_missing_session_id_is_rejected(self):
-        tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
-        with pytest.raises(MCPClientToolError, match="required"):
-            await tool(command="list_tools", tool_context=_tool_context())
-
-
-class TestUrlNormalisation:
-    """The URL canonicalisation used for allowlist matching."""
-
-    def test_canonicalise_strips_trailing_slash(self):
-        assert _canonicalise_url("https://Example.com/mcp/") == "https://example.com/mcp"
-
-    def test_canonicalise_lowercases_scheme_and_host(self):
-        assert _canonicalise_url("HTTPS://EXAMPLE.COM/PATH") == "https://example.com/PATH"
-
-    def test_canonicalise_preserves_non_default_port_and_query(self):
-        assert _canonicalise_url("https://Example.com:8443/mcp?token=abc") == "https://example.com:8443/mcp?token=abc"
-
-    def test_canonicalise_drops_default_https_port(self):
-        # `https://host` and `https://host:443` must canonicalise identically so an
-        # allowlist entry without the port still matches a connect URL that names it.
-        assert _canonicalise_url("https://mcp.example.com:443/mcp") == "https://mcp.example.com/mcp"
-
-    def test_canonicalise_drops_default_http_port(self):
-        assert _canonicalise_url("http://mcp.example.com:80/mcp") == "http://mcp.example.com/mcp"
-
-    def test_configs_colliding_on_same_key_are_rejected(self):
-        # Two different configs that canonicalise to the same key should raise,
-        # not silently drop one (which could send wrong credentials).
+    def test_configs_colliding_on_same_key_are_rejected(self) -> None:
         with pytest.raises(ValueError, match="two different configs|duplicate"):
             make_mcp_client(
                 servers=[
@@ -307,12 +222,74 @@ class TestUrlNormalisation:
             )
 
 
+class TestConnectInputValidation:
+    """Connect requires ``server``; call_tool requires ``tool_name``."""
+
+    @pytest.mark.asyncio
+    async def test_connect_without_server_is_rejected(self) -> None:
+        t = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        with pytest.raises(MCPClientToolError, match="server"):
+            await t(command="connect", tool_context=_tool_context())
+
+    @pytest.mark.asyncio
+    async def test_call_tool_without_name_is_rejected(self) -> None:
+        t = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        agent = _StubAgent()
+        with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers") as client_cls:
+            client_cls.return_value = [_mcp_instance()]
+            await t(command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent))
+            with pytest.raises(MCPClientToolError, match="tool_name"):
+                await t(command="call_tool", tool_context=_tool_context(agent))
+
+    @pytest.mark.asyncio
+    async def test_commands_without_active_connection_are_rejected(self) -> None:
+        t = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        for command in ("list_tools", "call_tool", "disconnect"):
+            with pytest.raises(MCPClientToolError, match="No active connection"):
+                await t(command=command, tool_context=_tool_context())
+
+
+class TestAgentIsolation:
+    """Each agent has an independent connection."""
+
+    @pytest.mark.asyncio
+    async def test_connection_from_another_agent_is_not_visible(self) -> None:
+        tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers") as client_cls:
+            client_cls.return_value = [_mcp_instance()]
+            agent_a = _StubAgent(label="a")
+            agent_b = _StubAgent(label="b")
+
+            await tool(command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent_a))
+
+            with pytest.raises(MCPClientToolError, match="No active connection"):
+                await tool(command="list_tools", tool_context=_tool_context(agent_b))
+
+
+class TestUrlNormalisation:
+    """The URL canonicalisation used for allowlist matching."""
+
+    def test_canonicalise_strips_trailing_slash(self) -> None:
+        assert _canonicalise_url("https://Example.com/mcp/") == "https://example.com/mcp"
+
+    def test_canonicalise_lowercases_scheme_and_host(self) -> None:
+        assert _canonicalise_url("HTTPS://EXAMPLE.COM/PATH") == "https://example.com/PATH"
+
+    def test_canonicalise_preserves_non_default_port_and_query(self) -> None:
+        assert _canonicalise_url("https://Example.com:8443/mcp?token=abc") == "https://example.com:8443/mcp?token=abc"
+
+    def test_canonicalise_drops_default_https_port(self) -> None:
+        assert _canonicalise_url("https://mcp.example.com:443/mcp") == "https://mcp.example.com/mcp"
+
+    def test_canonicalise_drops_default_http_port(self) -> None:
+        assert _canonicalise_url("http://mcp.example.com:80/mcp") == "http://mcp.example.com/mcp"
+
+
 class TestCancelSignal:
     """The agent cancel signal is forwarded to call_tool_async."""
 
     @pytest.mark.asyncio
-    async def test_cancel_signal_forwarded_to_call_tool_async(self):
-
+    async def test_cancel_signal_forwarded_to_call_tool_async(self) -> None:
         tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
         captured: dict[str, Any] = {}
 
@@ -320,9 +297,7 @@ class TestCancelSignal:
             captured["cancel_signal"] = kwargs.get("cancel_signal")
             return {"status": "success", "content": []}
 
-        client_class, instance = _fake_mcp_client_class(
-            list_tools_return=[_make_agent_tool(name="slow")],
-        )
+        client_class, instance = _fake_mcp_client_class()
         instance.call_tool_async = _call
 
         cancel = threading.Event()
@@ -331,13 +306,8 @@ class TestCancelSignal:
         ctx.cancel_signal = cancel
 
         with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers", client_class):
-            connected = await tool(command="connect", server="https://mcp.example.com/mcp", tool_context=ctx)
-            await tool(
-                command="call_tool",
-                session_id=connected["session_id"],
-                tool_name="slow",
-                tool_context=ctx,
-            )
+            await tool(command="connect", server="https://mcp.example.com/mcp", tool_context=ctx)
+            await tool(command="call_tool", tool_name="slow", tool_context=ctx)
 
         assert captured["cancel_signal"] is cancel
 
@@ -346,43 +316,36 @@ class TestToolNameResolution:
     """list_tools returns server-side names so call_tool can invoke them directly."""
 
     @pytest.mark.asyncio
-    async def test_prefixed_name_maps_to_server_side_name(self):
-        """list_tools must return the server-side name (mcp_tool.name) regardless of prefix config."""
+    async def test_prefixed_name_maps_to_server_side_name(self) -> None:
         tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
         agent = _StubAgent()
-        # Simulate a client configured with prefix="fs": agent_tool.tool_name="fs_echo", mcp_tool.name="echo"
         agent_tool = MCPAgentTool(
             mcp_tool=_make_mcp_tool(name="echo"),
             mcp_client=MagicMock(),
             name_override="fs_echo",
         )
-        client_class, instance = _fake_mcp_client_class(list_tools_return=[agent_tool])
+        client_class, _ = _fake_mcp_client_class(list_tools_return=[agent_tool])
         with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers", client_class):
-            connected = await tool(
-                command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent)
-            )
-            tools = await tool(
-                command="list_tools", session_id=connected["session_id"], tool_context=_tool_context(agent)
-            )
-        # list_tools must expose the server-side name so the model can pass it directly to call_tool.
+            await tool(command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent))
+            tools = await tool(command="list_tools", tool_context=_tool_context(agent))
         assert tools[0]["name"] == "echo"
 
 
 class TestToolMetadata:
     """The tool exposes a sensible name, description, and input schema."""
 
-    def test_custom_name(self):
+    def test_custom_name(self) -> None:
         t = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}], name="my_mcp")
         assert t.tool_name == "my_mcp"
 
-    def test_default_description_includes_permitted_servers(self):
+    def test_default_description_includes_permitted_servers(self) -> None:
         t = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
         assert "https://mcp.example.com/mcp" in t.tool_spec["description"]
 
-    def test_schema_exposes_command_field_and_hides_context(self):
+    def test_schema_exposes_command_field_and_hides_context(self) -> None:
         t = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
         props = t.tool_spec["inputSchema"]["json"]["properties"]
         assert "command" in props
         assert "server" in props
-        assert "session_id" in props
+        assert "session_id" not in props
         assert "tool_context" not in props

--- a/strands-py/tests/strands/vended_tools/test_mcp_client.py
+++ b/strands-py/tests/strands/vended_tools/test_mcp_client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import threading
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from mcp.types import Tool as MCPTool
@@ -15,12 +15,11 @@ from strands.vended_tools import make_mcp_client
 from strands.vended_tools.mcp_client.mcp_client import (
     MCPClientToolError,
     _canonicalise_url,
-    _validate_servers,
 )
 
 
 class _StubAgent:
-    """A minimal agent stand-in that supports weakref (SimpleNamespace does not)."""
+    """A minimal agent stand-in."""
 
     def __init__(self, label: str | None = None) -> None:
         self.label = label
@@ -62,12 +61,11 @@ def _fake_mcp_client_class(
     instance.start = MagicMock()
     instance.stop = MagicMock()
     instance._list_all_tools_sync = MagicMock(return_value=list_tools_return or [])
-    instance.load_tools = AsyncMock(return_value=list_tools_return or [])
 
     async def _call(*args: Any, **kwargs: Any) -> Any:
         return call_tool_return or {"status": "success", "content": [{"text": "ok"}]}
 
-    instance.call_tool_async = _call
+    instance.call_tool_async = MagicMock(side_effect=_call)
     return MagicMock(return_value=[instance]), instance
 
 
@@ -75,7 +73,6 @@ def _mcp_instance(tools: list[MCPAgentTool] | None = None) -> MagicMock:
     """Return a MagicMock that satisfies _build_client_from_config's return contract."""
     instance = MagicMock()
     instance._list_all_tools_sync = MagicMock(return_value=tools or [])
-    instance.load_tools = AsyncMock(return_value=tools or [])
     return instance
 
 
@@ -119,6 +116,11 @@ class TestSessionLifecycle:
             assert call_result["status"] == "success"
             assert call_result["content"][0]["text"] == "hello world"
             assert "truncated" not in call_result
+            # Verify the correct tool name and arguments were forwarded to the server.
+            instance.call_tool_async.assert_called_once()
+            call_kwargs = instance.call_tool_async.call_args.kwargs
+            assert call_kwargs["name"] == "echo"
+            assert call_kwargs["arguments"] == {"msg": "hi"}
 
             disconnect_result = await tool(
                 command="disconnect", session_id=connect_result["session_id"], tool_context=_tool_context(agent)
@@ -132,6 +134,37 @@ class TestSessionLifecycle:
                     session_id=connect_result["session_id"],
                     tool_context=_tool_context(agent),
                 )
+
+
+class TestConfigForwarding:
+    """The matched server config is forwarded correctly to MCPClient."""
+
+    @pytest.mark.asyncio
+    async def test_matched_config_reaches_load_servers(self):
+        """Verify that the config corresponding to the connected server is passed to load_servers."""
+        server_config = {"url": "https://mcp.example.com/mcp", "headers": {"X-Api-Key": "secret"}}
+        tool = make_mcp_client(servers=[server_config])
+        agent = _StubAgent()
+
+        with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers") as mock_load:
+            mock_load.return_value = [_mcp_instance()]
+            await tool(command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent))
+
+        mock_load.assert_called_once()
+        _, passed_config = mock_load.call_args[0][0].popitem()
+        assert passed_config["headers"] == {"X-Api-Key": "secret"}
+
+    @pytest.mark.asyncio
+    async def test_stdio_connect_key_round_trips_to_output(self):
+        """A stdio server's key (full invocation) is returned in ConnectOutput.server."""
+        tool = make_mcp_client(servers=[{"command": "npx", "args": ["-y", "my-server"]}])
+        agent = _StubAgent()
+
+        with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers") as mock_load:
+            mock_load.return_value = [_mcp_instance()]
+            result = await tool(command="connect", server="npx -y my-server", tool_context=_tool_context(agent))
+
+        assert result["server"] == "npx -y my-server"
 
 
 class TestAllowlistEnforcement:
@@ -213,18 +246,6 @@ class TestSessionScoping:
     """Sessions are scoped to the agent that opened them."""
 
     @pytest.mark.asyncio
-    async def test_unknown_session_id_is_rejected(self):
-        tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
-        with pytest.raises(MCPClientToolError, match="No active session"):
-            await tool(command="list_tools", session_id="does-not-exist", tool_context=_tool_context())
-
-    @pytest.mark.asyncio
-    async def test_missing_session_id_is_rejected(self):
-        tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
-        with pytest.raises(MCPClientToolError, match="required"):
-            await tool(command="list_tools", tool_context=_tool_context())
-
-    @pytest.mark.asyncio
     async def test_session_id_from_another_agent_is_rejected(self):
         tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
         with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers") as client_cls:
@@ -240,6 +261,18 @@ class TestSessionScoping:
                 await tool(
                     command="list_tools", session_id=connected["session_id"], tool_context=_tool_context(agent_b)
                 )
+
+    @pytest.mark.asyncio
+    async def test_unknown_session_id_is_rejected(self):
+        tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        with pytest.raises(MCPClientToolError, match="No active session"):
+            await tool(command="list_tools", session_id="does-not-exist", tool_context=_tool_context())
+
+    @pytest.mark.asyncio
+    async def test_missing_session_id_is_rejected(self):
+        tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        with pytest.raises(MCPClientToolError, match="required"):
+            await tool(command="list_tools", tool_context=_tool_context())
 
 
 class TestUrlNormalisation:
@@ -262,23 +295,16 @@ class TestUrlNormalisation:
     def test_canonicalise_drops_default_http_port(self):
         assert _canonicalise_url("http://mcp.example.com:80/mcp") == "http://mcp.example.com/mcp"
 
-    def test_validate_servers_deduplicates(self):
-        server_map = _validate_servers(
-            [
-                {"url": "https://example.com/mcp"},
-                {"url": "HTTPS://EXAMPLE.COM/mcp/"},
-            ]
-        )
-        assert set(server_map.keys()) == {"https://example.com/mcp"}
-
-    def test_validate_servers_treats_default_port_as_equal(self):
-        server_map = _validate_servers(
-            [
-                {"url": "https://example.com/mcp"},
-                {"url": "https://example.com:443/mcp"},
-            ]
-        )
-        assert set(server_map.keys()) == {"https://example.com/mcp"}
+    def test_configs_colliding_on_same_key_are_rejected(self):
+        # Two different configs that canonicalise to the same key should raise,
+        # not silently drop one (which could send wrong credentials).
+        with pytest.raises(ValueError, match="two different configs|duplicate"):
+            make_mcp_client(
+                servers=[
+                    {"url": "https://mcp.example.com/mcp", "headers": {"Authorization": "Bearer A"}},
+                    {"url": "HTTPS://mcp.example.com:443/mcp/", "headers": {"Authorization": "Bearer B"}},
+                ]
+            )
 
 
 class TestCancelSignal:
@@ -314,6 +340,32 @@ class TestCancelSignal:
             )
 
         assert captured["cancel_signal"] is cancel
+
+
+class TestToolNameResolution:
+    """list_tools returns server-side names so call_tool can invoke them directly."""
+
+    @pytest.mark.asyncio
+    async def test_prefixed_name_maps_to_server_side_name(self):
+        """list_tools must return the server-side name (mcp_tool.name) regardless of prefix config."""
+        tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        agent = _StubAgent()
+        # Simulate a client configured with prefix="fs": agent_tool.tool_name="fs_echo", mcp_tool.name="echo"
+        agent_tool = MCPAgentTool(
+            mcp_tool=_make_mcp_tool(name="echo"),
+            mcp_client=MagicMock(),
+            name_override="fs_echo",
+        )
+        client_class, instance = _fake_mcp_client_class(list_tools_return=[agent_tool])
+        with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers", client_class):
+            connected = await tool(
+                command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent)
+            )
+            tools = await tool(
+                command="list_tools", session_id=connected["session_id"], tool_context=_tool_context(agent)
+            )
+        # list_tools must expose the server-side name so the model can pass it directly to call_tool.
+        assert tools[0]["name"] == "echo"
 
 
 class TestToolMetadata:

--- a/strands-py/tests/strands/vended_tools/test_mcp_client.py
+++ b/strands-py/tests/strands/vended_tools/test_mcp_client.py
@@ -12,10 +12,7 @@ from mcp.types import Tool as MCPTool
 from strands.tools.mcp import MCPAgentTool
 from strands.types.tools import ToolContext
 from strands.vended_tools import make_mcp_client
-from strands.vended_tools.mcp_client.mcp_client import (
-    MCPClientToolError,
-    _canonicalise_url,
-)
+from strands.vended_tools.mcp_client.mcp_client import MCPClientToolError
 
 
 class _StubAgent:
@@ -76,8 +73,95 @@ def _mcp_instance(tools: list[MCPAgentTool] | None = None) -> MagicMock:
     return instance
 
 
+class TestServerValidation:
+    """_validate_servers rejects invalid configs at construction time."""
+
+    def test_empty_allowlist_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="must not be empty"):
+            make_mcp_client(servers=[])
+
+    def test_disabled_config_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="disabled"):
+            make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp", "disabled": True}])
+
+    def test_both_url_and_command_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="both 'url'.*and 'command'|both.*url.*command"):
+            make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp", "command": "node"}])
+
+    def test_neither_url_nor_command_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="url.*or.*command|command.*or.*url|must have either"):
+            make_mcp_client(servers=[{"args": ["server.js"]}])
+
+    def test_different_configs_colliding_on_same_key_are_rejected(self) -> None:
+        with pytest.raises(ValueError, match="two different configs|duplicate"):
+            make_mcp_client(
+                servers=[
+                    {"url": "https://mcp.example.com/mcp", "headers": {"Authorization": "Bearer A"}},
+                    {"url": "https://mcp.example.com/mcp", "headers": {"Authorization": "Bearer B"}},
+                ]
+            )
+
+    def test_identical_configs_are_deduplicated(self) -> None:
+        config = {"url": "https://mcp.example.com/mcp"}
+        tool = make_mcp_client(servers=[config, config])
+        assert tool is not None
+
+    def test_stdio_config_without_command_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="url.*or.*command|command.*or.*url|must have either"):
+            make_mcp_client(servers=[{"args": ["server.js"]}])
+
+    def test_stdio_config_is_accepted(self) -> None:
+        tool = make_mcp_client(servers=[{"command": "node", "args": ["server.js"]}])
+        assert tool.tool_name == "mcp_client"
+        assert "node server.js" in tool.tool_spec["description"]
+
+
+class TestConnect:
+    """connect enforces the allowlist, validates input, and handles errors."""
+
+    @pytest.mark.asyncio
+    async def test_url_not_on_allowlist_is_rejected(self) -> None:
+        tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        with pytest.raises(MCPClientToolError, match="not on the allowlist"):
+            await tool(command="connect", server="https://evil.example.com/mcp", tool_context=_tool_context())
+
+    @pytest.mark.asyncio
+    async def test_missing_server_is_rejected(self) -> None:
+        t = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        with pytest.raises(MCPClientToolError, match="server"):
+            await t(command="connect", tool_context=_tool_context())
+
+    @pytest.mark.asyncio
+    async def test_agent_isolation(self) -> None:
+        """A connection opened by agent A is not visible to agent B."""
+        tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers") as client_cls:
+            client_cls.return_value = [_mcp_instance()]
+            agent_a = _StubAgent(label="a")
+            agent_b = _StubAgent(label="b")
+            await tool(command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent_a))
+            with pytest.raises(MCPClientToolError, match="No active connection"):
+                await tool(command="list_tools", tool_context=_tool_context(agent_b))
+
+    @pytest.mark.asyncio
+    async def test_start_failure_stops_client_and_leaves_no_connection(self) -> None:
+        """If start() raises, the partially-started client is stopped and no connection is registered."""
+        t = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        client_class, instance = _fake_mcp_client_class()
+        instance.start = MagicMock(side_effect=RuntimeError("connection refused"))
+        agent = _StubAgent()
+
+        with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers", client_class):
+            with pytest.raises(RuntimeError, match="connection refused"):
+                await t(command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent))
+
+        instance.stop.assert_called_once()
+        with pytest.raises(MCPClientToolError, match="No active connection"):
+            await t(command="list_tools", tool_context=_tool_context(agent))
+
+
 class TestSessionLifecycle:
-    """A full connect -> list_tools -> call_tool -> disconnect flow."""
+    """Full connect -> list_tools -> call_tool -> disconnect flow and reconnect behaviour."""
 
     @pytest.mark.asyncio
     async def test_full_lifecycle(self) -> None:
@@ -119,7 +203,7 @@ class TestSessionLifecycle:
                 await tool(command="list_tools", tool_context=_tool_context(agent))
 
     @pytest.mark.asyncio
-    async def test_connect_stops_existing_client_before_reconnecting(self) -> None:
+    async def test_reconnect_stops_existing_client(self) -> None:
         """connect always stops the existing client and starts a fresh one."""
         tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
         client_class, instance = _fake_mcp_client_class()
@@ -129,9 +213,81 @@ class TestSessionLifecycle:
             await tool(command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent))
             await tool(command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent))
 
-        # Second connect must stop the first client and start a new one.
         assert instance.stop.call_count == 1
         assert instance.start.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_commands_without_active_connection_are_rejected(self) -> None:
+        t = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        for command in ("list_tools", "call_tool"):
+            with pytest.raises(MCPClientToolError, match="No active connection"):
+                await t(command=command, tool_context=_tool_context())
+
+    @pytest.mark.asyncio
+    async def test_call_tool_without_name_is_rejected(self) -> None:
+        t = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        agent = _StubAgent()
+        with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers") as client_cls:
+            client_cls.return_value = [_mcp_instance()]
+            await t(command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent))
+            with pytest.raises(MCPClientToolError, match="tool_name"):
+                await t(command="call_tool", tool_context=_tool_context(agent))
+
+    @pytest.mark.asyncio
+    async def test_disconnect_when_stop_raises_still_evicts(self) -> None:
+        """RuntimeError from stop() must not prevent session eviction."""
+        t = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        agent = _StubAgent()
+        client_class, instance = _fake_mcp_client_class()
+        instance.stop = MagicMock(side_effect=RuntimeError("already closed"))
+
+        with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers", client_class):
+            await t(command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent))
+            result = await t(command="disconnect", tool_context=_tool_context(agent))
+
+        assert result == "Successfully disconnected"
+        with pytest.raises(MCPClientToolError, match="No active connection"):
+            await t(command="list_tools", tool_context=_tool_context(agent))
+
+    @pytest.mark.asyncio
+    async def test_cancel_signal_forwarded_to_call_tool_async(self) -> None:
+        tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        captured: dict[str, Any] = {}
+
+        async def _call(*args: Any, **kwargs: Any) -> Any:
+            captured["cancel_signal"] = kwargs.get("cancel_signal")
+            return {"status": "success", "content": []}
+
+        client_class, instance = _fake_mcp_client_class()
+        instance.call_tool_async = _call
+
+        cancel = threading.Event()
+        agent = _StubAgent()
+        ctx = _tool_context(agent)
+        ctx.cancel_signal = cancel
+
+        with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers", client_class):
+            await tool(command="connect", server="https://mcp.example.com/mcp", tool_context=ctx)
+            await tool(command="call_tool", tool_name="slow", tool_context=ctx)
+
+        assert captured["cancel_signal"] is cancel
+
+    @pytest.mark.asyncio
+    async def test_list_tools_returns_server_side_names(self) -> None:
+        """list_tools must return mcp_tool.name (server-side) regardless of prefix config."""
+        tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        agent = _StubAgent()
+        agent_tool = MCPAgentTool(
+            mcp_tool=_make_mcp_tool(name="echo"),
+            mcp_client=MagicMock(),
+            name_override="fs_echo",
+        )
+        client_class, _ = _fake_mcp_client_class(list_tools_return=[agent_tool])
+        with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers", client_class):
+            await tool(command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent))
+            tools = await tool(command="list_tools", tool_context=_tool_context(agent))
+        assert tools[0]["name"] == "echo"
+
 
 class TestConfigForwarding:
     """The matched server config is forwarded correctly to MCPClient."""
@@ -160,175 +316,6 @@ class TestConfigForwarding:
             result = await tool(command="connect", server="npx -y my-server", tool_context=_tool_context(agent))
 
         assert "npx -y my-server" in result
-
-
-class TestAllowlistEnforcement:
-    """Server allowlist rejects anything the developer didn't sign off on."""
-
-    @pytest.mark.asyncio
-    async def test_url_not_on_allowlist_is_rejected(self) -> None:
-        tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
-        with pytest.raises(MCPClientToolError, match="not on the allowlist"):
-            await tool(command="connect", server="https://evil.example.com/mcp", tool_context=_tool_context())
-
-    @pytest.mark.asyncio
-    async def test_allowlist_match_is_scheme_and_host_case_insensitive(self) -> None:
-        tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
-        with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers") as client_cls:
-            instance = _mcp_instance()
-            client_cls.return_value = [instance]
-            result = await tool(
-                command="connect", server="HTTPS://MCP.EXAMPLE.COM/mcp", tool_context=_tool_context()
-            )
-        assert "Successfully connected" in result
-        instance.start.assert_called_once()
-
-    def test_empty_allowlist_is_rejected_at_construction(self) -> None:
-        with pytest.raises(ValueError, match="must not be empty"):
-            make_mcp_client(servers=[])
-
-    def test_disallowed_scheme_in_allowlist_is_rejected_at_construction(self) -> None:
-        with pytest.raises(ValueError, match="unsupported scheme"):
-            make_mcp_client(servers=[{"url": "file:///etc/passwd"}])
-
-    def test_missing_host_in_allowlist_is_rejected(self) -> None:
-        with pytest.raises(ValueError, match="no host"):
-            make_mcp_client(servers=[{"url": "https:///"}])
-
-    def test_stdio_config_is_rejected_at_construction(self) -> None:
-        with pytest.raises(ValueError, match="url.*or.*command|command.*or.*url|must have either"):
-            make_mcp_client(servers=[{"args": ["server.js"]}])
-
-    def test_stdio_config_is_accepted_at_construction(self) -> None:
-        tool = make_mcp_client(servers=[{"command": "node", "args": ["server.js"]}])
-        assert tool.tool_name == "mcp_client"
-        assert "node server.js" in tool.tool_spec["description"]
-
-    def test_config_with_both_url_and_command_is_rejected(self) -> None:
-        with pytest.raises(ValueError, match="both 'url'.*and 'command'|both.*url.*command"):
-            make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp", "command": "node"}])
-
-    def test_disabled_config_is_rejected_at_construction(self) -> None:
-        with pytest.raises(ValueError, match="disabled"):
-            make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp", "disabled": True}])
-
-    def test_configs_colliding_on_same_key_are_rejected(self) -> None:
-        with pytest.raises(ValueError, match="two different configs|duplicate"):
-            make_mcp_client(
-                servers=[
-                    {"url": "https://mcp.example.com/mcp", "headers": {"Authorization": "Bearer A"}},
-                    {"url": "HTTPS://mcp.example.com:443/mcp/", "headers": {"Authorization": "Bearer B"}},
-                ]
-            )
-
-
-class TestConnectInputValidation:
-    """Connect requires ``server``; call_tool requires ``tool_name``."""
-
-    @pytest.mark.asyncio
-    async def test_connect_without_server_is_rejected(self) -> None:
-        t = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
-        with pytest.raises(MCPClientToolError, match="server"):
-            await t(command="connect", tool_context=_tool_context())
-
-    @pytest.mark.asyncio
-    async def test_call_tool_without_name_is_rejected(self) -> None:
-        t = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
-        agent = _StubAgent()
-        with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers") as client_cls:
-            client_cls.return_value = [_mcp_instance()]
-            await t(command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent))
-            with pytest.raises(MCPClientToolError, match="tool_name"):
-                await t(command="call_tool", tool_context=_tool_context(agent))
-
-    @pytest.mark.asyncio
-    async def test_commands_without_active_connection_are_rejected(self) -> None:
-        t = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
-        for command in ("list_tools", "call_tool", "disconnect"):
-            with pytest.raises(MCPClientToolError, match="No active connection"):
-                await t(command=command, tool_context=_tool_context())
-
-
-class TestAgentIsolation:
-    """Each agent has an independent connection."""
-
-    @pytest.mark.asyncio
-    async def test_connection_from_another_agent_is_not_visible(self) -> None:
-        tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
-        with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers") as client_cls:
-            client_cls.return_value = [_mcp_instance()]
-            agent_a = _StubAgent(label="a")
-            agent_b = _StubAgent(label="b")
-
-            await tool(command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent_a))
-
-            with pytest.raises(MCPClientToolError, match="No active connection"):
-                await tool(command="list_tools", tool_context=_tool_context(agent_b))
-
-
-class TestUrlNormalisation:
-    """The URL canonicalisation used for allowlist matching."""
-
-    def test_canonicalise_strips_trailing_slash(self) -> None:
-        assert _canonicalise_url("https://Example.com/mcp/") == "https://example.com/mcp"
-
-    def test_canonicalise_lowercases_scheme_and_host(self) -> None:
-        assert _canonicalise_url("HTTPS://EXAMPLE.COM/PATH") == "https://example.com/PATH"
-
-    def test_canonicalise_preserves_non_default_port_and_query(self) -> None:
-        assert _canonicalise_url("https://Example.com:8443/mcp?token=abc") == "https://example.com:8443/mcp?token=abc"
-
-    def test_canonicalise_drops_default_https_port(self) -> None:
-        assert _canonicalise_url("https://mcp.example.com:443/mcp") == "https://mcp.example.com/mcp"
-
-    def test_canonicalise_drops_default_http_port(self) -> None:
-        assert _canonicalise_url("http://mcp.example.com:80/mcp") == "http://mcp.example.com/mcp"
-
-
-class TestCancelSignal:
-    """The agent cancel signal is forwarded to call_tool_async."""
-
-    @pytest.mark.asyncio
-    async def test_cancel_signal_forwarded_to_call_tool_async(self) -> None:
-        tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
-        captured: dict[str, Any] = {}
-
-        async def _call(*args: Any, **kwargs: Any) -> Any:
-            captured["cancel_signal"] = kwargs.get("cancel_signal")
-            return {"status": "success", "content": []}
-
-        client_class, instance = _fake_mcp_client_class()
-        instance.call_tool_async = _call
-
-        cancel = threading.Event()
-        agent = _StubAgent()
-        ctx = _tool_context(agent)
-        ctx.cancel_signal = cancel
-
-        with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers", client_class):
-            await tool(command="connect", server="https://mcp.example.com/mcp", tool_context=ctx)
-            await tool(command="call_tool", tool_name="slow", tool_context=ctx)
-
-        assert captured["cancel_signal"] is cancel
-
-
-class TestToolNameResolution:
-    """list_tools returns server-side names so call_tool can invoke them directly."""
-
-    @pytest.mark.asyncio
-    async def test_prefixed_name_maps_to_server_side_name(self) -> None:
-        tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
-        agent = _StubAgent()
-        agent_tool = MCPAgentTool(
-            mcp_tool=_make_mcp_tool(name="echo"),
-            mcp_client=MagicMock(),
-            name_override="fs_echo",
-        )
-        client_class, _ = _fake_mcp_client_class(list_tools_return=[agent_tool])
-        with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers", client_class):
-            await tool(command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent))
-            tools = await tool(command="list_tools", tool_context=_tool_context(agent))
-        assert tools[0]["name"] == "echo"
 
 
 class TestToolMetadata:

--- a/strands-py/tests/strands/vended_tools/test_mcp_client.py
+++ b/strands-py/tests/strands/vended_tools/test_mcp_client.py
@@ -1,27 +1,21 @@
-"""Tests for the vended MCP client tool.
-
-The tool is a thin shim over ``strands.tools.mcp.MCPClient``. These tests exercise the
-security surface — allowlist enforcement, SSRF guard, session scoping, session cap — with
-the real code paths, and cover the connect->list->call->disconnect happy path by patching
-``MCPClient`` so no real MCP server is needed.
-"""
+"""Tests for the vended MCP client tool."""
 
 from __future__ import annotations
 
-import gc
-import socket
+import threading
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from mcp.types import Tool as MCPTool
 
+from strands.tools.mcp import MCPAgentTool
 from strands.types.tools import ToolContext
 from strands.vended_tools import make_mcp_client
 from strands.vended_tools.mcp_client.mcp_client import (
+    MCPClientToolError,
     _canonicalise_url,
-    _cap_structured_content,
-    _no_redirect_httpx_client_factory,
-    _normalise_allowlist,
+    _validate_servers,
 )
 
 
@@ -33,7 +27,7 @@ class _StubAgent:
 
 
 def _tool_context(agent: Any | None = None) -> ToolContext:
-    """Build a ToolContext with a distinct sentinel agent object for identity checks."""
+    """Build a ToolContext with a distinct agent object."""
     if agent is None:
         agent = _StubAgent()
     return ToolContext(
@@ -43,429 +37,56 @@ def _tool_context(agent: Any | None = None) -> ToolContext:
     )
 
 
-class _FakeMCPTool:
-    def __init__(self, name: str, description: str, input_schema: dict[str, Any]) -> None:
-        self.name = name
-        self.description = description
-        self.inputSchema = input_schema
-        self.outputSchema: dict[str, Any] | None = None
+def _make_mcp_tool(name: str = "test_tool", description: str = "A test tool", **kwargs) -> MCPTool:
+    """Build a real MCPTool; delegates to mcp.types.Tool so tool_spec works correctly."""
+    return MCPTool(
+        name=name,
+        description=description,
+        inputSchema=kwargs.pop("inputSchema", {"type": "object", "properties": {}}),
+        **kwargs,
+    )
 
 
-class _FakeAgentTool:
-    def __init__(self, tool: _FakeMCPTool) -> None:
-        self.mcp_tool = tool
-
-
-class _FakePaginatedList(list):
-    def __init__(self, items: list[Any], token: str | None = None) -> None:
-        super().__init__(items)
-        self.pagination_token = token
+def _make_agent_tool(name: str = "test_tool", description: str = "A test tool", **kwargs) -> MCPAgentTool:
+    """Wrap a real MCPTool in a real MCPAgentTool backed by a MagicMock client."""
+    return MCPAgentTool(mcp_tool=_make_mcp_tool(name=name, description=description, **kwargs), mcp_client=MagicMock())
 
 
 def _fake_mcp_client_class(
     *,
-    list_tools_return: list[_FakeAgentTool] | None = None,
+    list_tools_return: list[MCPAgentTool] | None = None,
     call_tool_return: dict[str, Any] | None = None,
 ) -> Any:
     """Return a MagicMock-based MCPClient replacement whose start/stop record calls."""
     instance = MagicMock()
     instance.start = MagicMock()
     instance.stop = MagicMock()
-    instance.list_tools_sync = MagicMock(return_value=_FakePaginatedList(list_tools_return or [], token=None))
+    instance._list_all_tools_sync = MagicMock(return_value=list_tools_return or [])
+    instance.load_tools = AsyncMock(return_value=list_tools_return or [])
 
     async def _call(*args: Any, **kwargs: Any) -> Any:
         return call_tool_return or {"status": "success", "content": [{"text": "ok"}]}
 
     instance.call_tool_async = _call
-    return MagicMock(return_value=instance), instance
+    return MagicMock(return_value=[instance]), instance
 
 
-def _mcp_instance(tools: list[_FakeAgentTool] | None = None) -> MagicMock:
-    """Return a MagicMock configured to look enough like an ``MCPClient`` that connect works.
-
-    ``_list_tools_via_client`` reads ``pagination_token`` off the returned page and
-    iterates it, so a bare ``MagicMock`` (whose ``pagination_token`` is another
-    ``MagicMock`` rather than ``None``) would loop forever.
-    """
+def _mcp_instance(tools: list[MCPAgentTool] | None = None) -> MagicMock:
+    """Return a MagicMock that satisfies _build_client_from_config's return contract."""
     instance = MagicMock()
-    instance.list_tools_sync = MagicMock(return_value=_FakePaginatedList(tools or [], token=None))
+    instance._list_all_tools_sync = MagicMock(return_value=tools or [])
+    instance.load_tools = AsyncMock(return_value=tools or [])
     return instance
 
 
-class TestAllowlistEnforcement:
-    """URL allowlist rejects anything the developer didn't sign off on."""
-
-    @pytest.mark.asyncio
-    async def test_url_not_on_allowlist_is_rejected(self):
-        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
-        with pytest.raises(ValueError, match="not on the developer-set allowlist"):
-            await tool(op="connect", server_url="https://evil.example.com/mcp", tool_context=_tool_context())
-
-    @pytest.mark.asyncio
-    async def test_allowlist_match_is_scheme_and_host_case_insensitive(self):
-        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
-        with (
-            patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai,
-            patch("strands.vended_tools.mcp_client.mcp_client.MCPClient") as client_cls,
-        ):
-            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
-            instance = _mcp_instance()
-            client_cls.return_value = instance
-            result = await tool(
-                op="connect",
-                server_url="HTTPS://MCP.EXAMPLE.COM/mcp",
-                tool_context=_tool_context(),
-            )
-        assert "session_id" in result
-        instance.start.assert_called_once()
-
-    def test_empty_allowlist_is_rejected_at_construction(self):
-        with pytest.raises(ValueError, match="must not be empty"):
-            make_mcp_client(allowed_urls=[])
-
-    def test_disallowed_scheme_in_allowlist_is_rejected_at_construction(self):
-        with pytest.raises(ValueError, match="unsupported scheme"):
-            make_mcp_client(allowed_urls=["file:///etc/passwd"])
-
-    def test_missing_host_in_allowlist_is_rejected(self):
-        with pytest.raises(ValueError, match="no host"):
-            make_mcp_client(allowed_urls=["https:///"])
-
-    def test_allowlist_entry_with_userinfo_is_rejected(self):
-        # A canonicaliser that dropped userinfo would let `https://user:pass@host/x`
-        # collide with `https://host/x` on the allowlist. Reject at construction.
-        with pytest.raises(ValueError, match="credentials"):
-            make_mcp_client(allowed_urls=["https://user:pass@mcp.example.com/mcp"])
-
-    def test_allowlist_entry_with_fragment_is_rejected(self):
-        with pytest.raises(ValueError, match="fragment"):
-            make_mcp_client(allowed_urls=["https://mcp.example.com/mcp#anchor"])
-
-    @pytest.mark.asyncio
-    async def test_connect_url_with_userinfo_is_rejected(self):
-        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
-        with pytest.raises(ValueError, match="credentials"):
-            await tool(
-                op="connect",
-                server_url="https://user:pass@mcp.example.com/mcp",
-                tool_context=_tool_context(),
-            )
-
-    @pytest.mark.asyncio
-    async def test_connect_url_with_fragment_is_rejected(self):
-        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
-        with pytest.raises(ValueError, match="fragment"):
-            await tool(
-                op="connect",
-                server_url="https://mcp.example.com/mcp#x",
-                tool_context=_tool_context(),
-            )
-
-    @pytest.mark.parametrize("bad", [0, -1, 1.5, True, False, "8"])
-    def test_session_limit_must_be_positive_integer(self, bad):
-        with pytest.raises(ValueError, match="positive integer"):
-            make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"], session_limit=bad)  # type: ignore[arg-type]
-
-
-class TestSSRFGuard:
-    """The SSRF guard rejects hostnames that resolve to non-public addresses."""
-
-    @pytest.mark.asyncio
-    async def test_hostname_resolving_to_private_ip_is_rejected(self):
-        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
-        with patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai:
-            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("10.0.0.5", 0))]
-            with pytest.raises(ValueError, match="non-public address"):
-                await tool(
-                    op="connect",
-                    server_url="https://mcp.example.com/mcp",
-                    tool_context=_tool_context(),
-                )
-
-    @pytest.mark.asyncio
-    async def test_hostname_resolving_to_loopback_is_rejected(self):
-        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
-        with patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai:
-            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", 0))]
-            with pytest.raises(ValueError, match="non-public address"):
-                await tool(
-                    op="connect",
-                    server_url="https://mcp.example.com/mcp",
-                    tool_context=_tool_context(),
-                )
-
-    @pytest.mark.asyncio
-    async def test_literal_private_ip_in_url_is_rejected(self):
-        tool = make_mcp_client(allowed_urls=["http://192.168.1.1/mcp"])
-        with pytest.raises(ValueError, match="non-public address"):
-            await tool(op="connect", server_url="http://192.168.1.1/mcp", tool_context=_tool_context())
-
-    @pytest.mark.asyncio
-    async def test_link_local_metadata_ip_is_rejected(self):
-        tool = make_mcp_client(allowed_urls=["http://169.254.169.254/mcp"])
-        with pytest.raises(ValueError, match="metadata address|non-public address"):
-            await tool(op="connect", server_url="http://169.254.169.254/mcp", tool_context=_tool_context())
-
-    @pytest.mark.asyncio
-    async def test_cgnat_ip_is_rejected(self):
-        tool = make_mcp_client(allowed_urls=["http://100.64.0.1/mcp"])
-        with pytest.raises(ValueError, match="non-public address"):
-            await tool(op="connect", server_url="http://100.64.0.1/mcp", tool_context=_tool_context())
-
-    @pytest.mark.asyncio
-    async def test_ipv4_mapped_cgnat_is_rejected(self):
-        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
-        with patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai:
-            gai.return_value = [(socket.AF_INET6, socket.SOCK_STREAM, 0, "", ("::ffff:100.64.0.1", 0, 0, 0))]
-            with pytest.raises(ValueError, match="non-public address"):
-                await tool(
-                    op="connect",
-                    server_url="https://mcp.example.com/mcp",
-                    tool_context=_tool_context(),
-                )
-
-    @pytest.mark.asyncio
-    async def test_ipv4_mapped_private_is_rejected(self):
-        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
-        with patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai:
-            gai.return_value = [(socket.AF_INET6, socket.SOCK_STREAM, 0, "", ("::ffff:10.0.0.5", 0, 0, 0))]
-            with pytest.raises(ValueError, match="non-public address"):
-                await tool(
-                    op="connect",
-                    server_url="https://mcp.example.com/mcp",
-                    tool_context=_tool_context(),
-                )
-
-    @pytest.mark.asyncio
-    async def test_ipv4_multicast_is_rejected(self):
-        """`is_global` returns True for multicast on CPython — the guard must layer explicit checks."""
-        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
-        with patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai:
-            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("239.255.0.1", 0))]
-            with pytest.raises(ValueError, match="non-public address"):
-                await tool(
-                    op="connect",
-                    server_url="https://mcp.example.com/mcp",
-                    tool_context=_tool_context(),
-                )
-
-    @pytest.mark.asyncio
-    async def test_ipv6_multicast_is_rejected(self):
-        """`is_global` also returns True for IPv6 multicast (`ff00::/8`) on CPython."""
-        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
-        with patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai:
-            gai.return_value = [(socket.AF_INET6, socket.SOCK_STREAM, 0, "", ("ff02::1", 0, 0, 0))]
-            with pytest.raises(ValueError, match="non-public address"):
-                await tool(
-                    op="connect",
-                    server_url="https://mcp.example.com/mcp",
-                    tool_context=_tool_context(),
-                )
-
-    @pytest.mark.asyncio
-    async def test_ipv6_site_local_is_rejected(self):
-        """`fec0::/10` slips through `is_global` on some Python versions — explicit block."""
-        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
-        with patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai:
-            gai.return_value = [(socket.AF_INET6, socket.SOCK_STREAM, 0, "", ("fec0::1", 0, 0, 0))]
-            with pytest.raises(ValueError, match="non-public address"):
-                await tool(
-                    op="connect",
-                    server_url="https://mcp.example.com/mcp",
-                    tool_context=_tool_context(),
-                )
-
-    @pytest.mark.asyncio
-    async def test_unresolvable_host_is_rejected(self):
-        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
-        with patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai:
-            gai.side_effect = socket.gaierror("nope")
-            with pytest.raises(ValueError, match="Could not resolve host"):
-                await tool(
-                    op="connect",
-                    server_url="https://mcp.example.com/mcp",
-                    tool_context=_tool_context(),
-                )
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        "host",
-        [
-            "svc.internal",
-            "db.corp",
-            "printer.local",
-            "example.LOCAL",
-            "gateway.home",
-            "onboarding.i2p",
-            "secret.onion",
-            "svc.internal.",  # trailing dot
-        ],
-    )
-    async def test_suffix_denylist_rejects_before_dns(self, host):
-        tool = make_mcp_client(allowed_urls=[f"https://{host}/mcp"])
-        with pytest.raises(ValueError, match="blocked suffix"):
-            await tool(op="connect", server_url=f"https://{host}/mcp", tool_context=_tool_context())
-
-
-class TestSessionScoping:
-    """Sessions are scoped to the agent that opened them."""
-
-    @pytest.mark.asyncio
-    async def test_session_id_from_another_agent_is_rejected(self):
-        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
-        with (
-            patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai,
-            patch("strands.vended_tools.mcp_client.mcp_client.MCPClient") as client_cls,
-        ):
-            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
-            client_cls.return_value = _mcp_instance()
-
-            agent_a = _StubAgent(label="a")
-            agent_b = _StubAgent(label="b")
-
-            connected = await tool(
-                op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context(agent_a)
-            )
-            session_id = connected["session_id"]
-
-            with pytest.raises(ValueError, match="No active session"):
-                await tool(op="list_tools", session_id=session_id, tool_context=_tool_context(agent_b))
-
-    @pytest.mark.asyncio
-    async def test_gc_of_owning_agent_invalidates_sessions(self):
-        """If the owning agent is garbage-collected, its sessions become unreachable.
-
-        The check-that-fresh-agent-cannot-list-sessions branch of this test is not
-        specific to GC — cross-agent rejection would fire whether the tool held an
-        ``id(agent)`` or a ``weakref.ref(agent)``. To exercise the GC-specific path
-        we also keep our own :class:`weakref.ref` to the agent and assert it is
-        dead after :func:`gc.collect`; that assertion fails if GC didn't actually
-        run (e.g. because something held a strong reference), which is what the
-        second-pass reviewer asked us to prove.
-        """
-        import weakref as _weakref
-
-        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
-        with (
-            patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai,
-            patch("strands.vended_tools.mcp_client.mcp_client.MCPClient") as client_cls,
-        ):
-            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
-            client_cls.return_value = _mcp_instance()
-
-            class _Agent:
-                pass
-
-            agent = _Agent()
-            # Independent weakref: dies iff the agent object is GC'd. Distinct from
-            # the tool's internal weakref so it proves GC actually happened.
-            gc_witness = _weakref.ref(agent)
-
-            connected = await tool(
-                op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context(agent)
-            )
-            session_id = connected["session_id"]
-
-            # Sanity: while a strong reference exists, our witness is alive.
-            assert gc_witness() is agent
-
-            # Drop the only strong reference and run GC.
-            del agent
-            gc.collect()
-
-            # This is the GC-specific assertion. If nothing else holds `agent`, this
-            # is None; if it isn't, GC didn't actually clean up and the test fails.
-            assert gc_witness() is None
-
-            # And the enforcement path still returns the shared error string.
-            with pytest.raises(ValueError, match="No active session"):
-                await tool(
-                    op="list_tools",
-                    session_id=session_id,
-                    tool_context=_tool_context(_Agent()),
-                )
-
-    @pytest.mark.asyncio
-    async def test_unknown_session_id_is_rejected(self):
-        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
-        with pytest.raises(ValueError, match="No active session"):
-            await tool(op="list_tools", session_id="does-not-exist", tool_context=_tool_context())
-
-    @pytest.mark.asyncio
-    async def test_missing_session_id_is_rejected(self):
-        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
-        with pytest.raises(ValueError, match="required"):
-            await tool(op="list_tools", tool_context=_tool_context())
-
-
-class TestSessionLimit:
-    """The tool refuses to open more than ``session_limit`` sessions concurrently."""
-
-    @pytest.mark.asyncio
-    async def test_session_limit_rejects_further_connects(self):
-        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"], session_limit=1)
-        # Persistent agents: otherwise the ephemeral `_tool_context()` agents get
-        # garbage-collected between calls and the dead-session purge in connect
-        # frees the slot before the cap check.
-        agent_a = _StubAgent(label="a")
-        agent_b = _StubAgent(label="b")
-        with (
-            patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai,
-            patch("strands.vended_tools.mcp_client.mcp_client.MCPClient") as client_cls,
-        ):
-            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
-            client_cls.return_value = _mcp_instance()
-            await tool(op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context(agent_a))
-            with pytest.raises(RuntimeError, match="concurrent sessions"):
-                await tool(
-                    op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context(agent_b)
-                )
-
-    @pytest.mark.asyncio
-    async def test_dead_sessions_are_purged_before_enforcing_cap(self):
-        # If a session's owning agent is garbage-collected, the slot should be
-        # reclaimed automatically at the next connect. Otherwise a stream of
-        # connect-and-forget agents pins the cap at zero forever.
-        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"], session_limit=1)
-        with (
-            patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai,
-            patch("strands.vended_tools.mcp_client.mcp_client.MCPClient") as client_cls,
-        ):
-            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
-            client_cls.return_value = _mcp_instance()
-
-            class _Agent:
-                pass
-
-            ephemeral = _Agent()
-            await tool(
-                op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context(ephemeral)
-            )
-            del ephemeral
-            gc.collect()
-
-            # A second connect from a fresh agent should now succeed: the first
-            # session is unreachable and its slot has been returned to the pool.
-            client_cls.return_value = _mcp_instance()
-            connected = await tool(
-                op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context()
-            )
-            assert "session_id" in connected
-
-
-class TestHappyPath:
+class TestSessionLifecycle:
     """A full connect -> list_tools -> call_tool -> disconnect flow."""
 
     @pytest.mark.asyncio
     async def test_full_lifecycle(self):
-        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
-        fake_tool = _FakeMCPTool(
-            name="echo",
-            description="Echoes input",
-            input_schema={"type": "object", "properties": {"msg": {"type": "string"}}},
-        )
+        tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
         client_class, instance = _fake_mcp_client_class(
-            list_tools_return=[_FakeAgentTool(fake_tool)],
+            list_tools_return=[_make_agent_tool(name="echo", description="Echoes input")],
             call_tool_return={
                 "status": "success",
                 "content": [{"text": "hello world"}],
@@ -474,134 +95,151 @@ class TestHappyPath:
 
         agent = _StubAgent(label="a")
 
-        with (
-            patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai,
-            patch("strands.vended_tools.mcp_client.mcp_client.MCPClient", client_class),
-        ):
-            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
-
+        with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers", client_class):
             connect_result = await tool(
-                op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context(agent)
+                command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent)
             )
             assert "session_id" in connect_result
-            assert connect_result["server_url"] == "https://mcp.example.com/mcp"
+            assert connect_result["server"] == "https://mcp.example.com/mcp"
             instance.start.assert_called_once()
 
             list_result = await tool(
-                op="list_tools", session_id=connect_result["session_id"], tool_context=_tool_context(agent)
+                command="list_tools", session_id=connect_result["session_id"], tool_context=_tool_context(agent)
             )
-            assert len(list_result["tools"]) == 1
-            assert list_result["tools"][0]["name"] == "echo"
+            assert len(list_result) == 1
+            assert list_result[0]["name"] == "echo"
 
             call_result = await tool(
-                op="call_tool",
+                command="call_tool",
                 session_id=connect_result["session_id"],
                 tool_name="echo",
                 arguments={"msg": "hi"},
                 tool_context=_tool_context(agent),
             )
             assert call_result["status"] == "success"
-            assert call_result["text"] == "hello world"
+            assert call_result["content"][0]["text"] == "hello world"
             assert "truncated" not in call_result
 
             disconnect_result = await tool(
-                op="disconnect", session_id=connect_result["session_id"], tool_context=_tool_context(agent)
+                command="disconnect", session_id=connect_result["session_id"], tool_context=_tool_context(agent)
             )
-            assert disconnect_result == {"disconnected": True}
+            assert disconnect_result == f"Session successfully disconnected: {connect_result['session_id']}"
             instance.stop.assert_called_once()
 
-            with pytest.raises(ValueError, match="No active session"):
-                await tool(op="list_tools", session_id=connect_result["session_id"], tool_context=_tool_context(agent))
-
-    @pytest.mark.asyncio
-    async def test_call_tool_rejects_name_not_advertised_by_server(self):
-        # Both SDKs cache the tool set at connect and reject unadvertised names
-        # locally, so an obvious typo fails with a clear error instead of hitting
-        # the server. Mirror-tested on the TypeScript side.
-        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
-        fake_tool = _FakeMCPTool(name="echo", description="", input_schema={"type": "object"})
-        client_class, _ = _fake_mcp_client_class(list_tools_return=[_FakeAgentTool(fake_tool)])
-        agent = _StubAgent()
-        with (
-            patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai,
-            patch("strands.vended_tools.mcp_client.mcp_client.MCPClient", client_class),
-        ):
-            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
-            connected = await tool(
-                op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context(agent)
-            )
-            with pytest.raises(ValueError, match="not exposed by the connected server"):
+            with pytest.raises(MCPClientToolError, match="No active session"):
                 await tool(
-                    op="call_tool",
-                    session_id=connected["session_id"],
-                    tool_name="not_a_real_tool",
+                    command="list_tools",
+                    session_id=connect_result["session_id"],
                     tool_context=_tool_context(agent),
                 )
 
 
-class TestResultTruncation:
-    """Oversized tool-call results are truncated before being returned to the model."""
+class TestAllowlistEnforcement:
+    """Server allowlist rejects anything the developer didn't sign off on."""
 
     @pytest.mark.asyncio
-    async def test_oversized_text_is_truncated(self):
-        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
-        big_text = "x" * 250_000
-        fake_tool = _FakeMCPTool(name="anything", description="", input_schema={"type": "object"})
-        client_class, _ = _fake_mcp_client_class(
-            list_tools_return=[_FakeAgentTool(fake_tool)],
-            call_tool_return={"status": "success", "content": [{"text": big_text}]},
-        )
-        agent = _StubAgent(label="a")
-
-        with (
-            patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai,
-            patch("strands.vended_tools.mcp_client.mcp_client.MCPClient", client_class),
-        ):
-            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
-            connect_result = await tool(
-                op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context(agent)
-            )
-            call_result = await tool(
-                op="call_tool",
-                session_id=connect_result["session_id"],
-                tool_name="anything",
-                tool_context=_tool_context(agent),
-            )
-        assert call_result["truncated"] is True
-        assert len(call_result["text"]) < len(big_text)
+    async def test_url_not_on_allowlist_is_rejected(self):
+        tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        with pytest.raises(MCPClientToolError, match="not on the allowlist"):
+            await tool(command="connect", server="https://evil.example.com/mcp", tool_context=_tool_context())
 
     @pytest.mark.asyncio
-    async def test_oversized_structured_content_is_capped(self):
-        tool = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
-        big_structured = {"payload": "y" * 250_000}
-        fake_tool = _FakeMCPTool(name="anything", description="", input_schema={"type": "object"})
-        client_class, _ = _fake_mcp_client_class(
-            list_tools_return=[_FakeAgentTool(fake_tool)],
-            call_tool_return={
-                "status": "success",
-                "content": [{"text": "ok"}],
-                "structuredContent": big_structured,
-            },
-        )
-        agent = _StubAgent(label="a")
+    async def test_allowlist_match_is_scheme_and_host_case_insensitive(self):
+        tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers") as client_cls:
+            instance = _mcp_instance()
+            client_cls.return_value = [instance]
+            result = await tool(
+                command="connect",
+                server="HTTPS://MCP.EXAMPLE.COM/mcp",
+                tool_context=_tool_context(),
+            )
+        assert "session_id" in result
+        instance.start.assert_called_once()
 
-        with (
-            patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai,
-            patch("strands.vended_tools.mcp_client.mcp_client.MCPClient", client_class),
-        ):
-            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
-            connect_result = await tool(
-                op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context(agent)
+    def test_empty_allowlist_is_rejected_at_construction(self):
+        with pytest.raises(ValueError, match="must not be empty"):
+            make_mcp_client(servers=[])
+
+    def test_disallowed_scheme_in_allowlist_is_rejected_at_construction(self):
+        with pytest.raises(ValueError, match="unsupported scheme"):
+            make_mcp_client(servers=[{"url": "file:///etc/passwd"}])
+
+    def test_missing_host_in_allowlist_is_rejected(self):
+        with pytest.raises(ValueError, match="no host"):
+            make_mcp_client(servers=[{"url": "https:///"}])
+
+    def test_stdio_config_is_rejected_at_construction(self):
+        with pytest.raises(ValueError, match="url.*or.*command|command.*or.*url|must have either"):
+            make_mcp_client(servers=[{"args": ["server.js"]}])
+
+    def test_stdio_config_is_accepted_at_construction(self):
+        # A stdio config with command+args must be accepted; transport creation happens at connect time.
+        tool = make_mcp_client(servers=[{"command": "node", "args": ["server.js"]}])
+        assert tool.tool_name == "mcp_client"
+
+    def test_config_with_both_url_and_command_is_rejected(self):
+        with pytest.raises(ValueError, match="both 'url'.*and 'command'|both.*url.*command"):
+            make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp", "command": "node"}])
+
+    def test_disabled_config_is_rejected_at_construction(self):
+        with pytest.raises(ValueError, match="disabled"):
+            make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp", "disabled": True}])
+
+
+class TestConnectInputValidation:
+    """Connect requires ``server``; call_tool requires ``tool_name``."""
+
+    @pytest.mark.asyncio
+    async def test_connect_without_server_is_rejected(self):
+        t = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        with pytest.raises(MCPClientToolError, match="server"):
+            await t(command="connect", tool_context=_tool_context())
+
+    @pytest.mark.asyncio
+    async def test_call_tool_without_name_is_rejected(self):
+        t = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        agent = _StubAgent()
+        with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers") as client_cls:
+            client_cls.return_value = [_mcp_instance()]
+            connect_result = await t(
+                command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent)
             )
-            call_result = await tool(
-                op="call_tool",
-                session_id=connect_result["session_id"],
-                tool_name="anything",
-                tool_context=_tool_context(agent),
+            with pytest.raises(MCPClientToolError, match="tool_name"):
+                await t(command="call_tool", session_id=connect_result["session_id"], tool_context=_tool_context(agent))
+
+
+class TestSessionScoping:
+    """Sessions are scoped to the agent that opened them."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_session_id_is_rejected(self):
+        tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        with pytest.raises(MCPClientToolError, match="No active session"):
+            await tool(command="list_tools", session_id="does-not-exist", tool_context=_tool_context())
+
+    @pytest.mark.asyncio
+    async def test_missing_session_id_is_rejected(self):
+        tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        with pytest.raises(MCPClientToolError, match="required"):
+            await tool(command="list_tools", tool_context=_tool_context())
+
+    @pytest.mark.asyncio
+    async def test_session_id_from_another_agent_is_rejected(self):
+        tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers") as client_cls:
+            client_cls.return_value = [_mcp_instance()]
+
+            agent_a = _StubAgent(label="a")
+            agent_b = _StubAgent(label="b")
+
+            connected = await tool(
+                command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent_a)
             )
-        assert call_result["truncated"] is True
-        assert call_result["structured_content"] != big_structured
-        assert call_result["structured_content"].get("__truncated__") is True
+            with pytest.raises(MCPClientToolError, match="No active session"):
+                await tool(
+                    command="list_tools", session_id=connected["session_id"], tool_context=_tool_context(agent_b)
+                )
 
 
 class TestUrlNormalisation:
@@ -624,87 +262,75 @@ class TestUrlNormalisation:
     def test_canonicalise_drops_default_http_port(self):
         assert _canonicalise_url("http://mcp.example.com:80/mcp") == "http://mcp.example.com/mcp"
 
-    def test_normalise_allowlist_deduplicates(self):
-        allowlist = _normalise_allowlist(["https://example.com/mcp", "HTTPS://EXAMPLE.COM/mcp/"])
-        assert allowlist == frozenset({"https://example.com/mcp"})
+    def test_validate_servers_deduplicates(self):
+        server_map = _validate_servers(
+            [
+                {"url": "https://example.com/mcp"},
+                {"url": "HTTPS://EXAMPLE.COM/mcp/"},
+            ]
+        )
+        assert set(server_map.keys()) == {"https://example.com/mcp"}
 
-    def test_normalise_allowlist_treats_default_port_as_equal(self):
-        allowlist = _normalise_allowlist(["https://example.com/mcp", "https://example.com:443/mcp"])
-        assert allowlist == frozenset({"https://example.com/mcp"})
+    def test_validate_servers_treats_default_port_as_equal(self):
+        server_map = _validate_servers(
+            [
+                {"url": "https://example.com/mcp"},
+                {"url": "https://example.com:443/mcp"},
+            ]
+        )
+        assert set(server_map.keys()) == {"https://example.com/mcp"}
 
 
-class TestNoRedirect:
-    """The httpx client used by MCP refuses to follow redirects."""
+class TestCancelSignal:
+    """The agent cancel signal is forwarded to call_tool_async."""
 
-    def test_no_redirect_factory_disables_follow_redirects(self):
-        # `_no_redirect_httpx_client_factory` is the MCP-shaped hook that guarantees
-        # an allowlisted URL cannot be 3xx'd to a private endpoint the SSRF guard
-        # never saw. Assert the resulting client is actually configured that way.
-        client = _no_redirect_httpx_client_factory()
-        assert client.follow_redirects is False
+    @pytest.mark.asyncio
+    async def test_cancel_signal_forwarded_to_call_tool_async(self):
 
+        tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        captured: dict[str, Any] = {}
 
-class TestStructuredContentCap:
-    """Structured content is size-capped and reports the size in the unit it caps in."""
+        async def _call(*args: Any, **kwargs: Any) -> Any:
+            captured["cancel_signal"] = kwargs.get("cancel_signal")
+            return {"status": "success", "content": []}
 
-    def test_non_json_serialisable_structured_content_is_replaced(self):
-        # Sets are not JSON-serialisable; the cap must swap the value for a marker
-        # rather than smuggle an opaque blob through to the model.
-        response: dict[str, Any] = {"status": "success", "text": ""}
-        capped = _cap_structured_content({"key": {1, 2, 3}}, response)
-        assert response.get("truncated") is True
-        assert capped == {"__truncated__": True, "reason": "structured_content was not JSON-serialisable"}
+        client_class, instance = _fake_mcp_client_class(
+            list_tools_return=[_make_agent_tool(name="slow")],
+        )
+        instance.call_tool_async = _call
 
-    def test_capped_size_is_reported_in_bytes(self):
-        # A payload of multi-byte characters exceeding the byte cap should report
-        # the byte length in `size`, matching the unit the cap is measured in.
-        multibyte = "é" * 90_000  # each character is two UTF-8 bytes → 180_000 bytes
-        response: dict[str, Any] = {"status": "success", "text": ""}
-        capped = _cap_structured_content({"payload": multibyte}, response)
-        assert response.get("truncated") is True
-        assert isinstance(capped, dict)
-        assert capped["__truncated__"] is True
-        # `size` should be a byte count (>= 180_000), not a character count (~90_000).
-        assert capped["size"] > 100_000
+        cancel = threading.Event()
+        agent = _StubAgent()
+        ctx = _tool_context(agent)
+        ctx.cancel_signal = cancel
+
+        with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers", client_class):
+            connected = await tool(command="connect", server="https://mcp.example.com/mcp", tool_context=ctx)
+            await tool(
+                command="call_tool",
+                session_id=connected["session_id"],
+                tool_name="slow",
+                tool_context=ctx,
+            )
+
+        assert captured["cancel_signal"] is cancel
 
 
 class TestToolMetadata:
     """The tool exposes a sensible name, description, and input schema."""
 
     def test_custom_name(self):
-        t = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"], name="my_mcp")
+        t = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}], name="my_mcp")
         assert t.tool_name == "my_mcp"
 
-    def test_schema_exposes_op_field_and_hides_context(self):
-        t = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
+    def test_default_description_includes_permitted_servers(self):
+        t = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        assert "https://mcp.example.com/mcp" in t.tool_spec["description"]
+
+    def test_schema_exposes_command_field_and_hides_context(self):
+        t = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
         props = t.tool_spec["inputSchema"]["json"]["properties"]
-        assert "op" in props
-        assert "server_url" in props
+        assert "command" in props
+        assert "server" in props
         assert "session_id" in props
         assert "tool_context" not in props
-
-
-class TestConnectInputValidation:
-    """Connect requires ``server_url``; call_tool requires ``tool_name``."""
-
-    @pytest.mark.asyncio
-    async def test_connect_without_url_is_rejected(self):
-        t = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
-        with pytest.raises(ValueError, match="server_url"):
-            await t(op="connect", tool_context=_tool_context())
-
-    @pytest.mark.asyncio
-    async def test_call_tool_without_name_is_rejected(self):
-        t = make_mcp_client(allowed_urls=["https://mcp.example.com/mcp"])
-        agent = _StubAgent()
-        with (
-            patch("strands.vended_tools.mcp_client.mcp_client.socket.getaddrinfo") as gai,
-            patch("strands.vended_tools.mcp_client.mcp_client.MCPClient") as client_cls,
-        ):
-            gai.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))]
-            client_cls.return_value = _mcp_instance()
-            connect_result = await t(
-                op="connect", server_url="https://mcp.example.com/mcp", tool_context=_tool_context(agent)
-            )
-            with pytest.raises(ValueError, match="tool_name"):
-                await t(op="call_tool", session_id=connect_result["session_id"], tool_context=_tool_context(agent))

--- a/strands-py/tests/strands/vended_tools/test_mcp_client.py
+++ b/strands-py/tests/strands/vended_tools/test_mcp_client.py
@@ -75,34 +75,20 @@ def _mcp_instance(tools: list[MCPAgentTool] | None = None) -> MagicMock:
 
 
 class TestServerValidation:
-    """_validate_servers rejects invalid configs at construction time."""
+    """make_mcp_client rejects invalid configs at construction time."""
 
     def test_empty_allowlist_is_rejected(self) -> None:
         with pytest.raises(ValueError, match="must not be empty"):
-            make_mcp_client(servers=[])
+            make_mcp_client(servers={})
 
-    def test_different_configs_colliding_on_same_key_are_rejected(self) -> None:
-        with pytest.raises(ValueError, match="two different configs"):
-            make_mcp_client(
-                servers=[
-                    {"command": "npx", "args": ["my-server"], "env": {"TOKEN": "A"}},
-                    {"command": "npx", "args": ["my-server"], "env": {"TOKEN": "B"}},
-                ]
-            )
-
-    def test_neither_url_nor_command_is_rejected(self) -> None:
-        with pytest.raises(ValueError, match="url.*or.*command|command.*or.*url|must have either"):
-            make_mcp_client(servers=[{"args": ["server.js"]}])
-
-    def test_identical_configs_are_deduplicated(self) -> None:
-        config = {"url": "https://mcp.example.com/mcp"}
-        tool = make_mcp_client(servers=[config, config])
-        assert tool is not None
+    def test_description_includes_server_names(self) -> None:
+        tool = make_mcp_client(servers={"my-server": {"url": "https://mcp.example.com/mcp"}})
+        assert "my-server" in tool.tool_spec["description"]
 
     def test_stdio_config_is_accepted(self) -> None:
-        tool = make_mcp_client(servers=[{"command": "node", "args": ["server.js"]}])
+        tool = make_mcp_client(servers={"local": {"command": "node", "args": ["server.js"]}})
         assert tool.tool_name == "mcp_client"
-        assert "node server.js" in tool.tool_spec["description"]
+        assert "local" in tool.tool_spec["description"]
 
 
 class TestConnect:
@@ -110,39 +96,39 @@ class TestConnect:
 
     @pytest.mark.asyncio
     async def test_url_not_on_allowlist_is_rejected(self) -> None:
-        tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        tool = make_mcp_client(servers={"mcp": {"url": "https://mcp.example.com/mcp"}})
         with pytest.raises(MCPClientToolError, match="not on the allowlist"):
-            await tool(command="connect", server="https://evil.example.com/mcp", tool_context=_tool_context())
+            await tool(command="connect", server_name="evil", tool_context=_tool_context())
 
     @pytest.mark.asyncio
     async def test_missing_server_is_rejected(self) -> None:
-        t = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        t = make_mcp_client(servers={"mcp": {"url": "https://mcp.example.com/mcp"}})
         with pytest.raises(MCPClientToolError, match="server"):
             await t(command="connect", tool_context=_tool_context())
 
     @pytest.mark.asyncio
     async def test_agent_isolation(self) -> None:
         """A connection opened by agent A is not visible to agent B."""
-        tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        tool = make_mcp_client(servers={"mcp": {"url": "https://mcp.example.com/mcp"}})
         with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers") as client_cls:
             client_cls.return_value = [_mcp_instance()]
             agent_a = _StubAgent(label="a")
             agent_b = _StubAgent(label="b")
-            await tool(command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent_a))
+            await tool(command="connect", server_name="mcp", tool_context=_tool_context(agent_a))
             with pytest.raises(MCPClientToolError, match="No active connection"):
                 await tool(command="list_tools", tool_context=_tool_context(agent_b))
 
     @pytest.mark.asyncio
     async def test_start_failure_stops_client_and_leaves_no_connection(self) -> None:
         """If start() raises, the partially-started client is stopped and no connection is registered."""
-        t = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        t = make_mcp_client(servers={"mcp": {"url": "https://mcp.example.com/mcp"}})
         client_class, instance = _fake_mcp_client_class()
         instance.start = MagicMock(side_effect=RuntimeError("connection refused"))
         agent = _StubAgent()
 
         with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers", client_class):
             with pytest.raises(RuntimeError, match="connection refused"):
-                await t(command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent))
+                await t(command="connect", server_name="mcp", tool_context=_tool_context(agent))
 
         instance.stop.assert_called_once()
         with pytest.raises(MCPClientToolError, match="No active connection"):
@@ -154,7 +140,7 @@ class TestSessionLifecycle:
 
     @pytest.mark.asyncio
     async def test_full_lifecycle(self) -> None:
-        tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        tool = make_mcp_client(servers={"mcp": {"url": "https://mcp.example.com/mcp"}})
         client_class, instance = _fake_mcp_client_class(
             list_tools_return=[_make_agent_tool(name="echo", description="Echoes input")],
             call_tool_return={"status": "success", "content": [{"text": "hello world"}]},
@@ -162,10 +148,8 @@ class TestSessionLifecycle:
         agent = _StubAgent()
 
         with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers", client_class):
-            connect_result = await tool(
-                command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent)
-            )
-            assert connect_result == "Successfully connected to https://mcp.example.com/mcp"
+            connect_result = await tool(command="connect", server_name="mcp", tool_context=_tool_context(agent))
+            assert connect_result == "Successfully connected to mcp"
             instance.start.assert_called_once()
 
             list_result = await tool(command="list_tools", tool_context=_tool_context(agent))
@@ -194,44 +178,44 @@ class TestSessionLifecycle:
     @pytest.mark.asyncio
     async def test_reconnect_stops_existing_client(self) -> None:
         """connect always stops the existing client and starts a fresh one."""
-        tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        tool = make_mcp_client(servers={"mcp": {"url": "https://mcp.example.com/mcp"}})
         client_class, instance = _fake_mcp_client_class()
         agent = _StubAgent()
 
         with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers", client_class):
-            await tool(command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent))
-            await tool(command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent))
+            await tool(command="connect", server_name="mcp", tool_context=_tool_context(agent))
+            await tool(command="connect", server_name="mcp", tool_context=_tool_context(agent))
 
         assert instance.stop.call_count == 1
         assert instance.start.call_count == 2
 
     @pytest.mark.asyncio
     async def test_commands_without_active_connection_are_rejected(self) -> None:
-        t = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        t = make_mcp_client(servers={"mcp": {"url": "https://mcp.example.com/mcp"}})
         for command in ("list_tools", "call_tool"):
             with pytest.raises(MCPClientToolError, match="No active connection"):
                 await t(command=command, tool_context=_tool_context())
 
     @pytest.mark.asyncio
     async def test_call_tool_without_name_is_rejected(self) -> None:
-        t = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        t = make_mcp_client(servers={"mcp": {"url": "https://mcp.example.com/mcp"}})
         agent = _StubAgent()
         with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers") as client_cls:
             client_cls.return_value = [_mcp_instance()]
-            await t(command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent))
+            await t(command="connect", server_name="mcp", tool_context=_tool_context(agent))
             with pytest.raises(MCPClientToolError, match="tool_name"):
                 await t(command="call_tool", tool_context=_tool_context(agent))
 
     @pytest.mark.asyncio
     async def test_disconnect_when_stop_raises_still_evicts(self) -> None:
         """RuntimeError from stop() must not prevent session eviction."""
-        t = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        t = make_mcp_client(servers={"mcp": {"url": "https://mcp.example.com/mcp"}})
         agent = _StubAgent()
         client_class, instance = _fake_mcp_client_class()
         instance.stop = MagicMock(side_effect=RuntimeError("already closed"))
 
         with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers", client_class):
-            await t(command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent))
+            await t(command="connect", server_name="mcp", tool_context=_tool_context(agent))
             result = await t(command="disconnect", tool_context=_tool_context(agent))
 
         assert result == "Successfully disconnected"
@@ -240,7 +224,7 @@ class TestSessionLifecycle:
 
     @pytest.mark.asyncio
     async def test_cancel_signal_forwarded_to_call_tool_async(self) -> None:
-        tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        tool = make_mcp_client(servers={"mcp": {"url": "https://mcp.example.com/mcp"}})
         captured: dict[str, Any] = {}
 
         async def _call(*args: Any, **kwargs: Any) -> Any:
@@ -256,7 +240,7 @@ class TestSessionLifecycle:
         ctx.cancel_signal = cancel
 
         with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers", client_class):
-            await tool(command="connect", server="https://mcp.example.com/mcp", tool_context=ctx)
+            await tool(command="connect", server_name="mcp", tool_context=ctx)
             await tool(command="call_tool", tool_name="slow", tool_context=ctx)
 
         assert captured["cancel_signal"] is cancel
@@ -264,7 +248,7 @@ class TestSessionLifecycle:
     @pytest.mark.asyncio
     async def test_list_tools_returns_server_side_names(self) -> None:
         """list_tools must return mcp_tool.name (server-side) regardless of prefix config."""
-        tool = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        tool = make_mcp_client(servers={"mcp": {"url": "https://mcp.example.com/mcp"}})
         agent = _StubAgent()
         agent_tool = MCPAgentTool(
             mcp_tool=_make_mcp_tool(name="echo"),
@@ -273,7 +257,7 @@ class TestSessionLifecycle:
         )
         client_class, _ = _fake_mcp_client_class(list_tools_return=[agent_tool])
         with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers", client_class):
-            await tool(command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent))
+            await tool(command="connect", server_name="mcp", tool_context=_tool_context(agent))
             tools = await tool(command="list_tools", tool_context=_tool_context(agent))
         assert tools[0]["name"] == "echo"
 
@@ -284,44 +268,44 @@ class TestConfigForwarding:
     @pytest.mark.asyncio
     async def test_matched_config_reaches_load_servers(self) -> None:
         server_config = {"url": "https://mcp.example.com/mcp", "headers": {"X-Api-Key": "secret"}}
-        tool = make_mcp_client(servers=[server_config])
+        tool = make_mcp_client(servers={"mcp": server_config})
         agent = _StubAgent()
 
         with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers") as mock_load:
             mock_load.return_value = [_mcp_instance()]
-            await tool(command="connect", server="https://mcp.example.com/mcp", tool_context=_tool_context(agent))
+            await tool(command="connect", server_name="mcp", tool_context=_tool_context(agent))
 
         mock_load.assert_called_once()
         _, passed_config = mock_load.call_args[0][0].popitem()
         assert passed_config["headers"] == {"X-Api-Key": "secret"}
 
     @pytest.mark.asyncio
-    async def test_stdio_connect_key_round_trips_to_output(self) -> None:
-        tool = make_mcp_client(servers=[{"command": "npx", "args": ["-y", "my-server"]}])
+    async def test_stdio_connect_succeeds(self) -> None:
+        tool = make_mcp_client(servers={"local": {"command": "npx", "args": ["-y", "my-server"]}})
         agent = _StubAgent()
 
         with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers") as mock_load:
             mock_load.return_value = [_mcp_instance()]
-            result = await tool(command="connect", server="npx -y my-server", tool_context=_tool_context(agent))
+            result = await tool(command="connect", server_name="local", tool_context=_tool_context(agent))
 
-        assert "npx -y my-server" in result
+        assert "local" in result
 
 
 class TestToolMetadata:
     """The tool exposes a sensible name, description, and input schema."""
 
     def test_custom_name(self) -> None:
-        t = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}], name="my_mcp")
+        t = make_mcp_client(servers={"mcp": {"url": "https://mcp.example.com/mcp"}}, name="my_mcp")
         assert t.tool_name == "my_mcp"
 
     def test_default_description_includes_permitted_servers(self) -> None:
-        t = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
-        assert "https://mcp.example.com/mcp" in t.tool_spec["description"]
+        t = make_mcp_client(servers={"mcp": {"url": "https://mcp.example.com/mcp"}})
+        assert "mcp" in t.tool_spec["description"]
 
     def test_schema_exposes_command_field_and_hides_context(self) -> None:
-        t = make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp"}])
+        t = make_mcp_client(servers={"mcp": {"url": "https://mcp.example.com/mcp"}})
         props = t.tool_spec["inputSchema"]["json"]["properties"]
         assert "command" in props
-        assert "server" in props
+        assert "server_name" in props
         assert "session_id" not in props
         assert "tool_context" not in props

--- a/strands-py/tests/strands/vended_tools/test_mcp_client.py
+++ b/strands-py/tests/strands/vended_tools/test_mcp_client.py
@@ -10,6 +10,7 @@ import pytest
 from mcp.types import Tool as MCPTool
 
 from strands.tools.mcp import MCPAgentTool
+from strands.types.collections import PaginatedList
 from strands.types.tools import ToolContext
 from strands.vended_tools import make_mcp_client
 from strands.vended_tools.mcp_client.mcp_client import MCPClientToolError
@@ -57,7 +58,7 @@ def _fake_mcp_client_class(
     instance = MagicMock()
     instance.start = MagicMock()
     instance.stop = MagicMock()
-    instance._list_all_tools_sync = MagicMock(return_value=list_tools_return or [])
+    instance.list_tools_sync = MagicMock(return_value=PaginatedList(list_tools_return or []))
 
     async def _call(*args: Any, **kwargs: Any) -> Any:
         return call_tool_return or {"status": "success", "content": [{"text": "ok"}]}
@@ -69,7 +70,7 @@ def _fake_mcp_client_class(
 def _mcp_instance(tools: list[MCPAgentTool] | None = None) -> MagicMock:
     """Return a MagicMock that satisfies load_servers' return contract."""
     instance = MagicMock()
-    instance._list_all_tools_sync = MagicMock(return_value=tools or [])
+    instance.list_tools_sync = MagicMock(return_value=PaginatedList(tools or []))
     return instance
 
 

--- a/strands-py/tests/strands/vended_tools/test_mcp_client.py
+++ b/strands-py/tests/strands/vended_tools/test_mcp_client.py
@@ -81,6 +81,10 @@ class TestServerValidation:
         with pytest.raises(ValueError, match="must not be empty"):
             make_mcp_client(servers={})
 
+    def test_zero_max_connections_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="max_connections"):
+            make_mcp_client(servers={"mcp": {"url": "https://mcp.example.com/mcp"}}, max_connections=0)
+
     def test_description_includes_server_names(self) -> None:
         tool = make_mcp_client(servers={"my-server": {"url": "https://mcp.example.com/mcp"}})
         assert "my-server" in tool.tool_spec["description"]
@@ -98,13 +102,76 @@ class TestConnect:
     async def test_url_not_on_allowlist_is_rejected(self) -> None:
         tool = make_mcp_client(servers={"mcp": {"url": "https://mcp.example.com/mcp"}})
         with pytest.raises(MCPClientToolError, match="not on the allowlist"):
-            await tool(command="connect", server_name="evil", tool_context=_tool_context())
+            await tool(command="connect", server_name="evil", connection_id="c1", tool_context=_tool_context())
 
     @pytest.mark.asyncio
-    async def test_missing_server_is_rejected(self) -> None:
+    async def test_missing_connection_id_is_rejected(self) -> None:
         t = make_mcp_client(servers={"mcp": {"url": "https://mcp.example.com/mcp"}})
-        with pytest.raises(MCPClientToolError, match="server"):
-            await t(command="connect", tool_context=_tool_context())
+        with pytest.raises(MCPClientToolError, match="connection_id"):
+            await t(command="connect", server_name="mcp", tool_context=_tool_context())
+
+    @pytest.mark.asyncio
+    async def test_missing_server_name_is_rejected(self) -> None:
+        t = make_mcp_client(servers={"mcp": {"url": "https://mcp.example.com/mcp"}})
+        with pytest.raises(MCPClientToolError, match="server_name"):
+            await t(command="connect", connection_id="c1", tool_context=_tool_context())
+
+    @pytest.mark.asyncio
+    async def test_multiple_connections_simultaneously(self) -> None:
+        """Two connections with different IDs can coexist."""
+        tool = make_mcp_client(
+            servers={
+                "server-a": {"url": "https://a.example.com/mcp"},
+                "server-b": {"url": "https://b.example.com/mcp"},
+            }
+        )
+        agent = _StubAgent()
+        with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers") as client_cls:
+            client_cls.return_value = [_mcp_instance()]
+            await tool(
+                command="connect",
+                server_name="server-a",
+                connection_id="conn-a",
+                tool_context=_tool_context(agent),
+            )
+            await tool(
+                command="connect",
+                server_name="server-b",
+                connection_id="conn-b",
+                tool_context=_tool_context(agent),
+            )
+            # Both connections are live — list_tools works on each.
+            await tool(command="list_tools", connection_id="conn-a", tool_context=_tool_context(agent))
+            await tool(command="list_tools", connection_id="conn-b", tool_context=_tool_context(agent))
+
+    @pytest.mark.asyncio
+    async def test_reconnect_with_same_id_raises(self) -> None:
+        """Reusing an existing connection_id raises an error."""
+        tool = make_mcp_client(servers={"mcp": {"url": "https://mcp.example.com/mcp"}})
+        client_class, instance = _fake_mcp_client_class()
+        agent = _StubAgent()
+        with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers", client_class):
+            await tool(command="connect", server_name="mcp", connection_id="c1", tool_context=_tool_context(agent))
+            with pytest.raises(MCPClientToolError, match="already exists"):
+                await tool(command="connect", server_name="mcp", connection_id="c1", tool_context=_tool_context(agent))
+        # Both starts ran; the second was stopped after the duplicate was detected post-start.
+        assert instance.start.call_count == 2
+        instance.stop.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_connection_cap_is_enforced(self) -> None:
+        """Opening more connections than max_connections raises with active IDs listed."""
+        tool = make_mcp_client(
+            servers={"mcp": {"url": "https://mcp.example.com/mcp"}},
+            max_connections=2,
+        )
+        agent = _StubAgent()
+        with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers") as client_cls:
+            client_cls.return_value = [_mcp_instance()]
+            await tool(command="connect", server_name="mcp", connection_id="c1", tool_context=_tool_context(agent))
+            await tool(command="connect", server_name="mcp", connection_id="c2", tool_context=_tool_context(agent))
+            with pytest.raises(MCPClientToolError, match="Connection limit of 2"):
+                await tool(command="connect", server_name="mcp", connection_id="c3", tool_context=_tool_context(agent))
 
     @pytest.mark.asyncio
     async def test_agent_isolation(self) -> None:
@@ -114,13 +181,13 @@ class TestConnect:
             client_cls.return_value = [_mcp_instance()]
             agent_a = _StubAgent(label="a")
             agent_b = _StubAgent(label="b")
-            await tool(command="connect", server_name="mcp", tool_context=_tool_context(agent_a))
+            await tool(command="connect", server_name="mcp", connection_id="c1", tool_context=_tool_context(agent_a))
             with pytest.raises(MCPClientToolError, match="No active connection"):
-                await tool(command="list_tools", tool_context=_tool_context(agent_b))
+                await tool(command="list_tools", connection_id="c1", tool_context=_tool_context(agent_b))
 
     @pytest.mark.asyncio
     async def test_start_failure_stops_client_and_leaves_no_connection(self) -> None:
-        """If start() raises, the partially-started client is stopped and no connection is registered."""
+        """If start() raises, the client is stopped and no connection is registered."""
         t = make_mcp_client(servers={"mcp": {"url": "https://mcp.example.com/mcp"}})
         client_class, instance = _fake_mcp_client_class()
         instance.start = MagicMock(side_effect=RuntimeError("connection refused"))
@@ -128,15 +195,15 @@ class TestConnect:
 
         with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers", client_class):
             with pytest.raises(RuntimeError, match="connection refused"):
-                await t(command="connect", server_name="mcp", tool_context=_tool_context(agent))
+                await t(command="connect", server_name="mcp", connection_id="c1", tool_context=_tool_context(agent))
 
         instance.stop.assert_called_once()
-        with pytest.raises(MCPClientToolError, match="No active connection"):
+        with pytest.raises(MCPClientToolError, match="connection_id.*required|No active connection"):
             await t(command="list_tools", tool_context=_tool_context(agent))
 
 
 class TestSessionLifecycle:
-    """Full connect -> list_tools -> call_tool -> disconnect flow and reconnect behaviour."""
+    """Full connect -> list_tools -> call_tool -> disconnect flow."""
 
     @pytest.mark.asyncio
     async def test_full_lifecycle(self) -> None:
@@ -148,16 +215,20 @@ class TestSessionLifecycle:
         agent = _StubAgent()
 
         with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers", client_class):
-            connect_result = await tool(command="connect", server_name="mcp", tool_context=_tool_context(agent))
-            assert connect_result == "Successfully connected to mcp"
+            connect_result = await tool(
+                command="connect", server_name="mcp", connection_id="c1", tool_context=_tool_context(agent)
+            )
+            assert "mcp" in connect_result
+            assert "c1" in connect_result
             instance.start.assert_called_once()
 
-            list_result = await tool(command="list_tools", tool_context=_tool_context(agent))
+            list_result = await tool(command="list_tools", connection_id="c1", tool_context=_tool_context(agent))
             assert len(list_result) == 1
             assert list_result[0]["name"] == "echo"
 
             call_result = await tool(
                 command="call_tool",
+                connection_id="c1",
                 tool_name="echo",
                 arguments={"msg": "hi"},
                 tool_context=_tool_context(agent),
@@ -168,33 +239,12 @@ class TestSessionLifecycle:
             assert call_kwargs["name"] == "echo"
             assert call_kwargs["arguments"] == {"msg": "hi"}
 
-            disconnect_result = await tool(command="disconnect", tool_context=_tool_context(agent))
+            disconnect_result = await tool(command="disconnect", connection_id="c1", tool_context=_tool_context(agent))
             assert disconnect_result == "Successfully disconnected"
             instance.stop.assert_called_once()
 
             with pytest.raises(MCPClientToolError, match="No active connection"):
-                await tool(command="list_tools", tool_context=_tool_context(agent))
-
-    @pytest.mark.asyncio
-    async def test_reconnect_stops_existing_client(self) -> None:
-        """connect always stops the existing client and starts a fresh one."""
-        tool = make_mcp_client(servers={"mcp": {"url": "https://mcp.example.com/mcp"}})
-        client_class, instance = _fake_mcp_client_class()
-        agent = _StubAgent()
-
-        with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers", client_class):
-            await tool(command="connect", server_name="mcp", tool_context=_tool_context(agent))
-            await tool(command="connect", server_name="mcp", tool_context=_tool_context(agent))
-
-        assert instance.stop.call_count == 1
-        assert instance.start.call_count == 2
-
-    @pytest.mark.asyncio
-    async def test_commands_without_active_connection_are_rejected(self) -> None:
-        t = make_mcp_client(servers={"mcp": {"url": "https://mcp.example.com/mcp"}})
-        for command in ("list_tools", "call_tool"):
-            with pytest.raises(MCPClientToolError, match="No active connection"):
-                await t(command=command, tool_context=_tool_context())
+                await tool(command="list_tools", connection_id="c1", tool_context=_tool_context(agent))
 
     @pytest.mark.asyncio
     async def test_call_tool_without_name_is_rejected(self) -> None:
@@ -202,25 +252,25 @@ class TestSessionLifecycle:
         agent = _StubAgent()
         with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers") as client_cls:
             client_cls.return_value = [_mcp_instance()]
-            await t(command="connect", server_name="mcp", tool_context=_tool_context(agent))
+            await t(command="connect", server_name="mcp", connection_id="c1", tool_context=_tool_context(agent))
             with pytest.raises(MCPClientToolError, match="tool_name"):
-                await t(command="call_tool", tool_context=_tool_context(agent))
+                await t(command="call_tool", connection_id="c1", tool_context=_tool_context(agent))
 
     @pytest.mark.asyncio
     async def test_disconnect_when_stop_raises_still_evicts(self) -> None:
-        """RuntimeError from stop() must not prevent session eviction."""
+        """RuntimeError from stop() must not prevent connection eviction."""
         t = make_mcp_client(servers={"mcp": {"url": "https://mcp.example.com/mcp"}})
         agent = _StubAgent()
         client_class, instance = _fake_mcp_client_class()
         instance.stop = MagicMock(side_effect=RuntimeError("already closed"))
 
         with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers", client_class):
-            await t(command="connect", server_name="mcp", tool_context=_tool_context(agent))
-            result = await t(command="disconnect", tool_context=_tool_context(agent))
+            await t(command="connect", server_name="mcp", connection_id="c1", tool_context=_tool_context(agent))
+            result = await t(command="disconnect", connection_id="c1", tool_context=_tool_context(agent))
 
         assert result == "Successfully disconnected"
         with pytest.raises(MCPClientToolError, match="No active connection"):
-            await t(command="list_tools", tool_context=_tool_context(agent))
+            await t(command="list_tools", connection_id="c1", tool_context=_tool_context(agent))
 
     @pytest.mark.asyncio
     async def test_cancel_signal_forwarded_to_call_tool_async(self) -> None:
@@ -240,8 +290,8 @@ class TestSessionLifecycle:
         ctx.cancel_signal = cancel
 
         with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers", client_class):
-            await tool(command="connect", server_name="mcp", tool_context=ctx)
-            await tool(command="call_tool", tool_name="slow", tool_context=ctx)
+            await tool(command="connect", server_name="mcp", connection_id="c1", tool_context=ctx)
+            await tool(command="call_tool", connection_id="c1", tool_name="slow", tool_context=ctx)
 
         assert captured["cancel_signal"] is cancel
 
@@ -257,8 +307,8 @@ class TestSessionLifecycle:
         )
         client_class, _ = _fake_mcp_client_class(list_tools_return=[agent_tool])
         with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers", client_class):
-            await tool(command="connect", server_name="mcp", tool_context=_tool_context(agent))
-            tools = await tool(command="list_tools", tool_context=_tool_context(agent))
+            await tool(command="connect", server_name="mcp", connection_id="c1", tool_context=_tool_context(agent))
+            tools = await tool(command="list_tools", connection_id="c1", tool_context=_tool_context(agent))
         assert tools[0]["name"] == "echo"
 
 
@@ -273,22 +323,24 @@ class TestConfigForwarding:
 
         with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers") as mock_load:
             mock_load.return_value = [_mcp_instance()]
-            await tool(command="connect", server_name="mcp", tool_context=_tool_context(agent))
+            await tool(command="connect", server_name="mcp", connection_id="c1", tool_context=_tool_context(agent))
 
         mock_load.assert_called_once()
         _, passed_config = mock_load.call_args[0][0].popitem()
         assert passed_config["headers"] == {"X-Api-Key": "secret"}
 
     @pytest.mark.asyncio
-    async def test_stdio_connect_succeeds(self) -> None:
-        tool = make_mcp_client(servers={"local": {"command": "npx", "args": ["-y", "my-server"]}})
+    async def test_server_name_used_as_load_servers_key(self) -> None:
+        """server_name flows through as the load_servers key (used as application_name)."""
+        tool = make_mcp_client(servers={"my-api": {"url": "https://mcp.example.com/mcp"}})
         agent = _StubAgent()
 
         with patch("strands.vended_tools.mcp_client.mcp_client.MCPClient.load_servers") as mock_load:
             mock_load.return_value = [_mcp_instance()]
-            result = await tool(command="connect", server_name="local", tool_context=_tool_context(agent))
+            await tool(command="connect", server_name="my-api", connection_id="c1", tool_context=_tool_context(agent))
 
-        assert "local" in result
+        key = list(mock_load.call_args[0][0].keys())[0]
+        assert key == "my-api"
 
 
 class TestToolMetadata:
@@ -298,14 +350,10 @@ class TestToolMetadata:
         t = make_mcp_client(servers={"mcp": {"url": "https://mcp.example.com/mcp"}}, name="my_mcp")
         assert t.tool_name == "my_mcp"
 
-    def test_default_description_includes_permitted_servers(self) -> None:
-        t = make_mcp_client(servers={"mcp": {"url": "https://mcp.example.com/mcp"}})
-        assert "mcp" in t.tool_spec["description"]
-
-    def test_schema_exposes_command_field_and_hides_context(self) -> None:
+    def test_schema_exposes_expected_fields(self) -> None:
         t = make_mcp_client(servers={"mcp": {"url": "https://mcp.example.com/mcp"}})
         props = t.tool_spec["inputSchema"]["json"]["properties"]
         assert "command" in props
         assert "server_name" in props
-        assert "session_id" not in props
+        assert "connection_id" in props
         assert "tool_context" not in props

--- a/strands-py/tests/strands/vended_tools/test_mcp_client.py
+++ b/strands-py/tests/strands/vended_tools/test_mcp_client.py
@@ -107,10 +107,6 @@ class TestServerValidation:
         tool = make_mcp_client(servers=[config, config])
         assert tool is not None
 
-    def test_stdio_config_without_command_is_rejected(self) -> None:
-        with pytest.raises(ValueError, match="url.*or.*command|command.*or.*url|must have either"):
-            make_mcp_client(servers=[{"args": ["server.js"]}])
-
     def test_stdio_config_is_accepted(self) -> None:
         tool = make_mcp_client(servers=[{"command": "node", "args": ["server.js"]}])
         assert tool.tool_name == "mcp_client"

--- a/strands-py/tests/strands/vended_tools/test_mcp_client.py
+++ b/strands-py/tests/strands/vended_tools/test_mcp_client.py
@@ -52,8 +52,8 @@ def _fake_mcp_client_class(
     *,
     list_tools_return: list[MCPAgentTool] | None = None,
     call_tool_return: dict[str, Any] | None = None,
-) -> Any:
-    """Return a MagicMock-based MCPClient replacement whose start/stop record calls."""
+) -> tuple[Any, MagicMock]:
+    """Return (load_servers patch target, mock client instance) for patching MCPClient."""
     instance = MagicMock()
     instance.start = MagicMock()
     instance.stop = MagicMock()

--- a/strands-py/tests/strands/vended_tools/test_mcp_client.py
+++ b/strands-py/tests/strands/vended_tools/test_mcp_client.py
@@ -81,26 +81,18 @@ class TestServerValidation:
         with pytest.raises(ValueError, match="must not be empty"):
             make_mcp_client(servers=[])
 
-    def test_disabled_config_is_rejected(self) -> None:
-        with pytest.raises(ValueError, match="disabled"):
-            make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp", "disabled": True}])
-
-    def test_both_url_and_command_is_rejected(self) -> None:
-        with pytest.raises(ValueError, match="both 'url'.*and 'command'|both.*url.*command"):
-            make_mcp_client(servers=[{"url": "https://mcp.example.com/mcp", "command": "node"}])
+    def test_different_configs_colliding_on_same_key_are_rejected(self) -> None:
+        with pytest.raises(ValueError, match="two different configs"):
+            make_mcp_client(
+                servers=[
+                    {"command": "npx", "args": ["my-server"], "env": {"TOKEN": "A"}},
+                    {"command": "npx", "args": ["my-server"], "env": {"TOKEN": "B"}},
+                ]
+            )
 
     def test_neither_url_nor_command_is_rejected(self) -> None:
         with pytest.raises(ValueError, match="url.*or.*command|command.*or.*url|must have either"):
             make_mcp_client(servers=[{"args": ["server.js"]}])
-
-    def test_different_configs_colliding_on_same_key_are_rejected(self) -> None:
-        with pytest.raises(ValueError, match="two different configs|duplicate"):
-            make_mcp_client(
-                servers=[
-                    {"url": "https://mcp.example.com/mcp", "headers": {"Authorization": "Bearer A"}},
-                    {"url": "https://mcp.example.com/mcp", "headers": {"Authorization": "Bearer B"}},
-                ]
-            )
 
     def test_identical_configs_are_deduplicated(self) -> None:
         config = {"url": "https://mcp.example.com/mcp"}


### PR DESCRIPTION
## Description

Adds `make_mcp_router` to the Python vended tools — a factory that lets an agent connect to MCP servers at runtime, discover their tools, invoke one, and disconnect. This replaces the [mcp_client](https://github.com/strands-agents/tools/blob/main/src/strands_tools/mcp_client.py) tool from the tools repository, enabling us to deprecate it.

The implementation was loosely based on https://github.com/strands-agents/harness-sdk/pull/3376. All network egress and SSRF protection belongs at the encapsulation layer. The tool's own security boundary is the developer-set server allowlist, which accepts `dict[str, MCPServerConfig]`. 

### Public API Changes

Basic usage:
```python
from strands import Agent
from strands.vended_tools import make_mcp_router

mcp_router = make_mcp_router(servers={
    "files": {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]},
    "my-api": {"url": "https://mcp.example.com/mcp"},
})

agent = Agent(tools=[mcp_router])
```

Full configuration:
```python
from strands import Agent
from strands.vended_tools import make_mcp_router

mcp_router = make_mcp_router(
    name="mcp_router",
    description="Routes agent requests to permitted MCP servers. Use 'files' for filesystem access and 'api' for REST calls.",
    servers={
        "files": {
            "command": "npx",
            "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
            "env": {"NODE_ENV": "production"},
        },
        "api": {
            "url": "https://mcp.example.com/mcp",
            "headers": {"Authorization": "Bearer ${env:API_TOKEN}"},
        },
    },
    max_connections=5,
)
agent = Agent(tools=[mcp_router])
```

## Related Issues

Part of #3248.

## Documentation PR

Documentation added under `site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx` in this PR.

## Type of Change

New feature

## Testing

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
