### PR TITLE
refactor(bidi): rename model configuration validator

### DIFF
--- a/strands-py/src/strands/experimental/bidi/models/bedrock.py
+++ b/strands-py/src/strands/experimental/bidi/models/bedrock.py
@@ -70,7 +70,7 @@ from .configs import (
     BidiConnectionConfig,
     BidiModelConfig,
     _validate_audio_config,
-    _validate_bidi_config,
+    _validate_model_config,
 )
 from .model import AudioCapable, BidiModel, BidiModelTimeoutError
 
@@ -228,7 +228,7 @@ class BedrockNovaSonicModel(BidiModel, AudioCapable):
         if boto_session is not None and region is not None:
             raise ValueError("Cannot specify both 'boto_session' and 'region'")
 
-        _validate_bidi_config(model_config)
+        _validate_model_config(model_config)
         _validate_audio_config(audio)
         self._config = BidiModelConfig(**model_config)
         self._config.setdefault("model_id", NOVA_SONIC_V2_MODEL_ID)
@@ -270,7 +270,7 @@ class BedrockNovaSonicModel(BidiModel, AudioCapable):
         Args:
             **model_config: Configuration overrides.
         """
-        _validate_bidi_config(model_config)
+        _validate_model_config(model_config)
         self._config.update(model_config)
 
     @override

--- a/strands-py/src/strands/experimental/bidi/models/configs.py
+++ b/strands-py/src/strands/experimental/bidi/models/configs.py
@@ -71,7 +71,7 @@ class BidiModelConfig(TypedDict, total=False):
     connection: BidiConnectionConfig
 
 
-def _validate_bidi_config(config: Mapping[str, Any]) -> None:
+def _validate_model_config(config: Mapping[str, Any]) -> None:
     """Validate shared bidirectional model configuration."""
     validate_config_keys(config, BidiModelConfig)
     validate_config_keys(config.get("connection", {}), BidiConnectionConfig)

--- a/strands-py/src/strands/experimental/bidi/models/google.py
+++ b/strands-py/src/strands/experimental/bidi/models/google.py
@@ -51,7 +51,7 @@ from .configs import (
     BidiModelConfig,
     _merge_config,
     _validate_audio_config,
-    _validate_bidi_config,
+    _validate_model_config,
 )
 from .model import AudioCapable, BidiModel, BidiModelTimeoutError
 
@@ -95,7 +95,7 @@ class GoogleGeminiLiveModel(BidiModel, AudioCapable):
             audio: Audio configuration.
             **model_config: Model configuration.
         """
-        _validate_bidi_config(model_config)
+        _validate_model_config(model_config)
         _validate_audio_config(audio)
         self._config = BidiModelConfig(**model_config)
         self._config.setdefault("model_id", "gemini-2.5-flash-native-audio-preview-09-2025")
@@ -136,7 +136,7 @@ class GoogleGeminiLiveModel(BidiModel, AudioCapable):
         Args:
             **model_config: Configuration overrides.
         """
-        _validate_bidi_config(model_config)
+        _validate_model_config(model_config)
         self._config.update(model_config)
 
     @override

--- a/strands-py/src/strands/experimental/bidi/models/openai.py
+++ b/strands-py/src/strands/experimental/bidi/models/openai.py
@@ -47,7 +47,7 @@ from .configs import (
     BidiModelConfig,
     _merge_config,
     _validate_audio_config,
-    _validate_bidi_config,
+    _validate_model_config,
 )
 from .model import AudioCapable, BidiModel, BidiModelTimeoutError
 
@@ -134,7 +134,7 @@ class OpenAIRealtimeModel(BidiModel, AudioCapable):
         Raises:
             ValueError: If the API key is missing or ``timeout_s`` exceeds the maximum.
         """
-        _validate_bidi_config(model_config)
+        _validate_model_config(model_config)
         _validate_audio_config(audio)
         self._config = BidiModelConfig(**model_config)
         self._config.setdefault("model_id", DEFAULT_MODEL)
@@ -192,7 +192,7 @@ class OpenAIRealtimeModel(BidiModel, AudioCapable):
         Args:
             **model_config: Configuration overrides.
         """
-        _validate_bidi_config(model_config)
+        _validate_model_config(model_config)
         self._config.update(model_config)
 
     @override

--- a/strands-py/tests/strands/experimental/bidi/models/test_configs.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_configs.py
@@ -4,7 +4,7 @@ import copy
 
 import pytest
 
-from strands.experimental.bidi.models.configs import _merge_config, _validate_audio_config, _validate_bidi_config
+from strands.experimental.bidi.models.configs import _merge_config, _validate_audio_config, _validate_model_config
 
 
 @pytest.mark.parametrize(
@@ -14,9 +14,9 @@ from strands.experimental.bidi.models.configs import _merge_config, _validate_au
         pytest.param({"connection": {"restart_after": 30}}, "restart_after", id="connection"),
     ],
 )
-def test__validate_bidi_config_warns_invalid_keys(model_config, invalid_key):
+def test__validate_model_config_warns_invalid_keys(model_config, invalid_key):
     with pytest.warns(UserWarning, match=invalid_key):
-        _validate_bidi_config(model_config)
+        _validate_model_config(model_config)
 
 
 def test__validate_audio_config_warns_invalid_keys():


### PR DESCRIPTION
## Description

Use parallel names for model and audio configuration validation in the bidi providers. This is an internal rename with no behavior change.

## Related Issues

None.

## Documentation PR

Not needed for this internal rename.

## Type of Change

Other (internal refactor)

## Testing

Ran the repository Python pre-push checks (lint, type checking, and 6,643 passing unit tests; 31 skipped) and a direct validator smoke check covering valid configuration and warnings for invalid model and connection keys.

- [x] I ran `hatch run prepare`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
