### PR TITLE
fix(sandbox): decode process output as UTF-8 across chunk boundaries

### DIFF
--- a/strands-ts/src/sandbox/__tests__/stream-process.test.node.ts
+++ b/strands-ts/src/sandbox/__tests__/stream-process.test.node.ts
@@ -1,0 +1,42 @@
+import { Buffer } from 'node:buffer'
+import { describe, it, expect } from 'vitest'
+import { streamProcess } from '../stream-process.js'
+import type { ExecutionResult } from '../types.js'
+
+describe('streamProcess', () => {
+  // guards against U+FFFD replacement characters when a multibyte UTF-8 sequence
+  // straddles a pipe read boundary (#4156)
+  it('decodes multibyte UTF-8 split across chunk boundaries', async () => {
+    const text = 'café ☕ 你好'
+    const bytes = Buffer.from(text, 'utf8')
+    const splitAt = bytes.indexOf(0xa9) // second byte of 'é' (0xC3 0xA9)
+    const first = [...bytes.subarray(0, splitAt)].join(',')
+    const rest = [...bytes.subarray(splitAt)].join(',')
+    const script =
+      `process.stdout.write(Buffer.from([${first}])); ` +
+      `process.stderr.write(Buffer.from([${first}])); ` +
+      'setTimeout(() => { ' +
+      `process.stdout.write(Buffer.from([${rest}])); ` +
+      `process.stderr.write(Buffer.from([${rest}]))` +
+      '}, 50)'
+
+    const chunks: string[] = []
+    let result: ExecutionResult | undefined
+    for await (const item of streamProcess(process.execPath, ['-e', script])) {
+      if (item.type === 'streamChunk' && item.streamType === 'stdout') {
+        chunks.push(item.data)
+      } else if (item.type === 'executionResult') {
+        result = item
+      }
+    }
+
+    expect(chunks.join('')).toBe(text)
+    expect(result).toEqual({
+      type: 'executionResult',
+      exitCode: 0,
+      stdout: text,
+      stderr: text,
+      outputFiles: [],
+    })
+  })
+})

--- a/strands-ts/src/sandbox/stream-process.ts
+++ b/strands-ts/src/sandbox/stream-process.ts
@@ -50,6 +50,9 @@ export async function* streamProcess(
   options?: StreamProcessOptions
 ): AsyncGenerator<StreamChunk | ExecutionResult, void, undefined> {
   const proc = spawn(command, args)
+  // decode at the stream so multibyte UTF-8 characters split across chunks are reassembled
+  proc.stdout?.setEncoding('utf8')
+  proc.stderr?.setEncoding('utf8')
   const chunks: StreamChunk[] = []
   let stdout = ''
   let stderr = ''


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

`streamProcess` spawned child processes without setting an encoding on `stdout`/`stderr`, so each `data` event delivered a raw `Buffer` that the handlers decoded independently with `String(data)`. When a multibyte UTF-8 sequence straddled a pipe read boundary, each half decoded to U+FFFD, corrupting both the incremental `StreamChunk.data` and the final `ExecutionResult.stdout`/`stderr`. This reached every sandbox backend (`NotASandboxLocalEnvironment`, `DockerSandbox`, `SshSandbox`), so any command emitting non-ASCII text (accents, CJK, emoji) could be silently corrupted.

Setting the stream encoding to `utf8` right after `spawn` makes Node decode with a `StringDecoder` that carries partial multibyte bytes across chunks, so the handlers receive complete characters.

## Related Issues

<!-- Link to related issues using #issue-number format -->

Resolves: #4156

## Documentation PR

<!-- If this PR requires documentation changes, include them in this PR under site/ -->

No documentation changes needed.

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change? Verify that the changes do not break functionality or introduce new warnings.

- Added `src/sandbox/__tests__/stream-process.test.node.ts`: spawns a process that writes `café ☕ 你好` to stdout and stderr in two halves, split in the middle of a multibyte sequence. The test fails on `main` (`caf ☕ 你好`) and passes with this change; it asserts both the concatenated stream chunks and the whole final `ExecutionResult`.
- Ran the unit suite (`npm test`): 4523 passed, 0 failed. Also ran `eslint`, `prettier --check`, `npm run build`, and type-checks for both the `src` and `test/integ` projects.
- Exercised the fix end to end on Windows with the reproduction from the issue (split writes of multibyte output through a spawned process).

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
