### PR TITLE
fix(bidi): align reference semantics with Agent and Model

### DIFF
--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/hooks.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/hooks.mdx
@@ -287,7 +287,9 @@ for the final sync. See [Session Management](session-management.md).
 
 ## Accessing Invocation State
 
-Pass context through `start(invocation_state=...)` and read it in shared tool hooks:
+Pass context through `start(invocation_state=...)` or `run(..., invocation_state=...)`.
+Tools and their hooks share the caller's dictionary until the agent stops, including
+across connection restarts. Changes made by any of them are visible to the others.
 
 ```python
 from strands import LocalAgent, tool

--- a/strands-py/src/strands/agent/agent.py
+++ b/strands-py/src/strands/agent/agent.py
@@ -376,8 +376,7 @@ class Agent(AgentBase, LocalAgent):
         # Resolve once: configured sandbox, or this agent's own host default (not shared across agents).
         self._sandbox: Sandbox = sandbox or NotASandboxLocalEnvironment()
         self._storage: Storage | None = storage
-        # initializing self._system_prompt for backwards compatibility
-        self._system_prompt, self._system_prompt_content = split_system_prompt(system_prompt)
+        _, self._system_prompt_content = split_system_prompt(system_prompt)
         self._default_structured_output_model = structured_output_model
         self._structured_output_prompt = structured_output_prompt
         self.agent_id = _identifier.validate(agent_id or _DEFAULT_AGENT_ID, _identifier.Identifier.AGENT)
@@ -790,15 +789,14 @@ class Agent(AgentBase, LocalAgent):
         Returns:
             The system prompt as a string, or None if no text content exists.
         """
-        return self._system_prompt
+        return split_system_prompt(self._system_prompt_content)[0]
 
     @system_prompt.setter
     def system_prompt(self, value: str | list[SystemContentBlock] | None) -> None:
         """Set the system prompt and update internal content representation.
 
         Accepts either a string or list of SystemContentBlock objects.
-        When set, both the backwards-compatible string representation and the internal
-        content block representation are updated to maintain consistency.
+        The string representation is derived from the stored content blocks.
 
         Args:
             value: System prompt as string, list of SystemContentBlock objects, or None.
@@ -806,7 +804,7 @@ class Agent(AgentBase, LocalAgent):
                   - list[SystemContentBlock]: Content blocks with features like caching
                   - None: Clear the system prompt
         """
-        self._system_prompt, self._system_prompt_content = split_system_prompt(value)
+        _, self._system_prompt_content = split_system_prompt(value)
 
     @property
     def system_prompt_content(self) -> list[SystemContentBlock] | None:

--- a/strands-py/src/strands/experimental/bidi/agent/agent.py
+++ b/strands-py/src/strands/experimental/bidi/agent/agent.py
@@ -119,8 +119,8 @@ class BidiAgent(LocalAgent):
         else:
             raise TypeError("model must be a BidiModel, string, or None")
 
-        self._system_prompt, self._system_prompt_content = split_system_prompt(system_prompt)
-        self.messages = messages or []
+        _, self._system_prompt_content = split_system_prompt(system_prompt)
+        self.messages = messages if messages is not None else []
 
         # Agent identification
         self.agent_id = _identifier.validate(agent_id or _DEFAULT_AGENT_ID, _identifier.Identifier.AGENT)
@@ -219,12 +219,12 @@ class BidiAgent(LocalAgent):
     @property
     def system_prompt(self) -> str | None:
         """Get the system prompt as a string."""
-        return self._system_prompt
+        return split_system_prompt(self._system_prompt_content)[0]
 
     @system_prompt.setter
     def system_prompt(self, value: str | list[SystemContentBlock] | None) -> None:
         """Set the system prompt and retain its structured content representation."""
-        self._system_prompt, self._system_prompt_content = split_system_prompt(value)
+        _, self._system_prompt_content = split_system_prompt(value)
 
     @property
     def system_prompt_content(self) -> list[SystemContentBlock] | None:
@@ -278,9 +278,9 @@ class BidiAgent(LocalAgent):
         model events, tool execution, and connection management.
 
         Args:
-            invocation_state: Optional context to pass to tools during execution.
-                This allows passing custom data (user_id, session_id, database connections, etc.)
-                that tools can access via their invocation_state parameter.
+            invocation_state: Optional context shared by reference with tools and hooks until stop(),
+                including across connection restarts. Tools access it through ToolContext.invocation_state.
+                Defaults to a new empty dictionary.
 
         Raises:
             RuntimeError:
@@ -412,9 +412,9 @@ class BidiAgent(LocalAgent):
         Args:
             inputs: Input callables to read data from a source
             outputs: Output callables to receive events from the agent
-            invocation_state: Optional context to pass to tools during execution.
-                This allows passing custom data (user_id, session_id, database connections, etc.)
-                that tools can access via their invocation_state parameter.
+            invocation_state: Optional context shared by reference with tools and hooks for the duration of run(),
+                including across connection restarts. Tools access it through ToolContext.invocation_state.
+                Defaults to a new empty dictionary.
 
         Example:
             ```python

--- a/strands-py/src/strands/experimental/bidi/agent/loop.py
+++ b/strands-py/src/strands/experimental/bidi/agent/loop.py
@@ -189,7 +189,7 @@ class _BidiAgentLoop:
         self._task_pool = _TaskPool()
         self._model_task = self._task_pool.create(self._run_model(self._generation))
 
-        self._invocation_state = invocation_state or {}
+        self._invocation_state = invocation_state if invocation_state is not None else {}
         self._send_gate.set()
         self._started = True
 
@@ -719,16 +719,9 @@ class _BidiAgentLoop:
         tool_results: list[ToolResult] = []
 
         # Ensure request_state exists for tools like strands_tools.stop
-        if "request_state" not in self._invocation_state:
-            self._invocation_state["request_state"] = {}
-
-        invocation_state: dict[str, Any] = {
-            **self._invocation_state,
-            "agent": self._agent,
-            "model": self._agent.model,
-            "messages": self._agent.messages,
-            "system_prompt": self._agent.system_prompt,
-        }
+        invocation_state = self._invocation_state
+        if "request_state" not in invocation_state:
+            invocation_state["request_state"] = {}
 
         tool_call_span = self._tracer.start_tool_call_span(tool_use, parent_span=self._session_span)
         tool_result: ToolResult | None = None

--- a/strands-py/src/strands/experimental/bidi/models/bedrock.py
+++ b/strands-py/src/strands/experimental/bidi/models/bedrock.py
@@ -275,8 +275,8 @@ class BedrockNovaSonicModel(BidiModel, AudioCapable):
 
     @override
     def get_config(self) -> BidiModelConfig:
-        """Return a copy of the model configuration."""
-        return self._config.copy()
+        """Return the model configuration by reference."""
+        return self._config
 
     @override
     def get_audio_config(self) -> AudioConfig:

--- a/strands-py/src/strands/experimental/bidi/models/google.py
+++ b/strands-py/src/strands/experimental/bidi/models/google.py
@@ -141,8 +141,8 @@ class GoogleGeminiLiveModel(BidiModel, AudioCapable):
 
     @override
     def get_config(self) -> BidiModelConfig:
-        """Return a copy of the model configuration."""
-        return self._config.copy()
+        """Return the model configuration by reference."""
+        return self._config
 
     @override
     def get_audio_config(self) -> AudioConfig:

--- a/strands-py/src/strands/experimental/bidi/models/openai.py
+++ b/strands-py/src/strands/experimental/bidi/models/openai.py
@@ -197,8 +197,8 @@ class OpenAIRealtimeModel(BidiModel, AudioCapable):
 
     @override
     def get_config(self) -> BidiModelConfig:
-        """Return a copy of the model configuration."""
-        return self._config.copy()
+        """Return the model configuration by reference."""
+        return self._config
 
     @override
     def get_audio_config(self) -> AudioConfig:

--- a/strands-py/tests/strands/agent/test_agent.py
+++ b/strands-py/tests/strands/agent/test_agent.py
@@ -1258,7 +1258,7 @@ async def test_stream_async_multi_modal_input(mock_model, agent, agenerator, ali
 
 
 def test_system_prompt_setter_string():
-    """Test that setting system_prompt with string updates both internal fields."""
+    """Test that setting system_prompt with a string updates its content blocks."""
     agent = Agent(system_prompt="initial prompt")
 
     agent.system_prompt = "updated prompt"
@@ -1268,7 +1268,7 @@ def test_system_prompt_setter_string():
 
 
 def test_system_prompt_setter_list():
-    """Test that setting system_prompt with list updates both internal fields."""
+    """Test that setting system_prompt with a list updates its content blocks."""
     agent = Agent()
 
     content_blocks = [{"text": "You are helpful"}, {"cache_control": {"type": "ephemeral"}}]
@@ -1279,7 +1279,7 @@ def test_system_prompt_setter_list():
 
 
 def test_system_prompt_setter_none():
-    """Test that setting system_prompt to None clears both internal fields."""
+    """Test that setting system_prompt to None clears its content blocks."""
     agent = Agent(system_prompt="initial prompt")
 
     agent.system_prompt = None
@@ -1313,6 +1313,24 @@ def test_system_prompt_content_returns_copy():
     content = agent.system_prompt_content
     content.append({"text": "injected"})
     assert agent.system_prompt_content == [{"text": "hello"}]
+
+
+@pytest.mark.parametrize("use_setter", [False, True])
+def test_system_prompt_tracks_content_changes(use_setter):
+    """The string prompt reflects edits to shared content blocks."""
+    content_blocks = [{"text": "initial prompt"}, {"cachePoint": {"type": "default"}}]
+    agent = Agent(system_prompt=None if use_setter else content_blocks)
+    if use_setter:
+        agent.system_prompt = content_blocks
+
+    content_blocks[0]["text"] = "updated prompt"
+    assert agent.system_prompt == "updated prompt"
+
+    agent.system_prompt_content[0]["text"] = "another update"
+    assert agent.system_prompt == "another update"
+
+    content_blocks.pop(0)
+    assert agent.system_prompt is None
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests/strands/experimental/bidi/agent/test_agent.py
+++ b/strands-py/tests/strands/experimental/bidi/agent/test_agent.py
@@ -164,6 +164,45 @@ def test_bidi_agent_system_prompt_setter(mock_model):
     assert agent.system_prompt_content == content_blocks
 
 
+@pytest.mark.parametrize("use_setter", [False, True])
+def test_system_prompt_tracks_content_changes(mock_model, use_setter):
+    """The string prompt reflects edits to shared content blocks."""
+    content_blocks = [{"text": "initial prompt"}, {"cachePoint": {"type": "default"}}]
+    agent = BidiAgent(model=mock_model, system_prompt=None if use_setter else content_blocks)
+    if use_setter:
+        agent.system_prompt = content_blocks
+
+    content_blocks[0]["text"] = "updated prompt"
+    assert agent.system_prompt == "updated prompt"
+
+    agent.system_prompt_content[0]["text"] = "another update"
+    assert agent.system_prompt == "another update"
+
+    content_blocks.pop(0)
+    assert agent.system_prompt is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("messages", [[], [{"role": "user", "content": [{"text": "Earlier message"}]}]])
+async def test_messages_preserve_caller_list(mock_model, messages):
+    """Messages sent by the agent are appended to the caller's history list."""
+    agent = BidiAgent(model=mock_model, messages=messages)
+    await agent.start()
+    try:
+        await agent.send("New message")
+    finally:
+        await agent.stop()
+
+    assert agent.messages is messages
+    tru_message = messages[-1]
+    exp_message = {
+        "role": "user",
+        "content": [{"text": "New message"}],
+        "tracking_id": unittest.mock.ANY,
+    }
+    assert tru_message == exp_message
+
+
 def test_bidi_agent_tool_emits_shared_hook_events_and_retries(mock_model):
     """Test BidiAgent emits shared tool hook events and honors retry requests."""
     call_count = 0

--- a/strands-py/tests/strands/experimental/bidi/agent/test_loop.py
+++ b/strands-py/tests/strands/experimental/bidi/agent/test_loop.py
@@ -5,7 +5,7 @@ import warnings
 import pytest
 import pytest_asyncio
 
-from strands import tool
+from strands import ToolContext, tool
 from strands.experimental.bidi import BidiAgent
 from strands.experimental.bidi.agent.loop import _ReaderError
 from strands.experimental.bidi.hooks.events import BidiAgentStopEvent, BidiBeforeConnectionRestartEvent
@@ -24,7 +24,7 @@ from strands.experimental.bidi.types.events import (
     BidiTranscriptStreamEvent,
     BidiUsageEvent,
 )
-from strands.hooks import MessageAddedEvent
+from strands.hooks import AfterToolCallEvent, BeforeToolCallEvent, MessageAddedEvent
 from strands.types._events import ToolResultEvent, ToolResultMessageEvent, ToolUseStreamEvent
 from tests.fixtures.mock_hook_provider import MockHookProvider
 
@@ -181,7 +181,8 @@ async def test_bidi_agent_loop_receive_restart_connection(loop, agent, agenerato
 
     agent.model.receive = unittest.mock.Mock(side_effect=[timeout_error, agenerator([text_event])])
 
-    await loop.start()
+    invocation_state = {"custom_data": "preserved"}
+    await loop.start(invocation_state=invocation_state)
 
     tru_events = []
     async for event in loop.receive():
@@ -194,6 +195,7 @@ async def test_bidi_agent_loop_receive_restart_connection(loop, agent, agenerato
         text_event,
     ]
     assert tru_events == exp_events
+    assert loop._invocation_state is invocation_state
 
     # The reactive path restarts through the provider method and forwards the timeout config.
     assert agent.model.start.call_count == 1
@@ -1272,38 +1274,48 @@ async def test_bidi_agent_loop_stop_conversation_deprecated_but_works(loop, agen
 
 
 @pytest.mark.asyncio
-async def test_bidi_agent_loop_request_state_preserved_with_invocation_state(agent, agenerator):
-    """Test that existing invocation_state is preserved when request_state is initialized."""
+@pytest.mark.parametrize("invocation_state", [{}, {"custom_data": "preserved"}])
+async def test_tools_share_invocation_state(agent, agenerator, invocation_state):
+    """Tools, hooks, and the caller share state throughout the invocation."""
+    exp_state = {**invocation_state, "call_count": 2, "request_state": {}}
+    tool_states = []
 
-    @tool(name="check_invocation_state")
-    async def check_invocation_state(custom_key: str) -> str:
-        return f"custom_key: {custom_key}"
+    @tool(context=True)
+    async def count_calls(tool_context: ToolContext) -> str:
+        """Count calls in the shared invocation state."""
+        state = tool_context.invocation_state
+        tool_states.append(state)
+        state["call_count"] = state.get("call_count", 0) + 1
+        return str(state["call_count"])
 
-    agent.tool_registry.register_tool(check_invocation_state)
+    agent.tool_registry.register_tool(count_calls)
+    hooks = MockHookProvider([BeforeToolCallEvent, AfterToolCallEvent])
+    agent.hooks.add_hook(hooks)
+    tool_uses = [{"toolUseId": f"call-{number}", "name": count_calls.tool_name, "input": {}} for number in (1, 2)]
+    agent.model.receive = unittest.mock.Mock(
+        return_value=agenerator([ToolUseStreamEvent(current_tool_use=tool_use, delta="") for tool_use in tool_uses])
+    )
 
-    tool_use = {"toolUseId": "t4", "name": "check_invocation_state", "input": {"custom_key": "from_state"}}
-    tool_use_event = ToolUseStreamEvent(current_tool_use=tool_use, delta="")
+    await agent.start(invocation_state=invocation_state)
+    tru_results = []
+    try:
+        async for event in agent.receive():
+            if isinstance(event, ToolResultMessageEvent):
+                tru_results.append(event["message"]["content"][0]["toolResult"])
+                if len(tru_results) == len(tool_uses):
+                    break
+    finally:
+        await agent.stop()
 
-    agent.model.receive = unittest.mock.Mock(return_value=agenerator([tool_use_event]))
-
-    loop = agent._loop
-    # Start with custom invocation_state but no request_state
-    await loop.start(invocation_state={"custom_data": "preserved"})
-
-    tru_events = []
-    async for event in loop.receive():
-        tru_events.append(event)
-        if len(tru_events) >= 3:
-            break
-
-    # Verify tool executed successfully
-    tool_result_event = tru_events[1]
-    assert isinstance(tool_result_event, ToolResultEvent)
-    assert tool_result_event.tool_result["status"] == "success"
-
-    # Verify request_state was added without removing custom_data
-    assert "request_state" in loop._invocation_state
-    assert loop._invocation_state.get("custom_data") == "preserved"
+    exp_results = [
+        {"toolUseId": f"call-{number}", "status": "success", "content": [{"text": str(number)}]} for number in (1, 2)
+    ]
+    assert tru_results == exp_results
+    assert all(state is invocation_state for state in tool_states)
+    assert len(hooks.events_received) == 2 * len(tool_uses)
+    assert all(event.invocation_state is invocation_state for event in hooks.events_received)
+    tru_state = {key: invocation_state[key] for key in exp_state}
+    assert tru_state == exp_state
 
 
 @pytest.mark.asyncio

--- a/strands-py/tests/strands/experimental/bidi/models/test_bedrock.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_bedrock.py
@@ -104,7 +104,7 @@ async def test_model_initialization(model_id, boto_session):
     assert model._connection_id is None
 
 
-def test_get_config_returns_copy(boto_session):
+def test_get_config_returns_reference(boto_session):
     model = BedrockNovaSonicModel(boto_session=boto_session)
 
     config = model.get_config()
@@ -116,7 +116,9 @@ def test_get_config_returns_copy(boto_session):
     assert config == exp_config
 
     config["model_id"] = NOVA_SONIC_V1_MODEL_ID
+    exp_config["model_id"] = NOVA_SONIC_V1_MODEL_ID
     assert model.get_config() == exp_config
+    assert model.get_config() is config
 
 
 @pytest.mark.parametrize(

--- a/strands-py/tests/strands/experimental/bidi/models/test_google.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_google.py
@@ -190,7 +190,9 @@ def test_model_initialization(mock_genai_client, model_id, api_key):
     }
     assert tru_config == exp_config
     tru_config["model_id"] = "updated-model"
+    exp_config["model_id"] = "updated-model"
     assert model_default.get_config() == exp_config
+    assert model_default.get_config() is tru_config
 
     model_with_key = GoogleGeminiLiveModel(model_id=model_id, client_args={"api_key": api_key})
     assert model_with_key.model_id == model_id

--- a/strands-py/tests/strands/experimental/bidi/models/test_openai.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_openai.py
@@ -110,7 +110,9 @@ def test_model_initialization(api_key, model_name, monkeypatch):
     }
     assert tru_config == exp_config
     tru_config["model_id"] = "updated-model"
+    exp_config["model_id"] = "updated-model"
     assert model_default.get_config() == exp_config
+    assert model_default.get_config() is tru_config
 
     model_custom = OpenAIRealtimeModel(
         model_id=model_name,


### PR DESCRIPTION
## Description

Bidi copied invocation state for each tool call, so top-level tool updates disappeared between calls while nested updates persisted. Preserve the caller's invocation state and message history by reference, including empty containers, to match `Agent`.

Both agents also cached prompt text separately from shared content blocks. Derive the text from those blocks so in-place edits cannot leave `system_prompt` stale.

### Public API Changes

Tools and hooks now mutate the caller's invocation-state dictionary, including the context fields added by the shared tool executor. Bidi model `get_config()` returns the stored dictionary, so top-level configuration edits also affect the model. Callers that need the previous shallow-copy behavior can request it explicitly:

```python
config = model.get_config().copy()
```

This all matches `Agent` behavior.

## Related Issues

Follow-up to #4255.

## Documentation PR

Included in this PR under `site/`, along with API docstring updates.

## Type of Change

Bug fix

## Testing

- [x] I ran `hatch run prepare`

Passed the full Python 3.10–3.14 matrix and all 15 live Bidi integration tests. The updated documentation compiles as MDX. `prepare` ran in an isolated worktree containing the changes because its formatter also updates seven pre-existing upstream files. Those unrelated formatting edits are excluded from this PR.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
