### PR TITLE
refactor(bidi): standardize system prompt content contract

### DIFF
--- a/strands-py/src/strands/experimental/bidi/agent/agent.py
+++ b/strands-py/src/strands/experimental/bidi/agent/agent.py
@@ -88,7 +88,7 @@ class BidiAgent(LocalAgent):
             model: BidiModel instance, string model_id, or None for default detection.
             tools: Optional list of tools with flexible format support.
             system_prompt: System prompt for conversations as a string or structured content blocks.
-                Structured blocks are retained, while their text is passed to Bidi models as a string.
+                Structured blocks are retained and passed to Bidi models.
             messages: Optional conversation history to initialize with.
             record_direct_tool_call: Whether to record direct tool calls in message history.
             load_tools_from_directory: Whether to load and automatically reload tools in the `./tools/` directory.

--- a/strands-py/src/strands/experimental/bidi/agent/loop.py
+++ b/strands-py/src/strands/experimental/bidi/agent/loop.py
@@ -171,7 +171,7 @@ class _BidiAgentLoop:
         )
         try:
             await self._agent.model.start(
-                system_prompt=self._agent.system_prompt,
+                system_prompt_content=self._agent.system_prompt_content,
                 tools=self._agent.tool_registry.get_all_tool_specs(),
                 messages=self._agent.messages,
             )
@@ -496,16 +496,26 @@ class _BidiAgentLoop:
     async def _restart_model(self, restart_kwargs: dict[str, Any]) -> None:
         """Restart through the provider when supported, otherwise use ``stop()`` then ``start()``."""
         model = self._agent.model
-        system_prompt = self._agent.system_prompt
+        system_prompt_content = self._agent.system_prompt_content
         tools = self._agent.tool_registry.get_all_tool_specs()
         messages = self._agent.messages
 
         if isinstance(model, Restartable):
-            await model.restart(system_prompt, tools, messages, **restart_kwargs)
+            await model.restart(
+                system_prompt_content=system_prompt_content,
+                tools=tools,
+                messages=messages,
+                **restart_kwargs,
+            )
             return
 
         await model.stop()
-        await model.start(system_prompt, tools, messages, **restart_kwargs)
+        await model.start(
+            system_prompt_content=system_prompt_content,
+            tools=tools,
+            messages=messages,
+            **restart_kwargs,
+        )
 
     async def _wait_for_model_task(self, task: asyncio.Task | None) -> None:
         """Await a superseded reader after its stream is closed; cancel only as a backstop.

--- a/strands-py/src/strands/experimental/bidi/models/bedrock.py
+++ b/strands-py/src/strands/experimental/bidi/models/bedrock.py
@@ -48,7 +48,7 @@ from typing_extensions import Unpack, override
 
 from ....models._validation import validate_region
 from ....types._events import ToolResultEvent, ToolUseStreamEvent
-from ....types.content import Messages
+from ....types.content import Messages, SystemContentBlock
 from ....types.tools import ToolResult, ToolSpec, ToolUse
 from .._async import stop_all
 from ..types.events import (
@@ -72,7 +72,12 @@ from .configs import (
     _validate_audio_config,
     _validate_bidi_config,
 )
-from .model import AudioCapable, BidiModel, BidiModelTimeoutError
+from .model import (
+    AudioCapable,
+    BidiModel,
+    BidiModelTimeoutError,
+    _system_prompt_content_to_text,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -285,7 +290,8 @@ class BedrockNovaSonicModel(BidiModel, AudioCapable):
 
     async def start(
         self,
-        system_prompt: str | None = None,
+        *,
+        system_prompt_content: list[SystemContentBlock] | None = None,
         tools: list[ToolSpec] | None = None,
         messages: Messages | None = None,
         **kwargs: Any,
@@ -293,7 +299,7 @@ class BedrockNovaSonicModel(BidiModel, AudioCapable):
         """Establish bidirectional connection to Nova Sonic.
 
         Args:
-            system_prompt: System instructions for the model.
+            system_prompt_content: Structured system instructions for the model.
             tools: List of tools available to the model.
             messages: Conversation history to initialize with.
             **kwargs: Additional configuration options.
@@ -342,21 +348,24 @@ class BedrockNovaSonicModel(BidiModel, AudioCapable):
         )
         logger.debug("region=<%s> | nova sonic bidirectional stream established", self.region)
 
-        init_events = self._build_initialization_events(system_prompt, tools, messages)
+        init_events = self._build_initialization_events(system_prompt_content, tools, messages)
         logger.debug("event_count=<%d> | sending nova sonic initialization events", len(init_events))
         await self._send_nova_events(init_events)
 
         logger.info("connection_id=<%s> | nova sonic connection established", self._connection_id)
 
     def _build_initialization_events(
-        self, system_prompt: str | None, tools: list[ToolSpec] | None, messages: Messages | None
+        self,
+        system_prompt_content: list[SystemContentBlock] | None,
+        tools: list[ToolSpec] | None,
+        messages: Messages | None,
     ) -> list[str]:
         """Build the sequence of initialization events."""
         tools = tools or []
         events = [
             self._get_connection_start_event(),
             self._get_prompt_start_event(tools),
-            *self._get_system_prompt_events(system_prompt),
+            *self._get_system_prompt_events(system_prompt_content),
         ]
 
         # Add conversation history if provided
@@ -654,7 +663,8 @@ class BedrockNovaSonicModel(BidiModel, AudioCapable):
 
     async def restart(
         self,
-        system_prompt: str | None = None,
+        *,
+        system_prompt_content: list[SystemContentBlock] | None = None,
         tools: list[ToolSpec] | None = None,
         messages: Messages | None = None,
         **restart_kwargs: Any,
@@ -662,14 +672,19 @@ class BedrockNovaSonicModel(BidiModel, AudioCapable):
         """Restart by closing the connection and starting a new one, replaying messages.
 
         Args:
-            system_prompt: System instructions for the new connection.
+            system_prompt_content: Structured system instructions for the new connection.
             tools: Tool specifications for the new connection.
             messages: Conversation history to replay into the new connection.
             **restart_kwargs: Reserved for provider-specific restart options.
         """
         logger.debug("nova restart starting")
         await self.stop()
-        await self.start(system_prompt, tools, messages, **restart_kwargs)
+        await self.start(
+            system_prompt_content=system_prompt_content,
+            tools=tools,
+            messages=messages,
+            **restart_kwargs,
+        )
         logger.debug("connection_id=<%s> | nova restart complete", self._connection_id)
 
     def _convert_nova_event(
@@ -863,9 +878,10 @@ class BedrockNovaSonicModel(BidiModel, AudioCapable):
             )
         return tool_config
 
-    def _get_system_prompt_events(self, system_prompt: str | None) -> list[str]:
+    def _get_system_prompt_events(self, system_prompt_content: list[SystemContentBlock] | None) -> list[str]:
         """Generate system prompt events."""
         content_name = str(uuid.uuid4())
+        system_prompt = _system_prompt_content_to_text(system_prompt_content)
         return [
             self._get_text_content_start_event(content_name, "SYSTEM", interactive=False),
             self._get_text_input_event(content_name, system_prompt or ""),

--- a/strands-py/src/strands/experimental/bidi/models/google.py
+++ b/strands-py/src/strands/experimental/bidi/models/google.py
@@ -26,7 +26,7 @@ from google.genai.types import LiveConnectConfigOrDict, LiveServerContent, LiveS
 from typing_extensions import Unpack, override
 
 from ....types._events import ToolResultEvent, ToolUseStreamEvent
-from ....types.content import Messages
+from ....types.content import Messages, SystemContentBlock
 from ....types.tools import ToolResult, ToolSpec, ToolUse
 from .._async import stop_all
 from ..types.events import (
@@ -53,7 +53,12 @@ from .configs import (
     _validate_audio_config,
     _validate_bidi_config,
 )
-from .model import AudioCapable, BidiModel, BidiModelTimeoutError
+from .model import (
+    AudioCapable,
+    BidiModel,
+    BidiModelTimeoutError,
+    _system_prompt_content_to_text,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -151,7 +156,8 @@ class GoogleGeminiLiveModel(BidiModel, AudioCapable):
 
     async def start(
         self,
-        system_prompt: str | None = None,
+        *,
+        system_prompt_content: list[SystemContentBlock] | None = None,
         tools: list[ToolSpec] | None = None,
         messages: Messages | None = None,
         **kwargs: Any,
@@ -159,7 +165,7 @@ class GoogleGeminiLiveModel(BidiModel, AudioCapable):
         """Establish bidirectional connection with Gemini Live API.
 
         Args:
-            system_prompt: System instructions for the model.
+            system_prompt_content: Structured system instructions for the model.
             tools: List of tools available to the model.
             messages: Conversation history to initialize with.
             **kwargs: Additional configuration options.
@@ -183,7 +189,12 @@ class GoogleGeminiLiveModel(BidiModel, AudioCapable):
             and any("text" in block for message in messages for block in message["content"])
             and "live_session_handle" not in kwargs
         )
-        live_config = self._build_live_config(system_prompt, tools, has_messages=has_messages, **kwargs)
+        live_config = self._build_live_config(
+            system_prompt_content,
+            tools,
+            has_messages=has_messages,
+            **kwargs,
+        )
 
         # Create the context manager and session
         self._live_session_context_manager = self._client.aio.live.connect(
@@ -594,7 +605,8 @@ class GoogleGeminiLiveModel(BidiModel, AudioCapable):
 
     async def restart(
         self,
-        system_prompt: str | None = None,
+        *,
+        system_prompt_content: list[SystemContentBlock] | None = None,
         tools: list[ToolSpec] | None = None,
         messages: Messages | None = None,
         **restart_kwargs: Any,
@@ -607,7 +619,7 @@ class GoogleGeminiLiveModel(BidiModel, AudioCapable):
         When no handle is available yet, falls back to a fresh connection with history replay.
 
         Args:
-            system_prompt: System instructions for the resumed connection.
+            system_prompt_content: Structured system instructions for the resumed connection.
             tools: Tool specifications for the resumed connection.
             messages: Conversation history, replayed only when resuming without a handle.
             **restart_kwargs: Provider restart options; ``live_session_handle`` resumes the session.
@@ -616,17 +628,32 @@ class GoogleGeminiLiveModel(BidiModel, AudioCapable):
         logger.debug("session_handle=<%s> | gemini restart starting", handle)
         await self.stop()
 
-        if handle is not None and await self._try_resume(system_prompt, tools, handle, **restart_kwargs):
+        if handle is not None and await self._try_resume(
+            system_prompt_content=system_prompt_content,
+            tools=tools,
+            handle=handle,
+            **restart_kwargs,
+        ):
             logger.debug("connection_id=<%s> | gemini restart complete via resume", self._connection_id)
             return
 
         # No handle, or the server refused it: start fresh and replay history so the conversation
         # continues rather than going silent.
-        await self.start(system_prompt, tools, messages, **restart_kwargs)
+        await self.start(
+            system_prompt_content=system_prompt_content,
+            tools=tools,
+            messages=messages,
+            **restart_kwargs,
+        )
         logger.debug("connection_id=<%s> | gemini restart complete via fresh session", self._connection_id)
 
     async def _try_resume(
-        self, system_prompt: str | None, tools: list[ToolSpec] | None, handle: str, **restart_kwargs: Any
+        self,
+        *,
+        system_prompt_content: list[SystemContentBlock] | None,
+        tools: list[ToolSpec] | None,
+        handle: str,
+        **restart_kwargs: Any,
     ) -> bool:
         """Attempt to resume the session via ``handle``; report whether it succeeded.
 
@@ -634,7 +661,7 @@ class GoogleGeminiLiveModel(BidiModel, AudioCapable):
         torn down, leaving the model ready for a fresh start.
 
         Args:
-            system_prompt: System instructions for the resumed connection.
+            system_prompt_content: Structured system instructions for the resumed connection.
             tools: Tool specifications for the resumed connection.
             handle: The session resumption handle to resume with.
             **restart_kwargs: Additional provider restart options.
@@ -643,7 +670,12 @@ class GoogleGeminiLiveModel(BidiModel, AudioCapable):
             ``True`` if the session resumed, ``False`` if the handle was refused.
         """
         try:
-            await self.start(system_prompt, tools, live_session_handle=handle, **restart_kwargs)
+            await self.start(
+                system_prompt_content=system_prompt_content,
+                tools=tools,
+                live_session_handle=handle,
+                **restart_kwargs,
+            )
             return True
         except Exception as error:
             logger.warning("error=<%s> | gemini resume failed | falling back to fresh session", error)
@@ -663,7 +695,10 @@ class GoogleGeminiLiveModel(BidiModel, AudioCapable):
             logger.debug("error=<%s> | teardown after failed resume", stop_error)
 
     def _build_live_config(
-        self, system_prompt: str | None = None, tools: list[ToolSpec] | None = None, **kwargs: Any
+        self,
+        system_prompt_content: list[SystemContentBlock] | None = None,
+        tools: list[ToolSpec] | None = None,
+        **kwargs: Any,
     ) -> dict[str, Any]:
         """Build LiveConnectConfig for the official SDK.
 
@@ -688,7 +723,7 @@ class GoogleGeminiLiveModel(BidiModel, AudioCapable):
         if has_messages and getattr(self._client, "vertexai", False) is not True:
             config_dict["history_config"] = {"initial_history_in_client_content": True}
 
-        # Add system instruction if provided
+        system_prompt = _system_prompt_content_to_text(system_prompt_content)
         if system_prompt:
             config_dict["system_instruction"] = system_prompt
 

--- a/strands-py/src/strands/experimental/bidi/models/model.py
+++ b/strands-py/src/strands/experimental/bidi/models/model.py
@@ -20,12 +20,17 @@ from typing import Any, NoReturn, Protocol, cast, runtime_checkable
 
 from ....models.model import Model
 from ....types._events import ToolResultEvent
-from ....types.content import Messages
+from ....types.content import Messages, SystemContentBlock, split_system_prompt
 from ....types.tools import ToolSpec
 from ..types.events import BidiInputEvent, BidiOutputEvent
 from .configs import AudioConfig, BidiConnectionConfig
 
 logger = logging.getLogger(__name__)
+
+
+def _system_prompt_content_to_text(system_prompt_content: list[SystemContentBlock] | None) -> str | None:
+    """Render structured system prompt content for providers that accept text instructions."""
+    return split_system_prompt(system_prompt_content)[0]
 
 
 @runtime_checkable
@@ -34,7 +39,8 @@ class Restartable(Protocol):
 
     async def restart(
         self,
-        system_prompt: str | None = None,
+        *,
+        system_prompt_content: list[SystemContentBlock] | None = None,
         tools: list[ToolSpec] | None = None,
         messages: Messages | None = None,
         **restart_kwargs: Any,
@@ -42,7 +48,7 @@ class Restartable(Protocol):
         """Replace the active connection while preserving conversation context.
 
         Args:
-            system_prompt: System instructions for the new connection.
+            system_prompt_content: Structured system instructions for the new connection.
             tools: Tool specifications for the new connection.
             messages: Conversation history to replay when required by the provider.
             **restart_kwargs: Provider-specific restart options.
@@ -87,7 +93,8 @@ class BidiModel(Model, abc.ABC):
     # pragma: no cover
     async def start(
         self,
-        system_prompt: str | None = None,
+        *,
+        system_prompt_content: list[SystemContentBlock] | None = None,
         tools: list[ToolSpec] | None = None,
         messages: Messages | None = None,
         **kwargs: Any,
@@ -99,7 +106,7 @@ class BidiModel(Model, abc.ABC):
         closed. Must be called before any send() or receive() operations.
 
         Args:
-            system_prompt: System instructions to configure model behavior.
+            system_prompt_content: Structured system instructions to configure model behavior.
             tools: Tool specifications that the model can invoke during the conversation.
             messages: Initial conversation history to provide context.
             **kwargs: Provider-specific configuration options.

--- a/strands-py/src/strands/experimental/bidi/models/openai.py
+++ b/strands-py/src/strands/experimental/bidi/models/openai.py
@@ -19,7 +19,7 @@ from typing_extensions import Unpack, override
 from websockets import ClientConnection
 
 from ....types._events import ToolResultEvent, ToolUseStreamEvent
-from ....types.content import Messages
+from ....types.content import Messages, SystemContentBlock
 from ....types.tools import ToolResult, ToolSpec, ToolUse
 from .._async import stop_all
 from ..types.events import (
@@ -49,7 +49,12 @@ from .configs import (
     _validate_audio_config,
     _validate_bidi_config,
 )
-from .model import AudioCapable, BidiModel, BidiModelTimeoutError
+from .model import (
+    AudioCapable,
+    BidiModel,
+    BidiModelTimeoutError,
+    _system_prompt_content_to_text,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -207,7 +212,8 @@ class OpenAIRealtimeModel(BidiModel, AudioCapable):
 
     async def start(
         self,
-        system_prompt: str | None = None,
+        *,
+        system_prompt_content: list[SystemContentBlock] | None = None,
         tools: list[ToolSpec] | None = None,
         messages: Messages | None = None,
         **kwargs: Any,
@@ -215,7 +221,7 @@ class OpenAIRealtimeModel(BidiModel, AudioCapable):
         """Establish bidirectional connection to OpenAI Realtime API.
 
         Args:
-            system_prompt: System instructions for the model.
+            system_prompt_content: Structured system instructions for the model.
             tools: List of tools available to the model.
             messages: Conversation history to initialize with.
             **kwargs: Additional configuration options.
@@ -244,7 +250,7 @@ class OpenAIRealtimeModel(BidiModel, AudioCapable):
         logger.debug("connection_id=<%s> | websocket connected successfully", self._connection_id)
 
         # Configure session
-        session_config = self._build_session_config(system_prompt, tools)
+        session_config = self._build_session_config(system_prompt_content, tools)
         await self._send_event({"type": "session.update", "session": session_config})
 
         # Add conversation history if provided
@@ -266,13 +272,18 @@ class OpenAIRealtimeModel(BidiModel, AudioCapable):
         # Other voice activity events are logged but don't create events
         return None
 
-    def _build_session_config(self, system_prompt: str | None, tools: list[ToolSpec] | None) -> dict[str, Any]:
+    def _build_session_config(
+        self,
+        system_prompt_content: list[SystemContentBlock] | None,
+        tools: list[ToolSpec] | None,
+    ) -> dict[str, Any]:
         """Build session configuration for OpenAI Realtime API.
 
         Model params recursively override defaults and directly supplied options.
         """
         config: dict[str, Any] = copy.deepcopy(DEFAULT_SESSION_CONFIG)
 
+        system_prompt = _system_prompt_content_to_text(system_prompt_content)
         if system_prompt:
             config["instructions"] = system_prompt
 
@@ -805,7 +816,8 @@ class OpenAIRealtimeModel(BidiModel, AudioCapable):
 
     async def restart(
         self,
-        system_prompt: str | None = None,
+        *,
+        system_prompt_content: list[SystemContentBlock] | None = None,
         tools: list[ToolSpec] | None = None,
         messages: Messages | None = None,
         **restart_kwargs: Any,
@@ -817,14 +829,19 @@ class OpenAIRealtimeModel(BidiModel, AudioCapable):
         swap.
 
         Args:
-            system_prompt: System instructions for the new connection.
+            system_prompt_content: Structured system instructions for the new connection.
             tools: Tool specifications for the new connection.
             messages: Conversation history to replay into the new connection.
             **restart_kwargs: Reserved for provider-specific restart options.
         """
         logger.debug("openai realtime restart starting")
         await self.stop()
-        await self.start(system_prompt, tools, messages, **restart_kwargs)
+        await self.start(
+            system_prompt_content=system_prompt_content,
+            tools=tools,
+            messages=messages,
+            **restart_kwargs,
+        )
         # Re-anchor the fresh session so it continues the conversation rather than drifting. This is
         # a best-effort nudge: if the send fails, the connection is still healthy, so log and move on
         # rather than let a failed nudge tear down the session.

--- a/strands-py/tests/strands/experimental/bidi/agent/test_agent.py
+++ b/strands-py/tests/strands/experimental/bidi/agent/test_agent.py
@@ -39,7 +39,7 @@ class MockBidiModel(BidiModel):
     def get_config(self):
         return self._config.copy()
 
-    async def start(self, system_prompt=None, tools=None, messages=None, **kwargs):
+    async def start(self, *, system_prompt_content=None, tools=None, messages=None, **kwargs):
         if self._started:
             raise RuntimeError("model already started | call stop before starting again")
         self._connection_id = str(uuid4())
@@ -50,9 +50,14 @@ class MockBidiModel(BidiModel):
             self._started = False
             self._connection_id = None
 
-    async def restart(self, system_prompt=None, tools=None, messages=None, **restart_kwargs):
+    async def restart(self, *, system_prompt_content=None, tools=None, messages=None, **restart_kwargs):
         await self.stop()
-        await self.start(system_prompt, tools, messages, **restart_kwargs)
+        await self.start(
+            system_prompt_content=system_prompt_content,
+            tools=tools,
+            messages=messages,
+            **restart_kwargs,
+        )
 
     async def send(self, content):
         if not self._started:

--- a/strands-py/tests/strands/experimental/bidi/agent/test_loop.py
+++ b/strands-py/tests/strands/experimental/bidi/agent/test_loop.py
@@ -52,6 +52,27 @@ async def loop(agent):
 
 
 @pytest.mark.asyncio
+async def test_start_passes_structured_system_prompt_to_model(loop, agent, agenerator):
+    system_prompt_content = [
+        {"text": "Primary instructions"},
+        {"cachePoint": {"type": "default"}},
+        {"text": "Additional instructions"},
+    ]
+    agent.system_prompt = system_prompt_content
+    agent.model.receive = unittest.mock.Mock(return_value=agenerator([]))
+
+    await loop.start()
+    try:
+        agent.model.start.assert_awaited_once_with(
+            system_prompt_content=system_prompt_content,
+            tools=agent.tool_registry.get_all_tool_specs(),
+            messages=agent.messages,
+        )
+    finally:
+        await loop.stop()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("stop_reason", ["complete", "interrupted", "error", "tool_use"])
 async def test_response_complete_hook(agent, agenerator, stop_reason):
     hooks = MockHookProvider([BidiResponseCompleteHookEvent])
@@ -200,9 +221,9 @@ async def test_bidi_agent_loop_receive_restart_connection(loop, agent, agenerato
     # The reactive path restarts through the provider method and forwards the timeout config.
     assert agent.model.start.call_count == 1
     agent.model.restart.assert_called_once_with(
-        agent.system_prompt,
-        agent.tool_registry.get_all_tool_specs(),
-        agent.messages,
+        system_prompt_content=agent.system_prompt_content,
+        tools=agent.tool_registry.get_all_tool_specs(),
+        messages=agent.messages,
         test_restart_config=1,
     )
 
@@ -378,8 +399,8 @@ class _NonRestartableModel(BidiModel):
     def get_config(self):
         return {"model_id": "test-model"}
 
-    async def start(self, system_prompt=None, tools=None, messages=None, **kwargs):
-        self.started.append(system_prompt)
+    async def start(self, *, system_prompt_content=None, tools=None, messages=None, **kwargs):
+        self.started.append(system_prompt_content)
 
     async def stop(self):
         self.stopped += 1
@@ -398,7 +419,7 @@ async def test_restart_falls_back_to_stop_start_when_provider_is_not_restartable
     await agent._loop._restart_model({})
 
     assert model.stopped == 1
-    assert model.started == ["hi"]  # start() called once with the agent's system prompt
+    assert model.started == [[{"text": "hi"}]]
 
 
 class _StreamModel(BidiModel):
@@ -418,17 +439,22 @@ class _StreamModel(BidiModel):
     def get_config(self):
         return {"model_id": "test-model"}
 
-    async def start(self, system_prompt=None, tools=None, messages=None, **kwargs):
+    async def start(self, *, system_prompt_content=None, tools=None, messages=None, **kwargs):
         self._closed = asyncio.Event()
         self._inbox = asyncio.Queue()
 
     async def stop(self):
         self._closed.set()
 
-    async def restart(self, system_prompt=None, tools=None, messages=None, **kwargs):
+    async def restart(self, *, system_prompt_content=None, tools=None, messages=None, **kwargs):
         self.restart_calls += 1
         await self.stop()
-        await self.start(system_prompt, tools, messages, **kwargs)
+        await self.start(
+            system_prompt_content=system_prompt_content,
+            tools=tools,
+            messages=messages,
+            **kwargs,
+        )
 
     async def send(self, content):
         return None

--- a/strands-py/tests/strands/experimental/bidi/models/test_bedrock.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_bedrock.py
@@ -467,12 +467,27 @@ def test_prompt_start_event_audio_output_config(boto_session, audio, expected):
     assert prompt_start["audioOutputConfiguration"] == expected
 
 
+def test_system_prompt_content_renders_text_blocks(boto_session):
+    """Nova receives text blocks in order and ignores unsupported structural blocks."""
+    model = BedrockNovaSonicModel(boto_session=boto_session)
+    system_prompt_content = [
+        {"text": "Primary instructions"},
+        {"cachePoint": {"type": "default"}},
+        {"text": "Additional instructions"},
+    ]
+
+    events = model._get_system_prompt_events(system_prompt_content)
+
+    text_input = json.loads(events[1])["event"]["textInput"]
+    assert text_input["content"] == "Primary instructions\nAdditional instructions"
+
+
 @pytest.mark.asyncio
 async def test_connection_lifecycle(nova_model, mock_client, mock_stream):
     """Test complete connection lifecycle with various configurations."""
 
     # Test basic connection
-    await nova_model.start(system_prompt="Test system prompt")
+    await nova_model.start(system_prompt_content=[{"text": "Test system prompt"}])
     assert nova_model._stream == mock_stream
     assert nova_model._connection_id is not None
     assert mock_client.invoke_model_with_bidirectional_stream.called
@@ -490,7 +505,7 @@ async def test_connection_lifecycle(nova_model, mock_client, mock_stream):
             "inputSchema": {"json": json.dumps({"type": "object", "properties": {}})},
         }
     ]
-    await nova_model.start(system_prompt="You are helpful", tools=tools)
+    await nova_model.start(system_prompt_content=[{"text": "You are helpful"}], tools=tools)
     # Verify initialization events were sent (connectionStart, promptStart, system prompt)
     assert mock_stream.input_stream.send.call_count >= 3
     await nova_model.stop()
@@ -820,11 +835,11 @@ async def test_restart_replays_history_through_start_path(nova_model, mock_strea
         {"role": "assistant", "content": [{"text": "It's sunny and 72 degrees."}]},
     ]
 
-    await nova_model.start(system_prompt="You are helpful", tools=tools, messages=messages)
+    await nova_model.start(system_prompt_content=[{"text": "You are helpful"}], tools=tools, messages=messages)
     first_connection_id = nova_model._connection_id
     mock_stream.input_stream.send.reset_mock()
 
-    await nova_model.restart(system_prompt="You are helpful", tools=tools, messages=messages)
+    await nova_model.restart(system_prompt_content=[{"text": "You are helpful"}], tools=tools, messages=messages)
 
     # Old stream was closed and a fresh connection established with a new id.
     assert mock_stream.close.called
@@ -845,9 +860,9 @@ async def test_restart_replays_history_through_start_path(nova_model, mock_strea
 @pytest.mark.asyncio
 async def test_restart_twice_does_not_raise(nova_model):
     """Two restarts in succession are safe because stop() is idempotent."""
-    await nova_model.start(system_prompt="You are helpful")
-    await nova_model.restart(system_prompt="You are helpful")
-    await nova_model.restart(system_prompt="You are helpful")
+    await nova_model.start(system_prompt_content=[{"text": "You are helpful"}])
+    await nova_model.restart(system_prompt_content=[{"text": "You are helpful"}])
+    await nova_model.restart(system_prompt_content=[{"text": "You are helpful"}])
     assert nova_model._connection_id is not None
     await nova_model.stop()
 
@@ -952,7 +967,7 @@ async def test_connection_with_message_history(nova_model, mock_client, mock_str
     ]
 
     # Start connection with message history
-    await nova_model.start(system_prompt="You are a helpful assistant", messages=messages)
+    await nova_model.start(system_prompt_content=[{"text": "You are a helpful assistant"}], messages=messages)
 
     # Verify initialization events were sent
     # Should include: sessionStart, promptStart, system prompt (3 events),

--- a/strands-py/tests/strands/experimental/bidi/models/test_google.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_google.py
@@ -222,7 +222,7 @@ async def test_connection_lifecycle(mock_genai_client, model, system_prompt, too
     mock_live_session_cm.__aexit__.assert_called_once()
 
     # Test connection with system prompt
-    await model.start(system_prompt=system_prompt)
+    await model.start(system_prompt_content=[{"text": system_prompt}])
     call_args = mock_client.aio.live.connect.call_args
     config = call_args.kwargs.get("config", {})
     assert config.get("system_instruction") == system_prompt
@@ -363,7 +363,7 @@ async def test_restart_uses_updated_config(mock_genai_client, model):
     )
     connect.assert_called_once()
 
-    await model.restart(system_prompt="Direct instructions")
+    await model.restart(system_prompt_content=[{"text": "Direct instructions"}])
 
     assert connect.call_count == 2
     restarted_request = connect.call_args.kwargs
@@ -381,7 +381,7 @@ async def test_restart_resumes_via_session_handle(mock_genai_client, model):
     await model.start()
     model._live_session_handle = "handle-abc"
 
-    await model.restart(system_prompt="hi")
+    await model.restart(system_prompt_content=[{"text": "hi"}])
 
     assert mock_live_session_cm.__aexit__.called  # old connection torn down
     assert model._connection_id is not None  # new connection established
@@ -400,7 +400,7 @@ async def test_restart_prefers_explicit_handle_from_restart_kwargs(mock_genai_cl
     await model.start()
     model._live_session_handle = "tracked"
 
-    await model.restart(system_prompt="hi", live_session_handle="from-error")
+    await model.restart(system_prompt_content=[{"text": "hi"}], live_session_handle="from-error")
 
     config = mock_client.aio.live.connect.call_args.kwargs["config"]
     assert config["session_resumption"]["handle"] == "from-error"
@@ -437,7 +437,7 @@ async def test_restart_without_handle_starts_fresh_and_replays_history(mock_gena
     await model.start()
     assert model._live_session_handle is None
 
-    await model.restart(system_prompt="hi", messages=messages)
+    await model.restart(system_prompt_content=[{"text": "hi"}], messages=messages)
 
     # Fresh session (no resumption handle), with history replayed via send_client_content.
     config = mock_client.aio.live.connect.call_args.kwargs["config"]
@@ -467,7 +467,7 @@ async def test_restart_falls_back_to_fresh_session_when_resume_rejected(mock_gen
 
     mock_live_session_cm.__aenter__.side_effect = aenter_rejects_resume
 
-    await model.restart(system_prompt="hi", messages=messages)
+    await model.restart(system_prompt_content=[{"text": "hi"}], messages=messages)
 
     # Handle dropped, a fresh session established, and history replayed.
     assert model._live_session_handle is None
@@ -1304,8 +1304,14 @@ def test_config_building(model, system_prompt, tool_spec):
     assert isinstance(config_basic, dict)
 
     # Test with system prompt
-    config_prompt = model._build_live_config(system_prompt=system_prompt)
-    assert config_prompt["system_instruction"] == system_prompt
+    config_prompt = model._build_live_config(
+        system_prompt_content=[
+            {"text": system_prompt},
+            {"cachePoint": {"type": "default"}},
+            {"text": "Additional instructions"},
+        ]
+    )
+    assert config_prompt["system_instruction"] == f"{system_prompt}\nAdditional instructions"
 
     # Test with tools
     config_tools = model._build_live_config(tools=[tool_spec])
@@ -1378,7 +1384,7 @@ def test__build_live_config_params_override_direct_options(
     )
 
     tru_config = model._build_live_config(
-        system_prompt=system_prompt,
+        system_prompt_content=[{"text": system_prompt}],
         tools=[tool_spec],
         has_messages=True,
         live_session_handle="direct-handle",
@@ -1407,7 +1413,7 @@ def test__build_live_config_merges_nested_params(mock_genai_client, api_key):
     )
 
     tru_config = model._build_live_config(
-        system_prompt="Direct instructions",
+        system_prompt_content=[{"text": "Direct instructions"}],
         has_messages=True,
         live_session_handle="resume-handle",
     )
@@ -1498,7 +1504,7 @@ def test_update_config_replaces_params(mock_genai_client, api_key, params, exp_v
 
     model.update_config(params=params)
 
-    config = model._build_live_config(system_prompt="Direct instructions")
+    config = model._build_live_config(system_prompt_content=[{"text": "Direct instructions"}])
     assert model.get_config()["params"] == params
     assert config["system_instruction"] == "Direct instructions"
     tru_speech = config["speech_config"]

--- a/strands-py/tests/strands/experimental/bidi/models/test_model.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_model.py
@@ -8,11 +8,15 @@ from pydantic import BaseModel
 
 from strands.experimental.bidi import Restartable
 from strands.experimental.bidi.models.configs import AudioConfig
-from strands.experimental.bidi.models.model import AudioCapable, BidiModel
+from strands.experimental.bidi.models.model import (
+    AudioCapable,
+    BidiModel,
+    _system_prompt_content_to_text,
+)
 from strands.experimental.bidi.types.events import BidiInputEvent, BidiOutputEvent
 from strands.models import Model
 from strands.types._events import ToolResultEvent
-from strands.types.content import Messages
+from strands.types.content import Messages, SystemContentBlock
 from strands.types.tools import ToolSpec
 
 
@@ -33,7 +37,8 @@ class _TestBidiModel(BidiModel):
 
     async def start(
         self,
-        system_prompt: str | None = None,
+        *,
+        system_prompt_content: list[SystemContentBlock] | None = None,
         tools: list[ToolSpec] | None = None,
         messages: Messages | None = None,
         **kwargs: Any,
@@ -67,7 +72,8 @@ class _AudioBidiModel(_TestBidiModel):
 class _TestRestartableBidiModel(_TestBidiModel):
     async def restart(
         self,
-        system_prompt: str | None = None,
+        *,
+        system_prompt_content: list[SystemContentBlock] | None = None,
         tools: list[ToolSpec] | None = None,
         messages: Messages | None = None,
         **restart_kwargs: Any,
@@ -90,6 +96,18 @@ def test_model_without_restart_is_not_restartable():
 
 def test_model_with_restart_is_restartable():
     assert isinstance(_TestRestartableBidiModel(), Restartable)
+
+
+def test_system_prompt_content_to_text():
+    system_prompt_content = [
+        {"text": "Primary instructions"},
+        {"cachePoint": {"type": "default"}},
+        {"text": "Additional instructions"},
+    ]
+
+    assert _system_prompt_content_to_text(system_prompt_content) == "Primary instructions\nAdditional instructions"
+    assert _system_prompt_content_to_text([{"cachePoint": {"type": "default"}}]) is None
+    assert _system_prompt_content_to_text(None) is None
 
 
 def test_stream_raises_not_implemented():

--- a/strands-py/tests/strands/experimental/bidi/models/test_openai.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_openai.py
@@ -227,7 +227,7 @@ async def test_connection_lifecycle(mock_websockets_connect, model, system_promp
 
     # Test connection with system prompt
     mock_ws.send.reset_mock()
-    await model.start(system_prompt=system_prompt)
+    await model.start(system_prompt_content=[{"text": system_prompt}])
     session_update = json.loads(mock_ws.send.call_args.args[0])
     assert session_update["type"] == "session.update"
     assert session_update["session"]["instructions"] == system_prompt
@@ -712,8 +712,15 @@ def test__build_session_config_direct_options(api_key, system_prompt, tool_spec)
         audio={"input_rate": 16000, "output_rate": 48000, "voice": "coral"},
     )
 
-    config = model._build_session_config(system_prompt, [tool_spec])
-    assert config["instructions"] == system_prompt
+    config = model._build_session_config(
+        [
+            {"text": system_prompt},
+            {"cachePoint": {"type": "default"}},
+            {"text": "Additional instructions"},
+        ],
+        [tool_spec],
+    )
+    assert config["instructions"] == f"{system_prompt}\nAdditional instructions"
     assert config["tools"] == [
         {
             "type": "function",
@@ -759,7 +766,7 @@ def test__build_session_config_merges_params_last(api_key, system_prompt, tool_s
         },
     )
 
-    tru_config = model._build_session_config(system_prompt, [tool_spec])
+    tru_config = model._build_session_config([{"text": system_prompt}], [tool_spec])
     exp_config = {
         "type": "realtime",
         "instructions": "",
@@ -791,7 +798,7 @@ def test__build_session_config_preserves_defaults(model, api_key, system_prompt,
         params={"output_modalities": ["text"]},
     )
 
-    config = custom_model._build_session_config(system_prompt, [tool_spec])
+    config = custom_model._build_session_config([{"text": system_prompt}], [tool_spec])
     config["audio"]["input"]["turn_detection"]["threshold"] = 0.9
 
     tru_config = model._build_session_config(None, None)
@@ -807,7 +814,7 @@ async def test_start_preserves_explicit_nulls(api_key, mock_websockets_connect):
         params={"audio": {"input": {"turn_detection": None, "transcription": None}}, "tracing": None},
     )
 
-    await model.start(system_prompt="Test instructions")
+    await model.start(system_prompt_content=[{"text": "Test instructions"}])
 
     tru_event = json.loads(mock_ws.send.call_args.args[0])
     exp_event = {
@@ -848,7 +855,7 @@ def test_update_config_replaces_params(api_key, params, exp_voice):
 
     model.update_config(params=params)
 
-    config = model._build_session_config("Direct instructions", None)
+    config = model._build_session_config([{"text": "Direct instructions"}], None)
     assert model.get_config()["params"] == params
     assert config["instructions"] == "Direct instructions"
     tru_output = config["audio"]["output"]
@@ -1186,14 +1193,14 @@ def test_update_config_warns_invalid_keys(model, model_config, invalid_key):
 async def test_restart_uses_updated_config(mock_websockets_connect, model):
     """Restart opens a new connection using the updated model ID and params."""
     mock_connect, mock_ws = mock_websockets_connect
-    await model.start(system_prompt="Initial instructions")
+    await model.start(system_prompt_content=[{"text": "Initial instructions"}])
     model.update_config(
         model_id="updated-model",
         params={"instructions": "Configured instructions", "max_output_tokens": 512},
     )
     mock_connect.assert_called_once()
 
-    await model.restart(system_prompt="Direct instructions")
+    await model.restart(system_prompt_content=[{"text": "Direct instructions"}])
 
     assert mock_connect.call_count == 2
     assert mock_connect.call_args.args[0] == "wss://api.openai.com/v1/realtime?model=updated-model"
@@ -1215,7 +1222,7 @@ async def test_restart_reestablishes_and_replays_history(mock_websockets_connect
     first_connection_id = model._connection_id
     mock_ws.send.reset_mock()
 
-    await model.restart(system_prompt=system_prompt, messages=messages)
+    await model.restart(system_prompt_content=[{"text": system_prompt}], messages=messages)
 
     mock_ws.close.assert_called_once()
     assert mock_connect.call_count == 2


### PR DESCRIPTION
## Description

Bidi currently preserves structured system prompt blocks on `BidiAgent` but flattens them before invoking the model, creating two prompt representations and preventing model providers from receiving the canonical content shape. This change standardizes the lifecycle contract on `system_prompt_content` before bidi graduates from experimental.

### Public API Changes

`BidiModel.start()` and `Restartable.restart()` now accept structured prompt content and require lifecycle arguments to be passed by keyword:

```python
# Before
await model.start(
    system_prompt="You are a helpful assistant.",
    tools=tools,
    messages=messages,
)

# After
await model.start(
    system_prompt_content=[{"text": "You are a helpful assistant."}],
    tools=tools,
    messages=messages,
)
```

`BidiAgent` usage is unchanged: developers can continue passing either a string or structured blocks through `system_prompt`. Built-in providers render supported text blocks at their wire boundary while retaining a structured, extensible model contract.

### Breaking Changes

Direct `BidiModel` callers and custom providers must replace the `system_prompt` lifecycle parameter with `system_prompt_content` and update `start()` and `restart()` implementations to use keyword-only arguments.

## Related Issues

None.

## Documentation PR

The shared model API design was updated in this PR. No site documentation changes are required for this experimental API refinement.

## Type of Change

Breaking change

## Testing

- Ran the bidi agent, loop, and provider unit suites: 278 passed
- Ran all collectible bidi tests outside the optional Rich IO modules: 376 passed
- Changed-file Ruff formatting and lint checks passed
- [ ] I ran `hatch run prepare`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
