### PR TITLE
feat: make BeforeModelCallEvent interruptible

### DIFF
--- a/site/src/content/docs/user-guide/concepts/interrupts.mdx
+++ b/site/src/content/docs/user-guide/concepts/interrupts.mdx
@@ -32,7 +32,7 @@ Users can raise interrupts within their [hook callbacks](./agents/hooks.md) to p
 <Tabs>
 <Tab label="Python">
 
-Both `BeforeToolCallEvent` and `BeforeToolsEvent` are interruptible. Interrupting on a `BeforeToolCallEvent` allows users to intercept an individual tool call before execution, while interrupting on `BeforeToolsEvent` pauses the entire batch of tool calls before any of them execute — useful for approving a whole set of tool calls at once.
+`BeforeToolCallEvent`, `BeforeToolsEvent`, and `BeforeModelCallEvent` are interruptible. Interrupting on a `BeforeToolCallEvent` allows users to intercept an individual tool call before execution, while interrupting on `BeforeToolsEvent` pauses the entire batch of tool calls before any of them execute — useful for approving a whole set of tool calls at once. Interrupting on `BeforeModelCallEvent` pauses the agent before it calls the model; resuming re-enters the same model call.
 
 #### BeforeToolCallEvent
 
@@ -159,10 +159,40 @@ while result.stop_reason == "interrupt":
 
 Setting `event.cancel` (to `True` for a default message, or a string for a custom one) produces an error tool result for every tool in the batch and skips execution entirely, so no per-tool `BeforeToolCallEvent` fires.
 
+#### BeforeModelCallEvent
+
+```python
+from strands import Agent
+from strands.hooks import BeforeModelCallEvent
+
+
+def approve_model_call(event: BeforeModelCallEvent) -> None:
+    approval = event.interrupt(
+        "myapp-model-call-approval",
+        reason="Approve this model call?",
+    )
+    if approval.lower() != "y":
+        event.cancel = "Model call cancelled by user"
+
+
+agent = Agent(hooks=[approve_model_call], callback_handler=None)
+result = agent("Summarize the quarterly report")
+
+while result.stop_reason == "interrupt":
+    responses = []
+    for interrupt in result.interrupts:
+        user_input = input(f"{interrupt.reason} (y/N): ")
+        responses.append(
+            {"interruptResponse": {"interruptId": interrupt.id, "response": user_input}}
+        )
+
+    result = agent(responses)
+```
+
 </Tab>
 <Tab label="TypeScript">
 
-Both `BeforeToolCallEvent` and `BeforeToolsEvent` are interruptible. Interrupting on a `BeforeToolCallEvent` allows users to intercept individual tool calls before execution, while `BeforeToolsEvent` allows intercepting the entire batch of tool calls before any execute.
+`BeforeToolCallEvent`, `BeforeToolsEvent`, and `BeforeModelCallEvent` are interruptible. Interrupting on a `BeforeToolCallEvent` allows users to intercept individual tool calls before execution, while `BeforeToolsEvent` allows intercepting the entire batch of tool calls before any execute. Interrupting on `BeforeModelCallEvent` pauses the agent before it calls the model; resuming re-enters the same model call.
 
 #### BeforeToolCallEvent
 
@@ -179,8 +209,21 @@ Both `BeforeToolCallEvent` and `BeforeToolsEvent` are interruptible. Interruptin
 
 --8<-- "user-guide/concepts/interrupts.ts:hooks_before_tools"
 ```
+
+#### BeforeModelCallEvent
+
+```typescript
+--8<-- "user-guide/concepts/interrupts_imports.ts:hooks_before_model_call_imports"
+
+--8<-- "user-guide/concepts/interrupts.ts:hooks_before_model_call"
+```
+
 </Tab>
 </Tabs>
+
+`BeforeModelCallEvent` fires before each model call attempt, including retries.
+On resume and retries, `event.interrupt` reuses the approval. The SDK clears it
+after tool execution or when the request completes.
 
 ### Components
 
@@ -190,7 +233,7 @@ Interrupts in Strands are comprised of the following components:
 <Tab label="Python">
 
 - `event.interrupt` - Raises an interrupt with a unique name and optional reason
-    - The `name` must be unique across all interrupt calls configured on the same event (`BeforeToolCallEvent` or `BeforeToolsEvent`). In the example above, we demonstrate using `app_name` to namespace the interrupt call. This is particularly helpful if you plan to vend your hooks to other users.
+    - The `name` must be unique across all interrupt calls configured on the same event (`BeforeToolCallEvent`, `BeforeToolsEvent`, or `BeforeModelCallEvent`). Use a namespace prefix to avoid collisions when sharing hooks.
     - You can assign additional context for raising the interrupt to the `reason` field. Note, the `reason` must be JSON-serializable. 
 - `result.stop_reason` - Check if agent stopped due to "interrupt"
 - `result.interrupts` - List of interrupts that were raised
@@ -201,15 +244,20 @@ Interrupts in Strands are comprised of the following components:
     - You can either set `cancel_tool` to `True` or provide a custom cancellation message.
 - `event.cancel` (`BeforeToolsEvent`) - Cancel every tool call in the batch based on the interrupt response
     - You can either set `cancel` to `True` or provide a custom cancellation message.
+- `event.cancel` (`BeforeModelCallEvent`) - End the turn without calling the model
+    - Set `cancel` to `True` for a default message or provide a custom string. The
+      cancellation message becomes the assistant's final message.
 
 For additional details on each of these components, refer to the [Python API Reference](@api/python/strands.types.interrupt).
 </Tab>
 <Tab label="TypeScript">
 
-- [`BeforeToolCallEvent`](@api/typescript/BeforeToolCallEvent) / [`BeforeToolsEvent`](@api/typescript/BeforeToolsEvent): hook events that expose the ability to interrupt via the `interrupt` method
+- [`BeforeToolCallEvent`](@api/typescript/BeforeToolCallEvent) / [`BeforeToolsEvent`](@api/typescript/BeforeToolsEvent) / [`BeforeModelCallEvent`](@api/typescript/BeforeModelCallEvent): hook events that expose the ability to interrupt via the `interrupt` method
     - `event.interrupt({ name, reason? })`: halts the agent loop. `name` is a string identifier and `reason` is an optional JSON-serializable value providing context for why the interrupt was raised.
     - The `name` must be unique across all interrupt calls configured on the same event. In the example above, we demonstrate using a namespace prefix for the interrupt call. This is particularly helpful if you plan to vend your hooks to other users.
-    - `event.cancel`: cancel tool execution based on the interrupt response. Set to `true` for a default message or provide a custom cancellation message string.
+    - `event.cancel`: cancel tool execution (or, on `BeforeModelCallEvent`, the model call) based on the interrupt response. Set to `true` for a default message or provide a custom cancellation message string.
+        - On `BeforeModelCallEvent`, this ends the turn without calling the model and
+          returns the cancellation message as the assistant's final message.
 - [`AgentResult`](@api/typescript/AgentResult): returned by `invoke()` / `stream()`, contains interrupt information when the agent pauses
     - `result.stopReason`: check if agent stopped due to `'interrupt'`
     - `result.interrupts`: array of `Interrupt` objects, each containing the user-provided `name` and `reason`, along with a unique `id`

--- a/site/src/content/docs/user-guide/concepts/interrupts.ts
+++ b/site/src/content/docs/user-guide/concepts/interrupts.ts
@@ -3,6 +3,7 @@
 
 import { Agent, tool, SessionManager, FileStorage } from '@strands-agents/sdk'
 import {
+  BeforeModelCallEvent,
   BeforeToolCallEvent,
   BeforeToolsEvent,
   BeforeNodeCallEvent,
@@ -81,9 +82,7 @@ async function hooksBeforeToolCallExample() {
 async function hooksBeforeToolsExample() {
   // --8<-- [start:hooks_before_tools]
   const agent = new Agent({
-    tools: [
-      /* ... */
-    ],
+    tools: [/* ... */],
   })
 
   agent.addHook(BeforeToolsEvent, (event) => {
@@ -102,6 +101,42 @@ async function hooksBeforeToolsExample() {
     }
   })
   // --8<-- [end:hooks_before_tools]
+}
+
+// =====================
+// Hooks — BeforeModelCallEvent Example
+// =====================
+
+async function hooksBeforeModelCallExample() {
+  // --8<-- [start:hooks_before_model_call]
+  const agent = new Agent()
+
+  agent.addHook(BeforeModelCallEvent, (event) => {
+    const response = event.interrupt<{ approved: boolean }>({
+      name: 'model_call_approval',
+      reason: 'Approve this model call?',
+    })
+    if (!response.approved) {
+      event.cancel = 'Model call cancelled by user'
+    }
+  })
+
+  let result = await agent.invoke('Summarize the quarterly report')
+
+  while (result.stopReason === 'interrupt') {
+    const responses = result.interrupts!.map((interrupt) => ({
+      interruptResponse: {
+        interruptId: interrupt.id,
+        // In a real app, collect user input here
+        response: { approved: true },
+      },
+    }))
+
+    result = await agent.invoke(responses)
+  }
+
+  console.log('MESSAGE:', JSON.stringify(result.lastMessage))
+  // --8<-- [end:hooks_before_model_call]
 }
 
 // =====================
@@ -326,6 +361,7 @@ async function graphBeforeNodeCallExample() {
 // Suppress unused function warnings
 void hooksBeforeToolCallExample
 void hooksBeforeToolsExample
+void hooksBeforeModelCallExample
 void toolsExample
 void sessionManagementExample
 void swarmBeforeNodeCallExample

--- a/site/src/content/docs/user-guide/concepts/interrupts_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/interrupts_imports.ts
@@ -10,6 +10,10 @@ import { z } from 'zod'
 import { Agent, BeforeToolsEvent } from '@strands-agents/sdk'
 // --8<-- [end:hooks_before_tools_imports]
 
+// --8<-- [start:hooks_before_model_call_imports]
+import { Agent, BeforeModelCallEvent } from '@strands-agents/sdk'
+// --8<-- [end:hooks_before_model_call_imports]
+
 // --8<-- [start:tools_example_imports]
 import { Agent, tool } from '@strands-agents/sdk'
 import { z } from 'zod'

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -1589,14 +1589,6 @@ class Agent(AgentBase, LocalAgent):
                             agent_result = AgentResult(*event["stop"])
                         yield event
 
-                    # A resumed AgentStreamStage interrupt that finished without tool execution
-                    # never hits the tool path's deactivate(), so clear the interrupt state here.
-                    if (
-                        self._interrupt_state.activated
-                        and (agent_result is None or agent_result.stop_reason != "interrupt")
-                        and self._interrupt_state.pending_tool_execution is None
-                    ):
-                        self._interrupt_state.deactivate()
                 except InterruptException as interrupt_exception:
                     # Refuse a late interrupt — resuming would re-call the model
                     # and corrupt history.
@@ -1641,7 +1633,13 @@ class Agent(AgentBase, LocalAgent):
                 caught_error = error
                 raise
             finally:
-                if not self._interrupt_state.activated:
+                if (
+                    (self._interrupt_state.activated or self._interrupt_state.interrupts)
+                    and (agent_result is None or agent_result.stop_reason != "interrupt")
+                    and self._interrupt_state.pending_tool_execution is None
+                ):
+                    self._interrupt_state.deactivate()
+                elif not self._interrupt_state.activated:
                     self._interrupt_state.end_interrupt_cycle()
 
                 self.conversation_manager.apply_management(self)

--- a/strands-py/src/strands/hooks/events.py
+++ b/strands-py/src/strands/hooks/events.py
@@ -302,12 +302,13 @@ class AfterToolCallEvent(HookEvent[_LocalAgentT]):
 
 
 @dataclass
-class BeforeModelCallEvent(HookEvent):
+class BeforeModelCallEvent(HookEvent, _Interruptible):
     """Event triggered before the model is invoked.
 
     This event is fired just before the agent calls the model for inference,
     allowing hook providers to inspect or modify the messages and configuration
-    that will be sent to the model.
+    that will be sent to the model. Hook callbacks can raise an interrupt to pause
+    the agent before the call; resuming re-enters the same model call.
 
     Note: This event is not fired for invocations to structured_output.
 
@@ -319,8 +320,8 @@ class BeforeModelCallEvent(HookEvent):
             Computed by the agent loop from message metadata and token estimation.
             Available for hooks and plugins (e.g. conversation managers) to make
             proactive decisions about context management. None if estimation failed.
-        cancel: When set, cancels the model call. If a string, used as the cancellation message.
-            If True, a default message is used.
+        cancel: When set, ends the turn without calling the model. If a string, it becomes
+            the assistant's final message. If True, a default message is used.
     """
 
     invocation_state: dict[str, Any] = field(default_factory=dict)
@@ -329,6 +330,18 @@ class BeforeModelCallEvent(HookEvent):
 
     def _can_write(self, name: str) -> bool:
         return name == "cancel"
+
+    @override
+    def _interrupt_id(self, name: str) -> str:
+        """Unique id for the interrupt.
+
+        Args:
+            name: User defined name for the interrupt.
+
+        Returns:
+            Interrupt id.
+        """
+        return f"v1:before_model_call:{uuid.uuid5(uuid.NAMESPACE_OID, name)}"
 
 
 @dataclass

--- a/strands-py/tests/strands/agent/test_agent_hooks.py
+++ b/strands-py/tests/strands/agent/test_agent_hooks.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
 
 import pytest
@@ -15,7 +16,8 @@ from strands.hooks import (
     BeforeToolCallEvent,
     MessageAddedEvent,
 )
-from strands.interrupt import Interrupt, InterruptException
+from strands.interrupt import Interrupt
+from strands.types._snapshot import Snapshot
 from strands.types.content import Messages
 from strands.types.exceptions import ModelThrottledException
 from strands.types.tools import ToolResult, ToolUse
@@ -1120,29 +1122,112 @@ def test_hooks_param_callable_invoked_during_lifecycle():
     assert isinstance(before_events[0], BeforeInvocationEvent)
 
 
-def test_before_model_call_hook_interrupt_stops_and_resumes_at_model_call():
-    interrupt = Interrupt(id="v1:model_call:approve", name="approve", reason="Approve the model call?")
+def test_before_model_call_hook_reuses_approval_on_resume_and_retry():
     responses_seen = []
 
     def gate_model_call(event: BeforeModelCallEvent):
-        registered = event.agent._interrupt_state.interrupts.get(interrupt.id)
-        if registered is None or registered.response is None:
-            raise InterruptException(interrupt)
-        responses_seen.append(registered.response)
+        responses_seen.append(event.interrupt("approve", reason="Approve the model call?"))
 
-    agent = Agent(
-        model=MockedModelProvider([{"role": "assistant", "content": [{"text": "Approved"}]}]),
-        callback_handler=None,
+    model = MockedModelProvider(
+        [
+            {"role": "assistant", "content": [{"text": "Retry this response"}]},
+            {"role": "assistant", "content": [{"text": "Approved"}]},
+        ]
     )
+
+    def retry_model_call(event: AfterModelCallEvent):
+        event.retry = model.index == 1
+
+    agent = Agent(model=model, callback_handler=None)
     agent.hooks.add_callback(BeforeModelCallEvent, gate_model_call)
+    agent.hooks.add_callback(AfterModelCallEvent, retry_model_call)
 
     interrupted = agent("do something")
-    assert interrupted.stop_reason == "interrupt"
-    assert [pending.id for pending in interrupted.interrupts] == [interrupt.id]
-    assert len(agent.messages) == 1
 
-    result = agent([{"interruptResponse": {"interruptId": interrupt.id, "response": "yes"}}])
+    tru_interrupts = interrupted.interrupts
+    exp_interrupts = [
+        Interrupt(
+            id="v1:before_model_call:5cf56bed-067e-5438-a1ef-dbfa3405e45d",
+            name="approve",
+            reason="Approve the model call?",
+        )
+    ]
+    assert interrupted.stop_reason == "interrupt"
+    assert model.index == 0
+    assert tru_interrupts == exp_interrupts
+    assert len(agent.messages) == 1
+    assert responses_seen == []
+
+    result = agent([{"interruptResponse": {"interruptId": exp_interrupts[0].id, "response": "yes"}}])
+
     assert result.stop_reason == "end_turn"
     assert result.message["content"][0]["text"] == "Approved"
-    assert responses_seen == ["yes"]
+    assert model.index == 2
+    assert responses_seen == ["yes", "yes"]
     assert agent._interrupt_state.activated is False
+
+    assert agent("request requiring approval").stop_reason == "interrupt"
+
+
+@pytest.mark.parametrize("fail_model", [False, True])
+def test_before_model_call_hook_clears_preemptive_approval_after_request(fail_model):
+    model = MockedModelProvider(
+        [
+            {"role": "assistant", "content": [{"text": "Approved"}]},
+            {"role": "assistant", "content": [{"text": "Must require a new approval"}]},
+        ]
+    )
+    preapprove = True
+
+    def gate_model_call(event: BeforeModelCallEvent):
+        event.interrupt("approve", response="yes" if preapprove else None)
+
+    agent = Agent(model=model, callback_handler=None)
+    agent.hooks.add_callback(BeforeModelCallEvent, gate_model_call)
+    if fail_model:
+        with patch.object(model, "stream", side_effect=RuntimeError("model failed")):
+            with pytest.raises(RuntimeError, match="model failed"):
+                agent("preapproved request")
+    else:
+        assert agent("preapproved request").stop_reason == "end_turn"
+    preapprove = False
+
+    restored = Agent(model=model, callback_handler=None)
+    restored.hooks.add_callback(BeforeModelCallEvent, gate_model_call)
+    snapshot = json.loads(json.dumps(agent.take_snapshot(preset="session").to_dict()))
+    restored.load_snapshot(Snapshot.from_dict(snapshot))
+
+    for next_agent in [agent, restored]:
+        result = next_agent("request requiring approval")
+        assert result.stop_reason == "interrupt"
+        tru_interrupts = result.interrupts
+        exp_interrupts = [Interrupt(id="v1:before_model_call:5cf56bed-067e-5438-a1ef-dbfa3405e45d", name="approve")]
+        assert tru_interrupts == exp_interrupts
+    assert model.index == (0 if fail_model else 1)
+
+
+def test_before_model_call_hook_requires_new_approval_after_tools():
+    @strands.tool
+    def work():
+        return "done"
+
+    model = MockedModelProvider(
+        [
+            {"role": "assistant", "content": [{"toolUse": {"name": "work", "toolUseId": "tool-1", "input": {}}}]},
+            {"role": "assistant", "content": [{"text": "Must require a new approval"}]},
+        ]
+    )
+    agent = Agent(model=model, tools=[work], callback_handler=None)
+
+    def gate_model_call(event: BeforeModelCallEvent):
+        event.interrupt("approve", response="yes" if model.index == 0 else None)
+
+    agent.hooks.add_callback(BeforeModelCallEvent, gate_model_call)
+    result = agent("do work")
+
+    assert result.stop_reason == "interrupt"
+    tru_interrupts = result.interrupts
+    exp_interrupts = [Interrupt(id="v1:before_model_call:5cf56bed-067e-5438-a1ef-dbfa3405e45d", name="approve")]
+    assert tru_interrupts == exp_interrupts
+    assert model.index == 1
+    assert agent.messages[-1]["content"][0]["toolResult"]["content"] == [{"text": "done"}]

--- a/strands-py/tests/strands/session/test_repository_session_manager.py
+++ b/strands-py/tests/strands/session/test_repository_session_manager.py
@@ -16,6 +16,7 @@ from strands.types.content import ContentBlock
 from strands.types.exceptions import SessionException
 from strands.types.session import Session, SessionAgent, SessionMessage, SessionType
 from tests.fixtures.mock_session_repository import MockedSessionRepository
+from tests.fixtures.mocked_model_provider import MockedModelProvider
 
 
 @pytest.fixture
@@ -762,7 +763,12 @@ def test_sync_agent_skips_update_when_state_not_dirty_and_internal_state_unchang
     session_manager = RepositorySessionManager(session_id="test-session", session_repository=mock_repository)
 
     # Create and initialize agent
-    agent = Agent(agent_id="test-agent", session_manager=session_manager)
+    agent = Agent(
+        agent_id="test-agent",
+        model=MockedModelProvider([{"role": "assistant", "content": [{"text": "Hello!"}]}] * 3),
+        session_manager=session_manager,
+        callback_handler=None,
+    )
 
     # Track update_agent calls
     update_agent_calls = []
@@ -783,6 +789,10 @@ def test_sync_agent_skips_update_when_state_not_dirty_and_internal_state_unchang
 
     # Second sync without changes should skip update
     session_manager.sync_agent(agent)
+    assert len(update_agent_calls) == 0
+
+    for _ in range(3):
+        agent("Hello")
     assert len(update_agent_calls) == 0
 
 

--- a/strands-ts/src/agent/__tests__/agent.interrupt.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.interrupt.test.ts
@@ -4,15 +4,18 @@ import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
 import { createMockTool } from '../../__fixtures__/tool-helpers.js'
 import { TextBlock, ToolResultBlock, ToolUseBlock } from '../../types/messages.js'
 import {
+  AfterModelCallEvent,
   AfterToolCallEvent,
+  BeforeModelCallEvent,
   BeforeToolCallEvent,
   BeforeToolsEvent,
   InterruptEvent,
   MessageAddedEvent,
+  ModelStreamUpdateEvent,
 } from '../../hooks/events.js'
 import { FunctionTool } from '../../tools/function-tool.js'
 import { InterruptResponseContent } from '../../types/interrupt.js'
-import type { InterruptState, PendingToolExecution } from '../../interrupt.js'
+import { Interrupt, type InterruptState, type PendingToolExecution } from '../../interrupt.js'
 import { anyTrackingId } from '../../__fixtures__/message-helpers.js'
 
 /** Access the agent's internal interrupt state for test assertions. */
@@ -226,6 +229,173 @@ describe('Agent interrupt system', () => {
         stopReason: 'interrupt',
         interrupts: [{ name: 'batch_approval', reason: 'Approve all tools?' }],
       })
+    })
+  })
+
+  describe('interrupt from BeforeModelCallEvent hook', () => {
+    it('clears an answered approval when invalid resume limits reject the invocation', async () => {
+      const agent = new Agent({ model: new MockMessageModel(), printer: false })
+      agent.addHook(BeforeModelCallEvent, (event) => {
+        event.interrupt({ name: 'approve' })
+      })
+      const interrupted = await agent.invoke('First request')
+      expect(interrupted.stopReason).toBe('interrupt')
+
+      await expect(
+        agent.invoke([new InterruptResponseContent({ interruptId: interrupted.interrupts![0]!.id, response: 'yes' })], {
+          limits: { turns: 0 },
+        })
+      ).rejects.toThrow(new TypeError('limits.turns must be a positive finite number, got 0'))
+
+      expect(await agent.invoke('Fresh request')).toMatchObject({
+        stopReason: 'interrupt',
+        interrupts: [{ id: 'hook:beforeModelCall:approve', name: 'approve', response: undefined }],
+      })
+    })
+
+    it.each(['success', 'model error', 'consumer break', 'hook error'])(
+      'clears obsolete interrupts after resume: %s',
+      async (outcome) => {
+        const model = new MockMessageModel()
+          .addTurn(outcome === 'model error' ? new Error('model failed') : { type: 'textBlock', text: 'Approved' })
+          .addTurn({ type: 'textBlock', text: 'Must require a new approval' })
+        const agent = new Agent({ model, printer: false })
+        let requireBudgetApproval = true
+        agent.addHook(BeforeModelCallEvent, (event) => {
+          event.interrupt({ name: 'approve' })
+        })
+        agent.addHook(BeforeModelCallEvent, (event) => {
+          if (requireBudgetApproval) event.interrupt({ name: 'budget' })
+        })
+
+        const interrupted = await agent.invoke('do something')
+        expect(interrupted.interrupts).toStrictEqual([
+          new Interrupt({ id: 'hook:beforeModelCall:approve', name: 'approve' }),
+          new Interrupt({ id: 'hook:beforeModelCall:budget', name: 'budget' }),
+        ])
+
+        requireBudgetApproval = false
+        if (outcome === 'hook error') {
+          agent.addHook(ModelStreamUpdateEvent, () => {
+            throw new Error('streaming hook failed')
+          })
+        }
+        const responses = [
+          new InterruptResponseContent({ interruptId: 'hook:beforeModelCall:approve', response: 'yes' }),
+        ]
+        if (outcome === 'consumer break') {
+          for await (const event of agent.stream(responses)) {
+            if (event instanceof ModelStreamUpdateEvent) break
+          }
+        } else if (outcome === 'model error' || outcome === 'hook error') {
+          await expect(agent.invoke(responses)).rejects.toThrow(
+            outcome === 'model error' ? 'model failed' : 'streaming hook failed'
+          )
+        } else {
+          expect((await agent.invoke(responses)).stopReason).toBe('endTurn')
+        }
+
+        const nextResult = await agent.invoke('request requiring approval')
+        expect(nextResult).toMatchObject({
+          stopReason: 'interrupt',
+          interrupts: [{ id: 'hook:beforeModelCall:approve', name: 'approve' }],
+        })
+        expect(model.callCount).toBe(1)
+      }
+    )
+
+    it('preserves a streamed interrupt through resume and model retries', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'textBlock', text: 'Retry this response' })
+        .addTurn({ type: 'textBlock', text: 'Approved' })
+      const responsesSeen: unknown[] = []
+      const agent = new Agent({ model, printer: false })
+      agent.addHook(BeforeModelCallEvent, (event) => {
+        responsesSeen.push(event.interrupt({ name: 'approve', reason: 'Approve the model call?' }))
+      })
+      agent.addHook(AfterModelCallEvent, (event) => {
+        event.retry = model.callCount === 1
+      })
+      let interruptEvent: InterruptEvent | undefined
+
+      for await (const event of agent.stream('do something')) {
+        if (event instanceof InterruptEvent) {
+          interruptEvent = event
+          break
+        }
+      }
+
+      expect(interruptEvent?.interrupt).toMatchObject({
+        id: 'hook:beforeModelCall:approve',
+        name: 'approve',
+        reason: 'Approve the model call?',
+      })
+      expect(model.callCount).toBe(0)
+      expect(agent.messages).toHaveLength(1)
+      expect(responsesSeen).toEqual([])
+
+      const result = await agent.invoke([
+        new InterruptResponseContent({ interruptId: 'hook:beforeModelCall:approve', response: 'yes' }),
+      ])
+
+      expect(result.stopReason).toBe('endTurn')
+      expect(result.lastMessage.content).toEqual([new TextBlock('Approved')])
+      expect(model.callCount).toBe(2)
+      expect(responsesSeen).toEqual(['yes', 'yes'])
+      expect((await agent.invoke('request requiring approval')).stopReason).toBe('interrupt')
+    })
+
+    it.each([false, true])('clears preemptive approvals after a request (model fails: %s)', async (failModel) => {
+      const model = new MockMessageModel()
+        .addTurn(failModel ? new Error('model failed') : { type: 'textBlock', text: 'Approved' })
+        .addTurn({ type: 'textBlock', text: 'Must require a new approval' })
+      let preapprove = true
+      const gateModelCall = (event: BeforeModelCallEvent): void => {
+        event.interrupt({ name: 'approve', ...(preapprove ? { response: 'yes' } : {}) })
+      }
+      const agent = new Agent({ model, printer: false })
+      agent.addHook(BeforeModelCallEvent, gateModelCall)
+
+      if (failModel) {
+        await expect(agent.invoke('preapproved request')).rejects.toThrow('model failed')
+      } else {
+        expect((await agent.invoke('preapproved request')).stopReason).toBe('endTurn')
+      }
+      preapprove = false
+
+      const restored = new Agent({ model, printer: false })
+      restored.addHook(BeforeModelCallEvent, gateModelCall)
+      restored.loadSnapshot(JSON.parse(JSON.stringify(agent.takeSnapshot({ preset: 'session' }))))
+
+      for (const nextAgent of [agent, restored]) {
+        const result = await nextAgent.invoke('request requiring approval')
+        expect(result).toMatchObject({
+          stopReason: 'interrupt',
+          interrupts: [{ id: 'hook:beforeModelCall:approve', name: 'approve' }],
+        })
+      }
+      expect(model.callCount).toBe(1)
+    })
+
+    it('requires a new approval after a preapproved model call executes tools', async () => {
+      const model = new MockMessageModel()
+        .addTurn({ type: 'toolUseBlock', name: 'work', toolUseId: 'tool-1', input: {} })
+        .addTurn({ type: 'textBlock', text: 'Must require a new approval' })
+      const workCallback = vi.fn(() => 'done')
+      const work = createMockTool('work', workCallback)
+      const agent = new Agent({ model, tools: [work], printer: false })
+      agent.addHook(BeforeModelCallEvent, (event) => {
+        event.interrupt({ name: 'approve', ...(model.callCount === 0 ? { response: 'yes' } : {}) })
+      })
+
+      const result = await agent.invoke('do work')
+
+      expect(result).toMatchObject({
+        stopReason: 'interrupt',
+        interrupts: [{ id: 'hook:beforeModelCall:approve', name: 'approve' }],
+      })
+      expect(model.callCount).toBe(1)
+      expect(workCallback).toHaveBeenCalledOnce()
     })
   })
 

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -1313,6 +1313,7 @@ export class Agent implements LocalAgent, InvokableAgent {
     // async function* doesn't bind lexical `this`; capture for the terminal callback.
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this
+    let completed = false
     try {
       const { result } = yield* this._middlewareRegistry.invoke(
         AgentStreamStage,
@@ -1329,13 +1330,7 @@ export class Agent implements LocalAgent, InvokableAgent {
           return { result }
         }
       )
-      if (
-        this._interruptState.activated &&
-        result.stopReason !== 'interrupt' &&
-        !this._interruptState.pendingToolExecution
-      ) {
-        this._interruptState.deactivate()
-      }
+      completed = result.stopReason !== 'interrupt'
       return result
     } catch (error) {
       if (error instanceof InterruptError) {
@@ -1359,6 +1354,15 @@ export class Agent implements LocalAgent, InvokableAgent {
         })
       }
       throw error
+    } finally {
+      // Keep unfinished tool calls and approvals the agent is still waiting for, even if the caller stops reading.
+      // Otherwise, discard old approvals so the next request cannot reuse them.
+      if (
+        !this._interruptState.pendingToolExecution &&
+        (completed || !this._interruptState.activated || !this._interruptState.getUnansweredInterrupt())
+      ) {
+        this._interruptState.deactivate()
+      }
     }
   }
 
@@ -1603,6 +1607,7 @@ export class Agent implements LocalAgent, InvokableAgent {
     const agentSpan = this._tracer.startAgentSpan(agentSpanOptions)
 
     let caughtError: Error | undefined
+    let interrupted = false
     try {
       // Register structured output tool if schema provided
       if (structuredOutputTool) {
@@ -1796,14 +1801,9 @@ export class Agent implements LocalAgent, InvokableAgent {
           yield this._appendMessage(assistantMessage, invocationState)
           yield this._appendMessage(toolResultMessage, invocationState)
 
-          // Both messages are in history, so any stored pending execution is now stale.
-          this._interruptState.clearPendingToolExecution()
-
           // Deactivate interrupt state after successful tool execution so the next
           // cycle starts with a clean slate (new interrupts can be raised again).
-          if (this._interruptState.activated) {
-            this._interruptState.deactivate()
-          }
+          this._interruptState.deactivate()
 
           closeCycle()
 
@@ -1893,8 +1893,12 @@ export class Agent implements LocalAgent, InvokableAgent {
       if (error instanceof InterruptError) {
         // Handles interrupts from tools/hooks that propagated up through the agent loop.
         // AgentStreamStage middleware interrupts are caught separately in _streamWithMiddleware().
+        interrupted = true
         for (const interrupt of error.interrupts) {
           this._interruptState.registerInterrupt(interrupt)
+        }
+        if (!this._interruptState.pendingToolExecution) {
+          this._interruptState.activate()
         }
         // Fan out one event per interrupt. Each event exposes `interrupt.source` so
         // consumers can filter by origin (tool callback vs hook callback) without
@@ -1908,6 +1912,9 @@ export class Agent implements LocalAgent, InvokableAgent {
       caughtError = error as Error
       throw error
     } finally {
+      if (!interrupted && !this._interruptState.pendingToolExecution) {
+        this._interruptState.deactivate()
+      }
       // If cancelled but the catch block was bypassed (generator terminated
       // via .return() when the consumer breaks out of for-await), close an
       // existing user turn so the agent can be reinvoked.

--- a/strands-ts/src/hooks/events.ts
+++ b/strands-ts/src/hooks/events.ts
@@ -378,8 +378,9 @@ export class AfterToolCallEvent extends HookableEvent {
 /**
  * Event triggered just before the model is invoked.
  * Fired before sending messages to the model for inference.
+ * Hook callbacks can call {@link interrupt} to pause the agent before the call.
  */
-export class BeforeModelCallEvent extends HookableEvent {
+export class BeforeModelCallEvent extends HookableEvent implements Interruptible {
   readonly type = 'beforeModelCallEvent' as const
   readonly agent: LocalAgent
   readonly model: Model
@@ -413,6 +414,20 @@ export class BeforeModelCallEvent extends HookableEvent {
     if (data.projectedInputTokens !== undefined) {
       this.projectedInputTokens = data.projectedInputTokens
     }
+  }
+
+  /**
+   * Raises an interrupt for human-in-the-loop workflows.
+   * If a response is available (from a previous resume), returns it immediately.
+   * Otherwise, throws an InterruptError to halt agent execution before the model
+   * is called; resuming re-enters the same model call.
+   *
+   * @param params - Interrupt parameters including name and optional reason
+   * @returns The user's response when resuming from an interrupt
+   * @throws InterruptError when no response is available
+   */
+  interrupt<T = JSONValue>(params: InterruptParams): T {
+    return interruptFromAgent<T>(this.agent, `hook:beforeModelCall:${params.name}`, params, 'hook')
   }
 
   /**

--- a/strands-ts/src/interrupt.ts
+++ b/strands-ts/src/interrupt.ts
@@ -213,13 +213,6 @@ export class InterruptState implements InterruptStateData {
   }
 
   /**
-   * Clears the pending tool execution state.
-   */
-  clearPendingToolExecution(): void {
-    this.pendingToolExecution = undefined
-  }
-
-  /**
    * Returns the list of interrupts as an array.
    */
   getInterruptsList(): Interrupt[] {

--- a/strands-ts/src/middleware/__tests__/middleware-interrupts.test.ts
+++ b/strands-ts/src/middleware/__tests__/middleware-interrupts.test.ts
@@ -4,9 +4,10 @@ import { MockMessageModel } from '../../__fixtures__/mock-message-model.js'
 import { collectGenerator } from '../../__fixtures__/model-test-helpers.js'
 import { createMockTool } from '../../__fixtures__/tool-helpers.js'
 import { ExecuteToolStage, AgentStreamStage } from '../stages.js'
-import { TextBlock, ToolResultBlock } from '../../types/messages.js'
+import { Message, TextBlock, ToolResultBlock } from '../../types/messages.js'
+import { AgentResult } from '../../types/agent.js'
 import { InterruptResponseContent } from '../../types/interrupt.js'
-import { AfterInvocationEvent, InterruptEvent } from '../../hooks/events.js'
+import { AfterInvocationEvent, BeforeModelCallEvent, ContentBlockEvent, InterruptEvent } from '../../hooks/events.js'
 
 describe('Middleware interrupts', () => {
   describe('ExecuteToolStage', () => {
@@ -279,6 +280,84 @@ describe('Middleware interrupts', () => {
 
       expect(finalResult.stopReason).toBe('endTurn')
     })
+
+    it.each(['short circuit', 'error', 'consumer break'])(
+      'requires a new approval after middleware resumes without next(): %s',
+      async (outcome) => {
+        const agent = new Agent({ model: new MockMessageModel(), printer: false })
+        const message = new Message({ role: 'assistant', content: [new TextBlock('Denied')] })
+        agent.addMiddleware(AgentStreamStage, async function* (context) {
+          context.interrupt({ name: 'gate' })
+          if (outcome === 'error') throw new Error('middleware failed')
+          if (outcome === 'consumer break') {
+            yield new ContentBlockEvent({ agent, contentBlock: new TextBlock('Starting'), invocationState: {} })
+          }
+          return { result: new AgentResult({ stopReason: 'endTurn', lastMessage: message, invocationState: {} }) }
+        })
+
+        const interrupted = await agent.invoke('First request')
+        expect(interrupted.stopReason).toBe('interrupt')
+        const responses = [
+          new InterruptResponseContent({ interruptId: interrupted.interrupts![0]!.id, response: 'yes' }),
+        ]
+        if (outcome === 'error') {
+          await expect(agent.invoke(responses)).rejects.toThrow('middleware failed')
+        } else if (outcome === 'consumer break') {
+          for await (const event of agent.stream(responses)) {
+            if (event instanceof ContentBlockEvent) break
+          }
+        } else {
+          expect((await agent.invoke(responses)).stopReason).toBe('endTurn')
+        }
+
+        expect(await agent.invoke('Fresh request')).toMatchObject({
+          stopReason: 'interrupt',
+          interrupts: [{ id: 'middleware:agentStream:gate', name: 'gate', response: undefined }],
+        })
+      }
+    )
+
+    it.each(['output transformation', 'short circuit'])(
+      'clears unanswered interrupts when middleware completes a partial resume: %s',
+      async (outcome) => {
+        const agent = new Agent({ model: new MockMessageModel(), printer: false })
+        agent.addHook(BeforeModelCallEvent, (event) => {
+          event.interrupt({ name: 'approve' })
+        })
+        agent.addHook(BeforeModelCallEvent, (event) => {
+          event.interrupt({ name: 'budget' })
+        })
+        const interrupted = await agent.invoke('First request')
+        expect(interrupted.interrupts).toHaveLength(2)
+        const result = new AgentResult({
+          stopReason: 'endTurn',
+          lastMessage: new Message({ role: 'assistant', content: [new TextBlock('Denied')] }),
+          invocationState: {},
+        })
+        const remove =
+          outcome === 'output transformation'
+            ? agent.addMiddleware(AgentStreamStage.Output, () => ({ result }))
+            : // eslint-disable-next-line require-yield
+              agent.addMiddleware(AgentStreamStage, async function* () {
+                return { result }
+              })
+
+        expect(
+          await agent.invoke([
+            new InterruptResponseContent({ interruptId: interrupted.interrupts![0]!.id, response: 'yes' }),
+          ])
+        ).toBe(result)
+        remove()
+
+        expect(await agent.invoke('Fresh request')).toMatchObject({
+          stopReason: 'interrupt',
+          interrupts: [
+            { id: 'hook:beforeModelCall:approve', name: 'approve', response: undefined },
+            { id: 'hook:beforeModelCall:budget', name: 'budget', response: undefined },
+          ],
+        })
+      }
+    )
 
     it('clears interrupt state after resuming to a non-tool completion so the agent is reusable', async () => {
       const model = new MockMessageModel()


### PR DESCRIPTION
## Description

`BeforeModelCallEvent` lacks the interrupt API available to tool hooks, so applications cannot use the standard approval/resume flow to gate model inference. This exposes `event.interrupt()` in both SDKs: execution pauses before the model call, and the supplied response becomes available to the hook when the agent resumes.

Approval state is cleared when work completes or fails so an approval cannot silently authorize a later request. Pending interrupts remain resumable when the caller stops consuming the stream.

### Public API Changes

Inside a `BeforeModelCallEvent` callback:

```python
from strands.hooks import BeforeModelCallEvent


def approve_model_call(event: BeforeModelCallEvent) -> None:
    if not event.interrupt("model_approval", reason="Approve this model call?"):
        event.cancel = True
```

```typescript
import { BeforeModelCallEvent } from '@strands-agents/sdk'

function approveModelCall(event: BeforeModelCallEvent): void {
  if (!event.interrupt<boolean>({ name: 'model_approval', reason: 'Approve this model call?' })) {
    event.cancel = true
  }
}
```

Resume through the existing `interruptResponse` input format, supplying a boolean approval for these examples.

## Related Issues

Follow-up to #4226 and #4026.

## Documentation PR

Included in this PR under `site/`: Python and TypeScript examples in the interrupts guide.

## Type of Change

New feature

## Testing

Ran the full Python and TypeScript unit suites, affected Chromium tests, documentation checks, and package smoke tests. The existing local dependency audit remains nonzero (3 high and 8 moderate affected packages); dependency manifests and lockfiles are unchanged by this PR.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
