### PR TITLE
fix(ts): interrupt retry backoff on cancellation

### DIFF
--- a/strands-ts/src/agent/__tests__/agent.model-retry.test.ts
+++ b/strands-ts/src/agent/__tests__/agent.model-retry.test.ts
@@ -41,6 +41,31 @@ describe('Agent retryStrategy wiring', () => {
     expect(result.lastMessage.content[0]).toEqual({ type: 'textBlock', text: 'ok' })
   })
 
+  it('interrupts retry backoff on cancellation without another model call', async () => {
+    const model = new MockMessageModel()
+      .addTurn(new ModelThrottledError('rate limited'))
+      .addTurn({ type: 'textBlock', text: 'unexpected retry' })
+    const controller = new AbortController()
+    const agent = new Agent({
+      model,
+      retryStrategy: new DefaultModelRetryStrategy({
+        maxAttempts: 3,
+        backoff: new ConstantBackoff({ delayMs: 5000 }),
+      }),
+    })
+
+    const invokePromise = agent.invoke('hi', { cancelSignal: controller.signal })
+    await vi.advanceTimersByTimeAsync(499)
+    expect(model.callCount).toBe(1)
+
+    controller.abort()
+    const result = await invokePromise
+
+    expect(result.stopReason).toBe('cancelled')
+    expect(model.callCount).toBe(1)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
   it('does not retry non-throttling errors', async () => {
     const model = new MockMessageModel().addTurn(new Error('boom'))
 

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -2120,6 +2120,7 @@ export class Agent implements LocalAgent, InvokableAgent {
 
     let attemptCount = 1
     while (true) {
+      this._throwIfCancelled()
       const selectedModel = this._modelForAttempt(invocationState)
       let projectedInputTokens: number | undefined
       try {

--- a/strands-ts/src/agent/agent.ts
+++ b/strands-ts/src/agent/agent.ts
@@ -2120,6 +2120,7 @@ export class Agent implements LocalAgent, InvokableAgent {
 
     let attemptCount = 1
     while (true) {
+      // An abort during retry backoff must stop before another model attempt begins.
       this._throwIfCancelled()
       const selectedModel = this._modelForAttempt(invocationState)
       let projectedInputTokens: number | undefined

--- a/strands-ts/src/retry/__tests__/default-model-retry-strategy.test.ts
+++ b/strands-ts/src/retry/__tests__/default-model-retry-strategy.test.ts
@@ -62,6 +62,23 @@ describe('DefaultModelRetryStrategy', () => {
     expect(event.retry).toBe(true)
   })
 
+  it('does not schedule a backoff timer when cancellation was already requested', async () => {
+    const strategy = new DefaultModelRetryStrategy({
+      maxAttempts: 3,
+      backoff: new ConstantBackoff({ delayMs: 500 }),
+    })
+    const controller = new AbortController()
+    controller.abort()
+    const agent = createMockAgent({ extra: { cancelSignal: controller.signal } })
+    strategy.initAgent(agent)
+
+    const event = makeErrorEvent(agent, new ModelThrottledError('rate limited'), 1)
+    await invokeTrackedHook(agent, event)
+
+    expect(event.retry).toBe(true)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
   it('does not retry non-retryable errors', async () => {
     const strategy = new DefaultModelRetryStrategy({
       backoff: new ConstantBackoff({ delayMs: 10 }),

--- a/strands-ts/src/retry/model-retry-strategy.ts
+++ b/strands-ts/src/retry/model-retry-strategy.ts
@@ -111,6 +111,7 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise((resolve) => {
     const onAbort = (): void => {
       globalThis.clearTimeout(timer)
+      // Resolve so the retry loop can re-check cancellation before another model attempt.
       resolve()
     }
     const timer = globalThis.setTimeout(() => {

--- a/strands-ts/src/retry/model-retry-strategy.ts
+++ b/strands-ts/src/retry/model-retry-strategy.ts
@@ -76,7 +76,7 @@ export abstract class ModelRetryStrategy implements Plugin {
     const decision = await this.computeRetryDecision(event)
     if (!decision.retry) return
 
-    await sleep(decision.waitMs)
+    await sleep(decision.waitMs, event.agent.cancelSignal)
     event.retry = true
   }
 
@@ -105,6 +105,18 @@ export abstract class ModelRetryStrategy implements Plugin {
   }
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => globalThis.setTimeout(resolve, ms))
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.resolve()
+
+  return new Promise((resolve) => {
+    const onAbort = (): void => {
+      globalThis.clearTimeout(timer)
+      resolve()
+    }
+    const timer = globalThis.setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+    signal?.addEventListener('abort', onAbort, { once: true })
+  })
 }


### PR DESCRIPTION
## Description

Cancellation can arrive while a model retry strategy is waiting through backoff. The invocation currently keeps the timer alive and can enter another model attempt after the caller has disconnected.

This makes retry delays observe the invocation signal and adds a cancellation checkpoint before every model attempt. A cancelled invocation now settles promptly with `stopReason: cancelled` without starting another provider call. Normal retries and the retry strategy API remain unchanged.

## Related Issues

Resolves: #4250

## Documentation PR

No documentation change is needed because this corrects the existing `cancelSignal` contract.

## Type of Change

Bug fix

## Testing

- `npm run test:coverage` (4,661 tests passed; pre-commit gate)
- `npm run lint`
- `npm run format:check`
- `npm run type-check`
- `npm run check:browser-bundle`
- `npm run test:package`
- Targeted Chromium tests for retry strategy and agent retry wiring (25 passed)
- `npm run test:integ:selective` reached the provider-dependent suites; 44 tests passed, while eight tests and two suites could not run without Bedrock credentials. The failures are unrelated to this change.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added necessary tests that prove the fix is effective
- [x] No documentation changes are needed for this bug fix
- [x] No new example is needed because the public API is unchanged
- [x] My changes generate no new warnings
- [x] This change has no dependent changes

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
