### PR TITLE
fix(streaming): preserve text with pending tool use

### DIFF
--- a/strands-py/src/strands/event_loop/streaming.py
+++ b/strands-py/src/strands/event_loop/streaming.py
@@ -336,7 +336,7 @@ def handle_content_block_stop(state: dict[str, Any]) -> dict[str, Any]:
         content.append({"toolUse": tool_use})
         state["current_tool_use"] = {}
 
-    elif text:
+    if text:
         if citations_content:
             citations_block: CitationsContentBlock = {"citations": citations_content, "content": [{"text": text}]}
             content.append({"citationsContent": citations_block})
@@ -345,7 +345,7 @@ def handle_content_block_stop(state: dict[str, Any]) -> dict[str, Any]:
             content.append({"text": text})
         state["text"] = ""
 
-    elif reasoning_text or "signature" in state:
+    if reasoning_text or "signature" in state:
         content_block: ContentBlock = {
             "reasoningContent": {
                 "reasoningText": {
@@ -360,7 +360,7 @@ def handle_content_block_stop(state: dict[str, Any]) -> dict[str, Any]:
 
         content.append(content_block)
         state["reasoningText"] = ""
-    elif redacted_content:
+    if redacted_content:
         content.append({"reasoningContent": {"redactedContent": redacted_content}})
         state["redactedContent"] = b""
 

--- a/strands-py/tests/strands/event_loop/test_streaming.py
+++ b/strands-py/tests/strands/event_loop/test_streaming.py
@@ -669,6 +669,28 @@ def test_handle_content_block_stop_preserves_text_with_tool_use():
     assert tru_updated_state == exp_updated_state
 
 
+@pytest.mark.asyncio
+async def test_process_stream_preserves_text_with_pending_tool_use(agenerator, alist):
+    """Preserve text when a tool use stops before the text block closes (#4004)."""
+    response = [
+        {"messageStart": {"role": "assistant"}},
+        {"contentBlockDelta": {"delta": {"text": "Let me check that for you."}}},
+        {"contentBlockStart": {"start": {"toolUse": {"toolUseId": "tool-1", "name": "read_file"}}}},
+        {"contentBlockDelta": {"delta": {"toolUse": {"input": "{}"}}}},
+        {"contentBlockStop": {}},
+        {"messageStop": {"stopReason": "tool_use"}},
+    ]
+
+    tru_events = await alist(strands.event_loop.streaming.process_stream(agenerator(response)))
+    tru_message = _get_message_from_event(cast(ModelStopReason, tru_events[-1]))
+    exp_content = [
+        {"toolUse": {"toolUseId": "tool-1", "name": "read_file", "input": {}}},
+        {"text": "Let me check that for you."},
+    ]
+
+    assert tru_message["content"] == exp_content
+
+
 @unittest.mock.patch("strands.event_loop.streaming.logger")
 def test_handle_content_block_stop_logs_warning_on_malformed_json(mock_logger):
     state = {

--- a/strands-py/tests/strands/event_loop/test_streaming.py
+++ b/strands-py/tests/strands/event_loop/test_streaming.py
@@ -636,6 +636,39 @@ def test_handle_content_block_stop(state, exp_updated_state):
     assert tru_updated_state == exp_updated_state
 
 
+def test_handle_content_block_stop_preserves_text_with_tool_use():
+    """Preserve accumulated text when a tool use stops in the same block (#4004)."""
+    state = {
+        "content": [],
+        "current_tool_use": {"toolUseId": "tool-1", "name": "read_file", "input": "{}"},
+        "text": "Let me check that for you.",
+        "reasoningText": "",
+        "citationsContent": [],
+        "redactedContent": b"",
+    }
+
+    tru_updated_state = strands.event_loop.streaming.handle_content_block_stop(state)
+    exp_updated_state = {
+        "content": [
+            {
+                "toolUse": {
+                    "toolUseId": "tool-1",
+                    "name": "read_file",
+                    "input": {},
+                }
+            },
+            {"text": "Let me check that for you."},
+        ],
+        "current_tool_use": {},
+        "text": "",
+        "reasoningText": "",
+        "citationsContent": [],
+        "redactedContent": b"",
+    }
+
+    assert tru_updated_state == exp_updated_state
+
+
 @unittest.mock.patch("strands.event_loop.streaming.logger")
 def test_handle_content_block_stop_logs_warning_on_malformed_json(mock_logger):
     state = {


### PR DESCRIPTION
## Description

A provider that begins text and then opens a tool-use block without closing the text block can lose that preamble from conversation history when the tool-use block stops. Preserving every pending content type at the stop boundary keeps assistant history faithful for affected providers and custom model adapters.

## Related Issues

Resolves: #4004

## Documentation PR

No documentation changes are needed.

## Type of Change

Bug fix

## Testing

- `hatch test tests/strands/event_loop/test_streaming.py`
- `hatch check code`

- [ ] I ran `hatch run prepare`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] No documentation updates are needed
- [x] No documentation example is needed
- [x] My changes generate no new warnings
- [x] No dependent changes are required