### PR TITLE
docs(memory): add file memory store docs

### DIFF
--- a/site/src/config/navigation.yml
+++ b/site/src/config/navigation.yml
@@ -94,6 +94,7 @@ sidebar:
               - label: "Overview"
                 slug: docs/user-guide/concepts/memory/overview
               - docs/user-guide/concepts/memory/test-memory-store
+              - docs/user-guide/concepts/memory/file-memory-store
               - docs/user-guide/concepts/memory/bedrock-knowledge-base
           - docs/user-guide/concepts/agents/retry-strategies
           - label: Sandbox

--- a/site/src/content/docs/user-guide/concepts/memory/file-memory-store.mdx
+++ b/site/src/content/docs/user-guide/concepts/memory/file-memory-store.mdx
@@ -1,0 +1,306 @@
+---
+title: File Memory Store
+description: "A file-based memory store backed by the Storage
+  interface: markdown files with keyword search and
+  topic-aware extraction."
+tags: [memory]
+sourceLinks:
+  - path: strands-py/src/strands/vended_memory_stores/file_memory_store/store.py
+  - path: strands-ts/src/vended-memory-stores/file-memory-store/store.ts
+addedDate: 2026-09-08
+sidebar:
+  label: "File Store"
+---
+
+`FileMemoryStore` is a [`MemoryStore`](./overview#stores)
+that persists knowledge as markdown files through the SDK's
+unified `Storage` interface. Each topic gets its own `.md`
+file, and repeated writes to the same topic append rather
+than overwrite, so related facts accumulate in one place.
+
+Point it at a store name and the default local-file backend
+handles the rest:
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands import Agent
+from strands.memory import MemoryManager
+from strands.vended_memory_stores.file_memory_store import (
+    FileMemoryStore,
+)
+
+store = FileMemoryStore(name="agent-memory")
+
+agent = Agent(
+    memory_manager=MemoryManager(stores=[store]),
+)
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/memory/file-memory-store_imports.ts:basic_imports"
+
+--8<-- "user-guide/concepts/memory/file-memory-store.ts:basic"
+```
+</Tab>
+</Tabs>
+
+The store is writable by default, so the
+[`add_memory` tool](./overview#memory-tools) and
+[automatic extraction](./overview#automatic-extraction)
+work without extra setup.
+
+Search is keyword matching, not semantic. For
+embedding-based search over a managed vector store, use the
+[Bedrock Knowledge Base store](./bedrock-knowledge-base).
+
+## How It Works
+
+The store writes one markdown file per topic under a
+`memory/<name>/` namespace in storage. When you add content,
+the first line becomes the filename (slugified, truncated to
+50 characters, lowercased). A heading like
+`# Travel preferences` produces `travel-preferences.md`.
+
+If a file with that slug already exists, the new facts
+(lines after the heading) are appended to the existing file
+rather than overwriting it. This keeps related knowledge
+grouped by topic without the agent needing to know what
+already exists.
+
+When the slug has no usable characters (all punctuation,
+for example), the store falls back to a timestamped name
+like `entry-1717459200000.md`.
+
+## Configuration
+
+`FileMemoryStore` accepts the
+[shared `MemoryStore` fields](./overview#stores) (`name`,
+`description`,
+<Syntax py="max_search_results" ts="maxSearchResults" />,
+`writable`, `extraction`) plus one of its own:
+
+| Field | Purpose |
+|-------|---------|
+| `storage` | The `Storage` backend for file operations. Defaults to `LocalFileStorage` at `./.strands/`. Keys are auto-scoped under `memory/<name>/`, so stores with distinct names safely share one backend. |
+
+`writable` defaults to `true`. Construction accepts an
+empty `name` (the store scopes under `memory//`, which is
+valid but not recommended).
+
+The TypeScript SDK accepts additional extraction options
+(<Syntax py="extraction" ts="extraction" /> as an object):
+
+| Field | Purpose |
+|-------|---------|
+| `search` | Override the search strategy. When set, <Syntax py="search" ts="search" /> delegates to this strategy instead of the default keyword scan. TypeScript only. |
+| `extraction.model` | Model the built-in extractor uses to distill facts. Defaults to the agent's own model; set a cheaper one to cut cost. TypeScript only. |
+| `extraction.systemPrompt` | Custom framing for what counts as a durable fact, replacing the default guidance. TypeScript only. |
+
+## Storage Backend
+
+The default `LocalFileStorage` writes to `./.strands/`
+relative to the working directory, so a store named
+`agent-memory` lands at `./.strands/memory/agent-memory/`.
+
+Swap the backend to persist elsewhere. Any `Storage`
+implementation works: `S3Storage` for a shared bucket,
+`InMemoryStorage` for ephemeral runs, or a custom backend:
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands.storage import S3Storage
+from strands.vended_memory_stores.file_memory_store import (
+    FileMemoryStore,
+)
+
+store = FileMemoryStore(
+    name="agent-memory",
+    storage=S3Storage(bucket="my-memory-bucket"),
+)
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/memory/file-memory-store_imports.ts:custom_storage_imports"
+
+--8<-- "user-guide/concepts/memory/file-memory-store.ts:custom_storage"
+```
+</Tab>
+</Tabs>
+
+The store auto-scopes keys under `memory/<name>/` unless
+the provided storage is already namespaced, so two stores
+with different names on the same backend stay isolated. Two
+stores with the *same* name on the same backend share
+files: give them different names to keep them separate.
+
+## Search
+
+`search` ranks files by keyword token overlap: it counts
+how many distinct words from the query appear in each
+file's name and content, and returns the top scorers. A
+query with no usable words returns nothing.
+
+:::note
+Search is lexical, not semantic. "Seat" matches "seat" but
+not "chair." For synonym-aware retrieval, use the
+[Bedrock Knowledge Base store](./bedrock-knowledge-base)
+or plug in a custom search strategy (TypeScript only).
+:::
+
+## Writing Memories
+
+<Syntax py="add" ts="add" /> stores content and returns
+the canonical storage key. The heading line drives the
+filename; subsequent lines are the facts:
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands.vended_memory_stores.file_memory_store import (
+    FileMemoryStore,
+)
+
+store = FileMemoryStore(name="agent-memory")
+
+key = await store.add(
+    "# Travel preferences\n- Prefers aisle seats"
+)
+
+results = await store.search("seat preference")
+for entry in results:
+    print(entry.content, entry.metadata.get("score"))
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/memory/file-memory-store_imports.ts:search_and_add_imports"
+
+--8<-- "user-guide/concepts/memory/file-memory-store.ts:search_and_add"
+```
+</Tab>
+</Tabs>
+
+Concurrent writes to the same file are serialized so they
+don't clobber each other.
+
+## Extraction
+
+Enable [automatic extraction](./overview#automatic-extraction)
+to capture memories from the conversation without the agent
+calling a tool:
+
+<Tabs>
+<Tab label="Python">
+
+```python
+from strands.vended_memory_stores.file_memory_store import (
+    FileMemoryStore,
+)
+
+store = FileMemoryStore(
+    name="agent-memory",
+    extraction=True,
+)
+```
+</Tab>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/memory/file-memory-store_imports.ts:extraction_imports"
+
+--8<-- "user-guide/concepts/memory/file-memory-store.ts:extraction"
+```
+</Tab>
+</Tabs>
+
+With <Syntax py="extraction=True" ts="extraction: true" />,
+the store creates a **key-aware
+extractor** that reads the existing file headings from
+storage and injects them into the extraction prompt. The
+model then reuses those headings when new facts belong to
+an existing topic, keeping related knowledge grouped
+instead of fragmenting across files.
+
+<Tabs>
+<Tab label="Python">
+
+To steer what the extractor captures, pass an
+`ExtractionConfig` with a custom `ModelExtractor`:
+
+```python
+from strands.models import BedrockModel
+from strands.memory.extraction.model_extractor import (
+    ModelExtractor,
+)
+from strands.memory.extraction.types import ExtractionConfig
+from strands.vended_memory_stores.file_memory_store import (
+    FileMemoryStore,
+)
+
+store = FileMemoryStore(
+    name="agent-memory",
+    extraction=ExtractionConfig(
+        extractor=ModelExtractor(
+            model=BedrockModel(
+                model_id="us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            ),
+            system_prompt="Extract durable user preferences as discrete facts.",
+        ),
+    ),
+)
+```
+</Tab>
+<Tab label="TypeScript">
+
+Pass `model` and `systemPrompt` directly in the extraction
+config to customize the built-in extractor without
+replacing it:
+
+```typescript
+--8<-- "user-guide/concepts/memory/file-memory-store_imports.ts:extraction_custom_imports"
+
+--8<-- "user-guide/concepts/memory/file-memory-store.ts:extraction_custom"
+```
+</Tab>
+</Tabs>
+
+The store implements <Syntax py="add" ts="add" /> but not
+<Syntax py="add_messages" ts="addMessages" />, so
+extraction runs client-side: a `ModelExtractor` distills
+facts from the conversation and writes each through `add`.
+To change the cadence or swap the extractor, see
+[Automatic Extraction](./overview#automatic-extraction).
+
+## Scale and Limitations
+
+The store suits working memory for a single agent or a
+small team: hundreds to low thousands of files. Each
+`add` reads the target file and rewrites it, so throughput
+depends on the storage backend, not the store itself.
+
+Separate instances or processes writing the same storage
+namespace are not coordinated beyond the per-key lock
+within a single process. Avoid pointing two instances at
+the same namespace; the last write wins.
+
+## Related
+
+- [Memory](./overview) - the `MemoryManager` concept
+  this store plugs into, including the tools, extraction,
+  and injection it enables.
+- [Test memory store](./test-memory-store) - the
+  zero-setup vended `MemoryStore` backed by a local JSON
+  file, for prototyping and tests.
+- [Bedrock Knowledge Base store](./bedrock-knowledge-base) -
+  the managed `MemoryStore` with semantic search, for
+  production workloads.

--- a/site/src/content/docs/user-guide/concepts/memory/file-memory-store.mdx
+++ b/site/src/content/docs/user-guide/concepts/memory/file-memory-store.mdx
@@ -143,17 +143,40 @@ files: give them different names to keep them separate.
 
 ## Search
 
-`search` ranks files by keyword token overlap: it counts
-how many distinct words from the query appear in each
-file's name and content, and returns the top scorers. A
-query with no usable words returns nothing.
+The default search ranks files by keyword token overlap: it
+counts how many distinct words from the query appear in
+each file's name and content, and returns the top scorers.
+A query with no usable words returns nothing.
 
 :::note
-Search is lexical, not semantic. "Seat" matches "seat" but
-not "chair." For synonym-aware retrieval, use the
-[Bedrock Knowledge Base store](./bedrock-knowledge-base)
-or plug in a custom search strategy (TypeScript only).
+The default search is lexical, not semantic. "Seat" matches
+"seat" but not "chair." For embedding-based semantic search
+over a managed vector store, use the
+[Bedrock Knowledge Base store](./bedrock-knowledge-base).
 :::
+
+<Tabs>
+<Tab label="Python">
+
+Python uses the built-in keyword search. To change the
+search behavior, implement a custom `MemoryStore` that
+wraps `FileMemoryStore` and overrides `search`.
+
+</Tab>
+<Tab label="TypeScript">
+
+Pass a `search` strategy to replace the default keyword
+scan. The SDK ships `QmdSearchStrategy` for BM25 ranking
+(requires `@tobilu/qmd`), or implement the
+`SearchStrategy` interface for your own backend:
+
+```typescript
+--8<-- "user-guide/concepts/memory/file-memory-store_imports.ts:custom_search_imports"
+
+--8<-- "user-guide/concepts/memory/file-memory-store.ts:custom_search"
+```
+</Tab>
+</Tabs>
 
 ## Writing Memories
 

--- a/site/src/content/docs/user-guide/concepts/memory/file-memory-store.ts
+++ b/site/src/content/docs/user-guide/concepts/memory/file-memory-store.ts
@@ -1,6 +1,7 @@
 import { Agent, BedrockModel, MemoryManager } from '@strands-agents/sdk'
 import { FileMemoryStore } from '@strands-agents/sdk/vended-memory-stores/file-memory-store'
 import { S3Storage } from '@strands-agents/sdk/storage'
+import { QmdSearchStrategy } from '@strands-agents/sdk/storage/search/qmd'
 
 // =====================
 // Basic usage
@@ -55,6 +56,22 @@ async function searchAndAdd() {
   // --8<-- [end:search_and_add]
 }
 void searchAndAdd
+
+// =====================
+// Custom search strategy (BM25 via QMD)
+// =====================
+
+function customSearch() {
+  // --8<-- [start:custom_search]
+  const store = new FileMemoryStore({
+    name: 'agent-memory',
+    search: new QmdSearchStrategy(),
+  })
+  // --8<-- [end:custom_search]
+
+  void store
+}
+void customSearch
 
 // =====================
 // Extraction with defaults

--- a/site/src/content/docs/user-guide/concepts/memory/file-memory-store.ts
+++ b/site/src/content/docs/user-guide/concepts/memory/file-memory-store.ts
@@ -1,0 +1,95 @@
+import { Agent, BedrockModel, MemoryManager } from '@strands-agents/sdk'
+import { FileMemoryStore } from '@strands-agents/sdk/vended-memory-stores/file-memory-store'
+import { S3Storage } from '@strands-agents/sdk/storage'
+
+// =====================
+// Basic usage
+// =====================
+
+function basic() {
+  // --8<-- [start:basic]
+  const store = new FileMemoryStore({ name: 'agent-memory' })
+
+  const agent = new Agent({
+    model: new BedrockModel(),
+    memoryManager: new MemoryManager({
+      stores: [store],
+    }),
+  })
+  // --8<-- [end:basic]
+
+  void agent
+}
+void basic
+
+// =====================
+// Custom storage backend
+// =====================
+
+function customStorage() {
+  // --8<-- [start:custom_storage]
+  const store = new FileMemoryStore({
+    name: 'agent-memory',
+    storage: new S3Storage({ bucket: 'my-memory-bucket' }),
+  })
+  // --8<-- [end:custom_storage]
+
+  void store
+}
+void customStorage
+
+// =====================
+// Search and add
+// =====================
+
+async function searchAndAdd() {
+  // --8<-- [start:search_and_add]
+  const store = new FileMemoryStore({ name: 'agent-memory' })
+
+  await store.add('# Travel preferences\n- Prefers aisle seats')
+
+  const results = await store.search('seat preference')
+  for (const entry of results) {
+    console.log(entry.content, entry.metadata?.score)
+  }
+  // --8<-- [end:search_and_add]
+}
+void searchAndAdd
+
+// =====================
+// Extraction with defaults
+// =====================
+
+function extraction() {
+  // --8<-- [start:extraction]
+  const store = new FileMemoryStore({
+    name: 'agent-memory',
+    extraction: true,
+  })
+  // --8<-- [end:extraction]
+
+  void store
+}
+void extraction
+
+// =====================
+// Extraction with custom model
+// =====================
+
+function extractionCustom() {
+  // --8<-- [start:extraction_custom]
+  const store = new FileMemoryStore({
+    name: 'agent-memory',
+    extraction: {
+      model: new BedrockModel({
+        modelId: 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
+      }),
+      systemPrompt:
+        'Extract durable user preferences as discrete facts.',
+    },
+  })
+  // --8<-- [end:extraction_custom]
+
+  void store
+}
+void extractionCustom

--- a/site/src/content/docs/user-guide/concepts/memory/file-memory-store_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/memory/file-memory-store_imports.ts
@@ -1,0 +1,24 @@
+// @ts-nocheck
+
+// --8<-- [start:basic_imports]
+import { Agent, BedrockModel, MemoryManager } from '@strands-agents/sdk'
+import { FileMemoryStore } from '@strands-agents/sdk/vended-memory-stores/file-memory-store'
+// --8<-- [end:basic_imports]
+
+// --8<-- [start:custom_storage_imports]
+import { FileMemoryStore } from '@strands-agents/sdk/vended-memory-stores/file-memory-store'
+import { S3Storage } from '@strands-agents/sdk/storage'
+// --8<-- [end:custom_storage_imports]
+
+// --8<-- [start:search_and_add_imports]
+import { FileMemoryStore } from '@strands-agents/sdk/vended-memory-stores/file-memory-store'
+// --8<-- [end:search_and_add_imports]
+
+// --8<-- [start:extraction_imports]
+import { FileMemoryStore } from '@strands-agents/sdk/vended-memory-stores/file-memory-store'
+// --8<-- [end:extraction_imports]
+
+// --8<-- [start:extraction_custom_imports]
+import { BedrockModel } from '@strands-agents/sdk'
+import { FileMemoryStore } from '@strands-agents/sdk/vended-memory-stores/file-memory-store'
+// --8<-- [end:extraction_custom_imports]

--- a/site/src/content/docs/user-guide/concepts/memory/file-memory-store_imports.ts
+++ b/site/src/content/docs/user-guide/concepts/memory/file-memory-store_imports.ts
@@ -14,6 +14,11 @@ import { S3Storage } from '@strands-agents/sdk/storage'
 import { FileMemoryStore } from '@strands-agents/sdk/vended-memory-stores/file-memory-store'
 // --8<-- [end:search_and_add_imports]
 
+// --8<-- [start:custom_search_imports]
+import { FileMemoryStore } from '@strands-agents/sdk/vended-memory-stores/file-memory-store'
+import { QmdSearchStrategy } from '@strands-agents/sdk/storage/search/qmd'
+// --8<-- [end:custom_search_imports]
+
 // --8<-- [start:extraction_imports]
 import { FileMemoryStore } from '@strands-agents/sdk/vended-memory-stores/file-memory-store'
 // --8<-- [end:extraction_imports]

--- a/site/src/content/docs/user-guide/concepts/memory/overview.mdx
+++ b/site/src/content/docs/user-guide/concepts/memory/overview.mdx
@@ -502,6 +502,7 @@ Three SDK features manage different kinds of state; memory is the one that cross
 ## Related
 
 - [Test memory store](./test-memory-store) - the zero-setup vended `MemoryStore` backed by a local JSON file, for prototyping and testing.
+- [File memory store](./file-memory-store) - the vended `MemoryStore` backed by the `Storage` interface, persisting knowledge as markdown files with topic-aware extraction.
 - [Bedrock Knowledge Base store](./bedrock-knowledge-base) - the vended `MemoryStore` backed by Amazon Bedrock Knowledge Bases.
 - [Context Injector](../plugins/context-injector) - the generic injection plugin that memory injection builds on.
 - [Session management](../agents/session-management) - persist the conversation itself across restarts.

--- a/site/src/content/docs/user-guide/concepts/memory/test-memory-store.mdx
+++ b/site/src/content/docs/user-guide/concepts/memory/test-memory-store.mdx
@@ -204,5 +204,7 @@ backing file raises rather than returning bad data; a missing file starts empty.
 
 - [Memory](./overview) - the `MemoryManager` concept this store plugs into, including the
   tools, extraction, and injection it enables.
+- [File memory store](./file-memory-store) - the vended `MemoryStore` backed by the
+  `Storage` interface, persisting knowledge as markdown files with topic-aware extraction.
 - [Bedrock Knowledge Base store](./bedrock-knowledge-base) - the managed `MemoryStore`
   with semantic search, for production workloads.


### PR DESCRIPTION

## Description
Add user-facing docs for the FileMemoryStore vended memory store, covering storage backend, search, write behavior, topic-aware extraction, and configuration. Includes TypeScript snippet files and updates to sidebar navigation and Related sections on sibling memory pages.


## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Documentation update

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [ ] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
