### PR TITLE
feat(vended-tools): route web-fetch through the sandbox

### DIFF
--- a/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
+++ b/site/src/content/docs/user-guide/concepts/tools/vended-tools.mdx
@@ -400,13 +400,10 @@ configured at construction time via `make_web_fetch` / `makeWebFetch`:
 
 The `max_bytes` / `maxBytes` parameter caps the HTTP response size (default 5 MiB);
 `max_content_chars` / `maxContentChars` caps the extracted content delivered to the model or
-analyst (default 50,000 characters). For `mode='agentic'` / `mode: 'agentic'`,
-the factory also accepts a `model` for the analyst; the agent's own model is
+analyst (default 50,000 characters). The `timeout` parameter sets
+the curl request timeout (default 30 s; pass `0` to disable). For `mode='agentic'` /
+`mode: 'agentic'`, the factory also accepts a `model` for the analyst; the agent's own model is
 used when none is supplied.
-
-The Python tool delegates all networking to an `httpx.AsyncClient`. Use the
-`make_web_fetch` factory to supply a pre-configured client with custom
-timeouts, redirects, proxies, or caching.
 
 _Supported in: Node.js (TypeScript); Python (all platforms)._
 
@@ -431,9 +428,9 @@ npm install turndown
 
 :::note[Security posture]
 Web fetch accepts only `http://` and `https://` URLs and caps response bodies
-at 5 MiB by default. Egress control belongs at the layer that encapsulates the
-agent — a sandbox, microVM, or network policy — where it can be enforced
-consistently across all tools, including `shell`.
+at 5 MiB by default. Requests run inside the agent's sandbox, so network
+access is scoped to whatever the sandbox permits. Egress control at the
+network or sandbox boundary is still recommended for production deployments.
 :::
 
 **Example:**
@@ -485,19 +482,18 @@ agent = Agent(tools=[web_fetch])
 agent("Read https://example.com/docs and then explain the architecture")
 ```
 
-Tighter response cap with a dedicated analyst model and custom transport:
+Tighter response cap with a dedicated analyst model:
 
 ```python
-import httpx
 from strands import Agent
 from strands.models import BedrockModel
 from strands.vended_tools import make_web_fetch
 
 web_fetch = make_web_fetch(
     mode="agentic",
-    client=httpx.AsyncClient(timeout=10.0),
     max_bytes=1 * 1024 * 1024,
     max_content_chars=25_000,
+    timeout=15,
     model=BedrockModel(model_id="us.amazon.nova-micro-v1:0"),
 )
 agent = Agent(tools=[web_fetch])

--- a/strands-py/src/strands/vended_tools/web_fetch/web_fetch.py
+++ b/strands-py/src/strands/vended_tools/web_fetch/web_fetch.py
@@ -10,19 +10,17 @@ construction time:
 * ``markdown``: HTML is converted to clean markdown with scripts, styles, and
   noise stripped. Use when the agent needs full pages for reasoning.
 
-The tool delegates all networking to the ``httpx.AsyncClient`` instance
-provided by the operator, giving full control over transport configuration,
-caching, proxies, redirects, and connection pooling.
+The tool routes all HTTP requests through the agent's sandbox by running
+``curl``, keeping network access inside the sandbox boundary.
 """
 
 from __future__ import annotations
 
-import asyncio
-import threading
+import shlex
 from typing import TYPE_CHECKING, Literal
 
-import httpx
-
+from ...sandbox.errors import SandboxTimeoutError
+from ...sandbox.types import ExecutionResult
 from ...tools.decorator import tool
 from ...types.tools import ToolContext
 from ._extract import html_to_markdown
@@ -37,13 +35,11 @@ if TYPE_CHECKING:
     from ...models.model import Model
     from ...tools.decorator import DecoratedFunctionTool
 
-_HEADERS = {
-    "User-Agent": "strands-agents-web-fetch/1.0",
-    "Accept": "text/html,application/xhtml+xml;q=0.9,*/*;q=0.8",
-}
+_USER_AGENT = "strands-agents-web-fetch/1.0"
 
 _DEFAULT_MAX_BYTES = 5 * 1024 * 1024  # 5 MiB
 _DEFAULT_MAX_CONTENT_CHARS = 50_000
+_DEFAULT_TIMEOUT_SECONDS = 30
 
 _ANALYST_PROMPT = (
     "You answer a request about a single fetched web page. Use only the provided "
@@ -59,7 +55,7 @@ def make_web_fetch(
     description: str | None = None,
     max_bytes: int = _DEFAULT_MAX_BYTES,
     max_content_chars: int = _DEFAULT_MAX_CONTENT_CHARS,
-    client: httpx.AsyncClient | None = None,
+    timeout: float = _DEFAULT_TIMEOUT_SECONDS,
     model: Model | None = None,
     mode: Literal["markdown", "agentic"] = "agentic",
 ) -> DecoratedFunctionTool:
@@ -70,28 +66,30 @@ def make_web_fetch(
         description: Tool description shown to the model. Defaults to a mode-appropriate
             description when ``None``.
         max_bytes: Maximum response body size in bytes. Responses larger than
-            this are rejected without buffering the entire body. Defaults to
-            5 MiB.
+            this are rejected. Defaults to 5 MiB.
         max_content_chars: Maximum characters of extracted content delivered to
             the model or analyst. Content exceeding this is truncated with a
             visible marker. Defaults to 50,000.
-        client: Optional ``httpx.AsyncClient`` to use for requests. When
-            provided, the tool uses it directly and will not close it.
-            When ``None``, a new client is created per request with
-            ``follow_redirects=True`` and httpx's default timeout (5s).
+        timeout: Maximum time in seconds to wait for the curl request.
+            Defaults to 30. Pass ``0`` to disable the timeout.
         model: Optional model for the analyst. Only used when ``mode='agentic'``.
             Resolution order: this model, then the host agent's model,
             then ``WebFetchError`` if neither is available.
         mode: Extraction mode. Defaults to ``agentic``.
 
     Returns:
-        A decorated tool that fetches a URL and extracts content according to
-        the configured mode:
+        A decorated tool that fetches a URL via the agent's sandbox and
+        extracts content according to the configured mode:
+
         - ``agentic`` (default): HTML is converted to markdown and passed to an
           analyst agent that answers a ``prompt``; the full page never enters
           the main agent's context.
         - ``markdown``: HTML converted to clean markdown; other content
           types returned as-is.
+
+    Raises:
+        ValueError: If ``max_bytes`` or ``max_content_chars`` is not positive,
+            or ``mode`` is invalid.
     """
     if max_bytes <= 0:
         raise ValueError(f"max_bytes must be positive, got {max_bytes}")
@@ -102,30 +100,22 @@ def make_web_fetch(
     resolved_description = description or (
         WEB_FETCH_DESCRIPTION_MARKDOWN if mode == "markdown" else WEB_FETCH_DESCRIPTION_AGENTIC
     )
-    external_client = client
     analyst_model = model
 
     @tool(name=name, description=resolved_description, context=True)
     async def web_fetch_tool_markdown(
         url: str,
-        tool_context: ToolContext | None = None,
+        tool_context: ToolContext,
     ) -> str:
         """Fetches an HTTP(S) URL and returns clean markdown.
 
-        Raises ``WebFetchError`` if the request fails or the client's timeout is exceeded.
+        Raises ``WebFetchError`` if the request fails or the size cap is exceeded.
 
         Args:
             url: The URL to fetch. Must be ``http://`` or ``https://``.
-            tool_context: Framework-injected. Not model-visible. Carries the
-                agent so the tool can read its cancel signal.
+            tool_context: Framework-injected. Not model-visible.
         """
-        cancel_signal = tool_context.cancel_signal if tool_context else None
-        content_type, raw = await _fetch_once(
-            url=url,
-            max_bytes=max_bytes,
-            client=external_client,
-            cancel_signal=cancel_signal,
-        )
+        content_type, raw = await _fetch_once(url=url, max_bytes=max_bytes, timeout=timeout, tool_context=tool_context)
 
         is_markup = "html" in content_type.lower() or "xml" in content_type.lower()
         content = html_to_markdown(raw) if is_markup else raw
@@ -137,17 +127,16 @@ def make_web_fetch(
     async def web_fetch_tool_agentic(
         url: str,
         prompt: str,
-        tool_context: ToolContext | None = None,
+        tool_context: ToolContext,
     ) -> str:
         """Fetches an HTTP(S) URL and returns an analyst's answer about it.
 
-        Raises ``WebFetchError`` if the request fails or the client's timeout is exceeded.
+        Raises ``WebFetchError`` if the request fails or the size cap is exceeded.
 
         Args:
             url: The URL to fetch. Must be ``http://`` or ``https://``.
             prompt: The question or instruction about the page content.
-            tool_context: Framework-injected. Not model-visible. Carries the
-                agent so the tool can read its cancel signal.
+            tool_context: Framework-injected. Not model-visible.
         """
         # Local import to avoid circular dependency
         from ...agent.agent import Agent
@@ -155,7 +144,7 @@ def make_web_fetch(
         if not prompt.strip():
             raise WebFetchError("web_fetch: agentic mode requires a non-empty prompt.")
 
-        host_model = getattr(tool_context.agent, "model", None) if tool_context else None
+        host_model = getattr(tool_context.agent, "model", None)
         effective_model = analyst_model or host_model
         if effective_model is None:
             raise WebFetchError(
@@ -163,13 +152,7 @@ def make_web_fetch(
                 "Pass model= to make_web_fetch or call the tool from an agent."
             )
 
-        cancel_signal = tool_context.cancel_signal if tool_context else None
-        content_type, raw = await _fetch_once(
-            url=url,
-            max_bytes=max_bytes,
-            client=external_client,
-            cancel_signal=cancel_signal,
-        )
+        content_type, raw = await _fetch_once(url=url, max_bytes=max_bytes, timeout=timeout, tool_context=tool_context)
 
         # Fresh agent per call — no history from one fetch bleeds into the next.
         analyst = Agent(
@@ -183,7 +166,7 @@ def make_web_fetch(
             content = content[:max_content_chars] + "\n\n[content truncated]"
         invoke_prompt = f"URL: {url}\n\nRequest: {prompt}\n\n--- Content ---\n{content}"
         try:
-            result = await analyst.invoke_async(invoke_prompt, cancel_signal=cancel_signal)
+            result = await analyst.invoke_async(invoke_prompt, cancel_signal=tool_context.cancel_signal)
         except Exception as exc:
             raise WebFetchError(f"Web fetch analyst failed for {url}: {exc}") from exc
         return str(result)
@@ -202,64 +185,44 @@ async def _fetch_once(
     *,
     url: str,
     max_bytes: int,
-    client: httpx.AsyncClient | None,
-    cancel_signal: threading.Event | None,
+    timeout: float,
+    tool_context: ToolContext,
 ) -> tuple[str, str]:
     """Perform one HTTP GET, returning ``(content_type, body_text)``.
 
     Raises:
-        asyncio.CancelledError: When the agent cancel signal is set.
-        WebFetchError: On timeout, transport failure, HTTP error status, or
-            body exceeding ``max_bytes``.
+        WebFetchError: On transport failure, HTTP error status, or body exceeding
+            ``max_bytes``.
+        SandboxTimeoutError: When the sandbox execution times out.
     """
-    if cancel_signal is not None and cancel_signal.is_set():
-        raise asyncio.CancelledError("Web fetch tool request cancelled")
+    if not url.startswith("http://") and not url.startswith("https://"):
+        raise WebFetchError(f"url=<{url}> | fetch failed: only http and https URLs are supported")
 
-    owns_client = client is None
-    active_client = client if client is not None else httpx.AsyncClient(follow_redirects=True)
+    # --max-filesize exits 63 when Content-Length exceeds the cap.
+    # --write-out writes the final-hop content-type to stderr, separate from the content.
+    command = (
+        f"curl -sSLg --fail-with-body --max-filesize {max_bytes} -A {shlex.quote(_USER_AGENT)}"
+        f" --write-out {shlex.quote('%{stderr}%{content_type}')} {shlex.quote(url)}"
+    )
+
+    effective_timeout = timeout if timeout > 0 else None
     try:
-        try:
-            request = active_client.build_request("GET", url, headers=_HEADERS)
-            response = await active_client.send(request, stream=True)
-        except httpx.TimeoutException as error:
-            raise WebFetchError(f"Fetch timed out: {url!r}") from error
-        except (httpx.InvalidURL, httpx.RequestError, ValueError) as exc:
-            raise WebFetchError(f"Fetch failed: {exc}") from exc
-        try:
-            content_type = response.headers.get("content-type", "")
-            if response.status_code >= 400:
-                raise WebFetchError(f"HTTP {response.status_code} {response.reason_phrase}")
-            chunks: list[bytes] = []
-            total = 0
-            async for chunk in response.aiter_bytes():
-                if cancel_signal is not None and cancel_signal.is_set():
-                    raise asyncio.CancelledError("Web fetch tool request cancelled")
-                total += len(chunk)
-                if total > max_bytes:
-                    raise WebFetchError(f"Response body exceeded {max_bytes} bytes. Refusing to buffer more.")
-                chunks.append(chunk)
-            body = b"".join(chunks)
-        finally:
-            await response.aclose()
-    finally:
-        if owns_client:
-            await active_client.aclose()
+        result: ExecutionResult = await tool_context.agent.sandbox.execute(command, timeout=effective_timeout)
+    except SandboxTimeoutError:
+        raise
+    except Exception as exc:
+        raise WebFetchError(f"url=<{url}> | fetch failed: {exc}") from exc
 
-    charset = _parse_charset(content_type)
-    try:
-        raw = body.decode(charset, errors="replace")
-    except LookupError:
-        raw = body.decode("utf-8", errors="replace")
+    # Length check covers chunked responses.
+    if result.exit_code == 63 or len(result.stdout) > max_bytes:
+        raise WebFetchError(f"Response body exceeded {max_bytes} bytes. Refusing to buffer more.")
 
-    return content_type, raw
+    if result.exit_code != 0:
+        first_line = result.stderr.split("\n")[0].strip()
+        detail = first_line or f"curl exited with code {result.exit_code}"
+        raise WebFetchError(f"url=<{url}> | fetch failed: {detail}")
 
+    # On success, stderr contains only the content-type written by --write-out.
+    content_type = result.stderr.strip()
 
-def _parse_charset(content_type: str) -> str:
-    """Extract the charset from a Content-Type header, defaulting to ``utf-8``."""
-    for part in content_type.split(";"):
-        part = part.strip()
-        if part.lower().startswith("charset="):
-            value = part[8:].strip().strip("'\"")
-            if value:
-                return value
-    return "utf-8"
+    return content_type, result.stdout

--- a/strands-py/tests/strands/vended_tools/test_web_fetch.py
+++ b/strands-py/tests/strands/vended_tools/test_web_fetch.py
@@ -2,15 +2,15 @@
 
 from __future__ import annotations
 
-import asyncio
-import threading
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
-import httpx
 import pytest
 from bs4 import BeautifulSoup
 
 import strands.agent.agent as agent_module
+from strands.sandbox.errors import SandboxTimeoutError
+from strands.sandbox.types import ExecutionResult
 from strands.types.tools import ToolContext, ToolUse
 from strands.vended_tools.web_fetch import (
     WebFetchError,
@@ -18,23 +18,43 @@ from strands.vended_tools.web_fetch import (
 )
 from strands.vended_tools.web_fetch import _extract as extract_module
 from strands.vended_tools.web_fetch._extract import _tag_attribute, html_to_markdown
-from strands.vended_tools.web_fetch.web_fetch import _parse_charset
 
 
-def _transport(handler):
-    """Build a mock httpx transport from a request handler callable."""
-    return httpx.MockTransport(handler)
+def _make_execution_result(
+    stdout: str = "",
+    stderr: str = "",
+    exit_code: int = 0,
+) -> ExecutionResult:
+    return ExecutionResult(exit_code=exit_code, stdout=stdout, stderr=stderr)
 
 
-def _client(handler) -> httpx.AsyncClient:
-    return httpx.AsyncClient(transport=_transport(handler))
+def _make_curl_result(
+    body: str,
+    *,
+    content_type: str = "text/plain",
+    exit_code: int = 0,
+    stderr: str | None = None,
+) -> ExecutionResult:
+    """Build a mock ExecutionResult matching --write-out '%{stderr}%{content_type}' output:
+    body in stdout, content-type in stderr (on success).
+    """
+    effective_stderr = stderr if stderr is not None else (content_type if exit_code == 0 else "")
+    return _make_execution_result(stdout=body, stderr=effective_stderr, exit_code=exit_code)
 
 
-def _make_ctx(cancel: threading.Event | None = None) -> ToolContext:
-    cancel = cancel or threading.Event()
-    agent = SimpleNamespace(model=None, _cancel_signal=cancel)
+def _make_sandbox(execute_result: ExecutionResult | Exception | None = None) -> SimpleNamespace:
+    if isinstance(execute_result, Exception):
+        mock = AsyncMock(side_effect=execute_result)
+    else:
+        mock = AsyncMock(return_value=execute_result or _make_curl_result(""))
+    return SimpleNamespace(execute=mock)
+
+
+def _make_ctx(sandbox: SimpleNamespace | None = None) -> ToolContext:
+    sandbox = sandbox or _make_sandbox()
+    agent = SimpleNamespace(model=None, sandbox=sandbox)
     tool_use = ToolUse(toolUseId="test-wf", name="web_fetch", input={})
-    return ToolContext(tool_use=tool_use, agent=agent, invocation_state={}, cancel_signal=cancel)
+    return ToolContext(tool_use=tool_use, agent=agent, invocation_state={})
 
 
 def _raising_beautiful_soup(*args, **kwargs):
@@ -57,186 +77,109 @@ class TestLazyLoad:
 
 
 class TestWebFetchToolCall:
-    """End-to-end tool behavior with the transport stubbed out."""
+    """End-to-end tool behavior with the sandbox stubbed out."""
 
     @pytest.mark.asyncio
-    async def test_html_response_returns_markdown(self):
-        html = "<html><head><title>T</title></head><body><h1>Hi</h1></body></html>"
-
-        def handler(_request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, headers={"content-type": "text/html; charset=utf-8"}, text=html)
-
-        tool = make_web_fetch(client=_client(handler), mode="markdown")
-        tru_result = await tool(url="https://example.com/")
-        assert "# T" in tru_result
+    async def test_response_body_is_passed_through_html_to_markdown(self):
+        sandbox = _make_sandbox(_make_curl_result("<h1>Hi</h1>", content_type="text/html"))
+        tru_result = await make_web_fetch(mode="markdown")(url="https://example.com/", tool_context=_make_ctx(sandbox))
         assert "# Hi" in tru_result
 
     @pytest.mark.asyncio
-    async def test_non_html_response_returns_body(self):
-        def handler(_request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, headers={"content-type": "text/plain"}, text="plain text response")
-
-        tool = make_web_fetch(client=_client(handler), mode="markdown")
-        tru_result = await tool(url="https://example.com/robots.txt")
-        assert tru_result == "plain text response"
-
-    @pytest.mark.asyncio
     async def test_xml_content_type_is_converted_to_markdown(self):
-        def handler(_request: httpx.Request) -> httpx.Response:
-            return httpx.Response(
-                200,
-                headers={"content-type": "application/xhtml+xml"},
-                text="<html><body><p>xhtml</p></body></html>",
-            )
-
-        tool = make_web_fetch(client=_client(handler), mode="markdown")
-        tru_result = await tool(url="https://example.com/page.xhtml")
+        sandbox = _make_sandbox(
+            _make_curl_result("<html><body><p>xhtml</p></body></html>", content_type="application/xhtml+xml")
+        )
+        tru_result = await make_web_fetch(mode="markdown")(
+            url="https://example.com/page.xhtml", tool_context=_make_ctx(sandbox)
+        )
         assert "xhtml" in tru_result
 
     @pytest.mark.asyncio
+    async def test_non_html_response_is_returned_as_is(self):
+        sandbox = _make_sandbox(_make_curl_result("plain text response", content_type="text/plain"))
+        tru_result = await make_web_fetch(mode="markdown")(
+            url="https://example.com/robots.txt", tool_context=_make_ctx(sandbox)
+        )
+        assert tru_result == "plain text response"
+
+    @pytest.mark.asyncio
     async def test_markdown_content_is_truncated(self):
-        # max_content_chars limits what the main agent receives, with a marker.
-        body = "x" * 200
-
-        def handler(_request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, headers={"content-type": "text/plain"}, text=body)
-
-        tool = make_web_fetch(client=_client(handler), mode="markdown", max_content_chars=50)
-        tru_result = await tool(url="https://example.com/")
-        assert tru_result.startswith("x" * 50)
+        sandbox = _make_sandbox(_make_curl_result("x" * 200, content_type="text/plain"))
+        tru_result = await make_web_fetch(mode="markdown", max_content_chars=50)(
+            url="https://example.com/", tool_context=_make_ctx(sandbox)
+        )
         assert "[content truncated]" in tru_result
 
     @pytest.mark.asyncio
     async def test_rejects_non_http_scheme(self):
-        with pytest.raises(WebFetchError, match="Fetch failed"):
-            await make_web_fetch(mode="markdown")(url="file:///etc/passwd")
+        sandbox = _make_sandbox()
+        with pytest.raises(WebFetchError):
+            await make_web_fetch(mode="markdown")(url="file:///etc/passwd", tool_context=_make_ctx(sandbox))
 
     @pytest.mark.asyncio
-    async def test_transport_error_is_wrapped_as_value_error(self):
-        def handler(_request: httpx.Request) -> httpx.Response:
-            raise httpx.ConnectError("connection refused")
-
-        tool = make_web_fetch(client=_client(handler), mode="markdown")
-        with pytest.raises(WebFetchError, match="Fetch failed"):
-            await tool(url="https://example.com/")
+    async def test_sandbox_error_is_wrapped_as_web_fetch_error(self):
+        sandbox = _make_sandbox(RuntimeError("connection refused"))
+        with pytest.raises(WebFetchError, match="fetch failed"):
+            await make_web_fetch(mode="markdown")(url="https://example.com/", tool_context=_make_ctx(sandbox))
 
     @pytest.mark.asyncio
-    async def test_body_over_cap_is_rejected(self):
-        big = b"x" * 100
-
-        def handler(_request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, headers={"content-type": "text/plain"}, content=big)
-
-        tool = make_web_fetch(client=_client(handler), max_bytes=50, mode="markdown")
+    async def test_rejects_oversized_body_with_content_length(self):
+        sandbox = _make_sandbox(_make_execution_result(exit_code=63))
         with pytest.raises(WebFetchError, match="exceeded"):
-            await tool(url="https://example.com/")
+            await make_web_fetch(mode="markdown")(url="https://example.com/", tool_context=_make_ctx(sandbox))
+
+    @pytest.mark.asyncio
+    async def test_rejects_oversized_body(self):
+        sandbox = _make_sandbox(_make_curl_result("x" * 100, content_type="text/plain"))
+        with pytest.raises(WebFetchError, match="exceeded"):
+            await make_web_fetch(mode="markdown", max_bytes=50)(
+                url="https://example.com/", tool_context=_make_ctx(sandbox)
+            )
 
     @pytest.mark.asyncio
     async def test_error_status_raises(self):
-        def handler(_request: httpx.Request) -> httpx.Response:
-            return httpx.Response(404, text="Not Found")
-
-        tool = make_web_fetch(client=_client(handler), mode="markdown")
-        with pytest.raises(WebFetchError, match="HTTP 404"):
-            await tool(url="https://example.com/missing")
+        sandbox = _make_sandbox(_make_execution_result(exit_code=22, stderr="HTTP/2 404 Not Found"))
+        with pytest.raises(WebFetchError, match="HTTP"):
+            await make_web_fetch(mode="markdown")(url="https://example.com/missing", tool_context=_make_ctx(sandbox))
 
     @pytest.mark.asyncio
-    async def test_user_client_redirect_behaviour_is_respected(self):
-        def handler(request: httpx.Request) -> httpx.Response:
-            if request.url.path == "/old":
-                return httpx.Response(
-                    301, headers={"location": "https://example.com/new", "content-type": "text/plain"}, text="moved"
-                )
-            return httpx.Response(200, headers={"content-type": "text/plain"}, text="new page")
-
-        # User-supplied client with follow_redirects=False: redirect is not followed.
-        client = httpx.AsyncClient(transport=_transport(handler), follow_redirects=False)
-        tool = make_web_fetch(client=client, mode="markdown")
-        tru_result = await tool(url="https://example.com/old")
-        assert tru_result == "moved"
-
-    @pytest.mark.asyncio
-    async def test_timeout_is_wrapped_as_web_fetch_error(self):
-        async def handler(_request: httpx.Request) -> httpx.Response:
-            raise httpx.TimeoutException("timed out")
-
-        tool = make_web_fetch(client=httpx.AsyncClient(transport=httpx.MockTransport(handler)), mode="markdown")
-        with pytest.raises(WebFetchError, match="timed out"):
-            await tool(url="https://example.com/")
+    async def test_propagates_sandbox_timeout_unwrapped(self):
+        sandbox = _make_sandbox(SandboxTimeoutError(30))
+        with pytest.raises(SandboxTimeoutError):
+            await make_web_fetch(mode="markdown")(url="https://example.com/", tool_context=_make_ctx(sandbox))
 
     @pytest.mark.asyncio
     async def test_html_extraction_failure_falls_back_to_raw(self, monkeypatch):
-        # html_to_markdown falls back to raw input on parser failure,
-        # so the model always receives readable content.
-        def handler(_request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, headers={"content-type": "text/html"}, text="<p>raw content</p>")
-
+        sandbox = _make_sandbox(_make_curl_result("<p>raw content</p>", content_type="text/html"))
         monkeypatch.setattr(extract_module, "BeautifulSoup", _raising_beautiful_soup)
-        tool = make_web_fetch(client=_client(handler), mode="markdown")
-        tru_result = await tool(url="https://example.com/")
+        tru_result = await make_web_fetch(mode="markdown")(url="https://example.com/", tool_context=_make_ctx(sandbox))
         assert tru_result == "<p>raw content</p>"
 
     @pytest.mark.asyncio
-    async def test_sends_correct_headers(self):
-        received: dict[str, str] = {}
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            received.update(request.headers)
-            return httpx.Response(200, headers={"content-type": "text/plain"}, text="ok")
-
-        tool = make_web_fetch(client=_client(handler), mode="markdown")
-        await tool(url="https://example.com/")
-        assert "strands-agents-web-fetch" in received.get("user-agent", "")
+    async def test_sends_correct_user_agent_in_curl_command(self):
+        sandbox = _make_sandbox(_make_curl_result("ok"))
+        await make_web_fetch(mode="markdown")(url="https://example.com/", tool_context=_make_ctx(sandbox))
+        command = sandbox.execute.call_args[0][0]
+        assert "strands-agents-web-fetch/1.0" in command
 
     @pytest.mark.asyncio
-    async def test_pre_flight_cancel_short_circuits(self):
-        def handler(_request: httpx.Request) -> httpx.Response:
-            raise AssertionError("transport should not be called if cancel is pre-set")
-
-        cancel = threading.Event()
-        cancel.set()
-        ctx = _make_ctx(cancel)
-
-        tool = make_web_fetch(client=_client(handler), mode="markdown")
-        with pytest.raises(asyncio.CancelledError):
-            await tool(url="https://example.com/", tool_context=ctx)
-
-    @pytest.mark.asyncio
-    async def test_mid_flight_cancel_aborts_between_chunks(self):
-        cancel = threading.Event()
-
-        def handler(_request: httpx.Request) -> httpx.Response:
-            async def body():
-                yield b"chunk-one"
-                cancel.set()  # signal mid-stream
-                yield b"chunk-two"
-
-            return httpx.Response(200, headers={"content-type": "text/plain"}, content=body())
-
-        ctx = _make_ctx(cancel)
-
-        tool = make_web_fetch(client=_client(handler), mode="markdown")
-        with pytest.raises(asyncio.CancelledError):
-            await tool(url="https://example.com/", tool_context=ctx)
+    async def test_url_is_safely_quoted(self):
+        sandbox = _make_sandbox(_make_curl_result("ok"))
+        await make_web_fetch(mode="markdown")(url="https://example.com/path?q=a&b=c", tool_context=_make_ctx(sandbox))
+        command = sandbox.execute.call_args[0][0]
+        assert "'https://example.com/path?q=a&b=c'" in command
 
 
 class TestAnalyst:
     """Analyst agent is called when model + prompt are both provided."""
 
-    def _page_client(self, body: str = "<p>page content</p>") -> httpx.AsyncClient:
-        def handler(_request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, headers={"content-type": "text/html"}, text=body)
-
-        return _client(handler)
+    def _sandbox(self, body: str = "<p>page content</p>") -> SimpleNamespace:
+        return _make_sandbox(_make_curl_result(body, content_type="text/html"))
 
     @pytest.mark.asyncio
     async def test_agentic_content_is_truncated_before_analyst(self, monkeypatch):
-        # max_content_chars limits what the analyst receives.
-        body = "x" * 200
-
-        def page_handler(_request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, headers={"content-type": "text/plain"}, text=body)
-
+        sandbox = _make_sandbox(_make_curl_result("x" * 200, content_type="text/plain"))
         received_prompt: list[str] = []
 
         class _FakeAgent:
@@ -248,27 +191,21 @@ class TestAnalyst:
                 return "answer"
 
         monkeypatch.setattr(agent_module, "Agent", _FakeAgent)
-        tool = make_web_fetch(
-            client=_client(page_handler),
-            model=SimpleNamespace(),
-            mode="agentic",
-            max_content_chars=50,
-        )
-        await tool(url="https://example.com/", prompt="Summarize")
+        tool = make_web_fetch(model=SimpleNamespace(), mode="agentic", max_content_chars=50)
+        await tool(url="https://example.com/", prompt="Summarize", tool_context=_make_ctx(sandbox))
         assert "x" * 50 in received_prompt[0]
         assert "x" * 51 not in received_prompt[0]
         assert "[content truncated]" in received_prompt[0]
 
     @pytest.mark.asyncio
     async def test_prompt_without_model_and_no_agent_raises(self):
-        # No factory model and no host agent — agentic mode has nowhere to go.
-        tool = make_web_fetch(client=self._page_client(), mode="agentic")
         with pytest.raises(WebFetchError, match="agentic mode requires a model"):
-            await tool(url="https://example.com/", prompt="What is this about?")
+            await make_web_fetch(mode="agentic")(
+                url="https://example.com/", prompt="What is this about?", tool_context=_make_ctx(self._sandbox())
+            )
 
     @pytest.mark.asyncio
     async def test_prompt_uses_host_agent_model_when_no_factory_model(self, monkeypatch):
-        # When no factory model is set, the host agent's model is used.
         host_model = SimpleNamespace()
         received_model: list = []
 
@@ -280,41 +217,24 @@ class TestAnalyst:
                 return "host answer"
 
         monkeypatch.setattr(agent_module, "Agent", _FakeAgent)
+        sandbox = self._sandbox()
+        agent = SimpleNamespace(model=host_model, sandbox=sandbox)
         tool_use = ToolUse(toolUseId="wf_2", name="web_fetch", input={})
-        host_agent = SimpleNamespace(_cancel_signal=None, model=host_model)
-        ctx = ToolContext(tool_use=tool_use, agent=host_agent, invocation_state={})
+        ctx = ToolContext(tool_use=tool_use, agent=agent, invocation_state={})
 
-        tool = make_web_fetch(client=self._page_client(), mode="agentic")
-        tru_result = await tool(url="https://example.com/", prompt="Summarize", tool_context=ctx)
+        tru_result = await make_web_fetch(mode="agentic")(
+            url="https://example.com/", prompt="Summarize", tool_context=ctx
+        )
         assert tru_result == "host answer"
         assert received_model[0] is host_model
-
-    @pytest.mark.asyncio
-    async def test_empty_prompt_with_model_returns_markdown(self, monkeypatch):
-        # markdown mode skips the analyst regardless of model configuration.
-        fake_model = SimpleNamespace()
-        invoked: list[bool] = []
-
-        class _FakeAgent:
-            def __init__(self, **kwargs):
-                pass
-
-            async def invoke_async(self, prompt: str, **kwargs):
-                invoked.append(True)
-                return "answer"
-
-        monkeypatch.setattr(agent_module, "Agent", _FakeAgent)
-        tool = make_web_fetch(client=self._page_client(), model=fake_model, mode="markdown")
-        tru_result = await tool(url="https://example.com/")
-        assert not invoked
-        assert "page content" in tru_result
 
     @pytest.mark.parametrize("prompt", ["", "   "])
     @pytest.mark.asyncio
     async def test_agentic_mode_with_empty_prompt_raises(self, prompt):
-        tool = make_web_fetch(client=self._page_client(), model=SimpleNamespace(), mode="agentic")
         with pytest.raises(WebFetchError, match="agentic mode requires a non-empty prompt"):
-            await tool(url="https://example.com/", prompt=prompt)
+            await make_web_fetch(model=SimpleNamespace(), mode="agentic")(
+                url="https://example.com/", prompt=prompt, tool_context=_make_ctx(self._sandbox())
+            )
 
     @pytest.mark.asyncio
     async def test_prompt_with_model_invokes_analyst(self, monkeypatch):
@@ -330,28 +250,13 @@ class TestAnalyst:
                 return "the answer"
 
         monkeypatch.setattr(agent_module, "Agent", _FakeAgent)
-        tool = make_web_fetch(client=self._page_client(), model=fake_model, mode="agentic")
-        tru_result = await tool(url="https://example.com/", prompt="What is this about?")
+        tru_result = await make_web_fetch(model=fake_model, mode="agentic")(
+            url="https://example.com/", prompt="What is this about?", tool_context=_make_ctx(self._sandbox())
+        )
         assert tru_result == "the answer"
         assert len(received_prompt) == 1
         assert "What is this about?" in received_prompt[0]
         assert "page content" in received_prompt[0]
-
-
-class TestParseCharset:
-    """_parse_charset extracts charset from Content-Type values, defaulting to utf-8."""
-
-    def test_plain_charset(self):
-        assert _parse_charset("text/html; charset=utf-8") == "utf-8"
-
-    def test_quoted_charset(self):
-        assert _parse_charset('text/html; charset="iso-8859-1"') == "iso-8859-1"
-
-    def test_missing_charset_defaults_to_utf8(self):
-        assert _parse_charset("text/plain") == "utf-8"
-
-    def test_empty_charset_defaults_to_utf8(self):
-        assert _parse_charset("text/html; charset=") == "utf-8"
 
 
 class TestHtmlToMarkdown:
@@ -406,7 +311,6 @@ class TestHtmlToMarkdown:
 
     @pytest.mark.parametrize("prefix", [" ", "\t", "\u200b", "\ufeff", "\u00ad"])
     def test_javascript_href_with_invisible_prefix_is_dropped(self, prefix):
-        # Invisible/whitespace prefixes before "javascript:" must not bypass the check.
         html = f'<a href="{prefix}javascript:alert(1)">click</a>'
         md = html_to_markdown(html)
         assert "javascript:" not in md
@@ -440,6 +344,5 @@ class TestHtmlToMarkdown:
 
 
 def test__tag_attribute_joins_list_values():
-    # BS4 returns ``class`` as a list; _tag_attribute must join it.
     tag = BeautifulSoup('<div class="foo bar">', "html.parser").div
     assert _tag_attribute(tag, "class") == "foo bar"

--- a/strands-ts/src/vended-tools/web-fetch/README.md
+++ b/strands-ts/src/vended-tools/web-fetch/README.md
@@ -7,8 +7,8 @@ Fetches an HTTP(S) URL and returns its relevant content. Distinct from the http-
 **This tool makes outbound HTTP requests to URLs chosen by the model.**
 
 - Only use with trusted input
-- Requests execute with the network access of the host process
-- For production deployments, consider running in a sandboxed environment (containers, VMs, etc.)
+- Requests execute with the network access of the sandbox
+- For production deployments, consider restricting sandbox network access (containers, VMs, network policies, etc.)
 - Never expose this tool to untrusted users or untrusted prompt input without additional security measures
 
 ## Install
@@ -72,6 +72,7 @@ The default tool, produced by `makeWebFetch()` with `mode: 'agentic'` and defaul
 | `description`     | `string`                  | (built-in)    | Tool description shown to the model. Defaults to a mode-appropriate description.        |
 | `maxBytes`        | `number`                  | `5242880`     | Maximum response body size in bytes (5 MiB).                                            |
 | `maxContentChars` | `number`                  | `50000`       | Maximum characters of extracted content delivered to the model.                         |
+| `timeout`         | `number`                  | `30`          | Maximum seconds to wait for the curl request. Pass `0` to disable.                      |
 | `model`           | `Model`                   |               | Analyst model for agentic mode. Falls back to the host agent's model when not provided. |
 
 Throws if `maxBytes` or `maxContentChars` is not a positive number.

--- a/strands-ts/src/vended-tools/web-fetch/__tests__/web-fetch.test.ts
+++ b/strands-ts/src/vended-tools/web-fetch/__tests__/web-fetch.test.ts
@@ -1,8 +1,11 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { ToolContext } from '../../../tools/tool.js'
 import type { LocalAgent } from '../../../types/agent.js'
+import type { ExecutionResult } from '../../../sandbox/types.js'
+import type { Sandbox } from '../../../sandbox/base.js'
+import { SandboxAbortError, SandboxTimeoutError } from '../../../sandbox/errors.js'
 import { Agent } from '../../../agent/agent.js'
-import { makeWebFetch, webFetch, DEFAULT_MAX_BYTES, DEFAULT_MAX_CONTENT_CHARS } from '../web-fetch.js'
+import { makeWebFetch, webFetch } from '../web-fetch.js'
 import { WEB_FETCH_DESCRIPTION_MARKDOWN, WEB_FETCH_DESCRIPTION_AGENTIC } from '../types.js'
 
 const mockInvoke = vi.fn()
@@ -26,45 +29,61 @@ vi.mock('../extract.js', () => ({
   htmlToMarkdown: vi.fn((html: string) => `md:${html}`),
 }))
 
-describe('webFetch tool', () => {
-  const originalFetch = globalThis.fetch
+function makeSandbox(overrides: Partial<{ execute: Sandbox['execute'] }> = {}): Sandbox {
+  return {
+    execute: vi.fn(),
+    executeStreaming: vi.fn(),
+    executeCode: vi.fn(),
+    executeCodeStreaming: vi.fn(),
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+    removeFile: vi.fn(),
+    listFiles: vi.fn(),
+    getTools: vi.fn().mockReturnValue([]),
+    readText: vi.fn(),
+    writeText: vi.fn(),
+    ...overrides,
+  } as unknown as Sandbox
+}
 
+function makeExecutionResult(stdout: string, options: { exitCode?: number; stderr?: string } = {}): ExecutionResult {
+  return {
+    type: 'executionResult',
+    exitCode: options.exitCode ?? 0,
+    stdout,
+    stderr: options.stderr ?? '',
+    outputFiles: [],
+  }
+}
+
+/**
+ * Build a mock ExecutionResult matching curl --write-out output:
+ * body in stdout, content-type in stderr.
+ */
+function makeCurlResult(
+  body: string,
+  options: { contentType?: string; exitCode?: number; stderr?: string } = {}
+): ExecutionResult {
+  const { contentType = 'text/plain', exitCode = 0 } = options
+  const stderr = options.stderr ?? (exitCode === 0 ? contentType : '')
+  return makeExecutionResult(body, { exitCode, stderr })
+}
+
+function makeContext(sandbox: Sandbox, overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    toolUse: { name: 'web_fetch', toolUseId: 'test-id', input: {} },
+    agent: { model: undefined, sandbox } as unknown as LocalAgent,
+    invocationState: {},
+    cancelSignal: new AbortController().signal,
+    interrupt: vi.fn() as ToolContext['interrupt'],
+    ...overrides,
+  }
+}
+
+describe('webFetch tool', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
-
-  afterEach(() => {
-    globalThis.fetch = originalFetch
-  })
-
-  function mockFetch(body: string, options: { status?: number; statusText?: string; contentType?: string } = {}): void {
-    const { status = 200, statusText = 'OK', contentType = 'text/plain' } = options
-    const headers = new Map<string, string>([['content-type', contentType]])
-    const encoded = new TextEncoder().encode(body)
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: status < 400,
-      status,
-      statusText,
-      headers: { get: (key: string) => headers.get(key) ?? null },
-      body: new ReadableStream({
-        start(controller) {
-          controller.enqueue(encoded)
-          controller.close()
-        },
-      }),
-    })
-  }
-
-  function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
-    return {
-      toolUse: { name: 'web_fetch', toolUseId: 'test-id', input: {} },
-      agent: { model: undefined } as unknown as LocalAgent,
-      invocationState: {},
-      cancelSignal: new AbortController().signal,
-      interrupt: vi.fn() as ToolContext['interrupt'],
-      ...overrides,
-    }
-  }
 
   describe('makeWebFetch factory', () => {
     it('defaults to agentic mode', () => {
@@ -91,199 +110,212 @@ describe('webFetch tool', () => {
       expect(() => makeWebFetch({ maxContentChars: 0 })).toThrow(/maxContentChars/)
       expect(() => makeWebFetch({ maxContentChars: -1 })).toThrow(/maxContentChars/)
     })
-
-    it('exports correct default constants', () => {
-      expect(DEFAULT_MAX_BYTES).toBe(5 * 1024 * 1024)
-      expect(DEFAULT_MAX_CONTENT_CHARS).toBe(50_000)
-    })
   })
 
   describe('markdown mode', () => {
     it('html response is converted to markdown', async () => {
-      mockFetch('<h1>Hi</h1>', { contentType: 'text/html' })
-      const result = await makeWebFetch({ mode: 'markdown' }).invoke({ url: 'https://example.com/' })
+      const sandbox = makeSandbox({
+        execute: vi.fn().mockResolvedValue(makeCurlResult('<h1>Hi</h1>', { contentType: 'text/html' })),
+      })
+      const result = await makeWebFetch({ mode: 'markdown' }).invoke(
+        { url: 'https://example.com/' },
+        makeContext(sandbox)
+      )
       expect(result).toBe('md:<h1>Hi</h1>')
     })
 
     it('xml content type is also converted to markdown', async () => {
-      mockFetch('<p>xhtml</p>', { contentType: 'application/xhtml+xml' })
-      const result = await makeWebFetch({ mode: 'markdown' }).invoke({ url: 'https://example.com/page.xhtml' })
+      const sandbox = makeSandbox({
+        execute: vi.fn().mockResolvedValue(makeCurlResult('<p>xhtml</p>', { contentType: 'application/xhtml+xml' })),
+      })
+      const result = await makeWebFetch({ mode: 'markdown' }).invoke(
+        { url: 'https://example.com/page.xhtml' },
+        makeContext(sandbox)
+      )
       expect(result).toBe('md:<p>xhtml</p>')
     })
 
     it('non-html response is returned as-is', async () => {
-      mockFetch('plain text response', { contentType: 'text/plain' })
-      const result = await makeWebFetch({ mode: 'markdown' }).invoke({ url: 'https://example.com/robots.txt' })
+      const sandbox = makeSandbox({
+        execute: vi.fn().mockResolvedValue(makeCurlResult('plain text response', { contentType: 'text/plain' })),
+      })
+      const result = await makeWebFetch({ mode: 'markdown' }).invoke(
+        { url: 'https://example.com/robots.txt' },
+        makeContext(sandbox)
+      )
       expect(result).toBe('plain text response')
     })
 
     it('content is truncated at maxContentChars', async () => {
-      mockFetch('x'.repeat(200), { contentType: 'text/plain' })
-      const result = await makeWebFetch({ mode: 'markdown', maxContentChars: 50 }).invoke({
-        url: 'https://example.com/',
+      const sandbox = makeSandbox({
+        execute: vi.fn().mockResolvedValue(makeCurlResult('x'.repeat(200), { contentType: 'text/plain' })),
       })
-      expect(result).toContain('x'.repeat(50))
-      expect(result).not.toContain('x'.repeat(51))
+      const result = await makeWebFetch({ mode: 'markdown', maxContentChars: 50 }).invoke(
+        { url: 'https://example.com/' },
+        makeContext(sandbox)
+      )
       expect(result).toContain('[content truncated]')
     })
 
     it('rejects non-http scheme', async () => {
-      await expect(makeWebFetch({ mode: 'markdown' }).invoke({ url: 'file:///etc/passwd' })).rejects.toThrow(
-        /only http and https/
-      )
+      const sandbox = makeSandbox()
+      await expect(
+        makeWebFetch({ mode: 'markdown' }).invoke({ url: 'file:///etc/passwd' }, makeContext(sandbox))
+      ).rejects.toThrow(/only http and https/)
     })
 
     it('rejects invalid URL', async () => {
-      await expect(makeWebFetch({ mode: 'markdown' }).invoke({ url: 'not a url' })).rejects.toThrow(/invalid URL/)
+      const sandbox = makeSandbox()
+      await expect(
+        makeWebFetch({ mode: 'markdown' }).invoke({ url: 'not a url' }, makeContext(sandbox))
+      ).rejects.toThrow(/invalid URL/)
     })
 
     it('rejects 4xx status', async () => {
-      mockFetch('Not Found', { status: 404, statusText: 'Not Found' })
-      await expect(makeWebFetch({ mode: 'markdown' }).invoke({ url: 'https://example.com/missing' })).rejects.toThrow(
-        'HTTP 404'
-      )
-    })
-
-    it('rejects response body exceeding maxBytes', async () => {
-      globalThis.fetch = vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        statusText: 'OK',
-        headers: { get: () => null },
-        body: new ReadableStream({
-          start(controller) {
-            controller.enqueue(new Uint8Array(DEFAULT_MAX_BYTES + 1))
-            controller.close()
-          },
-        }),
+      const sandbox = makeSandbox({
+        execute: vi.fn().mockResolvedValue(makeExecutionResult('', { exitCode: 22, stderr: 'HTTP/2 404 Not Found' })),
       })
-      await expect(makeWebFetch({ mode: 'markdown' }).invoke({ url: 'https://example.com/' })).rejects.toThrow(
-        /max_bytes/
-      )
+      await expect(
+        makeWebFetch({ mode: 'markdown' }).invoke({ url: 'https://example.com/missing' }, makeContext(sandbox))
+      ).rejects.toThrow(/fetch failed: HTTP\/\S+ 404/)
     })
 
-    it('wraps network errors', async () => {
-      globalThis.fetch = vi.fn().mockRejectedValue(new Error('connection refused'))
-      await expect(makeWebFetch({ mode: 'markdown' }).invoke({ url: 'https://example.com/' })).rejects.toThrow(
-        /fetch failed/
-      )
-    })
-
-    it('throws on abort signal', async () => {
-      globalThis.fetch = vi.fn().mockRejectedValue(Object.assign(new Error('aborted'), { name: 'AbortError' }))
-      await expect(makeWebFetch({ mode: 'markdown' }).invoke({ url: 'https://example.com/' })).rejects.toThrow(
-        'Web fetch tool request cancelled'
-      )
-    })
-
-    it('decodes response body using charset from Content-Type', async () => {
-      // iso-8859-1 byte 0xA9 is the copyright sign ©; under utf-8 it would be a replacement char
-      const latin1Bytes = new Uint8Array([0x3c, 0x70, 0x3e, 0xa9, 0x3c, 0x2f, 0x70, 0x3e]) // <p>©</p>
-      globalThis.fetch = vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        statusText: 'OK',
-        headers: { get: (key: string) => (key === 'content-type' ? 'text/plain; charset=iso-8859-1' : null) },
-        body: new ReadableStream({
-          start(controller) {
-            controller.enqueue(latin1Bytes)
-            controller.close()
-          },
-        }),
+    it('rejects oversized body announced via Content-Length (curl exit 63)', async () => {
+      const sandbox = makeSandbox({
+        execute: vi.fn().mockResolvedValue(makeExecutionResult('', { exitCode: 63 })),
       })
-      const result = await makeWebFetch({ mode: 'markdown' }).invoke({ url: 'https://example.com/' })
-      expect(result).toContain('©')
+      await expect(
+        makeWebFetch({ mode: 'markdown' }).invoke({ url: 'https://example.com/' }, makeContext(sandbox))
+      ).rejects.toThrow(/max_bytes/)
     })
 
-    it('aborts mid-body-read when the stream reader throws an AbortError', async () => {
-      let readCount = 0
-      const mockCancel = vi.fn().mockResolvedValue(undefined)
-      globalThis.fetch = vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        statusText: 'OK',
-        headers: { get: () => null },
-        body: {
-          getReader: () => ({
-            read: vi.fn().mockImplementation(async () => {
-              readCount += 1
-              if (readCount === 1) return { done: false, value: new Uint8Array([0x61]) }
-              throw new DOMException('The operation was aborted', 'AbortError')
-            }),
-            releaseLock: vi.fn(),
-            cancel: mockCancel,
-          }),
-        },
+    it('rejects oversized chunked body (exit 0, no Content-Length)', async () => {
+      const sandbox = makeSandbox({
+        execute: vi.fn().mockResolvedValue(makeCurlResult('x'.repeat(100))),
       })
-      await expect(makeWebFetch({ mode: 'markdown' }).invoke({ url: 'https://example.com/' })).rejects.toThrow(
-        'Web fetch tool request cancelled'
-      )
-      expect(mockCancel).toHaveBeenCalled()
+      await expect(
+        makeWebFetch({ mode: 'markdown', maxBytes: 50 }).invoke({ url: 'https://example.com/' }, makeContext(sandbox))
+      ).rejects.toThrow(/max_bytes/)
     })
 
-    it('sends correct user-agent header and passes cancel signal', async () => {
-      mockFetch('ok')
+    it('wraps sandbox errors', async () => {
+      const sandbox = makeSandbox({
+        execute: vi.fn().mockRejectedValue(new Error('connection refused')),
+      })
+      await expect(
+        makeWebFetch({ mode: 'markdown' }).invoke({ url: 'https://example.com/' }, makeContext(sandbox))
+      ).rejects.toThrow(/fetch failed/)
+    })
+
+    it('maps SandboxAbortError to cancelled error', async () => {
+      const sandbox = makeSandbox({
+        execute: vi.fn().mockRejectedValue(new SandboxAbortError()),
+      })
+      await expect(
+        makeWebFetch({ mode: 'markdown' }).invoke({ url: 'https://example.com/' }, makeContext(sandbox))
+      ).rejects.toThrow('Web fetch tool request cancelled')
+    })
+
+    it('propagates SandboxTimeoutError unwrapped', async () => {
+      const sandbox = makeSandbox({
+        execute: vi.fn().mockRejectedValue(new SandboxTimeoutError(30)),
+      })
+      await expect(
+        makeWebFetch({ mode: 'markdown' }).invoke({ url: 'https://example.com/' }, makeContext(sandbox))
+      ).rejects.toBeInstanceOf(SandboxTimeoutError)
+    })
+
+    it('passes cancel signal to sandbox.execute', async () => {
+      const executeMock = vi.fn().mockResolvedValue(makeCurlResult('ok'))
+      const sandbox = makeSandbox({ execute: executeMock })
       const controller = new AbortController()
       await makeWebFetch({ mode: 'markdown' }).invoke(
         { url: 'https://example.com/' },
-        makeContext({ cancelSignal: controller.signal })
+        makeContext(sandbox, { cancelSignal: controller.signal })
       )
-      expect(globalThis.fetch).toHaveBeenCalledWith(
-        'https://example.com/',
-        expect.objectContaining({
-          headers: expect.objectContaining({ 'User-Agent': 'strands-agents-web-fetch/1.0' }),
-        })
+      expect(executeMock).toHaveBeenCalledWith(
+        expect.stringContaining('curl'),
+        expect.objectContaining({ signal: controller.signal })
+      )
+    })
+
+    it('sends the correct user-agent', async () => {
+      const executeMock = vi.fn().mockResolvedValue(makeCurlResult('ok'))
+      const sandbox = makeSandbox({ execute: executeMock })
+      await makeWebFetch({ mode: 'markdown' }).invoke({ url: 'https://example.com/' }, makeContext(sandbox))
+      expect(executeMock).toHaveBeenCalledWith(
+        expect.stringContaining('strands-agents-web-fetch/1.0'),
+        expect.anything()
+      )
+    })
+
+    it('throws when context is missing', async () => {
+      await expect(makeWebFetch({ mode: 'markdown' }).invoke({ url: 'https://example.com/' })).rejects.toThrow(
+        'Tool context is required'
       )
     })
   })
 
   describe('agentic mode', () => {
     it('requires a non-empty prompt', async () => {
-      mockFetch('<p>content</p>', { contentType: 'text/html' })
+      const sandbox = makeSandbox({
+        execute: vi.fn().mockResolvedValue(makeCurlResult('<p>content</p>', { contentType: 'text/html' })),
+      })
       await expect(
-        makeWebFetch({ mode: 'agentic', model: {} as LocalAgent['model'] }).invoke({
-          url: 'https://example.com/',
-          prompt: '   ',
-        })
+        makeWebFetch({ mode: 'agentic', model: {} as LocalAgent['model'] }).invoke(
+          { url: 'https://example.com/', prompt: '   ' },
+          makeContext(sandbox)
+        )
       ).rejects.toThrow('agentic mode requires a non-empty prompt')
     })
 
-    it('requires a model when no context agent', async () => {
-      mockFetch('<p>content</p>', { contentType: 'text/html' })
+    it('requires a model when no context agent model', async () => {
+      const sandbox = makeSandbox({
+        execute: vi.fn().mockResolvedValue(makeCurlResult('<p>content</p>', { contentType: 'text/html' })),
+      })
       await expect(
-        makeWebFetch({ mode: 'agentic' }).invoke({ url: 'https://example.com/', prompt: 'Summarize' })
+        makeWebFetch({ mode: 'agentic' }).invoke(
+          { url: 'https://example.com/', prompt: 'Summarize' },
+          makeContext(sandbox)
+        )
       ).rejects.toThrow('agentic mode requires a model')
     })
 
     it('uses factory model when provided', async () => {
-      mockFetch('<p>page content</p>', { contentType: 'text/html' })
+      const sandbox = makeSandbox({
+        execute: vi.fn().mockResolvedValue(makeCurlResult('<p>page content</p>', { contentType: 'text/html' })),
+      })
       const fakeModel = {} as LocalAgent['model']
       mockInvoke.mockResolvedValue(makeAgentResult('the answer'))
-      await makeWebFetch({ mode: 'agentic', model: fakeModel }).invoke({
-        url: 'https://example.com/',
-        prompt: 'What is this?',
-      })
+      await makeWebFetch({ mode: 'agentic', model: fakeModel }).invoke(
+        { url: 'https://example.com/', prompt: 'What is this?' },
+        makeContext(sandbox)
+      )
       expect(vi.mocked(Agent).mock.calls.at(-1)?.[0]?.model).toBe(fakeModel)
     })
 
     it('falls back to host agent model', async () => {
-      mockFetch('<p>page content</p>', { contentType: 'text/html' })
       const hostModel = {} as LocalAgent['model']
+      const sandbox = makeSandbox({
+        execute: vi.fn().mockResolvedValue(makeCurlResult('<p>page content</p>', { contentType: 'text/html' })),
+      })
       mockInvoke.mockResolvedValue(makeAgentResult('host answer'))
       await makeWebFetch({ mode: 'agentic' }).invoke(
         { url: 'https://example.com/', prompt: 'Summarize' },
-        makeContext({ agent: { model: hostModel } as unknown as LocalAgent })
+        makeContext(sandbox, { agent: { model: hostModel, sandbox } as unknown as LocalAgent })
       )
       expect(vi.mocked(Agent).mock.calls.at(-1)?.[0]?.model).toBe(hostModel)
     })
 
     it('passes prompt and page content to analyst', async () => {
-      mockFetch('page content', { contentType: 'text/plain' })
-      mockInvoke.mockResolvedValue(makeAgentResult('the answer'))
-      const result = await makeWebFetch({ mode: 'agentic', model: {} as LocalAgent['model'] }).invoke({
-        url: 'https://example.com/',
-        prompt: 'What is this about?',
+      const sandbox = makeSandbox({
+        execute: vi.fn().mockResolvedValue(makeCurlResult('page content', { contentType: 'text/plain' })),
       })
+      mockInvoke.mockResolvedValue(makeAgentResult('the answer'))
+      const result = await makeWebFetch({ mode: 'agentic', model: {} as LocalAgent['model'] }).invoke(
+        { url: 'https://example.com/', prompt: 'What is this about?' },
+        makeContext(sandbox)
+      )
       expect(result).toBe('the answer')
       const [invokePrompt] = mockInvoke.mock.calls[0] ?? []
       expect(invokePrompt).toContain('What is this about?')
@@ -291,7 +323,9 @@ describe('webFetch tool', () => {
     })
 
     it('strips reasoning blocks from analyst result', async () => {
-      mockFetch('page content', { contentType: 'text/plain' })
+      const sandbox = makeSandbox({
+        execute: vi.fn().mockResolvedValue(makeCurlResult('page content', { contentType: 'text/plain' })),
+      })
       mockInvoke.mockResolvedValue({
         lastMessage: {
           content: [
@@ -300,35 +334,38 @@ describe('webFetch tool', () => {
           ],
         },
       })
-      const result = await makeWebFetch({ mode: 'agentic', model: {} as LocalAgent['model'] }).invoke({
-        url: 'https://example.com/',
-        prompt: 'Summarize',
-      })
+      const result = await makeWebFetch({ mode: 'agentic', model: {} as LocalAgent['model'] }).invoke(
+        { url: 'https://example.com/', prompt: 'Summarize' },
+        makeContext(sandbox)
+      )
       expect(result).toBe('the answer')
       expect(result).not.toContain('chain-of-thought')
     })
 
     it('truncates content before passing to analyst', async () => {
-      mockFetch('x'.repeat(200), { contentType: 'text/plain' })
-      mockInvoke.mockResolvedValue(makeAgentResult('answer'))
-      await makeWebFetch({ mode: 'agentic', model: {} as LocalAgent['model'], maxContentChars: 50 }).invoke({
-        url: 'https://example.com/',
-        prompt: 'Summarize',
+      const sandbox = makeSandbox({
+        execute: vi.fn().mockResolvedValue(makeCurlResult('x'.repeat(200), { contentType: 'text/plain' })),
       })
+      mockInvoke.mockResolvedValue(makeAgentResult('answer'))
+      await makeWebFetch({ mode: 'agentic', model: {} as LocalAgent['model'], maxContentChars: 50 }).invoke(
+        { url: 'https://example.com/', prompt: 'Summarize' },
+        makeContext(sandbox)
+      )
       const [invokePrompt] = mockInvoke.mock.calls[0] ?? []
-      expect(invokePrompt).toContain('x'.repeat(50))
-      expect(invokePrompt).not.toContain('x'.repeat(51))
       expect(invokePrompt).toContain('[content truncated]')
+      expect(invokePrompt).not.toContain('x'.repeat(51))
     })
 
     it('wraps analyst error with url context', async () => {
-      mockFetch('<p>content</p>', { contentType: 'text/html' })
+      const sandbox = makeSandbox({
+        execute: vi.fn().mockResolvedValue(makeCurlResult('<p>content</p>', { contentType: 'text/html' })),
+      })
       mockInvoke.mockRejectedValue(new Error('analyst boom'))
       await expect(
-        makeWebFetch({ mode: 'agentic', model: {} as LocalAgent['model'] }).invoke({
-          url: 'https://example.com/',
-          prompt: 'Summarize',
-        })
+        makeWebFetch({ mode: 'agentic', model: {} as LocalAgent['model'] }).invoke(
+          { url: 'https://example.com/', prompt: 'Summarize' },
+          makeContext(sandbox)
+        )
       ).rejects.toThrow(/web fetch analyst failed/)
     })
   })

--- a/strands-ts/src/vended-tools/web-fetch/types.ts
+++ b/strands-ts/src/vended-tools/web-fetch/types.ts
@@ -48,4 +48,9 @@ export interface MakeWebFetchOptions {
   model?: Model
   /** Extraction mode. Defaults to `'agentic'`. */
   mode?: 'markdown' | 'agentic'
+  /**
+   * Maximum time in seconds to wait for the curl request. Defaults to 30.
+   * Pass `0` to disable the timeout.
+   */
+  timeout?: number
 }

--- a/strands-ts/src/vended-tools/web-fetch/web-fetch.ts
+++ b/strands-ts/src/vended-tools/web-fetch/web-fetch.ts
@@ -1,17 +1,18 @@
 import { z } from 'zod'
 
 import { Agent } from '../../agent/agent.js'
+import { SandboxAbortError, SandboxTimeoutError } from '../../sandbox/errors.js'
+import { shellQuote } from '../../sandbox/constants.js'
 import { tool } from '../../tools/tool-factory.js'
+import type { ToolContext } from '../../tools/tool.js'
 import { htmlToMarkdown } from './extract.js'
 import { type MakeWebFetchOptions, WEB_FETCH_DESCRIPTION_MARKDOWN, WEB_FETCH_DESCRIPTION_AGENTIC } from './types.js'
 
 export const DEFAULT_MAX_BYTES = 5 * 1024 * 1024 // 5 MiB
 export const DEFAULT_MAX_CONTENT_CHARS = 50_000
+export const DEFAULT_TIMEOUT_SECONDS = 30
 
-const _HEADERS = {
-  'User-Agent': 'strands-agents-web-fetch/1.0',
-  Accept: 'text/html,application/xhtml+xml;q=0.9,*/*;q=0.8',
-}
+const _USER_AGENT = 'strands-agents-web-fetch/1.0'
 
 const _ANALYST_PROMPT =
   'You answer a request about a single fetched web page. Use only the provided ' +
@@ -42,6 +43,7 @@ export function makeWebFetch(options: MakeWebFetchOptions = {}): ReturnType<type
   const { mode = 'agentic', model: analystModel } = options
   const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES
   const maxContentChars = options.maxContentChars ?? DEFAULT_MAX_CONTENT_CHARS
+  const timeout = options.timeout ?? DEFAULT_TIMEOUT_SECONDS
   if (maxBytes <= 0) {
     throw new Error(`maxBytes must be a positive number, got ${maxBytes}`)
   }
@@ -58,10 +60,10 @@ export function makeWebFetch(options: MakeWebFetchOptions = {}): ReturnType<type
     description,
     inputSchema: webFetchMarkdownInputSchema,
     callback: async (input, context) => {
-      const { url } = input
-      const signal = context?.cancelSignal ?? null
-
-      const [contentType, raw] = await fetchOnce(url, maxBytes, signal)
+      if (!context) {
+        throw new Error('Tool context is required for web_fetch')
+      }
+      const [contentType, raw] = await fetchOnce(input.url, maxBytes, timeout, context)
 
       const isMarkup = contentType.toLowerCase().includes('html') || contentType.toLowerCase().includes('xml')
       let content = isMarkup ? await htmlToMarkdown(raw) : raw
@@ -77,22 +79,24 @@ export function makeWebFetch(options: MakeWebFetchOptions = {}): ReturnType<type
     description,
     inputSchema: webFetchAgenticInputSchema,
     callback: async (input, context) => {
+      if (!context) {
+        throw new Error('Tool context is required for web_fetch')
+      }
       const { url, prompt } = input
 
       if (!prompt.trim()) {
         throw new Error('web_fetch: agentic mode requires a non-empty prompt.')
       }
 
-      const effectiveModel = analystModel ?? context?.agent.model
+      const effectiveModel = analystModel ?? context.agent.model
       if (!effectiveModel) {
         throw new Error(
           'web_fetch: agentic mode requires a model. ' + 'Pass model to makeWebFetch or call the tool from an agent.'
         )
       }
 
-      const signal = context?.cancelSignal ?? null
-      const invokeOptions = context?.cancelSignal ? { cancelSignal: context.cancelSignal } : {}
-      const [contentType, raw] = await fetchOnce(url, maxBytes, signal)
+      const invokeOptions = context.cancelSignal ? { cancelSignal: context.cancelSignal } : {}
+      const [contentType, raw] = await fetchOnce(url, maxBytes, timeout, context)
 
       const isMarkup = contentType.toLowerCase().includes('html') || contentType.toLowerCase().includes('xml')
       let content = isMarkup ? await htmlToMarkdown(raw) : raw
@@ -128,8 +132,12 @@ export const webFetch = makeWebFetch()
 
 // ---- Internals ----
 
-async function fetchOnce(url: string, maxBytes: number, signal: AbortSignal | null): Promise<[string, string]> {
-  // Validate scheme before hitting the network
+async function fetchOnce(
+  url: string,
+  maxBytes: number,
+  timeout: number,
+  context: ToolContext
+): Promise<[string, string]> {
   if (!URL.canParse(url)) {
     throw new Error(`url=<${url}> | fetch failed: invalid URL`)
   }
@@ -138,66 +146,41 @@ async function fetchOnce(url: string, maxBytes: number, signal: AbortSignal | nu
     throw new Error(`url=<${url}> | fetch failed: only http and https URLs are supported`)
   }
 
-  let response: Response
+  // --max-filesize exits 63 when Content-Length exceeds the cap.
+  // --write-out writes the final-hop content-type to stderr, separate from the content.
+  const command =
+    `curl -sSLg --fail-with-body --max-filesize ${maxBytes}` +
+    ` -A ${shellQuote(_USER_AGENT)} --write-out ${shellQuote('%{stderr}%{content_type}')} ${shellQuote(url)}`
+
+  let result
   try {
-    response = await globalThis.fetch(url, { method: 'GET', headers: _HEADERS, signal })
+    result = await context.agent.sandbox.execute(command, {
+      timeout: timeout > 0 ? timeout : undefined,
+      signal: context.cancelSignal,
+    })
   } catch (error) {
-    if (error instanceof Error && error.name === 'AbortError') {
+    if (error instanceof SandboxAbortError) {
       throw new Error('Web fetch tool request cancelled', { cause: error })
     }
+    if (error instanceof SandboxTimeoutError) throw error
     throw new Error(`url=<${url}> | fetch failed: ${error instanceof Error ? error.message : String(error)}`, {
       cause: error,
     })
   }
 
-  if (!response.ok) {
-    await response.body?.cancel()
-    throw new Error(`HTTP ${response.status} ${response.statusText}: GET ${url}`)
+  // Length check covers chunked responses.
+  if (result.exitCode === 63 || result.stdout.length > maxBytes) {
+    throw new Error(`Response body exceeded max_bytes=${maxBytes}. Refusing to buffer more.`)
   }
 
-  // Stream the body and enforce the size cap on decompressed bytes as they arrive.
-  if (!response.body) {
-    return [response.headers.get('content-type') ?? '', '']
+  if (result.exitCode !== 0) {
+    const firstLine = (result.stderr.split('\n')[0] ?? '').trim()
+    const detail = firstLine || `curl exited with code ${result.exitCode}`
+    throw new Error(`url=<${url}> | fetch failed: ${detail}`)
   }
 
-  const contentType = response.headers.get('content-type') ?? ''
-  const charset = _parseCharset(contentType)
-  const reader = response.body.getReader()
-  const decoder = new TextDecoder(charset)
-  const chunks: string[] = []
-  let total = 0
+  // On success, stderr contains only the content-type written by --write-out.
+  const contentType = result.stderr.trim()
 
-  try {
-    while (true) {
-      const { done, value } = await reader.read()
-      if (done) break
-      total += value.byteLength
-      if (total > maxBytes) {
-        throw new Error(`Response body exceeded max_bytes=${maxBytes}. Refusing to buffer more.`)
-      }
-      chunks.push(decoder.decode(value, { stream: true }))
-    }
-    chunks.push(decoder.decode())
-  } catch (error) {
-    if (error instanceof Error && error.name === 'AbortError') {
-      throw new Error('Web fetch tool request cancelled', { cause: error })
-    }
-    throw error
-  } finally {
-    reader.cancel().catch(() => {})
-    reader.releaseLock()
-  }
-
-  return [contentType, chunks.join('')]
-}
-
-function _parseCharset(contentType: string): string {
-  const match = contentType.match(/charset=(?:"([^"]+)"|'([^']+)'|([^;\s]+))/i)
-  const charset = (match?.[1] ?? match?.[2] ?? match?.[3] ?? 'utf-8').toLowerCase()
-  try {
-    new TextDecoder(charset)
-    return charset
-  } catch {
-    return 'utf-8'
-  }
+  return [contentType, result.stdout]
 }


### PR DESCRIPTION
## Description

Previously, `web_fetch` made direct outbound HTTP requests from the host process — bypassing whatever sandbox the agent was configured with. This PR moves all fetching through `sandbox.execute("curl …")`, keeping network access inside the sandbox boundary alongside every other tool.

`httpx` is no longer involved in the fetch path. A `timeout_seconds` / `timeoutSeconds` option (default 30 s) is added to both factories to prevent curl from hanging on unresolvable hosts. The `client` parameter is removed from `make_web_fetch`, which is a breaking change but acceptable because the web fetch tool is new.

## Public API Changes

The `client` parameter is removed from the Python factory; `timeout_seconds` (Python) and `timeoutSeconds` (TypeScript) are added to both.

```python
# Before
web_fetch = make_web_fetch(
    client=httpx.AsyncClient(timeout=10.0),
    max_bytes=1 * 1024 * 1024,
)

# After
web_fetch = make_web_fetch(
    timeout_seconds=10,
    max_bytes=1 * 1024 * 1024,
)
```

```typescript
// Before — no timeout option
const webFetch = makeWebFetch({ maxBytes: 1 * 1024 * 1024 })

// After
const webFetch = makeWebFetch({ maxBytes: 1 * 1024 * 1024, timeoutSeconds: 10 })
```

## Related Issues

## Documentation PR

Documentation updated inline under `site/`.

## Type of Change

New feature

## Testing

- [x] I ran `hatch run prepare`
- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.