### PR TITLE
refactor(python): share repository session methods through LocalAgent

### DIFF
--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/session-management.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/session-management.mdx
@@ -6,6 +6,10 @@ sidebar:
 experimental: true
 tags: [bidi-streaming, session-management, snapshots]
 sourceLinks:
+  - path: strands-py/src/strands/experimental/bidi/agent/agent.py
+  - path: strands-py/src/strands/session/session_manager.py
+  - path: strands-py/src/strands/session/repository_session_manager.py
+  - path: strands-py/src/strands/types/session.py
   - path: strands-py/src/strands/session/file_session_manager.py
   - path: strands-py/src/strands/session/s3_session_manager.py
 ---
@@ -78,6 +82,11 @@ Strands offers two built-in session managers for persisting bidirectional stream
 1. **FileSessionManager**: Stores sessions in the local filesystem
 2. **S3SessionManager**: Stores sessions in Amazon S3 buckets
 
+Both inherit the shared `RepositorySessionManager` implementation. For a custom backend,
+implement a
+[session repository](../agents/session-management.md#custom-session-repositories).
+`SnapshotSessionManager` does not support `BidiAgent`.
+
 ### FileSessionManager
 
 The `FileSessionManager` provides a simple way to persist sessions to the local filesystem:
@@ -137,34 +146,55 @@ agent = BidiAgent(
 
 ### Session Creation
 
-Sessions are created automatically when the agent starts:
+Create the session by constructing a session manager. Passing it to `BidiAgent`
+initializes the agent's session data during construction:
 
 ```python
-session_manager = FileSessionManager(session_id="new_session")
-agent = BidiAgent(model=model, session_manager=session_manager)
+from strands.experimental.bidi import BidiAgent
+from strands.experimental.bidi.models import BedrockNovaSonicModel
+from strands.session import FileSessionManager
 
-# Session created on first start
-await agent.start()
+session_manager = FileSessionManager(session_id="user_123", storage_dir="./sessions/")
+agent = BidiAgent(
+    model=BedrockNovaSonicModel(),
+    agent_id="voice-assistant",
+    session_manager=session_manager,
+)
 ```
 
 ### Session Restoration
 
-When an agent starts with an existing session ID, the conversation history is automatically restored:
+To reload saved messages and application state, construct a new session manager over the
+same storage and pass it to `BidiAgent` with the same session ID and agent ID. Restoration
+happens during construction, before `await agent.start()` opens the model connection.
 
 ```python
+from strands.experimental.bidi import BidiAgent
+from strands.experimental.bidi.models import BedrockNovaSonicModel
+from strands.session import FileSessionManager
+
 # First conversation
-session_manager = FileSessionManager(session_id="user_123")
-agent = BidiAgent(model=model, session_manager=session_manager)
+session_manager = FileSessionManager(session_id="user_123", storage_dir="./sessions/")
+agent = BidiAgent(
+    model=BedrockNovaSonicModel(),
+    agent_id="voice-assistant",
+    session_manager=session_manager,
+)
 await agent.start()
 await agent.send("My name is Alice")
 # ... conversation continues ...
 await agent.stop()
 
-# Later - conversation history restored
-session_manager = FileSessionManager(session_id="user_123")
-agent = BidiAgent(model=model, session_manager=session_manager)
-await agent.start()  # Previous messages automatically loaded
-await agent.send("What's my name?")  # Agent remembers: "Alice"
+# Later: constructing a new agent restores the saved messages and state.
+session_manager = FileSessionManager(session_id="user_123", storage_dir="./sessions/")
+agent = BidiAgent(
+    model=BedrockNovaSonicModel(),
+    agent_id="voice-assistant",
+    session_manager=session_manager,
+)
+await agent.start()
+await agent.send("What's my name?")
+await agent.stop()
 ```
 
 ### Session Updates

--- a/strands-py/src/strands/experimental/bidi/agent/agent.py
+++ b/strands-py/src/strands/experimental/bidi/agent/agent.py
@@ -79,7 +79,7 @@ class BidiAgent(LocalAgent):
         description: str | None = None,
         hooks: list[HookProvider] | None = None,
         state: AgentState | dict | None = None,
-        session_manager: "SessionManager | None" = None,
+        session_manager: "SessionManager[LocalAgent] | None" = None,
         tool_executor: ToolExecutor | None = None,
         **kwargs: Any,
     ):

--- a/strands-py/src/strands/session/repository_session_manager.py
+++ b/strands-py/src/strands/session/repository_session_manager.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from ..agent.state import AgentState
 from ..tools._tool_helpers import generate_missing_tool_result_content
+from ..types.agent import LocalAgent
 from ..types.content import ContentBlock, Message, _generate_tracking_id
 from ..types.exceptions import SessionException
 from ..types.session import (
@@ -18,14 +19,12 @@ from .session_manager import SessionManager
 from .session_repository import SessionRepository
 
 if TYPE_CHECKING:
-    from ..agent.agent import Agent
-    from ..experimental.bidi.agent.agent import BidiAgent
     from ..multiagent.base import MultiAgentBase
 
 logger = logging.getLogger(__name__)
 
 
-class RepositorySessionManager(SessionManager):
+class RepositorySessionManager(SessionManager[LocalAgent]):
     """Session manager for persisting agents in a SessionRepository.
 
     This manager uses a :class:`SessionRepository` (a structured per-message CRUD interface),
@@ -75,7 +74,7 @@ class RepositorySessionManager(SessionManager):
         # Track the previously synced internal state for each agent to detect changes.
         self._last_synced_internal_state: dict[str, dict[str, Any]] = {}
 
-    def append_message(self, message: Message, agent: "Agent", **kwargs: Any) -> None:
+    def append_message(self, message: Message, agent: "LocalAgent", **kwargs: Any) -> None:
         """Append a message to the agent's session.
 
         Args:
@@ -94,7 +93,7 @@ class RepositorySessionManager(SessionManager):
         self._latest_agent_message[agent.agent_id] = session_message
         self.session_repository.create_message(self.session_id, agent.agent_id, session_message)
 
-    def redact_latest_message(self, redact_message: Message, agent: "Agent", **kwargs: Any) -> None:
+    def redact_latest_message(self, redact_message: Message, agent: "LocalAgent", **kwargs: Any) -> None:
         """Redact the latest message appended to the session.
 
         Args:
@@ -108,17 +107,22 @@ class RepositorySessionManager(SessionManager):
         latest_agent_message.redact_message = redact_message
         return self.session_repository.update_message(self.session_id, agent.agent_id, latest_agent_message)
 
-    def sync_agent(self, agent: "Agent", **kwargs: Any) -> None:
+    def sync_agent(self, agent: "LocalAgent", **kwargs: Any) -> None:
         """Serialize and update the agent into the session repository.
 
-        Only updates the agent if state has been modified or internal state has changed.
-        This optimization reduces unnecessary I/O operations when the agent processes
-        messages without modifying its state.
+        For Agent, only updates if state or internal state has changed. BidiAgent is
+        written on every sync, preserving its existing persistence behavior.
 
         Args:
             agent: Agent to sync to the session.
             **kwargs: Additional keyword arguments for future extensibility.
         """
+        from ..agent.agent import Agent
+
+        if not isinstance(agent, Agent):
+            self.session_repository.update_agent(self.session_id, SessionAgent.from_agent(agent))
+            return
+
         # Get current versions and conversation manager state
         current_state_version = agent.state._get_version()
         current_interrupt_state_version = agent._interrupt_state._get_version()
@@ -175,14 +179,20 @@ class RepositorySessionManager(SessionManager):
             "model_state": copy.deepcopy(current_model_state),
         }
 
-    def initialize(self, agent: "Agent", **kwargs: Any) -> None:
+    def initialize(self, agent: "LocalAgent", **kwargs: Any) -> None:
         """Initialize an agent with a session.
 
         Args:
             agent: Agent to initialize from the session
             **kwargs: Additional keyword arguments for future extensibility.
         """
-        if not RepositorySessionManager._warned_storage_ignored and agent.storage is not None:
+        from ..agent.agent import Agent
+
+        if (
+            isinstance(agent, Agent)
+            and not RepositorySessionManager._warned_storage_ignored
+            and agent.storage is not None
+        ):
             RepositorySessionManager._warned_storage_ignored = True
             logger.warning(
                 "agent_id=<%s> | agent-level storage is set but RepositorySessionManager does not use it;"
@@ -225,23 +235,26 @@ class RepositorySessionManager(SessionManager):
             session_agent.initialize_internal_state(agent)
 
             # Restore the conversation manager to its previous state, and get the optional prepend messages
-            prepend_messages = agent.conversation_manager.restore_from_session(session_agent.conversation_manager_state)
-
-            if prepend_messages is None:
-                prepend_messages = []
+            prepend_messages = []
+            offset = 0
+            if isinstance(agent, Agent):
+                prepend_messages = (
+                    agent.conversation_manager.restore_from_session(session_agent.conversation_manager_state) or []
+                )
+                offset = agent.conversation_manager.removed_message_count
 
             # List the messages currently in the session, using an offset of the messages previously removed
             # by the conversation manager.
             session_messages = self.session_repository.list_messages(
                 session_id=self.session_id,
                 agent_id=agent.agent_id,
-                offset=agent.conversation_manager.removed_message_count,
+                offset=offset,
             )
             if len(session_messages) > 0:
                 self._latest_agent_message[agent.agent_id] = session_messages[-1]
 
             # Skip restoring messages when conversation is managed server-side
-            if agent.model.stateful:
+            if isinstance(agent, Agent) and agent.model.stateful:
                 logger.debug(
                     "agent_id=<%s> | session_id=<%s> | skipping message restore for server-managed conversation",
                     agent.agent_id,
@@ -372,93 +385,3 @@ class RepositorySessionManager(SessionManager):
             source.deserialize_state(state)
 
         self._is_new_session = False
-
-    def initialize_bidi_agent(self, agent: "BidiAgent", **kwargs: Any) -> None:
-        """Initialize a bidirectional agent with a session.
-
-        Args:
-            agent: BidiAgent to initialize from the session
-            **kwargs: Additional keyword arguments for future extensibility.
-        """
-        if agent.agent_id in self._latest_agent_message:
-            raise SessionException("The `agent_id` of an agent must be unique in a session.")
-        self._latest_agent_message[agent.agent_id] = None
-
-        # Skip read_agent call for new sessions since no agents can exist yet
-        if self._is_new_session:
-            session_agent = None
-        else:
-            session_agent = self.session_repository.read_agent(self.session_id, agent.agent_id)
-
-        if session_agent is None:
-            logger.debug(
-                "agent_id=<%s> | session_id=<%s> | creating bidi agent",
-                agent.agent_id,
-                self.session_id,
-            )
-
-            session_agent = SessionAgent.from_bidi_agent(agent)
-            self.session_repository.create_agent(self.session_id, session_agent)
-            # Initialize messages with sequential indices
-            session_message = None
-            for i, message in enumerate(agent.messages):
-                session_message = SessionMessage.from_message(message, i)
-                self.session_repository.create_message(self.session_id, agent.agent_id, session_message)
-            self._latest_agent_message[agent.agent_id] = session_message
-        else:
-            logger.debug(
-                "agent_id=<%s> | session_id=<%s> | restoring bidi agent",
-                agent.agent_id,
-                self.session_id,
-            )
-            agent.state = AgentState(session_agent.state)
-
-            session_agent.initialize_bidi_internal_state(agent)
-
-            # BidiAgent has no conversation_manager, so no prepend_messages or removed_message_count
-            session_messages = self.session_repository.list_messages(
-                session_id=self.session_id,
-                agent_id=agent.agent_id,
-                offset=0,
-            )
-            if len(session_messages) > 0:
-                self._latest_agent_message[agent.agent_id] = session_messages[-1]
-
-            # Restore the agents messages array
-            agent.messages = [session_message.to_message() for session_message in session_messages]
-
-            # Fix broken session histories: https://github.com/strands-agents/harness-sdk/issues/859
-            agent.messages = self._fix_broken_tool_use(agent.messages)
-
-        self._is_new_session = False
-
-    def append_bidi_message(self, message: Message, agent: "BidiAgent", **kwargs: Any) -> None:
-        """Append a message to the bidirectional agent's session.
-
-        Args:
-            message: Message to add to the agent in the session
-            agent: BidiAgent to append the message to
-            **kwargs: Additional keyword arguments for future extensibility.
-        """
-        # Calculate the next index (0 if this is the first message, otherwise increment the previous index)
-        latest_agent_message = self._latest_agent_message[agent.agent_id]
-        if latest_agent_message:
-            next_index = latest_agent_message.message_id + 1
-        else:
-            next_index = 0
-
-        session_message = SessionMessage.from_message(message, next_index)
-        self._latest_agent_message[agent.agent_id] = session_message
-        self.session_repository.create_message(self.session_id, agent.agent_id, session_message)
-
-    def sync_bidi_agent(self, agent: "BidiAgent", **kwargs: Any) -> None:
-        """Serialize and update the bidirectional agent into the session repository.
-
-        Args:
-            agent: BidiAgent to sync to the session.
-            **kwargs: Additional keyword arguments for future extensibility.
-        """
-        self.session_repository.update_agent(
-            self.session_id,
-            SessionAgent.from_bidi_agent(agent),
-        )

--- a/strands-py/src/strands/session/session_manager.py
+++ b/strands-py/src/strands/session/session_manager.py
@@ -2,7 +2,9 @@
 
 import logging
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Generic
+
+from typing_extensions import TypeVar
 
 from ..experimental.hooks.events import (
     BidiAfterInvocationEvent,
@@ -22,19 +24,25 @@ from ..types.content import Message
 
 if TYPE_CHECKING:
     from ..agent.agent import Agent
-    from ..experimental.bidi.agent.agent import BidiAgent
     from ..multiagent.base import MultiAgentBase
+    from ..types.agent import LocalAgent
 
 logger = logging.getLogger(__name__)
 
 
-class SessionManager(HookProvider, ABC):
+_SessionAgentT = TypeVar("_SessionAgentT", bound="LocalAgent", default="Agent", contravariant=True)
+
+
+class SessionManager(HookProvider, ABC, Generic[_SessionAgentT]):
     """Abstract interface for managing sessions.
 
     A session manager is in charge of persisting the conversation and state of an agent across its interaction.
     Changes made to the agents conversation, state, or other attributes should be persisted immediately after
     they are changed. The different methods introduced in this class are called at important lifecycle events
     for an agent, and should be persisted in the session.
+
+    The agent type defaults to Agent. Managers supporting both Agent and BidiAgent
+    implement SessionManager[LocalAgent].
     """
 
     session_id: str
@@ -59,13 +67,13 @@ class SessionManager(HookProvider, ABC):
         registry.add_callback(AfterMultiAgentInvocationEvent, lambda event: self.sync_multi_agent(event.source))
 
         # Register BidiAgent hooks
-        registry.add_callback(BidiAgentInitializedEvent, lambda event: self.initialize_bidi_agent(event.agent))
-        registry.add_callback(BidiMessageAddedEvent, lambda event: self.append_bidi_message(event.message, event.agent))
-        registry.add_callback(BidiMessageAddedEvent, lambda event: self.sync_bidi_agent(event.agent))
-        registry.add_callback(BidiAfterInvocationEvent, lambda event: self.sync_bidi_agent(event.agent))
+        registry.add_callback(BidiAgentInitializedEvent, lambda event: self.initialize(event.agent))
+        registry.add_callback(BidiMessageAddedEvent, lambda event: self.append_message(event.message, event.agent))
+        registry.add_callback(BidiMessageAddedEvent, lambda event: self.sync_agent(event.agent))
+        registry.add_callback(BidiAfterInvocationEvent, lambda event: self.sync_agent(event.agent))
 
     @abstractmethod
-    def redact_latest_message(self, redact_message: Message, agent: "Agent", **kwargs: Any) -> None:
+    def redact_latest_message(self, redact_message: Message, agent: _SessionAgentT, **kwargs: Any) -> None:
         """Redact the message most recently appended to the agent in the session.
 
         Args:
@@ -75,7 +83,7 @@ class SessionManager(HookProvider, ABC):
         """
 
     @abstractmethod
-    def append_message(self, message: Message, agent: "Agent", **kwargs: Any) -> None:
+    def append_message(self, message: Message, agent: _SessionAgentT, **kwargs: Any) -> None:
         """Append a message to the agent's session.
 
         Args:
@@ -85,7 +93,7 @@ class SessionManager(HookProvider, ABC):
         """
 
     @abstractmethod
-    def sync_agent(self, agent: "Agent", **kwargs: Any) -> None:
+    def sync_agent(self, agent: _SessionAgentT, **kwargs: Any) -> None:
         """Serialize and sync the agent with the session storage.
 
         Args:
@@ -94,7 +102,7 @@ class SessionManager(HookProvider, ABC):
         """
 
     @abstractmethod
-    def initialize(self, agent: "Agent", **kwargs: Any) -> None:
+    def initialize(self, agent: _SessionAgentT, **kwargs: Any) -> None:
         """Initialize an agent with a session.
 
         Args:
@@ -130,44 +138,4 @@ class SessionManager(HookProvider, ABC):
             f"{self.__class__.__name__} does not support multi-agent persistence "
             "(initialize_multi_agent). Provide an implementation or use a "
             "SessionManager with session_type=SessionType.MULTI_AGENT."
-        )
-
-    def initialize_bidi_agent(self, agent: "BidiAgent", **kwargs: Any) -> None:
-        """Initialize a bidirectional agent with a session.
-
-        Args:
-            agent: BidiAgent to initialize
-            **kwargs: Additional keyword arguments for future extensibility.
-        """
-        raise NotImplementedError(
-            f"{self.__class__.__name__} does not support bidirectional agent persistence "
-            "(initialize_bidi_agent). Provide an implementation or use a "
-            "SessionManager with bidirectional agent support."
-        )
-
-    def append_bidi_message(self, message: Message, agent: "BidiAgent", **kwargs: Any) -> None:
-        """Append a message to the bidirectional agent's session.
-
-        Args:
-            message: Message to add to the agent in the session
-            agent: BidiAgent to append the message to
-            **kwargs: Additional keyword arguments for future extensibility.
-        """
-        raise NotImplementedError(
-            f"{self.__class__.__name__} does not support bidirectional agent persistence "
-            "(append_bidi_message). Provide an implementation or use a "
-            "SessionManager with bidirectional agent support."
-        )
-
-    def sync_bidi_agent(self, agent: "BidiAgent", **kwargs: Any) -> None:
-        """Serialize and sync the bidirectional agent with the session storage.
-
-        Args:
-            agent: BidiAgent who should be synchronized with the session storage
-            **kwargs: Additional keyword arguments for future extensibility.
-        """
-        raise NotImplementedError(
-            f"{self.__class__.__name__} does not support bidirectional agent persistence "
-            "(sync_bidi_agent). Provide an implementation or use a "
-            "SessionManager with bidirectional agent support."
         )

--- a/strands-py/src/strands/types/session.py
+++ b/strands-py/src/strands/types/session.py
@@ -11,8 +11,7 @@ from ..interrupt import _InterruptState
 from .content import Message
 
 if TYPE_CHECKING:
-    from ..agent.agent import Agent
-    from ..experimental.bidi.agent.agent import BidiAgent
+    from .agent import LocalAgent
 
 
 class SessionType(str, Enum):
@@ -124,41 +123,25 @@ class SessionAgent:
     updated_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
 
     @classmethod
-    def from_agent(cls, agent: "Agent") -> "SessionAgent":
-        """Convert an Agent to a SessionAgent."""
+    def from_agent(cls, agent: "LocalAgent") -> "SessionAgent":
+        """Convert a local agent to a SessionAgent."""
+        from ..agent.agent import Agent
+
         if agent.agent_id is None:
             raise ValueError("agent_id needs to be defined.")
-        return cls(
-            agent_id=agent.agent_id,
-            conversation_manager_state=agent.conversation_manager.get_state(),
-            state=agent.state.get(),
-            _internal_state={
+
+        internal_state = {}
+        conversation_manager_state = {}
+        if isinstance(agent, Agent):
+            conversation_manager_state = agent.conversation_manager.get_state()
+            internal_state = {
                 "interrupt_state": agent._interrupt_state.to_dict(),
                 "model_state": agent._model_state,
-            },
-        )
-
-    @classmethod
-    def from_bidi_agent(cls, agent: "BidiAgent") -> "SessionAgent":
-        """Convert a BidiAgent to a SessionAgent.
-
-        Args:
-            agent: BidiAgent to convert
-
-        Returns:
-            SessionAgent with empty conversation_manager_state (BidiAgent doesn't use conversation manager)
-        """
-        if agent.agent_id is None:
-            raise ValueError("agent_id needs to be defined.")
-
-        # BidiAgent doesn't have _interrupt_state yet, so we use empty dict for internal state
-        internal_state = {}
-        if hasattr(agent, "_interrupt_state"):
-            internal_state["interrupt_state"] = agent._interrupt_state.to_dict()
+            }
 
         return cls(
             agent_id=agent.agent_id,
-            conversation_manager_state={},  # BidiAgent has no conversation_manager
+            conversation_manager_state=conversation_manager_state,
             state=agent.state.get(),
             _internal_state=internal_state,
         )
@@ -173,23 +156,17 @@ class SessionAgent:
         """Convert the SessionAgent to a dictionary representation."""
         return encode_bytes_values(asdict(self))  # type: ignore[no-any-return]
 
-    def initialize_internal_state(self, agent: "Agent") -> None:
-        """Initialize internal state of agent."""
+    def initialize_internal_state(self, agent: "LocalAgent") -> None:
+        """Restore internal state for Agent instances."""
+        from ..agent.agent import Agent
+
+        if not isinstance(agent, Agent):
+            return
+
         if "interrupt_state" in self._internal_state:
             agent._interrupt_state = _InterruptState.from_dict(self._internal_state["interrupt_state"])
         if "model_state" in self._internal_state:
             agent._model_state = self._internal_state["model_state"]
-
-    def initialize_bidi_internal_state(self, agent: "BidiAgent") -> None:
-        """Initialize internal state of BidiAgent.
-
-        Args:
-            agent: BidiAgent to initialize internal state for
-        """
-        # BidiAgent doesn't have _interrupt_state yet, so we skip interrupt state restoration
-        # When BidiAgent adds _interrupt_state support, this will automatically work
-        if "interrupt_state" in self._internal_state and hasattr(agent, "_interrupt_state"):
-            agent._interrupt_state = _InterruptState.from_dict(self._internal_state["interrupt_state"])
 
 
 @dataclass

--- a/strands-py/tests/strands/agent/test_agent_storage.py
+++ b/strands-py/tests/strands/agent/test_agent_storage.py
@@ -210,10 +210,7 @@ class TestRepositorySessionManagerWarnOnce:
         repository.create_session = MagicMock()
         session_mgr = RepositorySessionManager("test-session", session_repository=repository)
 
-        agent = MagicMock()
-        agent.storage = UnifiedInMemoryStorage()
-        agent.agent_id = "agent-1"
-        agent.messages = []
+        agent = Agent(model=MockedModelProvider(SIMPLE_RESPONSE), agent_id="agent-1", storage=UnifiedInMemoryStorage())
 
         with caplog.at_level(logging.WARNING):
             session_mgr.initialize(agent)
@@ -226,21 +223,16 @@ class TestRepositorySessionManagerWarnOnce:
         repository.create_session = MagicMock()
         session_mgr = RepositorySessionManager("test-session", session_repository=repository)
 
-        agent = MagicMock()
-        agent.storage = UnifiedInMemoryStorage()
-        agent.agent_id = "agent-1"
-        agent.messages = []
+        agent = Agent(model=MockedModelProvider(SIMPLE_RESPONSE), agent_id="agent-1", storage=UnifiedInMemoryStorage())
 
         with caplog.at_level(logging.WARNING):
             session_mgr.initialize(agent)
 
+        assert "agent-level storage is set but RepositorySessionManager does not use it" in caplog.text
         caplog.clear()
 
         session_mgr2 = RepositorySessionManager("test-session-2", session_repository=repository)
-        agent2 = MagicMock()
-        agent2.storage = UnifiedInMemoryStorage()
-        agent2.agent_id = "agent-2"
-        agent2.messages = []
+        agent2 = Agent(model=MockedModelProvider(SIMPLE_RESPONSE), agent_id="agent-2", storage=UnifiedInMemoryStorage())
 
         with caplog.at_level(logging.WARNING):
             session_mgr2.initialize(agent2)

--- a/strands-py/tests/strands/session/test_repository_session_manager.py
+++ b/strands-py/tests/strands/session/test_repository_session_manager.py
@@ -10,6 +10,10 @@ from strands.agent.conversation_manager.null_conversation_manager import NullCon
 from strands.agent.conversation_manager.sliding_window_conversation_manager import SlidingWindowConversationManager
 from strands.agent.conversation_manager.summarizing_conversation_manager import SummarizingConversationManager
 from strands.agent.state import AgentState
+from strands.experimental.bidi import BidiAgent
+from strands.experimental.bidi.models.model import BidiModel
+from strands.experimental.hooks.events import BidiAfterInvocationEvent
+from strands.hooks import AfterInvocationEvent
 from strands.interrupt import _InterruptState
 from strands.session.repository_session_manager import RepositorySessionManager
 from strands.types.content import ContentBlock
@@ -578,17 +582,16 @@ def test_fix_broken_tool_use_does_not_change_valid_message(session_manager):
 @pytest.fixture
 def mock_bidi_agent():
     """Create a mock BidiAgent for testing."""
-    agent = Mock()
+    agent = Mock(spec=BidiAgent)
     agent.agent_id = "bidi-agent-1"
     agent.messages = [{"role": "user", "content": [{"text": "Hello from bidi!"}]}]
     agent.state = AgentState({"key": "value"})
-    # BidiAgent doesn't have _interrupt_state yet
     return agent
 
 
-def test_initialize_bidi_agent_creates_new(session_manager, mock_bidi_agent):
+def test_initialize_with_bidi_creates_new(session_manager, mock_bidi_agent):
     """Test initializing a new BidiAgent creates session data."""
-    session_manager.initialize_bidi_agent(mock_bidi_agent)
+    session_manager.initialize(mock_bidi_agent)
 
     # Verify agent created in repository
     agent_data = session_manager.session_repository.read_agent("test-session", "bidi-agent-1")
@@ -603,7 +606,7 @@ def test_initialize_bidi_agent_creates_new(session_manager, mock_bidi_agent):
     assert messages[0].message["role"] == "user"
 
 
-def test_initialize_bidi_agent_restores_existing(existing_session_manager, mock_bidi_agent):
+def test_initialize_with_bidi_restores_existing(existing_session_manager, mock_bidi_agent):
     """Test initializing BidiAgent restores from existing session."""
     # Create existing session data
     session_agent = SessionAgent(
@@ -620,7 +623,7 @@ def test_initialize_bidi_agent_restores_existing(existing_session_manager, mock_
     existing_session_manager.session_repository.create_message("test-session", "bidi-agent-1", msg2)
 
     # Initialize agent
-    existing_session_manager.initialize_bidi_agent(mock_bidi_agent)
+    existing_session_manager.initialize(mock_bidi_agent)
 
     # Verify state restored
     assert mock_bidi_agent.state.get() == {"restored": "state"}
@@ -631,14 +634,14 @@ def test_initialize_bidi_agent_restores_existing(existing_session_manager, mock_
     assert mock_bidi_agent.messages[1]["role"] == "assistant"
 
 
-def test_append_bidi_message(session_manager, mock_bidi_agent):
+def test_append_message_with_bidi(session_manager, mock_bidi_agent):
     """Test appending messages to BidiAgent session."""
     # Initialize agent first
-    session_manager.initialize_bidi_agent(mock_bidi_agent)
+    session_manager.initialize(mock_bidi_agent)
 
     # Append new message
     new_message = {"role": "assistant", "content": [{"text": "Response"}]}
-    session_manager.append_bidi_message(new_message, mock_bidi_agent)
+    session_manager.append_message(new_message, mock_bidi_agent)
 
     # Verify message stored
     messages = session_manager.session_repository.list_messages("test-session", "bidi-agent-1")
@@ -646,25 +649,29 @@ def test_append_bidi_message(session_manager, mock_bidi_agent):
     assert messages[1].message["role"] == "assistant"
 
 
-def test_sync_bidi_agent(session_manager, mock_bidi_agent):
-    """Test syncing BidiAgent state to session."""
+def test_sync_agent_with_bidi(session_manager, mock_bidi_agent, monkeypatch):
+    """Test syncing BidiAgent writes state even when unchanged."""
     # Initialize agent
-    session_manager.initialize_bidi_agent(mock_bidi_agent)
+    session_manager.initialize(mock_bidi_agent)
+    update_agent = Mock(wraps=session_manager.session_repository.update_agent)
+    monkeypatch.setattr(session_manager.session_repository, "update_agent", update_agent)
 
     # Update agent state
     mock_bidi_agent.state = AgentState({"updated": "state"})
 
     # Sync agent
-    session_manager.sync_bidi_agent(mock_bidi_agent)
+    session_manager.sync_agent(mock_bidi_agent)
+    session_manager.sync_agent(mock_bidi_agent)
 
     # Verify state updated in repository
     agent_data = session_manager.session_repository.read_agent("test-session", "bidi-agent-1")
     assert agent_data.state == {"updated": "state"}
+    assert update_agent.call_count == 2
 
 
 def test_bidi_agent_no_conversation_manager(session_manager, mock_bidi_agent):
     """Test that BidiAgent session doesn't use conversation_manager."""
-    session_manager.initialize_bidi_agent(mock_bidi_agent)
+    session_manager.initialize(mock_bidi_agent)
 
     # Verify conversation_manager_state is empty
     agent_data = session_manager.session_repository.read_agent("test-session", "bidi-agent-1")
@@ -674,7 +681,7 @@ def test_bidi_agent_no_conversation_manager(session_manager, mock_bidi_agent):
 def test_bidi_agent_unique_id_constraint(session_manager, mock_bidi_agent):
     """Test that BidiAgent agent_id must be unique in session."""
     # Initialize first agent
-    session_manager.initialize_bidi_agent(mock_bidi_agent)
+    session_manager.initialize(mock_bidi_agent)
 
     # Try to initialize another agent with same ID
     agent2 = Mock()
@@ -683,7 +690,7 @@ def test_bidi_agent_unique_id_constraint(session_manager, mock_bidi_agent):
     agent2.state = AgentState({})
 
     with pytest.raises(SessionException, match="The `agent_id` of an agent must be unique in a session."):
-        session_manager.initialize_bidi_agent(agent2)
+        session_manager.initialize(agent2)
 
 
 def test_bidi_agent_messages_with_offset_zero(existing_session_manager, mock_bidi_agent):
@@ -702,10 +709,71 @@ def test_bidi_agent_messages_with_offset_zero(existing_session_manager, mock_bid
         existing_session_manager.session_repository.create_message("test-session", "bidi-agent-1", msg)
 
     # Initialize agent
-    existing_session_manager.initialize_bidi_agent(mock_bidi_agent)
+    existing_session_manager.initialize(mock_bidi_agent)
 
     # Verify all messages restored (offset=0, no removed_message_count)
     assert len(mock_bidi_agent.messages) == 5
+
+
+def test_bidi_session_shared_methods_round_trip(session_manager, mock_repository):
+    agent = BidiAgent(
+        model=Mock(spec=BidiModel),
+        agent_id="bidi",
+        messages=[{"role": "user", "content": [{"text": "Hello"}], "tracking_id": "initial"}],
+        session_manager=session_manager,
+    )
+    session_manager.append_message(
+        {"role": "assistant", "content": [{"text": "Secret"}], "tracking_id": "response"}, agent
+    )
+    redacted_message = {"role": "assistant", "content": [{"text": "Redacted"}], "tracking_id": "response"}
+    session_manager.redact_latest_message(redacted_message, agent)
+    agent.state.set("saved", "state")
+    session_manager.sync_agent(agent)
+
+    # Bidi history is restored even when the provider manages its own conversation.
+    restored_model = Mock(spec=BidiModel, stateful=True)
+    restored_manager = RepositorySessionManager("test-session", mock_repository)
+    restored = BidiAgent(model=restored_model, agent_id="bidi", session_manager=restored_manager)
+
+    assert restored.state.get() == {"saved": "state"}
+    assert restored.messages == [agent.messages[0], redacted_message]
+
+    next_message = {"role": "user", "content": [{"text": "Next"}]}
+    restored_manager.append_message(next_message, restored)
+    tru_messages = [
+        (message.message_id, message.to_message()) for message in mock_repository.list_messages("test-session", "bidi")
+    ]
+    exp_messages = [(0, agent.messages[0]), (1, redacted_message), (2, next_message)]
+    assert tru_messages == exp_messages
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("agent_type", "after_event_type"), [(Agent, AfterInvocationEvent), (BidiAgent, BidiAfterInvocationEvent)]
+)
+async def test_register_hooks_persists_messages_and_state(session_manager, agent_type, after_event_type):
+    model_kwargs = {"model": Mock(spec=BidiModel)} if agent_type is BidiAgent else {}
+    agent = agent_type(agent_id="shared", session_manager=session_manager, **model_kwargs)
+    message = {"role": "user", "content": [{"text": "Hello"}], "tracking_id": "message-1"}
+    agent.state.set("saved", "state")
+    await agent._append_messages(message)
+
+    tru_state = session_manager.session_repository.read_agent("test-session", "shared").state
+    exp_state = {"saved": "state"}
+    assert tru_state == exp_state
+    tru_messages = [
+        (message.message_id, message.to_message())
+        for message in session_manager.session_repository.list_messages("test-session", "shared")
+    ]
+    exp_messages = [(0, message)]
+    assert tru_messages == exp_messages
+
+    agent.state.set("completed", True)
+    await agent.hooks.invoke_callbacks_async(after_event_type(agent=agent))
+
+    tru_state = session_manager.session_repository.read_agent("test-session", "shared").state
+    exp_state = {"saved": "state", "completed": True}
+    assert tru_state == exp_state
 
 
 def test_fix_broken_tool_use_removes_orphaned_tool_result_at_start(session_manager):
@@ -1078,8 +1146,8 @@ def test_initialize_calls_read_agent_for_existing_session(mock_repository):
     assert read_agent_calls[0] == ("existing-session", "test-agent")
 
 
-def test_initialize_bidi_agent_skips_read_agent_for_new_session(mock_repository):
-    """Test that initialize_bidi_agent() skips read_agent() call when _is_new_session is True."""
+def test_initialize_with_bidi_skips_read_agent_for_new_session(mock_repository):
+    """Test that initialize() skips read_agent() for bidi when _is_new_session is True."""
     # Create manager (new session)
     manager = RepositorySessionManager(session_id="new-session", session_repository=mock_repository)
     assert manager._is_new_session is True
@@ -1101,14 +1169,14 @@ def test_initialize_bidi_agent_skips_read_agent_for_new_session(mock_repository)
     bidi_agent.state = AgentState({})
 
     # Initialize bidi agent
-    manager.initialize_bidi_agent(bidi_agent)
+    manager.initialize(bidi_agent)
 
     # read_agent should NOT be called for new session
     assert len(read_agent_calls) == 0
 
 
-def test_initialize_bidi_agent_calls_read_agent_for_existing_session(mock_repository):
-    """Test that initialize_bidi_agent() calls read_agent() when _is_new_session is False."""
+def test_initialize_with_bidi_calls_read_agent_for_existing_session(mock_repository):
+    """Test that initialize() calls read_agent() for bidi when _is_new_session is False."""
     # Create session first
     session = Session(session_id="existing-session", session_type=SessionType.AGENT)
     mock_repository.create_session(session)
@@ -1134,7 +1202,7 @@ def test_initialize_bidi_agent_calls_read_agent_for_existing_session(mock_reposi
     bidi_agent.state = AgentState({})
 
     # Initialize bidi agent
-    manager.initialize_bidi_agent(bidi_agent)
+    manager.initialize(bidi_agent)
 
     # read_agent should be called for existing session
     assert len(read_agent_calls) == 1

--- a/strands-py/tests/strands/types/test_session.py
+++ b/strands-py/tests/strands/types/test_session.py
@@ -2,8 +2,12 @@ import json
 import unittest.mock
 from uuid import uuid4
 
+import pytest
+
+from strands import Agent
 from strands.agent.conversation_manager.null_conversation_manager import NullConversationManager
 from strands.agent.state import AgentState
+from strands.experimental.bidi import BidiAgent
 from strands.interrupt import _InterruptState
 from strands.types.session import (
     Session,
@@ -129,7 +133,7 @@ def test_session_message_redaction_preserves_durable_id():
 
 
 def test_session_agent_from_agent():
-    agent = unittest.mock.Mock()
+    agent = unittest.mock.Mock(spec=Agent)
     agent.agent_id = "a1"
     agent.conversation_manager = unittest.mock.Mock(get_state=lambda: {"test": "conversation"})
     agent.state = AgentState({"test": "state"})
@@ -152,7 +156,7 @@ def test_session_agent_from_agent():
 
 
 def test_session_agent_initialize_internal_state():
-    agent = unittest.mock.Mock()
+    agent = unittest.mock.Mock(spec=Agent)
     session_agent = SessionAgent(
         agent_id="a1",
         conversation_manager_state={},
@@ -172,6 +176,59 @@ def test_session_agent_initialize_internal_state():
     tru_model_state = agent._model_state
     exp_model_state = {"response_id": "resp_abc"}
     assert tru_model_state == exp_model_state
+
+
+@pytest.mark.parametrize("has_interrupt_state", [False, True])
+def test_session_agent_from_agent_with_bidi(has_interrupt_state):
+    agent = unittest.mock.Mock(spec=BidiAgent)
+    agent.agent_id = "bidi"
+    agent.state = AgentState({"data": {"count": 2}})
+    if has_interrupt_state:
+        agent._interrupt_state = _InterruptState(context={"resume": "tool"})
+
+    session_agent = SessionAgent.from_agent(agent)
+    tru_session_agent = SessionAgent.from_dict(json.loads(json.dumps(session_agent.to_dict())))
+    exp_session_agent = SessionAgent(
+        agent_id="bidi",
+        state={"data": {"count": 2}},
+        conversation_manager_state={},
+        _internal_state={},
+        created_at=unittest.mock.ANY,
+        updated_at=unittest.mock.ANY,
+    )
+    assert tru_session_agent == exp_session_agent
+
+
+@pytest.mark.parametrize("has_interrupt_state", [False, True])
+def test_session_agent_initialize_internal_state_skips_bidi(has_interrupt_state):
+    agent = unittest.mock.Mock(spec=BidiAgent)
+    original_interrupt_state = _InterruptState(context={"existing": "bidi"})
+    if has_interrupt_state:
+        agent._interrupt_state = original_interrupt_state
+    saved_interrupt_state = _InterruptState(context={"resume": "tool"})
+    session_agent = SessionAgent(
+        agent_id="bidi",
+        state={},
+        conversation_manager_state={},
+        _internal_state={
+            "interrupt_state": saved_interrupt_state.to_dict(),
+            "model_state": {"response_id": "agent-only"},
+        },
+    )
+
+    session_agent.initialize_internal_state(agent)
+
+    assert hasattr(agent, "_interrupt_state") == has_interrupt_state
+    if has_interrupt_state:
+        assert agent._interrupt_state is original_interrupt_state
+    assert not hasattr(agent, "_model_state")
+
+
+@pytest.mark.parametrize("agent_type", [Agent, BidiAgent])
+def test_session_agent_requires_agent_id(agent_type):
+    agent = unittest.mock.Mock(spec=agent_type, agent_id=None)
+    with pytest.raises(ValueError, match="agent_id needs to be defined"):
+        SessionAgent.from_agent(agent)
 
 
 def test_session_agent_with_bytes():

--- a/strands-py/tests_integ/bidi/tools/test_direct.py
+++ b/strands-py/tests_integ/bidi/tools/test_direct.py
@@ -4,6 +4,7 @@ import pytest
 
 from strands import tool
 from strands.experimental.bidi.agent import BidiAgent
+from strands.session import FileSessionManager
 
 
 @pytest.fixture
@@ -74,4 +75,34 @@ def test_bidi_agent_tool_direct_call(agent):
             "tracking_id": unittest.mock.ANY,
         },
     ]
+    assert tru_messages == exp_messages
+
+
+def test_bidi_agent_tool_direct_call_with_file_session(weather_tool, tmp_path):
+    agent = BidiAgent(
+        record_direct_tool_call=True,
+        tools=[weather_tool],
+        session_manager=FileSessionManager(session_id="bidi-session", storage_dir=tmp_path),
+    )
+    agent.state.set("city", "new york")
+    agent.tool.weather_tool(city_name="new york")
+
+    restored_manager = FileSessionManager(session_id="bidi-session", storage_dir=tmp_path)
+    restored_agent = BidiAgent(record_direct_tool_call=True, tools=[weather_tool], session_manager=restored_manager)
+
+    tru_state = restored_agent.state.get()
+    exp_state = {"city": "new york"}
+    assert tru_state == exp_state
+    tru_messages = restored_agent.messages
+    exp_messages = agent.messages
+    assert tru_messages == exp_messages
+
+    restored_agent.tool.weather_tool(city_name="seattle")
+
+    tru_messages = [
+        (message.message_id, message.to_message())
+        for message in restored_manager.list_messages("bidi-session", restored_agent.agent_id)
+    ]
+    exp_messages = list(enumerate(restored_agent.messages))
+    assert len(exp_messages) == 8
     assert tru_messages == exp_messages

--- a/strands-py/tests_integ/bidi/tools/test_direct.py
+++ b/strands-py/tests_integ/bidi/tools/test_direct.py
@@ -104,5 +104,6 @@ def test_bidi_agent_tool_direct_call_with_file_session(weather_tool, tmp_path):
         for message in restored_manager.list_messages("bidi-session", restored_agent.agent_id)
     ]
     exp_messages = list(enumerate(restored_agent.messages))
+    # Two calls, each recording a user prompt, tool use, tool result, and assistant acknowledgement.
     assert len(exp_messages) == 8
     assert tru_messages == exp_messages

--- a/strands-py/tests_typing/test_local_agent.py
+++ b/strands-py/tests_typing/test_local_agent.py
@@ -5,6 +5,11 @@ from typing_extensions import assert_type
 from strands import Agent, LocalAgent, ToolContext, tool
 from strands.experimental.bidi import BidiAgent
 from strands.hooks import AfterToolCallEvent, BeforeToolCallEvent
+from strands.session.repository_session_manager import RepositorySessionManager
+from strands.session.session_manager import SessionManager
+from strands.session.snapshot_session_manager import SnapshotSessionManager
+from strands.types.content import Message
+from strands.types.session import SessionAgent
 
 
 @tool(context=True)
@@ -66,3 +71,53 @@ def register_hooks(agent: Agent, bidi_agent: BidiAgent, local_agent: LocalAgent)
 
 def local_agent_excludes_agent_only_members(local_agent: LocalAgent) -> None:
     local_agent.cleanup()  # type: ignore[attr-defined]
+
+
+def persist_local_agent(manager: RepositorySessionManager, agent: LocalAgent, message: Message) -> None:
+    manager.initialize(agent)
+    manager.append_message(message, agent)
+    manager.redact_latest_message(message, agent)
+    manager.sync_agent(agent)
+    session_agent = SessionAgent.from_agent(agent)
+    assert_type(session_agent, SessionAgent)
+    session_agent.initialize_internal_state(agent)
+
+
+class AgentOnlySessionManager(SessionManager):
+    def initialize(self, agent: Agent, **kwargs: Any) -> None:
+        pass
+
+    def append_message(self, message: Message, agent: Agent, **kwargs: Any) -> None:
+        pass
+
+    def sync_agent(self, agent: Agent, **kwargs: Any) -> None:
+        pass
+
+    def redact_latest_message(self, redact_message: Message, agent: Agent, **kwargs: Any) -> None:
+        pass
+
+
+def session_manager_types(
+    manager: SessionManager,
+    shared_manager: SessionManager[LocalAgent],
+    repository_manager: RepositorySessionManager,
+    snapshot_manager: SnapshotSessionManager,
+    agent: Agent,
+    bidi_agent: BidiAgent,
+    message: Message,
+) -> None:
+    manager.append_message(message, agent)
+    manager.append_message(message, bidi_agent)  # type: ignore[arg-type]
+    shared_manager.append_message(message, agent)
+    shared_manager.append_message(message, bidi_agent)
+
+    standard_manager: SessionManager = repository_manager
+    shared_repository_manager: SessionManager[LocalAgent] = repository_manager
+    Agent(session_manager=standard_manager)
+    Agent(session_manager=shared_manager)
+    Agent(session_manager=AgentOnlySessionManager())
+    Agent(session_manager=snapshot_manager)
+    BidiAgent(session_manager=shared_repository_manager)
+    BidiAgent(session_manager=shared_manager)
+    BidiAgent(session_manager=manager)  # type: ignore[arg-type]
+    BidiAgent(session_manager=snapshot_manager)  # type: ignore[arg-type]


### PR DESCRIPTION
## Description

Repository session persistence has separate Agent and BidiAgent entry points for the same operations, requiring fixes and behavior changes to be maintained twice. Consolidate those operations around `LocalAgent` while preserving the existing Agent-specific persistence behavior and typing defaults.

### Public API Changes

`SessionManager` defaults to `Agent`, so existing Agent-only subclasses keep their signatures. Managers supporting both agent types implement `SessionManager[LocalAgent]`; `RepositorySessionManager` now provides that shared implementation.

The experimental bidi entry points are removed. Callers and custom implementations should use their shared equivalents:

```python
# Before
manager.initialize_bidi_agent(agent)
manager.append_bidi_message(message, agent)
manager.sync_bidi_agent(agent)
SessionAgent.from_bidi_agent(agent)
session_agent.initialize_bidi_internal_state(agent)

# After
manager.initialize(agent)
manager.append_message(message, agent)
manager.sync_agent(agent)
SessionAgent.from_agent(agent)
session_agent.initialize_internal_state(agent)
```

Bidi persistence covers application state and message history. Conversation-manager, interrupt, and model state remain specific to `Agent`. Sharing the remaining hook events and integrating bidi snapshots are separate follow-ups.

## Related Issues

Related to #3764.

## Documentation PR

Included in this PR: the bidi session-management guide now explains the shared repository session manager, clarifies when sessions are created and restored, and shows the first conversation followed by a later restored conversation. It also notes that `SnapshotSessionManager` does not support `BidiAgent`.

## Type of Change

Other (please describe): session persistence refactor, including removal of experimental bidi-specific APIs.

## Testing

- [x] I ran `hatch run prepare`

Passed lint, type checks, and unit tests on Python 3.10–3.14. Relevant bidi, session, snapshot, and interrupt-session integration suites: 25 passed, with four OpenAI/Google cases skipped because API keys were unavailable. Both Bedrock audio cases passed, but logged CRT shutdown task exceptions (`AWS_ERROR_HTTP_STREAM_HAS_COMPLETED`).

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

