### PR TITLE
fix(models): route Bedrock Mantle openai.gpt-6-* to /openai/v1

### DIFF
--- a/strands-py/src/strands/models/_defaults.py
+++ b/strands-py/src/strands/models/_defaults.py
@@ -89,6 +89,7 @@ _CONTEXT_WINDOW_LIMITS: dict[str, int] = {
     "amazon.nova-2-lite-v1:0": 1_000_000,
     "amazon.nova-2-pro-preview-20251202-v1:0": 1_000_000,
     # OpenAI
+    "gpt-6-astra": 1_050_000,
     "gpt-5.6": 1_050_000,
     "gpt-5.6-sol": 1_050_000,
     "gpt-5.6-terra": 1_050_000,

--- a/strands-py/src/strands/models/_openai_bedrock.py
+++ b/strands-py/src/strands/models/_openai_bedrock.py
@@ -23,11 +23,11 @@ _MANTLE_DOCS_URL = "https://docs.aws.amazon.com/bedrock/latest/userguide/inferen
 # Mantle model lines served from /openai/v1; every other Mantle model uses /v1, and the
 # wrong base path fails with HTTP 400. The base path is a per-model property that no
 # Mantle API reports, so these prefixes were verified against the ``us-east-1`` catalog on
-# 2026-08-05. Scope each prefix to a single model line, never a vendor: one vendor's lines
+# 2026-09-10. Scope each prefix to a single model line, never a vendor: one vendor's lines
 # can split across base paths (``google.gemma-4-*`` is on /openai/v1, ``google.gemma-3-*``
 # is on /v1). An unmatched new line falls through to /v1; the ``test_mantle_routing``
 # integ test fails naming any id that routes wrong.
-_OPENAI_PATH_MODEL_PREFIXES: tuple[str, ...] = ("openai.gpt-5.", "xai.grok-4.", "google.gemma-4-")
+_OPENAI_PATH_MODEL_PREFIXES: tuple[str, ...] = ("openai.gpt-5.", "openai.gpt-6-", "xai.grok-4.", "google.gemma-4-")
 
 
 def _resolve_mantle_base_path(model_id: str) -> str:

--- a/strands-py/src/strands/models/_openai_bedrock.py
+++ b/strands-py/src/strands/models/_openai_bedrock.py
@@ -23,7 +23,7 @@ _MANTLE_DOCS_URL = "https://docs.aws.amazon.com/bedrock/latest/userguide/inferen
 # Mantle model lines served from /openai/v1; every other Mantle model uses /v1, and the
 # wrong base path fails with HTTP 400. The base path is a per-model property that no
 # Mantle API reports, so these prefixes were verified against the ``us-east-1`` catalog on
-# 2026-09-10. Scope each prefix to a single model line, never a vendor: one vendor's lines
+# 2026-08-05. Scope each prefix to a single model line, never a vendor: one vendor's lines
 # can split across base paths (``google.gemma-4-*`` is on /openai/v1, ``google.gemma-3-*``
 # is on /v1). An unmatched new line falls through to /v1; the ``test_mantle_routing``
 # integ test fails naming any id that routes wrong.

--- a/strands-py/tests/strands/models/test_defaults.py
+++ b/strands-py/tests/strands/models/test_defaults.py
@@ -21,6 +21,7 @@ class TestGetContextWindowLimit:
         assert get_context_window_limit("amazon.nova-micro-v1:0") == 128_000
 
     def test_known_openai(self):
+        assert get_context_window_limit("gpt-6-astra") == 1_050_000
         assert get_context_window_limit("gpt-5.4") == 1_050_000
         assert get_context_window_limit("gpt-4o") == 128_000
         assert get_context_window_limit("o3") == 200_000

--- a/strands-py/tests/strands/models/test_openai.py
+++ b/strands-py/tests/strands/models/test_openai.py
@@ -2111,6 +2111,7 @@ class TestOpenAIModelBedrockMantleConfig:
             # Point releases within a verified line, beyond the verified catalog.
             ("xai.grok-4.9", "/openai/v1"),
             ("openai.gpt-5.9-unreleased", "/openai/v1"),
+            ("openai.gpt-6-nova", "/openai/v1"),
             # New lines the prefixes deliberately do not cover.
             ("xai.grok-5", "/v1"),
             ("xai.grok-5-preview", "/v1"),

--- a/strands-py/tests/strands/models/test_openai.py
+++ b/strands-py/tests/strands/models/test_openai.py
@@ -2078,6 +2078,7 @@ class TestOpenAIModelBedrockMantleConfig:
             ("google.gemma-4-26b-a4b", "/openai/v1"),
             ("google.gemma-4-e2b", "/openai/v1"),
             ("openai.gpt-5.6-terra", "/openai/v1"),
+            ("openai.gpt-6-astra", "/openai/v1"),
             # Gemma 3 is served from /v1 while Gemma 4 is not, so `google.` cannot be a prefix.
             ("google.gemma-3-27b-it", "/v1"),
             ("google.gemma-3-4b-it", "/v1"),

--- a/strands-py/tests/strands/models/test_openai_responses.py
+++ b/strands-py/tests/strands/models/test_openai_responses.py
@@ -1974,6 +1974,7 @@ class TestOpenAIResponsesModelBedrockMantleConfig:
             # Point releases within a verified line, beyond the verified catalog.
             ("xai.grok-4.9", "/openai/v1"),
             ("openai.gpt-5.9-unreleased", "/openai/v1"),
+            ("openai.gpt-6-nova", "/openai/v1"),
             # New lines the prefixes deliberately do not cover.
             ("xai.grok-5", "/v1"),
             ("xai.grok-5-preview", "/v1"),

--- a/strands-py/tests/strands/models/test_openai_responses.py
+++ b/strands-py/tests/strands/models/test_openai_responses.py
@@ -1951,6 +1951,7 @@ class TestOpenAIResponsesModelBedrockMantleConfig:
             ("xai.grok-4.3", "/openai/v1"),
             ("google.gemma-4-31b", "/openai/v1"),
             ("openai.gpt-5.6-terra", "/openai/v1"),
+            ("openai.gpt-6-astra", "/openai/v1"),
             # Gemma 3 is served from /v1 while Gemma 4 is not, so `google.` cannot be a prefix.
             ("google.gemma-3-27b-it", "/v1"),
             ("openai.gpt-oss-120b", "/v1"),

--- a/strands-ts/src/models/__tests__/defaults.test.ts
+++ b/strands-ts/src/models/__tests__/defaults.test.ts
@@ -14,6 +14,7 @@ describe('getContextWindowLimit', () => {
     expect(getContextWindowLimit('amazon.nova-pro-v1:0')).toBe(300_000)
     expect(getContextWindowLimit('amazon.nova-micro-v1:0')).toBe(128_000)
     // OpenAI
+    expect(getContextWindowLimit('gpt-6-astra')).toBe(1_050_000)
     expect(getContextWindowLimit('gpt-5.4')).toBe(1_050_000)
     expect(getContextWindowLimit('gpt-4o')).toBe(128_000)
     expect(getContextWindowLimit('o3')).toBe(200_000)

--- a/strands-ts/src/models/defaults.ts
+++ b/strands-ts/src/models/defaults.ts
@@ -121,6 +121,7 @@ const CONTEXT_WINDOW_LIMITS: Record<string, number> = {
   'amazon.nova-2-pro-preview-20251202-v1:0': 1_000_000,
 
   // OpenAI
+  'gpt-6-astra': 1_050_000,
   'gpt-5.6': 1_050_000,
   'gpt-5.6-sol': 1_050_000,
   'gpt-5.6-terra': 1_050_000,

--- a/strands-ts/src/models/openai/__tests__/mantle.test.ts
+++ b/strands-ts/src/models/openai/__tests__/mantle.test.ts
@@ -198,6 +198,7 @@ describe('OpenAIModel bedrockMantleConfig', () => {
       ['google.gemma-4-26b-a4b', '/openai/v1'],
       ['google.gemma-4-e2b', '/openai/v1'],
       ['openai.gpt-5.6-terra', '/openai/v1'],
+      ['openai.gpt-6-astra', '/openai/v1'],
       // Gemma 3 is served from /v1 while Gemma 4 is not, so `google.` cannot be a prefix.
       ['google.gemma-3-27b-it', '/v1'],
       ['google.gemma-3-4b-it', '/v1'],

--- a/strands-ts/src/models/openai/__tests__/mantle.test.ts
+++ b/strands-ts/src/models/openai/__tests__/mantle.test.ts
@@ -223,6 +223,7 @@ describe('OpenAIModel bedrockMantleConfig', () => {
       // Point releases within a verified line, beyond the verified catalog.
       ['xai.grok-4.9', '/openai/v1'],
       ['openai.gpt-5.9-unreleased', '/openai/v1'],
+      ['openai.gpt-6-nova', '/openai/v1'],
       // New lines the prefixes deliberately do not cover.
       ['xai.grok-5', '/v1'],
       ['xai.grok-5-preview', '/v1'],

--- a/strands-ts/src/models/openai/mantle.ts
+++ b/strands-ts/src/models/openai/mantle.ts
@@ -16,13 +16,13 @@ const MANTLE_DOCS_URL = 'https://docs.aws.amazon.com/bedrock/latest/userguide/in
  * Mantle model lines served from `/openai/v1`; every other Mantle model uses
  * `/v1`, and the wrong base path fails with HTTP 400. The base path is a
  * per-model property that no Mantle API reports, so these prefixes were
- * verified against the `us-east-1` catalog on 2026-08-05. Scope each prefix to
+ * verified against the `us-east-1` catalog on 2026-09-10. Scope each prefix to
  * a single model line, never a vendor: one vendor's lines can split across base
  * paths (`google.gemma-4-*` is on `/openai/v1`, `google.gemma-3-*` is on
  * `/v1`). An unmatched new line falls through to `/v1`; the `mantle-routing`
  * integ test fails naming any id that routes wrong.
  */
-const OPENAI_PATH_MODEL_PREFIXES = ['openai.gpt-5.', 'xai.grok-4.', 'google.gemma-4-'] as const
+const OPENAI_PATH_MODEL_PREFIXES = ['openai.gpt-5.', 'openai.gpt-6-', 'xai.grok-4.', 'google.gemma-4-'] as const
 
 // Matches AWS region identifiers such as us-east-1, ap-southeast-1, and us-gov-east-1.
 // Anchored so a malformed region (e.g. one containing '@', ':', '/', '#') cannot re-point

--- a/strands-ts/src/models/openai/mantle.ts
+++ b/strands-ts/src/models/openai/mantle.ts
@@ -16,7 +16,7 @@ const MANTLE_DOCS_URL = 'https://docs.aws.amazon.com/bedrock/latest/userguide/in
  * Mantle model lines served from `/openai/v1`; every other Mantle model uses
  * `/v1`, and the wrong base path fails with HTTP 400. The base path is a
  * per-model property that no Mantle API reports, so these prefixes were
- * verified against the `us-east-1` catalog on 2026-09-10. Scope each prefix to
+ * verified against the `us-east-1` catalog on 2026-08-05. Scope each prefix to
  * a single model line, never a vendor: one vendor's lines can split across base
  * paths (`google.gemma-4-*` is on `/openai/v1`, `google.gemma-3-*` is on
  * `/v1`). An unmatched new line falls through to `/v1`; the `mantle-routing`


### PR DESCRIPTION
## Description

Bedrock Mantle serves each model from exactly one base path and 400s on the other. The SDK picks the path from a hand-maintained prefix list (`_OPENAI_PATH_MODEL_PREFIXES` / `OPENAI_PATH_MODEL_PREFIXES`) that only knew the `openai.gpt-5.` line, so the new `openai.gpt-6-astra` (GA on Bedrock 2026-09-08) was sent to `/v1` and every call failed with:

```
400 validation_error: The model 'openai.gpt-6-astra' does not support the '/v1/responses' API
```

This adds the `openai.gpt-6-` line to the list in both SDKs (same shape as the existing entries: one model line per prefix, so `openai.gpt-oss-*` stays on `/v1`), and adds `gpt-6-astra` to both context-window tables (1,050,000 per OpenAI's model page).

The "verified against the us-east-1 catalog" date in the comment is deliberately left alone: only the new model was exercised live (see below), not a full catalog sweep.

## Related Issues

None filed; the failure is reproduced below.

## Documentation PR

No docs list Mantle base paths or model ids, so nothing to update under `site/`.

## Type of Change

Bug fix

## Testing

Exercised end to end against Mantle in us-west-2 with `bedrock_mantle_config`/`bedrockMantleConfig` and `model_id="openai.gpt-6-astra"`:

- Python: `Agent` on `OpenAIResponsesModel` and on `OpenAIModel` both answer; `get_config()["context_window_limit"]` resolves to `1050000`.
- TypeScript: `Agent` on `OpenAIModel` with `api: 'responses'` and `api: 'chat'` both answer.
- Control: the same probe on `/v1` still returns the 400 above, and `openai.gpt-oss-120b` still resolves to `/v1` (and 400s on `/openai/v1`).

Local gates: `hatch test tests/strands/models/{test_openai,test_openai_responses,test_defaults}.py` 297 passed; `ruff format --check` / `ruff check` / `mypy` clean on the touched files; the husky pre-commit hook (build, `vitest --coverage` 4594 tests, eslint, `tsc`) passed on both commits.

The `test_mantle_routing` live-catalog sweep could not be run from my environment (no `bedrock-mantle:ListModels`); CI runs it.

- [x] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

<details><summary>Independent review ledger</summary>

Two fresh-context review rounds on this branch.

**Round 1 — APPROVE with one should-fix.** The commit had bumped the "verified on" date in the prefix comment; the reviewer pointed out that one model checked in us-west-2 doesn't back a us-east-1 catalog date. Reverted. Nit taken: an unverified-id test row (`openai.gpt-6-nova` → `/openai/v1`) pinning that the prefix is line-wide, in both SDKs. Two pre-existing issues noted, not addressed here: TS `getContextWindowLimit` doesn't strip the `openai.` vendor prefix, so Mantle ids (`openai.gpt-5.6-*` today, `openai.gpt-6-astra` now) get no limit in TS while Python resolves them; and `_resolve_mantle_base_path` doesn't strip cross-region prefixes (`us.openai.*`). Happy to file issues for both.

**Round 2 — APPROVE.** Confirmed both fixes landed identically in Py and TS; no regressions. Residual nit not taken: the comment above the unverified-id block says "point releases", and `gpt-6-nova` is a sibling name rather than a point release.

</details>

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.