### PR TITLE
feat(vended-tools): include exit_code in shell tool result

### DIFF
--- a/site/src/content/docs/user-guide/concepts/sandbox/index.mdx
+++ b/site/src/content/docs/user-guide/concepts/sandbox/index.mdx
@@ -87,7 +87,7 @@ See [Available Sandboxes](./available-sandboxes.mdx) for Docker and SSH configur
 
 When a sandbox is configured, the agent automatically registers two tools so the model can operate in the sandboxed environment without additional setup:
 
-- **`sandbox_shell`** — Executes shell commands. Each call runs in a fresh shell; state such as variables and the working directory does not persist across calls.
+- **`sandbox_shell`** — Executes shell commands and returns output (stdout), error (stderr), and exit_code (non-zero means the command failed). Each call runs in a fresh shell; state such as variables and the working directory does not persist across calls.
 - **`sandbox_file_editor`** — Views, creates, and edits files using absolute paths. Supports view (with line ranges), create, string replace, and insert operations.
 
 If a tool with the same name is already registered on the agent, the sandbox-vended version is skipped. This lets you override a vended tool with a stricter variant:

--- a/strands-py/src/strands/vended_tools/shell/shell.py
+++ b/strands-py/src/strands/vended_tools/shell/shell.py
@@ -51,7 +51,7 @@ def make_shell(
 
     @tool(name=name, description=description, context="tool_context")
     async def shell_tool(command: str, tool_context: ToolContext, timeout: int = _DEFAULT_TIMEOUT) -> ShellOutput:
-        """Executes a shell command and returns its output.
+        """Executes a shell command and returns its output and exit code.
 
         Args:
             command: The shell command to execute.
@@ -66,7 +66,7 @@ def make_shell(
         except Exception as e:
             # ShellExecutionError subclasses RuntimeError, so prior handlers still match.
             raise ShellExecutionError(str(e)) from e
-        return {"output": result.stdout, "error": result.stderr}
+        return {"output": result.stdout, "error": result.stderr, "exit_code": result.exit_code}
 
     return shell_tool
 

--- a/strands-py/src/strands/vended_tools/shell/types.py
+++ b/strands-py/src/strands/vended_tools/shell/types.py
@@ -9,10 +9,12 @@ class ShellOutput(TypedDict):
     Attributes:
         output: Standard output captured from the command.
         error: Standard error captured from the command. Empty when there was none.
+        exit_code: Exit code of the command. Non-zero means the command failed.
     """
 
     output: str
     error: str
+    exit_code: int
 
 
 class ShellExecutionError(RuntimeError):
@@ -25,7 +27,8 @@ class ShellExecutionError(RuntimeError):
 
 
 SANDBOX_SHELL_DESCRIPTION = (
-    "Executes shell commands. Each call runs in a fresh shell; "
+    "Executes shell commands and returns output (stdout), error (stderr), and exit_code (non-zero means the "
+    "command failed). Each call runs in a fresh shell; "
     "state such as variables and the working directory does not persist across calls."
 )
 """Description for the shell tool."""

--- a/strands-py/tests/strands/vended_tools/test_shell.py
+++ b/strands-py/tests/strands/vended_tools/test_shell.py
@@ -37,11 +37,18 @@ class TestMakeShell:
         result = await sandbox_shell(command='echo "hello sandbox"', tool_context=_tool_context())
         assert "hello sandbox" in result["output"]
         assert result["error"] == ""
+        assert result["exit_code"] == 0
 
     @pytest.mark.asyncio
     async def test_captures_stderr_via_sandbox(self, sandbox_shell):
         result = await sandbox_shell(command='echo "oops" >&2', tool_context=_tool_context())
         assert "oops" in result["error"]
+        assert result["exit_code"] == 0
+
+    @pytest.mark.asyncio
+    async def test_reports_nonzero_exit_code(self, sandbox_shell):
+        result = await sandbox_shell(command="exit 42", tool_context=_tool_context())
+        assert result["exit_code"] == 42
 
     @pytest.mark.asyncio
     async def test_does_not_persist_state_between_calls(self, sandbox_shell):

--- a/strands-ts/src/vended-tools/shell/README.md
+++ b/strands-ts/src/vended-tools/shell/README.md
@@ -53,6 +53,7 @@ Without a bound sandbox, the tool reads `context.agent.sandbox` at call time.
 interface ShellOutput {
   output: string // Standard output (stdout)
   error: string // Standard error (stderr) - empty string if no errors
+  exit_code: number // Exit code of the command - non-zero means it failed
 }
 ```
 

--- a/strands-ts/src/vended-tools/shell/__tests__/shell.test.node.ts
+++ b/strands-ts/src/vended-tools/shell/__tests__/shell.test.node.ts
@@ -32,6 +32,14 @@ describe.skipIf(process.platform === 'win32')('makeShell', () => {
 
     expect((result as ShellOutput).output).toContain('hello sandbox')
     expect((result as ShellOutput).error).toBe('')
+    expect((result as ShellOutput).exit_code).toBe(0)
+  })
+
+  it('reports a non-zero exit code', async () => {
+    const { sandboxShell, context } = createSandboxShell()
+    const result = await sandboxShell.invoke({ command: 'exit 42' }, context)
+
+    expect((result as ShellOutput).exit_code).toBe(42)
   })
 
   it('captures stderr via sandbox', async () => {
@@ -39,6 +47,7 @@ describe.skipIf(process.platform === 'win32')('makeShell', () => {
     const result = await sandboxShell.invoke({ command: 'echo "oops" >&2' }, context)
 
     expect((result as ShellOutput).error).toContain('oops')
+    expect((result as ShellOutput).exit_code).toBe(0)
   })
 
   it('does not persist state between calls (stateless)', async () => {

--- a/strands-ts/src/vended-tools/shell/make-shell.ts
+++ b/strands-ts/src/vended-tools/shell/make-shell.ts
@@ -60,7 +60,7 @@ export function makeShell(
       const sandbox = boundSandbox ?? context.agent.sandbox
       try {
         const result = await sandbox.execute(input.command, { timeout: input.timeout ?? 120 })
-        return { output: result.stdout, error: result.stderr } as ShellOutput
+        return { output: result.stdout, error: result.stderr, exit_code: result.exitCode } as ShellOutput
       } catch (err) {
         // Shell* extends Bash* so pre-rename catch clauses keep matching.
         if (err instanceof SandboxTimeoutError) throw new ShellTimeoutError(err.message)

--- a/strands-ts/src/vended-tools/shell/types.ts
+++ b/strands-ts/src/vended-tools/shell/types.ts
@@ -8,7 +8,8 @@
 import { BashTimeoutError, BashSessionError } from '../bash/types.js'
 
 export const SANDBOX_SHELL_DESCRIPTION =
-  'Executes shell commands. Each call runs in a fresh shell; ' +
+  'Executes shell commands and returns output (stdout), error (stderr), and exit_code (non-zero means the ' +
+  'command failed). Each call runs in a fresh shell; ' +
   'state such as variables and the working directory does not persist across calls.'
 
 /**
@@ -38,9 +39,8 @@ export class ShellExecutionError extends BashSessionError {
 }
 
 /**
- * Output format for shell command execution. Structurally identical to the bash
- * tool's output, so pre-rename consumers keep working, but declared standalone;
- * mirrors the Python SDK's `ShellOutput`.
+ * Output format for shell command execution. Declared standalone; mirrors the
+ * Python SDK's `ShellOutput`.
  */
 export interface ShellOutput {
   /**
@@ -55,7 +55,12 @@ export interface ShellOutput {
   error: string
 
   /**
+   * Exit code of the command. Non-zero means the command failed.
+   */
+  exit_code: number
+
+  /**
    * Allow indexing with string keys for JSONValue compatibility.
    */
-  [key: string]: string
+  [key: string]: string | number
 }


### PR DESCRIPTION
## Description

The vended, sandbox-routed `shell` tool returned only `{output, error}`, discarding the exit code that `sandbox.execute()` already produces in `ExecutionResult`. Without it a model can't tell a failing command from a succeeding one when stderr is empty (`grep` returning 1, a test runner that prints to stdout, `exit 42`) — and harnesses built on the SDK (e.g. strands-agents/stan#85) end up re-implementing the tool just to get the code back.

This adds `exit_code` to the result in both SDKs and mentions it in the tool description so the model knows to read it. `output`/`error` are unchanged, timeouts still raise (`SandboxTimeoutError` → `ShellTimeoutError` in TS) so they surface as a failed tool call, and non-timeout errors are still wrapped in `ShellExecutionError`.

## Public API Changes

`ShellOutput` gains a required `exit_code` field. The key is `exit_code` in both SDKs (model-facing wire key, same convention as the file editor's `old_str`/`file_text`).

```python
# Before
{"output": "", "error": "oops\n"}
# After
{"output": "", "error": "oops\n", "exit_code": 3}
```

TypeScript only: the `ShellOutput` index signature widens from `string` to `string | number`, so `ShellOutput` is no longer assignable to the deprecated `bash` tool's `BashOutput`. This is type-level only; runtime consumers of `output`/`error` are unaffected. The persistent TS `bash` tool still returns `{output, error}` — its sentinel protocol would need to carry `$?`, so that's left as a follow-up.

## Related Issues

strands-agents/stan#85 (the shape this lets stan drop)

## Documentation PR

`site/.../concepts/sandbox/index.mdx` and `strands-ts/src/vended-tools/shell/README.md` updated in this PR to reflect the new field/description.

## Type of Change

New feature

## Testing

- [x] I ran `hatch run prepare` — equivalent gates run directly: `ruff format --check`, `ruff check`, `mypy` (vended_tools/shell + sandbox), `pytest tests/strands/vended_tools tests/strands/sandbox` (357 passed); TS `prettier`, `eslint`, `npm run type-check`, `check:browser-bundle`, `vitest --project unit-node src/vended-tools src/sandbox` (311 passed).
- Exercised end to end against `NotASandboxLocalEnvironment`: `echo ok` → `exit_code: 0`; `echo oops >&2; exit 3` → `exit_code: 3`; `sleep 5` with `timeout=1` → still raises `SandboxTimeoutError`.
- Independent review pass (fresh context) found no blockers; its doc-drift findings (TS README, stale "structurally identical to BashOutput" comment, sandbox docs bullet) are fixed in this commit.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

---
_Opened by `strandly-the-agent` on request of `mkmeral`._