### PR TITLE
feat(session): add capture_fields to scope SnapshotSessionManager persistence

### DIFF
--- a/strands-py/src/strands/session/snapshot_session_manager.py
+++ b/strands-py/src/strands/session/snapshot_session_manager.py
@@ -38,7 +38,7 @@ from ..hooks.events import (
 from ..hooks.registry import HookRegistry
 from ..storage.local_file_storage import LocalFileStorage
 from ..storage.storage import _NAMESPACED, Storage, _NamespacedStorage
-from ..types._snapshot import Snapshot
+from ..types._snapshot import Snapshot, SnapshotField, resolve_snapshot_fields
 from ..types.content import Message
 from ..types.exceptions import SnapshotException
 from ..types.session import decode_bytes_values, encode_bytes_values
@@ -200,6 +200,10 @@ class SnapshotSessionManager(SessionManager):
         session = SnapshotSessionManager("my-session", storage=LocalFileStorage())
         agent = Agent(session_manager=session)
         ```
+
+    Hosts that reconstruct the agent per invocation (e.g. AgentCore Harness) can narrow what is
+    persisted so restore never overwrites per-request configuration ussing ``capture_fields``.
+        ```
     """
 
     def __init__(
@@ -209,6 +213,7 @@ class SnapshotSessionManager(SessionManager):
         storage: Storage | None = None,
         save_latest_on: SaveLatestStrategy = "invocation",
         snapshot_trigger: SnapshotTrigger | None = None,
+        capture_fields: list[SnapshotField] | None = None,
         **kwargs: Any,
     ) -> None:
         """Initialize the snapshot session manager.
@@ -223,12 +228,16 @@ class SnapshotSessionManager(SessionManager):
             snapshot_trigger: Optional callback invoked after each invocation; when it
                 returns True an immutable snapshot is appended for checkpointing. An immutable
                 snapshot can also be forced at any point via :meth:`save_snapshot`.
+            capture_fields: Which agent fields to persist and restore. Defaults to the full
+                session plus the system prompt, so a rehydrated agent behaves identically to the
+                original. Pass an explicit list to persist only those fields. 
             **kwargs: Additional keyword arguments for future extensibility.
 
         Raises:
             ValueError: If ``session_id`` is empty, is a relative-path segment (``.`` or ``..``),
                 normalizes to empty, or contains a path separator; or if ``save_latest_on`` is
                 not a recognized strategy.
+            SnapshotException: If ``capture_fields`` contains an unknown field name or is empty.
         """
         self.session_id = validate_identifier(session_id, Identifier.SESSION)
         # validate_identifier permits "."/".."/whitespace, which either collapse the session
@@ -243,6 +252,11 @@ class SnapshotSessionManager(SessionManager):
         self._storage: Storage | None = _resolve_storage(storage) if storage is not None else None
         self._save_latest_on: SaveLatestStrategy = save_latest_on
         self._snapshot_trigger = snapshot_trigger
+
+        if capture_fields is None:
+            self._capture_fields = resolve_snapshot_fields(preset="session", include=["system_prompt"])
+        else:
+            self._capture_fields = resolve_snapshot_fields(include=capture_fields)
 
     @property
     def _resolved_storage(self) -> Storage:
@@ -462,7 +476,10 @@ class SnapshotSessionManager(SessionManager):
         data = await self._resolved_storage.read(key)
         if data is None:
             return False
-        agent.load_snapshot(_deserialize_snapshot(data))
+
+        snapshot = _deserialize_snapshot(data)
+        snapshot.data = {name: value for name, value in snapshot.data.items() if name in self._capture_fields}
+        agent.load_snapshot(snapshot)
         return True
 
     async def _save_latest(self, agent: "Agent") -> None:
@@ -516,10 +533,9 @@ class SnapshotSessionManager(SessionManager):
             await self._save_latest(event.agent)
 
     def _capture(self, agent: "Agent") -> Snapshot:
-        """Capture a full session snapshot including the system prompt.
+        """Capture a snapshot of the configured ``capture_fields``.
 
-        The shared ``"session"`` preset omits ``system_prompt`` (opt-in for callers like
-        the goal plugin); session persistence includes it so a rehydrated agent behaves
-        identically to the original, matching the TypeScript SDK's session preset.
+        Defaults to the full ``"session"`` preset plus ``system_prompt`` so a rehydrated agent
+        behaves identically to the original, matching the TypeScript SDK's session preset.
         """
-        return agent.take_snapshot(preset="session", include=["system_prompt"])
+        return agent.take_snapshot(include=list(self._capture_fields))

--- a/strands-py/tests/strands/session/test_snapshot_session_manager.py
+++ b/strands-py/tests/strands/session/test_snapshot_session_manager.py
@@ -14,6 +14,7 @@ from strands.hooks.registry import HookRegistry
 from strands.multiagent import GraphBuilder, Swarm
 from strands.session.snapshot_session_manager import (
     SnapshotSessionManager,
+    _deserialize_snapshot,
     _new_snapshot_id,
     _session_prefix,
     _snapshot_key,
@@ -793,6 +794,77 @@ async def test_corrupt_snapshot_raises_typed_error_on_restore(temp_dir):
 
     with pytest.raises(SnapshotException, match="Failed to deserialize snapshot"):
         Agent(model=_model("hi"), session_manager=SnapshotSessionManager("s1", storage=storage), agent_id="a1")
+
+
+@pytest.mark.asyncio
+async def test_default_captures_full_session_including_system_prompt(storage):
+    """Without capture_fields, the saved blob holds all six fields (guards the default scope)."""
+    manager = SnapshotSessionManager("s1", storage=storage)
+    Agent(model=_model("ok"), session_manager=manager, agent_id="a1", system_prompt="be helpful")("hi")
+
+    snapshot = _deserialize_snapshot(await storage.read(_on_disk_key("s1", "a1")))
+    assert set(snapshot.data) == {
+        "messages",
+        "state",
+        "conversation_manager_state",
+        "interrupt_state",
+        "system_prompt",
+        "model_state",
+    }
+
+
+@pytest.mark.asyncio
+async def test_capture_fields_narrows_saved_blob(storage):
+    """capture_fields persists exactly the requested fields and nothing else."""
+    manager = SnapshotSessionManager("s1", storage=storage, capture_fields=["messages", "state"])
+    Agent(model=_model("ok"), session_manager=manager, agent_id="a1", system_prompt="be helpful")("hi")
+
+    snapshot = _deserialize_snapshot(await storage.read(_on_disk_key("s1", "a1")))
+    assert set(snapshot.data) == {"messages", "state"}
+
+
+def test_capture_fields_restore_leaves_per_request_config(storage):
+    """A narrow scope restores history and state without overwriting the request's system prompt.
+
+    Mirrors a host (e.g. AgentCore Harness) that reconstructs the agent per invocation with a
+    fresh system prompt: the prior conversation and plugin state carry over, the new prompt stays.
+    """
+    manager = SnapshotSessionManager("s1", storage=storage, capture_fields=["messages", "state"])
+    agent = Agent(model=_model("stored"), session_manager=manager, agent_id="a1", system_prompt="prompt A")
+    agent.state.set("todos", ["ship it"])
+    agent("remember this")
+
+    manager_2 = SnapshotSessionManager("s1", storage=storage, capture_fields=["messages", "state"])
+    agent_2 = Agent(model=_model("x"), session_manager=manager_2, agent_id="a1", system_prompt="prompt B")
+
+    assert "remember this" in _texts(agent_2)  # history carried over
+    assert agent_2.state.get("todos") == ["ship it"]  # plugin state carried over
+    assert agent_2.system_prompt == "prompt B"  # the request's own prompt is untouched
+
+
+def test_restore_filters_out_of_scope_fields_from_stale_broad_snapshot(storage):
+    """A snapshot written under a broad scope cannot overwrite config once the scope is narrowed.
+
+    A snapshot_latest written by the default (full) manager still on disk must not push its
+    system_prompt/model_state onto an agent a later narrow-scoped manager restores into.
+    """
+    broad = SnapshotSessionManager("s1", storage=storage)
+    agent = Agent(model=_model("stored"), session_manager=broad, agent_id="a1", system_prompt="prompt A")
+    agent._model_state = {"response_id": "resp-A"}
+    agent("first turn")
+
+    narrow = SnapshotSessionManager("s1", storage=storage, capture_fields=["messages", "state"])
+    agent_2 = Agent(model=_model("x"), session_manager=narrow, agent_id="a1", system_prompt="prompt B")
+
+    assert "first turn" in _texts(agent_2)  # in-scope field still restored
+    assert agent_2.system_prompt == "prompt B"  # out-of-scope system_prompt filtered out
+    assert agent_2._model_state == {}  # out-of-scope model_state filtered out
+
+
+def test_capture_fields_rejects_unknown_field(storage):
+    """An unknown capture field fails fast at construction, not at the first save."""
+    with pytest.raises(SnapshotException, match="Invalid snapshot field"):
+        SnapshotSessionManager("s1", storage=storage, capture_fields=["messages", "bogus"])  # type: ignore[list-item]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

`SnapshotSessionManager` always captures and thus restores the full session preset plus the system prompt (messages, agent state, conversation-manager state, interrupt state, model state, system prompt). That is correct when the same agent resumes across restarts, but wrong for a host that reconstructs the `Agent` on every invocation with per-request configuration, as AgentCore Harness does. There, restoring `system_prompt`/`model_state` overwrites the caller's config for the current request, and restoring `conversation_manager_state` breaks when the truncation strategy differs between invocations. Such hosts only want conversation history and plugin state to carry forward.

This adds a `capture_fields` constructor option to scope what is persisted. Because `Agent.load_snapshot` only applies fields present in the stored blob, capture scope already drives restore scope; `_restore` additionally strips out-of-scope fields before applying, so a snapshot written under a broader scope (e.g. one left on disk from before a host narrowed its config) can never overwrite the reconstructed agent's model, system prompt, or conversation manager.

Python-only; the matching TypeScript `captureFields` is a follow-up. Default behavior is unchanged.

## Public API Changes

`SnapshotSessionManager.__init__` gains an optional `capture_fields` parameter. Omitting it preserves today's full-session-plus-system-prompt scope.

```python
# Before: always persists and restores all six fields
session = SnapshotSessionManager("my-session", storage=LocalFileStorage())

# After: persist and restore only conversation history and plugin state, so a per-invocation
# rebuilt agent keeps its own model / system prompt / conversation manager
session = SnapshotSessionManager(
    "my-session", storage=LocalFileStorage(), capture_fields=["messages", "state"]
)
```

An unknown field name (or an empty list) raises `SnapshotException` at construction.

## Related Issues

N/A

## Documentation PR

Follow-up

## Type of Change

New feature

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

Ran the `SnapshotSessionManager` unit suite (covers the default full scope, a narrowed scope, that restore leaves a differing per-request system prompt intact, that a stale broad snapshot is filtered on restore, and the invalid-field failure), plus `hatch fmt --linter` and `hatch run complexity` on the changed source. Also exercised the AgentCore reconstruct-per-invocation pattern end to end against on-disk `LocalFileStorage` — reconstructing the agent hundreds of times with a rotating model, system prompt, and conversation-manager type — and confirmed history and state carry forward while per-request config is never overwritten.

- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
