### PR TITLE
fix(agent): forward invocation state to agent tools

### DIFF
--- a/strands-py/src/strands/agent/_agent_as_tool.py
+++ b/strands-py/src/strands/agent/_agent_as_tool.py
@@ -228,7 +228,11 @@ class _AgentAsTool(AgentTool):
             )
 
             result = None
-            async for event in self._agent.stream_async(prompt, cancel_signal=cancel_signal):
+            async for event in self._agent.stream_async(
+                prompt,
+                invocation_state=invocation_state,
+                cancel_signal=cancel_signal,
+            ):
                 if "result" in event:
                     result = event["result"]
                 else:

--- a/strands-py/tests/strands/agent/test_agent_as_tool.py
+++ b/strands-py/tests/strands/agent/test_agent_as_tool.py
@@ -140,7 +140,7 @@ async def test_stream_passes_input_to_agent(tool, mock_agent, tool_use, agent_re
     async for _ in tool.stream(tool_use, {}):
         pass
 
-    mock_agent.stream_async.assert_called_once_with("hello", cancel_signal=None)
+    mock_agent.stream_async.assert_called_once_with("hello", invocation_state={}, cancel_signal=None)
 
 
 @pytest.mark.asyncio
@@ -155,7 +155,7 @@ async def test_stream_empty_input(tool, mock_agent, agent_result):
     async for _ in tool.stream(empty_tool_use, {}):
         pass
 
-    mock_agent.stream_async.assert_called_once_with("", cancel_signal=None)
+    mock_agent.stream_async.assert_called_once_with("", invocation_state={}, cancel_signal=None)
 
 
 @pytest.mark.asyncio
@@ -170,7 +170,7 @@ async def test_stream_string_input(tool, mock_agent, agent_result):
     async for _ in tool.stream(tool_use, {}):
         pass
 
-    mock_agent.stream_async.assert_called_once_with("direct string", cancel_signal=None)
+    mock_agent.stream_async.assert_called_once_with("direct string", invocation_state={}, cancel_signal=None)
 
 
 @pytest.mark.asyncio
@@ -727,15 +727,17 @@ def test_agent_mixed_with_regular_tools_in_tools_list():
 
 @pytest.mark.asyncio
 async def test_stream_forwards_parent_cancel_signal_to_sub_agent(tool, mock_agent, tool_use, agent_result):
-    """The wrapped agent receives the parent's cancellation signal as its external signal."""
+    """The wrapped agent receives the parent's invocation state and cancellation signal."""
     from strands.agent.agent import Agent
 
     mock_agent.stream_async.return_value = _mock_stream_async(agent_result)
     parent = Agent(name="parent", callback_handler=None)
+    invocation_state = {"agent": parent, "request_state": {"auth_token": "secret"}}
 
-    async for _ in tool.stream(tool_use, {"agent": parent}):
+    async for _ in tool.stream(tool_use, invocation_state):
         pass
 
+    assert mock_agent.stream_async.call_args.kwargs["invocation_state"] is invocation_state
     assert mock_agent.stream_async.call_args.kwargs["cancel_signal"] is parent.cancel_signal
 
 


### PR DESCRIPTION
## Description

Invocation-scoped context supplied to a parent agent must remain available when it delegates work to an agent used as a tool. Without that propagation, child-agent hooks and tools cannot access request-specific context such as authentication or correlation data.

## Related Issues

Resolves: #3931

## Documentation PR

No documentation changes are needed.

## Type of Change

Bug fix

## Testing

- `hatch test tests/strands/agent/test_agent_as_tool.py tests/strands/agent/test_agent.py`
- `hatch check code`

- [ ] I ran `hatch run prepare`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have reviewed and understand every line of code in this PR, including any generated by AI tools, and I can explain why it works
- [x] My change is focused and reasonably small; I have split unrelated work into separate PRs
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] No documentation updates are needed
- [x] No documentation example is needed
- [x] My changes generate no new warnings
- [x] No dependent changes are required