### PR TITLE
refactor(bidi): refine model audio configuration

### DIFF
--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/agent.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/agent.mdx
@@ -221,12 +221,10 @@ from strands.experimental.bidi.models import BedrockNovaSonicModel
 model = BedrockNovaSonicModel(
     model_id="amazon.nova-2-sonic-v1:0",
     region="us-east-1",
+    voice="matthew",
     audio={
-        "input_rate": 16000,
-        "output_rate": 16000,
-        "channels": 1,
-        "format": "pcm",
-        "voice": "matthew",
+        "input": {"sample_rate": 16000},
+        "output": {"sample_rate": 16000},
     },
 )
 ```

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/io.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/io.mdx
@@ -132,6 +132,8 @@ generation finishes or is interrupted.
 
 ### Configurations
 
+Use these options to configure audio devices and buffering:
+
 | Parameter | Description | Example | Default |
 | --------- | ----------- | ------- | ------- |
 | `input_buffer_size` | Maximum number of audio chunks to buffer from microphone before dropping oldest. | `1024` | None (unbounded) |
@@ -140,6 +142,14 @@ generation finishes or is interrupted.
 | `output_buffer_size` | Maximum number of audio chunks to buffer for speaker playback before dropping oldest. | `2048` | None (unbounded) |
 | `output_device_index` | Specific speaker device ID to use for audio output. | `2` | None (system default) |
 | `output_frames_per_buffer` | Number of audio frames to be written per output callback (affects latency and performance). | `1024` | 512 |
+
+Configure voice and supported sample rates on the model. `BidiAudioIO` reads
+`model.get_audio_config()`, which returns separate `input` and `output` dictionaries,
+each containing `sample_rate`, `channels`, and `format`. It uses those values to
+configure capture and playback, so you do not need to repeat them on the I/O channel.
+
+`BidiAudioIO` requires signed 16-bit little-endian PCM. Starting a device stream with
+another encoding raises `ValueError`. Use custom I/O for other encodings.
 
 ### Interruption Handling
 

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/bedrock.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/bedrock.mdx
@@ -54,7 +54,7 @@ async def main() -> None:
     model = BedrockNovaSonicModel(
         model_id="amazon.nova-2-sonic-v1:0",
         region="us-east-1",
-        audio={"voice": "tiffany"},
+        voice="tiffany",
     )
     agent = BidiAgent(model=model, tools=[calculator, stop])
     audio_io = BidiAudioIO()
@@ -126,13 +126,10 @@ For more details on this approach, please refer to the [boto3 session docs](http
 | Parameter | Description | Example | Options |
 | --------- | ----------- | ------- | ------- |
 | `model_id` | Nova Sonic model identifier. | `"amazon.nova-2-sonic-v1:0"` | Nova Sonic model IDs |
-| `audio` | Audio configuration. | `{"output_rate": 24000, "voice": "tiffany"}` | [reference](@api/python/strands.experimental.bidi.models.configs#AudioConfig) |
+| `audio` | Input and output stream options. | `{"output": {"sample_rate": 24000}}` | [reference](@api/python/strands.experimental.bidi.models.bedrock#BedrockNovaSonicAudioConfig) |
+| `voice` | Output voice identifier. Defaults to `"matthew"`. | `"tiffany"` | Nova Sonic voices |
 | `params` | Provider-specific session parameters, such as inference and turn detection configuration. | `{"inferenceConfiguration": {"temperature": 0.7}}` | [`sessionStart` fields](https://docs.aws.amazon.com/nova/latest/nova2-userguide/sonic-input-events.html) |
 | `connection` | Reconnect timing overrides. | `{"auto_reconnect": false}` | [reference](@api/python/strands.experimental.bidi.models.configs#BidiConnectionConfig) |
-
-:::note
-The `audio` config accepts any sample rate supported by the underlying model API. Refer to the [Nova Sonic documentation](https://docs.aws.amazon.com/nova/latest/nova2-userguide/using-conversational-speech.html) for the full list of supported rates.
-:::
 
 :::caution[Conversation History Limits]
 Nova Sonic caps conversation history passed via `messages` at 50KB per message and 200KB total. Messages exceeding the per-message limit are truncated; if the total exceeds 200KB, the oldest messages are dropped until it fits. This happens silently (only visible via debug-level logs) and only applies to history provided at connection start, not to turns generated during the live conversation.

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/google.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/google.mdx
@@ -49,7 +49,7 @@ from strands_tools import calculator, stop
 async def main() -> None:
     model = GoogleGeminiLiveModel(
         model_id="gemini-2.5-flash-native-audio-preview-09-2025",
-        audio={"voice": "Kore"},
+        voice="Kore",
         client_args={"api_key": "<GOOGLE_API_KEY>"},
     )
     # stop tool allows user to verbally stop agent execution.
@@ -75,15 +75,14 @@ the [Google GenAI client reference](https://googleapis.github.io/python-genai/ge
 | Parameter | Description | Example | Options |
 | --------- | ----------- | ------- | ------- |
 | `model_id` | Gemini Live model identifier. | `"gemini-2.5-flash-native-audio-preview-09-2025"` | [Gemini models](https://ai.google.dev/gemini-api/docs/models) |
-| `audio` | Audio configuration. | `{"voice": "Kore"}` | [reference](@api/python/strands.experimental.bidi.models.configs#AudioConfig) |
+| `audio` | Input audio options. | `{"input": {"sample_rate": 48000}}` | [reference](@api/python/strands.experimental.bidi.models.google#GoogleGeminiLiveAudioConfig) |
+| `voice` | Prebuilt output voice name. Uses the provider default when omitted. | `"Kore"` | [Voices and languages](https://docs.cloud.google.com/text-to-speech/docs/list-voices-and-types) |
 | `params` | Gemini Live session parameters. | `{"temperature": 0.7}` | [`LiveConnectConfig`](https://googleapis.github.io/python-genai/genai.html#genai.types.LiveConnectConfig) |
 | `connection` | Reconnect timing overrides. | `{"auto_reconnect": false}` | [reference](@api/python/strands.experimental.bidi.models.configs#BidiConnectionConfig) |
 
-For the list of supported voices and languages, see [here](https://docs.cloud.google.com/text-to-speech/docs/list-voices-and-types).
-
 ### Additional Provider Options
 
-Use direct options such as `audio` for common settings. For additional Google GenAI
+Use direct options such as `voice` for common settings. For additional Google GenAI
 options, pass `params` using snake_case field names.
 
 ```python
@@ -91,7 +90,7 @@ from strands.experimental.bidi.models import GoogleGeminiLiveModel
 
 model = GoogleGeminiLiveModel(
     client_args={"api_key": "<GOOGLE_API_KEY>"},
-    audio={"voice": "Kore"},
+    voice="Kore",
     params={"temperature": 0.7, "speech_config": {"language_code": "en-US"}},
 )
 ```

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/openai.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/models/openai.mdx
@@ -48,7 +48,7 @@ from strands_tools import calculator, stop
 async def main() -> None:
     model = OpenAIRealtimeModel(
         model_id="gpt-realtime",
-        audio={"voice": "coral"},
+        voice="coral",
         api_key="<OPENAI_API_KEY>",
     )
     # stop tool allows user to verbally stop agent execution.
@@ -78,15 +78,13 @@ if __name__ == "__main__":
 | Parameter | Description | Example | Options |
 | --------- | ----------- | ------- | ------- |
 | `model_id` | OpenAI Realtime model identifier. | `"gpt-realtime"` | [OpenAI models](https://platform.openai.com/docs/models) |
-| `audio` | Audio configuration. | `{"voice": "coral"}` | [reference](@api/python/strands.experimental.bidi.models.configs#AudioConfig) |
-| `params` | OpenAI Realtime session parameters. | `{"max_output_tokens": 4096}` | [`session.update`](https://platform.openai.com/docs/api-reference/realtime-client-events/session/update) |
+| `voice` | Output voice identifier. Defaults to `"alloy"`. | `"coral"` | [Voice options](https://platform.openai.com/docs/guides/realtime-conversations#voice-options) |
+| `params` | OpenAI Realtime session parameters. Audio must remain mono PCM at 24000 Hz. | `{"max_output_tokens": 4096}` | [`session.update`](https://platform.openai.com/docs/api-reference/realtime-client-events/session/update) |
 | `connection` | Reconnect timing overrides. | `{"auto_reconnect": false}` | [reference](@api/python/strands.experimental.bidi.models.configs#BidiConnectionConfig) |
-
-For the list of supported voices, see [here](https://platform.openai.com/docs/guides/realtime-conversations#voice-options).
 
 ### Additional Provider Options
 
-Use direct options such as `audio` for common settings, and pass additional OpenAI
+Use direct options such as `voice` for common settings, and pass additional OpenAI
 Realtime options through `params`.
 
 ```python
@@ -94,7 +92,7 @@ from strands.experimental.bidi.models import OpenAIRealtimeModel
 
 model = OpenAIRealtimeModel(
     api_key="<OPENAI_API_KEY>",
-    audio={"voice": "coral"},
+    voice="coral",
     params={"audio": {"input": {"turn_detection": {"threshold": 0.3}}}},
 )
 ```

--- a/site/src/content/docs/user-guide/concepts/bidirectional-streaming/quickstart.mdx
+++ b/site/src/content/docs/user-guide/concepts/bidirectional-streaming/quickstart.mdx
@@ -288,7 +288,7 @@ Each provider has different features, timeout limits, and audio quality. See the
 
 ## Configuring Audio Settings
 
-Customize audio configuration for both the model and I/O:
+Choose supported audio settings on the model and device buffering on the I/O channel:
 
 ```python
 import asyncio
@@ -298,11 +298,8 @@ from strands.experimental.bidi.models import GoogleGeminiLiveModel
 
 # Configure model audio settings
 model = GoogleGeminiLiveModel(
-    audio={
-        "input_rate": 48000,   # Higher quality input
-        "output_rate": 24000,  # Standard output
-        "voice": "Puck"
-    }
+    audio={"input": {"sample_rate": 48000}},
+    voice="Puck",
 )
 
 # Configure I/O buffer settings
@@ -324,7 +321,9 @@ async def main():
 asyncio.run(main())
 ```
 
-The I/O automatically configures hardware to match the model's audio requirements.
+`BidiAudioIO` reads the model's resolved input and output formats through
+`get_audio_config()`. You do not need to repeat rates or channel counts on the I/O
+channel.
 
 ## Handling Interruptions
 

--- a/strands-py/src/strands/experimental/bidi/__init__.py
+++ b/strands-py/src/strands/experimental/bidi/__init__.py
@@ -12,7 +12,7 @@ from ...types._events import (
 from .agent.agent import BidiAgent
 
 # Model interface (for custom implementations)
-from .models.configs import AudioConfig, BidiConnectionConfig, BidiModelConfig
+from .models.configs import AudioConfig, AudioStreamConfig, BidiConnectionConfig, BidiModelConfig
 from .models.model import AudioCapable, BidiModel, Restartable
 
 # Built-in tools (deprecated - use strands_tools.stop instead)
@@ -75,6 +75,7 @@ __all__ = [
     # Model interface
     "AudioCapable",
     "AudioConfig",
+    "AudioStreamConfig",
     "BidiModel",
     "BidiModelConfig",
     "Restartable",

--- a/strands-py/src/strands/experimental/bidi/_audio.py
+++ b/strands-py/src/strands/experimental/bidi/_audio.py
@@ -57,19 +57,28 @@ class _BidiAudioProcessor:
         self._far_buffer_size = far_buffer_size
         self._far_buffer: queue.Queue[bytes] | None = None
 
-    def start(self, *, input_rate: int, output_rate: int, num_channels: int) -> None:
+    def start(self, *, input_rate: int, output_rate: int | None = None, num_channels: int) -> None:
         """Initialize the native processor for an audio session.
 
         Args:
             input_rate: Microphone sample rate in Hz.
                 Must be supported by pywebrtc-audio.
             output_rate: Speaker sample rate in Hz.
+                Required when echo cancellation is enabled.
                 Reference audio is resampled to input_rate when the rates differ.
             num_channels: Number of audio channels.
+                Only mono (1) is supported.
 
         Raises:
             ValueError: If the audio format is invalid.
         """
+        if num_channels != 1:
+            raise ValueError(
+                f"Audio processing currently supports only mono audio (num_channels=1), received {num_channels}"
+            )
+        if self._echo_cancellation and output_rate is None:
+            raise ValueError("Echo cancellation requires output_rate")
+
         self._input_rate = input_rate
         self._output_rate = output_rate
         self._processor = AudioProcessor(
@@ -82,7 +91,7 @@ class _BidiAudioProcessor:
         )
         self._far_buffer = queue.Queue[bytes](self._far_buffer_size or 0) if self._echo_cancellation else None
         logger.debug(
-            "input_rate=<%d>, output_rate=<%d>, channels=<%d> | audio processor initialized",
+            "input_rate=<%d>, output_rate=<%s>, channels=<%d> | audio processor initialized",
             input_rate,
             output_rate,
             num_channels,
@@ -154,7 +163,7 @@ class _BidiAudioProcessor:
 
         Returns samples unchanged when rates match.
         """
-        if self._output_rate == self._input_rate:
+        if self._output_rate is None or self._output_rate == self._input_rate:
             return samples
 
         if len(samples) == 0:

--- a/strands-py/src/strands/experimental/bidi/agent/agent.py
+++ b/strands-py/src/strands/experimental/bidi/agent/agent.py
@@ -431,8 +431,8 @@ class BidiAgent(LocalAgent):
             # Using custom audio config:
             model = BedrockNovaSonicModel(
                 audio={
-                    "input_rate": 48000,
-                    "output_rate": 24000,
+                    "input": {"sample_rate": 16000},
+                    "output": {"sample_rate": 24000},
                 }
             )
             audio_io = BidiAudioIO()

--- a/strands-py/src/strands/experimental/bidi/io/audio.py
+++ b/strands-py/src/strands/experimental/bidi/io/audio.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any, TypedDict
 import pyaudio
 from typing_extensions import Unpack
 
+from ..models.configs import AudioStreamConfig
 from ..models.model import AudioCapable
 from ..types.events import (
     BidiAudioInputEvent,
@@ -192,7 +193,7 @@ class _BidiAudioInput(BidiInput):
             agent: The BidiAgent instance, providing access to model configuration.
 
         Raises:
-            ValueError: If audio processing is enabled but the input rate is unsupported.
+            ValueError: If the audio format or audio processing configuration is unsupported.
         """
         logger.debug("starting audio input stream")
 
@@ -200,28 +201,33 @@ class _BidiAudioInput(BidiInput):
             raise TypeError("BidiAudioIO requires a model that implements AudioCapable")
 
         audio_config = agent.model.get_audio_config()
-        self._channels = audio_config["channels"]
-        self._format = audio_config["format"]
-        self._rate = audio_config["input_rate"]
+        self._audio_config = audio_config["input"]
+        self._validate_audio_config(self._audio_config)
 
         if self._audio_processor is not None:
+            output_config = audio_config["output"]
+            if self._audio_processor.echo_cancellation_enabled:
+                self._validate_audio_config(output_config)
+                if self._audio_config["channels"] != output_config["channels"]:
+                    raise ValueError("Echo cancellation requires matching input and output channel counts")
+
             self._audio_processor.start(
-                input_rate=self._rate,
-                output_rate=audio_config["output_rate"],
-                num_channels=self._channels,
+                input_rate=self._audio_config["sample_rate"],
+                output_rate=output_config["sample_rate"],
+                num_channels=self._audio_config["channels"],
             )
             if self._audio_processor.echo_cancellation_enabled:
-                self._frames_per_buffer = self._audio_processor.frames_per_buffer(self._rate)
+                self._frames_per_buffer = self._audio_processor.frames_per_buffer(self._audio_config["sample_rate"])
 
         self._buffer.start()
         self._audio = pyaudio.PyAudio()
         self._stream = self._audio.open(
-            channels=self._channels,
+            channels=self._audio_config["channels"],
             format=pyaudio.paInt16,
             frames_per_buffer=self._frames_per_buffer,
             input=True,
             input_device_index=self._device_index,
-            rate=self._rate,
+            rate=self._audio_config["sample_rate"],
             stream_callback=self._callback,
         )
 
@@ -249,9 +255,7 @@ class _BidiAudioInput(BidiInput):
 
         return BidiAudioInputEvent(
             audio=base64.b64encode(data).decode("utf-8"),
-            channels=self._channels,
-            format=self._format,
-            sample_rate=self._rate,
+            **self._audio_config,
         )
 
     def _callback(
@@ -262,6 +266,12 @@ class _BidiAudioInput(BidiInput):
         """Callback to receive audio data from PyAudio."""
         self._buffer.put(in_data or b"")
         return (None, pyaudio.paContinue)
+
+    @staticmethod
+    def _validate_audio_config(config: AudioStreamConfig) -> None:
+        """Require PCM for microphone and echo cancellation reference audio."""
+        if config["format"] != "pcm":
+            raise ValueError(f"BidiAudioIO requires signed 16-bit PCM, received {config['format']}")
 
 
 class _BidiAudioOutput(BidiOutput):
@@ -305,28 +315,30 @@ class _BidiAudioOutput(BidiOutput):
 
         Args:
             agent: The BidiAgent instance, providing access to model configuration.
+
+        Raises:
+            ValueError: If the model's output encoding is unsupported.
         """
         logger.debug("starting audio output stream")
 
         if not isinstance(agent.model, AudioCapable):
             raise TypeError("BidiAudioIO requires a model that implements AudioCapable")
 
-        audio_config = agent.model.get_audio_config()
-        self._channels = audio_config["channels"]
-        self._rate = audio_config["output_rate"]
+        self._audio_config = agent.model.get_audio_config()["output"]
+        self._validate_audio_config(self._audio_config)
 
         if self._audio_processor is not None:
-            self._frames_per_buffer = self._audio_processor.frames_per_buffer(self._rate)
+            self._frames_per_buffer = self._audio_processor.frames_per_buffer(self._audio_config["sample_rate"])
 
         self._buffer.start()
         self._audio = pyaudio.PyAudio()
         self._stream = self._audio.open(
-            channels=self._channels,
+            channels=self._audio_config["channels"],
             format=pyaudio.paInt16,
             frames_per_buffer=self._frames_per_buffer,
             output=True,
             output_device_index=self._device_index,
-            rate=self._rate,
+            rate=self._audio_config["sample_rate"],
             stream_callback=self._callback,
         )
         await self._transcript_output.start(agent)
@@ -349,10 +361,16 @@ class _BidiAudioOutput(BidiOutput):
         logger.debug("audio output stream stopped")
 
     async def __call__(self, event: BidiOutputEvent) -> None:
-        """Send audio to output stream."""
+        """Send audio to output stream.
+
+        Raises:
+            ValueError: If the audio encoding, rate, or channels differ from the playback stream.
+        """
         await self._transcript_output(event)
 
         if isinstance(event, BidiAudioStreamEvent):
+            self._validate_audio_event(event, self._audio_config)
+
             data = base64.b64decode(event["audio"])
             self._buffer.put(data)
             logger.debug("audio_bytes=<%d> | audio chunk buffered for playback", len(data))
@@ -374,13 +392,29 @@ class _BidiAudioOutput(BidiOutput):
         When echo cancellation is enabled, records played audio as the reference at the moment it exits the
         speaker — the correct temporal alignment point for echo cancellation.
         """
-        byte_count = frame_count * pyaudio.get_sample_size(pyaudio.paInt16)
+        byte_count = frame_count * self._audio_config["channels"] * pyaudio.get_sample_size(pyaudio.paInt16)
         data = self._buffer.get(byte_count)
 
         if self._audio_processor is not None:
             self._audio_processor.add_far_data(data)
 
         return (data, pyaudio.paContinue)
+
+    @staticmethod
+    def _validate_audio_config(config: AudioStreamConfig) -> None:
+        """Require PCM for speaker audio."""
+        if config["format"] != "pcm":
+            raise ValueError(f"BidiAudioIO requires signed 16-bit PCM, received {config['format']}")
+
+    @staticmethod
+    def _validate_audio_event(event: BidiAudioStreamEvent, config: AudioStreamConfig) -> None:
+        """Require audio to match the playback format."""
+        if (event.format, event.sample_rate, event.channels) != (
+            config["format"],
+            config["sample_rate"],
+            config["channels"],
+        ):
+            raise ValueError("Audio output does not match the playback format. Restart audio I/O to reconfigure it.")
 
 
 class BidiAudioIO:

--- a/strands-py/src/strands/experimental/bidi/models/__init__.py
+++ b/strands-py/src/strands/experimental/bidi/models/__init__.py
@@ -2,12 +2,13 @@
 
 from typing import Any
 
-from .configs import AudioConfig, BidiConnectionConfig, BidiModelConfig
+from .configs import AudioConfig, AudioStreamConfig, BidiConnectionConfig, BidiModelConfig
 from .model import AudioCapable, BidiModel, BidiModelTimeoutError, Restartable
 
 __all__ = [
     "AudioCapable",
     "AudioConfig",
+    "AudioStreamConfig",
     "BidiConnectionConfig",
     "BidiModel",
     "BidiModelConfig",

--- a/strands-py/src/strands/experimental/bidi/models/bedrock.py
+++ b/strands-py/src/strands/experimental/bidi/models/bedrock.py
@@ -28,7 +28,7 @@ import logging
 import uuid
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, Literal, TypedDict, cast
 
 import boto3
 from aws_sdk_bedrock_runtime.client import AsyncBedrockRuntimeClient, InvokeModelWithBidirectionalStreamOperationInput
@@ -46,7 +46,7 @@ from smithy_core.shapes import ShapeID
 from smithy_http.aio.crt import AWSCRTHTTPClient, AWSCRTHTTPResponse
 from typing_extensions import Unpack, override
 
-from ....models._validation import validate_region
+from ....models._validation import validate_config_keys, validate_region
 from ....types._events import ToolResultEvent, ToolUseStreamEvent
 from ....types.content import Messages
 from ....types.tools import ToolResult, ToolSpec, ToolUse
@@ -67,6 +67,7 @@ from ..types.events import (
 )
 from .configs import (
     AudioConfig,
+    AudioStreamConfig,
     BidiConnectionConfig,
     BidiModelConfig,
     _validate_audio_config,
@@ -191,6 +192,30 @@ class _ResponseState:
         self.transcript = ""
 
 
+class BedrockNovaSonicAudioStreamConfig(TypedDict):
+    """Nova Sonic stream options. Audio uses mono PCM.
+
+    Attributes:
+        sample_rate: Sample rate in Hz.
+    """
+
+    sample_rate: Literal[8000, 16000, 24000]
+
+
+class BedrockNovaSonicAudioConfig(TypedDict, total=False):
+    """Nova Sonic input and output audio options.
+
+    Omitted streams use a sample rate of 16000 Hz.
+
+    Attributes:
+        input: Input stream options.
+        output: Output stream options.
+    """
+
+    input: BedrockNovaSonicAudioStreamConfig
+    output: BedrockNovaSonicAudioStreamConfig
+
+
 class BedrockNovaSonicModel(BidiModel, AudioCapable):
     """Amazon Bedrock Nova Sonic implementation for bidirectional streaming.
 
@@ -211,7 +236,8 @@ class BedrockNovaSonicModel(BidiModel, AudioCapable):
         *,
         boto_session: Session | None = None,
         region: str | None = None,
-        audio: AudioConfig | None = None,
+        audio: BedrockNovaSonicAudioConfig | None = None,
+        voice: str = "matthew",
         **model_config: Unpack[BidiModelConfig],
     ) -> None:
         """Initialize Nova Sonic bidirectional model.
@@ -220,18 +246,20 @@ class BedrockNovaSonicModel(BidiModel, AudioCapable):
             boto_session: Boto3 session used to resolve credentials and region.
             region: AWS region. Cannot be combined with ``boto_session``.
             audio: Audio configuration.
+            voice: Output voice identifier. Defaults to ``matthew``.
             **model_config: Model configuration.
 
         Raises:
-            ValueError: If both ``boto_session`` and ``region`` are provided or the resolved region is invalid.
+            ValueError: If audio options or the resolved region are invalid, or both ``boto_session`` and
+                ``region`` are provided.
         """
         if boto_session is not None and region is not None:
             raise ValueError("Cannot specify both 'boto_session' and 'region'")
 
         _validate_model_config(model_config)
-        _validate_audio_config(audio)
         self._config = BidiModelConfig(**model_config)
         self._config.setdefault("model_id", NOVA_SONIC_V2_MODEL_ID)
+        self._config["params"] = dict(self._config.get("params") or {})
 
         # Nova caps a connection at ~8 min; reconnect at 7 min, leaving headroom below the cap.
         # It also reports cumulative usage totals.
@@ -240,14 +268,8 @@ class BedrockNovaSonicModel(BidiModel, AudioCapable):
         )
         self.usage_is_cumulative = True
 
-        default_audio: AudioConfig = {
-            "input_rate": 16000,
-            "output_rate": 16000,
-            "channels": 1,
-            "format": "pcm",
-        }
-        self._audio_config = AudioConfig(**{**default_audio, **(audio or {})})
-        self._config["params"] = dict(self._config.get("params") or {})
+        self._resolve_audio_config(audio)
+        self._voice = voice
 
         self._session = boto_session or boto3.Session()
         resolved_region = region if region is not None else self._session.region_name or "us-east-1"
@@ -282,6 +304,25 @@ class BedrockNovaSonicModel(BidiModel, AudioCapable):
     def get_audio_config(self) -> AudioConfig:
         """Get the resolved audio configuration."""
         return self._audio_config
+
+    def _resolve_audio_config(self, config: BedrockNovaSonicAudioConfig | None) -> None:
+        """Resolve and validate input and output audio settings."""
+        config = config or {}
+        validate_config_keys(config, BedrockNovaSonicAudioConfig)
+
+        input_config = config.get("input", {"sample_rate": 16000})
+        output_config = config.get("output", {"sample_rate": 16000})
+        for stream in (input_config, output_config):
+            validate_config_keys(stream, BedrockNovaSonicAudioStreamConfig)
+            sample_rate = stream["sample_rate"]
+            if sample_rate not in (8000, 16000, 24000):
+                raise ValueError(f"Unsupported sample rate: {sample_rate}. Expected 8000, 16000, or 24000.")
+
+        self._audio_config = AudioConfig(
+            input=AudioStreamConfig(sample_rate=input_config["sample_rate"], channels=1, format="pcm"),
+            output=AudioStreamConfig(sample_rate=output_config["sample_rate"], channels=1, format="pcm"),
+        )
+        _validate_audio_config(self._audio_config)
 
     async def start(
         self,
@@ -512,9 +553,9 @@ class BedrockNovaSonicModel(BidiModel, AudioCapable):
         # Build audio input configuration from config
         audio_input_config = {
             "mediaType": "audio/lpcm",
-            "sampleRateHertz": self._audio_config["input_rate"],
+            "sampleRateHertz": self._audio_config["input"]["sample_rate"],
             "sampleSizeBits": 16,
-            "channelCount": self._audio_config["channels"],
+            "channelCount": self._audio_config["input"]["channels"],
             "audioType": "SPEECH",
             "encoding": "base64",
         }
@@ -700,9 +741,7 @@ class BedrockNovaSonicModel(BidiModel, AudioCapable):
             return [
                 BidiAudioStreamEvent(
                     audio=audio_content,
-                    format="pcm",
-                    sample_rate=self._audio_config["output_rate"],
-                    channels=self._audio_config["channels"],
+                    **self._audio_config["output"],
                 )
             ]
 
@@ -823,10 +862,10 @@ class BedrockNovaSonicModel(BidiModel, AudioCapable):
         """Generate Nova Sonic prompt start event with tool configuration."""
         audio_output_config = {
             "mediaType": "audio/lpcm",
-            "sampleRateHertz": self._audio_config["output_rate"],
+            "sampleRateHertz": self._audio_config["output"]["sample_rate"],
             "sampleSizeBits": 16,
-            "channelCount": self._audio_config["channels"],
-            "voiceId": self._audio_config.get("voice", "matthew"),
+            "channelCount": self._audio_config["output"]["channels"],
+            "voiceId": self._voice,
             "encoding": "base64",
             "audioType": "SPEECH",
         }

--- a/strands-py/src/strands/experimental/bidi/models/configs.py
+++ b/strands-py/src/strands/experimental/bidi/models/configs.py
@@ -5,34 +5,38 @@ from collections.abc import Mapping
 from typing import Any, TypedDict
 
 from ....models._validation import validate_config_keys
-from ..types.events import AudioChannel, AudioFormat, AudioSampleRate
+from ..types.events import AudioChannel, AudioFormat
 
-__all__ = ["AudioConfig", "BidiConnectionConfig", "BidiModelConfig"]
+__all__ = ["AudioConfig", "AudioStreamConfig", "BidiConnectionConfig", "BidiModelConfig"]
 
 
-class AudioConfig(TypedDict, total=False):
-    """Audio configuration for bidirectional streaming models.
-
-    Defines common audio parameters supported by bidirectional model providers.
-    All fields are optional to support models that only need specific parameters.
-
-    Model providers build this configuration by merging user-provided values
-    with their own defaults. Audio I/O implementations use the stream settings
-    to configure hardware, while model providers apply settings such as voice.
+class AudioStreamConfig(TypedDict):
+    """Resolved format of an audio stream.
 
     Attributes:
-        input_rate: Input sample rate in Hz (e.g., 8000, 16000, 24000, 48000)
-        output_rate: Output sample rate in Hz (e.g., 8000, 16000, 24000, 48000)
-        channels: Number of audio channels (1=mono, 2=stereo)
-        format: Audio encoding format
-        voice: Voice used for model audio output.
+        sample_rate: Sample rate in Hz.
+        channels: Number of audio channels.
+        format: Audio encoding.
     """
 
-    input_rate: AudioSampleRate
-    output_rate: AudioSampleRate
+    sample_rate: int
     channels: AudioChannel
     format: AudioFormat
-    voice: str
+
+
+class AudioConfig(TypedDict):
+    """Resolved input and output formats consumed by audio I/O.
+
+    Pass provider-specific audio options to the model constructor and use
+    ``get_audio_config()`` to obtain the resulting stream formats.
+
+    Attributes:
+        input: Audio format configured for model input.
+        output: Audio format produced by the model.
+    """
+
+    input: AudioStreamConfig
+    output: AudioStreamConfig
 
 
 class BidiConnectionConfig(TypedDict, total=False):
@@ -77,9 +81,11 @@ def _validate_model_config(config: Mapping[str, Any]) -> None:
     validate_config_keys(config.get("connection", {}), BidiConnectionConfig)
 
 
-def _validate_audio_config(config: Mapping[str, Any] | None) -> None:
+def _validate_audio_config(config: AudioConfig) -> None:
     """Validate shared audio configuration."""
-    validate_config_keys(config or {}, AudioConfig)
+    validate_config_keys(config, AudioConfig)
+    validate_config_keys(config["input"], AudioStreamConfig)
+    validate_config_keys(config["output"], AudioStreamConfig)
 
 
 def _merge_config(config: dict[str, Any], overrides: dict[str, Any]) -> dict[str, Any]:

--- a/strands-py/src/strands/experimental/bidi/models/google.py
+++ b/strands-py/src/strands/experimental/bidi/models/google.py
@@ -18,13 +18,14 @@ import logging
 import uuid
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, TypedDict, cast
 
 from google import genai
 from google.genai import types as genai_types
 from google.genai.types import LiveConnectConfigOrDict, LiveServerContent, LiveServerMessage, UsageMetadata
 from typing_extensions import Unpack, override
 
+from ....models._validation import validate_config_keys
 from ....types._events import ToolResultEvent, ToolUseStreamEvent
 from ....types.content import Messages
 from ....types.tools import ToolResult, ToolSpec, ToolUse
@@ -47,6 +48,7 @@ from ..types.events import (
 )
 from .configs import (
     AudioConfig,
+    AudioStreamConfig,
     BidiConnectionConfig,
     BidiModelConfig,
     _merge_config,
@@ -73,6 +75,28 @@ class _TurnState:
     output_transcript: str = ""
 
 
+class GoogleGeminiLiveAudioStreamConfig(TypedDict):
+    """Gemini Live input stream options. Audio uses mono PCM.
+
+    Attributes:
+        sample_rate: Input sample rate in Hz.
+    """
+
+    sample_rate: int
+
+
+class GoogleGeminiLiveAudioConfig(TypedDict, total=False):
+    """Gemini Live audio options. Output is mono PCM at 24000 Hz.
+
+    Omitting the input stream uses a sample rate of 16000 Hz.
+
+    Attributes:
+        input: Input stream options.
+    """
+
+    input: GoogleGeminiLiveAudioStreamConfig
+
+
 class GoogleGeminiLiveModel(BidiModel, AudioCapable):
     """Google Gemini Live implementation using the official Google GenAI SDK.
 
@@ -85,7 +109,8 @@ class GoogleGeminiLiveModel(BidiModel, AudioCapable):
         self,
         *,
         client_args: dict[str, Any] | None = None,
-        audio: AudioConfig | None = None,
+        audio: GoogleGeminiLiveAudioConfig | None = None,
+        voice: str | None = None,
         **model_config: Unpack[BidiModelConfig],
     ) -> None:
         """Initialize the Google Gemini Live bidirectional model.
@@ -93,12 +118,16 @@ class GoogleGeminiLiveModel(BidiModel, AudioCapable):
         Args:
             client_args: Arguments for the underlying Google GenAI client.
             audio: Audio configuration.
+            voice: Prebuilt output voice name. Omit to use the provider's default.
             **model_config: Model configuration.
+
+        Raises:
+            ValueError: If the input sample rate is not positive.
         """
         _validate_model_config(model_config)
-        _validate_audio_config(audio)
         self._config = BidiModelConfig(**model_config)
         self._config.setdefault("model_id", "gemini-2.5-flash-native-audio-preview-09-2025")
+        self._config["params"] = dict(self._config.get("params") or {})
 
         # Gemini caps a single connection at ~10 min; reconnect before that, resuming the same
         # session via its handle. The GoAway message remains the reactive backstop.
@@ -108,17 +137,8 @@ class GoogleGeminiLiveModel(BidiModel, AudioCapable):
         # Gemini reports per-response token deltas, not cumulative session totals.
         self.usage_is_cumulative = False
 
-        self._audio_config = AudioConfig(
-            **{
-                "input_rate": 16000,
-                "output_rate": 24000,
-                "channels": 1,
-                "format": "pcm",
-                **(audio or {}),
-            }
-        )
-
-        self._config["params"] = dict(self._config.get("params") or {})
+        self._resolve_audio_config(audio)
+        self._voice = voice
 
         self.client_args = dict(client_args or {})
         self._client = genai.Client(**self.client_args)
@@ -148,6 +168,23 @@ class GoogleGeminiLiveModel(BidiModel, AudioCapable):
     def get_audio_config(self) -> AudioConfig:
         """Get the resolved audio configuration."""
         return self._audio_config
+
+    def _resolve_audio_config(self, config: GoogleGeminiLiveAudioConfig | None) -> None:
+        """Resolve and validate input and output audio settings."""
+        config = config or {}
+        validate_config_keys(config, GoogleGeminiLiveAudioConfig)
+
+        input_config = config.get("input", {"sample_rate": 16000})
+        validate_config_keys(input_config, GoogleGeminiLiveAudioStreamConfig)
+        sample_rate = input_config["sample_rate"]
+        if sample_rate <= 0:
+            raise ValueError(f"Unsupported sample rate: {sample_rate}. Expected a positive value.")
+
+        self._audio_config = AudioConfig(
+            input=AudioStreamConfig(sample_rate=sample_rate, channels=1, format="pcm"),
+            output=AudioStreamConfig(sample_rate=24000, channels=1, format="pcm"),
+        )
+        _validate_audio_config(self._audio_config)
 
     async def start(
         self,
@@ -292,9 +329,7 @@ class GoogleGeminiLiveModel(BidiModel, AudioCapable):
             events.append(
                 BidiAudioStreamEvent(
                     audio=audio_b64,
-                    format="pcm",
-                    sample_rate=self._audio_config["output_rate"],
-                    channels=self._audio_config["channels"],
+                    **self._audio_config["output"],
                 )
             )
 
@@ -513,7 +548,7 @@ class GoogleGeminiLiveModel(BidiModel, AudioCapable):
         audio_bytes = base64.b64decode(audio_input.audio)
 
         # Create audio blob for the SDK
-        mime_type = f"audio/pcm;rate={self._audio_config['input_rate']}"
+        mime_type = f"audio/pcm;rate={self._audio_config['input']['sample_rate']}"
         audio_blob = genai_types.Blob(data=audio_bytes, mime_type=mime_type)
 
         # Send real-time audio input - this automatically handles VAD and interruption
@@ -696,10 +731,8 @@ class GoogleGeminiLiveModel(BidiModel, AudioCapable):
         if tools:
             config_dict["tools"] = self._format_tools_for_live_api(tools)
 
-        if "voice" in self._audio_config:
-            config_dict.setdefault("speech_config", {}).setdefault("voice_config", {}).setdefault(
-                "prebuilt_voice_config", {}
-            )["voice_name"] = self._audio_config["voice"]
+        if self._voice is not None:
+            config_dict["speech_config"] = {"voice_config": {"prebuilt_voice_config": {"voice_name": self._voice}}}
 
         return _merge_config(config_dict, self._config.get("params") or {})
 

--- a/strands-py/src/strands/experimental/bidi/models/openai.py
+++ b/strands-py/src/strands/experimental/bidi/models/openai.py
@@ -23,7 +23,6 @@ from ....types.content import Messages
 from ....types.tools import ToolResult, ToolSpec, ToolUse
 from .._async import stop_all
 from ..types.events import (
-    AudioSampleRate,
     BidiAudioInputEvent,
     BidiAudioStreamEvent,
     BidiConnectionStartEvent,
@@ -43,6 +42,7 @@ from ..types.events import (
 )
 from .configs import (
     AudioConfig,
+    AudioStreamConfig,
     BidiConnectionConfig,
     BidiModelConfig,
     _merge_config,
@@ -87,7 +87,7 @@ DEFAULT_SESSION_CONFIG = {
                 "silence_duration_ms": 500,
             },
         },
-        "output": {"format": {"type": "audio/pcm", "rate": DEFAULT_SAMPLE_RATE}, "voice": "alloy"},
+        "output": {"format": {"type": "audio/pcm", "rate": DEFAULT_SAMPLE_RATE}},
     },
 }
 
@@ -118,7 +118,7 @@ class OpenAIRealtimeModel(BidiModel, AudioCapable):
         organization: str | None = None,
         project: str | None = None,
         timeout_s: int = OPENAI_MAX_TIMEOUT_S,
-        audio: AudioConfig | None = None,
+        voice: str = "alloy",
         **model_config: Unpack[BidiModelConfig],
     ) -> None:
         """Initialize OpenAI Realtime bidirectional model.
@@ -128,16 +128,17 @@ class OpenAIRealtimeModel(BidiModel, AudioCapable):
             organization: OpenAI organization. Defaults to ``OPENAI_ORGANIZATION``.
             project: OpenAI project. Defaults to ``OPENAI_PROJECT``.
             timeout_s: Maximum connection duration in seconds.
-            audio: Audio configuration.
+            voice: Output voice identifier. Defaults to ``alloy``.
             **model_config: Model configuration.
 
         Raises:
-            ValueError: If the API key is missing or ``timeout_s`` exceeds the maximum.
+            ValueError: If the API key is missing, ``timeout_s`` exceeds the maximum,
+                or audio formats are unsupported.
         """
         _validate_model_config(model_config)
-        _validate_audio_config(audio)
         self._config = BidiModelConfig(**model_config)
         self._config.setdefault("model_id", DEFAULT_MODEL)
+        self._config["params"] = dict(self._config.get("params") or {})
 
         # OpenAI reports per-response token usage on response.done, not cumulative session totals.
         self.usage_is_cumulative = False
@@ -166,17 +167,8 @@ class OpenAIRealtimeModel(BidiModel, AudioCapable):
             }
         )
 
-        self._audio_config = AudioConfig(
-            **{
-                "input_rate": cast(AudioSampleRate, DEFAULT_SAMPLE_RATE),
-                "output_rate": cast(AudioSampleRate, DEFAULT_SAMPLE_RATE),
-                "channels": 1,
-                "format": "pcm",
-                "voice": "alloy",
-                **(audio or {}),
-            }
-        )
-        self._config["params"] = dict(self._config.get("params") or {})
+        self._voice = voice
+        self._resolve_audio_config(self._config.get("params"))
 
         # Connection state (initialized in start())
         self._connection_id: str | None = None
@@ -191,8 +183,13 @@ class OpenAIRealtimeModel(BidiModel, AudioCapable):
 
         Args:
             **model_config: Configuration overrides.
+
+        Raises:
+            ValueError: If the configured audio formats are unsupported.
         """
         _validate_model_config(model_config)
+        if "params" in model_config:
+            self._resolve_audio_config(model_config["params"])
         self._config.update(model_config)
 
     @override
@@ -204,6 +201,27 @@ class OpenAIRealtimeModel(BidiModel, AudioCapable):
     def get_audio_config(self) -> AudioConfig:
         """Get the resolved audio configuration."""
         return self._audio_config
+
+    def _resolve_audio_config(self, params: dict[str, Any] | None) -> None:
+        """Resolve audio settings and validate native format overrides."""
+        audio = (params or {}).get("audio", {})
+        for direction in ("input", "output"):
+            stream = audio.get(direction, {})
+            audio_format = stream.get("format", {})
+
+            format_type = audio_format.get("type", "audio/pcm")
+            if format_type != "audio/pcm":
+                raise ValueError(f"Unsupported audio format: {format_type}. Expected audio/pcm.")
+
+            sample_rate = audio_format.get("rate", DEFAULT_SAMPLE_RATE)
+            if sample_rate != DEFAULT_SAMPLE_RATE:
+                raise ValueError(f"Unsupported sample rate: {sample_rate}. Expected {DEFAULT_SAMPLE_RATE}.")
+
+        self._audio_config = AudioConfig(
+            input=AudioStreamConfig(sample_rate=DEFAULT_SAMPLE_RATE, channels=1, format="pcm"),
+            output=AudioStreamConfig(sample_rate=DEFAULT_SAMPLE_RATE, channels=1, format="pcm"),
+        )
+        _validate_audio_config(self._audio_config)
 
     async def start(
         self,
@@ -279,20 +297,7 @@ class OpenAIRealtimeModel(BidiModel, AudioCapable):
         if tools:
             config["tools"] = self._convert_tools_to_openai_format(tools)
 
-        audio_config = self._audio_config
-
-        if "voice" in audio_config:
-            config.setdefault("audio", {}).setdefault("output", {})["voice"] = audio_config["voice"]
-
-        if "input_rate" in audio_config:
-            config.setdefault("audio", {}).setdefault("input", {}).setdefault("format", {})["rate"] = audio_config[
-                "input_rate"
-            ]
-
-        if "output_rate" in audio_config:
-            config.setdefault("audio", {}).setdefault("output", {}).setdefault("format", {})["rate"] = audio_config[
-                "output_rate"
-            ]
+        config["audio"]["output"]["voice"] = self._voice
 
         return _merge_config(config, self._config.get("params") or {})
 
@@ -466,17 +471,10 @@ class OpenAIRealtimeModel(BidiModel, AudioCapable):
         # Audio output
         elif event_type == "response.output_audio.delta":
             # Audio is already base64 string from OpenAI
-            # Use the resolved output sample rate from our merged configuration
-            sample_rate = self._audio_config["output_rate"]
-
-            # Channels from config is guaranteed to be 1 or 2
-            channels = self._audio_config["channels"]
             return [
                 BidiAudioStreamEvent(
                     audio=openai_event["delta"],
-                    format="pcm",
-                    sample_rate=sample_rate,
-                    channels=channels,
+                    **self._audio_config["output"],
                 )
             ]
 

--- a/strands-py/src/strands/experimental/bidi/types/events.py
+++ b/strands-py/src/strands/experimental/bidi/types/events.py
@@ -15,7 +15,7 @@ Key features:
 Audio format normalization:
 
 - Supports PCM, WAV, Opus, and MP3 formats
-- Standardizes sample rates (16kHz, 24kHz, 48kHz)
+- Describes sample rates in Hz
 - Normalizes channel configurations (mono/stereo)
 - Abstracts provider-specific encodings
 - Audio data stored as base64-encoded strings for JSON compatibility
@@ -39,8 +39,6 @@ AudioChannel = Literal[1, 2]
 """
 AudioFormat = Literal["pcm", "wav", "opus", "mp3"]
 """Audio encoding format."""
-AudioSampleRate = Literal[8000, 16000, 24000, 48000]
-"""Audio sample rate in Hz."""
 
 Role = Literal["user", "assistant"]
 """Role of a message sender.
@@ -132,7 +130,7 @@ class BidiAudioInputEvent(TypedEvent):
     Parameters:
         audio: Base64-encoded audio string to send to model.
         format: Audio format from SUPPORTED_AUDIO_FORMATS.
-        sample_rate: Sample rate from SUPPORTED_SAMPLE_RATES.
+        sample_rate: Number of audio samples per second in Hz.
         channels: Channel count from SUPPORTED_CHANNELS.
     """
 
@@ -140,7 +138,7 @@ class BidiAudioInputEvent(TypedEvent):
         self,
         audio: str,
         format: AudioFormat | str,
-        sample_rate: AudioSampleRate,
+        sample_rate: int,
         channels: AudioChannel,
     ):
         """Initialize audio input event."""
@@ -165,9 +163,9 @@ class BidiAudioInputEvent(TypedEvent):
         return cast(AudioFormat, self["format"])
 
     @property
-    def sample_rate(self) -> AudioSampleRate:
+    def sample_rate(self) -> int:
         """Number of audio samples per second in Hz."""
-        return cast(AudioSampleRate, self["sample_rate"])
+        return cast(int, self["sample_rate"])
 
     @property
     def channels(self) -> AudioChannel:
@@ -346,7 +344,7 @@ class BidiAudioStreamEvent(TypedEvent):
         self,
         audio: str,
         format: AudioFormat,
-        sample_rate: AudioSampleRate,
+        sample_rate: int,
         channels: AudioChannel,
     ):
         """Initialize audio stream event."""
@@ -371,9 +369,9 @@ class BidiAudioStreamEvent(TypedEvent):
         return cast(AudioFormat, self["format"])
 
     @property
-    def sample_rate(self) -> AudioSampleRate:
+    def sample_rate(self) -> int:
         """Number of audio samples per second in Hz."""
-        return cast(AudioSampleRate, self["sample_rate"])
+        return cast(int, self["sample_rate"])
 
     @property
     def channels(self) -> AudioChannel:

--- a/strands-py/tests/strands/experimental/bidi/io/test_audio.py
+++ b/strands-py/tests/strands/experimental/bidi/io/test_audio.py
@@ -62,10 +62,8 @@ def agent():
     mock = unittest.mock.MagicMock()
     mock.model = unittest.mock.MagicMock(spec=AudioCapable)
     mock.model.get_audio_config.return_value = {
-        "input_rate": 24000,
-        "output_rate": 16000,
-        "channels": 2,
-        "format": "test-format",
+        "input": {"sample_rate": 24000, "channels": 2, "format": "pcm"},
+        "output": {"sample_rate": 16000, "channels": 2, "format": "pcm"},
     }
     return mock
 
@@ -75,10 +73,8 @@ def aec_agent():
     mock = unittest.mock.MagicMock()
     mock.model = unittest.mock.MagicMock(spec=AudioCapable)
     mock.model.get_audio_config.return_value = {
-        "input_rate": 16000,
-        "output_rate": 16000,
-        "channels": 1,
-        "format": "pcm",
+        "input": {"sample_rate": 16000, "channels": 1, "format": "pcm"},
+        "output": {"sample_rate": 16000, "channels": 1, "format": "pcm"},
     }
     return mock
 
@@ -88,10 +84,8 @@ def agent_mixed_rates():
     mock = unittest.mock.MagicMock()
     mock.model = unittest.mock.MagicMock(spec=AudioCapable)
     mock.model.get_audio_config.return_value = {
-        "input_rate": 16000,
-        "output_rate": 24000,
-        "channels": 1,
-        "format": "pcm",
+        "input": {"sample_rate": 16000, "channels": 1, "format": "pcm"},
+        "output": {"sample_rate": 24000, "channels": 1, "format": "pcm"},
     }
     return mock
 
@@ -207,7 +201,7 @@ async def test_bidi_audio_io_input(audio_input):
     exp_event = BidiAudioInputEvent(
         audio=base64.b64encode(b"test-audio").decode("utf-8"),
         channels=2,
-        format="test-format",
+        format="pcm",
         sample_rate=24000,
     )
     assert tru_event == exp_event
@@ -230,13 +224,32 @@ async def test_bidi_audio_io_output(audio_output):
     audio_event = BidiAudioStreamEvent(
         audio=base64.b64encode(b"test-audio").decode("utf-8"),
         channels=2,
-        format="test-format",
+        format="pcm",
         sample_rate=16000,
     )
     await audio_output(audio_event)
 
-    tru_data, _ = audio_output._callback(None, frame_count=4)
+    tru_data, _ = audio_output._callback(None, frame_count=2)
     exp_data = b"test-aud"
+    assert tru_data == exp_data
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "stream",
+    [
+        {"format": "wav", "sample_rate": 16000, "channels": 2},
+        {"format": "pcm", "sample_rate": 24000, "channels": 2},
+        {"format": "pcm", "sample_rate": 16000, "channels": 1},
+    ],
+)
+async def test_bidi_audio_io_output_rejects_changed_format(audio_output, stream):
+    event = BidiAudioStreamEvent(audio=base64.b64encode(b"audio").decode(), **stream)
+    with pytest.raises(ValueError, match="does not match the playback format"):
+        await audio_output(event)
+
+    tru_data, _ = audio_output._callback(None, frame_count=1)
+    exp_data = b"\x00\x00\x00\x00"
     assert tru_data == exp_data
 
 
@@ -247,7 +260,7 @@ async def test_bidi_audio_io_output_interrupt(audio_output):
     audio_event = BidiAudioStreamEvent(
         audio=base64.b64encode(b"test-audio").decode("utf-8"),
         channels=2,
-        format="test-format",
+        format="pcm",
         sample_rate=16000,
     )
     await audio_output(audio_event)
@@ -255,7 +268,7 @@ async def test_bidi_audio_io_output_interrupt(audio_output):
     await audio_output(interrupt_event)
 
     tru_data, _ = audio_output._callback(None, frame_count=1)
-    exp_data = b"\x00\x00"
+    exp_data = b"\x00\x00\x00\x00"
     assert tru_data == exp_data
     transcript_output.assert_any_await(interrupt_event)
 
@@ -295,6 +308,28 @@ async def test_bidi_audio_io_start_rejects_model_without_audio_capability(pyaudi
     with pytest.raises(TypeError, match="BidiAudioIO requires a model that implements AudioCapable"):
         await io.start(agent)
 
+    pyaudio_module.PyAudio.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("direction", ["input", "output"])
+@pytest.mark.parametrize("format", ["wav", "opus", "mp3"])
+async def test_bidi_audio_io_start_rejects_unsupported_encoding(pyaudio_module, agent, direction, format):
+    agent.model.get_audio_config.return_value[direction]["format"] = format
+    audio_io = BidiAudioIO()
+    channel = audio_io.input() if direction == "input" else audio_io.output()
+
+    with pytest.raises(ValueError, match="requires signed 16-bit PCM"):
+        await channel.start(agent)
+    pyaudio_module.PyAudio.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_echo_cancellation_rejects_different_channel_counts(pyaudio_module, aec_agent):
+    aec_agent.model.get_audio_config.return_value["output"]["channels"] = 2
+    audio_io = BidiAudioIO(audio_processor=True)
+    with pytest.raises(ValueError, match="matching input and output channel counts"):
+        await audio_io.input().start(aec_agent)
     pyaudio_module.PyAudio.assert_not_called()
 
 
@@ -358,7 +393,8 @@ def test_processor_construction_respects_echo_cancellation_flag():
     assert processor_class.call_args.kwargs["echo_cancellation"] is False
 
 
-def test_ec_off_processes_capture_with_none_reference():
+@pytest.mark.parametrize("output_rate", [None, 16000])
+def test_ec_off_processes_capture_with_none_reference(output_rate):
     frame = np.ones(160, dtype=np.int16) * 1000
     cleaned = np.zeros(160, dtype=np.int16)
 
@@ -367,12 +403,12 @@ def test_ec_off_processes_capture_with_none_reference():
     processor_patch, _, _ = _fake_audio_processor(processor)
 
     with processor_patch:
-        proc = _create_processor(echo_cancellation=False)
+        proc = _create_processor(echo_cancellation=False, output_rate=output_rate)
         proc.process(frame.tobytes())
 
-    assert len(processor.process.call_args.args) == 2
-    np.testing.assert_array_equal(processor.process.call_args.args[0], frame)
-    assert processor.process.call_args.args[1] is None
+    near_frame, reference_frame = processor.process.call_args.args
+    np.testing.assert_array_equal(near_frame, frame)
+    assert reference_frame is None
 
 
 def test_process_empty_input_returns_empty():
@@ -472,6 +508,24 @@ def test_processor_construction_builds_audio_processor_with_config():
         auto_gain_control=True,
         stream_delay_ms=20,
     )
+
+
+@pytest.mark.parametrize("num_channels", [0, 2])
+@pytest.mark.parametrize("echo_cancellation", [False, True])
+def test_processor_start_rejects_non_mono_audio(num_channels, echo_cancellation):
+    processor_patch, processor_class, _ = _fake_audio_processor()
+    with processor_patch, pytest.raises(ValueError, match="Audio processing currently supports only mono audio"):
+        _create_processor(num_channels=num_channels, echo_cancellation=echo_cancellation)
+
+    processor_class.assert_not_called()
+
+
+def test_processor_start_requires_output_rate_for_echo_cancellation():
+    processor_patch, processor_class, _ = _fake_audio_processor()
+    with processor_patch, pytest.raises(ValueError, match="Echo cancellation requires output_rate"):
+        _create_processor(output_rate=None)
+
+    processor_class.assert_not_called()
 
 
 @pytest.mark.parametrize("rate", [8000, 16000, 24000, 44100, 48000, 96000, 384000])
@@ -923,7 +977,7 @@ def test_real_library_echo_cancellation_off_still_processes():
     # Echo cancellation off: no reference is used (far=None) and the frame is still processed by noise
     # suppression / AGC. Assert the output actually differs from the input, so the test fails if the config
     # were ignored (a length-only check would pass even on an identity pass-through).
-    proc = _create_processor(echo_cancellation=False)
+    proc = _create_processor(echo_cancellation=False, output_rate=None)
 
     rng = np.random.default_rng(0)
     out = np.array([], dtype=np.int16)

--- a/strands-py/tests/strands/experimental/bidi/models/test_bedrock.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_bedrock.py
@@ -26,6 +26,7 @@ from smithy_http.aio.crt import AWSCRTHTTPClient
 from strands.experimental.bidi.models.bedrock import (
     NOVA_SONIC_V1_MODEL_ID,
     NOVA_SONIC_V2_MODEL_ID,
+    BedrockNovaSonicAudioConfig,
     BedrockNovaSonicModel,
     _BedrockAWSCRTHTTPClient,
     _BedrockAWSCRTHTTPResponse,
@@ -379,92 +380,83 @@ async def test_crt_response_reports_cancelled_read_failure():
 # Audio Configuration Tests
 
 
-@pytest.mark.asyncio
-async def test_audio_config_defaults(model_id, boto_session):
-    """Test default audio configuration."""
-    model = BedrockNovaSonicModel(model_id=model_id, boto_session=boto_session)
+@pytest.mark.parametrize(
+    ("audio", "input_rate", "output_rate"),
+    [
+        pytest.param(None, 16000, 16000, id="defaults"),
+        pytest.param({}, 16000, 16000, id="empty"),
+        pytest.param({"input": {"sample_rate": 8000}}, 8000, 16000, id="input"),
+        pytest.param(BedrockNovaSonicAudioConfig(output={"sample_rate": 24000}), 16000, 24000, id="output"),
+        pytest.param({"input": {"sample_rate": 24000}, "output": {"sample_rate": 8000}}, 24000, 8000, id="both"),
+    ],
+)
+def test_get_audio_config(boto_session, audio, input_rate, output_rate):
+    model = BedrockNovaSonicModel(boto_session=boto_session, audio=audio)
 
-    assert model.get_audio_config() == {
-        "input_rate": 16000,
-        "output_rate": 16000,
-        "channels": 1,
-        "format": "pcm",
+    tru_config = model.get_audio_config()
+    exp_config = {
+        "input": {"sample_rate": input_rate, "channels": 1, "format": "pcm"},
+        "output": {"sample_rate": output_rate, "channels": 1, "format": "pcm"},
     }
+    assert tru_config == exp_config
+    assert model.get_audio_config() is tru_config
 
 
-@pytest.mark.asyncio
-async def test_audio_config_partial_override(model_id, boto_session):
-    """Test partial audio configuration override."""
-    model = BedrockNovaSonicModel(
-        model_id=model_id,
-        boto_session=boto_session,
-        audio={"output_rate": 24000, "voice": "ruth"},
-    )
-
-    assert model.get_audio_config() == {
-        "input_rate": 16000,
-        "output_rate": 24000,
-        "channels": 1,
-        "format": "pcm",
-        "voice": "ruth",
-    }
+@pytest.mark.parametrize("direction", ["input", "output"])
+def test__init__requires_audio_sample_rate(boto_session, direction):
+    with pytest.raises(KeyError, match="sample_rate"):
+        BedrockNovaSonicModel(boto_session=boto_session, audio={direction: {}})
 
 
-@pytest.mark.asyncio
-async def test_audio_config_full_override(model_id, boto_session):
-    """Test full audio configuration override."""
-    audio_config = {
-        "input_rate": 48000,
-        "output_rate": 48000,
-        "channels": 2,
-        "format": "pcm",
-        "voice": "stephen",
-    }
-    model = BedrockNovaSonicModel(
-        model_id=model_id,
-        boto_session=boto_session,
-        audio=audio_config,
-    )
-
-    assert model.get_audio_config() == audio_config
+@pytest.mark.parametrize("direction", ["input", "output"])
+def test__init__rejects_unsupported_audio_sample_rate(boto_session, direction):
+    with pytest.raises(ValueError, match="Unsupported sample rate"):
+        BedrockNovaSonicModel(boto_session=boto_session, audio={direction: {"sample_rate": 48000}})
 
 
 @pytest.mark.parametrize(
-    ("audio", "expected"),
+    ("audio", "invalid_key"),
     [
-        (
-            None,
-            {
-                "mediaType": "audio/lpcm",
-                "sampleRateHertz": 16000,
-                "sampleSizeBits": 16,
-                "channelCount": 1,
-                "voiceId": "matthew",
-                "encoding": "base64",
-                "audioType": "SPEECH",
-            },
-        ),
-        (
-            {"output_rate": 24000, "channels": 2, "voice": "ruth"},
-            {
-                "mediaType": "audio/lpcm",
-                "sampleRateHertz": 24000,
-                "sampleSizeBits": 16,
-                "channelCount": 2,
-                "voiceId": "ruth",
-                "encoding": "base64",
-                "audioType": "SPEECH",
-            },
-        ),
+        ({"input": {"sample_rate": 16000, "channels": 2}}, "channels"),
+        ({"output": {"sample_rate": 16000, "format": "wav"}}, "format"),
+        ({"voice": "ruth"}, "voice"),
     ],
 )
-def test_prompt_start_event_audio_output_config(boto_session, audio, expected):
+def test__init__warns_on_unknown_audio_keys(boto_session, audio, invalid_key):
+    with pytest.warns(UserWarning, match=invalid_key):
+        model = BedrockNovaSonicModel(boto_session=boto_session, audio=audio)
+
+    tru_config = model.get_audio_config()
+    exp_config = {
+        "input": {"sample_rate": 16000, "channels": 1, "format": "pcm"},
+        "output": {"sample_rate": 16000, "channels": 1, "format": "pcm"},
+    }
+    assert tru_config == exp_config
+
+
+@pytest.mark.parametrize(
+    ("options", "rate", "voice"),
+    [
+        pytest.param({}, 16000, "matthew", id="defaults"),
+        pytest.param({"audio": {"output": {"sample_rate": 24000}}, "voice": "ruth"}, 24000, "ruth", id="custom"),
+    ],
+)
+def test__get_prompt_start_event_audio_output_config(boto_session, options, rate, voice):
     """Prompt start uses the resolved audio output configuration."""
-    model = BedrockNovaSonicModel(boto_session=boto_session, audio=audio)
+    model = BedrockNovaSonicModel(boto_session=boto_session, **options)
 
     prompt_start = json.loads(model._get_prompt_start_event([]))["event"]["promptStart"]
-
-    assert prompt_start["audioOutputConfiguration"] == expected
+    tru_config = prompt_start["audioOutputConfiguration"]
+    exp_config = {
+        "mediaType": "audio/lpcm",
+        "sampleRateHertz": rate,
+        "sampleSizeBits": 16,
+        "channelCount": 1,
+        "voiceId": voice,
+        "encoding": "base64",
+        "audioType": "SPEECH",
+    }
+    assert tru_config == exp_config
 
 
 @pytest.mark.asyncio
@@ -1299,59 +1291,23 @@ async def test_message_history_empty_and_edge_cases(nova_model):
     assert "Second part" in content
 
 
-# Error Handling Tests
+# Audio Event Tests
 
 
-@pytest.mark.asyncio
-async def test_custom_audio_rates_in_events(model_id, boto_session):
-    """Test that audio events use configured sample rates."""
-    response_state = _ResponseState()
+@pytest.mark.parametrize(
+    ("audio", "rate"),
+    [
+        pytest.param(None, 16000, id="defaults"),
+        pytest.param({"output": {"sample_rate": 24000}}, 24000, id="custom"),
+    ],
+)
+def test__convert_nova_event_audio_format(boto_session, audio, rate):
+    model = BedrockNovaSonicModel(boto_session=boto_session, audio=audio)
+    audio_base64 = base64.b64encode(b"audio data").decode()
 
-    # Create model with custom audio configuration
-    model = BedrockNovaSonicModel(
-        model_id=model_id,
-        boto_session=boto_session,
-        audio={"output_rate": 48000, "channels": 2},
-    )
-
-    # Test audio output event uses custom configuration
-    audio_bytes = b"test audio data"
-    audio_base64 = base64.b64encode(audio_bytes).decode("utf-8")
-    nova_event = {"audioOutput": {"content": audio_base64}}
-    result = model._convert_nova_event(
-        nova_event,
-        response_state,
-    )[0]
-
-    assert isinstance(result, BidiAudioStreamEvent)
-    # Should use configured rates, not constants
-    assert result.sample_rate == 48000  # Custom config
-    assert result.channels == 2  # Custom config
-    assert result.format == "pcm"
-
-
-@pytest.mark.asyncio
-async def test_default_audio_rates_in_events(model_id, boto_session):
-    """Test that audio events use default sample rates when no custom config."""
-    response_state = _ResponseState()
-
-    # Create model without custom audio configuration
-    model = BedrockNovaSonicModel(model_id=model_id, boto_session=boto_session)
-
-    # Test audio output event uses defaults
-    audio_bytes = b"test audio data"
-    audio_base64 = base64.b64encode(audio_bytes).decode("utf-8")
-    nova_event = {"audioOutput": {"content": audio_base64}}
-    result = model._convert_nova_event(
-        nova_event,
-        response_state,
-    )[0]
-
-    assert isinstance(result, BidiAudioStreamEvent)
-    # Should use default rates
-    assert result.sample_rate == 16000  # Default output rate
-    assert result.channels == 1  # Default channels
-    assert result.format == "pcm"
+    tru_events = model._convert_nova_event({"audioOutput": {"content": audio_base64}}, _ResponseState())
+    exp_events = [BidiAudioStreamEvent(audio=audio_base64, format="pcm", sample_rate=rate, channels=1)]
+    assert tru_events == exp_events
 
 
 # Nova Sonic v2 Support Tests
@@ -1377,12 +1333,12 @@ async def test_nova_sonic_v1_instantiation(boto_session, mock_client):
     model_custom = BedrockNovaSonicModel(
         model_id=NOVA_SONIC_V1_MODEL_ID,
         boto_session=boto_session,
-        audio={"output_rate": 24000, "voice": "joanna"},
+        audio={"output": {"sample_rate": 24000}},
+        voice="joanna",
     )
 
     assert model_custom.model_id == NOVA_SONIC_V1_MODEL_ID
-    assert model_custom.get_audio_config()["output_rate"] == 24000
-    assert model_custom.get_audio_config()["voice"] == "joanna"
+    assert model_custom.get_audio_config()["output"]["sample_rate"] == 24000
 
 
 @pytest.mark.asyncio
@@ -1399,12 +1355,13 @@ async def test_nova_sonic_v2_instantiation(boto_session, mock_client):
     model_custom = BedrockNovaSonicModel(
         model_id=NOVA_SONIC_V2_MODEL_ID,
         boto_session=boto_session,
-        audio={"input_rate": 48000, "voice": "ruth"},
+        audio={"input": {"sample_rate": 24000}},
+        voice="ruth",
         params={"inferenceConfiguration": {"temperature": 0.8}},
     )
 
     assert model_custom.model_id == NOVA_SONIC_V2_MODEL_ID
-    assert model_custom.get_audio_config()["input_rate"] == 48000
+    assert model_custom.get_audio_config()["input"]["sample_rate"] == 24000
     assert (
         json.loads(model_custom._get_connection_start_event())["event"]["sessionStart"]["inferenceConfiguration"][
             "temperature"
@@ -1422,12 +1379,12 @@ async def test_nova_sonic_v1_v2_compatibility(boto_session, mock_client):
     model_v1 = BedrockNovaSonicModel(
         model_id=NOVA_SONIC_V1_MODEL_ID,
         boto_session=boto_session,
-        audio={"voice": "matthew"},
+        voice="matthew",
     )
     model_v2 = BedrockNovaSonicModel(
         model_id=NOVA_SONIC_V2_MODEL_ID,
         boto_session=boto_session,
-        audio={"voice": "matthew"},
+        voice="matthew",
     )
 
     assert model_v1.get_audio_config() == model_v2.get_audio_config()

--- a/strands-py/tests/strands/experimental/bidi/models/test_configs.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_configs.py
@@ -4,7 +4,13 @@ import copy
 
 import pytest
 
-from strands.experimental.bidi.models.configs import _merge_config, _validate_audio_config, _validate_model_config
+from strands.experimental.bidi.models.configs import (
+    AudioConfig,
+    AudioStreamConfig,
+    _merge_config,
+    _validate_audio_config,
+    _validate_model_config,
+)
 
 
 @pytest.mark.parametrize(
@@ -19,9 +25,24 @@ def test__validate_model_config_warns_invalid_keys(model_config, invalid_key):
         _validate_model_config(model_config)
 
 
-def test__validate_audio_config_warns_invalid_keys():
-    with pytest.warns(UserWarning, match="input_rte"):
-        _validate_audio_config({"input_rte": 48000})
+@pytest.mark.parametrize(
+    ("direction", "invalid_key"),
+    [
+        (None, "input_rate"),
+        ("input", "rate"),
+        ("output", "encoding"),
+    ],
+)
+def test__validate_audio_config_warns_invalid_keys(direction, invalid_key):
+    config = AudioConfig(
+        input=AudioStreamConfig(sample_rate=16000, channels=1, format="pcm"),
+        output=AudioStreamConfig(sample_rate=24000, channels=1, format="pcm"),
+    )
+    target = config if direction is None else config[direction]
+    target[invalid_key] = "invalid"
+
+    with pytest.warns(UserWarning, match=invalid_key):
+        _validate_audio_config(config)
 
 
 @pytest.mark.parametrize(

--- a/strands-py/tests/strands/experimental/bidi/models/test_google.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_google.py
@@ -17,7 +17,7 @@ import pytest
 from google.genai import types as genai_types
 
 from strands.experimental.bidi.agent import loop as loop_module
-from strands.experimental.bidi.models.google import GoogleGeminiLiveModel, _TurnState
+from strands.experimental.bidi.models.google import GoogleGeminiLiveAudioConfig, GoogleGeminiLiveModel, _TurnState
 from strands.experimental.bidi.models.model import BidiModelTimeoutError
 from strands.experimental.bidi.types.events import (
     BidiAudioInputEvent,
@@ -1236,62 +1236,82 @@ async def test_interruption_closes_response_without_complete(mock_genai_client, 
 # Audio Configuration Tests
 
 
-def test_audio_config_defaults(mock_genai_client, model_id, api_key):
-    """Test default audio configuration."""
-    _ = mock_genai_client
+@pytest.mark.parametrize("audio", [None, {}])
+def test_get_audio_config_defaults(mock_genai_client, api_key, audio):
+    model = GoogleGeminiLiveModel(client_args={"api_key": api_key}, audio=audio)
 
-    model = GoogleGeminiLiveModel(model_id=model_id, client_args={"api_key": api_key})
-
-    assert model.get_audio_config() == {
-        "input_rate": 16000,
-        "output_rate": 24000,
-        "channels": 1,
-        "format": "pcm",
+    tru_config = model.get_audio_config()
+    exp_config = {
+        "input": {"sample_rate": 16000, "channels": 1, "format": "pcm"},
+        "output": {"sample_rate": 24000, "channels": 1, "format": "pcm"},
     }
+    assert tru_config == exp_config
+    assert model.get_audio_config() is tru_config
+    assert "speech_config" not in model._build_live_config()
 
 
-def test_audio_config_partial_override(mock_genai_client, model_id, api_key):
-    """Test partial audio configuration override."""
-    _ = mock_genai_client
-
+def test_get_audio_config_custom_input(mock_genai_client, api_key):
     model = GoogleGeminiLiveModel(
-        model_id=model_id,
         client_args={"api_key": api_key},
-        audio={"output_rate": 48000, "voice": "Puck"},
+        audio=GoogleGeminiLiveAudioConfig(input={"sample_rate": 48000}),
+        voice="Puck",
     )
 
-    assert model.get_audio_config() == {
-        "input_rate": 16000,
-        "output_rate": 48000,
-        "channels": 1,
-        "format": "pcm",
-        "voice": "Puck",
+    tru_config = model.get_audio_config()
+    exp_config = {
+        "input": {"sample_rate": 48000, "channels": 1, "format": "pcm"},
+        "output": {"sample_rate": 24000, "channels": 1, "format": "pcm"},
     }
+    assert tru_config == exp_config
+    tru_speech = model._build_live_config()["speech_config"]
+    exp_speech = {"voice_config": {"prebuilt_voice_config": {"voice_name": "Puck"}}}
+    assert tru_speech == exp_speech
 
 
-def test_audio_config_full_override(mock_genai_client, model_id, api_key):
-    """Test full audio configuration override."""
-    _ = mock_genai_client
+@pytest.mark.parametrize(
+    ("audio", "invalid_key"),
+    [
+        ({"output": {"sample_rate": 48000}}, "output"),
+        ({"input": {"sample_rate": 16000, "channels": 2}}, "channels"),
+        ({"input": {"sample_rate": 16000, "format": "mp3"}}, "format"),
+    ],
+)
+def test__init__warns_on_unknown_audio_keys(mock_genai_client, api_key, audio, invalid_key):
+    with pytest.warns(UserWarning, match=invalid_key):
+        model = GoogleGeminiLiveModel(client_args={"api_key": api_key}, audio=audio)
 
-    model = GoogleGeminiLiveModel(
-        model_id=model_id,
-        client_args={"api_key": api_key},
-        audio={
-            "input_rate": 48000,
-            "output_rate": 48000,
-            "channels": 2,
-            "format": "pcm",
-            "voice": "Aoede",
-        },
+    tru_config = model.get_audio_config()
+    exp_config = {
+        "input": {"sample_rate": 16000, "channels": 1, "format": "pcm"},
+        "output": {"sample_rate": 24000, "channels": 1, "format": "pcm"},
+    }
+    assert tru_config == exp_config
+
+
+def test__init__requires_audio_sample_rate(mock_genai_client, api_key):
+    with pytest.raises(KeyError, match="sample_rate"):
+        GoogleGeminiLiveModel(client_args={"api_key": api_key}, audio={"input": {}})
+
+
+@pytest.mark.parametrize("rate", [0, -1])
+def test__init__rejects_invalid_audio_sample_rate(mock_genai_client, api_key, rate):
+    with pytest.raises(ValueError, match="positive"):
+        GoogleGeminiLiveModel(client_args={"api_key": api_key}, audio={"input": {"sample_rate": rate}})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("rate", [32000, 44100, 48000])
+async def test_send_audio_uses_resolved_input_rate(mock_genai_client, api_key, rate):
+    _, session, _ = mock_genai_client
+    model = GoogleGeminiLiveModel(client_args={"api_key": api_key}, audio={"input": {"sample_rate": rate}})
+    await model.start()
+    await model.send(
+        BidiAudioInputEvent(audio=base64.b64encode(b"audio").decode(), format="pcm", sample_rate=rate, channels=1)
     )
-
-    assert model.get_audio_config() == {
-        "input_rate": 48000,
-        "output_rate": 48000,
-        "channels": 2,
-        "format": "pcm",
-        "voice": "Aoede",
-    }
+    session.send_realtime_input.assert_awaited_once_with(
+        audio=genai_types.Blob(data=b"audio", mime_type=f"audio/pcm;rate={rate}")
+    )
+    await model.stop()
 
 
 # Helper Method Tests
@@ -1373,7 +1393,7 @@ def test__build_live_config_params_override_direct_options(
     exp_params = copy.deepcopy(params)
     model = GoogleGeminiLiveModel(
         client_args={"api_key": api_key},
-        audio={"voice": "Kore"},
+        voice="Kore",
         params=params,
     )
 
@@ -1402,7 +1422,7 @@ def test__build_live_config_merges_nested_params(mock_genai_client, api_key):
     }
     model = GoogleGeminiLiveModel(
         client_args={"api_key": api_key},
-        audio={"voice": "Kore"},
+        voice="Kore",
         params=params,
     )
 
@@ -1445,7 +1465,7 @@ async def test_start_passes_merged_config_to_genai(mock_genai_client, api_key):
     mock_client, _, _ = mock_genai_client
     model = GoogleGeminiLiveModel(
         client_args={"api_key": api_key},
-        audio={"voice": "Kore"},
+        voice="Kore",
         params={
             "speech_config": {
                 "language_code": "en-US",
@@ -1489,7 +1509,7 @@ async def test_start_passes_merged_config_to_genai(mock_genai_client, api_key):
 def test_update_config_replaces_params(mock_genai_client, api_key, params, exp_voice):
     model = GoogleGeminiLiveModel(
         client_args={"api_key": api_key},
-        audio={"voice": "Kore"},
+        voice="Kore",
         params={
             "system_instruction": "Configured instructions",
             "speech_config": {"voice_config": {"prebuilt_voice_config": {"voice_name": "Aoede"}}},
@@ -1518,60 +1538,27 @@ def test_tool_formatting(model, tool_spec):
     assert formatted_empty == []
 
 
-# Tool Result Content Tests
+# Audio Event Tests
 
 
-@pytest.mark.asyncio
-async def test_custom_audio_rates_in_events(mock_genai_client, model_id, api_key, live_message):
-    """Test that audio events use configured sample rates and channels."""
-    _, _, _ = mock_genai_client
+@pytest.mark.parametrize(
+    "audio",
+    [
+        pytest.param(None, id="defaults"),
+        pytest.param({"input": {"sample_rate": 48000}}, id="custom-input"),
+    ],
+)
+def test__convert_gemini_live_event_audio_format(mock_genai_client, api_key, live_message, audio):
+    model = GoogleGeminiLiveModel(client_args={"api_key": api_key}, audio=audio)
+    turn_state = _TurnState(response_open=True)
 
-    model = GoogleGeminiLiveModel(
-        model_id=model_id,
-        client_args={"api_key": api_key},
-        audio={"output_rate": 48000, "channels": 2},
-    )
-    await model.start()
-    turn_state = _TurnState(response_open=True)  # mid-response, so no response-start is prepended
-
-    # Test audio output event uses custom configuration
-    mock_audio = live_message(data=b"audio_data")
-
-    audio_events = model._convert_gemini_live_event(mock_audio, turn_state)
-    assert len(audio_events) == 1
-    audio_event = audio_events[0]
-    assert isinstance(audio_event, BidiAudioStreamEvent)
-    # Should use configured rates, not constants
-    assert audio_event.sample_rate == 48000  # Custom config
-    assert audio_event.channels == 2  # Custom config
-    assert audio_event.format == "pcm"
-
-    await model.stop()
-
-
-@pytest.mark.asyncio
-async def test_default_audio_rates_in_events(mock_genai_client, model_id, api_key, live_message):
-    """Test that audio events use default sample rates when no custom config."""
-    _, _, _ = mock_genai_client
-
-    # Create model without custom audio configuration
-    model = GoogleGeminiLiveModel(model_id=model_id, client_args={"api_key": api_key})
-    await model.start()
-    turn_state = _TurnState(response_open=True)  # mid-response, so no response-start is prepended
-
-    # Test audio output event uses defaults
-    mock_audio = live_message(data=b"audio_data")
-
-    audio_events = model._convert_gemini_live_event(mock_audio, turn_state)
-    assert len(audio_events) == 1
-    audio_event = audio_events[0]
-    assert isinstance(audio_event, BidiAudioStreamEvent)
-    # Should use default rates
-    assert audio_event.sample_rate == 24000  # Default output rate
-    assert audio_event.channels == 1  # Default channels
-    assert audio_event.format == "pcm"
-
-    await model.stop()
+    tru_events = model._convert_gemini_live_event(live_message(data=b"audio_data"), turn_state)
+    exp_events = [
+        BidiAudioStreamEvent(
+            audio=base64.b64encode(b"audio_data").decode(), format="pcm", sample_rate=24000, channels=1
+        )
+    ]
+    assert tru_events == exp_events
 
 
 # Tool Result Content Tests

--- a/strands-py/tests/strands/experimental/bidi/models/test_model.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_model.py
@@ -57,10 +57,8 @@ class _TestBidiModel(BidiModel):
 class _AudioBidiModel(_TestBidiModel):
     def get_audio_config(self) -> AudioConfig:
         return {
-            "input_rate": 16000,
-            "output_rate": 24000,
-            "channels": 1,
-            "format": "pcm",
+            "input": {"sample_rate": 16000, "channels": 1, "format": "pcm"},
+            "output": {"sample_rate": 24000, "channels": 1, "format": "pcm"},
         }
 
 

--- a/strands-py/tests/strands/experimental/bidi/models/test_openai.py
+++ b/strands-py/tests/strands/experimental/bidi/models/test_openai.py
@@ -140,64 +140,68 @@ def test_model_initialization(api_key, model_name, monkeypatch):
 # Audio Configuration Tests
 
 
-def test_audio_config_defaults(api_key, model_name):
-    """Test default audio configuration."""
-    model = OpenAIRealtimeModel(model_id=model_name, api_key=api_key)
+@pytest.mark.parametrize(
+    ("options", "voice"),
+    [
+        pytest.param({}, "alloy", id="defaults"),
+        pytest.param({"voice": "echo"}, "echo", id="custom-voice"),
+    ],
+)
+def test_get_audio_config(api_key, options, voice):
+    model = OpenAIRealtimeModel(api_key=api_key, **options)
 
-    assert model.get_audio_config() == {
-        "input_rate": 24000,
-        "output_rate": 24000,
-        "channels": 1,
-        "format": "pcm",
-        "voice": "alloy",
+    tru_config = model.get_audio_config()
+    exp_config = {
+        "input": {"sample_rate": 24000, "channels": 1, "format": "pcm"},
+        "output": {"sample_rate": 24000, "channels": 1, "format": "pcm"},
     }
+    assert tru_config == exp_config
+    assert model.get_audio_config() is tru_config
+
+    tru_output = model._build_session_config(None, None)["audio"]["output"]
+    exp_output = {"format": {"type": "audio/pcm", "rate": 24000}, "voice": voice}
+    assert tru_output == exp_output
 
 
-def test_audio_config_partial_override(api_key, model_name):
-    """Test partial audio configuration override."""
-    model = OpenAIRealtimeModel(
-        model_id=model_name,
-        api_key=api_key,
-        audio={"output_rate": 48000, "voice": "echo"},
-    )
+@pytest.mark.parametrize("direction", ["input", "output"])
+@pytest.mark.parametrize(
+    "audio_format",
+    [
+        {"rate": 48000},
+        {"rate": None},
+        {"type": "audio/pcmu"},
+        {"type": "audio/pcma"},
+        {"type": "audio/mp3"},
+    ],
+)
+def test__init__rejects_unsupported_audio_format(api_key, direction, audio_format):
+    with pytest.raises(ValueError, match="Unsupported"):
+        OpenAIRealtimeModel(api_key=api_key, params={"audio": {direction: {"format": audio_format}}})
 
-    assert model.get_audio_config() == {
-        "input_rate": 24000,
-        "output_rate": 48000,
-        "channels": 1,
-        "format": "pcm",
-        "voice": "echo",
+
+@pytest.mark.parametrize("direction", ["input", "output"])
+@pytest.mark.parametrize(
+    "audio_format",
+    [
+        {"type": "audio/pcmu"},
+        {"rate": 16000},
+    ],
+)
+def test_update_config_rejects_unsupported_audio_format(api_key, direction, audio_format):
+    model = OpenAIRealtimeModel(api_key=api_key, params={"max_output_tokens": 2048})
+    audio_config = model.get_audio_config()
+
+    with pytest.raises(ValueError, match="Unsupported"):
+        model.update_config(model_id="updated-model", params={"audio": {direction: {"format": audio_format}}})
+
+    tru_config = model.get_config()
+    exp_config = {
+        "model_id": "gpt-realtime",
+        "params": {"max_output_tokens": 2048},
+        "connection": {"restart_after_s": OPENAI_MAX_TIMEOUT_S - OPENAI_PROACTIVE_RECONNECT_MARGIN_S},
     }
-
-
-def test_audio_config_full_override(api_key, model_name):
-    """Test full audio configuration override."""
-    model = OpenAIRealtimeModel(
-        model_id=model_name,
-        api_key=api_key,
-        audio={
-            "input_rate": 48000,
-            "output_rate": 48000,
-            "channels": 2,
-            "format": "pcm",
-            "voice": "shimmer",
-        },
-    )
-
-    assert model.get_audio_config() == {
-        "input_rate": 48000,
-        "output_rate": 48000,
-        "channels": 2,
-        "format": "pcm",
-        "voice": "shimmer",
-    }
-
-
-def test_audio_config_voice_override(api_key, model_name):
-    """Test that voice can be configured independently."""
-    model = OpenAIRealtimeModel(model_id=model_name, api_key=api_key, audio={"voice": "fable"})
-
-    assert model.get_audio_config()["voice"] == "fable"
+    assert tru_config == exp_config
+    assert model.get_audio_config() is audio_config
 
 
 def test_init_without_api_key_raises(monkeypatch):
@@ -709,7 +713,7 @@ def test_convert_openai_event_transcript(model, event, expected):
 def test__build_session_config_direct_options(api_key, system_prompt, tool_spec):
     model = OpenAIRealtimeModel(
         api_key=api_key,
-        audio={"input_rate": 16000, "output_rate": 48000, "voice": "coral"},
+        voice="coral",
     )
 
     config = model._build_session_config(system_prompt, [tool_spec])
@@ -722,8 +726,8 @@ def test__build_session_config_direct_options(api_key, system_prompt, tool_spec)
             "parameters": tool_spec["inputSchema"]["json"],
         }
     ]
-    assert config["audio"]["input"]["format"] == {"type": "audio/pcm", "rate": 16000}
-    assert config["audio"]["output"] == {"format": {"type": "audio/pcm", "rate": 48000}, "voice": "coral"}
+    assert config["audio"]["input"]["format"] == {"type": "audio/pcm", "rate": 24000}
+    assert config["audio"]["output"] == {"format": {"type": "audio/pcm", "rate": 24000}, "voice": "coral"}
 
 
 def test__build_session_config_passes_through_params(api_key):
@@ -744,7 +748,7 @@ def test__build_session_config_merges_params_last(api_key, system_prompt, tool_s
     """Params override direct options while preserving unspecified nested defaults."""
     model = OpenAIRealtimeModel(
         api_key=api_key,
-        audio={"input_rate": 48000, "output_rate": 48000, "voice": "echo"},
+        voice="echo",
         params={
             "instructions": "",
             "tools": [],
@@ -787,7 +791,7 @@ def test__build_session_config_preserves_defaults(model, api_key, system_prompt,
     exp_config = model._build_session_config(None, None)
     custom_model = OpenAIRealtimeModel(
         api_key=api_key,
-        audio={"voice": "coral", "input_rate": 48000},
+        voice="coral",
         params={"output_modalities": ["text"]},
     )
 
@@ -842,7 +846,7 @@ async def test_start_preserves_explicit_nulls(api_key, mock_websockets_connect):
 def test_update_config_replaces_params(api_key, params, exp_voice):
     model = OpenAIRealtimeModel(
         api_key=api_key,
-        audio={"voice": "coral"},
+        voice="coral",
         params={"instructions": "Params instructions", "audio": {"output": {"voice": "echo"}}},
     )
 
@@ -915,87 +919,14 @@ async def test_send_event_helper(mock_websockets_connect, model):
     await model.stop()
 
 
-@pytest.mark.asyncio
-async def test_custom_audio_sample_rate(mock_websockets_connect, api_key):
-    """Test that a custom audio sample rate is used in audio events."""
-    _, mock_ws = mock_websockets_connect
+@pytest.mark.parametrize("voice", ["alloy", "echo"])
+def test__convert_openai_event_audio_format(api_key, voice):
+    model = OpenAIRealtimeModel(api_key=api_key, voice=voice)
+    audio_base64 = base64.b64encode(b"audio data").decode()
 
-    custom_sample_rate = 48000
-    model = OpenAIRealtimeModel(api_key=api_key, audio={"output_rate": custom_sample_rate})
-
-    await model.start()
-
-    # Simulate receiving an audio delta event from OpenAI
-    openai_audio_event = {"type": "response.output_audio.delta", "delta": "base64audiodata"}
-
-    # Convert the event
-    converted_events = model._convert_openai_event(openai_audio_event)
-
-    # Verify the audio event uses the custom sample rate
-    assert converted_events is not None
-    assert len(converted_events) == 1
-    audio_event = converted_events[0]
-    assert isinstance(audio_event, BidiAudioStreamEvent)
-    assert audio_event.sample_rate == custom_sample_rate
-    assert audio_event.format == "pcm"
-    assert audio_event.channels == 1
-
-    await model.stop()
-
-
-@pytest.mark.asyncio
-async def test_default_audio_sample_rate(mock_websockets_connect, api_key):
-    """Test that default audio sample rate is used when no custom config is provided."""
-    _, mock_ws = mock_websockets_connect
-
-    # Create model without custom audio config
-    model = OpenAIRealtimeModel(api_key=api_key)
-
-    await model.start()
-
-    # Simulate receiving an audio delta event from OpenAI
-    openai_audio_event = {"type": "response.output_audio.delta", "delta": "base64audiodata"}
-
-    # Convert the event
-    converted_events = model._convert_openai_event(openai_audio_event)
-
-    # Verify the audio event uses the default sample rate (24000)
-    assert converted_events is not None
-    assert len(converted_events) == 1
-    audio_event = converted_events[0]
-    assert isinstance(audio_event, BidiAudioStreamEvent)
-    assert audio_event.sample_rate == 24000  # Default from DEFAULT_SAMPLE_RATE
-    assert audio_event.format == "pcm"
-    assert audio_event.channels == 1
-
-    await model.stop()
-
-
-@pytest.mark.asyncio
-async def test_partial_audio_config(mock_websockets_connect, api_key):
-    """Test that partial audio config doesn't break and falls back to defaults."""
-    _, mock_ws = mock_websockets_connect
-
-    model = OpenAIRealtimeModel(api_key=api_key, audio={"voice": "alloy"})
-
-    await model.start()
-
-    # Simulate receiving an audio delta event from OpenAI
-    openai_audio_event = {"type": "response.output_audio.delta", "delta": "base64audiodata"}
-
-    # Convert the event
-    converted_events = model._convert_openai_event(openai_audio_event)
-
-    # Verify the audio event uses the default sample rate
-    assert converted_events is not None
-    assert len(converted_events) == 1
-    audio_event = converted_events[0]
-    assert isinstance(audio_event, BidiAudioStreamEvent)
-    assert audio_event.sample_rate == 24000  # Falls back to default
-    assert audio_event.format == "pcm"
-    assert audio_event.channels == 1
-
-    await model.stop()
+    tru_events = model._convert_openai_event({"type": "response.output_audio.delta", "delta": audio_base64})
+    exp_events = [BidiAudioStreamEvent(audio=audio_base64, format="pcm", sample_rate=24000, channels=1)]
+    assert tru_events == exp_events
 
 
 # Tool Result Content Tests
@@ -1337,6 +1268,11 @@ async def test_receive_binds_websocket_per_reader(mock_websockets_connect, model
         return_value=json.dumps({"type": "response.output_audio.delta", "delta": "FROM_WS2"})
     )
     model._websocket = ws2
+    blocker.set()
+    tru_event = await reader.__anext__()
+    exp_event = BidiAudioStreamEvent(audio="FROM_WS1", format="pcm", sample_rate=24000, channels=1)
+    assert tru_event == exp_event
+    blocker.clear()
 
     # The bound reader stays parked on ws1 and never touches the replacement socket.
     with pytest.raises(asyncio.TimeoutError):


### PR DESCRIPTION
## Description

The shared audio config mixes provider options with the stream formats consumed by I/O, allowing unsupported settings to be reported to capture and playback. Providers now accept only their configurable audio options and resolve complete input/output formats for `BidiAudioIO` and audio events. Voice remains a separate model setting.

### Public API Changes

```python
# Before
model = BedrockNovaSonicModel(audio={"output_rate": 24000, "voice": "tiffany"})

# After
model = BedrockNovaSonicModel(
    audio={"output": {"sample_rate": 24000}},
    voice="tiffany",
)
model.get_audio_config()
# {
#     "input": {"sample_rate": 16000, "channels": 1, "format": "pcm"},
#     "output": {"sample_rate": 24000, "channels": 1, "format": "pcm"},
# }
```

Nova Sonic accepts input/output sample rates through `BedrockNovaSonicAudioConfig`. Gemini accepts an input sample rate through `GoogleGeminiLiveAudioConfig` and has a fixed output format. OpenAI uses fixed mono PCM at 24000 Hz and validates audio format overrides in `params` during construction and `update_config()`.

### Breaking Changes

This changes the experimental bidi API. Move `audio["voice"]` to the direct `voice` argument on all three providers and replace flat rate settings with the supported nested options. OpenAI no longer accepts an `audio` constructor option. Custom `AudioCapable` models must return the complete nested `AudioConfig` shown above. Replace `AudioSampleRate` imports with `int`.

`BidiAudioIO` rejects non-PCM configurations and output events that do not match playback. Audio processing now explicitly rejects non-mono audio.

## Related Issues

None.

## Documentation PR

Included in this PR: provider configuration references, the quickstart, and agent/audio I/O examples.

## Type of Change

Breaking change (experimental bidi API)

## Testing

- [x] I ran `hatch run prepare`

Prepare passed lint, type checks, and the full unit-test matrix on Python 3.10–3.14. After rebasing onto the latest `upstream/main`, lint, type checks, all 503 bidi unit tests, and all 15 bidi integration tests passed again. Integration tests exercised live Nova Sonic v1/v2, OpenAI, and Google providers. The documentation build, type checks, snippet checks, and 613 site tests also passed (2 skipped).

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
