### PR TITLE
feat(vended-tools): port Python notebook improvements to TS

### DIFF
--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools-imports.ts
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools-imports.ts
@@ -24,6 +24,11 @@ import { Agent } from '@strands-agents/sdk'
 import { notebook } from '@strands-agents/sdk/vended-tools/notebook'
 // --8<-- [end:notebook_import]
 
+// --8<-- [start:notebook_custom_import]
+import { Agent } from '@strands-agents/sdk'
+import { makeNotebook } from '@strands-agents/sdk/vended-tools/notebook'
+// --8<-- [end:notebook_custom_import]
+
 // --8<-- [start:notebook_persistence_import]
 import { Agent, SessionManager, FileStorage } from '@strands-agents/sdk'
 import { notebook } from '@strands-agents/sdk/vended-tools/notebook'

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -201,9 +201,18 @@ print(notebooks.get("tasks"))
 </Tab>
 </Tabs>
 
-**Example - Custom configuration (Python):**
+**Example - Custom configuration:**
 
 <Tabs>
+<Tab label="TypeScript">
+
+```typescript
+--8<-- "user-guide/concepts/tools/vended-tools-imports.ts:notebook_custom_import"
+
+--8<-- "user-guide/concepts/tools/vended-tools.ts:notebook_custom_example"
+```
+
+</Tab>
 <Tab label="Python">
 
 ```python

--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.ts
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.ts
@@ -3,7 +3,7 @@ import { Agent } from '@strands-agents/sdk'
 import { bash } from '@strands-agents/sdk/vended-tools/bash'
 import { fileEditor } from '@strands-agents/sdk/vended-tools/file-editor'
 import { httpRequest } from '@strands-agents/sdk/vended-tools/http-request'
-import { notebook } from '@strands-agents/sdk/vended-tools/notebook'
+import { notebook, makeNotebook } from '@strands-agents/sdk/vended-tools/notebook'
 // --8<-- [end:basic_import]
 import { SessionManager, FileStorage } from '@strands-agents/sdk'
 import { sleep, makeSleep } from '@strands-agents/sdk/vended-tools/sleep'
@@ -88,6 +88,17 @@ async function notebookTaskExample() {
   // The agent uses the notebook to plan and track its work
   await agent.invoke('Write a project plan for building a personal budget tracker app')
   // --8<-- [end:notebook_example]
+}
+
+// Notebook custom configuration example
+async function notebookMakeExample() {
+  // --8<-- [start:notebook_custom_example]
+  const notes = makeNotebook({
+    name: 'notes',
+    maxNotebookSizeBytes: 64 * 1024, // 64 KiB
+  })
+  const agent = new Agent({ tools: [notes] })
+  // --8<-- [end:notebook_custom_example]
 }
 
 // Notebook state persistence example

--- a/strands-ts/src/vended-tools/notebook/README.md
+++ b/strands-ts/src/vended-tools/notebook/README.md
@@ -32,6 +32,33 @@ await agent.invoke('Add "- Create a CLI tool" to the ideas notebook')
 await agent.invoke('Read the ideas notebook')
 ```
 
+### Customising with `makeNotebook`
+
+Use `makeNotebook` to configure the tool's name, description, or per-notebook size cap before passing it to the agent.
+
+```typescript
+import { makeNotebook } from '@strands-agents/sdk/vended-tools/notebook'
+
+// Custom name and a 64 KiB cap per notebook
+const scratchpad = makeNotebook({
+  name: 'scratchpad',
+  description: 'A scratchpad for working notes.',
+  maxNotebookSizeBytes: 65_536,
+})
+
+const agent = new Agent({
+  model: new BedrockModel({
+    region: 'us-east-1',
+  }),
+  tools: [scratchpad],
+})
+```
+
+`makeNotebook` validates its arguments at call time:
+
+- `name` must be a non-empty string.
+- `maxNotebookSizeBytes` must be a positive integer. Defaults to 1 MiB (1,048,576 bytes).
+
 ### State Persistence
 
 The notebook tool automatically persists state within an agent session:
@@ -152,10 +179,27 @@ const content = await notebook.invoke(
 - **Automatic Persistence**: State persists within agent sessions automatically
 - **Natural Language**: Interact with notebooks using natural language through the agent
 - **State Management**: Save and restore notebook state across application restarts
+- **Size Limits**: Configurable per-notebook size cap (default 1 MiB) to prevent unbounded state growth
 - **Type Safety**: Full TypeScript support with runtime validation
 - **Universal**: Works in both browser and server environments
 
 ## API Reference
+
+### `makeNotebook(options?)`
+
+Creates a notebook tool instance.
+
+| Option                 | Type     | Default              | Description                                                                |
+| ---------------------- | -------- | -------------------- | -------------------------------------------------------------------------- |
+| `name`                 | `string` | `"notebook"`         | Tool name exposed to the model. Must be non-empty.                         |
+| `description`          | `string` | Built-in description | Tool description shown to the model.                                       |
+| `maxNotebookSizeBytes` | `number` | `1_048_576`          | Maximum UTF-8 byte size for a single notebook. Must be a positive integer. |
+
+The size cap is enforced after `create` and `write` operations (the only two that can grow a notebook). `clear` is never capped. If content would exceed the cap, the operation throws before persisting state.
+
+### `notebook`
+
+The default export — equivalent to `makeNotebook()` with all defaults.
 
 ### Input Schema
 

--- a/strands-ts/src/vended-tools/notebook/__tests__/notebook.test.ts
+++ b/strands-ts/src/vended-tools/notebook/__tests__/notebook.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { notebook } from '../notebook.js'
+import { makeNotebook, notebook } from '../notebook.js'
 import type { NotebookInput, NotebookState } from '../types.js'
 import type { ToolContext } from '../../../index.js'
 import { StateStore } from '../../../state-store.js'
@@ -502,14 +502,6 @@ describe('notebook tool', () => {
       notebooks = state.get<NotebookState>('notebooks')
       expect(notebooks!.notes).toBe('Initial\nAdded')
     })
-
-    it('initializes default notebook if state is empty', async () => {
-      const { state, context } = createFreshContext()
-      const result = await notebook.invoke({ mode: 'list' }, context)
-      expect(result).toContain('default: Empty')
-      const notebooks = state.get<NotebookState>('notebooks')
-      expect(notebooks!.default).toBe('')
-    })
   })
 
   describe('validation errors', () => {
@@ -556,6 +548,128 @@ describe('notebook tool', () => {
           context
         )
       ).rejects.toThrow()
+    })
+  })
+
+  describe('malformed state guard', () => {
+    it('throws when notebooks state is not a plain object', async () => {
+      const { state, context } = createFreshContext()
+      state.set('notebooks', 42)
+      await expect(notebook.invoke({ mode: 'list' }, context)).rejects.toThrow(
+        'Malformed notebooks state: expected a plain object'
+      )
+    })
+
+    it('throws when notebooks state contains a non-string value', async () => {
+      const { state, context } = createFreshContext()
+      state.set('notebooks', { notes: 123 })
+      await expect(notebook.invoke({ mode: 'list' }, context)).rejects.toThrow(
+        'Malformed notebooks state: keys and values must be strings'
+      )
+    })
+  })
+
+  describe('makeNotebook factory', () => {
+    it('throws when name is empty', () => {
+      expect(() => makeNotebook({ name: '' })).toThrow('name must be a non-empty string')
+    })
+
+    it('throws when maxNotebookSizeBytes is zero', () => {
+      expect(() => makeNotebook({ maxNotebookSizeBytes: 0 })).toThrow('maxNotebookSizeBytes must be a positive integer')
+    })
+
+    it('throws when maxNotebookSizeBytes is a float', () => {
+      expect(() => makeNotebook({ maxNotebookSizeBytes: 1.5 })).toThrow(
+        'maxNotebookSizeBytes must be a positive integer'
+      )
+    })
+
+    it('accepts a positive integer maxNotebookSizeBytes', () => {
+      expect(() => makeNotebook({ maxNotebookSizeBytes: 1024 })).not.toThrow()
+    })
+  })
+
+  describe('size cap enforcement', () => {
+    it('throws when create content exceeds the cap', async () => {
+      const smallTool = makeNotebook({ maxNotebookSizeBytes: 10 })
+      const { context } = createFreshContext()
+      await expect(
+        smallTool.invoke({ mode: 'create', name: 'nb', newStr: 'This is longer than ten bytes' }, context)
+      ).rejects.toThrow('would exceed maximum of 10 bytes')
+    })
+
+    it('throws when write (append) would exceed the cap', async () => {
+      const smallTool = makeNotebook({ maxNotebookSizeBytes: 20 })
+      const { state, context } = createFreshContext()
+      state.set('notebooks', { notes: 'Hello' })
+      await expect(
+        smallTool.invoke({ mode: 'write', name: 'notes', newStr: 'This string pushes it over the limit' }, context)
+      ).rejects.toThrow('would exceed maximum of 20 bytes')
+    })
+
+    it('throws when write (replace) would exceed the cap', async () => {
+      const smallTool = makeNotebook({ maxNotebookSizeBytes: 10 })
+      const { state, context } = createFreshContext()
+      state.set('notebooks', { notes: 'Hi' })
+      await expect(
+        smallTool.invoke({ mode: 'write', name: 'notes', oldStr: 'Hi', newStr: 'A string that is too long' }, context)
+      ).rejects.toThrow('would exceed maximum of 10 bytes')
+    })
+
+    it('does not apply the size cap for clear', async () => {
+      // clear cannot grow content, so cap must not apply even on a tool with a tiny cap
+      const smallTool = makeNotebook({ maxNotebookSizeBytes: 5 })
+      const { state, context } = createFreshContext()
+      state.set('notebooks', { notes: 'Big content here that exceeds 5 bytes' })
+      await expect(smallTool.invoke({ mode: 'clear', name: 'notes' }, context)).resolves.toBe(
+        "Cleared notebook 'notes'"
+      )
+    })
+
+    it('allows content exactly at the cap', async () => {
+      const content = 'abc' // 3 bytes
+      const smallTool = makeNotebook({ maxNotebookSizeBytes: 3 })
+      const { context } = createFreshContext()
+      await expect(smallTool.invoke({ mode: 'create', name: 'nb', newStr: content }, context)).resolves.toBe(
+        "Created notebook 'nb' with specified content"
+      )
+    })
+  })
+
+  describe('mutating mode state persistence gating', () => {
+    it('persists state after create', async () => {
+      const { state, context } = createFreshContext()
+      state.set('notebooks', { nb: '' })
+      await notebook.invoke({ mode: 'create', name: 'nb', newStr: 'hello' }, context)
+      expect(state.get<NotebookState>('notebooks')!.nb).toBe('hello')
+    })
+
+    it('persists state after write', async () => {
+      const { state, context } = createFreshContext()
+      state.set('notebooks', { nb: 'hello' })
+      await notebook.invoke({ mode: 'write', name: 'nb', newStr: ' world' }, context)
+      expect(state.get<NotebookState>('notebooks')!.nb).toBe('hello\n world')
+    })
+
+    it('persists state after clear', async () => {
+      const { state, context } = createFreshContext()
+      state.set('notebooks', { nb: 'data' })
+      await notebook.invoke({ mode: 'clear', name: 'nb' }, context)
+      expect(state.get<NotebookState>('notebooks')!.nb).toBe('')
+    })
+
+    it('does not persist state after read', async () => {
+      const { state, context } = createFreshContext()
+      state.set('notebooks', { nb: 'unchanged' })
+      await notebook.invoke({ mode: 'read', name: 'nb' }, context)
+      expect(state.get('notebooks')).toEqual({ nb: 'unchanged' })
+    })
+
+    it('does not persist state after list', async () => {
+      const { state, context } = createFreshContext()
+      state.set('notebooks', { nb: 'data' })
+      await notebook.invoke({ mode: 'list' }, context)
+      expect(state.get('notebooks')).toEqual({ nb: 'data' })
     })
   })
 })

--- a/strands-ts/src/vended-tools/notebook/__tests__/notebook.test.ts
+++ b/strands-ts/src/vended-tools/notebook/__tests__/notebook.test.ts
@@ -146,7 +146,14 @@ describe('notebook tool', () => {
       const { state, context } = createFreshContext()
       state.set('notebooks', { default: 'Line 1\nLine 2\nLine 3\nLine 4\nLine 5' })
       const result = await notebook.invoke({ mode: 'read', readRange: [10, 20] }, context)
-      expect(result).toBe('No valid lines found in range')
+      expect(result).toBe("No lines found in range [10, 20]. Notebook 'default' has 5 line(s).")
+    })
+
+    it('clamps a huge end bound', { timeout: 1000 }, async () => {
+      const { state, context } = createFreshContext()
+      state.set('notebooks', { default: 'Line 1\nLine 2\nLine 3' })
+      const result = await notebook.invoke({ mode: 'read', readRange: [1, 1e9] }, context)
+      expect(result).toBe('1: Line 1\n2: Line 2\n3: Line 3')
     })
   })
 
@@ -549,6 +556,22 @@ describe('notebook tool', () => {
         )
       ).rejects.toThrow()
     })
+
+    it('rejects write with both oldStr and insertLine', async () => {
+      const { state, context } = createFreshContext()
+      state.set('notebooks', { default: 'Line 1\nLine 2' })
+      await expect(
+        notebook.invoke(
+          {
+            mode: 'write',
+            oldStr: 'Line 1',
+            newStr: 'Replaced',
+            insertLine: 0,
+          } as any,
+          context
+        )
+      ).rejects.toThrow()
+    })
   })
 
   describe('malformed state guard', () => {
@@ -605,6 +628,7 @@ describe('notebook tool', () => {
       await expect(
         smallTool.invoke({ mode: 'write', name: 'notes', newStr: 'This string pushes it over the limit' }, context)
       ).rejects.toThrow('would exceed maximum of 20 bytes')
+      expect(state.get<NotebookState>('notebooks')!.notes).toBe('Hello')
     })
 
     it('throws when write (replace) would exceed the cap', async () => {
@@ -667,9 +691,10 @@ describe('notebook tool', () => {
 
     it('does not persist state after list', async () => {
       const { state, context } = createFreshContext()
-      state.set('notebooks', { nb: 'data' })
-      await notebook.invoke({ mode: 'list' }, context)
-      expect(state.get('notebooks')).toEqual({ nb: 'data' })
+      state.set('notebooks', {})
+      const result = await notebook.invoke({ mode: 'list' }, context)
+      expect(result).toContain('default: Empty')
+      expect(state.get('notebooks')).toEqual({})
     })
   })
 })

--- a/strands-ts/src/vended-tools/notebook/index.ts
+++ b/strands-ts/src/vended-tools/notebook/index.ts
@@ -2,5 +2,6 @@
  * Notebook tool for managing text notebooks within agent invocations.
  */
 
-export { notebook } from './notebook.js'
+export { notebook, makeNotebook } from './notebook.js'
+export type { MakeNotebookOptions } from './notebook.js'
 export type { NotebookState, NotebookInput } from './types.js'

--- a/strands-ts/src/vended-tools/notebook/notebook.ts
+++ b/strands-ts/src/vended-tools/notebook/notebook.ts
@@ -90,12 +90,15 @@ export function makeNotebook({
           const hasReplacement = data.oldStr !== undefined && data.newStr !== undefined
           const hasInsertion = data.insertLine !== undefined && data.newStr !== undefined
           const hasAppend = data.oldStr === undefined && data.insertLine === undefined && data.newStr !== undefined
-          return hasReplacement || hasInsertion || hasAppend
+          const isAmbiguous = data.oldStr !== undefined && data.insertLine !== undefined
+          return (hasReplacement || hasInsertion || hasAppend) && !isAmbiguous
         }
         return true
       },
       {
-        message: 'Write operation requires newStr, optionally with oldStr for replacement or insertLine for insertion',
+        message:
+          'Write operation requires newStr, optionally with oldStr for replacement or insertLine for insertion; ' +
+          'oldStr and insertLine cannot be combined',
       }
     )
 
@@ -112,7 +115,7 @@ export function makeNotebook({
       const notebooksObj = context.agent.appState.get('notebooks')
       let notebooks: Record<string, string>
 
-      if (!notebooksObj) {
+      if (notebooksObj == null) {
         notebooks = {}
       } else if (typeof notebooksObj === 'object' && !Array.isArray(notebooksObj)) {
         if (Object.values(notebooksObj as object).some((v) => typeof v !== 'string')) {
@@ -259,7 +262,11 @@ function handleRead(notebooks: Record<string, string>, name: string, readRange?:
     selectedLines.push(`${lineNum}: ${lines[lineNum - 1]}`)
   }
 
-  return selectedLines.length > 0 ? selectedLines.join('\n') : 'No valid lines found in range'
+  if (selectedLines.length === 0) {
+    return `No lines found in range [${readRange[0]}, ${readRange[1]}]. Notebook '${name}' has ${lines.length} line(s).`
+  }
+
+  return selectedLines.join('\n')
 }
 
 /**

--- a/strands-ts/src/vended-tools/notebook/notebook.ts
+++ b/strands-ts/src/vended-tools/notebook/notebook.ts
@@ -1,47 +1,180 @@
 import { tool } from '../../index.js'
 import { z } from 'zod'
-import type { NotebookState } from './types.js'
+import type { NotebookInput } from './types.js'
+import type { InvokableTool } from '../../tools/tool.js'
+
+const DEFAULT_MAX_NOTEBOOK_SIZE_BYTES = 1_048_576 // 1 MiB
+
+/** Modes that mutate `notebooks` state and must be persisted. */
+const MUTATING_MODES = new Set(['create', 'write', 'clear'])
+
+/** Modes that can grow state and therefore need size-cap enforcement. */
+const GROWING_MODES = new Set(['create', 'write'])
 
 /**
- * Zod schema for notebook input validation.
+ * Options for {@link makeNotebook}.
  */
-const notebookInputSchema = z
-  .object({
-    mode: z
-      .enum(['create', 'list', 'read', 'write', 'clear'])
-      .describe('The operation to perform: `create`, `list`, `read`, `write`, `clear`.'),
-    name: z.string().optional().describe('Name of the notebook to operate on. Defaults to "default".'),
-    newStr: z
-      .string()
-      .optional()
-      .describe('Text to append, or the new string for replacement and insertion operations.'),
-    readRange: z
-      .array(z.number())
-      .optional()
-      .describe('Optional parameter of `view` command. Line range to show [start, end]. Supports negative indices.'),
-    oldStr: z.string().optional().describe('String to replace in write mode when doing text replacement.'),
-    insertLine: z
-      .union([z.string(), z.number()])
-      .optional()
-      .describe(
-        'Line number (int) or search text (str) for insertion point in write mode.\nSupports negative indices.'
-      ),
-  })
-  .refine(
-    (data) => {
-      // Validate write mode requirements
-      if (data.mode === 'write') {
-        const hasReplacement = data.oldStr !== undefined && data.newStr !== undefined
-        const hasInsertion = data.insertLine !== undefined && data.newStr !== undefined
-        const hasAppend = data.oldStr === undefined && data.insertLine === undefined && data.newStr !== undefined
-        return hasReplacement || hasInsertion || hasAppend
+export interface MakeNotebookOptions {
+  /**
+   * Tool name exposed to the model.
+   * @defaultValue `"notebook"`
+   */
+  name?: string
+  /**
+   * Tool description shown to the model.
+   * @defaultValue The built-in notebook description string.
+   */
+  description?: string
+  /**
+   * Maximum size of a single notebook's content in bytes (UTF-8 encoded).
+   * @defaultValue `1_048_576` (1 MiB)
+   */
+  maxNotebookSizeBytes?: number
+}
+
+/**
+ * Creates a notebook tool with a custom name, description, and size cap.
+ *
+ * @param options - Configuration options for the tool.
+ * @returns A tool that manages text notebooks in agent state.
+ *
+ * @throws Error if `name` is empty or `maxNotebookSizeBytes` is not a positive integer.
+ *
+ * @example
+ * ```typescript
+ * const myNotebook = makeNotebook({ name: 'scratchpad', maxNotebookSizeBytes: 65536 })
+ * const agent = new Agent({ tools: [myNotebook] })
+ * ```
+ */
+export function makeNotebook({
+  name = 'notebook',
+  description = 'Manages text notebooks for note-taking and documentation. Supports create, list, read, write (append, replace, or insert), and clear operations. In write mode: newStr alone appends to the end; newStr with oldStr replaces matching text; newStr with insertLine inserts at a position. A write only succeeds on a notebook that already exists: use list to check, or create to start a new one (create replaces any existing content). Notebooks persist within the agent invocation.',
+  maxNotebookSizeBytes = DEFAULT_MAX_NOTEBOOK_SIZE_BYTES,
+}: MakeNotebookOptions = {}): InvokableTool<NotebookInput, string> {
+  if (!name) {
+    throw new Error('name must be a non-empty string')
+  }
+  if (!Number.isInteger(maxNotebookSizeBytes) || maxNotebookSizeBytes < 1) {
+    throw new Error('maxNotebookSizeBytes must be a positive integer')
+  }
+
+  /**
+   * Zod schema for notebook input validation.
+   */
+  const notebookInputSchema = z
+    .object({
+      mode: z
+        .enum(['create', 'list', 'read', 'write', 'clear'])
+        .describe('The operation to perform: `create`, `list`, `read`, `write`, `clear`.'),
+      name: z.string().optional().describe('Name of the notebook to operate on. Defaults to "default".'),
+      newStr: z
+        .string()
+        .optional()
+        .describe('Text to append, or the new string for replacement and insertion operations.'),
+      readRange: z
+        .array(z.number())
+        .optional()
+        .describe('Optional parameter of `read` command. Line range to show [start, end]. Supports negative indices.'),
+      oldStr: z.string().optional().describe('String to replace in write mode when doing text replacement.'),
+      insertLine: z
+        .union([z.string(), z.number()])
+        .optional()
+        .describe(
+          'Line number (int) or search text (str) for insertion point in write mode.\nSupports negative indices.'
+        ),
+    })
+    .refine(
+      (data) => {
+        // Validate write mode requirements
+        if (data.mode === 'write') {
+          const hasReplacement = data.oldStr !== undefined && data.newStr !== undefined
+          const hasInsertion = data.insertLine !== undefined && data.newStr !== undefined
+          const hasAppend = data.oldStr === undefined && data.insertLine === undefined && data.newStr !== undefined
+          return hasReplacement || hasInsertion || hasAppend
+        }
+        return true
+      },
+      {
+        message: 'Write operation requires newStr, optionally with oldStr for replacement or insertLine for insertion',
       }
-      return true
+    )
+
+  return tool({
+    name,
+    description,
+    inputSchema: notebookInputSchema,
+    callback: (input, context) => {
+      if (!context) {
+        throw new Error('Tool context is required for notebook operations')
+      }
+
+      // Get notebooks from state, or initialize if not present
+      const notebooksObj = context.agent.appState.get('notebooks')
+      let notebooks: Record<string, string>
+
+      if (!notebooksObj) {
+        notebooks = {}
+      } else if (typeof notebooksObj === 'object' && !Array.isArray(notebooksObj)) {
+        if (Object.values(notebooksObj as object).some((v) => typeof v !== 'string')) {
+          throw new Error('Malformed notebooks state: keys and values must be strings')
+        }
+        notebooks = notebooksObj as Record<string, string>
+      } else {
+        throw new Error('Malformed notebooks state: expected a plain object')
+      }
+
+      // Ensure default notebook exists
+      if (Object.keys(notebooks).length === 0) {
+        notebooks.default = ''
+      }
+
+      let result: string
+
+      switch (input.mode) {
+        case 'create':
+          result = handleCreate(notebooks, input.name ?? 'default', input.newStr)
+          break
+
+        case 'list':
+          result = handleList(notebooks)
+          break
+
+        case 'read':
+          result = handleRead(notebooks, input.name ?? 'default', input.readRange)
+          break
+
+        case 'write':
+          result = handleWrite(notebooks, input.name ?? 'default', input.oldStr, input.newStr, input.insertLine)
+          break
+
+        case 'clear':
+          result = handleClear(notebooks, input.name ?? 'default')
+          break
+
+        default:
+          throw new Error(`Unknown mode: ${input.mode}`)
+      }
+
+      if (GROWING_MODES.has(input.mode)) {
+        const notebookName = input.name ?? 'default'
+        const encoder = new TextEncoder()
+        const size = encoder.encode(notebooks[notebookName]).byteLength
+        if (size > maxNotebookSizeBytes) {
+          throw new Error(
+            `Notebook '${notebookName}' content (${size} bytes) would exceed maximum of ${maxNotebookSizeBytes} bytes`
+          )
+        }
+      }
+
+      if (MUTATING_MODES.has(input.mode)) {
+        // Persist notebooks back to state
+        context.agent.appState.set('notebooks', notebooks)
+      }
+
+      return result
     },
-    {
-      message: 'Write operation requires newStr, optionally with oldStr for replacement or insertLine for insertion',
-    }
-  )
+  })
+}
 
 /**
  * Notebook tool for managing persistent text notebooks.
@@ -63,61 +196,7 @@ const notebookInputSchema = z
  * )
  * ```
  */
-export const notebook = tool({
-  name: 'notebook',
-  description:
-    'Manages text notebooks for note-taking and documentation. Supports create, list, read, write (append, replace, or insert), and clear operations. In write mode: newStr alone appends to the end; newStr with oldStr replaces matching text; newStr with insertLine inserts at a position. A write only succeeds on a notebook that already exists: use list to check, or create to start a new one (create replaces any existing content). Notebooks persist within the agent invocation.',
-  inputSchema: notebookInputSchema,
-  callback: (input, context) => {
-    if (!context) {
-      throw new Error('Tool context is required for notebook operations')
-    }
-
-    // Get notebooks from state, or initialize if not present
-    let notebooks = context.agent.appState.get<NotebookState>('notebooks')
-
-    if (!notebooks) {
-      notebooks = {}
-    }
-
-    // Ensure default notebook exists
-    if (Object.keys(notebooks).length === 0) {
-      notebooks.default = ''
-    }
-
-    let result: string
-
-    switch (input.mode) {
-      case 'create':
-        result = handleCreate(notebooks, input.name ?? 'default', input.newStr)
-        break
-
-      case 'list':
-        result = handleList(notebooks)
-        break
-
-      case 'read':
-        result = handleRead(notebooks, input.name ?? 'default', input.readRange)
-        break
-
-      case 'write':
-        result = handleWrite(notebooks, input.name ?? 'default', input.oldStr, input.newStr, input.insertLine)
-        break
-
-      case 'clear':
-        result = handleClear(notebooks, input.name ?? 'default')
-        break
-
-      default:
-        throw new Error(`Unknown mode: ${input.mode}`)
-    }
-
-    // Persist notebooks back to state
-    context.agent.appState.set('notebooks', notebooks)
-
-    return result
-  },
-})
+export const notebook = makeNotebook()
 
 /**
  * Handles create operation.
@@ -176,10 +255,8 @@ function handleRead(notebooks: Record<string, string>, name: string, readRange?:
   }
 
   const selectedLines: string[] = []
-  for (let lineNum = start; lineNum <= end; lineNum++) {
-    if (lineNum >= 1 && lineNum <= lines.length) {
-      selectedLines.push(`${lineNum}: ${lines[lineNum - 1]}`)
-    }
+  for (let lineNum = Math.max(start, 1); lineNum <= Math.min(end, lines.length); lineNum++) {
+    selectedLines.push(`${lineNum}: ${lines[lineNum - 1]}`)
   }
 
   return selectedLines.length > 0 ? selectedLines.join('\n') : 'No valid lines found in range'


### PR DESCRIPTION
## Description
This PR ports improvements from the Python notebook vended tool (#4132) to TS:
- Size Caps: notebooks cannot grow beyond a configured size cap, preventing unbounded growth.
- Mutation Mode Check: read and list operations no longer alter notebooks, keeping them side effect free.
- Tool Factory: allows users to customize the tool name, description, and size caps.
- Read Range Length Check: checks there are 2 values in the read range, matching the intended readRange shape.

This also fixes minor bugs in the TS notebook that were discovered during the Python port: replace "view" with "read" in readRange param description, add malformed state guard, clamp readRange loop, and hints that oldStr + insertLine cannot be used together.

Example factory usage:
```
import { makeNotebook } from '@strands-agents/sdk/vended-tools/notebook'

const scratchpad = makeNotebook({
  name: 'scratchpad',
  description: 'A scratchpad for working notes.',
  maxNotebookSizeBytes: 65_536,
})

const agent = new Agent({
  model: new BedrockModel({
    region: 'us-east-1',
  }),
  tools: [scratchpad],
})
```

## Related Issues

Follow-up to #3240, Partially addresses #4133 (`__proto__` still fails to persist, but its fix adds complexity for a contrived input)

## Documentation PR

This updates the site docs and TS notebook README.

## Type of Change

New feature

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- [ ] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
