### PR TITLE
fix(python): force structured output retry by tool name

### DIFF
--- a/strands-py/src/strands/event_loop/event_loop.py
+++ b/strands-py/src/strands/event_loop/event_loop.py
@@ -371,7 +371,8 @@ async def event_loop_cycle(
                     raise StructuredOutputException(
                         "The model failed to invoke the structured output tool even after it was forced."
                     )
-                structured_output_context.set_forced_mode()
+                tool_spec = structured_output_context.get_tool_spec()
+                structured_output_context.set_forced_mode({"tool": {"name": tool_spec["name"]}} if tool_spec else None)
                 logger.debug("Forcing structured output tool")
                 await agent._append_messages(
                     {"role": "user", "content": [{"text": structured_output_context.structured_output_prompt}]}

--- a/strands-py/tests/strands/event_loop/test_event_loop_structured_output.py
+++ b/strands-py/tests/strands/event_loop/test_event_loop_structured_output.py
@@ -590,3 +590,54 @@ async def test_structured_output_stops_loop_after_extraction(mock_agent, structu
 
     # Extract_result should have been called
     structured_output_context.extract_result.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_event_loop_forces_structured_output_tool_by_name(mock_agent, agenerator, alist):
+    """Test that the forced retry names the output tool instead of using any."""
+    structured_output_context = StructuredOutputContext(structured_output_model=ProductModel)
+    mock_agent.model.stream.side_effect = [
+        agenerator(
+            [
+                {"contentBlockDelta": {"delta": {"text": "Here is the product info"}}},
+                {"contentBlockStop": {}},
+                {"messageStop": {"stopReason": "end_turn"}},
+            ]
+        ),
+        agenerator(
+            [
+                {
+                    "contentBlockStart": {
+                        "start": {
+                            "toolUse": {
+                                "toolUseId": "t1",
+                                "name": "ProductModel",
+                            }
+                        }
+                    }
+                },
+                {
+                    "contentBlockDelta": {
+                        "delta": {"toolUse": {"input": '{"title": "Book", "price": 19.99, "in_stock": true}'}}
+                    }
+                },
+                {"contentBlockStop": {}},
+                {"messageStop": {"stopReason": "tool_use"}},
+            ]
+        ),
+    ]
+
+    mock_agent.tool_executor._execute = Mock(return_value=agenerator([]))
+    test_result = ProductModel(title="Book", price=19.99, in_stock=True)
+    structured_output_context.extract_result = Mock(return_value=test_result)
+
+    stream = event_loop_cycle(
+        agent=mock_agent,
+        invocation_state={},
+        structured_output_context=structured_output_context,
+    )
+    await alist(stream)
+
+    assert mock_agent.model.stream.call_count == 2
+    forced_call = mock_agent.model.stream.call_args_list[1]
+    assert forced_call.kwargs["tool_choice"] == {"tool": {"name": "ProductModel"}}


### PR DESCRIPTION
## Description

The forced structured output retry used tool_choice any, so when a provider appends built-in tools after the loop narrows the specs, the model can pick a built-in instead of the output tool and the turn ends in StructuredOutputException. This forces by name, matching the TypeScript SDK (structuredOutputChoice). Providers that ignore tool_choice behave as before.

## Related Issues

Fixes #4251

## Documentation PR

No docs change needed for this behavior fix.

## Type of Change

Bug fix

## Testing

Ran the structured output event loop suites with the repo test deps: 45 passed across test_event_loop_structured_output.py, test_streaming_structured_output.py and tools/structured_output. Added test_event_loop_forces_structured_output_tool_by_name, which fails on the old code with tool_choice {'any': {}} and passes with the fix.

- [ ] I ran `hatch run prepare` (hatch was unavailable in my env, used the equivalent pytest run above)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published