### PR TITLE
feat(context-py): add session manager integration

### DIFF
--- a/strands-py/src/strands/_context_manager/context_manager.py
+++ b/strands-py/src/strands/_context_manager/context_manager.py
@@ -72,15 +72,30 @@ class ContextManager(Plugin):
         )
 
         self._stash: Stash | None = None
+        self._stash_is_durable: bool = False
         self._retrieval_tool_use_ids: set[str] = set()
         self._backfill_done: bool = False
 
         super().__init__()
 
+    @property
+    def stash(self) -> Stash | None:
+        """The L1 stash instance, if stash is enabled and the agent has been initialized."""
+        return self._stash
+
+    @property
+    def stash_is_durable(self) -> bool:
+        """Whether the stash is backed by durable storage that survives process restarts.
+
+        When True, stash data does not need to be embedded in session snapshots.
+        """
+        return self._stash_is_durable
+
     def init_agent(self, agent: Agent) -> None:
         """Register strategy hooks for proactive compression and overflow recovery."""
         if not self._stash_disabled:
             storage = self._stash_explicit_storage or getattr(agent, "storage", None) or InMemoryStorage()
+            self._stash_is_durable = not isinstance(storage, InMemoryStorage)
             self._stash = Stash(storage, agent.session_id, agent.agent_id)
 
         # Stash hook must register before strategy init so it captures pre-offload content.

--- a/strands-py/src/strands/_context_manager/context_manager.py
+++ b/strands-py/src/strands/_context_manager/context_manager.py
@@ -95,7 +95,9 @@ class ContextManager(Plugin):
         """Register strategy hooks for proactive compression and overflow recovery."""
         if not self._stash_disabled:
             storage = self._stash_explicit_storage or getattr(agent, "storage", None) or InMemoryStorage()
-            self._stash_is_durable = not isinstance(storage, InMemoryStorage)
+            from ..storage.storage import _EPHEMERAL
+
+            self._stash_is_durable = getattr(storage, "_ephemeral", None) is not _EPHEMERAL
             self._stash = Stash(storage, agent.session_id, agent.agent_id)
 
         # Stash hook must register before strategy init so it captures pre-offload content.

--- a/strands-py/src/strands/_context_manager/context_manager.py
+++ b/strands-py/src/strands/_context_manager/context_manager.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 from ..hooks.events import AfterModelCallEvent, BeforeModelCallEvent, MessageAddedEvent
 from ..plugins.plugin import Plugin
 from ..storage.in_memory_storage import InMemoryStorage
+from ..storage.storage import _EPHEMERAL
 from ..types.exceptions import ContextWindowOverflowException
 from .retrieval_tool import _create_retrieval_tool, _track_retrieval_tool_use_ids
 from .stash import Stash
@@ -95,8 +96,6 @@ class ContextManager(Plugin):
         """Register strategy hooks for proactive compression and overflow recovery."""
         if not self._stash_disabled:
             storage = self._stash_explicit_storage or getattr(agent, "storage", None) or InMemoryStorage()
-            from ..storage.storage import _EPHEMERAL
-
             self._stash_is_durable = getattr(storage, "_ephemeral", None) is not _EPHEMERAL
             self._stash = Stash(storage, agent.session_id, agent.agent_id)
 

--- a/strands-py/src/strands/_context_manager/stash.py
+++ b/strands-py/src/strands/_context_manager/stash.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import base64
 import json
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from ..storage.storage import _resolve_namespace
 from ..types.content import ContentBlock
@@ -58,7 +58,14 @@ class Stash:
     """Namespaced storage wrapper for persisting offloaded content blocks."""
 
     def __init__(self, storage: Storage, session_id: str, agent_id: str) -> None:
+        self._base_storage = storage
+        self._session_id = session_id
         self._storage = _resolve_namespace(storage, f"{STASH_PREFIX}/{session_id}/scopes/agent/{agent_id}")
+
+    @property
+    def storage_type_name(self) -> str:
+        """Name of the base storage class, for diagnostic logging."""
+        return type(self._base_storage).__name__
 
     async def store(self, block_id: str, block_index: int, data: bytes) -> str:
         """Store a content block and return its deterministic reference key."""
@@ -109,6 +116,47 @@ class Stash:
         """Delete a stashed entry."""
         await self._storage.delete(reference)
         logger.debug("reference=<%s> | deleted stash entry", reference)
+
+    async def take_snapshot(self) -> dict[str, Any]:
+        """Serialize all stash entries for snapshot persistence.
+
+        Returns:
+            Map of reference keys to their deserialized JSON values.
+        """
+        keys = await self.list()
+        entries: dict[str, Any] = {}
+        for key in keys:
+            data = await self._storage.read(key)
+            if data is not None:
+                entries[key] = _decode(data)
+        return entries
+
+    async def load_snapshot(self, entries: dict[str, Any]) -> None:
+        """Restore stash entries from a previously captured snapshot.
+
+        Args:
+            entries: Map of reference keys to their JSON values (from :meth:`take_snapshot`).
+        """
+        for key, data in entries.items():
+            await self._storage.write(key, _encode(data))
+
+    async def clear(self) -> None:
+        """Delete all entries in this agent's stash namespace."""
+        keys = await self.list()
+        for key in keys:
+            await self._storage.delete(key)
+
+    async def clear_session(self) -> None:
+        """Delete all stash data for this session across all agents.
+
+        Unlike :meth:`clear`, which is scoped to this agent's namespace, this
+        scans ``context/<session_id>/`` on the base storage to remove data from
+        every agent that wrote to the session.
+        """
+        prefix = f"{STASH_PREFIX}/{self._session_id}/"
+        keys = await self._base_storage.list(prefix)
+        for key in keys:
+            await self._base_storage.delete(key)
 
     async def _store_tool_result(self, block: ContentBlock) -> None:
         """Store each sub-block of a tool result individually."""

--- a/strands-py/src/strands/_context_manager/stash.py
+++ b/strands-py/src/strands/_context_manager/stash.py
@@ -11,7 +11,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
-from ..storage.storage import _resolve_namespace
+from ..storage.storage import _NamespacedStorage
 from ..types.content import ContentBlock
 
 if TYPE_CHECKING:
@@ -60,7 +60,7 @@ class Stash:
     def __init__(self, storage: Storage, session_id: str, agent_id: str) -> None:
         self._base_storage = storage
         self._session_id = session_id
-        self._storage = _resolve_namespace(storage, f"{STASH_PREFIX}/{session_id}/scopes/agent/{agent_id}")
+        self._storage = _NamespacedStorage(storage, f"{STASH_PREFIX}/{session_id}/scopes/agent/{agent_id}")
 
     @property
     def storage_type_name(self) -> str:

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -404,6 +404,12 @@ class Agent(AgentBase, LocalAgent):
             context_manager, conversation_manager, plugins
         )
 
+        from .._context_manager.context_manager import ContextManager as _ContextManager
+
+        self._context_manager: ContextManager | None = (
+            context_manager if isinstance(context_manager, _ContextManager) else None
+        )
+
         self.conversation_manager: ConversationManager
         if self.model.stateful:
             self.conversation_manager = NullConversationManager()
@@ -765,12 +771,7 @@ class Agent(AgentBase, LocalAgent):
     @property
     def context_manager(self) -> "ContextManager | None":
         """The ContextManager plugin, if one is registered on this agent."""
-        from .._context_manager.context_manager import ContextManager as _ContextManager
-
-        plugin = self._plugin_registry._plugins.get("strands:context-manager")
-        if isinstance(plugin, _ContextManager):
-            return plugin
-        return None
+        return self._context_manager
 
     @property
     def session_id(self) -> str:

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -763,6 +763,16 @@ class Agent(AgentBase, LocalAgent):
         return self._storage
 
     @property
+    def context_manager(self) -> "ContextManager | None":
+        """The ContextManager plugin, if one is registered on this agent."""
+        from .._context_manager.context_manager import ContextManager as _ContextManager
+
+        plugin = self._plugin_registry._plugins.get("strands:context-manager")
+        if isinstance(plugin, _ContextManager):
+            return plugin
+        return None
+
+    @property
     def session_id(self) -> str:
         """Identifier for the current conversation session.
 

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -406,9 +406,15 @@ class Agent(AgentBase, LocalAgent):
 
         from .._context_manager.context_manager import ContextManager as _ContextManager
 
-        self._context_manager: ContextManager | None = (
-            context_manager if isinstance(context_manager, _ContextManager) else None
-        )
+        if isinstance(context_manager, _ContextManager):
+            self._context_manager: ContextManager | None = context_manager
+        elif plugins and any(isinstance(plugin, _ContextManager) for plugin in plugins):
+            raise ValueError(
+                "A ContextManager was passed via plugins; pass it through the context_manager parameter instead "
+                "so session persistence can detect it"
+            )
+        else:
+            self._context_manager = None
 
         self.conversation_manager: ConversationManager
         if self.model.stateful:

--- a/strands-py/src/strands/session/snapshot_session_manager.py
+++ b/strands-py/src/strands/session/snapshot_session_manager.py
@@ -45,6 +45,7 @@ from ..types.session import decode_bytes_values, encode_bytes_values
 from .session_manager import SessionManager
 
 if TYPE_CHECKING:
+    from .._context_manager.stash import Stash
     from ..agent.agent import Agent
 
 logger = logging.getLogger(__name__)
@@ -243,6 +244,7 @@ class SnapshotSessionManager(SessionManager):
         self._storage: Storage | None = _resolve_storage(storage) if storage is not None else None
         self._save_latest_on: SaveLatestStrategy = save_latest_on
         self._snapshot_trigger = snapshot_trigger
+        self._agent_stash: Stash | None = None
 
     @property
     def _resolved_storage(self) -> Storage:
@@ -305,6 +307,9 @@ class SnapshotSessionManager(SessionManager):
         """
         if self._storage is None:
             self._storage = _resolve_storage(agent.storage if agent.storage is not None else LocalFileStorage())
+        cm = agent.context_manager
+        if cm is not None:
+            self._agent_stash = cm.stash
         run_async(lambda: self._initialize_async(agent))
 
     def sync_agent(self, agent: "Agent", **kwargs: Any) -> None:
@@ -414,14 +419,16 @@ class SnapshotSessionManager(SessionManager):
             The new immutable snapshot id, ready to pass to :meth:`restore_snapshot`, or ``None``
             when ``is_latest=True`` (``snapshot_latest`` is not addressed by id).
         """
-        data = _serialize_snapshot(self._capture(agent))
+        snapshot = self._capture(agent)
+        await self._include_stash_data(agent, snapshot)
+        data = _serialize_snapshot(snapshot)
         snapshot_id = None if is_latest else _new_snapshot_id()
         key = _snapshot_key(self.session_id, agent.agent_id, snapshot_id=snapshot_id)
         await self._resolved_storage.write(key, data)
         return snapshot_id
 
     async def delete_session(self) -> None:
-        """Delete all snapshots for this session."""
+        """Delete all snapshots and stash data for this session."""
         storage = self._resolved_storage
         keys = await storage.list(_session_prefix(self.session_id))
         semaphore = asyncio.Semaphore(_DELETE_CONCURRENCY)
@@ -431,6 +438,7 @@ class SnapshotSessionManager(SessionManager):
                 await storage.delete(key)
 
         await asyncio.gather(*(_delete(key) for key in keys))
+        await self._delete_stash_data()
 
     # -- Async internals --
 
@@ -462,7 +470,9 @@ class SnapshotSessionManager(SessionManager):
         data = await self._resolved_storage.read(key)
         if data is None:
             return False
-        agent.load_snapshot(_deserialize_snapshot(data))
+        snapshot = _deserialize_snapshot(data)
+        agent.load_snapshot(snapshot)
+        await self._restore_stash_data(agent, snapshot)
         return True
 
     async def _save_latest(self, agent: "Agent") -> None:
@@ -476,7 +486,9 @@ class SnapshotSessionManager(SessionManager):
         can leave an orphaned immutable snapshot (harmless — the next list simply includes it)
         but never a ``snapshot_latest`` pointing at history that was never written.
         """
-        data = _serialize_snapshot(self._capture(agent))
+        snapshot = self._capture(agent)
+        await self._include_stash_data(agent, snapshot)
+        data = _serialize_snapshot(snapshot)
         await self._resolved_storage.write(
             _snapshot_key(self.session_id, agent.agent_id, snapshot_id=_new_snapshot_id()), data
         )
@@ -523,3 +535,63 @@ class SnapshotSessionManager(SessionManager):
         identically to the original, matching the TypeScript SDK's session preset.
         """
         return agent.take_snapshot(preset="session", include=["system_prompt"])
+
+    # -- Stash integration --
+
+    async def _include_stash_data(self, agent: "Agent", snapshot: Snapshot) -> None:
+        """Include context-manager stash data in a snapshot during save.
+
+        If the stash storage is durable, writes a lightweight external reference.
+        If ephemeral (e.g. InMemoryStorage), serializes all entries inline.
+        """
+        cm = agent.context_manager
+        if cm is None or cm.stash is None:
+            return
+
+        if cm.stash_is_durable:
+            snapshot.data["stash"] = {
+                "location": "external",
+                "storage_type": cm.stash.storage_type_name,
+            }
+            return
+
+        entries = await cm.stash.take_snapshot()
+        if entries:
+            snapshot.data["stash"] = {
+                "location": "inline",
+                "entries": entries,
+            }
+
+    async def _restore_stash_data(self, agent: "Agent", snapshot: Snapshot) -> None:
+        """Restore context-manager stash data from a snapshot."""
+        stash_data = snapshot.data.get("stash")
+        if stash_data is None:
+            return
+
+        cm = agent.context_manager
+        if cm is None or cm.stash is None:
+            return
+
+        location = stash_data.get("location")
+        if location == "external":
+            snapshot_type = stash_data.get("storage_type", "")
+            current_type = cm.stash.storage_type_name
+            if snapshot_type and current_type and snapshot_type != current_type:
+                logger.warning(
+                    "session_id=<%s>, snapshot_storage=<%s>, current_storage=<%s> | "
+                    "stash storage type changed since snapshot was created, stash data may be inaccessible",
+                    self.session_id,
+                    snapshot_type,
+                    current_type,
+                )
+            return
+
+        if location == "inline":
+            entries = stash_data.get("entries", {})
+            await cm.stash.load_snapshot(entries)
+
+    async def _delete_stash_data(self) -> None:
+        """Delete all stash data during session deletion."""
+        if self._agent_stash is not None:
+            await self._agent_stash.clear()
+            await self._agent_stash.clear_session()

--- a/strands-py/src/strands/session/snapshot_session_manager.py
+++ b/strands-py/src/strands/session/snapshot_session_manager.py
@@ -543,27 +543,38 @@ class SnapshotSessionManager(SessionManager):
 
         If the stash storage is durable, writes a lightweight external reference.
         If ephemeral (e.g. InMemoryStorage), serializes all entries inline.
+
+        Storage errors are logged and swallowed so a stash failure never prevents a snapshot save.
         """
         context_manager = agent.context_manager
         if context_manager is None or context_manager.stash is None:
             return
 
-        if context_manager.stash_is_durable:
-            snapshot.data["stash"] = {
-                "location": "external",
-                "storage_type": context_manager.stash.storage_type_name,
-            }
-            return
+        try:
+            if context_manager.stash_is_durable:
+                snapshot.data["stash"] = {
+                    "location": "external",
+                    "storage_type": context_manager.stash.storage_type_name,
+                }
+                return
 
-        entries = await context_manager.stash.take_snapshot()
-        if entries:
-            snapshot.data["stash"] = {
-                "location": "inline",
-                "entries": entries,
-            }
+            entries = await context_manager.stash.take_snapshot()
+            if entries:
+                snapshot.data["stash"] = {
+                    "location": "inline",
+                    "entries": entries,
+                }
+        except Exception:
+            logger.warning(
+                "session_id=<%s> | failed to include stash data in snapshot, saving without stash",
+                self.session_id,
+            )
 
     async def _restore_stash_data(self, agent: "Agent", snapshot: Snapshot) -> None:
-        """Restore context-manager stash data from a snapshot."""
+        """Restore context-manager stash data from a snapshot.
+
+        Storage errors are logged and swallowed so a stash failure never prevents session restore.
+        """
         stash_data = snapshot.data.get("stash")
         if stash_data is None:
             return
@@ -572,25 +583,39 @@ class SnapshotSessionManager(SessionManager):
         if context_manager is None or context_manager.stash is None:
             return
 
-        location = stash_data.get("location")
-        if location == "external":
-            snapshot_type = stash_data.get("storage_type", "")
-            if snapshot_type and snapshot_type != context_manager.stash.storage_type_name:
-                logger.warning(
-                    "session_id=<%s>, snapshot_storage=<%s>, current_storage=<%s> | "
-                    "stash storage type changed since snapshot was created, stash data may be inaccessible",
-                    self.session_id,
-                    snapshot_type,
-                    context_manager.stash.storage_type_name,
-                )
-            return
+        try:
+            location = stash_data.get("location")
+            if location == "external":
+                snapshot_type = stash_data.get("storage_type", "")
+                if snapshot_type and snapshot_type != context_manager.stash.storage_type_name:
+                    logger.warning(
+                        "session_id=<%s>, snapshot_storage=<%s>, current_storage=<%s> | "
+                        "stash storage type changed since snapshot was created, stash data may be inaccessible",
+                        self.session_id,
+                        snapshot_type,
+                        context_manager.stash.storage_type_name,
+                    )
+                return
 
-        if location == "inline":
-            entries = stash_data.get("entries", {})
-            await context_manager.stash.load_snapshot(entries)
+            if location == "inline":
+                entries = stash_data.get("entries", {})
+                await context_manager.stash.load_snapshot(entries)
+        except Exception:
+            logger.warning(
+                "session_id=<%s> | failed to restore stash data from snapshot, continuing without stash",
+                self.session_id,
+            )
 
     async def _delete_stash_data(self) -> None:
-        """Delete all stash data during session deletion."""
+        """Delete all stash data during session deletion.
+
+        Storage errors are logged and swallowed so a stash failure never prevents session deletion.
+        """
         if self._agent_stash is not None:
-            await self._agent_stash.clear()
-            await self._agent_stash.clear_session()
+            try:
+                await self._agent_stash.clear_session()
+            except Exception:
+                logger.warning(
+                    "session_id=<%s> | failed to delete stash data during session deletion",
+                    self.session_id,
+                )

--- a/strands-py/src/strands/session/snapshot_session_manager.py
+++ b/strands-py/src/strands/session/snapshot_session_manager.py
@@ -575,14 +575,13 @@ class SnapshotSessionManager(SessionManager):
         location = stash_data.get("location")
         if location == "external":
             snapshot_type = stash_data.get("storage_type", "")
-            current_type = cm.stash.storage_type_name
-            if snapshot_type and current_type and snapshot_type != current_type:
+            if snapshot_type and snapshot_type != cm.stash.storage_type_name:
                 logger.warning(
                     "session_id=<%s>, snapshot_storage=<%s>, current_storage=<%s> | "
                     "stash storage type changed since snapshot was created, stash data may be inaccessible",
                     self.session_id,
                     snapshot_type,
-                    current_type,
+                    cm.stash.storage_type_name,
                 )
             return
 

--- a/strands-py/src/strands/session/snapshot_session_manager.py
+++ b/strands-py/src/strands/session/snapshot_session_manager.py
@@ -307,9 +307,9 @@ class SnapshotSessionManager(SessionManager):
         """
         if self._storage is None:
             self._storage = _resolve_storage(agent.storage if agent.storage is not None else LocalFileStorage())
-        cm = agent.context_manager
-        if cm is not None:
-            self._agent_stash = cm.stash
+        context_manager = agent.context_manager
+        if context_manager is not None:
+            self._agent_stash = context_manager.stash
         run_async(lambda: self._initialize_async(agent))
 
     def sync_agent(self, agent: "Agent", **kwargs: Any) -> None:
@@ -544,18 +544,18 @@ class SnapshotSessionManager(SessionManager):
         If the stash storage is durable, writes a lightweight external reference.
         If ephemeral (e.g. InMemoryStorage), serializes all entries inline.
         """
-        cm = agent.context_manager
-        if cm is None or cm.stash is None:
+        context_manager = agent.context_manager
+        if context_manager is None or context_manager.stash is None:
             return
 
-        if cm.stash_is_durable:
+        if context_manager.stash_is_durable:
             snapshot.data["stash"] = {
                 "location": "external",
-                "storage_type": cm.stash.storage_type_name,
+                "storage_type": context_manager.stash.storage_type_name,
             }
             return
 
-        entries = await cm.stash.take_snapshot()
+        entries = await context_manager.stash.take_snapshot()
         if entries:
             snapshot.data["stash"] = {
                 "location": "inline",
@@ -568,26 +568,26 @@ class SnapshotSessionManager(SessionManager):
         if stash_data is None:
             return
 
-        cm = agent.context_manager
-        if cm is None or cm.stash is None:
+        context_manager = agent.context_manager
+        if context_manager is None or context_manager.stash is None:
             return
 
         location = stash_data.get("location")
         if location == "external":
             snapshot_type = stash_data.get("storage_type", "")
-            if snapshot_type and snapshot_type != cm.stash.storage_type_name:
+            if snapshot_type and snapshot_type != context_manager.stash.storage_type_name:
                 logger.warning(
                     "session_id=<%s>, snapshot_storage=<%s>, current_storage=<%s> | "
                     "stash storage type changed since snapshot was created, stash data may be inaccessible",
                     self.session_id,
                     snapshot_type,
-                    cm.stash.storage_type_name,
+                    context_manager.stash.storage_type_name,
                 )
             return
 
         if location == "inline":
             entries = stash_data.get("entries", {})
-            await cm.stash.load_snapshot(entries)
+            await context_manager.stash.load_snapshot(entries)
 
     async def _delete_stash_data(self) -> None:
         """Delete all stash data during session deletion."""

--- a/strands-py/src/strands/session/snapshot_session_manager.py
+++ b/strands-py/src/strands/session/snapshot_session_manager.py
@@ -615,6 +615,7 @@ class SnapshotSessionManager(SessionManager):
         """
         try:
             if self._agent_stash is not None:
+                await self._agent_stash.clear()
                 await self._agent_stash.clear_session()
             elif self._raw_storage is not None:
                 from .._context_manager.stash import STASH_PREFIX

--- a/strands-py/src/strands/session/snapshot_session_manager.py
+++ b/strands-py/src/strands/session/snapshot_session_manager.py
@@ -241,6 +241,7 @@ class SnapshotSessionManager(SessionManager):
             # Silently accepting an unknown value would register no save hooks — the session
             # would persist nothing with no error.
             raise ValueError(f"save_latest_on must be one of {_SAVE_LATEST_STRATEGIES}, got {save_latest_on!r}")
+        self._raw_storage: Storage | None = storage
         self._storage: Storage | None = _resolve_storage(storage) if storage is not None else None
         self._save_latest_on: SaveLatestStrategy = save_latest_on
         self._snapshot_trigger = snapshot_trigger
@@ -306,7 +307,9 @@ class SnapshotSessionManager(SessionManager):
             **kwargs: Additional keyword arguments for future extensibility.
         """
         if self._storage is None:
-            self._storage = _resolve_storage(agent.storage if agent.storage is not None else LocalFileStorage())
+            raw = agent.storage if agent.storage is not None else LocalFileStorage()
+            self._raw_storage = raw
+            self._storage = _resolve_storage(raw)
         context_manager = agent.context_manager
         if context_manager is not None:
             self._agent_stash = context_manager.stash
@@ -604,14 +607,31 @@ class SnapshotSessionManager(SessionManager):
     async def _delete_stash_data(self) -> None:
         """Delete all stash data during session deletion.
 
+        When the manager was never initialized (no agent attached), falls back to
+        deleting the ``context/<session_id>/`` prefix directly on the base storage so
+        stash data is not orphaned.
+
         Storage errors are logged and swallowed so a stash failure never prevents session deletion.
         """
-        if self._agent_stash is not None:
-            try:
+        try:
+            if self._agent_stash is not None:
                 await self._agent_stash.clear()
                 await self._agent_stash.clear_session()
-            except Exception:
-                logger.warning(
-                    "session_id=<%s> | failed to delete stash data during session deletion",
-                    self.session_id,
-                )
+            elif self._raw_storage is not None:
+                from .._context_manager.stash import STASH_PREFIX
+
+                prefix = f"{STASH_PREFIX}/{self.session_id}/"
+                keys = await self._raw_storage.list(prefix)
+                for key in keys:
+                    await self._raw_storage.delete(key)
+                if keys:
+                    logger.debug(
+                        "session_id=<%s>, keys=<%s> | deleted orphaned stash data via storage fallback",
+                        self.session_id,
+                        len(keys),
+                    )
+        except Exception:
+            logger.warning(
+                "session_id=<%s> | failed to delete stash data during session deletion",
+                self.session_id,
+            )

--- a/strands-py/src/strands/session/snapshot_session_manager.py
+++ b/strands-py/src/strands/session/snapshot_session_manager.py
@@ -544,31 +544,26 @@ class SnapshotSessionManager(SessionManager):
         If the stash storage is durable, writes a lightweight external reference.
         If ephemeral (e.g. InMemoryStorage), serializes all entries inline.
 
-        Storage errors are logged and swallowed so a stash failure never prevents a snapshot save.
+        Raises on failure so the caller never persists a snapshot with missing stash data
+        while the agent messages still carry ``[ref: ...]`` placeholders.
         """
         context_manager = agent.context_manager
         if context_manager is None or context_manager.stash is None:
             return
 
-        try:
-            if context_manager.stash_is_durable:
-                snapshot.data["stash"] = {
-                    "location": "external",
-                    "storage_type": context_manager.stash.storage_type_name,
-                }
-                return
+        if context_manager.stash_is_durable:
+            snapshot.data["stash"] = {
+                "location": "external",
+                "storage_type": context_manager.stash.storage_type_name,
+            }
+            return
 
-            entries = await context_manager.stash.take_snapshot()
-            if entries:
-                snapshot.data["stash"] = {
-                    "location": "inline",
-                    "entries": entries,
-                }
-        except Exception:
-            logger.warning(
-                "session_id=<%s> | failed to include stash data in snapshot, saving without stash",
-                self.session_id,
-            )
+        entries = await context_manager.stash.take_snapshot()
+        if entries:
+            snapshot.data["stash"] = {
+                "location": "inline",
+                "entries": entries,
+            }
 
     async def _restore_stash_data(self, agent: "Agent", snapshot: Snapshot) -> None:
         """Restore context-manager stash data from a snapshot.

--- a/strands-py/src/strands/session/snapshot_session_manager.py
+++ b/strands-py/src/strands/session/snapshot_session_manager.py
@@ -615,7 +615,6 @@ class SnapshotSessionManager(SessionManager):
         """
         try:
             if self._agent_stash is not None:
-                await self._agent_stash.clear()
                 await self._agent_stash.clear_session()
             elif self._raw_storage is not None:
                 from .._context_manager.stash import STASH_PREFIX

--- a/strands-py/src/strands/session/snapshot_session_manager.py
+++ b/strands-py/src/strands/session/snapshot_session_manager.py
@@ -608,6 +608,7 @@ class SnapshotSessionManager(SessionManager):
         """
         if self._agent_stash is not None:
             try:
+                await self._agent_stash.clear()
                 await self._agent_stash.clear_session()
             except Exception:
                 logger.warning(

--- a/strands-py/src/strands/session/snapshot_session_manager.py
+++ b/strands-py/src/strands/session/snapshot_session_manager.py
@@ -609,7 +609,9 @@ class SnapshotSessionManager(SessionManager):
 
         When the manager was never initialized (no agent attached), falls back to
         deleting the ``context/<session_id>/`` prefix directly on the base storage so
-        stash data is not orphaned.
+        stash data is not orphaned. This assumes the stash shares the same storage backend
+        as the session manager; if the stash was configured with a separate storage, the
+        fallback will not find its data.
 
         Storage errors are logged and swallowed so a stash failure never prevents session deletion.
         """

--- a/strands-py/src/strands/storage/in_memory_storage.py
+++ b/strands-py/src/strands/storage/in_memory_storage.py
@@ -7,7 +7,7 @@ import threading
 from typing import TYPE_CHECKING
 
 from .search.keyword import KeywordSearchStrategy
-from .storage import _NamespacedStorage, _normalize_key, _normalize_prefix
+from .storage import _EPHEMERAL, _NamespacedStorage, _normalize_key, _normalize_prefix
 
 if TYPE_CHECKING:
     from .storage import StorageSearchResult
@@ -28,6 +28,8 @@ class InMemoryStorage:
         data = await storage.read("sessions/abc/state.json")
         ```
     """
+
+    _ephemeral = _EPHEMERAL
 
     def __init__(self) -> None:
         """Initialize an empty in-memory store."""

--- a/strands-py/src/strands/storage/storage.py
+++ b/strands-py/src/strands/storage/storage.py
@@ -21,6 +21,14 @@ SDK constructs use this to detect whether the caller already scoped the storage,
 so the default auto-prefix can be skipped.
 """
 
+_EPHEMERAL: object = object()
+"""Internal sentinel marking a storage backend as ephemeral (data does not survive restarts).
+
+Set on :class:`InMemoryStorage` and propagated by :class:`_NamespacedStorage` so that
+consumers (e.g. the session manager's stash integration) can detect ephemeral backends
+without an ``isinstance`` check that breaks for namespaced views of ephemeral storage.
+"""
+
 
 @dataclass
 class StorageSearchResult:
@@ -203,6 +211,8 @@ class _NamespacedStorage:
         normalized = _normalize_prefix(prefix).rstrip("/")
         self._storage = storage
         self._prefix = f"{normalized}/" if normalized else ""
+        if getattr(storage, "_ephemeral", None) is _EPHEMERAL:
+            self._ephemeral = _EPHEMERAL
 
     async def write(self, key: str, data: bytes) -> None:
         """Store data under the prefixed key."""

--- a/strands-py/tests/strands/_context_manager/test_context_manager.py
+++ b/strands-py/tests/strands/_context_manager/test_context_manager.py
@@ -382,3 +382,47 @@ class TestStrategyInitFallback:
         cm = ContextManager(strategies=[strategy])
         cm.init_agent(mock_agent)
         assert strategy.initialized is True
+
+
+class TestStashProperty:
+    """Tests for the stash property."""
+
+    def test_stash_is_none_before_init(self):
+        cm = ContextManager()
+        assert cm.stash is None
+
+    def test_stash_is_set_after_init(self, mock_agent):
+        mock_agent.session_id = "test-session"
+        mock_agent.storage = None
+        cm = ContextManager()
+        cm.init_agent(mock_agent)
+        assert cm.stash is not None
+
+    def test_stash_is_none_when_disabled(self, mock_agent):
+        cm = ContextManager(stash=False)
+        cm.init_agent(mock_agent)
+        assert cm.stash is None
+
+
+class TestStashIsDurable:
+    """Tests for the stash_is_durable property."""
+
+    def test_false_with_in_memory_storage(self, mock_agent):
+        mock_agent.session_id = "test-session"
+        mock_agent.storage = None
+        cm = ContextManager()
+        cm.init_agent(mock_agent)
+        assert cm.stash_is_durable is False
+
+    def test_true_with_non_in_memory_storage(self, mock_agent):
+        from strands.storage.local_file_storage import LocalFileStorage
+
+        mock_agent.session_id = "test-session"
+        mock_agent.storage = LocalFileStorage(base_dir="/tmp/test-stash-durable")
+        cm = ContextManager(stash=True)
+        cm.init_agent(mock_agent)
+        assert cm.stash_is_durable is True
+
+    def test_false_before_init(self):
+        cm = ContextManager()
+        assert cm.stash_is_durable is False

--- a/strands-py/tests/strands/_context_manager/test_context_manager.py
+++ b/strands-py/tests/strands/_context_manager/test_context_manager.py
@@ -3,6 +3,7 @@
 import unittest.mock
 
 import pytest
+
 from strands._context_manager.context_manager import ContextManager
 from strands._context_manager.strategies.offload import Offload
 from strands._context_manager.strategies.offload.truncate import EmergencyTruncateStrategy
@@ -387,20 +388,20 @@ class TestStashProperty:
     """Tests for the stash property."""
 
     def test_stash_is_none_before_init(self):
-        cm = ContextManager()
-        assert cm.stash is None
+        context_manager = ContextManager()
+        assert context_manager.stash is None
 
     def test_stash_is_set_after_init(self, mock_agent):
         mock_agent.session_id = "test-session"
         mock_agent.storage = None
-        cm = ContextManager()
-        cm.init_agent(mock_agent)
-        assert cm.stash is not None
+        context_manager = ContextManager()
+        context_manager.init_agent(mock_agent)
+        assert context_manager.stash is not None
 
     def test_stash_is_none_when_disabled(self, mock_agent):
-        cm = ContextManager(stash=False)
-        cm.init_agent(mock_agent)
-        assert cm.stash is None
+        context_manager = ContextManager(stash=False)
+        context_manager.init_agent(mock_agent)
+        assert context_manager.stash is None
 
 
 class TestStashIsDurable:
@@ -409,19 +410,19 @@ class TestStashIsDurable:
     def test_false_with_in_memory_storage(self, mock_agent):
         mock_agent.session_id = "test-session"
         mock_agent.storage = None
-        cm = ContextManager()
-        cm.init_agent(mock_agent)
-        assert cm.stash_is_durable is False
+        context_manager = ContextManager()
+        context_manager.init_agent(mock_agent)
+        assert context_manager.stash_is_durable is False
 
     def test_true_with_non_in_memory_storage(self, mock_agent):
         from strands.storage.local_file_storage import LocalFileStorage
 
         mock_agent.session_id = "test-session"
         mock_agent.storage = LocalFileStorage(base_dir="/tmp/test-stash-durable")
-        cm = ContextManager(stash=True)
-        cm.init_agent(mock_agent)
-        assert cm.stash_is_durable is True
+        context_manager = ContextManager(stash=True)
+        context_manager.init_agent(mock_agent)
+        assert context_manager.stash_is_durable is True
 
     def test_false_before_init(self):
-        cm = ContextManager()
-        assert cm.stash_is_durable is False
+        context_manager = ContextManager()
+        assert context_manager.stash_is_durable is False

--- a/strands-py/tests/strands/_context_manager/test_context_manager.py
+++ b/strands-py/tests/strands/_context_manager/test_context_manager.py
@@ -3,7 +3,6 @@
 import unittest.mock
 
 import pytest
-
 from strands._context_manager.context_manager import ContextManager
 from strands._context_manager.strategies.offload import Offload
 from strands._context_manager.strategies.offload.truncate import EmergencyTruncateStrategy

--- a/strands-py/tests/strands/_context_manager/test_context_manager.py
+++ b/strands-py/tests/strands/_context_manager/test_context_manager.py
@@ -423,6 +423,16 @@ class TestStashIsDurable:
         context_manager.init_agent(mock_agent)
         assert context_manager.stash_is_durable is True
 
+    def test_false_with_namespaced_in_memory_storage(self, mock_agent):
+        from strands.storage.in_memory_storage import InMemoryStorage
+        from strands.storage.storage import _NamespacedStorage
+
+        mock_agent.session_id = "test-session"
+        mock_agent.storage = _NamespacedStorage(InMemoryStorage(), "tenant")
+        context_manager = ContextManager(stash=True)
+        context_manager.init_agent(mock_agent)
+        assert context_manager.stash_is_durable is False
+
     def test_false_before_init(self):
         context_manager = ContextManager()
         assert context_manager.stash_is_durable is False

--- a/strands-py/tests/strands/_context_manager/test_stash.py
+++ b/strands-py/tests/strands/_context_manager/test_stash.py
@@ -4,7 +4,6 @@ import json
 import unittest.mock
 
 import pytest
-
 from strands._context_manager.stash import Stash, _BytesEncoder, _format_stash_refs
 from strands.storage.in_memory_storage import InMemoryStorage
 from strands.types.content import ContentBlock, Message

--- a/strands-py/tests/strands/_context_manager/test_stash.py
+++ b/strands-py/tests/strands/_context_manager/test_stash.py
@@ -240,3 +240,94 @@ class TestStoreMessageErrorHandling:
         )
         message = Message(role="user", content=[block])
         await stash.store_message(message)
+
+
+class TestStorageTypeName:
+    """Tests for storage_type_name property."""
+
+    def test_returns_class_name_of_base_storage(self):
+        storage = InMemoryStorage()
+        stash = Stash(storage, "s", "a")
+        assert stash.storage_type_name == "InMemoryStorage"
+
+
+class TestTakeSnapshot:
+    """Tests for take_snapshot — serializing all entries."""
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_dict_when_no_entries(self, stash):
+        result = await stash.take_snapshot()
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_returns_all_stored_entries(self, stash):
+        await stash.store("tool-1", 0, json.dumps({"text": "hello"}).encode("utf-8"))
+        await stash.store("tool-2", 0, json.dumps({"text": "world"}).encode("utf-8"))
+        result = await stash.take_snapshot()
+        assert result == {"tool-1_0": {"text": "hello"}, "tool-2_0": {"text": "world"}}
+
+
+class TestLoadSnapshot:
+    """Tests for load_snapshot — restoring entries from a snapshot."""
+
+    @pytest.mark.asyncio
+    async def test_restores_entries(self, stash):
+        entries = {"tool-1_0": {"text": "hello"}, "tool-2_0": {"text": "world"}}
+        await stash.load_snapshot(entries)
+        assert await stash.retrieve("tool-1_0") == {"text": "hello"}
+        assert await stash.retrieve("tool-2_0") == {"text": "world"}
+
+    @pytest.mark.asyncio
+    async def test_round_trip(self, stash):
+        await stash.store("tool-1", 0, json.dumps({"text": "original"}).encode("utf-8"))
+        snapshot = await stash.take_snapshot()
+
+        new_stash = Stash(InMemoryStorage(), "test-session", "test-agent")
+        await new_stash.load_snapshot(snapshot)
+        assert await new_stash.retrieve("tool-1_0") == {"text": "original"}
+
+
+class TestClear:
+    """Tests for clear — deleting all entries in the agent namespace."""
+
+    @pytest.mark.asyncio
+    async def test_deletes_all_entries(self, stash):
+        await stash.store("tool-1", 0, json.dumps({"text": "a"}).encode("utf-8"))
+        await stash.store("tool-2", 0, json.dumps({"text": "b"}).encode("utf-8"))
+        await stash.clear()
+        assert await stash.list() == []
+
+    @pytest.mark.asyncio
+    async def test_clear_on_empty_stash(self, stash):
+        await stash.clear()
+        assert await stash.list() == []
+
+
+class TestClearSession:
+    """Tests for clear_session — deleting all stash data for the session."""
+
+    @pytest.mark.asyncio
+    async def test_deletes_entries_across_agents(self):
+        storage = InMemoryStorage()
+        stash_a = Stash(storage, "sess-1", "agent-a")
+        stash_b = Stash(storage, "sess-1", "agent-b")
+        await stash_a.store("tool-1", 0, json.dumps({"text": "a"}).encode("utf-8"))
+        await stash_b.store("tool-1", 0, json.dumps({"text": "b"}).encode("utf-8"))
+
+        await stash_a.clear_session()
+
+        assert await stash_a.list() == []
+        assert await stash_b.list() == []
+
+    @pytest.mark.asyncio
+    async def test_does_not_affect_other_sessions(self):
+        storage = InMemoryStorage()
+        stash_s1 = Stash(storage, "sess-1", "agent-a")
+        stash_s2 = Stash(storage, "sess-2", "agent-a")
+        await stash_s1.store("tool-1", 0, json.dumps({"text": "s1"}).encode("utf-8"))
+        await stash_s2.store("tool-1", 0, json.dumps({"text": "s2"}).encode("utf-8"))
+
+        await stash_s1.clear_session()
+
+        assert await stash_s1.list() == []
+        assert await stash_s2.list() == ["tool-1_0"]

--- a/strands-py/tests/strands/_context_manager/test_stash.py
+++ b/strands-py/tests/strands/_context_manager/test_stash.py
@@ -4,6 +4,7 @@ import json
 import unittest.mock
 
 import pytest
+
 from strands._context_manager.stash import Stash, _BytesEncoder, _format_stash_refs
 from strands.storage.in_memory_storage import InMemoryStorage
 from strands.types.content import ContentBlock, Message
@@ -330,3 +331,17 @@ class TestClearSession:
 
         assert await stash_s1.list() == []
         assert await stash_s2.list() == ["tool-1_0"]
+
+    @pytest.mark.asyncio
+    async def test_prefix_boundary_does_not_broaden(self):
+        """Clearing session 's1' must not affect session 's10'."""
+        storage = InMemoryStorage()
+        stash_s1 = Stash(storage, "s1", "agent-a")
+        stash_s10 = Stash(storage, "s10", "agent-a")
+        await stash_s1.store("tool-1", 0, json.dumps({"text": "s1"}).encode("utf-8"))
+        await stash_s10.store("tool-1", 0, json.dumps({"text": "s10"}).encode("utf-8"))
+
+        await stash_s1.clear_session()
+
+        assert await stash_s1.list() == []
+        assert await stash_s10.list() == ["tool-1_0"]

--- a/strands-py/tests/strands/agent/test_agent_context_manager.py
+++ b/strands-py/tests/strands/agent/test_agent_context_manager.py
@@ -100,3 +100,22 @@ class TestContextManagerErrors:
     def test_raises_with_unsupported_value(self, mock_model):
         with pytest.raises(ValueError, match="Unsupported context_manager value"):
             Agent(model=mock_model, context_manager="manual")
+
+
+class TestContextManagerProperty:
+    """Tests for the Agent.context_manager property."""
+
+    def test_returns_none_when_no_context_manager(self, mock_model):
+        agent = Agent(model=mock_model)
+        assert agent.context_manager is None
+
+    def test_returns_context_manager_instance(self, mock_model):
+        from strands._context_manager.context_manager import ContextManager
+
+        cm = ContextManager()
+        agent = Agent(model=mock_model, context_manager=cm)
+        assert agent.context_manager is cm
+
+    def test_returns_none_for_auto_mode(self, mock_model):
+        agent = Agent(model=mock_model, context_manager="auto")
+        assert agent.context_manager is None

--- a/strands-py/tests/strands/agent/test_agent_context_manager.py
+++ b/strands-py/tests/strands/agent/test_agent_context_manager.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock
 
 import pytest
+
 from strands import Agent, Plugin
 from strands.agent.conversation_manager import SlidingWindowConversationManager, SummarizingConversationManager
 from strands.vended_plugins.context_offloader import ContextOffloader, InMemoryStorage
@@ -111,9 +112,9 @@ class TestContextManagerProperty:
     def test_returns_context_manager_instance(self, mock_model):
         from strands._context_manager.context_manager import ContextManager
 
-        cm = ContextManager()
-        agent = Agent(model=mock_model, context_manager=cm)
-        assert agent.context_manager is cm
+        context_manager = ContextManager()
+        agent = Agent(model=mock_model, context_manager=context_manager)
+        assert agent.context_manager is context_manager
 
     def test_returns_none_for_auto_mode(self, mock_model):
         agent = Agent(model=mock_model, context_manager="auto")

--- a/strands-py/tests/strands/agent/test_agent_context_manager.py
+++ b/strands-py/tests/strands/agent/test_agent_context_manager.py
@@ -3,7 +3,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-
 from strands import Agent, Plugin
 from strands.agent.conversation_manager import SlidingWindowConversationManager, SummarizingConversationManager
 from strands.vended_plugins.context_offloader import ContextOffloader, InMemoryStorage

--- a/strands-py/tests/strands/agent/test_agent_context_manager.py
+++ b/strands-py/tests/strands/agent/test_agent_context_manager.py
@@ -119,3 +119,10 @@ class TestContextManagerProperty:
     def test_returns_none_for_auto_mode(self, mock_model):
         agent = Agent(model=mock_model, context_manager="auto")
         assert agent.context_manager is None
+
+    def test_rejects_context_manager_passed_via_plugins(self, mock_model):
+        from strands._context_manager.context_manager import ContextManager
+
+        context_manager = ContextManager()
+        with pytest.raises(ValueError, match="passed via plugins"):
+            Agent(model=mock_model, plugins=[context_manager])

--- a/strands-py/tests/strands/session/test_snapshot_session_manager.py
+++ b/strands-py/tests/strands/session/test_snapshot_session_manager.py
@@ -1,12 +1,15 @@
 """Tests for SnapshotSessionManager."""
 
 import asyncio
+import json
+import logging
 import tempfile
 import uuid
 from unittest.mock import AsyncMock, Mock
 
 import pytest
 
+from strands._context_manager.context_manager import ContextManager
 from strands.agent.agent import Agent
 from strands.agent.conversation_manager.sliding_window_conversation_manager import SlidingWindowConversationManager
 from strands.experimental.hooks.events import BidiAgentInitializedEvent
@@ -15,10 +18,13 @@ from strands.multiagent import GraphBuilder, Swarm
 from strands.session.snapshot_session_manager import (
     SnapshotSessionManager,
     _new_snapshot_id,
+    _serialize_snapshot,
     _session_prefix,
     _snapshot_key,
 )
 from strands.storage import LocalFileStorage
+from strands.storage.in_memory_storage import InMemoryStorage
+from strands.types._snapshot import Snapshot
 from strands.types.content import ContentBlock
 from strands.types.exceptions import ContextWindowOverflowException, SnapshotException
 from tests.fixtures.mocked_model_provider import MockedModelProvider
@@ -827,38 +833,28 @@ async def test_wrong_shape_snapshot_raises_typed_error_on_restore(temp_dir, blob
 class TestSnapshotStashIntegration:
     """Tests for context-manager stash persistence through snapshots."""
 
-    def test_save_includes_inline_stash_for_ephemeral_storage(self, storage):
+    @pytest.mark.asyncio
+    async def test_save_includes_inline_stash_for_ephemeral_storage(self, storage):
         """Agent with InMemoryStorage-backed stash → stash entries are inlined in the snapshot."""
-        from strands._context_manager.context_manager import ContextManager
-        from strands.storage.in_memory_storage import InMemoryStorage
-
         context_manager = ContextManager(stash={"storage": InMemoryStorage()})
         manager = SnapshotSessionManager("s1", storage=storage)
         agent = Agent(model=_model("hi"), session_manager=manager, context_manager=context_manager, agent_id="a1")
         agent("go")
 
-        # Manually store something in the stash so save has content to inline
-        import asyncio
-
-        asyncio.run(context_manager.stash.load_snapshot({"ref-1": {"text": "stashed content"}}))
+        await context_manager.stash.load_snapshot({"ref-1": {"text": "stashed content"}})
         manager.sync_agent(agent)
 
         # Restore into a new agent and verify stash round-trips
-        cm2 = ContextManager(stash={"storage": InMemoryStorage()})
+        restored_context_manager = ContextManager(stash={"storage": InMemoryStorage()})
         manager2 = SnapshotSessionManager("s1", storage=storage)
-        Agent(model=_model("x"), session_manager=manager2, context_manager=cm2, agent_id="a1")
+        Agent(model=_model("x"), session_manager=manager2, context_manager=restored_context_manager, agent_id="a1")
 
-        result = asyncio.run(cm2.stash.retrieve("ref-1"))
+        result = await restored_context_manager.stash.retrieve("ref-1")
         assert result == {"text": "stashed content"}
 
-    def test_save_writes_external_ref_for_durable_storage(self, temp_dir):
+    @pytest.mark.asyncio
+    async def test_save_writes_external_ref_for_durable_storage(self, temp_dir):
         """Agent with durable stash storage → snapshot carries an external reference, not inline data."""
-        import asyncio
-        import json
-
-        from strands._context_manager.context_manager import ContextManager
-        from strands.storage import LocalFileStorage
-
         stash_storage = LocalFileStorage(f"{temp_dir}/stash")
         context_manager = ContextManager(stash={"storage": stash_storage})
         session_storage = LocalFileStorage(f"{temp_dir}/session")
@@ -866,64 +862,48 @@ class TestSnapshotStashIntegration:
         agent = Agent(model=_model("hi"), session_manager=manager, context_manager=context_manager, agent_id="a1")
         agent("go")
 
-        asyncio.run(context_manager.stash.load_snapshot({"ref-1": {"text": "durable"}}))
+        await context_manager.stash.load_snapshot({"ref-1": {"text": "durable"}})
         manager.sync_agent(agent)
 
         # Read the raw snapshot and verify it has an external ref
         key = _on_disk_key("s1", "a1")
-        raw = asyncio.run(session_storage.read(key))
+        raw = await session_storage.read(key)
         snapshot_data = json.loads(raw)
         stash_data = snapshot_data["data"].get("stash")
         assert stash_data is not None
         assert stash_data["location"] == "external"
         assert stash_data["storage_type"] == "LocalFileStorage"
 
-    def test_save_omits_stash_when_no_context_manager(self, storage):
+    @pytest.mark.asyncio
+    async def test_save_omits_stash_when_no_context_manager(self, storage):
         """Agent without ContextManager → snapshot has no stash key."""
-        import asyncio
-        import json
-
         manager = SnapshotSessionManager("s1", storage=storage)
         agent = Agent(model=_model("hi"), session_manager=manager, agent_id="a1")
         agent("go")
 
         key = _on_disk_key("s1", "a1")
-        raw = asyncio.run(storage.read(key))
+        raw = await storage.read(key)
         snapshot_data = json.loads(raw)
         assert "stash" not in snapshot_data["data"]
 
-    def test_save_omits_stash_when_empty(self, storage):
+    @pytest.mark.asyncio
+    async def test_save_omits_stash_when_empty(self, storage):
         """Agent with stash but no stored entries → no stash key in snapshot."""
-        import asyncio
-        import json
-
-        from strands._context_manager.context_manager import ContextManager
-        from strands.storage.in_memory_storage import InMemoryStorage
-
         context_manager = ContextManager(stash={"storage": InMemoryStorage()})
         manager = SnapshotSessionManager("s1", storage=storage)
         agent = Agent(model=_model("hi"), session_manager=manager, context_manager=context_manager, agent_id="a1")
         agent("go")
 
-        # Ensure the stash is empty before saving
-        asyncio.run(context_manager.stash.clear())
+        await context_manager.stash.clear()
         manager.sync_agent(agent)
 
         key = _on_disk_key("s1", "a1")
-        raw = asyncio.run(storage.read(key))
+        raw = await storage.read(key)
         snapshot_data = json.loads(raw)
         assert "stash" not in snapshot_data["data"]
 
     def test_restore_warns_on_storage_type_mismatch(self, storage, caplog):
         """Restoring an external-ref snapshot with a different storage type logs a warning."""
-        import asyncio
-        import logging
-
-        from strands._context_manager.context_manager import ContextManager
-        from strands.storage.in_memory_storage import InMemoryStorage
-        from strands.types._snapshot import Snapshot
-
-        # Write a snapshot with an external stash ref pointing at S3Storage
         snapshot = Snapshot(
             scope="agent",
             schema_version="1.0",
@@ -934,12 +914,9 @@ class TestSnapshotStashIntegration:
             },
             app_data={},
         )
-        from strands.session.snapshot_session_manager import _serialize_snapshot
-
         key = _on_disk_key("s1", "a1")
         asyncio.run(storage.write(key, _serialize_snapshot(snapshot)))
 
-        # Restore into agent with InMemoryStorage stash
         context_manager = ContextManager(stash={"storage": InMemoryStorage()})
         manager = SnapshotSessionManager("s1", storage=storage)
         with caplog.at_level(logging.WARNING, logger="strands.session.snapshot_session_manager"):
@@ -950,10 +927,6 @@ class TestSnapshotStashIntegration:
     @pytest.mark.asyncio
     async def test_delete_session_clears_stash(self, temp_dir):
         """delete_session removes stash data in addition to snapshots."""
-        from strands._context_manager.context_manager import ContextManager
-        from strands.storage import LocalFileStorage
-        from strands.storage.in_memory_storage import InMemoryStorage
-
         session_storage = LocalFileStorage(f"{temp_dir}/session")
         stash_mem = InMemoryStorage()
         context_manager = ContextManager(stash={"storage": stash_mem})
@@ -961,7 +934,6 @@ class TestSnapshotStashIntegration:
         agent = Agent(model=_model("hi"), session_manager=manager, context_manager=context_manager, agent_id="a1")
         agent("go")
 
-        # Put data in the stash
         await context_manager.stash.load_snapshot({"ref-1": {"text": "data"}})
         assert await context_manager.stash.list() != []
 
@@ -977,4 +949,42 @@ class TestSnapshotStashIntegration:
 
         manager2 = SnapshotSessionManager("s1", storage=storage)
         agent2 = Agent(model=_model("x"), session_manager=manager2, agent_id="a1")
+        assert _texts(agent2) == _texts(agent)
+
+    @pytest.mark.asyncio
+    async def test_save_succeeds_when_stash_storage_fails(self, storage):
+        """A stash storage error during save logs a warning but the snapshot is still persisted."""
+        context_manager = ContextManager(stash={"storage": InMemoryStorage()})
+        manager = SnapshotSessionManager("s1", storage=storage)
+        agent = Agent(model=_model("hi"), session_manager=manager, context_manager=context_manager, agent_id="a1")
+        agent("go")
+
+        context_manager.stash._storage.list = AsyncMock(side_effect=RuntimeError("disk full"))
+        manager.sync_agent(agent)
+
+        key = _on_disk_key("s1", "a1")
+        raw = await storage.read(key)
+        assert raw is not None
+        snapshot_data = json.loads(raw)
+        assert "stash" not in snapshot_data["data"]
+
+    def test_restore_succeeds_when_stash_load_fails(self, storage):
+        """A stash storage error during restore logs a warning but the agent is still restored."""
+        context_manager = ContextManager(stash={"storage": InMemoryStorage()})
+        manager = SnapshotSessionManager("s1", storage=storage)
+        agent = Agent(model=_model("hi"), session_manager=manager, context_manager=context_manager, agent_id="a1")
+        agent("go")
+
+        asyncio.run(context_manager.stash.load_snapshot({"ref-1": {"text": "data"}}))
+        manager.sync_agent(agent)
+
+        restored_context_manager = ContextManager(stash={"storage": InMemoryStorage()})
+        restored_context_manager._stash = Mock()
+        restored_context_manager._stash.load_snapshot = AsyncMock(side_effect=RuntimeError("corrupted"))
+        restored_context_manager._stash.storage_type_name = "InMemoryStorage"
+
+        manager2 = SnapshotSessionManager("s1", storage=storage)
+        agent2 = Agent(
+            model=_model("x"), session_manager=manager2, context_manager=restored_context_manager, agent_id="a1"
+        )
         assert _texts(agent2) == _texts(agent)

--- a/strands-py/tests/strands/session/test_snapshot_session_manager.py
+++ b/strands-py/tests/strands/session/test_snapshot_session_manager.py
@@ -6,6 +6,7 @@ import uuid
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+
 from strands.agent.agent import Agent
 from strands.agent.conversation_manager.sliding_window_conversation_manager import SlidingWindowConversationManager
 from strands.experimental.hooks.events import BidiAgentInitializedEvent
@@ -20,7 +21,6 @@ from strands.session.snapshot_session_manager import (
 from strands.storage import LocalFileStorage
 from strands.types.content import ContentBlock
 from strands.types.exceptions import ContextWindowOverflowException, SnapshotException
-
 from tests.fixtures.mocked_model_provider import MockedModelProvider
 
 
@@ -832,15 +832,15 @@ class TestSnapshotStashIntegration:
         from strands._context_manager.context_manager import ContextManager
         from strands.storage.in_memory_storage import InMemoryStorage
 
-        cm = ContextManager(stash={"storage": InMemoryStorage()})
+        context_manager = ContextManager(stash={"storage": InMemoryStorage()})
         manager = SnapshotSessionManager("s1", storage=storage)
-        agent = Agent(model=_model("hi"), session_manager=manager, context_manager=cm, agent_id="a1")
+        agent = Agent(model=_model("hi"), session_manager=manager, context_manager=context_manager, agent_id="a1")
         agent("go")
 
         # Manually store something in the stash so save has content to inline
         import asyncio
 
-        asyncio.run(cm.stash.load_snapshot({"ref-1": {"text": "stashed content"}}))
+        asyncio.run(context_manager.stash.load_snapshot({"ref-1": {"text": "stashed content"}}))
         manager.sync_agent(agent)
 
         # Restore into a new agent and verify stash round-trips
@@ -860,13 +860,13 @@ class TestSnapshotStashIntegration:
         from strands.storage import LocalFileStorage
 
         stash_storage = LocalFileStorage(f"{temp_dir}/stash")
-        cm = ContextManager(stash={"storage": stash_storage})
+        context_manager = ContextManager(stash={"storage": stash_storage})
         session_storage = LocalFileStorage(f"{temp_dir}/session")
         manager = SnapshotSessionManager("s1", storage=session_storage)
-        agent = Agent(model=_model("hi"), session_manager=manager, context_manager=cm, agent_id="a1")
+        agent = Agent(model=_model("hi"), session_manager=manager, context_manager=context_manager, agent_id="a1")
         agent("go")
 
-        asyncio.run(cm.stash.load_snapshot({"ref-1": {"text": "durable"}}))
+        asyncio.run(context_manager.stash.load_snapshot({"ref-1": {"text": "durable"}}))
         manager.sync_agent(agent)
 
         # Read the raw snapshot and verify it has an external ref
@@ -900,13 +900,13 @@ class TestSnapshotStashIntegration:
         from strands._context_manager.context_manager import ContextManager
         from strands.storage.in_memory_storage import InMemoryStorage
 
-        cm = ContextManager(stash={"storage": InMemoryStorage()})
+        context_manager = ContextManager(stash={"storage": InMemoryStorage()})
         manager = SnapshotSessionManager("s1", storage=storage)
-        agent = Agent(model=_model("hi"), session_manager=manager, context_manager=cm, agent_id="a1")
+        agent = Agent(model=_model("hi"), session_manager=manager, context_manager=context_manager, agent_id="a1")
         agent("go")
 
         # Ensure the stash is empty before saving
-        asyncio.run(cm.stash.clear())
+        asyncio.run(context_manager.stash.clear())
         manager.sync_agent(agent)
 
         key = _on_disk_key("s1", "a1")
@@ -940,10 +940,10 @@ class TestSnapshotStashIntegration:
         asyncio.run(storage.write(key, _serialize_snapshot(snapshot)))
 
         # Restore into agent with InMemoryStorage stash
-        cm = ContextManager(stash={"storage": InMemoryStorage()})
+        context_manager = ContextManager(stash={"storage": InMemoryStorage()})
         manager = SnapshotSessionManager("s1", storage=storage)
         with caplog.at_level(logging.WARNING, logger="strands.session.snapshot_session_manager"):
-            Agent(model=_model("x"), session_manager=manager, context_manager=cm, agent_id="a1")
+            Agent(model=_model("x"), session_manager=manager, context_manager=context_manager, agent_id="a1")
 
         assert any("stash storage type changed" in record.message for record in caplog.records)
 
@@ -956,18 +956,18 @@ class TestSnapshotStashIntegration:
 
         session_storage = LocalFileStorage(f"{temp_dir}/session")
         stash_mem = InMemoryStorage()
-        cm = ContextManager(stash={"storage": stash_mem})
+        context_manager = ContextManager(stash={"storage": stash_mem})
         manager = SnapshotSessionManager("s1", storage=session_storage)
-        agent = Agent(model=_model("hi"), session_manager=manager, context_manager=cm, agent_id="a1")
+        agent = Agent(model=_model("hi"), session_manager=manager, context_manager=context_manager, agent_id="a1")
         agent("go")
 
         # Put data in the stash
-        await cm.stash.load_snapshot({"ref-1": {"text": "data"}})
-        assert await cm.stash.list() != []
+        await context_manager.stash.load_snapshot({"ref-1": {"text": "data"}})
+        assert await context_manager.stash.list() != []
 
         await manager.delete_session()
 
-        assert await cm.stash.list() == []
+        assert await context_manager.stash.list() == []
 
     def test_no_context_manager_save_restore_works(self, storage):
         """Save/restore works normally when no ContextManager is present."""

--- a/strands-py/tests/strands/session/test_snapshot_session_manager.py
+++ b/strands-py/tests/strands/session/test_snapshot_session_manager.py
@@ -817,3 +817,164 @@ async def test_wrong_shape_snapshot_raises_typed_error_on_restore(temp_dir, blob
 
     with pytest.raises(SnapshotException):
         Agent(model=_model("hi"), session_manager=SnapshotSessionManager("s1", storage=storage), agent_id="a1")
+
+
+# ---------------------------------------------------------------------------
+# Stash integration
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotStashIntegration:
+    """Tests for context-manager stash persistence through snapshots."""
+
+    def test_save_includes_inline_stash_for_ephemeral_storage(self, storage):
+        """Agent with InMemoryStorage-backed stash → stash entries are inlined in the snapshot."""
+        from strands._context_manager.context_manager import ContextManager
+        from strands.storage.in_memory_storage import InMemoryStorage
+
+        cm = ContextManager(stash={"storage": InMemoryStorage()})
+        manager = SnapshotSessionManager("s1", storage=storage)
+        agent = Agent(model=_model("hi"), session_manager=manager, context_manager=cm, agent_id="a1")
+        agent("go")
+
+        # Manually store something in the stash so save has content to inline
+        import asyncio
+
+        asyncio.run(cm.stash.load_snapshot({"ref-1": {"text": "stashed content"}}))
+        manager.sync_agent(agent)
+
+        # Restore into a new agent and verify stash round-trips
+        cm2 = ContextManager(stash={"storage": InMemoryStorage()})
+        manager2 = SnapshotSessionManager("s1", storage=storage)
+        Agent(model=_model("x"), session_manager=manager2, context_manager=cm2, agent_id="a1")
+
+        result = asyncio.run(cm2.stash.retrieve("ref-1"))
+        assert result == {"text": "stashed content"}
+
+    def test_save_writes_external_ref_for_durable_storage(self, temp_dir):
+        """Agent with durable stash storage → snapshot carries an external reference, not inline data."""
+        import asyncio
+        import json
+
+        from strands._context_manager.context_manager import ContextManager
+        from strands.storage import LocalFileStorage
+
+        stash_storage = LocalFileStorage(f"{temp_dir}/stash")
+        cm = ContextManager(stash={"storage": stash_storage})
+        session_storage = LocalFileStorage(f"{temp_dir}/session")
+        manager = SnapshotSessionManager("s1", storage=session_storage)
+        agent = Agent(model=_model("hi"), session_manager=manager, context_manager=cm, agent_id="a1")
+        agent("go")
+
+        asyncio.run(cm.stash.load_snapshot({"ref-1": {"text": "durable"}}))
+        manager.sync_agent(agent)
+
+        # Read the raw snapshot and verify it has an external ref
+        key = _on_disk_key("s1", "a1")
+        raw = asyncio.run(session_storage.read(key))
+        snapshot_data = json.loads(raw)
+        stash_data = snapshot_data["data"].get("stash")
+        assert stash_data is not None
+        assert stash_data["location"] == "external"
+        assert stash_data["storage_type"] == "LocalFileStorage"
+
+    def test_save_omits_stash_when_no_context_manager(self, storage):
+        """Agent without ContextManager → snapshot has no stash key."""
+        import asyncio
+        import json
+
+        manager = SnapshotSessionManager("s1", storage=storage)
+        agent = Agent(model=_model("hi"), session_manager=manager, agent_id="a1")
+        agent("go")
+
+        key = _on_disk_key("s1", "a1")
+        raw = asyncio.run(storage.read(key))
+        snapshot_data = json.loads(raw)
+        assert "stash" not in snapshot_data["data"]
+
+    def test_save_omits_stash_when_empty(self, storage):
+        """Agent with stash but no stored entries → no stash key in snapshot."""
+        import asyncio
+        import json
+
+        from strands._context_manager.context_manager import ContextManager
+        from strands.storage.in_memory_storage import InMemoryStorage
+
+        cm = ContextManager(stash={"storage": InMemoryStorage()})
+        manager = SnapshotSessionManager("s1", storage=storage)
+        agent = Agent(model=_model("hi"), session_manager=manager, context_manager=cm, agent_id="a1")
+        agent("go")
+
+        # Ensure the stash is empty before saving
+        asyncio.run(cm.stash.clear())
+        manager.sync_agent(agent)
+
+        key = _on_disk_key("s1", "a1")
+        raw = asyncio.run(storage.read(key))
+        snapshot_data = json.loads(raw)
+        assert "stash" not in snapshot_data["data"]
+
+    def test_restore_warns_on_storage_type_mismatch(self, storage, caplog):
+        """Restoring an external-ref snapshot with a different storage type logs a warning."""
+        import asyncio
+        import logging
+
+        from strands._context_manager.context_manager import ContextManager
+        from strands.storage.in_memory_storage import InMemoryStorage
+        from strands.types._snapshot import Snapshot
+
+        # Write a snapshot with an external stash ref pointing at S3Storage
+        snapshot = Snapshot(
+            scope="agent",
+            schema_version="1.0",
+            data={
+                "messages": [],
+                "state": {},
+                "stash": {"location": "external", "storage_type": "S3Storage"},
+            },
+            app_data={},
+        )
+        from strands.session.snapshot_session_manager import _serialize_snapshot
+
+        key = _on_disk_key("s1", "a1")
+        asyncio.run(storage.write(key, _serialize_snapshot(snapshot)))
+
+        # Restore into agent with InMemoryStorage stash
+        cm = ContextManager(stash={"storage": InMemoryStorage()})
+        manager = SnapshotSessionManager("s1", storage=storage)
+        with caplog.at_level(logging.WARNING, logger="strands.session.snapshot_session_manager"):
+            Agent(model=_model("x"), session_manager=manager, context_manager=cm, agent_id="a1")
+
+        assert any("stash storage type changed" in record.message for record in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_delete_session_clears_stash(self, temp_dir):
+        """delete_session removes stash data in addition to snapshots."""
+        from strands._context_manager.context_manager import ContextManager
+        from strands.storage import LocalFileStorage
+        from strands.storage.in_memory_storage import InMemoryStorage
+
+        session_storage = LocalFileStorage(f"{temp_dir}/session")
+        stash_mem = InMemoryStorage()
+        cm = ContextManager(stash={"storage": stash_mem})
+        manager = SnapshotSessionManager("s1", storage=session_storage)
+        agent = Agent(model=_model("hi"), session_manager=manager, context_manager=cm, agent_id="a1")
+        agent("go")
+
+        # Put data in the stash
+        await cm.stash.load_snapshot({"ref-1": {"text": "data"}})
+        assert await cm.stash.list() != []
+
+        await manager.delete_session()
+
+        assert await cm.stash.list() == []
+
+    def test_no_context_manager_save_restore_works(self, storage):
+        """Save/restore works normally when no ContextManager is present."""
+        manager = SnapshotSessionManager("s1", storage=storage)
+        agent = Agent(model=_model("hi"), session_manager=manager, agent_id="a1")
+        agent("go")
+
+        manager2 = SnapshotSessionManager("s1", storage=storage)
+        agent2 = Agent(model=_model("x"), session_manager=manager2, agent_id="a1")
+        assert _texts(agent2) == _texts(agent)

--- a/strands-py/tests/strands/session/test_snapshot_session_manager.py
+++ b/strands-py/tests/strands/session/test_snapshot_session_manager.py
@@ -6,7 +6,6 @@ import uuid
 from unittest.mock import AsyncMock, Mock
 
 import pytest
-
 from strands.agent.agent import Agent
 from strands.agent.conversation_manager.sliding_window_conversation_manager import SlidingWindowConversationManager
 from strands.experimental.hooks.events import BidiAgentInitializedEvent
@@ -21,6 +20,7 @@ from strands.session.snapshot_session_manager import (
 from strands.storage import LocalFileStorage
 from strands.types.content import ContentBlock
 from strands.types.exceptions import ContextWindowOverflowException, SnapshotException
+
 from tests.fixtures.mocked_model_provider import MockedModelProvider
 
 

--- a/strands-py/tests/strands/session/test_snapshot_session_manager.py
+++ b/strands-py/tests/strands/session/test_snapshot_session_manager.py
@@ -951,23 +951,6 @@ class TestSnapshotStashIntegration:
         agent2 = Agent(model=_model("x"), session_manager=manager2, agent_id="a1")
         assert _texts(agent2) == _texts(agent)
 
-    @pytest.mark.asyncio
-    async def test_save_succeeds_when_stash_storage_fails(self, storage):
-        """A stash storage error during save logs a warning but the snapshot is still persisted."""
-        context_manager = ContextManager(stash={"storage": InMemoryStorage()})
-        manager = SnapshotSessionManager("s1", storage=storage)
-        agent = Agent(model=_model("hi"), session_manager=manager, context_manager=context_manager, agent_id="a1")
-        agent("go")
-
-        context_manager.stash._storage.list = AsyncMock(side_effect=RuntimeError("disk full"))
-        manager.sync_agent(agent)
-
-        key = _on_disk_key("s1", "a1")
-        raw = await storage.read(key)
-        assert raw is not None
-        snapshot_data = json.loads(raw)
-        assert "stash" not in snapshot_data["data"]
-
     def test_restore_succeeds_when_stash_load_fails(self, storage):
         """A stash storage error during restore logs a warning but the agent is still restored."""
         context_manager = ContextManager(stash={"storage": InMemoryStorage()})
@@ -988,3 +971,44 @@ class TestSnapshotStashIntegration:
             model=_model("x"), session_manager=manager2, context_manager=restored_context_manager, agent_id="a1"
         )
         assert _texts(agent2) == _texts(agent)
+
+    @pytest.mark.asyncio
+    async def test_immutable_snapshot_includes_stash(self, temp_dir):
+        """A snapshot_trigger produces an immutable checkpoint with inline stash data."""
+        session_storage = LocalFileStorage(f"{temp_dir}/session")
+        context_manager = ContextManager(stash={"storage": InMemoryStorage()})
+        manager = SnapshotSessionManager(
+            "s1", storage=session_storage, snapshot_trigger=lambda **_: True
+        )
+        agent = Agent(model=_model("hi"), session_manager=manager, context_manager=context_manager, agent_id="a1")
+
+        await context_manager.stash.load_snapshot({"ref-1": {"text": "immutable data"}})
+        agent("go")
+
+        immutable_prefix = f"session/{_session_prefix('s1')}scopes/agent/a1/snapshots/immutable_history/"
+        keys = await session_storage.list(immutable_prefix)
+        assert len(keys) >= 1
+
+        raw = await session_storage.read(keys[0])
+        snapshot_data = json.loads(raw)
+        assert snapshot_data["data"]["stash"]["location"] == "inline"
+        assert "ref-1" in snapshot_data["data"]["stash"]["entries"]
+
+    @pytest.mark.asyncio
+    async def test_ephemeral_detection_survives_namespacing(self, storage):
+        """An InMemoryStorage wrapped with .namespace() is still detected as ephemeral."""
+        from strands.storage.storage import _NamespacedStorage
+
+        namespaced = _NamespacedStorage(InMemoryStorage(), "tenant")
+        context_manager = ContextManager(stash={"storage": namespaced})
+        manager = SnapshotSessionManager("s1", storage=storage)
+        agent = Agent(model=_model("hi"), session_manager=manager, context_manager=context_manager, agent_id="a1")
+        agent("go")
+
+        await context_manager.stash.load_snapshot({"ref-1": {"text": "wrapped ephemeral"}})
+        manager.sync_agent(agent)
+
+        key = _on_disk_key("s1", "a1")
+        raw = await storage.read(key)
+        snapshot_data = json.loads(raw)
+        assert snapshot_data["data"]["stash"]["location"] == "inline"

--- a/strands-py/tests/strands/session/test_snapshot_session_manager.py
+++ b/strands-py/tests/strands/session/test_snapshot_session_manager.py
@@ -941,6 +941,23 @@ class TestSnapshotStashIntegration:
 
         assert await context_manager.stash.list() == []
 
+    @pytest.mark.asyncio
+    async def test_delete_session_without_initialize_clears_stash(self, temp_dir):
+        """delete_session on an uninitialized manager still clears stash data via storage fallback."""
+        shared_storage = LocalFileStorage(f"{temp_dir}/shared")
+        context_manager = ContextManager(stash={"storage": shared_storage})
+        manager = SnapshotSessionManager("s1", storage=shared_storage)
+        agent = Agent(model=_model("hi"), session_manager=manager, context_manager=context_manager, agent_id="a1")
+        agent("go")
+
+        await context_manager.stash.load_snapshot({"ref-1": {"text": "orphan"}})
+        assert await shared_storage.list("context/s1/") != []
+
+        bare_manager = SnapshotSessionManager("s1", storage=shared_storage)
+        await bare_manager.delete_session()
+
+        assert await shared_storage.list("context/s1/") == []
+
     def test_no_context_manager_save_restore_works(self, storage):
         """Save/restore works normally when no ContextManager is present."""
         manager = SnapshotSessionManager("s1", storage=storage)


### PR DESCRIPTION
## Description
Adds cross-session context management saturated by the session manager

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->


New feature

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [ ] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
