### PR TITLE
feat(bidi): render live transcripts with audio output

### DIFF
--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/io.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/io.mdx
@@ -8,6 +8,7 @@ tags: [bidi-streaming]
 sourceLinks:
   - path: strands-py/src/strands/experimental/bidi/io/text.py
   - path: strands-py/src/strands/experimental/bidi/io/audio.py
+  - path: strands-py/src/strands/experimental/bidi/io/transcript.py
 ---
 
 
@@ -94,9 +95,9 @@ The `run()` method handles the startup, execution, and shutdown of both the agen
 Out of the box, Strands provides `BidiAudioIO` to help connect your microphone and speakers to the bidi-agent using [PyAudio](https://pypi.org/project/PyAudio/).
 
 :::note[Installation Required]
-`BidiAudioIO` requires the `bidi-pyaudio` extra and the PortAudio system library:
+`BidiAudioIO` requires the `bidi-io` and `bidi-pyaudio` extras plus the PortAudio system library:
 ```bash
-pip install "strands-agents[bidi,bidi-pyaudio]"
+pip install "strands-agents[bidi,bidi-io,bidi-pyaudio]"
 ```
 :::
 
@@ -122,7 +123,12 @@ async def main():
 asyncio.run(main())
 ```
 
-This creates a voice-enabled agent that captures audio from your microphone, streams it to the model in real-time, and plays responses through your speakers.
+This creates a voice-enabled agent that captures audio from your microphone, streams
+it to the model in real time, and plays responses through your speakers.
+
+Audio output also displays live transcripts, with user speech in shaded `>` blocks
+and assistant speech as plain text. The next user prompt appears when response
+generation finishes or is interrupted.
 
 ### Configurations
 
@@ -148,9 +154,9 @@ This creates a voice-enabled agent that captures audio from your microphone, str
 Strands also provides `BidiTextIO` for terminal-based text input and output using [prompt-toolkit](https://pypi.org/project/prompt-toolkit/).
 
 :::note[Installation Required]
-`BidiTextIO` is included with the `bidi` extra:
+`BidiTextIO` is included with the `bidi-io` extra:
 ```bash
-pip install "strands-agents[bidi]"
+pip install "strands-agents[bidi-io]"
 ```
 :::
 
@@ -176,9 +182,8 @@ async def main():
 asyncio.run(main())
 ```
 
-This creates a text-based agent that reads user input from the terminal and prints transcripts and responses to the console.
-
-Note, the agent provides a preview of what it is about to say before producing the final output. This preview text is prefixed with `Preview:`.
+This creates a text-based agent that reads user input from the terminal and prints
+transcripts and responses to the console.
 
 ### Configurations
 
@@ -230,8 +235,8 @@ async def main():
 
     while True:
         output_event = json.loads(await websocket.recv())
-        if output_event["type"] == "bidi_transcript_stream" and output_event["is_final"]:
-            print(output_event["text"])
+        if output_event["type"] == "bidi_transcript_complete":
+            print(output_event["transcript"])
             break
 
     await websocket.close()

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/bedrock.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/bedrock.mdx
@@ -28,24 +28,24 @@ Bedrock Nova Sonic is configured as an optional dependency in Strands Agents.
 To install it, run:
 
 ```bash
-pip install 'strands-agents[bidi]'
+pip install 'strands-agents[bidi,bidi-io,bidi-pyaudio]'
 ```
 
 Or to install all bidirectional streaming providers at once:
 
 ```bash
-pip install 'strands-agents[bidi-all]'
+pip install 'strands-agents[bidi-all,bidi-pyaudio]'
 ```
 
 ## Usage
 
-After installing `strands-agents[bidi]`, you can import and initialize the Strands Agents' Bedrock Nova Sonic provider as follows:
+After installing the Bedrock Nova Sonic and local audio extras, create a voice agent:
 
 ```python
 import asyncio
 
 from strands.experimental.bidi import BidiAgent
-from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO
+from strands.experimental.bidi.io import BidiAudioIO
 from strands.experimental.bidi.models import BedrockNovaSonicModel
 from strands_tools import calculator, stop
 
@@ -58,8 +58,7 @@ async def main() -> None:
     )
     agent = BidiAgent(model=model, tools=[calculator, stop])
     audio_io = BidiAudioIO()
-    text_io = BidiTextIO()
-    await agent.run(inputs=[audio_io.input()], outputs=[audio_io.output(), text_io.output()])
+    await agent.run(inputs=[audio_io.input()], outputs=[audio_io.output()])
 
 
 if __name__ == "__main__":

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/google.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/google.mdx
@@ -24,29 +24,26 @@ The Google Gemini Live provider is configured as an optional dependency in Stran
 To install it, run:
 
 ```bash
-pip install 'strands-agents[bidi-google]'
+pip install 'strands-agents[bidi-google,bidi-io,bidi-pyaudio]'
 ```
 
 Or to install all bidirectional streaming providers at once:
 
 ```bash
-pip install 'strands-agents[bidi-all]'
+pip install 'strands-agents[bidi-all,bidi-pyaudio]'
 ```
 
 ## Usage
 
-After installing `strands-agents[bidi-google]`, import and initialize the Gemini Live
-model provider:
+After installing the Gemini Live and local audio extras, create a voice agent:
 
 ```python
 import asyncio
 
 from strands.experimental.bidi import BidiAgent
-from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO
+from strands.experimental.bidi.io import BidiAudioIO
 from strands.experimental.bidi.models import GoogleGeminiLiveModel
-from strands_tools import stop
-
-from strands_tools import calculator
+from strands_tools import calculator, stop
 
 
 async def main() -> None:
@@ -59,8 +56,7 @@ async def main() -> None:
     agent = BidiAgent(model=model, tools=[calculator, stop])
 
     audio_io = BidiAudioIO()
-    text_io = BidiTextIO()
-    await agent.run(inputs=[audio_io.input()], outputs=[audio_io.output(), text_io.output()])
+    await agent.run(inputs=[audio_io.input()], outputs=[audio_io.output()])
 
 
 if __name__ == "__main__":

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/openai.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/openai.mdx
@@ -23,28 +23,26 @@ OpenAI Realtime is configured as an optional dependency in Strands Agents.
 To install it, run:
 
 ```bash
-pip install 'strands-agents[bidi-openai]'
+pip install 'strands-agents[bidi-io,bidi-openai,bidi-pyaudio]'
 ```
 
 Or to install all bidirectional streaming providers at once:
 
 ```bash
-pip install 'strands-agents[bidi-all]'
+pip install 'strands-agents[bidi-all,bidi-pyaudio]'
 ```
 
 ## Usage
 
-After installing `strands-agents[bidi-openai]`, you can import and initialize the Strands Agents' OpenAI Realtime provider as follows:
+After installing the OpenAI Realtime and local audio extras, create a voice agent:
 
 ```python
 import asyncio
 
 from strands.experimental.bidi import BidiAgent
-from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO
+from strands.experimental.bidi.io import BidiAudioIO
 from strands.experimental.bidi.models import OpenAIRealtimeModel
-from strands_tools import stop
-
-from strands_tools import calculator
+from strands_tools import calculator, stop
 
 
 async def main() -> None:
@@ -57,8 +55,7 @@ async def main() -> None:
     agent = BidiAgent(model=model, tools=[calculator, stop])
 
     audio_io = BidiAudioIO()
-    text_io = BidiTextIO()
-    await agent.run(inputs=[audio_io.input()], outputs=[audio_io.output(), text_io.output()])
+    await agent.run(inputs=[audio_io.input()], outputs=[audio_io.output()])
 
 
 if __name__ == "__main__":

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/quickstart.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/quickstart.mdx
@@ -43,36 +43,37 @@ You can also install support for specific providers:
 
 ```bash
 # With local microphone and speaker I/O
-pip install "strands-agents[bidi,bidi-pyaudio]"
+pip install "strands-agents[bidi,bidi-io,bidi-pyaudio]"
 
-# Without local microphone and speaker I/O
-pip install "strands-agents[bidi]"
+# With terminal text I/O
+pip install "strands-agents[bidi,bidi-io]"
 ```
 </Tab>
 <Tab label="OpenAI Realtime">
 
 ```bash
 # With local audio I/O
-pip install "strands-agents[bidi,bidi-pyaudio,bidi-openai]"
+pip install "strands-agents[bidi-io,bidi-openai,bidi-pyaudio]"
 
-# Server-side only
-pip install "strands-agents[bidi,bidi-openai]"
+# With terminal text I/O
+pip install "strands-agents[bidi-io,bidi-openai]"
 ```
 </Tab>
 <Tab label="Google Gemini Live">
 
 ```bash
 # With local audio I/O
-pip install "strands-agents[bidi,bidi-pyaudio,bidi-google]"
+pip install "strands-agents[bidi-google,bidi-io,bidi-pyaudio]"
 
-# Server-side only
-pip install "strands-agents[bidi,bidi-google]"
+# With terminal text I/O
+pip install "strands-agents[bidi-google,bidi-io]"
 ```
 </Tab>
 </Tabs>
 
 :::note[Server-Side Deployments]
 The `bidi-pyaudio` extra provides PyAudio for direct microphone and speaker access.
+The `bidi-io` extra provides terminal text input and transcript rendering.
 For server deployments where clients handle audio I/O, omit `bidi-pyaudio` and
 implement custom I/O handlers using the `BidiInput` and `BidiOutput` protocols. See
 [I/O Channels](io.md) for details.
@@ -176,42 +177,18 @@ And that's it! We now have a voice-enabled agent that can:
 - Listen to your voice through the microphone
 - Process speech in real-time
 - Respond with natural voice output
+- Display live user and assistant transcripts
 - Handle interruptions when you start speaking
 
 :::note[Stopping the Conversation]
 The `run()` method runs indefinitely. See [Controlling Conversation Lifecycle](#controlling-conversation-lifecycle) for proper ways to stop conversations.
 :::
 
-## Adding Text I/O
+## Live Transcripts
 
-Combine audio with text input/output for debugging or multi-modal interactions:
-
-```python
-import asyncio
-from strands.experimental.bidi import BidiAgent, BidiAudioIO
-from strands.experimental.bidi.io import BidiTextIO
-from strands.experimental.bidi.models import BedrockNovaSonicModel
-
-model = BedrockNovaSonicModel()
-agent = BidiAgent(
-    model=model,
-    system_prompt="You are a helpful assistant."
-)
-
-# Setup both audio and text I/O
-audio_io = BidiAudioIO()
-text_io = BidiTextIO()
-
-async def main():
-    await agent.run(
-        inputs=[audio_io.input()],
-        outputs=[audio_io.output(), text_io.output()]  # Both audio and text
-    )
-
-asyncio.run(main())
-```
-
-Now you'll see transcripts printed to the console while audio plays through your speakers.
+`BidiAudioIO.output()` displays user and assistant transcripts while audio plays
+through the speakers. User speech appears in shaded `>` blocks and assistant
+speech appears as plain text.
 
 ## Controlling Conversation Lifecycle
 

--- a/strands-py/README.md
+++ b/strands-py/README.md
@@ -216,11 +216,11 @@ Build real-time voice and audio conversations with persistent streaming connecti
 # Server-side only (no audio I/O dependencies)
 pip install strands-agents[bidi]
 
-# With all portable Bidi providers, text I/O, and audio processing
+# With all portable Bidi providers, terminal I/O, and audio processing (no local audio devices)
 pip install strands-agents[bidi-all]
 
 # For local microphone/speaker access, install PortAudio for your OS first, then:
-pip install strands-agents[bidi-pyaudio]
+pip install strands-agents[bidi,bidi-io,bidi-pyaudio]
 ```
 
 > **Note**: Bedrock Nova Sonic requires Python 3.12+ due to its experimental AWS SDK dependency.
@@ -231,7 +231,7 @@ pip install strands-agents[bidi-pyaudio]
 import asyncio
 from strands.experimental.bidi import BidiAgent
 from strands.experimental.bidi.models import BedrockNovaSonicModel
-from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO
+from strands.experimental.bidi.io import BidiAudioIO
 from strands_tools import calculator, stop
 
 async def main():
@@ -239,25 +239,24 @@ async def main():
     model = BedrockNovaSonicModel()
     agent = BidiAgent(model=model, tools=[calculator, stop])
 
-    # Setup audio and text I/O (local audio requires the bidi-pyaudio extra)
+    # Setup audio I/O (local audio requires the bidi-pyaudio extra)
     audio_io = BidiAudioIO()
-    text_io = BidiTextIO()
 
-    # Run with real-time audio streaming
+    # Run with real-time audio streaming and terminal transcripts
     # stop tool allows user to verbally stop agent execution
     await agent.run(
         inputs=[audio_io.input()],
-        outputs=[audio_io.output(), text_io.output()]
+        outputs=[audio_io.output()]
     )
 
 if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-> **Note**: `BidiTextIO` is included with the `bidi` extra. `BidiAudioIO` requires the `bidi-pyaudio` extra and
-> the PortAudio system library. For server-side deployments where audio I/O is handled by clients (browsers,
-> mobile apps), install only `strands-agents[bidi]` and implement custom input/output handlers using the
-> `BidiInput` and `BidiOutput` protocols.
+> **Note**: `BidiTextIO` is included with the `bidi-io` extra. `BidiAudioIO` requires the `bidi-io` and
+> `bidi-pyaudio` extras plus the PortAudio system library. For server-side deployments where audio I/O is handled
+> by clients (browsers, mobile apps), install only `strands-agents[bidi]` and implement custom input/output handlers
+> using the `BidiInput` and `BidiOutput` protocols.
 
 **Configuration Options:**
 
@@ -288,19 +287,6 @@ audio_io = BidiAudioIO(
     output_device_index=1,  # Specific speaker
     input_buffer_size=10,
     output_buffer_size=10
-)
-
-# Text input mode (type messages instead of speaking)
-text_io = BidiTextIO()
-await agent.run(
-    inputs=[text_io.input()],  # Use text input
-    outputs=[audio_io.output(), text_io.output()]
-)
-
-# Multi-modal: Both audio and text input
-await agent.run(
-    inputs=[audio_io.input(), text_io.input()],  # Speak OR type
-    outputs=[audio_io.output(), text_io.output()]
 )
 ```
 

--- a/strands-py/pyproject.toml
+++ b/strands-py/pyproject.toml
@@ -82,17 +82,17 @@ cedar = ["cedarpy==4.8.7", "cedar-policy-mcp-schema-generator==0.6.0"]
 bidi = [
     "aws_sdk_bedrock_runtime[awscrt]>=0.11.0,<0.12.0; python_version>='3.12'",
     "awscrt==0.32.2; python_version>='3.12'",
-    "prompt_toolkit>=3.0.0,<4.0.0",
     "smithy-aws-core>=0.11.0,<0.12.0; python_version>='3.12'",
     "smithy-core>=0.8.0,<0.9.0; python_version>='3.12'",
     "smithy-http[awscrt]==0.5.0; python_version>='3.12'",
 ]
+bidi-io = ["prompt_toolkit>=3.0.0,<4.0.0", "rich>=15.0.0,<16.0.0"]
 bidi-google = ["google-genai>=2.0.0,<3.0.0"]
 bidi-openai = ["websockets>=16.0.0,<17.0.0"]
 bidi-aec = ["pywebrtc-audio>=0.2.0,<0.3.0", "numpy>=2.0.0,<3.0.0"]
 # Excluded from aggregate extras because PyAudio requires PortAudio as a system level install.
 bidi-pyaudio = ["pyaudio>=0.2.0,<0.3.0"]
-bidi-all = ["strands-agents[a2a,bidi,bidi-aec,bidi-google,bidi-openai,docs,otel]"]
+bidi-all = ["strands-agents[a2a,bidi,bidi-aec,bidi-google,bidi-io,bidi-openai,docs,otel]"]
 
 all = [
     "strands-agents[a2a,anthropic,bidi-all,cedar,docs,gemini,litellm,llamaapi,mistral,ollama,openai,writer,sagemaker,otel,web-fetch]"

--- a/strands-py/src/strands/experimental/bidi/agent/agent.py
+++ b/strands-py/src/strands/experimental/bidi/agent/agent.py
@@ -421,11 +421,10 @@ class BidiAgent(LocalAgent):
             # Using model defaults:
             model = BedrockNovaSonicModel()
             audio_io = BidiAudioIO()
-            text_io = BidiTextIO()
             agent = BidiAgent(model=model, tools=[calculator])
             await agent.run(
                 inputs=[audio_io.input()],
-                outputs=[audio_io.output(), text_io.output()],
+                outputs=[audio_io.output()],
                 invocation_state={"user_id": "user_123"}
             )
 

--- a/strands-py/src/strands/experimental/bidi/io/audio.py
+++ b/strands-py/src/strands/experimental/bidi/io/audio.py
@@ -27,6 +27,7 @@ from ..types.events import (
     BidiOutputEvent,
 )
 from ..types.io import BidiInput, BidiOutput
+from .transcript import _BidiTranscriptOutput
 
 if TYPE_CHECKING:
     from .._audio import _BidiAudioProcessor
@@ -297,6 +298,7 @@ class _BidiAudioOutput(BidiOutput):
 
         self._audio_processor = audio_processor
         self._buffer = _BidiAudioBuffer(self._buffer_size)
+        self._transcript_output = _BidiTranscriptOutput()
 
     async def start(self, agent: "BidiAgent") -> None:
         """Start output stream.
@@ -327,12 +329,15 @@ class _BidiAudioOutput(BidiOutput):
             rate=self._rate,
             stream_callback=self._callback,
         )
+        await self._transcript_output.start(agent)
 
         logger.debug("audio output stream started")
 
     async def stop(self) -> None:
         """Stop output stream."""
         logger.debug("stopping audio output stream")
+
+        await self._transcript_output.stop()
 
         if hasattr(self, "_stream"):
             self._stream.close()
@@ -345,6 +350,8 @@ class _BidiAudioOutput(BidiOutput):
 
     async def __call__(self, event: BidiOutputEvent) -> None:
         """Send audio to output stream."""
+        await self._transcript_output(event)
+
         if isinstance(event, BidiAudioStreamEvent):
             data = base64.b64decode(event["audio"])
             self._buffer.put(data)
@@ -379,8 +386,8 @@ class _BidiAudioOutput(BidiOutput):
 class BidiAudioIO:
     """Send and receive audio data from devices using PyAudio.
 
-    Reads microphone audio via ``input()`` and plays agent audio via ``output()``. On interruption, the
-    playback buffer is cleared to stop the agent mid-response.
+    Reads microphone audio via ``input()``, plays agent audio via ``output()``, and displays user and assistant
+    transcripts. Interruptions clear the playback buffer to stop the agent mid-response.
 
     When ``audio_processor=True`` or a ``BidiAudioProcessorConfig`` is passed, the microphone signal gets audio
     processing and, when echo cancellation is enabled, the agent's speaker output is used as a reference to

--- a/strands-py/src/strands/experimental/bidi/io/transcript.py
+++ b/strands-py/src/strands/experimental/bidi/io/transcript.py
@@ -1,0 +1,167 @@
+"""Terminal transcript output for bidirectional streaming."""
+
+import logging
+from typing import TYPE_CHECKING
+
+from rich.console import Console, ConsoleOptions, ConsoleRenderable, RenderableType, RenderResult
+from rich.live import Live
+from rich.segment import ControlType, Segment
+from rich.style import Style
+from rich.text import Text
+
+from ..types.events import (
+    BidiInterruptionEvent,
+    BidiOutputEvent,
+    BidiResponseCompleteEvent,
+    BidiTranscriptStreamEvent,
+    Role,
+)
+from ..types.io import BidiOutput
+
+if TYPE_CHECKING:
+    from ..agent.agent import BidiAgent
+
+logger = logging.getLogger(__name__)
+
+
+class _UserText(ConsoleRenderable):
+    """Render a full-width user block without adding copyable trailing spaces."""
+
+    BACKGROUND_COLOR = "#f3f3f3"
+    PLACEHOLDER = "Start talking ..."
+    PLACEHOLDER_COLOR = "#a0a0a0"
+    TEXT_COLOR = "#373737"
+    TEXT_PREFIX = "> "
+
+    def __init__(self, text: str | None = None) -> None:
+        """Initialize a user transcript block."""
+        self._text = text
+
+    def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult:
+        """Render wrapped text and color each row through the terminal edge."""
+        text = self.PLACEHOLDER if self._text is None else self._text
+        color = self.PLACEHOLDER_COLOR if self._text is None else self.TEXT_COLOR
+        style = Style(color=color, bgcolor=self.BACKGROUND_COLOR)
+        erase_to_end = Segment(
+            "\x1b[0K",
+            style,
+            ((ControlType.ERASE_IN_LINE, 0),),
+        )
+
+        yield erase_to_end
+        yield Segment.line()
+
+        lines = Text(text, style=style).wrap(
+            console,
+            max(options.max_width - len(self.TEXT_PREFIX), 1),
+            overflow="fold",
+        )
+        for index, line in enumerate(lines or [Text("", style=style)]):
+            prefix = self.TEXT_PREFIX if index == 0 else " " * len(self.TEXT_PREFIX)
+            row = Text(f"{prefix}{line.plain}", style=style, end="")
+            yield row
+            yield erase_to_end
+            yield Segment.line()
+
+        yield erase_to_end
+
+
+class _BidiTranscriptOutput(BidiOutput):
+    """Render transcript events to a terminal stream."""
+
+    def __init__(self) -> None:
+        """Initialize transcript output."""
+        self._console = Console()
+        self._live: Live
+        self._role: Role | None = None
+        self._transcript: str | None = None
+
+    async def start(self, _agent: "BidiAgent") -> None:
+        """Start transcript output."""
+        self._start_transcript("user")
+
+    async def stop(self) -> None:
+        """Finish pending transcript output and restore the terminal cursor."""
+        try:
+            self._stop_transcript()
+        finally:
+            self._console.show_cursor()
+
+    async def __call__(self, event: BidiOutputEvent) -> None:
+        """Render transcript lifecycle events."""
+        if isinstance(event, BidiTranscriptStreamEvent):
+            logger.debug("role=<%s> | transcript streamed", event.role)
+
+            if self._role != event.role or self._transcript is None:
+                self._restart_transcript(event.role, delta=event.delta)
+            else:
+                self._update_transcript(event.delta)
+
+        elif isinstance(event, BidiInterruptionEvent):
+            logger.debug("reason=<%s> | transcript interrupted", event.reason)
+
+            if self._role != "user" or self._transcript is None:
+                self._restart_transcript("user", delta="")
+
+        elif isinstance(event, BidiResponseCompleteEvent):
+            logger.debug("response_id=<%s>, role=<%s> | transcript complete", event.response_id, self._role)
+
+            if event.stop_reason == "interrupted":
+                if self._role != "user" or self._transcript is None:
+                    self._restart_transcript("user", delta="")
+            else:
+                self._restart_transcript("user")
+
+    def _start_transcript(
+        self,
+        role: Role,
+        *,
+        delta: str | None = None,
+    ) -> None:
+        """Start a mutable transcript."""
+        self._role = role
+        self._transcript = delta
+
+        self._live = Live(
+            self._build_renderable(),
+            console=self._console,
+            auto_refresh=False,
+            transient=delta is None,
+            redirect_stdout=False,
+            redirect_stderr=False,
+        )
+        self._live.start(refresh=True)
+
+    def _restart_transcript(
+        self,
+        role: Role,
+        *,
+        delta: str | None = None,
+    ) -> None:
+        """Stop the active transcript and start a new one."""
+        self._stop_transcript()
+        self._start_transcript(role, delta=delta)
+
+    def _update_transcript(self, delta: str) -> None:
+        """Update the active transcript."""
+        self._transcript = f"{self._transcript or ''}{delta}"
+        self._live.update(self._build_renderable(), refresh=True)
+
+    def _stop_transcript(self) -> None:
+        """Stop the active transcript."""
+        if self._role is not None:
+            self._live.stop()
+
+        self._role = None
+        self._transcript = None
+
+    def _build_renderable(self) -> RenderableType:
+        """Build the current Rich transcript block."""
+        transcript = " ".join(self._transcript.split()) if self._transcript is not None else None
+        match self._role:
+            case "assistant":
+                return Text(f"\n{transcript}\n")
+            case "user":
+                return _UserText(transcript)
+            case None:
+                raise RuntimeError("cannot render an inactive transcript")

--- a/strands-py/tests/strands/experimental/bidi/io/test_audio.py
+++ b/strands-py/tests/strands/experimental/bidi/io/test_audio.py
@@ -10,7 +10,12 @@ import pytest_asyncio
 from strands.experimental.bidi._audio import _BidiAudioProcessor
 from strands.experimental.bidi.io.audio import BidiAudioIO, BidiAudioProcessorConfig, _BidiAudioBuffer
 from strands.experimental.bidi.models import AudioCapable
-from strands.experimental.bidi.types.events import BidiAudioInputEvent, BidiAudioStreamEvent, BidiInterruptionEvent
+from strands.experimental.bidi.types.events import (
+    BidiAudioInputEvent,
+    BidiAudioStreamEvent,
+    BidiInterruptionEvent,
+    BidiResponseCompleteEvent,
+)
 
 
 def _fake_audio_processor(processor=None):
@@ -237,6 +242,8 @@ async def test_bidi_audio_io_output(audio_output):
 
 @pytest.mark.asyncio
 async def test_bidi_audio_io_output_interrupt(audio_output):
+    transcript_output = unittest.mock.AsyncMock()
+    audio_output._transcript_output = transcript_output
     audio_event = BidiAudioStreamEvent(
         audio=base64.b64encode(b"test-audio").decode("utf-8"),
         channels=2,
@@ -250,6 +257,19 @@ async def test_bidi_audio_io_output_interrupt(audio_output):
     tru_data, _ = audio_output._callback(None, frame_count=1)
     exp_data = b"\x00\x00"
     assert tru_data == exp_data
+    transcript_output.assert_any_await(interrupt_event)
+
+
+@pytest.mark.asyncio
+async def test_response_complete_is_forwarded_to_transcript_output(audio_output):
+    transcript_output = unittest.mock.AsyncMock()
+    audio_output._transcript_output = transcript_output
+    audio_output._buffer.put(b"\x01\x02\x03\x04")
+    event = BidiResponseCompleteEvent(response_id="response-1", stop_reason="complete")
+
+    await audio_output(event)
+
+    transcript_output.assert_awaited_once_with(event)
 
 
 def test_bidi_audio_io_output_configs(pyaudio_module, py_audio, audio_output):

--- a/strands-py/tests/strands/experimental/bidi/io/test_transcript.py
+++ b/strands-py/tests/strands/experimental/bidi/io/test_transcript.py
@@ -1,0 +1,146 @@
+import re
+from io import StringIO
+from unittest.mock import Mock
+
+import pytest
+import pytest_asyncio
+from rich.console import Console
+
+import strands.experimental.bidi.io.transcript as transcript_module
+from strands.experimental.bidi.io.transcript import _BidiTranscriptOutput, _UserText
+from strands.experimental.bidi.types.events import (
+    BidiInterruptionEvent,
+    BidiResponseCompleteEvent,
+    BidiResponseStartEvent,
+    BidiTranscriptStreamEvent,
+)
+
+_ANSI_ESCAPE = re.compile(r"\x1b\[[?0-9;]*[ -/]*[@-~]")
+
+
+@pytest.fixture
+def console(monkeypatch):
+    console = Console(file=StringIO(), force_terminal=False, width=80)
+    monkeypatch.setattr(transcript_module, "Console", lambda: console)
+    return console
+
+
+@pytest_asyncio.fixture
+async def output(console):
+    output = _BidiTranscriptOutput()
+    await output.start(Mock())
+    yield output
+    await output.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("user_events", "exp_lines"),
+    [
+        ([], ["First response", "Second response"]),
+        (
+            [BidiTranscriptStreamEvent("Next question", "user")],
+            ["First response", "> Next question", "Second response"],
+        ),
+    ],
+)
+async def test_call_streams_turns(output, console, user_events, exp_lines):
+    assert output._live.transient
+
+    for event in [
+        BidiTranscriptStreamEvent("First", "assistant"),
+        BidiTranscriptStreamEvent(" response", "assistant"),
+        BidiResponseCompleteEvent("first", "complete"),
+        *user_events,
+        BidiTranscriptStreamEvent("Second response", "assistant"),
+        BidiResponseCompleteEvent("second", "complete"),
+    ]:
+        await output(event)
+
+    rendered = _ANSI_ESCAPE.sub("", console.file.getvalue())
+    tru_lines = [line for line in rendered.splitlines() if line]
+    assert tru_lines == exp_lines
+    assert output._live.transient
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "event",
+    [BidiInterruptionEvent("user_speech"), BidiResponseCompleteEvent("first", "interrupted")],
+)
+@pytest.mark.parametrize(
+    ("initial", "exp_transcript"),
+    [
+        (None, ""),
+        (BidiTranscriptStreamEvent("Hello", "assistant"), ""),
+        (BidiTranscriptStreamEvent("Wait", "user"), "Wait"),
+    ],
+)
+async def test_call_interrupts_response(output, event, initial, exp_transcript):
+    if initial is not None:
+        await output(initial)
+    await output(event)
+
+    tru_state = (output._role, output._transcript, output._live.transient)
+    exp_state = ("user", exp_transcript, False)
+    assert tru_state == exp_state
+
+    user_live = output._live
+    await output(event)
+    await output(BidiTranscriptStreamEvent(" please", "user"))
+
+    assert output._live is user_live
+    assert output._transcript == f"{exp_transcript} please"
+
+
+@pytest.mark.asyncio
+async def test_call_ignores_response_start(output):
+    await output(BidiTranscriptStreamEvent("Wait", "user"))
+    user_live = output._live
+
+    await output(BidiResponseStartEvent("first"))
+    await output(BidiTranscriptStreamEvent(" please", "user"))
+
+    assert output._live is user_live
+    assert output._transcript == "Wait please"
+
+
+@pytest.mark.parametrize("no_color", [False, True])
+@pytest.mark.parametrize(
+    ("text", "exp_lines"),
+    [
+        ("Hello", ["", "> Hello"]),
+        ("alpha beta gamma delta", ["", "> alpha beta ", "  gamma delta"]),
+    ],
+)
+def test_user_text_render(monkeypatch, no_color, text, exp_lines):
+    if no_color:
+        monkeypatch.setenv("NO_COLOR", "1")
+    else:
+        monkeypatch.delenv("NO_COLOR", raising=False)
+    console = Console(file=StringIO(), force_terminal=True, color_system="truecolor", width=16, height=24)
+
+    console.print(_UserText(text))
+
+    rendered = console.file.getvalue()
+    tru_colors = ("38;2" in rendered, "48;2;243;243;243" in rendered)
+    exp_colors = (not no_color, not no_color)
+    assert tru_colors == exp_colors
+    assert "\x1b[0K" in rendered
+    tru_lines = _ANSI_ESCAPE.sub("", rendered).splitlines()
+    assert tru_lines == exp_lines
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("started", [False, True])
+async def test_stop_restores_cursor(console, monkeypatch, started):
+    output = _BidiTranscriptOutput()
+    if started:
+        await output.start(Mock())
+    show_cursor = Mock()
+    monkeypatch.setattr(console, "show_cursor", show_cursor)
+
+    await output.stop()
+
+    show_cursor.assert_called_with()
+    assert output._role is None


### PR DESCRIPTION
## Description

Voice sessions currently need a separate text output to display transcripts. `BidiAudioIO` now displays live user and assistant transcripts alongside audio playback, keeping each turn in one streaming message. The next user prompt appears when response generation finishes or is interrupted, even if queued audio is still playing.

### Public API Changes

Local terminal IO requires the new `bidi-io` extra. Existing `BidiTextIO` users who install only `bidi` must add `bidi-io`. Voice-only sessions can remove the additional text output.

```python
# Before
await agent.run(
    inputs=[audio_io.input()],
    outputs=[audio_io.output(), text_io.output()],
)

# After
await agent.run(
    inputs=[audio_io.input()],
    outputs=[audio_io.output()],
)
```

Keyboard input and transcript coordination remain a follow-up.

## Usage

This example uses Bedrock Nova Sonic and requires Python 3.12+, configured AWS credentials, and the PortAudio system library.

```bash
pip install "strands-agents[bidi,bidi-io,bidi-pyaudio]"
```

```python
import asyncio

from strands.experimental.bidi import BidiAgent
from strands.experimental.bidi.io import BidiAudioIO


async def main() -> None:
    agent = BidiAgent()
    audio_io = BidiAudioIO()
    await agent.run(
        inputs=[audio_io.input()],
        outputs=[audio_io.output()],
    )


asyncio.run(main())
```

Speak into the microphone to see user transcripts in shaded `>` blocks and assistant transcripts as plain text. Press Ctrl+C to stop.

## Related Issues

Follow-up to #4230.

## Documentation PR

Documentation and examples are included under `site/` and in the Python README.

## Type of Change

New feature

## Testing

- [x] I ran `hatch run prepare`

Formatting, lint, mypy, and the full unit suites passed on Python 3.10–3.14.

Bidi integration tests exercised Bedrock Nova Sonic v1/v2, OpenAI Realtime, and Google Gemini Live. The initial run had 14 passes and one Google 15-second response timeout. The Google test passed unchanged on an isolated retry.

All five edited MDX pages compiled. Physical microphone/speaker playback was not exercised.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
