### PR TITLE
catalog: add orcareplay — record a Strands run, replay it offline

### DIFF
--- a/site/src/content/catalog/orcareplay.yaml
+++ b/site/src/content/catalog/orcareplay.yaml
@@ -1,0 +1,8 @@
+name: orcareplay
+description: Records a Strands agent run from outside the process and replays it offline with no model call — a CLI that wraps the process, no SDK changes.
+integrationType: integration
+languages:
+  typescript:
+    package: orcareplay
+github: https://github.com/Continuum-AI-Corp/OrcaReplay
+addedDate: 2026-09-13


### PR DESCRIPTION
## Integration submission

**Package name:** `orcareplay`
**Integration type:** integration
**Languages published:** npm (`orcareplay`) — the recorder is a CLI; the Strands app it records is the Python SDK
**GitHub repo:** https://github.com/Continuum-AI-Corp/OrcaReplay
**What it does:** Records a Strands agent run from outside the process — nothing is imported into your agent — and can serve that recording back so the same run happens again without calling a provider.
**Relationship to service:** community-built, by the OrcaReplay maintainers
**Docs link included:** none — the card will link to the GitHub repo

### One note on the `languages` block

This is the one field where our entry is not a clean fit, so I would rather flag it than let a reviewer find it.

OrcaReplay is not a Strands-specific package: it is a CLI, installed from npm, that launches your
agent as a child process and points the OpenAI client's origin at a local proxy. The agent it
records here is a **Python** Strands app. So the honest reading of `languages` is "the registry
you install it from" (npm), not "the Strands SDK it works with" (Python).

The alternative shape is the guide-only one `langfuse.yaml` uses — `python: {}` plus a `docsUrl`
to a Strands page on our own site. I did not use that because we do not have that page yet, and
I did not want to point `docsUrl` at a page that does not document Strands. If you would prefer
the guide-only shape, say so and I will write the page and update this entry to match; if you
would rather this entry did not exist at all because the package is not Strands-specific, that is
a fair call and I will close this.

### How it works with Strands

`OpenAIModel` with no `client_args` builds an `OpenAI()` client, which reads `OPENAI_BASE_URL`
and `OPENAI_API_KEY` from the environment. `orca record` sets those **for the child process it
launches and only for that process**, so the Strands code is unchanged:

```bash
npm i -g orcareplay          # Node 20+
orca record generic-openai -- python my_strands_agent.py
orca replay last             # the same run again, no provider called
```

```python
from strands import Agent
from strands.models.openai import OpenAIModel

model = OpenAIModel(model_id="gpt-5.5")   # no base_url in code: the env is the route
agent = Agent(model=model)
agent("Say hello in three words.")
```

### What I actually ran before opening this

Against `strands-agents[openai]` on Python 3.12, recorded against a deterministic local origin,
then **the origin process was killed** and the run replayed:

```
info recorded run=run_d4ea37ab01cb events=6 blobs=0 exit=0
strands replied: the stub answered

$ orca replay run_d4ea37ab01cb
info replaying exchanges=1 egress=blocked
strands replied: the stub answered
info replay.done reused=1/1 exact=1 divergences=0 unmatched=0 exit=0
```

`exact=1` is a byte-identical request match, and the origin was not running for the replay.

An honest scope limit, in the same words the README uses: **`egress=blocked` means model-provider
egress, not network isolation.** Replay serves model responses from the trace, but it still runs
the recorded tool calls for real — a tool that shells out to `curl` will hit the network again.
Replay is not a sandbox.

### Submitter checklist

#### Package
- [x] This is a reusable integration (library/plugin/provider), not an example agent or application built with Strands
- [x] Published to npm under the exact `package` name in my entry
- [x] GitHub repository is public and includes a license (Apache-2.0)

#### Entry
- [x] Description accurately states what the package does in one sentence
- [x] `integrationType` matches what the package actually is
- [x] All URLs are working
- [x] `addedDate` is today
- [x] `featured` and `badges` are left unset

#### Docs
- [x] No `docsUrl` set, so the docs checklist does not apply

#### Conduct
- [x] I am a maintainer of the package
- [x] Entry uses the package's real name with no trademark misuse
